### PR TITLE
Fix undefined behavior while loading scripts

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -16,6 +16,7 @@ Contributors
 * Elijah Stone
 * Thomas Sänger (@HorayNarea)
 * Info Teddy (@InfoTeddy)
+* Alexandra Tildea (@AllyTally)
 * leo60228 (@leo60228)
 * Emmanuel Vadot (@evadot)
 * Rémi Verschelde (@akien-mga)

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -480,6 +480,7 @@ void Game::init(void)
     githubfriends.push_back("Elijah Stone");
     githubfriends.push_back("Thomas S|nger");
     githubfriends.push_back("Info Teddy");
+    githubfriends.push_back("Alexandra Tildea");
     githubfriends.push_back("leo60228");
     githubfriends.push_back("Emmanuel Vadot");
     githubfriends.push_back("Remi Verschelde"); // TODO: Change to "Rémi" if/when UTF-8 support is added

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -468,7 +468,11 @@ void editorclass::removehookfromscript(std::string t)
         {
             //If this line is not the start of a new hook, remove it!
             tstring=script.customscript[i];
-            tstring=tstring[tstring.length()-1];
+            if (tstring.length() > 0) {
+                tstring=tstring[tstring.length()-1];
+            } else {
+                tstring="";
+            }
             if(tstring==":")
             {
                 //this is a hook


### PR DESCRIPTION
## Changes:

In `editor.cpp`, there's a few sections of code that try and index stuff using `string.length()-1`.
This causes issues where if the string is empty, the result is -1, causing undefined behavior.
Flibit fixed a few of these cases, like on line `375` of editor.cpp:
`if((int) tstring.length() - 1 >= 0) // FIXME: This is sketchy. -flibit`
It turns out that one of these weren't caught, over at line `471`.
`tstring=tstring[tstring.length()-1];`
This causes builds compiled on Windows to segfault if you load more than one level in the editor.
I added a quick `if` around it, setting `tstring` to an empty string, which seems to fix the problem.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
