### PR TITLE
Fix crewmate-found text boxes overlapping in flip mode

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -2012,7 +2012,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 15;
             break;
         case 1011:
-            //Found a trinket!
+            //Found a crewmate!
             advancetext = true;
             state++;
             if (dwgfx.flipmode)
@@ -2024,15 +2024,15 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
                 if(int(map.customcrewmates-crewmates)==0)
                 {
-                    dwgfx.createtextbox("     All crewmates rescued!    ", 50, 135, 174, 174, 174);
+                    dwgfx.createtextbox("     All crewmates rescued!    ", 50, 65, 174, 174, 174);
                 }
                 else if(map.customcrewmates-crewmates==1)
                 {
-                    dwgfx.createtextbox("    " + help.number(int(map.customcrewmates-crewmates))+ " remains    ", 50, 135, 174, 174, 174);
+                    dwgfx.createtextbox("    " + help.number(int(map.customcrewmates-crewmates))+ " remains    ", 50, 65, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox("     " + help.number(int(map.customcrewmates-crewmates))+ " remain    ", 50, 135, 174, 174, 174);
+                    dwgfx.createtextbox("     " + help.number(int(map.customcrewmates-crewmates))+ " remain    ", 50, 65, 174, 174, 174);
                 }
                 dwgfx.textboxcenterx();
 


### PR DESCRIPTION
## Changes:

* **Fix crewmate-found text boxes overlapping in flip mode**

  The problem was that the code seemed to be wrongly copy-pasted from the code for generating the trinket-found text boxes (to the point where even the comment for the crewmate-found text boxes didn't get changed from `//Found a trinket!`).

  For the trinket-found text boxes, they use y-positions 85 and 135 if not in flip mode, and y-positions 105 and 65 if the game *is* in flip mode. These text boxes are positioned correctly in flip mode.

  However, for the crewmate-found text boxes, they use y-positions 85 and 135 if not in flip mode, as usual, but they use y-positions 105 and *135* if the game is in flip mode. Looks like someone forgot to change the second y-position when copy-pasting code around.

  Which is actually a bit funny, because I can conclude from this that it seems like the code to position these text boxes in flip mode was bolted-on *after* the initial code of these text boxes was written.

  I can also conclude (hot take incoming) that basically no one actually ever tested this game in flip mode (but that was already evident, given #140, less strongly #141, and #142 is another flip-mode-related bug which I guess sorta kinda doesn't really count since text outline wasn't enabled until version 2.3 of VVVVVV?).

  Furthermore, yet another hot take is that... no one actually ever *plays* this game in flip mode at all! Or at least not custom levels (which is the only place these crewmate-found text boxes can show up). I've only been informed about this bug today because @weee50 brought it up in the VVVVVV Discord server, and I never knew about this bug before then.

  So I fixed the second y-position to be 65, just like the y-position the trinket text boxes use. I even took the opportunity to fix the comment to say `//Found a crewmate!` instead of `//Found a trinket!`.

  **Before:**
  ![Wrong flip mode positioning](https://user-images.githubusercontent.com/59748578/74600753-aee0ee00-504a-11ea-92c7-7fb3da6d90db.png)

  **After:**
  ![Correct flip mode positioning](https://user-images.githubusercontent.com/59748578/74600758-bb654680-504a-11ea-9d85-2d0420dbf3ba.png)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
