### PR TITLE
Raise the trinket/crewmate limit and hardcode their text less

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1892,7 +1892,16 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				dwgfx.addline("You have found a shiny trinket!");
 				dwgfx.textboxcenterx();
 
-				dwgfx.createtextbox(" " + help.number(game.trinkets) + " out of Twenty ", 50, 135, 174, 174, 174);
+				std::string usethisnum;
+				if (map.custommode)
+				{
+					usethisnum = help.number(map.customtrinkets);
+				}
+				else
+				{
+					usethisnum = "Twenty";
+				}
+				dwgfx.createtextbox(" " + help.number(game.trinkets) + " out of " + usethisnum + " ", 50, 135, 174, 174, 174);
 				dwgfx.textboxcenterx();
 
 				if (!game.backgroundtext)

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -151,24 +151,42 @@ std::string UtilityClass::timestring( int t )
 
 std::string UtilityClass::number( int _t )
 {
-	const int BIGGEST_SMALL_NUMBER = 50;
-	const char* smallnumbers[] = {"Zero", "One", "Two", "Three", 
-		"Four", "Five", "Six", "Seven", "Eight", "Nine", 
-		"Ten", "Eleven", "Twelve", "Thirteen", "Fourteen", "Fifteen",
-		"Sixteen", "Seventeen", "Eighteen", "Nineteen", "Twenty", "Twenty One",
-		"Twenty Two", "Twenty Three", "Twenty Four", "Twenty Five",
-		"Twenty Six", "Twenty Seven", "Twenty Eight", "Twenty Nine",
-		"Thirty", "Thirty One", "Thirty Two", "Thirty Three", "Thirty Four",
-		"Thirty Five", "Thirty Six", "Thirty Seven", "Thirty Eight",
-		"Thirty Nine", "Forty Zero", "Forty One", "Forty Two", "Forty Three",
-		"Forty Four", "Forty Five", "Forty Six", "Forty Seven", "Forty Eight",
-		"Forty Nine", "Fifty"};
+	const std::string ones_place[] = {"One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine"};
+	const std::string tens_place[] = {"Ten", "Twenty", "Thirty", "Forty", "Fifty", "Sixty", "Seventy", "Eighty", "Ninety"};
+	const std::string teens[] = {"Eleven", "Twelve", "Thirteen", "Fourteen", "Fifteen", "Sixteen", "Seventeen", "Eighteen", "Nineteen"};
 
-	if(_t <= BIGGEST_SMALL_NUMBER) {
-		return smallnumbers[_t];
+	if (_t < 0)
+	{
+		return "???";
 	}
-
-	return "Lots";
+	else if (_t > 100)
+	{
+		return "Lots";
+	}
+	else if (_t == 0)
+	{
+		return "Zero";
+	}
+	else if (_t == 100)
+	{
+		return "One Hundred";
+	}
+	else if (_t >= 1 && _t <= 9)
+	{
+		return ones_place[_t-1];
+	}
+	else if (_t >= 11 && _t <= 19)
+	{
+		return teens[_t-11];
+	}
+	else if (_t % 10 == 0)
+	{
+		return tens_place[(_t/10)-1];
+	}
+	else
+	{
+		return tens_place[(_t/10)-1] + " " + ones_place[(_t%10)-1];
+	}
 }
 
 bool UtilityClass::intersects( SDL_Rect A, SDL_Rect B )

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -4995,7 +4995,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         {
                             if(ed.drawmode==3)
                             {
-                                if(ed.numtrinkets<20)
+                                if(ed.numtrinkets<100)
                                 {
                                     addedentity(ed.tilex+ (ed.levx*40),ed.tiley+ (ed.levy*30),9);
                                     ed.lclickdelay=1;
@@ -5003,7 +5003,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                                 }
                                 else
                                 {
-                                    ed.note="ERROR: Max number of trinkets is 20";
+                                    ed.note="ERROR: Max number of trinkets is 100";
                                     ed.notedelay=45;
                                 }
                             }
@@ -5090,7 +5090,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                             }
                             else if(ed.drawmode==15)  //Crewmate
                             {
-                                if(ed.numcrewmates<20)
+                                if(ed.numcrewmates<100)
                                 {
                                     addedentity(ed.tilex+ (ed.levx*40),ed.tiley+ (ed.levy*30),15,1 + int(fRandom() * 5));
                                     ed.lclickdelay=1;
@@ -5098,7 +5098,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                                 }
                                 else
                                 {
-                                    ed.note="ERROR: Max number of crewmates is 20";
+                                    ed.note="ERROR: Max number of crewmates is 100";
                                     ed.notedelay=45;
                                 }
                             }


### PR DESCRIPTION
## Changes:

* **Raise the limit of trinkets and crewmates to 100**

  The editor will now allow you to place up to 100 trinkets and crewmates.

  VVVVVV 2.2 will handle 100 trinkets and crewmates in a level just fine. It has 100 slots allocated for each already, and it will read and write those 100 slots to the level quicksave file no problem. Except only the first 20 slots get reset when starting from the beginning, but that's minor and is already fixed in 2.3 anyway.

* **Make `UtilityClass::number()` less hardcoded**

  It used to be a giant array of hardcoded numbers going up to Fifty. Now, it's less hardcoded to account for the new trinkets and crewmates limit of 100. For most numbers, it will find the number's tens-place, then find its one-place, and concatenate them together. Special exceptions include Zero through Nine, Eleven through Nineteen, and One Hundred. Negative numbers are "???", and numbers bigger than One Hundred are still simply Lots.

* **Fix the hardcoded "out of Twenty" in the `foundtrinket()` command**

  In custom levels `foundtrinket()` used to always say "out of Twenty" regardless of the actual amount of trinkets the level had. Now, it will actually print the correct amount of trinkets in the level.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
