### PR TITLE
Implement command-line playtesting

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -148,27 +148,27 @@ char *FILESYSTEM_getUserLevelDirectory()
 void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem,
                                  size_t *len, bool addnull)
 {
-        if (strcmp(name, "levels/special/stdin.vvvvvv") == 0) {
-            // this isn't *technically* necessary when piping directly from a file, but checking for that is annoying
-            static std::vector<char> STDIN_BUFFER;
-            static bool STDIN_LOADED = false;
-            if (!STDIN_LOADED) {
-                std::istreambuf_iterator<char> begin(std::cin), end;
-                STDIN_BUFFER.assign(begin, end);
-                STDIN_BUFFER.push_back(0); // there's no observable change in behavior if addnull is always true, but not vice versa
-                STDIN_LOADED = true;
-            }
+	if (strcmp(name, "levels/special/stdin.vvvvvv") == 0) {
+		// this isn't *technically* necessary when piping directly from a file, but checking for that is annoying
+		static std::vector<char> STDIN_BUFFER;
+		static bool STDIN_LOADED = false;
+		if (!STDIN_LOADED) {
+			std::istreambuf_iterator<char> begin(std::cin), end;
+			STDIN_BUFFER.assign(begin, end);
+			STDIN_BUFFER.push_back(0); // there's no observable change in behavior if addnull is always true, but not vice versa
+			STDIN_LOADED = true;
+		}
 
-            auto length = STDIN_BUFFER.size() - 1;
-            if (len != NULL) {
-                *len = length;
-            }
+		size_t length = STDIN_BUFFER.size() - 1;
+		if (len != NULL) {
+			*len = length;
+		}
 
-            ++length;
-            *mem = static_cast<unsigned char*>(malloc(length)); // STDIN_BUFFER.data() causes double-free
-            std::copy(STDIN_BUFFER.begin(), STDIN_BUFFER.end(), reinterpret_cast<char*>(*mem));
-            return;
-        }
+		++length;
+		*mem = static_cast<unsigned char*>(malloc(length)); // STDIN_BUFFER.data() causes double-free
+		std::copy(STDIN_BUFFER.begin(), STDIN_BUFFER.end(), reinterpret_cast<char*>(*mem));
+		return;
+	}
 
 	PHYSFS_File *handle = PHYSFS_openRead(name);
 	if (handle == NULL)

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -164,7 +164,7 @@ void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem,
                 *len = length;
             }
 
-            if (addnull) ++length;
+            ++length;
             *mem = static_cast<unsigned char*>(malloc(length)); // STDIN_BUFFER.data() causes double-free
             std::copy(STDIN_BUFFER.begin(), STDIN_BUFFER.end(), reinterpret_cast<char*>(*mem));
             return;

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -145,34 +145,28 @@ char *FILESYSTEM_getUserLevelDirectory()
 	return levelDir;
 }
 
-static unsigned char cast_to_unsigned_char(char orig) {
-    return static_cast<unsigned char>(orig);
-}
-
 void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem,
                                  size_t *len, bool addnull)
 {
         if (strcmp(name, "levels/special/stdin.vvvvvv") == 0) {
             // this isn't *technically* necessary when piping directly from a file, but checking for that is annoying
-            static bool STDIN_LOADED = false;
             static std::vector<char> STDIN_BUFFER;
+            static bool STDIN_LOADED = false;
             if (!STDIN_LOADED) {
                 std::istreambuf_iterator<char> begin(std::cin), end;
                 STDIN_BUFFER.assign(begin, end);
+                STDIN_BUFFER.push_back(0); // there's no observable change in behavior if addnull is always true, but not vice versa
                 STDIN_LOADED = true;
             }
 
-            auto length = STDIN_BUFFER.size();
+            auto length = STDIN_BUFFER.size() - 1;
             if (len != NULL) {
                 *len = length;
             }
-            if (addnull) {
-                *mem = (unsigned char *) malloc(length + 1);
-                (*mem)[length] = 0;
-            } else {
-                *mem = (unsigned char*) malloc(length);
-            }
-            std::transform(STDIN_BUFFER.begin(), STDIN_BUFFER.end(), *mem, cast_to_unsigned_char);
+
+            if (addnull) ++length;
+            *mem = static_cast<unsigned char*>(malloc(length)); // STDIN_BUFFER.data() causes double-free
+            std::copy(STDIN_BUFFER.begin(), STDIN_BUFFER.end(), reinterpret_cast<char*>(*mem));
             return;
         }
 

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -145,6 +145,10 @@ char *FILESYSTEM_getUserLevelDirectory()
 	return levelDir;
 }
 
