### PR TITLE
Allow using 'help', 'graphics', 'music', 'game', 'key', 'map', and 'obj' everywhere

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -113,9 +113,9 @@ bool GetButtonFromString(const char *pText, SDL_GameControllerButton *button)
 }
 
 
-Game::Game(void):
-    mutebutton(0)
+void Game::init(void)
 {
+    mutebutton = 0;
     infocus = true;
     paused = false;
     muted = false;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -17,7 +17,7 @@ class musicclass;
 class Game
 {
 public:
-    Game(void);
+    void init(void);
     ~Game(void);
 
 
@@ -361,5 +361,7 @@ public:
 
     bool skipfakeload;
 };
+
+extern Game game;
 
 #endif /* GAME_H */

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -4,8 +4,10 @@
 #include "Map.h"
 #include "Screen.h"
 
-Graphics::Graphics()
+void Graphics::init()
 {
+    grphx.init();
+
     flipmode = false;
     setRect(tiles_rect, 0,0,8,8);
     setRect(sprites_rect, 0,0,32,32);

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -23,7 +23,7 @@ class map;
 class Graphics
 {
 public:
-	Graphics();
+	void init();
 	~Graphics();
 
 	GraphicsResources grphx;
@@ -279,5 +279,7 @@ public:
 
 	bool translucentroomname;
 };
+
+extern Graphics graphics;
 
 #endif /* GRAPHICS_H */

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -80,7 +80,7 @@ SDL_Surface* LoadImage(const char *filename, bool noBlend = true, bool noAlpha =
 	}
 }
 
-GraphicsResources::GraphicsResources(void)
+void GraphicsResources::init(void)
 {
 	im_tiles =		LoadImage("graphics/tiles.png");
 	im_tiles2 =		LoadImage("graphics/tiles2.png");

--- a/desktop_version/src/GraphicsResources.h
+++ b/desktop_version/src/GraphicsResources.h
@@ -6,7 +6,7 @@
 class GraphicsResources
 {
 public:
-    GraphicsResources(void);
+    void init(void);
     ~GraphicsResources(void);
 
     SDL_Surface* im_tiles;

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -81,5 +81,6 @@ private:
 	Uint32 wasFullscreen;
 };
 
+extern KeyPoll key;
 
 #endif /* KEYPOLL_H */

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -179,4 +179,6 @@ public:
     int cursorstate, cursordelay;
 };
 
+extern mapclass map;
+
 #endif /* MAPGAME_H */

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -3,7 +3,7 @@
 #include "Music.h"
 #include "BinaryBlob.h"
 
-musicclass::musicclass()
+void musicclass::init()
 {
 	soundTracks.push_back(SoundTrack( "sounds/jump.wav" ));
 	soundTracks.push_back(SoundTrack( "sounds/jump2.wav" ));

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -10,7 +10,7 @@
 class musicclass
 {
 public:
-	musicclass();
+	void init();
 
 	void play(int t);
 	void loopmusic();
@@ -64,5 +64,6 @@ public:
 	bool usingmmmmmm;
 };
 
+extern musicclass music;
 
 #endif /* MUSIC_H */

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -43,4 +43,6 @@ public:
     std::vector<int> splitseconds;
 };
 
+extern UtilityClass help;
+
 #endif /* UTILITYCLASS_H */

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -34,6 +34,14 @@ scriptclass script;
 
  editorclass ed;
 
+UtilityClass help;
+Graphics graphics;
+musicclass music;
+Game game;
+KeyPoll key;
+mapclass map;
+entityclass obj;
+
 int main(int argc, char *argv[])
 {
     if(!FILESYSTEM_init(argv[0]))
@@ -90,16 +98,19 @@ int main(int argc, char *argv[])
 
 
 
-    UtilityClass help;
+    //UtilityClass help;
     // Load Ini
 
 
-    Graphics graphics;
+    //Graphics graphics;
+    graphics.init();
 
 
 
-    musicclass music;
-    Game game;
+    //musicclass music;
+    music.init();
+    //Game game;
+    game.init();
     game.infocus = true;
 
     graphics.MakeTileArray();
@@ -159,8 +170,8 @@ int main(int argc, char *argv[])
     game.menustart = false;
     game.mainmenu = 0;
 
-    KeyPoll key;
-    mapclass map;
+    //KeyPoll key;
+    //mapclass map;
 
     map.ypos = (700-29) * 8;
     map.bypos = map.ypos / 2;
@@ -217,7 +228,7 @@ int main(int argc, char *argv[])
 		if(game.bestrank[4]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_warp_fixed");
 		if(game.bestrank[5]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_final_fixed");
 
-    entityclass obj;
+    //entityclass obj;
     obj.init();
 
     //Quick hack to start in final level ---- //Might be useful to leave this commented in for testing


### PR DESCRIPTION
## Changes:

* **Allow using `help`, `graphics`, `music`, `game`, `key`, `map`, and `obj` everywhere**

  This PR makes `help`, `graphics`, `music`, `game`, `key`, `map`, and `obj` essentially static global objects that can be used everywhere. This is useful in case we ever need to add a new function in the future, so we don't have to bother with passing a new argument in which means we have to pass a new argument in to the function that calls that function which means having to pass a new argument into the function that calls *that* function, etc. which is a real headache when working on fan mods of the source code.

  Note that this changes *none* of the existing function signatures, it merely just makes those variables accessible everywhere in the same way `script` and `ed` are.

  Also note that some classes had to be initialized after the filesystem was initialized, or else the game would segfault. But C++ would keep initializing them before the filesystem got initialized, because I *had* to put them at the top of `main.cpp`, or else they wouldn't be global variables.

  The only way to work around this was to use entityclass's initialization style (which I'm pretty sure entityclass of all things doesn't need to be initialized this way), where you actually initialize the class in an `init()` function, and so then you do `graphics.init()` after the filesystem initialization, *after* doing `Graphics graphics` up at the top.

  I've had to do this for `graphics` (but only because its child GraphicsResources `grphx` needs to be initialized this way), `music`, and `game`. I don't think this will affect anything. Other than that, `help`, `key`, and `map` are still using the C++-intended method of having ClassName::ClassName() functions.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
