### PR TITLE
Fix being able to lower your score for a custom level by replaying it

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -449,7 +449,7 @@ void Game::updatecustomlevelstats(std::string clevel, int cscore)
             j=numcustomlevelstats+1;
         }
     }
-    if(tvar>=0)
+    if(tvar>=0 && cscore > customlevelscore[tvar])
     {
         //update existing entry
         customlevelscore[tvar]=cscore;


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

* **Fix being able to lower your score for a custom level by finishing it again**

  For reference, here is the list of scores for a custom level:
  ​    0 - not played
  ​    1 - finished
  ​    2 - all trinkets
  ​    3 - finished, all trinkets

  Previously, you could've played a level and finished it and set a score of 3. Then you could re-play the entire level, but manage to only get a score of 1, i.e. only finished but not with all trinkets. Then your score for that level would get set back to 1, which basically nullifies the time you spent playing that level and getting all of the trinkets.

  This pull request makes it so your new score will get set only if it is higher than the previous one.
