### PR TITLE
Add -basedir option to specify base user directory 

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -3,6 +3,7 @@ Contributors
 
 (Ordered alphabetically by last name.)
 
+* Matt "Stelpjo" Aaldenberg
 * Christoph Böhmwalder (@chrboe)
 * Charlie Bruce (@charliebruce)
 * Brian Callahan (@ibara)
@@ -10,6 +11,7 @@ Contributors
 * Allison Fleischer (AllisonFleischer)
 * Daniel Lee (@ddm999)
 * Fredrik Ljungdahl (@FredrIQ)
+* Matt Penny (@mwpenny)
 * Elliott Saltar (@eboyblue3)
 * Marvin Scholz (@ePirat)
 * Keith Stellyes (@keithstellyes)
@@ -22,4 +24,3 @@ Contributors
 * Rémi Verschelde (@akien-mga)
 * viri (viri.me)
 * Wouter (Xesxen)
-* Matt "Stelpjo" Aaldenberg

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -32,6 +32,12 @@ int mkdir(char* path, int mode)
 #define MAX_PATH PATH_MAX
 #endif
 
+#ifdef _WIN32
+	#define PATH_SEP '\\'
+#else
+	#define PATH_SEP '/'
+#endif
+
 char saveDir[MAX_PATH];
 char levelDir[MAX_PATH];
 
@@ -39,7 +45,7 @@ void PLATFORM_getOSDirectory(char* output);
 void PLATFORM_migrateSaveData(char* output);
 void PLATFORM_copyFile(const char *oldLocation, const char *newLocation);
 
-int FILESYSTEM_init(char *argvZero, char *assetsPath)
+int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 {
 	char output[MAX_PATH];
 	int mkdirResult;
@@ -48,7 +54,20 @@ int FILESYSTEM_init(char *argvZero, char *assetsPath)
 	PHYSFS_permitSymbolicLinks(1);
 
 	/* Determine the OS user directory */
-	PLATFORM_getOSDirectory(output);
+	if (baseDir && strlen(baseDir) > 0)
+	{
+		strcpy(output, baseDir);
+
+		/* We later append to this path and assume it ends in a slash */
+		if (output[strlen(output)] != PATH_SEP)
+		{
+			strcat(output, std::string(1, PATH_SEP).c_str());
+		}
+	}
+	else
+	{
+		PLATFORM_getOSDirectory(output);
+	}
 
 	/* Create base user directory, mount */
 	mkdirResult = mkdir(output, 0777);

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -32,12 +32,6 @@ int mkdir(char* path, int mode)
 #define MAX_PATH PATH_MAX
 #endif
 
-#ifdef _WIN32
-	#define PATH_SEP '\\'
-#else
-	#define PATH_SEP '/'
-#endif
-
 char saveDir[MAX_PATH];
 char levelDir[MAX_PATH];
 
@@ -49,6 +43,7 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 {
 	char output[MAX_PATH];
 	int mkdirResult;
+	const char* pathSep = PHYSFS_getDirSeparator();
 
 	PHYSFS_init(argvZero);
 	PHYSFS_permitSymbolicLinks(1);
@@ -59,9 +54,9 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 		strcpy(output, baseDir);
 
 		/* We later append to this path and assume it ends in a slash */
-		if (output[strlen(output)] != PATH_SEP)
+		if (strcmp(std::string(1, output[strlen(output) - 1]).c_str(), pathSep) != 0)
 		{
-			strcat(output, std::string(1, PATH_SEP).c_str());
+			strcat(output, pathSep);
 		}
 	}
 	else

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -6,7 +6,7 @@
 
 #include "tinyxml.h"
 
-int FILESYSTEM_init(char *argvZero, char* assetsPath);
+int FILESYSTEM_init(char *argvZero, char* baseDir, char* assetsPath);
 void FILESYSTEM_deinit();
 
 char *FILESYSTEM_getUserSaveDirectory();

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -468,12 +468,15 @@ void Game::init(void)
     patrons.push_back("Timothy Bragan");
 
     /* CONTRIBUTORS.txt, again listed alphabetically (according to `sort`) by last name */
+    githubfriends.push_back("Matt \"Stelpjo\" Aaldenberg");
     githubfriends.push_back("Christoph B{hmwalder");
     githubfriends.push_back("Charlie Bruce");
     githubfriends.push_back("Brian Callahan");
     githubfriends.push_back("Dav999");
     githubfriends.push_back("Allison Fleischer");
     githubfriends.push_back("Daniel Lee");
+    githubfriends.push_back("Fredrik Ljungdahl");
+    githubfriends.push_back("Matt Penny");
     githubfriends.push_back("Elliott Saltar");
     githubfriends.push_back("Marvin Scholz");
     githubfriends.push_back("Keith Stellyes");

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -51,19 +51,23 @@ int main(int argc, char *argv[])
         SDL_INIT_GAMECONTROLLER
     );
 
-    char* assets = NULL;
+    char* baseDir = NULL;
+    char* assetsPath = NULL;
 
     for (int i = 1; i < argc; ++i) {
         if (strcmp(argv[i], "-renderer") == 0) {
             ++i;
             SDL_SetHintWithPriority(SDL_HINT_RENDER_DRIVER, argv[i], SDL_HINT_OVERRIDE);
+        } else if (strcmp(argv[i], "-basedir") == 0) {
+            ++i;
+            baseDir = argv[i];
         } else if (strcmp(argv[i], "-assets") == 0) {
             ++i;
-            assets = argv[i];
+            assetsPath = argv[i];
         }
     }
 
-    if(!FILESYSTEM_init(argv[0], assets))
+    if(!FILESYSTEM_init(argv[0], baseDir, assetsPath))
     {
         return 1;
     }


### PR DESCRIPTION
## Changes:

Added a command-line argument to specify the location of the base user directory. This is useful for maintaining multiple save files or for debugging.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
