### PR TITLE
Destroy duplicate player entities when a gotoroom happens

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -900,10 +900,13 @@ void mapclass::gotoroom(int rx, int ry, Graphics& dwgfx, Game& game, entityclass
 		}
 	}
 
+	int theplayer = obj.getplayer();
 	for (int i = 0; i < obj.nentity; i++)
 	{
-		//Of course the player's always gonna be object zero, this is just in case
-		if (obj.entities[i].rule != 0) obj.entities[i].active = false;
+		if (i != theplayer)
+		{
+			obj.entities[i].active = false;
+		}
 	}
 	obj.cleanup();
 


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

* **Destroy duplicate player entities during a gotoroom**

  The game makes sure that the player entity is never destroyed, but in doing so, it doesn't destroy any duplicate player entities that might have been created via strange means e.g. a custom level doing a createentity with t=0.

  Duplicate player entities are, in a sense, not the "real" player entity. For one, they can take damage and die, but when they do they'll still be stuck inside the hazard, which can result in a softlock. For another, their position isn't updated when going between rooms. It's better to just destroy them when we can.
