### PR TITLE
actually return an error when data.zip is missing

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -1,0 +1,4 @@
+Contributors
+------------
+
+* Christoph Böhmwalder (@chrboe)

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -32,7 +32,7 @@ void PLATFORM_getOSDirectory(char* output);
 void PLATFORM_migrateSaveData(char* output);
 void PLATFORM_copyFile(const char *oldLocation, const char *newLocation);
 
-void FILESYSTEM_init(char *argvZero)
+int FILESYSTEM_init(char *argvZero)
 {
 	char output[MAX_PATH];
 	int mkdirResult;
@@ -78,6 +78,11 @@ void FILESYSTEM_init(char *argvZero)
 #endif
 	if (!PHYSFS_mount(output, NULL, 1))
 	{
+		puts("Error: data.zip missing!");
+		puts("You do not have data.zip!");
+		puts("Grab it from your purchased copy of the game,");
+		puts("or get it from the free Make and Play Edition.");
+
 		SDL_ShowSimpleMessageBox(
 			SDL_MESSAGEBOX_ERROR,
 			"data.zip missing!",
@@ -86,7 +91,9 @@ void FILESYSTEM_init(char *argvZero)
 			"\nor get it from the free Make and Play Edition.",
 			NULL
 		);
+		return 0;
 	}
+	return 1;
 }
 
 void FILESYSTEM_deinit()

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-void FILESYSTEM_init(char *argvZero);
+int FILESYSTEM_init(char *argvZero);
 void FILESYSTEM_deinit();
 
 char *FILESYSTEM_getUserSaveDirectory();

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -36,7 +36,10 @@ scriptclass script;
 
 int main(int argc, char *argv[])
 {
-    FILESYSTEM_init(argv[0]);
+    if(!FILESYSTEM_init(argv[0]))
+    {
+        return 1;
+    }
     SDL_Init(
         SDL_INIT_VIDEO |
         SDL_INIT_AUDIO |


### PR DESCRIPTION
More than two and a half years after messaging @flibitijibibo on Twitter, begging him for the source code, I'm very happy to finally be able to officially lay my eyes on this work of art (well, sort of).
Anyways, I'm also excited to share my first contribution to the game that has cost me countless hours of my life.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

We should return an error code when we can't find data.zip, just letting
the program crash is a little crude.

Note: The message box did not work for me, so I just swapped it for some `puts`s. I'm obviously open for suggestions here.
