### PR TITLE
fix actionscript misclassified as angelscript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.as linguist-language=ActionScript


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

Fix all the ActionScript in the repository being misclassified as AngelScript. I know you can't actually see it on the branch because linguist doesn't work on branches [but you can see it here](https://github.com/notviri/test1234) unless the language bar dissapears (it keeps flickering because I just committed the contents of the entire repo there), but:
![image](https://i.imgur.com/9ymz3Xq.png)