### PR TITLE
Add an accessibility option to be able to see through the room name background

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4443,6 +4443,11 @@ void Game::loadstats( mapclass& map, Graphics& dwgfx )
             dwgfx.notextoutline = atoi(pText);
         }
 
+        if (pKey == "translucentroomname")
+        {
+            dwgfx.translucentroomname = atoi(pText);
+        }
+
 		if (pKey == "flipButton")
 		{
 			SDL_GameControllerButton newButton;
@@ -4654,6 +4659,10 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
 
     msg = new TiXmlElement("notextoutline");
     msg->LinkEndChild(new TiXmlText(tu.String((int) _dwgfx.notextoutline).c_str()));
+    dataNode->LinkEndChild(msg);
+
+    msg = new TiXmlElement("translucentroomname");
+    msg->LinkEndChild(new TiXmlText(tu.String((int) _dwgfx.translucentroomname).c_str()));
     dataNode->LinkEndChild(msg);
 
     for (size_t i = 0; i < controllerButton_flip.size(); i += 1)
@@ -7042,11 +7051,13 @@ void Game::createmenu( std::string t )
         menuoptionsactive[4] = true;
         menuoptions[5] = "load screen";
         menuoptionsactive[5] = true;
-        menuoptions[6] = "return";
+        menuoptions[6] = "room name bg";
         menuoptionsactive[6] = true;
-        nummenuoptions = 7;
-        menuxoff = -60;
-        menuyoff = 0;
+        menuoptions[7] = "return";
+        menuoptionsactive[7] = true;
+        nummenuoptions = 8;
+        menuxoff = -85;
+        menuyoff = -10;
     }
 	else if(t == "controller")
 	{

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -122,6 +122,8 @@ Graphics::Graphics()
     trinketg = 0;
     trinketb = 0;
     warprect = SDL_Rect();
+
+    translucentroomname = false;
 }
 
 Graphics::~Graphics()

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -238,6 +238,7 @@ public:
 	SDL_Rect foot_rect;
 	SDL_Rect prect;
 	SDL_Rect footerrect;
+	SDL_Surface* footerbuffer;
 
 	int linestate, linedelay;
 	int backoffset;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -277,6 +277,7 @@ public:
 
 	int warpskip, warpfcol, warpbcol;
 
+	bool translucentroomname;
 };
 
 #endif /* GRAPHICS_H */

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -747,6 +747,12 @@ SDL_assert(0 && "Remove open level dir");
                     }
                     else if (game.currentmenuoption == 6)
                     {
+                        // toggle translucent roomname BG
+                        dwgfx.translucentroomname = !dwgfx.translucentroomname;
+                        music.playef(11, 10);
+                    }
+                    else if (game.currentmenuoption == 7)
+                    {
                         //back
                         music.playef(11, 10);
                         game.createmenu("options");

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3442,15 +3442,13 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                 if(ed.tiley<28)
                 {
                     if(ed.roomnamehide>0) ed.roomnamehide--;
-                    FillRect(dwgfx.backBuffer, 0,230+ed.roomnamehide,320,10, dwgfx.getRGB(0,0,0));
-                    dwgfx.Print(5,231+ed.roomnamehide,ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname, 196, 196, 255 - help.glow, true);
                 }
                 else
                 {
                     if(ed.roomnamehide<12) ed.roomnamehide++;
-                    FillRect(dwgfx.backBuffer, 0,230+ed.roomnamehide,320,10, dwgfx.getRGB(0,0,0));
-                    dwgfx.Print(5,231+ed.roomnamehide,ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname, 196, 196, 255 - help.glow, true);
                 }
+                FillRect(dwgfx.backBuffer, 0,230+ed.roomnamehide,320,10, dwgfx.getRGB(0,0,0));
+                dwgfx.Print(5,231+ed.roomnamehide,ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname, 196, 196, 255 - help.glow, true);
                 dwgfx.bprint(4, 222, "SPACE ^  SHIFT ^", 196, 196, 255 - help.glow, false);
                 dwgfx.bprint(268,222, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);
             }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3447,9 +3447,9 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                 {
                     if(ed.roomnamehide<12) ed.roomnamehide++;
                 }
-                dwgfx.footerrect.y = 230+ed.roomnamehide;
                 if (dwgfx.translucentroomname)
                 {
+                    dwgfx.footerrect.y = 230+ed.roomnamehide;
                     SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
                 }
                 else

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3447,7 +3447,8 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                 {
                     if(ed.roomnamehide<12) ed.roomnamehide++;
                 }
