### PR TITLE
Fix an out-of-bounds array access in findstartpoint()

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1595,7 +1595,7 @@ void editorclass::findstartpoint(Game& game)
         game.edsavery = 100;
         game.edsavegc = 0;
         game.edsavey--;
-        game.edsavedir=1-edentity[testeditor].p1;
+        game.edsavedir=1;
     }
     else
     {


### PR DESCRIPTION
## Changes:

* **Fix out-of-bounds array indexing in `editorclass::findstartpoint()`**

  Out-of-bounds array access is Undefined Behavior, which means Bad Things.

  In this particular case, it was indexing an array by using the `testeditor` variable. Which is fine, except it was indexing that array *in a conditional that only happens if `testeditor` is -1*. So it was indexing an array at position -1, which is Out of Bounds and is Not Good.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
