### PR TITLE
Render screen shaking in towers

### DIFF
--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -2933,7 +2933,15 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
         dwgfx.flashlight();
     }
 
-    dwgfx.render();
+    if (game.screenshake > 0 && !game.noflashingmode)
+    {
+        game.screenshake--;
+        dwgfx.screenshake();
+    }
+    else
+    {
+        dwgfx.render();
+    }
 }
 
 void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help)


### PR DESCRIPTION
## Changes:

* **Render screen shaking in towers**

  It's really obvious that screen shaking is not processed in towers if you bring up the pause menu then quickly quicksave and bring it back down. The screen won't shake, but it will suddenly start shaking if you exit the tower, finishing off the stalled screenshake timer.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