+static unsigned char cast_to_unsigned_char(char orig) {
+    return static_cast<unsigned char>(orig);
+}
+
 void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem,
                                  size_t *len, bool addnull)
 {
@@ -168,7 +172,7 @@ void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem,
             } else {
                 *mem = (unsigned char*) malloc(length);
             }
-            std::transform(STDIN_BUFFER.begin(), STDIN_BUFFER.end(), *mem, [](char c) -> unsigned char { return static_cast<unsigned char>(c); });
+            std::transform(STDIN_BUFFER.begin(), STDIN_BUFFER.end(), *mem, cast_to_unsigned_char);
             return;
         }
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -373,6 +373,13 @@ void Game::init(void)
 
     skipfakeload = false;
 
+    cliplaytest = false;
+    playx = 0;
+    playy = 0;
+    playrx = 0;
+    playry = 0;
+    playgc = 0;
+
     /* Terry's Patrons... */
     superpatrons.push_back("Anders Ekermo");
     superpatrons.push_back("Andreas K|mper");

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5154,6 +5154,15 @@ void Game::loadquick()
 
 void Game::customloadquick(std::string savfile)
 {
+    if (cliplaytest) {
+        savex = playx;
+        savey = savey;
+        saverx = playrx;
+        savery = playry;
+        savegc = playgc;
+        return;
+    }
+
     std::string levelfile = savfile.substr(7);
     TiXmlDocument doc;
     if (!FILESYSTEM_loadTiXmlDocument(("saves/"+levelfile+".vvv").c_str(), &doc)) return;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -315,13 +315,12 @@ public:
 
     bool skipfakeload;
 
-    bool cliplaytest = false;
-    int playx = 0;
-    int playy = 0;
-    int playrx = 0;
-    int playry = 0;
-    int playgc = 0;
-
+    bool cliplaytest;
+    int playx;
+    int playy;
+    int playrx;
+    int playry;
+    int playgc;
 };
 
 extern Game game;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -314,6 +314,14 @@ public:
     std::vector<SDL_GameControllerButton> controllerButton_esc;
 
     bool skipfakeload;
+
+    bool cliplaytest = false;
+    int playx = 0;
+    int playy = 0;
+    int playrx = 0;
+    int playry = 0;
+    int playgc = 0;
+
 };
 
 extern Game game;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -197,7 +197,6 @@ int main(int argc, char *argv[])
     FillRect(graphics.footerbuffer, SDL_MapRGB(fmt, 0, 0, 0));
     graphics.Makebfont();
 
-
     graphics.foregroundBuffer =  SDL_CreateRGBSurface(SDL_SWSURFACE ,320 ,240 ,fmt->BitsPerPixel,fmt->Rmask,fmt->Gmask,fmt->Bmask,fmt->Amask  );
     SDL_SetSurfaceBlendMode(graphics.foregroundBuffer, SDL_BLENDMODE_NONE);
 
