### PR TITLE
Fix Prize for the Reckless moving platform kludge happening in custom levels

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -576,7 +576,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
     {
         for (int i = 0; i < obj.nentity; i++)
         {
-            if (game.roomx == 111 && game.roomy == 107)
+            if (game.roomx == 111 && game.roomy == 107 && !map.custommode)
             {
                 if (obj.entities[i].type == 1)
                 {


### PR DESCRIPTION
## Changes:

* **Fix Prize for the Reckless moving platform kludge happening in custom levels**

  If you died in (11,7) and a moving platform was to the left of the line x=152, even if it was moving vertically it would get snapped to x=152, in custom levels.

  Surprised nobody has ran into this before (although people have ran into the other kludge, which is placing tile 59 at [18,9] if you're in a room on either the line x=11 or y=7).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
