### PR TITLE
Initialize x to 0 in ss_toi()

### DIFF
--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -58,7 +58,7 @@ const char *GCChar(SDL_GameControllerButton button)
 int ss_toi( std::string _s )
 {
 	std::istringstream i(_s);
-	int x;
+	int x = 0;
 	i >> x;
 	return x;
 }


### PR DESCRIPTION
## Changes:

* **Initialize `x` to 0 in `ss_toi()`**

  This fixes a source of undefined behavior, where the int returned by `ss_toi()` would be random garbage memory if the string passed into it would be empty. That's because if the string is empty, there are no characters to parse, so nothing simply gets put into `x`.

  The easiest way a user could trigger this UB to `ss_toi()` would be to use script commands with empty arguments.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