-                FillRect(dwgfx.backBuffer, 0,230+ed.roomnamehide,320,10, dwgfx.getRGB(0,0,0));
+                dwgfx.footerrect.y = 230+ed.roomnamehide;
+                SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
                 dwgfx.Print(5,231+ed.roomnamehide,ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname, 196, 196, 255 - help.glow, true);
                 dwgfx.bprint(4, 222, "SPACE ^  SHIFT ^", 196, 196, 255 - help.glow, false);
                 dwgfx.bprint(268,222, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3447,16 +3447,15 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                 {
                     if(ed.roomnamehide<12) ed.roomnamehide++;
                 }
+                dwgfx.footerrect.y = 230+ed.roomnamehide;
                 if (dwgfx.translucentroomname)
                 {
-                    SDL_SetSurfaceAlphaMod(dwgfx.footerbuffer, 127);
+                    SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
                 }
                 else
                 {
-                    SDL_SetSurfaceAlphaMod(dwgfx.footerbuffer, 255);
+                    FillRect(dwgfx.backBuffer, 0,230+ed.roomnamehide,320,10, dwgfx.getRGB(0,0,0));
                 }
-                dwgfx.footerrect.y = 230+ed.roomnamehide;
-                SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
                 dwgfx.bprint(5,231+ed.roomnamehide,ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname, 196, 196, 255 - help.glow, true);
                 dwgfx.bprint(4, 222, "SPACE ^  SHIFT ^", 196, 196, 255 - help.glow, false);
                 dwgfx.bprint(268,222, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3447,6 +3447,14 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                 {
                     if(ed.roomnamehide<12) ed.roomnamehide++;
                 }
+                if (dwgfx.translucentroomname)
+                {
+                    SDL_SetSurfaceAlphaMod(dwgfx.footerbuffer, 127);
+                }
+                else
+                {
+                    SDL_SetSurfaceAlphaMod(dwgfx.footerbuffer, 255);
+                }
                 dwgfx.footerrect.y = 230+ed.roomnamehide;
                 SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
                 dwgfx.Print(5,231+ed.roomnamehide,ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname, 196, 196, 255 - help.glow, true);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3457,7 +3457,7 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                 }
                 dwgfx.footerrect.y = 230+ed.roomnamehide;
                 SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
-                dwgfx.Print(5,231+ed.roomnamehide,ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname, 196, 196, 255 - help.glow, true);
+                dwgfx.bprint(5,231+ed.roomnamehide,ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname, 196, 196, 255 - help.glow, true);
                 dwgfx.bprint(4, 222, "SPACE ^  SHIFT ^", 196, 196, 255 - help.glow, false);
                 dwgfx.bprint(268,222, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);
             }

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -125,6 +125,9 @@ int main(int argc, char *argv[])
     const SDL_PixelFormat* fmt = gameScreen.GetFormat();
     graphics.backBuffer = SDL_CreateRGBSurface(SDL_SWSURFACE ,320 ,240 ,32,fmt->Rmask,fmt->Gmask,fmt->Bmask,fmt->Amask ) ;
     SDL_SetSurfaceBlendMode(graphics.backBuffer, SDL_BLENDMODE_NONE);
+    graphics.footerbuffer = SDL_CreateRGBSurface(SDL_SWSURFACE, 320, 10, 32, fmt->Rmask, fmt->Gmask, fmt->Bmask, fmt->Amask);
+    SDL_SetSurfaceBlendMode(graphics.footerbuffer, SDL_BLENDMODE_BLEND);
+    FillRect(graphics.footerbuffer, SDL_MapRGB(fmt, 0, 0, 0));
     graphics.Makebfont();
 
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -127,6 +127,7 @@ int main(int argc, char *argv[])
     SDL_SetSurfaceBlendMode(graphics.backBuffer, SDL_BLENDMODE_NONE);
     graphics.footerbuffer = SDL_CreateRGBSurface(SDL_SWSURFACE, 320, 10, 32, fmt->Rmask, fmt->Gmask, fmt->Bmask, fmt->Amask);
     SDL_SetSurfaceBlendMode(graphics.footerbuffer, SDL_BLENDMODE_BLEND);
+    SDL_SetSurfaceAlphaMod(graphics.footerbuffer, 127);
     FillRect(graphics.footerbuffer, SDL_MapRGB(fmt, 0, 0, 0));
     graphics.Makebfont();
 

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -553,6 +553,16 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 else
                     dwgfx.Print(-1, 75, "Fake loading screen is ON", tr, tg, tb, true);
             }
