### PR TITLE
Fixed some music bugs

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -246,7 +246,7 @@ void musicclass::play(int t)
 		{
 			// musicfade = 0;
 			currentsong = t;
-			if (currentsong == 0 || currentsong == 7)
+			if (currentsong == 0 || currentsong == 7 || currentsong == 16 || currentsong == 23)
 			{
 				// Level Complete theme, no fade in or repeat
 				// musicchannel = musicchan[currentsong].play(0);
@@ -412,7 +412,7 @@ void musicclass::processmusic()
 void musicclass::niceplay(int t)
 {
 	// important: do nothing if the correct song is playing!
-	if(currentsong!=t)
+	if((!mmmmmm && currentsong!=t) || (mmmmmm && usingmmmmmm && currentsong!=t) || (mmmmmm && !usingmmmmmm && currentsong!=t+16))
 	{
 		if(currentsong!=-1)
 		{


### PR DESCRIPTION
## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes

## Changes:

Previously, when MMMMMM is installed but the user is using PPPPPP, niceplay would still restart the song even if it's the same. That has been fixed. In addition, Plenary and Path Complete no longer loop when MMMMMM is installed but PPPPPP is in use.