### PR TITLE
Make "[Press ENTER to return to editor]" fade out after a bit

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -264,13 +264,18 @@ void Graphics::MakeSpriteArray()
 }
 
 
-void Graphics::Print( int _x, int _y, std::string _s, int r, int g, int b, bool cen /*= false*/ )
+void Graphics::Print( int _x, int _y, std::string _s, int r, int g, int b, bool cen /*= false*/ ) {
+    return PrintAlpha(_x,_y,_s,r,g,b,255,cen);
+}
+
+void Graphics::PrintAlpha( int _x, int _y, std::string _s, int r, int g, int b, int a, bool cen /*= false*/ )
 {
     r = clamp(r,0,255);
     g = clamp(g,0,255);
     b = clamp(b,0,255);
+    a = clamp(a,0,255);
 
-    ct.colour = getRGB(r, g, b);
+    ct.colour = getRGBA(r, g, b, a);
 
     if (cen)
         _x = ((160 ) - ((len(_s)) / 2));
@@ -358,11 +363,16 @@ int Graphics::len(std::string t)
     return bfontpos;
 }
 
-void Graphics::PrintOff( int _x, int _y, std::string _s, int r, int g, int b, bool cen /*= false*/ )
+void Graphics::PrintOff( int _x, int _y, std::string _s, int r, int g, int b, bool cen /*= false*/ ) {
+    PrintOffAlpha(_x,_y,_s,r,g,b,255,cen);
+}
+
+void Graphics::PrintOffAlpha( int _x, int _y, std::string _s, int r, int g, int b, int a, bool cen /*= false*/ )
 {
     r = clamp(r,0,255);
     g = clamp(g,0,255);
     b = clamp(b,0,255);
+    a = clamp(a,0,255);
 
     ct.colour = getRGB(r, g, b);
 
@@ -395,28 +405,32 @@ void Graphics::PrintOff( int _x, int _y, std::string _s, int r, int g, int b, bo
     }
 }
 
-void Graphics::bprint( int x, int y, std::string t, int r, int g, int b, bool cen /*= false*/ )
+void Graphics::bprint( int x, int y, std::string t, int r, int g, int b, bool cen /*= false*/ ) {
+    bprintalpha(x,y,t,r,g,b,255,cen);
+}
+
+void Graphics::bprintalpha( int x, int y, std::string t, int r, int g, int b, int a, bool cen /*= false*/ )
 {
 
     //printmask(x, y, t, cen);
     if (!notextoutline)
     {
-        Print(x, y - 1, t, 0, 0, 0, cen);
+        PrintAlpha(x, y - 1, t, 0, 0, 0, a, cen);
         if (cen)
         {
             //TODO find different
-            PrintOff(-1, y, t, 0, 0, 0, cen);
-            PrintOff(1, y, t, 0, 0, 0, cen);
+            PrintOffAlpha(-1, y, t, 0, 0, 0, a, cen);
+            PrintOffAlpha(1, y, t, 0, 0, 0, a, cen);
         }
         else
         {
-            Print(x  -1, y, t, 0, 0, 0, cen);
-            Print(x  +1, y, t, 0, 0, 0, cen);
+            PrintAlpha(x  -1, y, t, 0, 0, 0, a, cen);
+            PrintAlpha(x  +1, y, t, 0, 0, 0, a, cen);
         }
-        Print(x, y+1, t, 0, 0, 0, cen);
+        PrintAlpha(x, y+1, t, 0, 0, 0, a, cen);
     }
 
-    Print(x, y, t, r, g, b, cen);
+    PrintAlpha(x, y, t, r, g, b, a, cen);
 }
 
 void Graphics::RPrint( int _x, int _y, std::string _s, int r, int g, int b, bool cen /*= false*/ )
@@ -3144,6 +3158,11 @@ void Graphics::drawtele(int x, int y, int t, int c, UtilityClass& help)
 	if (t < 0) t = 0;
 
 	BlitSurfaceColoured(tele[t], NULL, backBuffer, &telerect, ct);
