### PR TITLE
Prevent removing the line if there is only one line in the script editor

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -546,7 +546,7 @@ void editorclass::clearscriptbuffer()
 void editorclass::removeline(int t)
 {
     //Remove line t from the script
-    if(sblength>0)
+    if(sblength>1)
     {
         if(sblength==t)
         {


### PR DESCRIPTION

## Changes:

* **Prevent removing the line if there is only one line in the script editor**

  This fixes another way you could end up typing on a non-existent line in the script editor.

  In a script with only 1 line, which is empty, the game would let you press backspace on it, removing the line. This results in you typing on a non-existent line.

  You will keep typing on it until you either close the script or press Up. If you press Up, you will be unable to get back to the non-existent line, for it doesn't exist - but the text you typed on the non-existent line will still be there, until you close the script and re-open it.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
