### PR TITLE
Add -assets option to specify data.zip

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -39,7 +39,7 @@ void PLATFORM_getOSDirectory(char* output);
 void PLATFORM_migrateSaveData(char* output);
 void PLATFORM_copyFile(const char *oldLocation, const char *newLocation);
 
-int FILESYSTEM_init(char *argvZero)
+int FILESYSTEM_init(char *argvZero, char *assetsPath)
 {
 	char output[MAX_PATH];
 	int mkdirResult;
@@ -79,8 +79,12 @@ int FILESYSTEM_init(char *argvZero)
 	}
 
 	/* Mount the stock content last */
-	strcpy(output, PHYSFS_getBaseDir());
-	strcat(output, "data.zip");
+	if (assetsPath) {
+            strcpy(output, assetsPath);
+        } else {
+            strcpy(output, PHYSFS_getBaseDir());
+            strcat(output, "data.zip");
+        }
 	if (!PHYSFS_mount(output, NULL, 1))
 	{
 		puts("Error: data.zip missing!");

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -80,11 +80,11 @@ int FILESYSTEM_init(char *argvZero, char *assetsPath)
 
 	/* Mount the stock content last */
 	if (assetsPath) {
-            strcpy(output, assetsPath);
-        } else {
-            strcpy(output, PHYSFS_getBaseDir());
-            strcat(output, "data.zip");
-        }
+		strcpy(output, assetsPath);
+	} else {
+		strcpy(output, PHYSFS_getBaseDir());
+		strcat(output, "data.zip");
+	}
 	if (!PHYSFS_mount(output, NULL, 1))
 	{
 		puts("Error: data.zip missing!");

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -6,7 +6,7 @@
 
 #include "tinyxml.h"
 
-int FILESYSTEM_init(char *argvZero);
+int FILESYSTEM_init(char *argvZero, char* assetsPath);
 void FILESYSTEM_deinit();
 
 char *FILESYSTEM_getUserSaveDirectory();

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -44,10 +44,6 @@ entityclass obj;
 
 int main(int argc, char *argv[])
 {
-    if(!FILESYSTEM_init(argv[0]))
-    {
-        return 1;
-    }
     SDL_Init(
         SDL_INIT_VIDEO |
         SDL_INIT_AUDIO |
@@ -55,9 +51,21 @@ int main(int argc, char *argv[])
         SDL_INIT_GAMECONTROLLER
     );
 
-    if (argc > 2 && strcmp(argv[1], "-renderer") == 0)
+    char* assets = NULL;
+
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "-renderer") == 0) {
+            ++i;
+            SDL_SetHintWithPriority(SDL_HINT_RENDER_DRIVER, argv[i], SDL_HINT_OVERRIDE);
+        } else if (strcmp(argv[i], "-assets") == 0) {
+            ++i;
+            assets = argv[i];
+        }
+    }
+
+    if(!FILESYSTEM_init(argv[0], assets))
     {
-        SDL_SetHintWithPriority(SDL_HINT_RENDER_DRIVER, argv[2], SDL_HINT_OVERRIDE);
+        return 1;
     }
 
     NETWORK_init();


### PR DESCRIPTION
## Changes:

This is useful for distributions, which may not want to put data.zip in the same directory as the binary. This can't be distribution-specific due to the license ("Altered source/binary versions must be plainly marked as such, and must not be misrepresented as being the original software.").


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes