### PR TITLE
Fix hardcoded (19,8) all-sides warp happening in custom levels

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1304,7 +1304,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		}
 	}
 
-	if (rx == 119 && ry == 108)
+	if (rx == 119 && ry == 108 && !custommode)
 	{
 		background = 5;
 		dwgfx.rcol = 3;

--- a/mobile_version/src/mapclass.as
+++ b/mobile_version/src/mapclass.as
@@ -892,7 +892,7 @@
 				}
 			}
 			
-			if (rx == 119 && ry == 108) {
+			if (rx == 119 && ry == 108 && !custommode) {
 				background = 5;
 				dwgfx.rcol = 3;
 				warpx = true;


### PR DESCRIPTION
## Changes:

* **Fix (19,8)'s hardcoded all-sides warping happening in custom levels**

  (19,8) is hardcoded to warp on all-sides no matter what. This is fine, except for the fact that it was doing this in custom levels, too, even despite the fact that the warp background and color would be overridden anyway. The only workaround was to add a warp line to the room in custom levels. I've added a check for custommode so that this won't happen.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
