### PR TITLE
Add an accessibility option to toggle the fake loading screen

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -393,6 +393,8 @@ Game::Game(void):
     state = 1;
     statedelay = 0;
     //updatestate(dwgfx, map, obj, help, music);
+
+    skipfakeload = false;
 }
 
 Game::~Game(void)
@@ -4336,6 +4338,11 @@ void Game::loadstats( mapclass& map, Graphics& dwgfx )
 					}
         }
 
+        if (pKey == "skipfakeload")
+        {
+            skipfakeload = atoi(pText);
+        }
+
 		if (pKey == "flipButton")
 		{
 			SDL_GameControllerButton newButton;
@@ -4540,6 +4547,10 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
     msg = new TiXmlElement( "usingmmmmmm" );
     msg->LinkEndChild( new TiXmlText( tu.String(usingmmmmmm).c_str()));
     dataNode->LinkEndChild( msg );
+
+    msg = new TiXmlElement("skipfakeload");
+    msg->LinkEndChild(new TiXmlText(tu.String((int) skipfakeload).c_str()));
+    dataNode->LinkEndChild(msg);
 
     for (size_t i = 0; i < controllerButton_flip.size(); i += 1)
     {
@@ -6923,9 +6934,11 @@ void Game::createmenu( std::string t )
         menuoptionsactive[2] = true;
         menuoptions[3] = "slowdown";
         menuoptionsactive[3] = true;
-        menuoptions[4] = "return";
+        menuoptions[4] = "load screen";
         menuoptionsactive[4] = true;
-        nummenuoptions = 5;
+        menuoptions[5] = "return";
+        menuoptionsactive[5] = true;
+        nummenuoptions = 6;
         menuxoff = -40;
         menuyoff = 16;
     }

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -354,6 +354,7 @@ public:
 	std::vector<SDL_GameControllerButton> controllerButton_flip;
 	std::vector<SDL_GameControllerButton> controllerButton_esc;
 
+    bool skipfakeload;
 };
 
 #endif /* GAME_H */

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -735,6 +735,12 @@ SDL_assert(0 && "Remove open level dir");
                     }
                     else if (game.currentmenuoption == 4)
                     {
+                        // toggle fake load screen
+                        game.skipfakeload = !game.skipfakeload;
+                        music.playef(11, 10);
+                    }
+                    else if (game.currentmenuoption == 5)
+                    {
                         //back
                         music.playef(11, 10);
                         game.createmenu("options");

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -164,6 +164,8 @@ int main(int argc, char *argv[])
 
     //Moved screensetting init here from main menu V2.1
     game.loadstats(map, graphics);
+    if (game.skipfakeload)
+        game.gamestate = TITLEMODE;
 		if(game.usingmmmmmm==0) music.usingmmmmmm=false;
 		if(game.usingmmmmmm==1) music.usingmmmmmm=true;
     if (game.slowdown == 0) game.slowdown = 30;

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -530,8 +530,10 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 {
                     dwgfx.Print( -1, 105, "Game speed is at 40%", tr, tg, tb, true);
                 }
-            } else if (game.currentmenuoption == 4) {
-                dwgfx.bigprint(-1, 30, "Fake load screen", tr, tg, tb, true);
+            }
+            else if (game.currentmenuoption == 4)
+            {
+                dwgfx.bigprint(-1, 30, "Fake Load Screen", tr, tg, tb, true);
                 if (game.skipfakeload)
                     dwgfx.Print(-1, 75, "Fake loading screen is OFF", tr/2, tg/2, tb/2, true);
                 else

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -530,6 +530,12 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 {
                     dwgfx.Print( -1, 105, "Game speed is at 40%", tr, tg, tb, true);
                 }
+            } else if (game.currentmenuoption == 4) {
+                dwgfx.bigprint(-1, 30, "Fake load screen", tr, tg, tb, true);
+                if (game.skipfakeload)
+                    dwgfx.Print(-1, 75, "Fake loading screen is OFF", tr/2, tg/2, tb/2, true);
+                else
+                    dwgfx.Print(-1, 75, "Fake loading screen is ON", tr, tg, tb, true);
             }
         }
         else if (game.currentmenuname == "playint1" || game.currentmenuname == "playint2")


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

* **Add an option in the Accessibility menu to toggle the fake loading screen**

  This is the variable `game.skipfakeload`, which gets saved as `<skipfakeload>` in `unlock.vvv`.