### PR TITLE
Fix off-by-one in script editor letting you type on a nonexistent line

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3834,7 +3834,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
             if(key.keymap[SDLK_DOWN] && ed.keydelay<=0)
             {
                 ed.keydelay=6;
-                if(ed.sby+ed.pagey<ed.sblength)
+                if(ed.sby+ed.pagey<ed.sblength-1)
                 {
                     ed.sby++;
                     if(ed.sby>=20)


### PR DESCRIPTION
## Changes:

* **Fix the off-by-one bug in the script editor that would let you type text on a nonexistent script line**

  For a long time, the script editor has had a bug where it would let you put the cursor on a nonexistent script line, which would *appear* to be the last line of the script... but in reality, it *wasn't* the last line of the script, and in fact, the *actual* last line was the line *above* the "last line".

  So, if you typed anything on this nonexistent line, it would appear to get erased when exiting the script and re-opening it. Thus, people have (erroneously) misdiagnosed this as the script editor somehow being trigger-happy and erasing lines when it shouldn't be, when in reality it shouldn't have let you gone onto that line in the first place!

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
