### PR TITLE
Update PhysFS APIs

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -4,3 +4,4 @@ Contributors
 * Christoph Böhmwalder (@chrboe)
 * Elijah Stone
 * Emmanuel Vadot (@evadot)
+* Marvin Scholz (@ePirat)

--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -91,7 +91,7 @@ bool binaryBlob::unPackBinary(const char* name)
 
 	size = PHYSFS_fileLength(handle);
 
-	PHYSFS_read(handle, &m_headers, 1, sizeof(resourceheader) * 128);
+	PHYSFS_readBytes(handle, &m_headers, sizeof(resourceheader) * 128);
 
 	int offset = 0 + (sizeof(resourceheader) * 128);
 
@@ -101,7 +101,7 @@ bool binaryBlob::unPackBinary(const char* name)
 		{
 			PHYSFS_seek(handle, offset);
 			m_memblocks[i] = (char*) malloc(m_headers[i].size);
-			PHYSFS_read(handle, m_memblocks[i], 1, m_headers[i].size);
+			PHYSFS_readBytes(handle, m_memblocks[i], m_headers[i].size);
 			offset += m_headers[i].size;
 		}
 	}

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -124,7 +124,7 @@ void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem, size_t *
 		*len = length;
 	}
 	*mem = (unsigned char*) malloc(length);
-	PHYSFS_read(handle, *mem, 1, length);
+	PHYSFS_readBytes(handle, *mem, length);
 	PHYSFS_close(handle);
 }
 

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -172,8 +172,7 @@ void PLATFORM_getOSDirectory(char* output)
 		strcat(output, "/VVVVVV/");
 	}
 #elif defined(__APPLE__)
-	strcpy(output, PHYSFS_getUserDir());
-	strcat(output, "Library/Application Support/VVVVVV/");
+	strcpy(output, PHYSFS_getPrefDir("distractionware", "VVVVVV"));
 #elif defined(_WIN32)
 	SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, output);
 	strcat(output, "\\VVVVVV\\");


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

Some deprecated PhysFS APIs were used, which were trivial to update to the
non-deprecated versions.

The `PHYSFS_getUserDir` is still used for Linux as I could not test the change there
yet but looking at the implementation of the function it should work to replace it too
at a later point.