### PR TITLE
Support pre-C++11 compilers

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -133,7 +133,7 @@ void Graphics::init()
     showmousecursor = true;
 }
 
-int Graphics::font_idx(char32_t ch) {
+int Graphics::font_idx(uint32_t ch) {
     if (font_positions.size() > 0) {
         std::map<int, int>::iterator iter = font_positions.find(ch);
         if (iter == font_positions.end()) {
@@ -194,7 +194,7 @@ void Graphics::Makebfont()
     }
 }
 
-int Graphics::bfontlen(char32_t ch) {
+int Graphics::bfontlen(uint32_t ch) {
     if (ch < 32) {
         return 6;
     } else {

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -19,6 +19,11 @@
 #include "GraphicsUtil.h"
 #include "Screen.h"
 
+#if __cplusplus < 201103L  // Pre-C++11
+typedef uint32_t char32_t;
+typedef uint16_t char16_t;
+#endif
+
 class map;
 
 class Graphics

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -19,11 +19,6 @@
 #include "GraphicsUtil.h"
 #include "Screen.h"
 
-#if __cplusplus < 201103L  // Pre-C++11
-typedef uint32_t char32_t;
-typedef uint16_t char16_t;
-#endif
-
 class map;
 
 class Graphics
@@ -34,8 +29,8 @@ public:
 
 	GraphicsResources grphx;
 
-	int bfontlen(char32_t ch);
-	int font_idx(char32_t ch);
+	int bfontlen(uint32_t ch);
+	int font_idx(uint32_t ch);
 
 	void Makebfont();
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -355,6 +355,8 @@ void editorclass::reset()
     hookmenu=0;
     numhooks=0;
     script.customscript.clear();
+
+    returneditoralpha = 0;
 }
 
 void editorclass::weirdloadthing(std::string t)

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -237,7 +237,7 @@ class editorclass{
   int dmtile;
   int dmtileeditor;
 
-  int returneditoralpha = 0;
+  int returneditoralpha;
 };
 
 void addedentity(int xp, int yp, int tp, int p1=0, int p2=0, int p3=0, int p4=0, int p5=320, int p6=240);


### PR DESCRIPTION
## Changes:

I love how active this repo seems to be! Unfortunately some of the changes are incompatible with older compilers. Fortunately, the problems are small and easy to fix.

1) Pre-C++11 compilers do not support initializing variables in class declarations.
    This only occurs once, in the editor class. I've moved the initialization to the `reset()` method instead. The added benefit is that the variable gets properly reset.
2) Pre-C++11 compilers do not support `char32_t`.
    Use `uint32_t` instead. Everywhere else in the code already uses either `uint32_t` or `int`.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
