### PR TITLE
Add graphics option to toggle mouse cursor

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4448,6 +4448,11 @@ void Game::loadstats( mapclass& map, Graphics& dwgfx )
             dwgfx.translucentroomname = atoi(pText);
         }
 
+        if (pKey == "showmousecursor")
+        {
+            dwgfx.showmousecursor = atoi(pText);
+        }
+
 		if (pKey == "flipButton")
 		{
 			SDL_GameControllerButton newButton;
@@ -4495,6 +4500,14 @@ void Game::loadstats( mapclass& map, Graphics& dwgfx )
         dwgfx.screenbuffer->toggleLinearFilter();
     }
     dwgfx.screenbuffer->ResizeScreen(width, height);
+
+    if (dwgfx.showmousecursor == true)
+    {
+        SDL_ShowCursor(SDL_ENABLE);
+    }
+    else {
+        SDL_ShowCursor(SDL_DISABLE);
+    }
 
     if (controllerButton_flip.size() < 1)
     {
@@ -4663,6 +4676,10 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
 
     msg = new TiXmlElement("translucentroomname");
     msg->LinkEndChild(new TiXmlText(tu.String((int) _dwgfx.translucentroomname).c_str()));
+    dataNode->LinkEndChild(msg);
+
+    msg = new TiXmlElement("showmousecursor");
+    msg->LinkEndChild(new TiXmlText(tu.String((int)_dwgfx.showmousecursor).c_str()));
     dataNode->LinkEndChild(msg);
 
     for (size_t i = 0; i < controllerButton_flip.size(); i += 1)
@@ -6888,9 +6905,11 @@ void Game::createmenu( std::string t )
         menuoptionsactive[2] = true;
         menuoptions[3] = "toggle analogue";
         menuoptionsactive[3] = true;
-        menuoptions[4] = "return";
+        menuoptions[4] = "toggle mouse";
         menuoptionsactive[4] = true;
-        nummenuoptions = 5;
+        menuoptions[5] = "return";
+        menuoptionsactive[5] = true;
+        nummenuoptions = 6;
         menuxoff = -50;
         menuyoff = 8;
         /* Old stuff, not used anymore

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -124,6 +124,7 @@ Graphics::Graphics()
     warprect = SDL_Rect();
 
     translucentroomname = false;
+    showmousecursor = true;
 }
 
 Graphics::~Graphics()

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -278,6 +278,8 @@ public:
 	int warpskip, warpfcol, warpbcol;
 
 	bool translucentroomname;
+
+	bool showmousecursor;
 };
 
 #endif /* GRAPHICS_H */

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -460,6 +460,17 @@ SDL_assert(0 && "Remove open level dir");
                       game.savestats(map, dwgfx);
                       game.createmenu("graphicoptions");
                       game.currentmenuoption = 3;
+                  }else if (game.currentmenuoption == 4) {
+                      //toggle mouse cursor
+                      music.playef(11, 10);
+                      if (dwgfx.showmousecursor == true) {
+                          SDL_ShowCursor(SDL_DISABLE);
+                          dwgfx.showmousecursor = false;
+                      }
+                      else {
+                          SDL_ShowCursor(SDL_ENABLE);
+                          dwgfx.showmousecursor = true;
+                      }
                   }
                   else
                   {

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -239,7 +239,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                   dwgfx.Print(-1, 85, "Current mode: SHOW", tr, tg, tb, true);
               }
               else {
-                  dwgfx.Print(-1, 85, "Current mode: HIDE", tr, tg, tb, true);
+                  dwgfx.Print(-1, 85, "Current mode: HIDE", tr/2, tg/2, tb/2, true);
               }
           }
         }

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -230,6 +230,18 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                     dwgfx.Print( -1, 75, "television set. Do not attempt to", tr, tg, tb, true);
                     dwgfx.Print( -1, 85, "adjust the picture.", tr, tg, tb, true);
                 }
+          else if (game.currentmenuoption == 4)
+          {
+              dwgfx.bigprint(-1, 30, "Toggle Mouse Cursor", tr, tg, tb, true);
+              dwgfx.Print(-1, 65, "Show/hide the system mouse cursor.", tr, tg, tb, true);
+
+              if (dwgfx.showmousecursor) {
+                  dwgfx.Print(-1, 85, "Current mode: SHOW", tr, tg, tb, true);
+              }
+              else {
+                  dwgfx.Print(-1, 85, "Current mode: HIDE", tr, tg, tb, true);
+              }
+          }
         }
         else if (game.currentmenuname == "credits")
         {


### PR DESCRIPTION
## Changes:

Adds a new setting to the graphics options menu to show or hide the system mouse cursor over the game window. This is nice to have if you find the cursor distracting, particularly in fullscreen mode. The cursor initially defaults to shown because that's what players are used to, and it's helpful for the level editor.

As a bonus, this should close #105.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
