### PR TITLE
Fix two script editor backspacing bugs (one related to frame ordering, the other simply being a lack of key delay)

### DIFF
--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -50,6 +50,8 @@ KeyPoll::KeyPoll()
 			useFullscreenSpaces = (strcmp(hint, "1") == 0);
 		}
 	}
+
+	linealreadyemptykludge = false;
 }
 
 void KeyPoll::enabletextentry()
@@ -94,7 +96,12 @@ void KeyPoll::Poll()
 			{
 				if (evt.key.keysym.sym == SDLK_BACKSPACE)
 				{
+					bool kbemptybefore = keybuffer.empty();
 					keybuffer = keybuffer.substr(0, keybuffer.length() - 1);
+					if (!kbemptybefore && keybuffer.empty())
+					{
+						linealreadyemptykludge = true;
+					}
 				}
 				else if (	evt.key.keysym.sym == SDLK_v &&
 						keymap[SDLK_LCTRL]	)

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -71,6 +71,8 @@ public:
 	bool pressedbackspace;
 	std::string keybuffer;
 
+	bool linealreadyemptykludge;
+
 private:
 	std::map<SDL_JoystickID, SDL_GameController*> controllers;
 	std::map<SDL_GameControllerButton, bool> buttonmap;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3870,6 +3870,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                     }
                 }
                 key.keybuffer=ed.sb[ed.pagey+ed.sby];
+                ed.keydelay=6;
             }
 
             ed.sb[ed.pagey+ed.sby]=key.keybuffer;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3846,7 +3846,13 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                 key.keybuffer=ed.sb[ed.pagey+ed.sby];
             }
 
-            if(key.pressedbackspace && ed.sb[ed.pagey+ed.sby]=="")
+            if(key.linealreadyemptykludge)
+            {
+                ed.keydelay=6;
+                key.linealreadyemptykludge=false;
+            }
+
+            if(key.pressedbackspace && ed.sb[ed.pagey+ed.sby]=="" && ed.keydelay<=0)
             {
                 //Remove this line completely
                 ed.removeline(ed.pagey+ed.sby);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -473,6 +473,9 @@ int main(int argc, char *argv[])
 
         }
 
+        //We did editorinput, now it's safe to turn this off
+        key.linealreadyemptykludge = false;
+
         if (game.savemystats)
         {
             game.savemystats = false;


### PR DESCRIPTION
## Changes:

* **Fix frame-ordering bug with backspacing the last character of a line in the script editor**

  There is a long-standing bug with the script editor where if you delete the last character of a line, it *immediately* deletes the line you're on, and then moves your cursor back to the previous line. This is annoying, to say the least.

  The reason for this is that, in the sequence of events that happens in one frame (known as frame ordering), the code that backspaces one character from the line when you press Backspace is ran *before* the code to remove an empty line if you backspace it is ran. The former is located in `key.Poll()`, and the latter is located in `editorinput()`.

  Thus, when you press Backspace, the game first runs `key.Poll()`, sees that you've pressed Backspace, and dutifully removes the last character from a line. The line is now empty. Then, when the game gets around to the "Are you pressing Backspace on an empty line?" check in `editorinput()`, it thinks that you're pressing Backspace on an empty line, and then does the usual line-removing stuff.

  This was noted in a comment in Ved's source code (which is a better VVVVVV level editor):

  ![ved_note_in_source_code_on_vvvvvv_bug](https://user-images.githubusercontent.com/59748578/72673693-0f1c4a00-3a23-11ea-9562-eb3ff623c2fa.png)

  `git blame` tells me this comment dates back to the initial commit of Ved's repository in 2017, but I think it's probably been in there since 2015.

  And actually, when it does the check in `editorinput()`, it *actually* asks "Are you pressing Backspace on *this* frame and was the line empty *last* frame?" because it's checking against its own copy of the input buffer, before copying the input buffer to its own local copy. So the problem only happens if you press and hold Backspace for more than 1 frame. It's a small consolation prize for this annoyance, getting to tap-tap-tap Backspace in the hopes that you only press it for 1 frame, while in the middle of something more important to do like, oh I don't know, writing a script.

  So there are two potential solutions here:

  ​ ​ ​ 1. ​ Just change the frame ordering around.

  ​ ​ ​ ​ ​ ​ ​ ​ This is risky to say the least, because I'm not sure what behavior depends on exactly which
  ​ ​ ​ ​ ​ ​ ​ ​ frame order. It's not like `key.Poll()` is run and then *immediately* afterwards `editorinput()`
  ​ ​ ​ ​ ​ ​ ​ ​ is run, it's more like `key.Poll()` gets run, some things that obviously depend on `key.Poll()`
  ​ ​ ​ ​ ​ ​ ​ ​ running before them get run right after, and *then* `editorinput()`. Also, `editorinput()` is
  ​ ​ ​ ​ ​ ​ ​ ​ only one possible thing that could be ran afterwards, on the next frame we could be running
  ​ ​ ​ ​ ​ ​ ​ ​ something else entirely instead.

  ​ ​ ​ 2. ​ Add a kludge variable to signal when the line is ALREADY empty so the game doesn't re-check
  ​ ​ ​ ​ ​ ​ ​ ​ the already-empty line and conclude that you're already immediately backspacing an empty
  ​ ​ ​ ​ ​ ​ ​ ​ line.

  I went with option 2 for this PR, and I've added the kludge variable `key.linealreadyemptykludge`.

  However, that by itself isn't enough to fix it. It only adds about a frame or so of delay before the game goes right back to saying "Oh, you're *already* somehow pressing backspace again? I'll just delete this line real quick" and the behavior is basically the same as before, except now you have to hit Backspace for *two* frames or less instead of one in order to not have it happen.

  What we need is to have a delay set as well, when the game deletes the last line of a char. So I set `ed.keydelay` to 6 as well if `editorinput()` sees that `key.linealreadyemptykludge` is on.

* **Set `ed.keydelay` to 6 when backspacing an empty line**

  Similar to the above, there's also a long-standing bug where if you backspace an empty line (and this time, the line *is* actually already empty, not merely emptied-earlier-in-the-frame), the game will quickly delete more blank lines if there are any above the blank line you deleted. Again, this is annoying too, if you so happen to need to use lots of blank lines.

  To fix this, it's simple - just set `ed.keydelay` to 6 when the game backspaces an empty line. Then it won't be so trigger-happy in deleting blank lines.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
