### PR TITLE
Don't deactivate the "- Press ENTER to Teleport -" prompt when dying

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -671,7 +671,6 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 }
 
                 game.gethardestroom(map);
-                game.activetele = false;
                 game.hascontrol = true;
 
 


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

* **Don't deactivate the teleport prompt when dying**

  This fixes a bug where if you died after activating a teleporter prompt and then respawned in the same room as the teleporter, the teleporter prompt would go away. Which would be very annoying if you wanted to, you know, teleport.

  You don't even have to R-press to make this happen. "Level Complete!" and Energize are two teleporter rooms in the main game that have hazards in them.

  I see no reason to set game.activetele to false when dying. For one, it gets set to false during a gotorom anyway. For another, I couldn't get the game to activate the teleport prompt in a room without a teleporter in my testing, mostly because when you touch a teleporter, your checkpoint is set to that teleporter, so you can't R-press to go to another room and carry over the teleport prompt.