### PR TITLE
Fix Prize for the Reckless quicksand fix kludge executing in unintended places

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -591,7 +591,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             {
                 //Ok! super magical exception for the room with the intention death for the shiny trinket
                 //fix this when the maps are finalised
-                if (game.roomx != 111 && game.roomy != 107)
+                if (game.roomx != 111 || game.roomy != 107 || map.custommode)
                 {
                     obj.entities[i].state = 4;
                 }

--- a/mobile_version/src/includes/logic.as
+++ b/mobile_version/src/includes/logic.as
@@ -465,7 +465,7 @@ public function gamelogic(key:KeyPoll, dwgfx:dwgraphicsclass, game:gameclass, ma
 			if (obj.entities[i].type == 2 && obj.entities[i].state == 3) {
 				//Ok! super magical exception for the room with the intention death for the shiny trinket
 				//fix this when the maps are finalised
-				if (game.roomx != 111 && game.roomy != 107) {
+				if (game.roomx != 111 || game.roomy != 107 || map.custommode) {
 				  obj.entities[i].state = 4;	
 				}else {
 				  obj.entities[i].state = 4;	


### PR DESCRIPTION
## Changes:

* **Fix the Prize for the Reckless quicksand fix kludge executing in custom levels and in way more rooms than needed**

  If you died in Prize for the Reckless, which is at (11,7), and respawned in the same room, tile 59 (a solid invisible tile) would be placed at [18,9] to prevent the moving platform from going back through the quicksand.

  Unfortunately, the way that this kludge was added is poor.

  First, the conditional makes it so that it doesn't happen in *only* (11,7). Instead of being behind a positive conditional, the tile is placed in the else-branch of an if-conditional that checks for the normal case, i.e. if the current room is *not* (11,7), thus being a negative conditional.

  In other words, the positive conditional is `game.roomx == 111 && game.roomy == 107`. To negate it, all you would have to do is `!(game.roomx == 111 && game.roomy == 107)`.

  However, whoever wrote this decided to go one step further, and actually *distribute* the negative into both statements. This would be fine, except if they actually got it right. You see, according to De Morgan's laws, when you distribute a negative across multiple statements you not only have to negate the statements themselves, but you have to negate all the *conjunctions*, too. In other words, you have to change all "and"s into "or"s and all "or"s into "and"s.

  Instead of making the conditional `game.roomx != 111 || game.roomy != 107`, the person who wrote this forgot to replace the "and" with an "or". Thus, it is `game.roomx != 111 && game.roomy != 107` instead. As a result, if we re-negate this and take a look at the positive conditional, i.e. the conditional that results in the else-branch executing, it turns out to be `game.roomx == 111 || game.roomy == 107`. This ends up forming a cross-shape of rooms where this kludge happens. As long as your room is either on the line x=11 or on the line y=7, this kludge will execute.

  You can see this if you go to Boldly To Go, since it is (11,13), which is on the line x=11. Checkpoint in that room, then touch a disappearing platform, wait for it to fully disappear, then die. Then an invisible tile will be placed to the left of the spikes on the ceiling.

  Anyway, to fix this, it's simple. Just change the "and" in the negative conditional to an "or".

  The second problem was that this kludge was happening in custom levels. So I've added a `map.custommode` check to it. I made sure not to make the same mistake originally made, i.e. I made sure to use an "or" instead of an "and". Thus, when you re-negate the negative conditional and turn it
into the positive conditional, it reads: `game.roomx == 111 && game.roomy == 107 && !map.custommode`.



## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
