### PR TITLE
Add a null terminator to loaded TinyXML files

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -165,11 +165,17 @@ bool FILESYSTEM_loadTiXmlDocument(const char *name, TiXmlDocument *doc)
 {
 	/* TiXmlDocument.SaveFile doesn't account for Unicode paths, PHYSFS does */
 	unsigned char *mem = NULL;
-	FILESYSTEM_loadFileToMemory(name, &mem, NULL);
+	size_t len = 0;
+	FILESYSTEM_loadFileToMemory(name, &mem, &len);
 	if (mem == NULL)
 	{
 		return false;
 	}
+
+	// Realloc including a null terminator
+	mem = (unsigned char *) realloc(mem, len + 1);
+	mem[len] = 0;
+
 	doc->Parse((const char*)mem);
 	FILESYSTEM_freeMemory(&mem);
 	return true;

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -12,7 +12,8 @@ void FILESYSTEM_deinit();
 char *FILESYSTEM_getUserSaveDirectory();
 char *FILESYSTEM_getUserLevelDirectory();
 
-void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem, size_t *len);
+void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem,
+                                 size_t *len, bool addnull = false);
 void FILESYSTEM_freeMemory(unsigned char **mem);
 bool FILESYSTEM_saveTiXmlDocument(const char *name, TiXmlDocument *doc);
 bool FILESYSTEM_loadTiXmlDocument(const char *name, TiXmlDocument *doc);


### PR DESCRIPTION
## Changes:

The TinyXML parse() function expect a C-like string, including terminator.
When xml loading was changed, it loaded the file, but included no such thing.
Thus, we load the file, then reallocate the memory so that we can insert a
null terminator to it, before passing it to parse().


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
