### PR TITLE
Fix level editor not using LoadTiXmlDocument

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -139,7 +139,7 @@ void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem,
 	if (addnull)
 	{
 		*mem = (unsigned char *) malloc(length + 1);
-		mem[length] = 0;
+		(*mem)[length] = 0;
 	}
 	else
 	{

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -116,18 +116,12 @@ void editorclass::getDirectoryData()
 }
 bool editorclass::getLevelMetaData(std::string& _path, LevelMetaData& _data )
 {
-    unsigned char *mem = NULL;
-    FILESYSTEM_loadFileToMemory(_path.c_str(), &mem, NULL);
-
-    if (mem == NULL)
+    TiXmlDocument doc;
+    if (!FILESYSTEM_loadTiXmlDocument(_path.c_str(), &doc))
     {
         printf("Level %s not found :(\n", _path.c_str());
         return false;
     }
-
-    TiXmlDocument doc;
-    doc.Parse((const char*) mem);
-    FILESYSTEM_freeMemory(&mem);
 
     TiXmlHandle hDoc(&doc);
     TiXmlElement* pElem;
@@ -1712,23 +1706,19 @@ void editorclass::load(std::string& _path)
 {
     reset();
 
-    unsigned char *mem = NULL;
     static const char *levelDir = "levels/";
     if (_path.compare(0, strlen(levelDir), levelDir) != 0)
     {
         _path = levelDir + _path;
     }
-    FILESYSTEM_loadFileToMemory(_path.c_str(), &mem, NULL);
 
-    if (mem == NULL)
+    TiXmlDocument doc;
+    if (!FILESYSTEM_loadTiXmlDocument(_path.c_str(), &doc))
     {
         printf("No level %s to load :(\n", _path.c_str());
         return;
     }
 
-    TiXmlDocument doc;
-    doc.Parse((const char*) mem);
-    FILESYSTEM_freeMemory(&mem);
 
     TiXmlHandle hDoc(&doc);
     TiXmlElement* pElem;


### PR DESCRIPTION
## Changes:

This fixes the level editor not using LoadTiXmlDocument,
and thus retaining the null terminator issue as addressed previously.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
