### PR TITLE
Correct "seperately" to "separately"

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -4,6 +4,7 @@ Contributors
 (Ordered alphabetically by last name.)
 
 * Christoph Böhmwalder (@chrboe)
+* Elliott Saltar (@eboyblue3)
 * Marvin Scholz (@ePirat)
 * Elijah Stone
 * Emmanuel Vadot (@evadot)

--- a/desktop_version/README.md
+++ b/desktop_version/README.md
@@ -38,7 +38,7 @@ each time Xcode updates.
 Including data.zip
 ------------
 You'll need the data.zip file from VVVVVV to actually run the game! It's
-available to download seperately for free in the
+available to download separately for free in the
 [Make and Play](http://distractionware.com/blog/category/vvvvvv-make-and-play/)
 edition of the game. Put this file next to your executable and the game should
 run.

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -955,7 +955,7 @@ SDL_assert(0 && "Remove open level dir");
                 {
                     if (game.currentmenuoption == 0)
                     {
-                        //unlock time trials seperately...
+                        //unlock time trials separately...
                         music.playef(11, 10);
                         game.createmenu("unlockmenutrials");
                         map.nexttowercolour();

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -785,7 +785,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
         {
             dwgfx.bigprint( -1, 30, "Unlock Time Trials", tr, tg, tb, true);
             dwgfx.Print( -1, 65, "You can unlock each time", tr, tg, tb, true);
-            dwgfx.Print( -1, 75, "trial seperately.", tr, tg, tb, true);
+            dwgfx.Print( -1, 75, "trial separately.", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "timetrials")
         {

--- a/mobile_version/src/includes/input.as
+++ b/mobile_version/src/includes/input.as
@@ -649,7 +649,7 @@ public function titleinput(key:KeyPoll, dwgfx:dwgraphicsclass, map:mapclass, gam
 					}
 				}else if (game.currentmenuname == "unlockmenu") {
 					if (game.currentmenuoption == 0) {
-						//unlock time trials seperately...
+						//unlock time trials separately...
 						music.playef(11, 10);
 						game.createmenu("unlockmenutrials");
 						map.nexttowercolour();

--- a/mobile_version/src/includes/render.as
+++ b/mobile_version/src/includes/render.as
@@ -483,7 +483,7 @@ public function titlerender(key:KeyPoll, dwgfx:dwgraphicsclass, map:mapclass, ga
 			/*
 			dwgfx.bigprint( -1, 30, "Unlock Time Trials", tr, tg, tb, true);
 			dwgfx.print( -1, 65, "You can unlock each time", tr, tg, tb, true);
-			dwgfx.print( -1, 75, "trial seperately.", tr, tg, tb, true);
+			dwgfx.print( -1, 75, "trial separately.", tr, tg, tb, true);
 			*/
 	  }else if (game.currentmenuname == "timetrials") {
 			/*


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [✔] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [✔] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

This one's pretty minimal, but I figured I'd contribute to this thing somehow.

The tile here's pretty self-explanatory; I corrected all instances of "seperately" to "separately." This shouldn't mess with any critical game logic since it's a single-character difference.