### PR TITLE
Make hardest room "Dimension VVVVVV" if it has no room name

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4171,6 +4171,10 @@ void Game::gethardestroom( mapclass& map )
             if (roomx == 50 && roomy == 53) hardestroom =map.specialnames[6];
             if (roomx == 50 && roomy == 54) hardestroom = map.specialnames[7];
         }
+        else if (map.roomname == "")
+        {
+            hardestroom = "Dimension VVVVVV";
+        }
     }
 }
 


### PR DESCRIPTION
## Changes:

* **Make the hardest room be named "Dimension VVVVVV" if it has no room name**

  The only places where you can die in a room without a room name is the Overworld, and I feel that calling it Dimension VVVVVV is appropriate.

  You can't naturally die in The Ship nor the Secret Lab, and you can only do it by pressing R, so I didn't feel it appropriate to add checks to make the hardest room be "The Ship" or "The Secret Lab" if you managed to get your hardest room to be a room in either of those areas.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
