### PR TITLE
Menu fixes and a typo

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -4,6 +4,7 @@ Contributors
 (Ordered alphabetically by last name.)
 
 * Christoph Böhmwalder (@chrboe)
+* Daniel Lee (@ddm999)
 * Elliott Saltar (@eboyblue3)
 * Marvin Scholz (@ePirat)
 * Elijah Stone

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -428,7 +428,6 @@ SDL_assert(0 && "Remove open level dir");
                   if (game.currentmenuoption == 0){
                     music.playef(11, 10);
                     dwgfx.screenbuffer->toggleFullScreen();
-                    music.playef(11, 10);
                     game.fullscreen = !game.fullscreen;
                     updategraphicsmode(game, dwgfx);
                     game.savestats(map, dwgfx);
@@ -437,7 +436,6 @@ SDL_assert(0 && "Remove open level dir");
                   }else if (game.currentmenuoption == 1){
                     music.playef(11, 10);
                     dwgfx.screenbuffer->toggleStretchMode();
-                    music.playef(11, 10);
                     game.stretchMode = (game.stretchMode + 1) % 3;
                     updategraphicsmode(game, dwgfx);
                     game.savestats(map, dwgfx);
@@ -446,7 +444,6 @@ SDL_assert(0 && "Remove open level dir");
                   }else if (game.currentmenuoption == 2){
                     music.playef(11, 10);
                     dwgfx.screenbuffer->toggleLinearFilter();
-                    music.playef(11, 10);
                     game.useLinearFilter = !game.useLinearFilter;
                     updategraphicsmode(game, dwgfx);
                     game.savestats(map, dwgfx);
@@ -709,6 +706,8 @@ SDL_assert(0 && "Remove open level dir");
                             music.playef(18, 10);
                             game.screenshake = 10;
                             game.flashlight = 5;
+                        }else{
+                            music.playef(11, 10);
                         }
                     }
                     else if (game.currentmenuoption == 2)
@@ -1015,7 +1014,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         //back
                         music.playef(11, 10);
-                        game.createmenu("mainmenu");
+                        game.createmenu("options");
                         map.nexttowercolour();
                     }
                 }
@@ -1332,6 +1331,7 @@ SDL_assert(0 && "Remove open level dir");
 
 					if (game.currentmenuoption == 4)
 					{
+                        music.playef(11, 10);
 						game.createmenu("options");
 
 						//Add extra menu for mmmmmm mod

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1331,7 +1331,7 @@ SDL_assert(0 && "Remove open level dir");
 
 					if (game.currentmenuoption == 4)
 					{
-                        music.playef(11, 10);
+						music.playef(11, 10);
 						game.createmenu("options");
 
 						//Add extra menu for mmmmmm mod

--- a/desktop_version/src/Scripts.cpp
+++ b/desktop_version/src/Scripts.cpp
@@ -5319,7 +5319,7 @@ void scriptclass::load(std::string t)
 
         add("squeak(blue)");
         add("text(blue,0,0,3)");
-        add("This lab is amazing! The scentists");
+        add("This lab is amazing! The scientists");
         add("who worked here know a lot more");
         add("about warp technology than we do!");
         add("position(blue,below)");


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

Fixes some UI things in the menu.
- Unlock Play Modes > Return goes up one menu to Game Options, instead of up two menus to the main menu
- Game Pad Options > Return plays a menu sound instead of being silent
- When disabling Screen Effects, a menu sound is played instead of being silent (enabling Screen Effects is unchanged)
- Changing the following Graphics Options > Fullscreen, Scaling (Letterbox), Filter plays a menu sound before the change, and not both before and after the change
  - as these changes are instant or near-instant, these would just overlap and make an excessively loud noise

Also fixes a typo from Victoria in the Secret Lab ("scentists" -> "scientists").