### PR TITLE
Fix warpdir() setting the wrong background if you set the warp direction to 0 in the current room

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -106,6 +106,15 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
           map.warpx=false; map.warpy=false;
           if(ed.level[curlevel].warpdir==0){
             map.background = 1;
+            //Be careful, we could be in a Lab or Warp Zone room...
+            if(ed.level[curlevel].tileset==2){
+              //Lab
+              map.background = 2;
+              dwgfx.rcol = ed.level[curlevel].tilecol;
+            }else if(ed.level[curlevel].tileset==3){
+              //Warp Zone
+              map.background = 6;
+            }
           }else if(ed.level[curlevel].warpdir==1){
             map.warpx=true;
             map.background=3;


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

* **Fix being able to get the wrong background set in the room with `warpdir()`**

  If you're in the room being targeted when a `warpdir()` command is run, and the command sets the warp direction to none (warp dir 0), and if you're in a Lab or Warp Zone room, the background will be set to the wrong one, because it will always set the background to the stars-going-left background, instead of setting it to the Lab background or the stars-going-up background.

  However, this is only a visual glitch, and is a temporary one, because if you manage to trigger a `gotoroom()` on the room, it will get set to its proper background.

  This PR makes it so if you're in a Lab room, the background gets set to the Lab background, and if you're in a Warp Zone room, the background gets set to the stars-going-up background.