### PR TITLE
Fix undefined behavior when activating scripts

### DIFF
--- a/desktop_version/src/Scripts.cpp
+++ b/desktop_version/src/Scripts.cpp
@@ -40,7 +40,11 @@ void scriptclass::load(std::string t)
         }else if(scriptend==-1){
           //Find the end
           tstring=script.customscript[i];
-          tstring=tstring[tstring.size()-1];
+          if (tstring.size() > 0) {
+            tstring=tstring[tstring.size()-1];
+          } else {
+            tstring="";
+          }
           if(tstring==":"){
             scriptend=i;
           }


### PR DESCRIPTION
## Changes:

It turns out that the line `tstring=tstring[tstring.size()-1];` also appears once in Scripts.cpp.
This causes the game to segfault after activating a terminal with an empty line at the end of it.
I added a quick `if` around this line, and set `tstring` to an empty string when needed.
(Sorry! If I knew there was more than one instance of this before making my last PR I would have fixed this too! Turns out `.size()` and `.length()` both exist...)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
