### PR TITLE
Fix hardreset() not resetting all 50 slots in (custom)collect

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -10,6 +10,7 @@ Contributors
 * Elliott Saltar (@eboyblue3)
 * Marvin Scholz (@ePirat)
 * Elijah Stone
+* Info Teddy (@InfoTeddy)
 * Emmanuel Vadot (@evadot)
 * Rémi Verschelde (@akien-mga)
 * viri (viri.me)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3536,7 +3536,7 @@ void scriptclass::hardreset( KeyPoll& key, Graphics& dwgfx, Game& game,mapclass&
     obj.customcrewmoods[i]=1;
   }
 
-	for (i = 0; i < 20; i++)
+	for (i = 0; i < 50; i++)
 	{
 		obj.collect[i] = 0;
 		obj.customcollect[i] = 0;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3536,7 +3536,7 @@ void scriptclass::hardreset( KeyPoll& key, Graphics& dwgfx, Game& game,mapclass&
     obj.customcrewmoods[i]=1;
   }
 
-	for (i = 0; i < 50; i++)
+	for (i = 0; i < 100; i++)
 	{
 		obj.collect[i] = 0;
 		obj.customcollect[i] = 0;


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

* **Fix `hardreset()` not resetting all 50 slots in `obj.collect` and `obj.customcollect`**

   This means you can actually use more than 20 trinkets/coins (slots in `obj.collect`) and 20 crewmates (slots in `obj.customcollect`) in a custom level, since the only problems with doing so previously was that they wouldn't get reset if you started the level from the beginning.