### PR TITLE
Don't render "[Press ENTER to return to editor]" if "- Press ACTION to advance text -" is also being rendered

### DIFF
--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -1558,7 +1558,7 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
         }
     }
 
-     if(map.custommode && !map.custommodeforreal){
+     if(map.custommode && !map.custommodeforreal && !game.advancetext){
         //Return to level editor
         dwgfx.bprint(5, 5, "[Press ENTER to return to editor]", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
       }


### PR DESCRIPTION
## Changes:

* **Don't render "[Press ENTER to return to editor]" if "- Press ACTION to advance text -" is also being rendered**

  This prevents a visual clash if both are being rendered on top of each other and there are no cutscene bars.

  Before:

  ![press_enter_advancetext_clash_before](https://user-images.githubusercontent.com/59748578/72593345-93eb5480-38b9-11ea-9359-f8118d7334d7.png)

  After:

  ![press_enter_advancetext_clash_after](https://user-images.githubusercontent.com/59748578/72593354-9b126280-38b9-11ea-88ee-83fe1f983668.png)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
