### PR TITLE
Fix NO_CUSTOM_LEVELS compile after #158

### DIFF
--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -1604,6 +1604,7 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
         }
     }
 
+#if !defined(NO_CUSTOM_LEVELS)
      if(map.custommode && !map.custommodeforreal && !game.advancetext){
         //Return to level editor
         dwgfx.bprintalpha(5, 5, "[Press ENTER to return to editor]", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), ed.returneditoralpha, false);
@@ -1611,6 +1612,7 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
             ed.returneditoralpha -= 15;
         }
       }
+#endif
 
 
     dwgfx.cutscenebars();


### PR DESCRIPTION
## Changes:

After PR #158, the "return to editor" text now fades out after a short time. The state of the fade is tracked via a variable in the editor class. If building with CUSTOM_LEVEL_SUPPORT=NO_CUSTOM_LEVELS (PR #157), the build now fails because the editor class is omitted. This PR ifdefs out the code that draws the "return to editor" text when compiling without custom level support.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
