### PR TITLE
Copy backBuffer to the tempBuffer in towerrender()

### DIFF
--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -2795,6 +2795,7 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
     }
       }*/
     dwgfx.cutscenebars();
+    BlitSurfaceStandard(dwgfx.backBuffer, NULL, dwgfx.tempBuffer, NULL);
 
     dwgfx.drawgui(help);
     if (dwgfx.flipmode)


### PR DESCRIPTION
## Changes:

* **Copy `backBuffer` to `tempBuffer` when executing `towerrender()`**

  This fixes a bug where bringing up the pause screen while in a tower would draw the room you entered *before* the given tower during the time it took for the pause screen to be brought up or down.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
