### PR TITLE
Draw entities backwards in towers like entities outside towers

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2477,7 +2477,7 @@ void Graphics::drawtowerentities( mapclass& map, entityclass& obj, UtilityClass&
     point tpoint;
     SDL_Rect trect;
 
-    for (int i = 0; i < obj.nentity; i++)
+    for (int i = obj.nentity - 1; i >= 0; i--)
     {
         if (!obj.entities[i].invis && obj.entities[i].active)
         {


### PR DESCRIPTION
## Changes:

* **Draw entities backwards in `towermode` like non-`towermode` entities**

  This fixes a bug where the player was going behind checkpoints in towers and it looked very weird and cursed.

  Before:
  ![Entity draw order in towers: before](https://user-images.githubusercontent.com/59748578/73710057-c10c7500-46b7-11ea-945c-b2ce5cced38d.png)

  After:
  ![Entity draw order in towers: after](https://user-images.githubusercontent.com/59748578/73710066-c964b000-46b7-11ea-8b51-a12e0de7a0fc.png)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
