### PR TITLE
Handle filepaths with non-ASCII characters properly on Windows

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -6,6 +6,7 @@ Contributors
 * Christoph Böhmwalder (@chrboe)
 * Charlie Bruce (@charliebruce)
 * Brian Callahan (@ibara)
+* Dav999 (Dav999-v)
 * Daniel Lee (@ddm999)
 * Elliott Saltar (@eboyblue3)
 * Marvin Scholz (@ePirat)

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -13,7 +13,12 @@
 #if defined(_WIN32)
 #include <windows.h>
 #include <shlobj.h>
-#define mkdir(a, b) CreateDirectory(a, NULL)
+int mkdir(char* path, int mode)
+{
+	WCHAR utf16_path[MAX_PATH];
+	MultiByteToWideChar(CP_UTF8, 0, path, -1, utf16_path, MAX_PATH);
+	return CreateDirectoryW(utf16_path, NULL);
+}
 #define VNEEDS_MIGRATION (mkdirResult != 0)
 #elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <sys/stat.h>
@@ -157,7 +162,9 @@ void PLATFORM_getOSDirectory(char* output)
 {
 #ifdef _WIN32
 	/* This block is here for compatibility, do not touch it! */
-	SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, output);
+	WCHAR utf16_path[MAX_PATH];
+	SHGetFolderPathW(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, utf16_path);
+	WideCharToMultiByte(CP_UTF8, 0, utf16_path, -1, output, MAX_PATH, NULL, NULL);
 	strcat(output, "\\VVVVVV\\");
 #else
 	strcpy(output, PHYSFS_getPrefDir("distractionware", "VVVVVV"));

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+#include "tinyxml.h"
+
 int FILESYSTEM_init(char *argvZero);
 void FILESYSTEM_deinit();
 
@@ -12,6 +14,8 @@ char *FILESYSTEM_getUserLevelDirectory();
 
 void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem, size_t *len);
 void FILESYSTEM_freeMemory(unsigned char **mem);
+bool FILESYSTEM_saveTiXmlDocument(const char *name, TiXmlDocument *doc);
+bool FILESYSTEM_loadTiXmlDocument(const char *name, TiXmlDocument *doc);
 
 std::vector<std::string> FILESYSTEM_getLevelDirFileNames();
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -310,8 +310,8 @@ Game::Game(void):
 
     saveFilePath = FILESYSTEM_getUserSaveDirectory();
 
