### PR TITLE
Call nexttowercolour() when exiting to menu from the Esc screen

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2336,6 +2336,7 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
                 if(dwgfx.setflipmode) dwgfx.flipmode = true;
                 dwgfx.fademode = 2;
                 music.fadeout();
+                map.nexttowercolour();
             }
         }
 


### PR DESCRIPTION
## Changes:

* **Call `mapclass::nexttowercolour()` when exiting to the menu from the Esc screen**

  This fixes a bug where you could get mismatched text and background colors on the menu screen by being in the Tower and exiting at a certain time.

  ![The text is cyan but the background is red. Looks cursed](https://user-images.githubusercontent.com/59748578/72948960-bc50d400-3d3b-11ea-845d-c2e7784a25c5.png)

  The background when mismatched will always be red, which seems to have something to do with the fact that when you enter the Tower the game always sets the background to be red.

  I could get a quick repro setup going by starting in the checkpoint in Teleporter Divot, then quickly entering the Tower, exiting, then re-entering, then pressing Esc and quitting - all done very quickly.

  The important thing about this mismatch is that it's only temporary, and will be corrected when you press ACTION and the color of the text and background in the menu both change at the same time, which is what `map.nexttowercolour()` does. So all I do is simply call that function when exiting to the menu, and it will fix the color mismatch.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
