### PR TITLE
FS: Use PHYSFS_getPrefDir on Linux/FreeBSD too

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -1,7 +1,10 @@
 Contributors
 ------------
 
+(Ordered alphabetically by last name.)
+
 * Christoph Böhmwalder (@chrboe)
+* Marvin Scholz (@ePirat)
 * Elijah Stone
 * Emmanuel Vadot (@evadot)
-* Marvin Scholz (@ePirat)
+* Rémi Verschelde (@akien-mga)

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -159,19 +159,7 @@ std::vector<std::string> FILESYSTEM_getLevelDirFileNames()
 
 void PLATFORM_getOSDirectory(char* output)
 {
-#if defined(__linux__) || defined(__FreeBSD__)
-	const char *homeDir = getenv("XDG_DATA_HOME");
-	if (homeDir == NULL)
-	{
-		strcpy(output, PHYSFS_getUserDir());
-		strcat(output, ".local/share/VVVVVV/");
-	}
-	else
-	{
-		strcpy(output, homeDir);
-		strcat(output, "/VVVVVV/");
-	}
-#elif defined(__APPLE__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
 	strcpy(output, PHYSFS_getPrefDir("distractionware", "VVVVVV"));
 #elif defined(_WIN32)
 	SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, output);


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

Follow-up to #19 which did the change for macOS.
It appears to work as expected on Linux too.

Tested on a distro where XDG_DATA_HOME is undefined by default,
and `PHYSFS_getPrefDir` also resolves to `~/.local/share/VVVVVV/`.
The first organization parameter is unused on Linux and macOS.

Added myself to `CONTRIBUTORS` as requested though this patch is trivial enough not to require attribute IMO - but I'll contribute some more hopefully to make up for it.

I suggest ordering contributors alphabetically to make it easier for new ones to know where to add themselves - alternatively the instructions could be to add oneself at the bottom of the list. If so I can amend this commit to change that.