### PR TITLE
Fix typo: "quiting" (one T) to "quitting" (two Ts)

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3157,7 +3157,7 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
         else if (game.currentmenuname == "ed_quit")
         {
             dwgfx.bigprint( -1, 90, "Save before", tr, tg, tb, true);
-            dwgfx.bigprint( -1, 110, "quiting?", tr, tg, tb, true);
+            dwgfx.bigprint( -1, 110, "quitting?", tr, tg, tb, true);
         }
 
         dwgfx.drawmenu(game, tr, tg, tb, 15);


### PR DESCRIPTION
## Changes:

This fixes the following typo: "quiting" (one T) to "quitting" (two Ts). This is in the "Save before quitting?" menu in the level editor.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
