### PR TITLE
Fix X and Y coordinates getting reversed in editorclass::reset()

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -318,11 +318,11 @@ void editorclass::reset()
         }
     }
 
-    for (int j = 0; j < 30 * maxwidth; j++)
+    for (int j = 0; j < 30 * maxheight; j++)
     {
-        for (int i = 0; i < 40 * maxheight; i++)
+        for (int i = 0; i < 40 * maxwidth; i++)
         {
-            contents[i+(j*30*maxwidth)]=0;
+            contents[i+(j*40*maxwidth)]=0;
         }
     }
 


### PR DESCRIPTION
## Changes:

* **Fix the X and Y bounds getting mixed up in `editorclass::reset()`**

  When `editorclass::reset()` was resetting the contents of the level previously, it was mixing up the X and Y bounds. The Y bound was supposed to be `30*maxheight`, and the X bound was supposed to be `40*maxwidth`. Instead, it took `30*maxwidth` as its Y bound and `40*maxheight` as its X bound.

  Then, when it actually indexes the contents vector to set each tile to 0, it used `30*maxwidth` instead of `40*maxwidth`.

  The difference between width and height is a bit hard to spot, but one thing you can do to remember the difference is to remember the fact that X corresponds with width, and Y corresponds with height. Also, rooms are 40 by 30 tiles, and so X (and therefore width) should correspond with 40, and Y (and therefore height) should correspond with 30.

  As a result of mixing up the variables, whenever you played a 20x20 map, quit the level and then started making a new 20x20 map, the tiles of the last four rows of the previous map would persist, from y=16 (1-indexed) all the way to y=20 (1-indexed).

  I don't recall anyone ever running into this bug before, which is a bit strange. But if no one truly has ever ran into this bug before, then I'm genuinely surprised.

  While working on the patch to fix the enemy type room property of each room not getting reset, and testing the fix, I noticed that for some reason some contents of the previous level I played in order to test the enemy type property persisting was *also* persisting alongside the enemy type property.

  Then I read the code and when I realized that the X and Y bounds were getting mixed up I groaned. Very loudly.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