@@ -275,25 +274,20 @@ int main(int argc, char *argv[])
     obj.init();
 
     if (startinplaytest) {
-        game.levelpage=0;
-        ed.getDirectoryData();
-        game.loadcustomlevelstats();
+        game.levelpage = 0;
+        game.playcustomlevel = 0;
 
-        bool found = false;
+        ed.directoryList = { playtestname };
 
-        // search for the file in the vector
-        for(size_t i = 0; i < ed.ListOfMetaData.size(); i++) {
-            LevelMetaData currentmeta = ed.ListOfMetaData[i];
-            if (currentmeta.filename == playtestname) {
-                game.playcustomlevel = (int)i;
-                found = true;
-                break;
-            }
-        }
-        if (!found) {
+        LevelMetaData meta;
+        if (ed.getLevelMetaData(playtestname, meta)) {
+            ed.ListOfMetaData = { meta };
+        } else {
             printf("Level not found\n");
             return 1;
         }
+
+        game.loadcustomlevelstats();
         game.customleveltitle=ed.ListOfMetaData[game.playcustomlevel].title;
         game.customlevelfilename=ed.ListOfMetaData[game.playcustomlevel].filename;
         if (savefileplaytest) {

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -265,34 +265,7 @@ int main(int argc, char *argv[])
         }
         game.customleveltitle=ed.ListOfMetaData[game.playcustomlevel].title;
         game.customlevelfilename=ed.ListOfMetaData[game.playcustomlevel].filename;
-        std::string name = game.saveFilePath + ed.ListOfMetaData[game.playcustomlevel].filename.substr(7) + ".vvv";
-        TiXmlDocument doc(name.c_str());
-        game.mainmenu = 22;
-        std::string filename = std::string(ed.ListOfMetaData[game.playcustomlevel].filename);
-        ed.load(filename);
-        ed.findstartpoint();
-        game.gamestate = GAMEMODE;
-        script.hardreset();
-        game.customstart();
-        game.jumpheld = true;
-        map.custommodeforreal = true;
-        map.custommode = true;
-        map.customx = 100;
-        map.customy = 100;
-        if(obj.entities.empty()) {
-            obj.createentity(game.savex, game.savey, 0, 0);
-        } else {
-            map.resetplayer();
-        }
-        map.gotoroom(game.saverx, game.savery);
-        ed.generatecustomminimap();
-        map.customshowmm=true;
-        if(ed.levmusic>0){
-            music.play(ed.levmusic);
-        } else {
-            music.currentsong=-1;
-        }
-
+        script.startgamemode(22);
     }
 
     volatile Uint32 time, timePrev = 0;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
         } else if (strcmp(argv[i], "-assets") == 0) {
             ++i;
             assetsPath = argv[i];
-        } else if (strcmp(argv[i], "--playing") == 0 || strcmp(argv[i], "-p") == 0) {
+        } else if (strcmp(argv[i], "-playing") == 0 || strcmp(argv[i], "-p") == 0) {
             if (i + 1 < argc) {
                 startinplaytest = true;
                 i++;
@@ -78,27 +78,27 @@ int main(int argc, char *argv[])
                 playtestname.append(argv[i]);
                 playtestname.append(std::string(".vvvvvv"));
             } else {
-                printf("--playing option requires one argument.\n");
+                printf("-playing option requires one argument.\n");
                 return 1;
             }
-        } else if (strcmp(argv[i], "--playx") == 0 ||
-                strcmp(argv[i], "--playy") == 0 ||
-                strcmp(argv[i], "--playrx") == 0 ||
-                strcmp(argv[i], "--playry") == 0 ||
-                strcmp(argv[i], "--playgc") == 0 ||
-                strcmp(argv[i], "--playmusic") == 0) {
+        } else if (strcmp(argv[i], "-playx") == 0 ||
+                strcmp(argv[i], "-playy") == 0 ||
+                strcmp(argv[i], "-playrx") == 0 ||
+                strcmp(argv[i], "-playry") == 0 ||
+                strcmp(argv[i], "-playgc") == 0 ||
+                strcmp(argv[i], "-playmusic") == 0) {
             if (i + 1 < argc) {
                 savefileplaytest = true;
                 auto v = std::atoi(argv[i+1]);
-                if (strcmp(argv[i], "--playx") == 0) savex = v;
-                else if (strcmp(argv[i], "--playy") == 0) savey = v;
-                else if (strcmp(argv[i], "--playrx") == 0) saverx = v;
-                else if (strcmp(argv[i], "--playry") == 0) savery = v;
-                else if (strcmp(argv[i], "--playgc") == 0) savegc = v;
-                else if (strcmp(argv[i], "--playmusic") == 0) savemusic = v;
+                if (strcmp(argv[i], "-playx") == 0) savex = v;
+                else if (strcmp(argv[i], "-playy") == 0) savey = v;
+                else if (strcmp(argv[i], "-playrx") == 0) saverx = v;
+                else if (strcmp(argv[i], "-playry") == 0) savery = v;
+                else if (strcmp(argv[i], "-playgc") == 0) savegc = v;
+                else if (strcmp(argv[i], "-playmusic") == 0) savemusic = v;
                 i++;
             } else {
-                printf("--playing option requires one argument.\n");
+                printf("-playing option requires one argument.\n");
                 return 1;
             }
         }

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -45,6 +45,14 @@ mapclass map;
 entityclass obj;
 
 bool startinplaytest = false;
