### PR TITLE
Properly reset roomdeaths and roomdeathsfinal in hardreset

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3520,8 +3520,8 @@ void scriptclass::hardreset( KeyPoll& key, Graphics& dwgfx, Game& game,mapclass&
 	{
 		for (i = 0; i < 20; i++)
 		{
-			map.roomdeaths[i] = 0;
-			map.roomdeathsfinal[i] = 0;
+			map.roomdeaths[i + (j * 20)] = 0;
+			map.roomdeathsfinal[i + (j * 20)] = 0;
 			map.explored[i + (j * 20)] = 0;
 		}
 	}


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

* **Properly reset `map.roomdeaths` and `map.roomdeathsfinal` in `hardreset()`**

  There are three map-related vectors that need to be reset in `hardreset()`: `map.roomdeaths`, `map.roomdeathsfinal`, and `map.explored`. All three of these vectors use the concatenated rows system, whereby each room is given a room number, calculated by doing X + Y*20, and this becomes their index in each vector.

  Previously, only the first row of rooms of each vector was getting reset properly, corresponding with only the first row of rooms in both Dimension VVVVVV and Outside Dimension VVVVVV getting reset properly. This led to [strange death counts](https://www.reddit.com/r/VVVVVV/comments/coihbz/death_count_bug/ewjlirq/) where the number of deaths in the hardest room could be higher than the amount of deaths you've actually died total in a game, if you decided to start a new game after already having played one, and hadn't closed the game window in the meantime.

  This PR makes sure that both vectors get reset properly.
