### PR TITLE
Prevent the game from thinking horizontal warp lines are cyan crewmates

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4381,7 +4381,7 @@ int entityclass::getcrewman( int t )
 
     for (int i = 0; i < nentity; i++)
     {
-        if ((entities[i].type == 12 || entities.[i].type == 14)
+        if ((entities[i].type == 12 || entities[i].type == 14)
         && (entities[i].rule == 6 || entities[i].rule == 7))
         {
             if(entities[i].colour==t)

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4381,7 +4381,8 @@ int entityclass::getcrewman( int t )
 
     for (int i = 0; i < nentity; i++)
     {
-        if (entities[i].rule == 6 || entities[i].rule == 7)
+        if ((entities[i].type == 12 || entities.[i].type == 14)
+        && (entities[i].rule == 6 || entities[i].rule == 7))
         {
             if(entities[i].colour==t)
             {


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

* **Add entity `type` checks to `getcrewman()`**

  This means that the game is no longer able to target other non-crewmate entities when it looks for a crewmate.

  This has actually happened in practice. A command like `position(cyan,above)` could position the text box above a horizontal warp line instead of the intended crewmate.

  This is because `getcrewman()` previously only checked the `rule` of entities, and if their `rule` happened to be 6 or 7. Usually this corresponds with crewmates being unflipped or flipped, respectively.

  But warp lines' `rule`s overlap with `rule`s 6 and 7. If a warp line is vertical, its `rule` is 5, and if it is horizontal, its `rule` is 7.

  Now, usually, this wouldn't be an issue since `getcrewman()` does a `colour` check as well. And for cyan, that is `colour` 0. However, if an entity doesn't use its `colour`, it just defaults to `colour` 0.

  So, `getcrewman()` found an entity with a `rule` of 7 and a `colour` of 0. This must mean it's a cyan crewmate! But, well, it's actually just a horizontal warp line.

  This PR prevents the above from happening.