### PR TITLE
Account for the height of the textbox in flipme()

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -573,7 +573,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "flipme")
 			{
-				if(dwgfx.flipmode) texty += 2*(120 - texty);
+				if(dwgfx.flipmode) texty += 2*(120 - texty) - 8*(txtnumlines+2);
 			}
 			else if (words[0] == "speak_active")
 			{


### PR DESCRIPTION
## Changes:

* **Fix `flipme()` positioning text boxes incorrectly**

  The problem with `flipme()` was that it *was* properly reflecting ("reflecting" as in mirroring over a given line) the text box over the line y=120, *but* it forgot to account for the height of the text box. Thus, the text box position would be off by the length of its own height. And when the text box got taller, this offset would worsen and worsen.

  Here are some screenshots to demonstrate the difference.

  Not in flip mode:
  ![flipme() when not in flip mode](https://user-images.githubusercontent.com/59748578/73619309-b8496f80-45e1-11ea-8eae-158abb6c8628.png)

  In flip mode, using buggy `flipme()` positioning:
  ![Buggy flipme() when in flip mode](https://user-images.githubusercontent.com/59748578/73619339-d44d1100-45e1-11ea-8804-2e493b71d436.png)

  In flip mode, with fixed `flipme()` positioning:
  ![Fixed flipme() when in flip mode](https://user-images.githubusercontent.com/59748578/73619366-f3e43980-45e1-11ea-9a8c-91118b14f9a7.png)



## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