+bool savefileplaytest = false;
+int savex = 0;
+int savey = 0;
+int saverx = 0;
+int savery = 0;
+int savegc = 0;
+int savemusic = 0;
+
 std::string playtestname;
 
 int main(int argc, char *argv[])
@@ -73,6 +81,29 @@ int main(int argc, char *argv[])
                 printf("--playing option requires one argument.\n");
                 return 1;
             }
+        } else if (strcmp(argv[i], "--playx") == 0 ||
+                strcmp(argv[i], "--playy") == 0 ||
+                strcmp(argv[i], "--playrx") == 0 ||
+                strcmp(argv[i], "--playry") == 0 ||
+                strcmp(argv[i], "--playgc") == 0 ||
+                strcmp(argv[i], "--playmusic") == 0) {
+            if (i + 1 < argc) {
+                savefileplaytest = true;
+                auto v = std::atoi(argv[i+1]);
+                if (strcmp(argv[i], "--playx") == 0) savex = v;
+                else if (strcmp(argv[i], "--playy") == 0) savey = v;
+                else if (strcmp(argv[i], "--playrx") == 0) saverx = v;
+                else if (strcmp(argv[i], "--playry") == 0) savery = v;
+                else if (strcmp(argv[i], "--playgc") == 0) savegc = v;
+                else if (strcmp(argv[i], "--playmusic") == 0) savemusic = v;
+                i++;
+            } else {
+                printf("--playing option requires one argument.\n");
+                return 1;
+            }
+        }
+        if (std::string(argv[i]) == "-renderer") {
+            SDL_SetHintWithPriority(SDL_HINT_RENDER_DRIVER, argv[2], SDL_HINT_OVERRIDE);
         }
     }
 
@@ -265,7 +296,18 @@ int main(int argc, char *argv[])
         }
         game.customleveltitle=ed.ListOfMetaData[game.playcustomlevel].title;
         game.customlevelfilename=ed.ListOfMetaData[game.playcustomlevel].filename;
-        script.startgamemode(22);
+        if (savefileplaytest) {
+            game.playx = savex;
+            game.playy = savey;
+            game.playrx = saverx;
+            game.playry = savery;
+            game.playgc = savegc;
+            game.cliplaytest = true;
+            music.play(savemusic);
+            script.startgamemode(23);
+        } else {
+            script.startgamemode(22);
+        }
     }
 
     volatile Uint32 time, timePrev = 0;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -308,6 +308,8 @@ int main(int argc, char *argv[])
         } else {
             script.startgamemode(22);
         }
+
+        graphics.fademode = 0;
     }
 
     volatile Uint32 time, timePrev = 0;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -44,6 +44,9 @@ KeyPoll key;
 mapclass map;
 entityclass obj;
 
+bool startinplaytest = false;
+std::string playtestname;
+
 int main(int argc, char *argv[])
 {
     char* baseDir = NULL;
@@ -59,6 +62,17 @@ int main(int argc, char *argv[])
         } else if (strcmp(argv[i], "-assets") == 0) {
             ++i;
             assetsPath = argv[i];
+        } else if (strcmp(argv[i], "--playing") == 0 || strcmp(argv[i], "-p") == 0) {
+            if (i + 1 < argc) {
+                startinplaytest = true;
+                i++;
+                playtestname = std::string("levels/");
+                playtestname.append(argv[i]);
+                playtestname.append(std::string(".vvvvvv"));
+            } else {
+                printf("--playing option requires one argument.\n");
+                return 1;
+            }
         }
     }
 
