### PR TITLE
Fix bug where translucent pixels were drawn badly

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2342,7 +2342,7 @@ void Graphics::drawmap( mapclass& map )
     ///TODO forground once;
     if (!foregrounddrawn)
     {
-        FillRect(foregroundBuffer, 0xDEADBEEF);
+        FillRect(foregroundBuffer, 0x00000000);
         if(map.tileset==0)
         {
             for (j = 0; j < 29+map.extrarow; j++)
@@ -2375,7 +2375,7 @@ void Graphics::drawmap( mapclass& map )
         }
         foregrounddrawn = true;
     }
-    OverlaySurfaceKeyed(foregroundBuffer, backBuffer, 0xDEADBEEF);
+    OverlaySurfaceKeyed(foregroundBuffer, backBuffer, 0x00000000);
     //SDL_BlitSurface(foregroundBuffer, NULL, backBuffer, NULL);
 
 }
@@ -2398,7 +2398,7 @@ void Graphics::drawfinalmap(mapclass & map)
 	}
 
 	if (!foregrounddrawn) {
-		FillRect(foregroundBuffer, 0xDEADBEEF);
+		FillRect(foregroundBuffer, 0x00000000);
 		if(map.tileset==0){
 			for (int j = 0; j < 29+map.extrarow; j++) {
 				for (int i = 0; i < 40; i++) {
@@ -2417,7 +2417,7 @@ void Graphics::drawfinalmap(mapclass & map)
 		foregrounddrawn=true;
 	}
 
-	OverlaySurfaceKeyed(foregroundBuffer, backBuffer, 0xDEADBEEF);
+	OverlaySurfaceKeyed(foregroundBuffer, backBuffer, 0x00000000);
 }
 
 void Graphics::drawtowermap( mapclass& map )


### PR DESCRIPTION
## Changes:

* **Fix the bug with translucent pixels being drawn incorrectly**

  For a long time, VVVVVV has had an issue where if you used custom graphics with translucent pixels (i.e. pixels whose opacity was neither 0% nor 100%, but somewhere between 0% and 100%), those pixels would end up looking very ugly. They seemed to be overlaid on top of some weird blue color, instead of actually being translucent.

  This bug only occurred when in-game and not in towermode. So, most of the time, basically. The translucent pixels only displayed properly inside the Tower, both minitowers, and the editor (when not playtesting).

  I traced this down to the use of the magic number 0xDEADBEEF in `Graphics::drawmap()` and `Graphics::drawfinalmap()`. Looks like someone had fun finding a color. Was it you, simoroth? Anyway, I've changed it so it simply uses 0 instead. Note that this magic number needs to be changed for BOTH `FillRect()` and `OverlaySurfaceKeyed()`, or else the game's background will be some random solid color instead of actually being drawn properly.

  Here are pictures for both before and after this change so you can see the problem that this PR fixes:

  **Before:**
  ![How translucent pixels were drawn before the bug was fixed.](https://user-images.githubusercontent.com/59748578/72864709-cc0fe000-3c89-11ea-9637-d9921b326855.png)

  **After:**
  ![How translucent pixels were drawn when the bug got fixed.](https://user-images.githubusercontent.com/59748578/72864729-eba70880-3c89-11ea-9ce1-13d1070c471d.png)



## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