-    TiXmlDocument doc((saveFilePath + "qsave.vvv").c_str());
-    if (!doc.LoadFile())
+    TiXmlDocument doc;
+    if (!FILESYSTEM_loadTiXmlDocument("saves/qsave.vvv", &doc))
     {
         quickcookieexists = false;
         quicksummary = "";
@@ -487,8 +487,8 @@ void Game::loadcustomlevelstats()
     //testing
     if(!customlevelstatsloaded)
     {
-        TiXmlDocument doc((saveFilePath+"levelstats.vvv").c_str());
-        if (!doc.LoadFile())
+        TiXmlDocument doc;
+        if (!FILESYSTEM_loadTiXmlDocument("saves/levelstats.vvv", &doc))
         {
             //No levelstats file exists; start new
             numcustomlevelstats=0;
@@ -598,7 +598,7 @@ void Game::savecustomlevelstats()
     msg->LinkEndChild( new TiXmlText( customlevelstatsstr.c_str() ));
     msgs->LinkEndChild( msg );
 
-    if(doc.SaveFile( (saveFilePath+"levelstats.vvv").c_str() ))
+    if(FILESYSTEM_saveTiXmlDocument("saves/levelstats.vvv", &doc))
     {
         printf("Level stats saved\n");
     }
@@ -4122,8 +4122,8 @@ void Game::unlocknum( int t, mapclass& map, Graphics& dwgfx )
 void Game::loadstats( mapclass& map, Graphics& dwgfx )
 {
     // TODO loadstats
-    TiXmlDocument doc((saveFilePath+"unlock.vvv").c_str());
-    if (!doc.LoadFile())
+    TiXmlDocument doc;
+    if (!FILESYSTEM_loadTiXmlDocument("saves/unlock.vvv", &doc))
     {
         savestats(map, dwgfx);
         printf("No Stats found. Assuming a new player\n");
@@ -4581,7 +4581,7 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
 	msg->LinkEndChild( new TiXmlText( tu.String(controllerSensitivity).c_str()));
 	dataNode->LinkEndChild( msg );
 
-    doc.SaveFile( (saveFilePath+"unlock.vvv").c_str() );
+    FILESYSTEM_saveTiXmlDocument("saves/unlock.vvv", &doc);
 }
 
 void Game::customstart( entityclass& obj, musicclass& music )
@@ -4809,8 +4809,8 @@ void Game::starttrial( int t, entityclass& obj, musicclass& music )
 
 void Game::loadquick( mapclass& map, entityclass& obj, musicclass& music )
 {
-    TiXmlDocument doc((saveFilePath+"qsave.vvv").c_str());
-    if (!doc.LoadFile()) return; ;
+    TiXmlDocument doc;
+    if (!FILESYSTEM_loadTiXmlDocument("saves/qsave.vvv", &doc)) return;
 
     TiXmlHandle hDoc(&doc);
     TiXmlElement* pElem;
@@ -5031,8 +5031,8 @@ void Game::loadquick( mapclass& map, entityclass& obj, musicclass& music )
 void Game::customloadquick(std::string savfile, mapclass& map, entityclass& obj, musicclass& music )
 {
     std::string levelfile = savfile.substr(7);
-    TiXmlDocument doc((saveFilePath+levelfile+".vvv").c_str());
-    if (!doc.LoadFile()) return; ;
+    TiXmlDocument doc;
+    if (!FILESYSTEM_loadTiXmlDocument(("saves/"+levelfile+".vvv").c_str(), &doc)) return;
 
     TiXmlHandle hDoc(&doc);
     TiXmlElement* pElem;
@@ -5406,8 +5406,8 @@ void Game::loadsummary( mapclass& map, UtilityClass& help )
         tele_currentarea = map.currentarea(map.area(l_saveX, l_saveY));
     }
 
-    TiXmlDocument doc((saveFilePath+"qsave.vvv").c_str());
-    if (!doc.LoadFile())
+    TiXmlDocument doc;
+    if (!FILESYSTEM_loadTiXmlDocument("saves/qsave.vvv", &doc))
     {
         quickcookieexists = false;
         quicksummary = "";
@@ -5751,7 +5751,7 @@ void Game::savetele( mapclass& map, entityclass& obj, musicclass& music )
     //telecookie.flush();
     //telecookie.close();
 
-    if(doc.SaveFile( (saveFilePath+"tsave.vvv").c_str() ))
+    if(FILESYSTEM_saveTiXmlDocument("saves/tsave.vvv", &doc))
     {
         printf("Game saved\n");
     }
@@ -5995,7 +5995,7 @@ void Game::savequick( mapclass& map, entityclass& obj, musicclass& music )
     //telecookie.flush();
     //telecookie.close();
 
-    if(doc.SaveFile( (saveFilePath+ "qsave.vvv").c_str() ))
+    if(FILESYSTEM_saveTiXmlDocument("saves/qsave.vvv", &doc))
     {
         printf("Game saved\n");
     }
@@ -6256,7 +6256,7 @@ void Game::customsavequick(std::string savfile, mapclass& map, entityclass& obj,
     //telecookie.close();
 
     std::string levelfile = savfile.substr(7);
-    if(doc.SaveFile( (saveFilePath+ levelfile+".vvv").c_str() ))
+    if(FILESYSTEM_saveTiXmlDocument(("saves/"+levelfile+".vvv").c_str(), &doc))
     {
         printf("Game saved\n");
     }
@@ -6270,8 +6270,8 @@ void Game::customsavequick(std::string savfile, mapclass& map, entityclass& obj,
 
 void Game::loadtele( mapclass& map, entityclass& obj, musicclass& music )
 {
-    TiXmlDocument doc((saveFilePath+"tsave.vvv").c_str());
-    if (!doc.LoadFile()) return; ;
+    TiXmlDocument doc;
+    if (!FILESYSTEM_loadTiXmlDocument("saves/tsave.vvv", &doc)) return;
 
     TiXmlHandle hDoc(&doc);
     TiXmlElement* pElem;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -348,8 +348,8 @@ Game::Game(void):
     }
 
 
-    TiXmlDocument docTele((saveFilePath+"tsave.vvv").c_str());
-    if (!docTele.LoadFile())
+    TiXmlDocument docTele;
+    if (!FILESYSTEM_loadTiXmlDocument("saves/tsave.vvv", &docTele))
     {
         telecookieexists = false;
         telesummary = "";
@@ -5315,8 +5315,8 @@ void Game::loadsummary( mapclass& map, UtilityClass& help )
     //	quick_crewstats = summary_crewstats.slice();
     //}
 
-    TiXmlDocument docTele((saveFilePath+"tsave.vvv").c_str());
-    if (!docTele.LoadFile())
+    TiXmlDocument docTele;
+    if (!FILESYSTEM_loadTiXmlDocument("saves/tsave.vvv", &docTele))
     {
         telecookieexists = false;
         telesummary = "";

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -4,6 +4,8 @@
 
 #include "tinyxml.h"
 
+#include "FileSystemUtils.h"
+
 // Found in titlerender.cpp
 void updategraphicsmode(Game& game, Graphics& dwgfx);
 
@@ -358,9 +360,9 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                     game.customleveltitle=ed.ListOfMetaData[game.playcustomlevel].title;
                     game.customlevelfilename=ed.ListOfMetaData[game.playcustomlevel].filename;
 
-                    std::string name = game.saveFilePath + ed.ListOfMetaData[game.playcustomlevel].filename.substr(7) + ".vvv";
-                    TiXmlDocument doc(name.c_str());
-	                  if (!doc.LoadFile()){
+                    std::string name = "saves/" + ed.ListOfMetaData[game.playcustomlevel].filename.substr(7) + ".vvv";
+                    TiXmlDocument doc;
+	                  if (!FILESYSTEM_loadTiXmlDocument(name.c_str(), &doc)){
 	                    game.mainmenu = 22;
                       dwgfx.fademode = 2;
 	                  }else{

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2107,7 +2107,7 @@ void editorclass::save(std::string& _path)
     msg->LinkEndChild( new TiXmlText( scriptString.c_str() ));
     data->LinkEndChild( msg );
 
-    doc.SaveFile((std::string(FILESYSTEM_getUserLevelDirectory()) + _path).c_str() );
+    FILESYSTEM_saveTiXmlDocument(("levels/" + _path).c_str(), &doc);
 }
 
 


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

On Windows, players with an account username that contains non-ASCII characters (any foreign characters, for example) will probably find that the VVVVVV directory is not created, or if it is, that no save/level files are created inside of it and any downloaded custom level cannot be loaded. This pull request fixes these issues.

The commit messages document things in more detail, but in summary: the two Windows API functions that are used to get the path to the Documents folder and to create new folders now use their "Wide" (UTF-16) variants converted to and from UTF-8, and loading and saving XML files now uses PHYSFS to load and save the files instead of using TinyXML's functions, since TinyXML doesn't handle UTF-8 paths properly, while PHYSFS does.