@@ -228,6 +242,58 @@ int main(int argc, char *argv[])
     if(game.bestrank[5]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_final_fixed");
 
     obj.init();
+
+    if (startinplaytest) {
+        game.levelpage=0;
+        ed.getDirectoryData();
+        game.loadcustomlevelstats();
+
+        bool found = false;
+
+        // search for the file in the vector
+        for(size_t i = 0; i < ed.ListOfMetaData.size(); i++) {
+            LevelMetaData currentmeta = ed.ListOfMetaData[i];
+            if (currentmeta.filename == playtestname) {
+                game.playcustomlevel = (int)i;
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            printf("Level not found\n");
+            return 1;
+        }
+        game.customleveltitle=ed.ListOfMetaData[game.playcustomlevel].title;
+        game.customlevelfilename=ed.ListOfMetaData[game.playcustomlevel].filename;
+        std::string name = game.saveFilePath + ed.ListOfMetaData[game.playcustomlevel].filename.substr(7) + ".vvv";
+        TiXmlDocument doc(name.c_str());
+        game.mainmenu = 22;
+        std::string filename = std::string(ed.ListOfMetaData[game.playcustomlevel].filename);
+        ed.load(filename);
+        ed.findstartpoint();
+        game.gamestate = GAMEMODE;
+        script.hardreset();
+        game.customstart();
+        game.jumpheld = true;
+        map.custommodeforreal = true;
+        map.custommode = true;
+        map.customx = 100;
+        map.customy = 100;
+        if(obj.entities.empty()) {
+            obj.createentity(game.savex, game.savey, 0, 0);
+        } else {
+            map.resetplayer();
+        }
+        map.gotoroom(game.saverx, game.savery);
+        ed.generatecustomminimap();
+        map.customshowmm=true;
+        if(ed.levmusic>0){
+            music.play(ed.levmusic);
+        } else {
+            music.currentsong=-1;
+        }
+
+    }
 
     volatile Uint32 time, timePrev = 0;
     game.infocus = true;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
                 strcmp(argv[i], "-playmusic") == 0) {
             if (i + 1 < argc) {
                 savefileplaytest = true;
-                auto v = std::atoi(argv[i+1]);
+                int v = std::atoi(argv[i+1]);
                 if (strcmp(argv[i], "-playx") == 0) savex = v;
                 else if (strcmp(argv[i], "-playy") == 0) savey = v;
                 else if (strcmp(argv[i], "-playrx") == 0) saverx = v;
@@ -277,11 +277,13 @@ int main(int argc, char *argv[])
         game.levelpage = 0;
         game.playcustomlevel = 0;
 
-        ed.directoryList = { playtestname };
+        ed.directoryList.clear();
+        ed.directoryList.push_back(playtestname);
 
         LevelMetaData meta;
         if (ed.getLevelMetaData(playtestname, meta)) {
-            ed.ListOfMetaData = { meta };
+            ed.ListOfMetaData.clear();
+            ed.ListOfMetaData.push_back(meta);
         } else {
             printf("Level not found\n");
             return 1;


### PR DESCRIPTION
## Changes:

A long-requested feature of third-party VVVVVV level editors like Ved
has been to support playtesting. However, that hasn't been possible. For
April Fools Ved included Vis, a clone of VVVVVV with jumping advertising
itself as just having physics glitches, but until recently there hasn't
been any way to *actually* playtest a level. In November, I created
libvloader, which only on Linuxenabled this functionality. It was
quickly integrated into Ved in a PR, but the difficulties of using
LD_PRELOAD from Lua, as well as only supporting Linux, this stalled.
VVVVVV-CE has replicated this functionality, but due to the lack of a
stable release as well as minor incompatibilities, Ved has been
reluctant to add playtesting support that only supports VVVVVV-CE, but
this PR ports the playtesting support back to upstream. If there's
anything VVVVVV-CE specific I accidentally included in this PR, please
tell me!


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
