### PR TITLE
Make tiles in tower mode consistent with tower tileset elsewhere

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -37,12 +37,6 @@ bool entityclass::checktowerspikes(int t, mapclass& map)
             }
         }
     }
-    if (temprect.w >= 12)
-    {
-        tpx1 = getgridpoint(temprect.x + 6);
-        if (map.collide(tpx1, tempy)) return true;
-        if (map.collide(tpx1, temph)) return true;
-    }
     return false;
 }
 

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -699,6 +699,10 @@ bool mapclass::collide(int x, int y)
 	if (towermode)
 	{
 		if (tower.at(x, y, 0) >= 12 && tower.at(x, y, 0) <= 27) return true;
+		if (invincibility)
+		{
+			if (tower.at(x, y, 0) >= 6 && tower.at(x, y, 0) <= 11) return true;
+		}
 	}
 	else if (tileset == 2)
 	{


### PR DESCRIPTION
Previously, in tower mode, being inside walls would just kill you, unlike
being inside walls outside tower mode, which was somewhat confusing.

Also, spikes behaved differently with regards to invincibility, being
unsolid in towers but solid outside them.

This does not change the behaviour of the "edge" spikes in towers.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
