### PR TITLE
Simplify std::vector initializations

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -73,28 +73,13 @@ void entityclass::init()
       customcrewmoods[i]=1;
     }
 
-    for (int i = 0; i < 100; i++)
-    {
-        int t =0;
-        flags.push_back(t);
-    }
+    flags.resize(100);
+    blocks.resize(500);
+    entities.resize(200);
+    linecrosskludge.resize(100);
+    collect.resize(100);
+    customcollect.resize(100);
 
-    for (int i = 0; i < 500; i++)
-    {
-        blocks.push_back(blockclass());
-    }
-
-    for (int z = 0; z < 200; z++)
-    {
-        entities.push_back(entclass());
-    }
-
-    for (int i = 0; i < 100; i++)
-    {
-        linecrosskludge.push_back(entclass());
-        collect.push_back(0);
-        customcollect.push_back(0);
-    }
     nlinecrosskludge = 0;
 }
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -207,18 +207,14 @@ Game::Game(void):
     }
     customcol=0;
 
-    for (int i = 0; i < 6; i++)
-    {
-        bool cstats;
-        cstats = false;
-        crewstats.push_back(cstats);
-        tele_crewstats.push_back(false);
-        quick_crewstats.push_back(false);
-        besttimes.push_back( -1);
-        besttrinkets.push_back( -1);
-        bestlives.push_back( -1);
-        bestrank.push_back( -1);
-    }
+    crewstats.resize(6);
+    tele_crewstats.resize(6);
+    quick_crewstats.resize(6);
+    besttimes.resize(6, -1);
+    besttrinkets.resize(6, -1);
+    bestlives.resize(6, -1);
+    bestrank.resize(6, -1);
+
     crewstats[0] = true;
     lastsaved = 0;
 
@@ -230,23 +226,10 @@ Game::Game(void):
     quick_currentarea = "Error! Error!";
 
     //Menu stuff initiliased here:
-    for (int mi = 0; mi < 25; mi++)
-    {
-        menuoptions.push_back(std::string());
-        menuoptionsactive.push_back(bool());
-
-        bool nb1, nb2;
-        nb1 = false;
-        nb2 = false;
-        unlock.push_back(nb1);
-        unlocknotify.push_back(nb2);
-    }
-
-    for (int ui = 0; ui < 25; ui++)
-    {
-        unlock[ui] = false;
-        unlocknotify[ui] = false;
-    }
+    menuoptions.resize(25);
+    menuoptionsactive.resize(25);
+    unlock.resize(25);
+    unlocknotify.resize(25);
 
     nummenuoptions = 0;
     currentmenuoption = 0;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -11,15 +11,10 @@ scriptclass::scriptclass()
     	//Start SDL
 
 	//Init
-	for (int init = 0; init < 500; init++)
-	{
-		commands.push_back(std::string());
-	}
-	for (int init = 0; init < 40; init++)
-	{
-		words.push_back(std::string());
-		txt.push_back(std::string());
-	}
+	commands.resize(500);
+	words.resize(40);
+	txt.resize(40);
+
 	position = 0;
 	scriptlength = 0;
 	scriptdelay = 0;


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

Resizing the vector does the same thing that the loops did, it changes
the size for the vector and initializes it with default-constructed
elements (or 0 or its equivalent for POD types).

Where a specific value is needed, it is set with the second
parameter of resize().
