### PR TITLE
Reset the Direct Mode property of each room in editorclass::reset()

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -314,6 +314,7 @@ void editorclass::reset()
             level[i+(j*maxwidth)].enemyy1=0;
             level[i+(j*maxwidth)].enemyx2=320;
             level[i+(j*maxwidth)].enemyy2=240;
+            level[i+(j*maxwidth)].directmode=0;
         }
     }
 


### PR DESCRIPTION
## Changes:

* **Reset the Direct Mode property of each room when `editorclass::reset()` is called**

  There's a long-standing issue where the Direct Mode status of the loaded custom map in memory never resets properly. So if you load a level with a certain layout of Direct Mode rooms, that same layout will be preserved if you start making a new level in the editor. This PR fixes that issue.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
