### PR TITLE
Conditionally build PhysFS Windows and Unix sources too

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -107,13 +107,15 @@ SET(PFS_SRC
 	../third_party/physfs/physfs_byteorder.c
 	../third_party/physfs/physfs_unicode.c
 	../third_party/physfs/physfs_platform_posix.c
-	../third_party/physfs/physfs_platform_unix.c
-	../third_party/physfs/physfs_platform_windows.c
 )
-IF(APPLE)
+if(APPLE)
 	# Are you noticing a pattern with this Apple crap yet?
-	SET(PFS_SRC ${PFS_SRC} ../third_party/physfs/physfs_platform_apple.m)
-ENDIF()
+	list(APPEND PFS_SRC ../third_party/physfs/physfs_platform_apple.m)
+elseif(WIN32)
+	list(APPEND PFS_SRC ../third_party/physfs/physfs_platform_windows.c)
+else()
+	list(APPEND PFS_SRC ../third_party/physfs/physfs_platform_unix.c)
+endif()
 SET(PNG_SRC ../third_party/lodepng/lodepng.c)
 
 # Executable information


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

Without doing this, due to preprocessor macros those files would
evaluate to an empty translation unit, and an empty object, which
produces warnings like:

```text
warning: ISO C requires a translation unit to contain at least one declaration
```

Note: WIN32 is true not only for 32bit Windows but 64bit too, so
should cover all cases.
