### PR TITLE
PR template: switch position of Legal Stuff & Changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,12 @@ things for you to read through first:
 If you understand these notes, you can delete the text in this section. Pull
 requests that still have this text will be closed automatically.
 
+
+## Changes:
+
+Describe your patch here!
+
+
 ## Legal Stuff:
 
 By submitting this pull request, I confirm that...
@@ -27,7 +33,3 @@ By submitting this pull request, I confirm that...
   example, a 2.3 update on Steam for Windows/macOS/Linux)
 - [ ] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
   will NOT be compensated for these changes
-
-## Changes:
-
-Describe your patch here!

--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -13,6 +13,7 @@ Contributors
 * Marvin Scholz (@ePirat)
 * Keith Stellyes (@keithstellyes)
 * Elijah Stone
+* Thomas Sänger (@HorayNarea)
 * Info Teddy (@InfoTeddy)
 * leo60228 (@leo60228)
 * Emmanuel Vadot (@evadot)


### PR DESCRIPTION
## Changes:

this makes the mouse-over tooltip of PRs actually useful instead of showing the same thing for every PR like this:
![mouseover.png](https://user-images.githubusercontent.com/1871153/72496264-52ab6400-3829-11ea-8407-7ec41c329a3b.png)

Compared with this PR:
![mouseover2](https://user-images.githubusercontent.com/1871153/72496731-cdc14a00-382a-11ea-877f-0b93f706be72.png)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes