### PR TITLE
Re-add the font outline from the Flash and mobile versions

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -380,19 +380,19 @@ void Graphics::bprint( int x, int y, std::string t, int r, int g, int b, bool ce
 {
 
     //printmask(x, y, t, cen);
-    //Print(x, y - 1, t, 0, 0, 0, cen);
-    //if (cen)
-    //{
-    //	//TODO find different
-    //	PrintOff(-1, y, t, 0, 0, 0, cen);
-    //	PrintOff(1, y, t, 0, 0, 0, cen);
-    //}
-    //else
-    //{
-    //	Print(x  -1, y, t, 0, 0, 0, cen);
-    //	Print(x , y, t, 0, 0, 0, cen);
-    //}
-    //Print(x, y+1, t, 0, 0, 0, cen);
+    Print(x, y - 1, t, 0, 0, 0, cen);
+    if (cen)
+    {
+        //TODO find different
+        PrintOff(-1, y, t, 0, 0, 0, cen);
+        PrintOff(1, y, t, 0, 0, 0, cen);
+    }
+    else
+    {
+        Print(x  -1, y, t, 0, 0, 0, cen);
+        Print(x  +1, y, t, 0, 0, 0, cen);
+    }
+    Print(x, y+1, t, 0, 0, 0, cen);
 
     Print(x, y, t, r, g, b, cen);
 }


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

* **Re-add the font outline from the Flash and mobile versions of the game**

  This uncomments the code for the font outline. Now, you will see the font outline on text that had it in the Flash version, most notably "- Press ENTER to Teleport -" and the time trial overlay text.

  This also fixes a problem with the commented code, where un-centered text didn't outline properly.
