### PR TITLE
Reset enemy type in editorclass::reset()

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -314,6 +314,7 @@ void editorclass::reset()
             level[i+(j*maxwidth)].enemyy1=0;
             level[i+(j*maxwidth)].enemyx2=320;
             level[i+(j*maxwidth)].enemyy2=240;
+            level[i+(j*maxwidth)].enemytype=0;
             level[i+(j*maxwidth)].directmode=0;
         }
     }


### PR DESCRIPTION
## Changes:

* **Reset the enemy type of each room in `editorclass::reset()`**

  This fixes a bug where if you loaded a level, then started making a new level in the editor, the enemy types from the previous level would persist.

  While working on VVVVVV: Community Edition and adding a new room property for enemy speed, I noticed that enemy type was not getting reset at all. After some testing, I confirmed that this was the case. So this bug is fixed now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
