### PR TITLE
Fix text() centering with x=-1

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -597,7 +597,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 					dwgfx.textboxmoveto(textx);
 				}
 
-				if (textx == -500)
+				if (textx == -500 || textx == -1)
 				{
 					dwgfx.textboxcenterx();
 				}
@@ -642,7 +642,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 					dwgfx.textboxmoveto(textx);
 				}
 
-				if (textx == -500)
+				if (textx == -500 || textx == -1)
 				{
 					dwgfx.textboxcenterx();
 				}


### PR DESCRIPTION
## Changes:

* **Fix `text()` centering with x=-1**

  The game uses magic values x=-500 and y=-500 to indicate when a text box should be centered horizontally or vertically. It does this for x=-1 too, but it's buggy because it only looks at the first line of the text box to center it. In this commit I fix it so that it will look at all of the lines of the text box to center it instead.

  Here's what x=-1 centering looked like before:
  ![x=-1 centering: before](https://user-images.githubusercontent.com/59748578/73576363-20a41f80-442f-11ea-9626-ec471fd81e98.png)

  Here's what x=-1 centering looks like after:
  ![x=-1 centering: after](https://user-images.githubusercontent.com/59748578/73576399-331e5900-442f-11ea-883a-689b7ef79b46.png)

  The script is:

  ```
  text(gray,-1,-500,2)
  this is
  a text box with two lines
  speak
  endtext
  ```

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
