### PR TITLE
Fix Werror always being enabled

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -124,9 +124,9 @@ IF(ENABLE_WARNINGS)
 	# Saves quite a few lines and boilerplate at the price of readability.
 	TARGET_COMPILE_OPTIONS(VVVVVV PRIVATE
 		$<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
-			-Wall $<$<BOOL:ENABLE_WERROR>:-Werror>>
+			-Wall $<$<BOOL:${ENABLE_WERROR}>:-Werror>>
 		$<$<CXX_COMPILER_ID:MSVC>:
-			/W4 $<$<BOOL:ENABLE_WERROR>:/WX>>)
+			/W4 $<$<BOOL:${ENABLE_WERROR}>:/WX>>)
 ENDIF()
 
 # Library information

--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -14,3 +14,4 @@ Contributors
 * Emmanuel Vadot (@evadot)
 * Rémi Verschelde (@akien-mga)
 * viri (viri.me)
+* Wouter (Xesxen)


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

CMake always enabled -Werror due to an error in evaluating ENABLE_WERROR. This patch fixes this problem by fetching the value instead of using the name as a boolean.

