### PR TITLE
Fix discoloration when entities warp in flip mode

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1464,7 +1464,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                             drawRect = sprites_rect;
                             drawRect.x += tpoint.x;
                             drawRect.y += tpoint.y;
-                            BlitSurfaceStandard(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                            BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                         }
                         if (tpoint.x > 300)
                         {
@@ -1472,7 +1472,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                             drawRect = sprites_rect;
                             drawRect.x += tpoint.x;
                             drawRect.y += tpoint.y;
-                            BlitSurfaceStandard(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                            BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                         }
                     }
                     else if (map.warpy)
@@ -1483,7 +1483,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                             drawRect = sprites_rect;
                             drawRect.x += tpoint.x;
                             drawRect.y += tpoint.y;
-                            BlitSurfaceStandard(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                            BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                         }
                         if (tpoint.y > 210)
                         {
@@ -1491,7 +1491,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                             drawRect = sprites_rect;
                             drawRect.x += tpoint.x;
                             drawRect.y += tpoint.y;
-                            BlitSurfaceStandard(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                            BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                         }
                     }
                 }


### PR DESCRIPTION
## Changes:

* **Fix warping entities being the wrong color in flip mode**

  In flip mode, warping entities would appear to change color for a brief moment. This is actually them defaulting to the actual color used in `flipsprites.png`, instead of first being whited-out and then re-colored using `graphics.setcol()`.

  To fix this, use `BlitSurfaceColoured()` and pass `ct` along instead of using `BlitSurfaceStandard()`.

  Before:
  ![Warping entities in flip mode: before](https://user-images.githubusercontent.com/59748578/73616653-ecfdfc80-45ca-11ea-8320-1e608923b793.png)

  After:
  ![Warping entities in flip mode: after](https://user-images.githubusercontent.com/59748578/73616642-d192f180-45ca-11ea-818a-c903d80510a8.png)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
