### PR TITLE
Don't quick fade when using musicclass::niceplay()

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -414,7 +414,11 @@ void musicclass::niceplay(int t)
 	// important: do nothing if the correct song is playing!
 	if(currentsong!=t)
 	{
-		if(currentsong!=-1) fadeout();
+		if(currentsong!=-1)
+		{
+			dontquickfade = true;
+			fadeout();
+		}
 		nicefade = 1;
 		nicechange = t;
 	}


### PR DESCRIPTION
## Changes:

* **Don't quick fade when using `musicclass::niceplay()`**

  Earlier in 53950e14de65a54d9369c5183a16337782d3dc4e, I made playing a song while a song was already fading quickly fade out the current song, but then added an exception for if the fade came from the `musicfadeout()` command. This commit adds another exception for if the fade came from `musicclass::niceplay()`, since otherwise the music transitions between areas in the game would go too quick.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
