### PR TITLE
Draw editor entities according to ingame order

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2432,7 +2432,9 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
     obj.customplatformtile=game.customcol*12;
 
     ed.temp=edentat(ed.tilex+ (ed.levx*40),ed.tiley+ (ed.levy*30));
-    for(int i=0; i< EditorData::GetInstance().numedentities; i++)
+
+    // Draw entities backward to remain accurate with ingame
+    for (int i = EditorData::GetInstance().numedentities - 1; i >= 0; i--)
     {
         //if() on screen
         int tx=(edentity[i].x-(edentity[i].x%40))/40;


### PR DESCRIPTION
Ingame entities are drawn backwards, probably to draw the player on top,
being entity 0 (usually, at least). Make the level editor draw entities
in the same order.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
