### PR TITLE
Fix "Exausted?" typo in roomname

### DIFF
--- a/desktop_version/src/Labclass.cpp
+++ b/desktop_version/src/Labclass.cpp
@@ -945,7 +945,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		obj.createentity(game, -8, 180, 11, 224);  // (horizontal gravity line)
 
 		rcol = 0;
-		roomname = "Exausted?";
+		roomname = "Exhausted?";
 		break;
 
 


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

* **Fix "Exausted?" typo in roomname**

  This name is the roomname of (7,17) (0-indexed) in the Lab.