### PR TITLE
Reset the position of the cutscene bars in hardreset()

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3501,6 +3501,7 @@ void scriptclass::hardreset( KeyPoll& key, Graphics& dwgfx, Game& game,mapclass&
 	dwgfx.textboxremovefast();
 	dwgfx.flipmode = false; //This will be reset if needs be elsewhere
 	dwgfx.showcutscenebars = false;
+	dwgfx.cutscenebarspos = 0;
 
   //mapclass
 	map.warpx = false;


### PR DESCRIPTION
## Changes:

* **Reset `dwgfx.cutscenebarspos` in `scriptclass::hardreset()`**

  This fixes a bug in the editor where if you had cutscene bars active while exiting playtesting, when you re-entered playtesting, the bars would do their closing animation even though they should be already gone.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
