### PR TITLE
Added an apostrophe to 'controllers' in game options

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -21,3 +21,4 @@ Contributors
 * Rémi Verschelde (@akien-mga)
 * viri (viri.me)
 * Wouter (Xesxen)
+* Matt "Stelpjo" Aaldenberg

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -130,7 +130,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
 							else if (game.currentmenuoption == 1)
 							{
 								dwgfx.bigprint( -1, 30, "Game Pad Options", tr, tg, tb, true);
-								dwgfx.Print( -1, 65, "Rebind your controllers buttons", tr, tg, tb, true);
+								dwgfx.Print( -1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
 								dwgfx.Print( -1, 75, "and adjust sensitivity", tr, tg, tb, true);
 							}
 							else if (game.currentmenuoption == 2)
@@ -165,7 +165,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
 							else if (game.currentmenuoption == 2)
 							{
 								dwgfx.bigprint( -1, 30, "Game Pad Options", tr, tg, tb, true);
-								dwgfx.Print( -1, 65, "Rebind your controllers buttons", tr, tg, tb, true);
+								dwgfx.Print( -1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
 								dwgfx.Print( -1, 75, "and adjust sensitivity", tr, tg, tb, true);
 							}
 							else if (game.currentmenuoption == 3)


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

Changed "controllers" to "controller's" in the game options menu.