### PR TITLE
Reset game.pausescript in scriptclass::hardreset()

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3496,6 +3496,8 @@ void scriptclass::hardreset( KeyPoll& key, Graphics& dwgfx, Game& game,mapclass&
   game.hascontrol = true;
   game.advancetext = false;
 
+	game.pausescript = false;
+
 	//dwgraphicsclass
 	dwgfx.backgrounddrawn = false;
 	dwgfx.textboxremovefast();


### PR DESCRIPTION
## Changes:

* **Reset `game.pausescript` in `scriptclass::hardreset()`**

  This fixes an issue where you could softlock the game if you exited playtesting mode by pressing Esc while a "- Press ACTION to advance text -" prompt was onscreen, then re-entered playtesting and then started any script.

  The "- Press ACTION to advance text -" prompt is most directly controlled by `game.advancetext`, but  when it appears, `game.pausescript` is usually set as well. However, both variables are required.

  You need to have both variables on at the same time in order to press ACTION and advance past the prompt. If only `advancetext` is on, then you won't be able to flip but can still move around, but if only `pausescript` is on, then the game softlocks because the only way you can turn `pausescript` off is by pressing ACTION, but the game will only let you press ACTION if *both* `advancetext` and `pausescript` are on. And if only `pausescript` is on, there's no way to advance to a point in the script where `advancetext` gets turned on. Thus, a softlock.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
