### PR TITLE
Make 'script.commands', 'ed.sb', and 'ed.hooklist' no longer use separate length-trackers

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -11,12 +11,10 @@ scriptclass::scriptclass()
     	//Start SDL
 
 	//Init
-	commands.resize(500);
 	words.resize(40);
 	txt.resize(40);
 
 	position = 0;
-	scriptlength = 0;
 	scriptdelay = 0;
 	running = false;
 
@@ -72,7 +70,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 {
 	while(running && scriptdelay<=0 && !game.pausescript)
 	{
-		if (position < scriptlength)
+		if (position < (int) commands.size())
 		{
 			//Let's split or command in an array of words
 			tokenize(commands[position]);
@@ -3596,7 +3594,7 @@ void scriptclass::hardreset( KeyPoll& key, Graphics& dwgfx, Game& game,mapclass&
 
 	//Script Stuff
 	position = 0;
-	scriptlength = 0;
+	commands.clear();
 	scriptdelay = 0;
 	scriptname = "null";
 	running = false;

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -23,8 +23,7 @@ public:
 
     void inline add(std::string t)
     {
-        commands[scriptlength] = t;
-        scriptlength++;
+        commands.push_back(t);
     }
 
     void clearcustom();
@@ -51,7 +50,7 @@ public:
     std::vector<std::string> words;
     std::vector<std::string> txt;
     std::string scriptname;
-    int position, scriptlength;
+    int position;
     int looppoint, loopcount;
 
     int scriptdelay;

--- a/desktop_version/src/Scripts.cpp
+++ b/desktop_version/src/Scripts.cpp
@@ -11,7 +11,7 @@ void scriptclass::load(std::string t)
 {
     //loads script name t into the array
     position = 0;
-    scriptlength=0;
+    commands.clear();
     running = true;
 
 	int maxlength = (std::min(int(t.length()),7));

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -209,9 +209,8 @@ class editorclass{
 
   bool scripteditmod;
   int scripthelppage, scripthelppagedelay;
-  std::string sb[500];
+  std::vector<std::string> sb;
   std::string sbscript;
-  int sblength;
   int sbx, sby;
   int pagey;
 
@@ -228,8 +227,7 @@ class editorclass{
   void clearscriptbuffer();
   void gethooks();
   bool checkhook(std::string t);
-  std::string hooklist[500];
-  int numhooks;
+  std::vector<std::string> hooklist;
 
   int hookmenupage, hookmenu;
 


### PR DESCRIPTION
## Changes:

* **Make `script.commands`, `ed.sb`, and `ed.hooklist` not use separate length-trackers**

  This is a refactor that turns the script-related arrays `ed.sb`, and `ed.hooklist` into C++ vectors (`script.commands` was already a vector, it was just misused). The code handling these vectors now looks more like idiomatic C++ than sloppily-pasted pseudo-ActionScript. This removes the variables `script.scriptlength`, `ed.sblength`, and `ed.numhooks`, too.

  This reduces the amount of code needed to e.g. simply remove something from any of these vectors. Previously the code had to manually shift the rest of the elements down one-by-one, and doing it manually is definitely error-prone and tedious.

  But now we can just use fancy functions like `std::vector::erase()` and `std::remove()` to do it all in one line!

  Don't worry, I checked and `std::remove()` is in the C++ standard since at least 1998.

  This patch makes it so the `commands` vector gets cleared when `scriptclass::load()` is ran. Previously, the `commands` vector never actually properly got cleared, so there could potentially be glitches that rely on the game indexing past the bounds set by `scriptlength` but still in-bounds in the eyes of C++, and people could potentially rely on such an exploit...

  However, I checked, and I'm pretty sure that no such glitch previously existed at all, because the only times the vector gets indexed are when `scriptlength` is either being incremented after starting from 0 (`add()`) or when it's underneath a `position < scriptlength` conditional.

  Furthermore, I'm unaware of anyone who has actually found or used such an exploit, and I've been in the custom level community for 6 years.

  So I think it's fine.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
