### PR TITLE
Correct Warp Zone's area name from "Warpzone" to "Warp Zone"

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1129,7 +1129,7 @@ std::string mapclass::currentarea(int t)
 		return "The Tower";
 		break;
 	case 4:
-		return "Warpzone";
+		return "Warp Zone";
 		break;
 	case 5:
 		return "Space Station";


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

* **Correct Warp Zone's area name from "Warpzone" to "Warp Zone"**

  This is the name that gets displayed in your save file.