### PR TITLE
Don't re-draw horizontal and vertical warp backgrounds if gotoroom()ing to the same room in custom levels

### DIFF
--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -121,6 +121,7 @@ public:
     int door_up;
     int door_down;
     int roomx, roomy, roomchangedir;
+    int prevroomx, prevroomy;
     int temp, j, k;
 
     int savex, savey, saverx, savery;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1059,8 +1059,17 @@ void mapclass::gotoroom(int rx, int ry, Graphics& dwgfx, Game& game, entityclass
 	loadlevel(game.roomx, game.roomy, dwgfx, game, obj, music);
 
 
-	dwgfx.backgrounddrawn = false; //Used for background caching speedup
+	//Do we need to reload the background?
+	bool redrawbg = game.roomx != game.prevroomx || game.roomy != game.prevroomy;
+
+	if(redrawbg)
+	{
+		dwgfx.backgrounddrawn = false; //Used for background caching speedup
+	}
 	dwgfx.foregrounddrawn = false; //Used for background caching speedup
+
+	game.prevroomx = game.roomx;
+	game.prevroomy = game.roomy;
 
 	//a very special case: if entering the communication room, room 13,4 before tag 5 is set, set the game state to a background
 	//textbox thingy. if tag five is not set when changing room, reset the game state. (tag 5 is set when you get back to the ship)
@@ -1605,7 +1614,10 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		}
 
 		//If screen warping, then override all that:
-		dwgfx.backgrounddrawn = false;
+		bool redrawbg = game.roomx != game.prevroomx || game.roomy != game.prevroomy;
+		if(redrawbg){
+			dwgfx.backgrounddrawn = false;
+		}
 		if(ed.level[curlevel].warpdir>0){
 			if(ed.level[curlevel].warpdir==1){
 			warpx=true;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3427,6 +3427,8 @@ void scriptclass::hardreset( KeyPoll& key, Graphics& dwgfx, Game& game,mapclass&
 	game.roomchange = false;
 	game.roomx = 0;
 	game.roomy = 0;
+	game.prevroomx = 0;
+	game.prevroomy = 0;
 	game.teleport_to_new_area = false;
 	game.teleport_to_x = 0;
 	game.teleport_to_y = 0;


### PR DESCRIPTION

## Changes:

### Summary

**Don't redraw horizontal and vertical warp backgrounds if `gotoroom` is being called on the current room in custom levels**

This has two benefits:
 1. The game uses less resources when it is asked to `gotoroom` to the same room from a `gotoroom` script box, because it is no longer re-drawing the warp background every single frame, which is very wasteful.
 2. The warp background no longer freezes or flickers if the player is standing inside a `gotoroom` script box (which calls `gotoroom` every frame or every other frame, because every time the `gotoroom` happens the script box gets reloaded, thus doing another `gotoroom`, etc.)

To demonstrate the fix, I have attached a custom level that has `gotoroom` script boxes so you can compare before and after. Before, the game is re-drawing the warp background every other frame, which is very wasteful, and causes a visual flicker which is jarring and distracting. After, the game no longer re-draws the warp background every other frame, which takes up less resources and also fixes the visual bug.

* [gotoroom_warp_bg_fix_demo.zip](https://github.com/TerryCavanagh/VVVVVV/files/4119737/gotoroom_warp_bg_fix_demo.zip)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
