### PR TITLE
Fix a stray "seperate" in Secret Lab dialogue

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -7,6 +7,7 @@ Contributors
 * Charlie Bruce (@charliebruce)
 * Brian Callahan (@ibara)
 * Dav999 (Dav999-v)
+* Allison Fleischer (AllisonFleischer)
 * Daniel Lee (@ddm999)
 * Elliott Saltar (@eboyblue3)
 * Marvin Scholz (@ePirat)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1911,7 +1911,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			{
 				dwgfx.textboxremovefast();
 
-				dwgfx.createtextbox("The secret lab is seperate from", 50, 85, 174, 174, 174);
+				dwgfx.createtextbox("The secret lab is separate from", 50, 85, 174, 174, 174);
 				dwgfx.addline("the rest of the game. You can");
 				dwgfx.addline("now come back here at any time");
 				dwgfx.addline("by selecting the new SECRET LAB");

--- a/mobile_version/src/scriptclass.as
+++ b/mobile_version/src/scriptclass.as
@@ -1063,7 +1063,7 @@
 					}else if (words[0] == "foundlab2") {						
 						dwgfx.textboxremovefast();
 						
-						dwgfx.createtextbox("The secret lab is seperate from", 50, 85, 174, 174, 174);
+						dwgfx.createtextbox("The secret lab is separate from", 50, 85, 174, 174, 174);
 						      dwgfx.addline("the rest of the game. You can");
 						      dwgfx.addline("now come back here at any time");
 									dwgfx.addline("by selecting the new SECRET LAB");


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

Just a small spelling error that wasn't caught in #28, in the dialogue that displays when you find the Secret Lab.