### PR TITLE
Add vsync option

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -191,6 +191,7 @@ Game::Game(void):
     gameframerate=34;
 
     fullscreen = false;// true; //Assumed true at first unless overwritten at some point!
+    vsync = false;
     stretchMode = 0;
     useLinearFilter = false;
     advanced_mode = false;
@@ -4259,6 +4260,11 @@ void Game::loadstats( mapclass& map, Graphics& dwgfx )
             fullscreen = atoi(pText);
         }
 
+        if(pKey == "vsync")
+        {
+            vsync = atoi(pText);
+        }
+
 	if (pKey == "stretch")
 	{
 		stretchMode = atoi(pText);
@@ -4391,6 +4397,10 @@ void Game::loadstats( mapclass& map, Graphics& dwgfx )
     {
         dwgfx.screenbuffer->toggleFullScreen();
     }
+    if(vsync)
+    {
+        dwgfx.screenbuffer->toggleVsync();
+    }
     for (int i = 0; i < stretchMode; i += 1)
     {
         dwgfx.screenbuffer->toggleStretchMode();
@@ -4497,6 +4507,10 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
 
     msg = new TiXmlElement( "fullscreen" );
     msg->LinkEndChild( new TiXmlText( tu.String(fullscreen).c_str()));
+    dataNode->LinkEndChild( msg );
+
+    msg = new TiXmlElement( "vsync" );
+    msg->LinkEndChild( new TiXmlText( tu.String(vsync).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "stretch" );
@@ -6775,15 +6789,17 @@ void Game::createmenu( std::string t )
     {
         menuoptions[0] = "toggle fullscreen";
         menuoptionsactive[0] = true;
-        menuoptions[1] = "toggle letterbox";
+        menuoptions[1] = "toggle vsync";
         menuoptionsactive[1] = true;
-        menuoptions[2] = "toggle filter";
+        menuoptions[2] = "toggle letterbox";
         menuoptionsactive[2] = true;
-        menuoptions[3] = "toggle analogue";
+        menuoptions[3] = "toggle filter";
         menuoptionsactive[3] = true;
-        menuoptions[4] = "return";
+        menuoptions[4] = "toggle analogue";
         menuoptionsactive[4] = true;
-        nummenuoptions = 5;
+        menuoptions[5] = "return";
+        menuoptionsactive[5] = true;
+        nummenuoptions = 6;
         menuxoff = -50;
         menuyoff = 8;
         /* Old stuff, not used anymore

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -240,6 +240,7 @@ public:
     std::vector<int> temp_unlocknotify;
     int stat_trinkets;
     bool fullscreen;
+    bool vsync;
     int bestgamedeaths;
 
     bool stat_screenshakes;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -436,14 +436,23 @@ SDL_assert(0 && "Remove open level dir");
                     game.currentmenuoption = 0;
                   }else if (game.currentmenuoption == 1){
                     music.playef(11, 10);
+                    dwgfx.screenbuffer->toggleVsync();
+                    music.playef(11, 10);
+                    game.vsync = !game.vsync;
+                    updategraphicsmode(game, dwgfx);
+                    game.savestats(map, dwgfx);
+                    game.createmenu("graphicoptions");
+                    game.currentmenuoption = 1;
+                  }else if(game.currentmenuoption == 2){
+                    music.playef(11, 10);
                     dwgfx.screenbuffer->toggleStretchMode();
                     music.playef(11, 10);
                     game.stretchMode = (game.stretchMode + 1) % 3;
                     updategraphicsmode(game, dwgfx);
                     game.savestats(map, dwgfx);
                     game.createmenu("graphicoptions");
-                    game.currentmenuoption = 1;
-                  }else if (game.currentmenuoption == 2){
+                    game.currentmenuoption = 2;
+                  }else if (game.currentmenuoption == 3){
                     music.playef(11, 10);
                     dwgfx.screenbuffer->toggleLinearFilter();
                     music.playef(11, 10);
@@ -451,8 +460,8 @@ SDL_assert(0 && "Remove open level dir");
                     updategraphicsmode(game, dwgfx);
                     game.savestats(map, dwgfx);
                     game.createmenu("graphicoptions");
-                    game.currentmenuoption = 2;
-                  }else if (game.currentmenuoption == 3){
+                    game.currentmenuoption = 3;
+                  }else if (game.currentmenuoption == 4){
                       //change smoothing
                       music.playef(11, 10);
                       game.fullScreenEffect_badSignal = !game.fullScreenEffect_badSignal;
@@ -461,7 +470,7 @@ SDL_assert(0 && "Remove open level dir");
 					  dwgfx.screenbuffer->badSignalEffect= !dwgfx.screenbuffer->badSignalEffect;
                       game.savestats(map, dwgfx);
                       game.createmenu("graphicoptions");
-                      game.currentmenuoption = 3;
+                      game.currentmenuoption = 4;
                   }
                   else
                   {

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -24,6 +24,7 @@ Screen::Screen()
     m_screenTexture = NULL;
     m_screen = NULL;
     isWindowed = true;
+	vsync = false;
     stretchMode = 0;
     isFiltered = false;
     filterSubrect.x = 1;
@@ -184,6 +185,16 @@ void Screen::toggleFullScreen()
 {
 	isWindowed = !isWindowed;
 	ResizeScreen(-1, -1);
+}
+
+void Screen::toggleVsync()
+{
+	vsync = !vsync;
+
+	if(vsync)
+		SDL_GL_SetSwapInterval(1);
+	else
+		SDL_GL_SetSwapInterval(0);
 }
 
 void Screen::toggleStretchMode()

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -18,10 +18,12 @@ public:
 	const SDL_PixelFormat* GetFormat();
 
 	void toggleFullScreen();
+	void toggleVsync();
 	void toggleStretchMode();
 	void toggleLinearFilter();
 
 	bool isWindowed;
+	bool vsync;
 	bool isFiltered;
 	bool badSignalEffect;
 	bool glScreen;

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -199,8 +199,16 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
               }else{
                 dwgfx.Print( -1, 85, "Current mode: WINDOWED", tr, tg, tb, true);
               }
+          }else if(game.currentmenuoption == 1)
+          {
+              dwgfx.bigprint( -1, 30, "Toggle Vsync", tr, tg, tb, true);
+              dwgfx.Print( -1, 65, "Toggles vsync.", tr, tg, tb, true);
 
-          }else if (game.currentmenuoption == 1)
+              if(game.vsync)
+                    dwgfx.Print( -1, 85, "vsync: ENABLED", tr, tg, tb, true);
+              else
+                    dwgfx.Print( -1, 85, "vsync: DISABLED", tr, tg, tb, true);
+          }else if (game.currentmenuoption == 2)
                 {
                     dwgfx.bigprint( -1, 30, "Toggle Letterbox", tr, tg, tb, true);
                     dwgfx.Print( -1, 65, "Choose letterbox/stretch/integer mode.", tr, tg, tb, true);
@@ -212,7 +220,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
               }else{
                 dwgfx.Print( -1, 85, "Current mode: LETTERBOX", tr, tg, tb, true);
               }
-          }else if (game.currentmenuoption == 2)
+          }else if (game.currentmenuoption == 3)
                 {
                     dwgfx.bigprint( -1, 30, "Toggle Filter", tr, tg, tb, true);
                     dwgfx.Print( -1, 65, "Change to nearest/linear filter.", tr, tg, tb, true);
@@ -223,7 +231,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 dwgfx.Print( -1, 85, "Current mode: NEAREST", tr, tg, tb, true);
               }
 
-                } else if (game.currentmenuoption == 3)
+                } else if (game.currentmenuoption == 4)
                 {
                     dwgfx.bigprint( -1, 30, "Analogue Mode", tr, tg, tb, true);
                     dwgfx.Print( -1, 65, "There is nothing wrong with your", tr, tg, tb, true);


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

I had screen tearing on linux, so I added a vsync option (using [SDL_GL_SetSwapInterval](https://wiki.libsdl.org/SDL_GL_SetSwapInterval)) which seems to work nicely
