### PR TITLE
Enable and fix warnings

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -3,6 +3,10 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
 
+# CMake Options
+OPTION(ENABLE_WARNINGS "Enable compilation warnings" ON)
+OPTION(ENABLE_WERROR "Treat compilation warnings as errors" OFF)
+
 # Architecture Flags
 IF(APPLE)
 	# Wow, Apple is a huge jerk these days huh?
@@ -101,6 +105,17 @@ IF(WIN32)
 	ADD_EXECUTABLE(vvvvvv WIN32 ${VVV_SRC})
 ELSE()
 	ADD_EXECUTABLE(vvvvvv ${VVV_SRC})
+ENDIF()
+
+# Build options
+IF(ENABLE_WARNINGS)
+	# The weird syntax is due to CMake generator expressions.
+	# Saves quite a few lines and boilerplate at the price of readability.
+	TARGET_COMPILE_OPTIONS(vvvvvv PRIVATE
+		$<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
+			-Wall $<$<BOOL:ENABLE_WERROR>:-Werror>>
+		$<$<CXX_COMPILER_ID:MSVC>:
+			/W4 $<$<BOOL:ENABLE_WERROR>:/WX>>)
 ENDIF()
 
 # Library information

--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -108,7 +108,7 @@ bool binaryBlob::unPackBinary(const char* name)
 	}
 	PHYSFS_close(handle);
 
-	printf("The complete reloaded file size: %li\n", size);
+	printf("The complete reloaded file size: %lli\n", size);
 
 	for (int i = 0; i < 128; i += 1)
 	{

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3078,8 +3078,12 @@ void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool
 
 	x -= (len(t));
 
-	if (r < -1) r = -1; if (g < 0) g = 0; if (b < 0) b = 0;
-	if (r > 255) r = 255; if (g > 255) g = 255; if (b > 255) b = 255;
+	if (r < -1) r = -1;
+	if (g < 0) g = 0;
+	if (b < 0) b = 0;
+	if (r > 255) r = 255;
+	if (g > 255) g = 255;
+	if (b > 255) b = 255;
 	ct.colour = getRGB(r, g, b);
 
 	if (cen)

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -200,7 +200,7 @@ SDL_Surface * ScaleSurfaceSlow( SDL_Surface *_surface, int Width, int Height)
 		// DrawPixel(_ret, static_cast<Sint32>(_stretch_factor_x * x) + o_x,
 		//static_cast<Sint32>(_stretch_factor_y * y) + o_y, ReadPixel(_surface, x, y));
 
-		return _ret;
+	return _ret;
 }
 
 SDL_Surface *  FlipSurfaceHorizontal(SDL_Surface* _src)


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

- CMake: Add ENABLE_WARNINGS and ENABLE_WERROR build options

ENABLE_WARNINGS is enabled by default, with `-Wall` on GCC/Clang and
`/W4` on MSVC.

ENABLE_WERROR is disabled by default, treats warnings as errors.

- Fix warnings raised by GCC 8