### PR TITLE
Disable pressing M to mute in the script editor

### DIFF
--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -481,7 +481,7 @@ int main(int argc, char *argv[])
         }
 
         //Mute button
-        if (key.isDown(KEYBOARD_m) && game.mutebutton<=0 && !ed.textentry)
+        if (key.isDown(KEYBOARD_m) && game.mutebutton<=0 && !ed.textentry && !key.textentrymode)
         {
             game.mutebutton = 8;
             if (game.muted)


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

* **Disable being able to mute the game while typing in the script editor**

  This disables being able to press M to mute while editing a script in the script editor. It also disables it in the script list, too, but I'm hoping no one thinks that's an issue, because I personally don't think it is.

