### PR TITLE
Don't play squeak twice when entering the 'quickloadlevel' menu

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -366,7 +366,6 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
 	                    game.mainmenu = 22;
                       dwgfx.fademode = 2;
 	                  }else{
-                      music.playef(11, 10);
                       game.createmenu("quickloadlevel");
                       map.nexttowercolour();
 	                  }


### PR DESCRIPTION
## Changes:

* **Don't play Viridian's squeak twice when entering the menu to load a level's quicksave or start from the beginning**

  This is another squeak-twice bug fixed.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