+}
+
+Uint32 Graphics::getRGBA(Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+{
+	return SDL_MapRGBA(backBuffer->format, b, g, r, a);
 }
 
 Uint32 Graphics::getRGB(Uint8 r, Uint8 g, Uint8 b)

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -112,11 +112,17 @@ public:
 
 	void Print(int _x, int _y, std::string _s, int r, int g, int b, bool cen = false);
 
+	void PrintAlpha(int _x, int _y, std::string _s, int r, int g, int b, int a, bool cen = false);
+
 	void RPrint(int _x, int _y, std::string _s, int r, int g, int b, bool cen = false);
 
 	void PrintOff(int _x, int _y, std::string _s, int r, int g, int b, bool cen = false);
 
+	void PrintOffAlpha(int _x, int _y, std::string _s, int r, int g, int b, int a, bool cen = false);
+
 	void bprint(int x, int y, std::string t, int r, int g, int b, bool cen = false);
+
+	void bprintalpha(int x, int y, std::string t, int r, int g, int b, int a, bool cen = false);
 
 	int len(std::string t);
 	void bigprint( int _x, int _y, std::string _s, int r, int g, int b, bool cen = false, int sc = 2 );
@@ -138,6 +144,8 @@ public:
 
 
 	void drawtele(int x, int y, int t, int c, UtilityClass& help);
+
+	Uint32 getRGBA(Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 	Uint32 getRGB(Uint8 r, Uint8 g, Uint8 b);
 

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -300,7 +300,11 @@ void BlitSurfaceColoured(
             Uint32 pixel = ReadPixel(_src, x, y);
             Uint32 Alpha = pixel & fmt.Amask;
             Uint32 result = ct.colour & 0x00FFFFFF;
-            DrawPixel(tempsurface, x, y, result | Alpha);
+            Uint32 CTAlpha = ct.colour & fmt.Amask;
+            float div1 = ((Alpha >> 24) / 255.0f);
+            float div2 = ((CTAlpha >> 24) / 255.0f);
+            Uint32 UseAlpha = (div1 * div2) * 255.0f;
+            DrawPixel(tempsurface, x, y, result | (UseAlpha << 24));
         }
     }
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -4575,6 +4575,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
 
                         music.stopmusic();
                         dwgfx.backgrounddrawn=false;
+                        ed.returneditoralpha = 1000; // Let's start it higher than 255 since it gets clamped
                         script.startgamemode(21, key, dwgfx, game, map, obj, help, music);
                     }
                     //Return to game

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -234,6 +234,8 @@ class editorclass{
   //Direct Mode variables
   int dmtile;
   int dmtileeditor;
+
+  int returneditoralpha = 0;
 };
 
 void addedentity(int xp, int yp, int tp, int p1=0, int p2=0, int p3=0, int p4=0, int p5=320, int p6=240);

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -1604,7 +1604,10 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
 
      if(map.custommode && !map.custommodeforreal && !game.advancetext){
         //Return to level editor
-        dwgfx.bprint(5, 5, "[Press ENTER to return to editor]", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
+        dwgfx.bprintalpha(5, 5, "[Press ENTER to return to editor]", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), ed.returneditoralpha, false);
+        if (ed.returneditoralpha > 0) {
+            ed.returneditoralpha -= 15;
+        }
       }
 
 


### PR DESCRIPTION
## Changes:

This makes the `[Press ENTER to return to editor]` text in the editor fade out after a few frames, allowing screenshots of custom levels to be cleaner and to make sure nothing is obscured while the user is editing their level.
This commit also adds alpha support in BlitSurfaceColoured, where it takes into account the alpha of the pixel *and* the alpha of the color.
`graphics::getRGBA(r,g,b,a)` was added to help with this.

This is useful for future changes if anyone needs to use BlitSurfaceColoured with an alpha color, which could be something like making the translucent roomname bar use BlitSurfaceColoured instead of an entirely new surface.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
