### PR TITLE
Look for data.zip in the OSDirectory

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -73,6 +73,12 @@ int FILESYSTEM_init(char *argvZero)
 #ifdef _WIN32
 	strcpy(output, PHYSFS_getBaseDir());
 	strcat(output, "data.zip");
+#elif defined(__FreeBSD__)
+	PLATFORM_getOSDirectory(output);
+	if (strlcat(output, "data.zip", sizeof(output)) >= sizeof(output)) {
+		puts("Cannot find location for data.zip\n");
+		return 0;
+	}
 #else
 	strcpy(output, "data.zip");
 #endif


### PR DESCRIPTION
For FreeBSD user it mean that they can just pkg install VVVVVV
once the package will be available and copy the data.zip in
~/.local/share/VVVVVV as the executable will be in
/usr/local/bin/ and users do not have the permission to write files
in this directory.

Signed-off-by: Emmanuel Vadot <manu@freebsd.org>

## The Basics

Thanks for making a pull request! Before making a pull request, we have some
things for you to read through first:

- We generally do not accept patches for formatting fixes, unless the formatting
  fixes are part of a functional patch (for example, when fixing a bug in a
  function you can fix up the lines surrounding it if needed).
- Patches that break compatibility with the original game data or save data will
  not be accepted.
- New features and user interface changes will most likely not be accepted
  unless they are for improving user accessibility.
- New platforms are acceptable if they use SDL + PhysicsFS and don't mess with
  the game source too much.
    - (No homebrew console targets, sorry! Maybe do the work in SDL instead?)
- Pull requests that do not fill out the Legal Stuff will be closed
  automatically.

If you understand these notes, you can delete the text in this section. Pull
requests that still have this text will be closed automatically.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

Describe your patch here!