+            else if (game.currentmenuoption == 6)
+            {
+                dwgfx.bigprint(-1, 30, "Room Name BG", tr, tg, tb, true);
+                dwgfx.Print( -1, 75, "Lets you see through what is behind", tr, tg, tb, true);
+                dwgfx.Print( -1, 85, "the name at the bottom of the screen.", tr, tg, tb, true);
+                if (dwgfx.translucentroomname)
+                    dwgfx.Print(-1, 105, "Room name background is TRANSLUCENT", tr/2, tg/2, tb/2, true);
+                else
+                    dwgfx.Print(-1, 105, "Room name background is OPAQUE", tr, tg, tb, true);
+            }
         }
         else if (game.currentmenuname == "playint1" || game.currentmenuname == "playint2")
         {
@@ -1552,6 +1562,14 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
 
     if(map.extrarow==0 || (map.custommode && map.roomname!=""))
     {
+        if (dwgfx.translucentroomname)
+        {
+            SDL_SetSurfaceAlphaMod(dwgfx.footerbuffer, 127);
+        }
+        else
+        {
+            SDL_SetSurfaceAlphaMod(dwgfx.footerbuffer, 255);
+        }
         dwgfx.footerrect.y = 230;
         SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
 
@@ -2809,6 +2827,14 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
     }
 
 
+    if (dwgfx.translucentroomname)
+    {
+        SDL_SetSurfaceAlphaMod(dwgfx.footerbuffer, 127);
+    }
+    else
+    {
+        SDL_SetSurfaceAlphaMod(dwgfx.footerbuffer, 255);
+    }
     dwgfx.footerrect.y = 230;
     SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
     dwgfx.Print(5, 231, map.roomname, 196, 196, 255 - help.glow, true);

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -1552,7 +1552,8 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
 
     if(map.extrarow==0 || (map.custommode && map.roomname!=""))
     {
-        FillRect(dwgfx.backBuffer, dwgfx.footerrect, 0);
+        dwgfx.footerrect.y = 230;
+        SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
 
         if (map.finalmode)
         {
@@ -2808,7 +2809,8 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
     }
 
 
-    FillRect(dwgfx.backBuffer, dwgfx.footerrect, 0x000000);
+    dwgfx.footerrect.y = 230;
+    SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
     dwgfx.Print(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
 
     //dwgfx.rprint(5, 231,help.String(game.coins), 255 - help.glow/2, 255 - help.glow/2, 196, true);

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -1576,9 +1576,9 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
         if (map.finalmode)
         {
         	map.glitchname = map.getglitchname(game.roomx, game.roomy);
-          dwgfx.Print(5, 231, map.glitchname, 196, 196, 255 - help.glow, true);
+          dwgfx.bprint(5, 231, map.glitchname, 196, 196, 255 - help.glow, true);
         }else{
-          dwgfx.Print(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
+          dwgfx.bprint(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
         }
     }
 
@@ -2837,7 +2837,7 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
     }
     dwgfx.footerrect.y = 230;
     SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
-    dwgfx.Print(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
+    dwgfx.bprint(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
 
     //dwgfx.rprint(5, 231,help.String(game.coins), 255 - help.glow/2, 255 - help.glow/2, 196, true);
     //dwgfx.drawhuetile(311, 230, 48, 1);

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -1562,16 +1562,15 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
 
     if(map.extrarow==0 || (map.custommode && map.roomname!=""))
     {
+        dwgfx.footerrect.y = 230;
         if (dwgfx.translucentroomname)
         {
-            SDL_SetSurfaceAlphaMod(dwgfx.footerbuffer, 127);
+            SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
         }
         else
         {
-            SDL_SetSurfaceAlphaMod(dwgfx.footerbuffer, 255);
+            FillRect(dwgfx.backBuffer, dwgfx.footerrect, 0);
         }
-        dwgfx.footerrect.y = 230;
-        SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
 
         if (map.finalmode)
         {
@@ -2827,16 +2826,15 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
     }
 
 
+    dwgfx.footerrect.y = 230;
     if (dwgfx.translucentroomname)
     {
-        SDL_SetSurfaceAlphaMod(dwgfx.footerbuffer, 127);
+        SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
     }
     else
     {
-        SDL_SetSurfaceAlphaMod(dwgfx.footerbuffer, 255);
+        FillRect(dwgfx.backBuffer, dwgfx.footerrect, 0);
     }
-    dwgfx.footerrect.y = 230;
-    SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
     dwgfx.bprint(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
 
     //dwgfx.rprint(5, 231,help.String(game.coins), 255 - help.glow/2, 255 - help.glow/2, 196, true);


### PR DESCRIPTION
## Changes:

### Summary

This PR adds an option to be able to make the room name background translucent.

Such an option would be very useful when playing through custom levels, since certain custom levels have problems with making their visuals clear with regards to the roomname. They might put collision behind it, making it look like there's an exit and you'd go through to the room below, even though they intend for you to magically know that there's collision there and then walk on it. Or they might just be mean and decide to hide spikes there.

**With an opaque room name background:**
![You can't tell which one is real.](https://user-images.githubusercontent.com/59748578/73116452-7e92ad80-3eeb-11ea-8368-bffb56e8a816.png)

**With a translucent room name background:**
![Now you can tell.](https://user-images.githubusercontent.com/59748578/73116500-10021f80-3eec-11ea-9672-bed9c2f7b21a.png)

### Details

* **Render room name backgrounds using an `SDL_Surface` and `SDL_BlitSurface()` instead of using `SDL_FillRect`**

  Unfortunately, it would be easy if we could simply change the `FillRect()` to use a translucent color. However, it seems like you cannot draw translucent rectangles this way. Someone should complain to the SDL people...

  So what I have to do instead is to make a new `SDL_Surface` named `dwgfx.footerbuffer`, and then use `SDL_BlitSurface()` to draw that. Then I can simply set the opacity with `SDL_SetSurfaceAlphaMod()`!

* **Add the accessibility option to make room name backgrounds translucent**

  This is controlled by the variable `dwgfx.translucentroomname`, and is stored in `unlock.vvv` as the XML tag `<translucentroomname>`.

  If it is true, then room names are drawn with opacity 127, which is between 0 and 255, and is thus half of opaque opacity.

* **Draw room names with text outline**

  Having a text outline on the room names makes it easier to see them when you have a translucent room name background.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
