### PR TITLE
Fix minor issue with respawning into a tower

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -826,6 +826,7 @@ void mapclass::showship()
 
 void mapclass::resetplayer(Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music)
 {
+	bool was_in_tower = towermode;
 	if (game.roomx != game.saverx || game.roomy != game.savery)
 	{
 		gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
@@ -845,6 +846,17 @@ void mapclass::resetplayer(Graphics& dwgfx, Game& game, entityclass& obj, musicc
 		obj.entities[i].colour = 0;
 		game.lifeseq = 10;
 		obj.entities[i].invis = true;
+
+		// If we entered a tower as part of respawn, reposition camera
+		if (!was_in_tower && towermode)
+		{
+			ypos = obj.entities[i].yp - 120;
+			if (ypos < 0)
+			{
+				ypos = 0;
+			}
+			bypos = ypos / 2;
+		}
 	}
 
 	game.scmhurt = false; //Just in case the supercrewmate is fucking this up!


### PR DESCRIPTION
When the game enter towermode, it adjusts player amd camera x/y depending
on what screen the player entered it from (The Tower) or the loadlevel
mode ("minitowers"; Panic Room and The Final Challenge). This code didn't
account for respawning to checkpoints. This is unlikely to matter in most
circumstances, but can cause problems in some corner cases, or with R abuse.
This could cause a player to die, respawn outside camera edges and then
immediately die again due to the edge spikes, repositioning the camera
properly. Invincibility would cause further issues, but that's Invincibility
Mode for you -- if this was the only problem I wouldn't bother.

I added a check that repositions the tower camera appropriately if a player
enter a tower as part of the respawn process.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
