### PR TITLE
Fix tower quicksave bug (only appeared in some builds)

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -51,6 +51,7 @@ void entityclass::init()
     nentity = 0;
     nblocks = 0;
 
+    skipblocks = false;
     skipdirblocks = false;
     platformtile = 0;
     customplatformtile=0;

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -219,7 +219,7 @@ public:
     std::vector<int> customcollect;
 
     int nblocks;
-    bool skipblocks, skipdirblocks;
+    bool skipblocks = false, skipdirblocks;
 
     int platformtile;
     bool vertplatforms, horplatforms;

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -219,7 +219,7 @@ public:
     std::vector<int> customcollect;
 
     int nblocks;
-    bool skipblocks = false, skipdirblocks;
+    bool skipblocks, skipdirblocks;
 
     int platformtile;
     bool vertplatforms, horplatforms;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3425,6 +3425,8 @@ void scriptclass::hardreset( KeyPoll& key, Graphics& dwgfx, Game& game,mapclass&
 	game.teleport = false;
 	game.companion = 0;
 	game.roomchange = false;
+	game.roomx = 0;
+	game.roomy = 0;
 	game.teleport_to_new_area = false;
 	game.teleport_to_x = 0;
 	game.teleport_to_y = 0;
@@ -3460,6 +3462,8 @@ void scriptclass::hardreset( KeyPoll& key, Graphics& dwgfx, Game& game,mapclass&
 	game.savetime = "00:00";
 	game.savearea = "nowhere";
 	game.savetrinkets = 0;
+	game.saverx = 0;
+	game.savery = 0;
 
 	game.intimetrial = false;
 	game.timetrialcountdown = 0;
@@ -3534,7 +3538,9 @@ void scriptclass::hardreset( KeyPoll& key, Graphics& dwgfx, Game& game,mapclass&
 	map.resetnames();
 	map.custommode=false;
 	map.custommodeforreal=false;
-
+	map.towermode=false;
+	map.cameraseekframe = 0;
+	map.resumedelay = 0;
 	map.customshowmm=true;
 
 	for (j = 0; j < 20; j++)


### PR DESCRIPTION
## Changes:

I ran the game through Valgrind to catch various issues.
One thing caught my attention -- map.resumedelay. This is
used by The Tower/etc to add a delay before the game is
resumed (probably for camera controls delaying it) for
spawning the player. This variable was uninitialized. Notably,
if I explicitly set it to 592851 or similar, it reproduces the
bug, even if I cannot reproduce it with my typical compilation
flags. So fixing this by initializing it to 0, alongside some
other Valgrind warnings, should fix the problem entirely.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
