### PR TITLE
zero a lot of uninitialized member vars

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -9,3 +9,4 @@ Contributors
 * Elijah Stone
 * Emmanuel Vadot (@evadot)
 * Rémi Verschelde (@akien-mga)
+* viri (viri.me)

--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -19,6 +19,7 @@ binaryBlob::binaryBlob()
 			m_headers[i].name[j] = '\0';
 		}
 	}
+	::memset(m_headers, 0, 128 * sizeof(resourceheader));
 }
 
 #ifdef VVV_COMPILEMUSIC

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -103,8 +103,30 @@ Graphics::Graphics()
     fadeamount = 0;
     fademode = 0;
 
-
-
+    // initialize everything else to zero
+    backBuffer = nullptr;
+    backboxrect = SDL_Rect{ 0, 0, 0, 0 };
+    bcol = 0;
+    bcol2 = 0;
+    ct = colourTransform{ 0 };
+    foot_rect = SDL_Rect{ 0, 0, 0, 0 };
+    foregrounddrawn = false;
+    foregroundBuffer = nullptr;
+    backgrounddrawn = false;
+    images_rect = SDL_Rect{ 0, 0, 0, 0 };
+    j = 0;
+    k = 0;
+    m = 0;
+    linedelay = 0;
+    menubuffer = nullptr;
+    screenbuffer = nullptr;
+    tempBuffer = nullptr;
+    tl = point{ 0, 0 };
+    towerbuffer = nullptr;
+    trinketr = 0;
+    trinketg = 0;
+    trinketb = 0;
+    warprect = SDL_Rect{ 0, 0, 0, 0 };
 }
 
 Graphics::~Graphics()
@@ -2322,7 +2344,7 @@ void Graphics::drawmap( mapclass& map )
     ///TODO forground once;
     if (!foregrounddrawn)
     {
-        FillRect(forgroundBuffer, 0xDEADBEEF);
+        FillRect(foregroundBuffer, 0xDEADBEEF);
         if(map.tileset==0)
         {
             for (j = 0; j < 29+map.extrarow; j++)
@@ -2355,8 +2377,8 @@ void Graphics::drawmap( mapclass& map )
         }
         foregrounddrawn = true;
     }
-    OverlaySurfaceKeyed(forgroundBuffer, backBuffer, 0xDEADBEEF);
-    //SDL_BlitSurface(forgroundBuffer, NULL, backBuffer, NULL);
+    OverlaySurfaceKeyed(foregroundBuffer, backBuffer, 0xDEADBEEF);
+    //SDL_BlitSurface(foregroundBuffer, NULL, backBuffer, NULL);
 
 }
 
@@ -2378,7 +2400,7 @@ void Graphics::drawfinalmap(mapclass & map)
 	}
 
 	if (!foregrounddrawn) {
-		FillRect(forgroundBuffer, 0xDEADBEEF);
+		FillRect(foregroundBuffer, 0xDEADBEEF);
 		if(map.tileset==0){
 			for (int j = 0; j < 29+map.extrarow; j++) {
 				for (int i = 0; i < 40; i++) {
@@ -2397,7 +2419,7 @@ void Graphics::drawfinalmap(mapclass & map)
 		foregrounddrawn=true;
 	}
 
-	OverlaySurfaceKeyed(forgroundBuffer, backBuffer, 0xDEADBEEF);
+	OverlaySurfaceKeyed(foregroundBuffer, backBuffer, 0xDEADBEEF);
 }
 
 void Graphics::drawtowermap( mapclass& map )
@@ -3156,7 +3178,7 @@ void Graphics::drawforetile(int x, int y, int t)
 	//frontbuffer.copyPixels(tiles[t], tiles_rect, tpoint);
 	SDL_Rect rect;
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
-	BlitSurfaceStandard(tiles[t],NULL, forgroundBuffer, &rect  );
+	BlitSurfaceStandard(tiles[t],NULL, foregroundBuffer, &rect  );
 }
 
 void Graphics::drawforetile2(int x, int y, int t)
@@ -3164,14 +3186,14 @@ void Graphics::drawforetile2(int x, int y, int t)
 	//frontbuffer.copyPixels(tiles2[t], tiles_rect, tpoint);
 	SDL_Rect rect;
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
-	BlitSurfaceStandard(tiles2[t],NULL, forgroundBuffer, &rect  );
+	BlitSurfaceStandard(tiles2[t],NULL, foregroundBuffer, &rect  );
 }
 
 void Graphics::drawforetile3(int x, int y, int t, int off)
 {
 	SDL_Rect rect;
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
-	BlitSurfaceStandard(tiles3[t+(off*30)],NULL, forgroundBuffer, &rect  );
+	BlitSurfaceStandard(tiles3[t+(off*30)],NULL, foregroundBuffer, &rect  );
 	//frontbuffer.copyPixels(tiles3[t+(off*30)], tiles_rect, tpoint);
 }
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -222,7 +222,7 @@ public:
 	Screen* screenbuffer;
 	SDL_Surface* menubuffer;
 	SDL_Surface* towerbuffer;
-	SDL_Surface* forgroundBuffer;
+	SDL_Surface* foregroundBuffer;
 	SDL_Surface* tempBuffer;
 
 	SDL_Rect bfont_rect;

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -206,8 +206,14 @@ musicclass::musicclass()
 	FadeVolAmountPerFrame = 0;
 
 	custompd = false;
-	// currentsong = -1;
-	// nicefade = 0;
+
+	currentsong = 0;
+	musicfade = 0;
+	musicfadein = 0;
+	nicechange = 0;
+	nicefade = 0;
+	resumesong = 0;
+	volume = 0.0f;
 }
 
 void musicclass::play(int t)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -25,7 +25,17 @@ scriptclass::scriptclass()
 	scriptdelay = 0;
 	running = false;
 
-
+	b = 0;
+	g = 0;
+	i = 0;
+	j = 0;
+	k = 0;
+	loopcount = 0;
+	looppoint = 0;
+	r = 0;
+	textx = 0;
+	texty = 0;
+	txtnumlines = 0;
 }
 
 void scriptclass::clearcustom(){

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -90,6 +90,9 @@ glow(0),
 	}
 
 	slowsine = 0;
+	globaltemp = 0;
+	temp = 0;
+	temp2 = 0;
 }
 
 std::string UtilityClass::String( int _v )

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -129,8 +129,8 @@ int main(int argc, char *argv[])
     graphics.Makebfont();
 
 
-    graphics.forgroundBuffer =  SDL_CreateRGBSurface(SDL_SWSURFACE ,320 ,240 ,fmt->BitsPerPixel,fmt->Rmask,fmt->Gmask,fmt->Bmask,fmt->Amask  );
-    SDL_SetSurfaceBlendMode(graphics.forgroundBuffer, SDL_BLENDMODE_NONE);
+    graphics.foregroundBuffer =  SDL_CreateRGBSurface(SDL_SWSURFACE ,320 ,240 ,fmt->BitsPerPixel,fmt->Rmask,fmt->Gmask,fmt->Bmask,fmt->Amask  );
+    SDL_SetSurfaceBlendMode(graphics.foregroundBuffer, SDL_BLENDMODE_NONE);
 
     graphics.screenbuffer = &gameScreen;
 


### PR DESCRIPTION
I'm not sure why you **need** debug + RTC but a good chance is that it's related to uninitialized values which are zeroed in debug but not release (had this exact mystery headache a while ago). This just sets a bunch of otherwise uninitialized member vars to 0, also getting rid of one compiler warning per variable initialized. Neat.

Also fixes a spelling error (`forground`) in the graphics class's buffers.
