### PR TITLE
Fix left-clicking on script boxes

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -5185,7 +5185,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                             key.keybuffer=ed.oldenttext;
                             ed.lclickdelay=1;
                         }
-                        else if(edentity[tmp].t==18)
+                        else if(edentity[tmp].t==18 || edentity[tmp].t==19)
                         {
                             ed.scripttextmod=true;
                             ed.oldenttext=edentity[tmp].scriptname;


### PR DESCRIPTION
## Changes:

* **Fix left-clicking on script boxes**

  This PR makes it so you can left-click on script boxes to change their script.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
