### PR TITLE
Reset warp directions when exiting playtesting

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1902,6 +1902,14 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 
           dwgfx.backgrounddrawn=false;
           music.fadeout();
+          //If warpdir() is used during playtesting, we need to set it back after!
+          for (int j = 0; j < ed.maxheight; j++)
+          {
+            for (int i = 0; i < ed.maxwidth; i++)
+            {
+              ed.level[i+(j*ed.maxwidth)].warpdir=ed.kludgewarpdir[i+(j*ed.maxwidth)];
+            }
+          }
         }
       }
     }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3181,6 +3181,14 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.gamestate = GAMEMODE;
 		music.fadeout();
 		hardreset(key, dwgfx, game, map, obj, help, music);
+		//If warpdir() is used during playtesting, we need to set it back after!
+		for (int j = 0; j < ed.maxheight; j++)
+		{
+			for (int i = 0; i < ed.maxwidth; i++)
+			{
+				ed.kludgewarpdir[i+(j*ed.maxwidth)]=ed.level[i+(j*ed.maxwidth)].warpdir;
+			}
+		}
 		game.customstart(obj, music);
 		game.jumpheld = true;
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -310,6 +310,7 @@ void editorclass::reset()
             level[i+(j*maxwidth)].enemyy2=240;
             level[i+(j*maxwidth)].enemytype=0;
             level[i+(j*maxwidth)].directmode=0;
+            kludgewarpdir[i+(j*maxwidth)]=0;
         }
     }
 

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -158,6 +158,7 @@ class editorclass{
   int numtrinkets;
   int numcrewmates;
   edlevelclass level[400]; //Maxwidth*maxheight
+  int kludgewarpdir[400]; //Also maxwidth*maxheight
 
   int temp;
   int notedelay;


### PR DESCRIPTION
## Changes:

* **Reset warp directions when exiting playtesting**

  This fixes a bug where if `warpdir()` was used during in-editor playtesting, the changed warp direction would persist even when leaving playtesting.

  This would be very annoying to correct back every time you playtested and `warpdir()` was used, so I've added some kludge to store the actual warp direction of each room when entering playtesting, and then set the warp directions back when leaving playtesting.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
