### PR TITLE
Set customwarpmode to true when createentity()ing warp lines

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2621,6 +2621,7 @@ void entityclass::createentity( Game& game, float xp, float yp, int t, float vx 
         //entities[k].colour = 0;
         entities[k].onentity = 1;
         entities[k].invis=true;
+        if (map.custommode) customwarpmode = true;
         break;
       case 52: //Vertical Warp Line
         entities[k].rule = 5;
@@ -2634,6 +2635,7 @@ void entityclass::createentity( Game& game, float xp, float yp, int t, float vx 
         //entities[k].colour = 0;
         entities[k].onentity = 1;
         entities[k].invis=true;
+        if (map.custommode) customwarpmode = true;
         break;
       case 53: //Horizontal Warp Line
         entities[k].rule = 7;
@@ -2646,6 +2648,7 @@ void entityclass::createentity( Game& game, float xp, float yp, int t, float vx 
         entities[k].h = 1;
         entities[k].onentity = 1;
         entities[k].invis=true;
+        if (map.custommode) customwarpmode = true;
         break;
       case 54: //Horizontal Warp Line
         entities[k].rule = 7;
@@ -2658,6 +2661,7 @@ void entityclass::createentity( Game& game, float xp, float yp, int t, float vx 
         entities[k].h = 1;
         entities[k].onentity = 1;
         entities[k].invis=true;
+        if (map.custommode) customwarpmode = true;
         break;
       case 55: // Crew Member (custom, collectable)
         //1 - position in array


### PR DESCRIPTION
## Changes:

* **Set `customwarpmode` to true when `createentity`ing warp lines**

  This fixes a bug where warp lines created through `createentity` wouldn't work without there already being a warp line present in the room as an edentity.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
