### PR TITLE
Refactor roomtext to not use ad-hoc objects or separate length-trackers

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -90,17 +90,6 @@ mapclass::mapclass()
 	}
 	resetnames();
 
-	//roomtext
-
-	for (int i = 0; i < 100; i++)
-	{
-		roomtextx[i]=0;
-		roomtexty[i]=0;
-		roomtext.push_back(std::string());
-	}
-	roomtexton = false;
-	roomtextnumlines = 0;
-
 	//Areamap starts at 100,100 and extends 20x20
 	std::vector<std::string> tmap;
 	tmap.push_back("1,2,2,2,2,2,2,2,0,3,0,0,0,4,4,4,4,4,4,4");
@@ -1201,7 +1190,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 
 
 	roomtexton = false;
-	roomtextnumlines = 0;
+	roomtext.clear();
 
 	obj.platformtile = 0;
 	obj.customplatformtile=0;
@@ -1336,13 +1325,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		if (otherlevel.roomtexton)
 		{
 			roomtexton = true;
-			roomtextx[0] = otherlevel.roomtextx;
-			roomtexty[0] = otherlevel.roomtexty;
-			roomtextnumlines = otherlevel.roomtextnumlines;
-			for (int i = 0; i < roomtextnumlines; i++)
-			{
-				roomtext[i] = otherlevel.roomtext[i];
-			}
+			roomtext = std::vector<Roomtext>(otherlevel.roomtext);
 		}
 		break;
 	case 2: //The Lab
@@ -1652,7 +1635,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 
 
 		roomtexton = false;
-		roomtextnumlines=0;
+		roomtext.clear();
 
 		for (int edj = 0; edj < 30; edj++){
 			for(int edi = 0; edi < 40; edi++){
@@ -1726,12 +1709,15 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 				obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8)-4,(edentity[edi].y*8)- ((ry-100)*30*8)+1, 55, ed.findcrewmate(edi), edentity[edi].p1, edentity[edi].p2);
 				break;
 				case 17: //Roomtext!
+				{
 				roomtexton = true;
-				roomtextx[roomtextnumlines] = edentity[edi].x - ((rx-100)*40);
-				roomtexty[roomtextnumlines] = edentity[edi].y - ((ry-100)*30);
-				roomtext[roomtextnumlines] = edentity[edi].scriptname;
-				roomtextnumlines++;
+				Roomtext text;
+				text.x = edentity[edi].x - ((rx-100)*40);
+				text.y = edentity[edi].y - ((ry-100)*30);
+				text.text = edentity[edi].scriptname;
+				roomtext.push_back(text);
 				break;
+				}
 				case 18: //Terminals
 				obj.customscript=edentity[edi].scriptname;
 				obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8)+8, 20, 1);
@@ -1763,19 +1749,6 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		customcrewmates=ed.numcrewmates;
 
 		//do the appear/remove roomname here
-		/*
-
-		if (otherlevel.roomtexton)
-		{
-			roomtexton = true;
-			roomtextx[0] = otherlevel.roomtextx;
-			roomtexty[0] = otherlevel.roomtexty;
-			roomtextnumlines = otherlevel.roomtextnumlines;
-			for (int i = 0; i < roomtextnumlines; i++)
-			{
-				roomtext[i] = otherlevel.roomtext[i];
-			}
-		}*/
 		break;
 #endif
 	}

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -160,10 +160,8 @@ public:
     bool showteleporters, showtargets, showtrinkets;
 
     //Roomtext
-    int roomtextx[100], roomtexty[100];
     bool roomtexton;
-    std::vector<std::string> roomtext;
-    int roomtextnumlines;
+    std::vector<Roomtext> roomtext;
 
     //Levels
     otherlevelclass otherlevel;

--- a/desktop_version/src/Otherlevel.cpp
+++ b/desktop_version/src/Otherlevel.cpp
@@ -2,18 +2,13 @@
 
 #include "MakeAndPlay.h"
 
-otherlevelclass::otherlevelclass()
-{
-	for (i = 0; i < 50; i++)
-	{
-		roomtext.push_back(std::string());
-	}
-}
-
 void otherlevelclass::addline(std::string t)
 {
-	roomtext[roomtextnumlines] = t;
-	roomtextnumlines++;
+	Roomtext text;
+	text.x = 0;
+	text.y = 0;
+	text.text = t;
+	roomtext.push_back(text);
 }
 
 std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game, entityclass& obj)
@@ -27,9 +22,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 	std::vector<std::string> tmap;
 	roomname = "";
 
-	roomtextnumlines = 0;
-	roomtextx = 0;
-	roomtexty = 0;
+	roomtext.clear();
 	roomtexton = false;
 
 	switch(t)

--- a/desktop_version/src/Otherlevel.h
+++ b/desktop_version/src/Otherlevel.h
@@ -7,6 +7,12 @@
 #include <string>
 #include <vector>
 
+struct Roomtext
+{
+    int x, y;
+    std::string text;
+};
+
 class otherlevelclass
 {
 public:
@@ -20,7 +26,6 @@ public:
         ACTIVITY
     };
 
-    otherlevelclass();
     void addline(std::string t);
     std::vector<std::string> loadlevel(int rx, int ry , Game& game, entityclass& obj);
 
@@ -31,8 +36,7 @@ public:
 
     // roomtext thing in other level
     bool roomtexton;
-    int roomtextx, roomtexty, roomtextnumlines;
-    std::vector<std::string> roomtext;
+    std::vector<Roomtext> roomtext;
 };
 
 #endif /* OTHERLEVEL_H */

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -1556,9 +1556,9 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
     if (map.roomtexton)
     {
         //Draw room text!
-        for (int i = 0; i < map.roomtextnumlines; i++)
+        for (size_t i = 0; i < map.roomtext.size(); i++)
         {
-            dwgfx.Print(map.roomtextx[i]*8, (map.roomtexty[i]*8), map.roomtext[i], 196, 196, 255 - help.glow);
+            dwgfx.Print(map.roomtext[i].x*8, (map.roomtext[i].y*8), map.roomtext[i].text, 196, 196, 255 - help.glow);
         }
     }
 


### PR DESCRIPTION
## Changes:

* **Refactor roomtext code to not use ad-hoc objects or separate length-trackers**

  This refactors the roomtext code to (1) not use ad-hoc objects and (2) not use a separate length-tracking variable to keep track of the actual amount of roomtext in a room.

  What I mean by ad-hoc object is, instead of formally creating a fully-fledged struct or class and storing one vector containing that object, this game instead hacks together an object by storing each attribute of an object in different vectors.

  In the case of roomtext, instead of making a Roomtext object that has attributes `x`, `y`, and `text`, the `text` attribute of each is stored in the vector `roomtext`, the `x` attribute of each is stored in the vector `roomtextx`, and the `y` attribute of each is stored in the vector `roomtexty`. It's only an object in the sense that you can grab the attributes of each roomtext by using the same index across all three vectors.

  This makes it somewhat annoying to maintain and deal with, like when I wanted add sub-tile positions to roomtext in [VVVVVV: Community Edition](/v6cord/VVVVVV-CE). Instead of being able to add attributes to an already-existing formalized `Roomtext` object, I would instead have to add two more vectors, which is inelegant. Or I could refactor the whole system, which is what I decided to do instead.

  So now I've made each roomtext into an actual struct named `Roomtext`, and now the `roomtext` vector will store these `Roomtext` objects.

  Furthermore, this PR removes the separate length-tracking variable `roomtextnumlines`, which makes the code much more easy to maintain and deal with, as the amount of roomtext is naturally tracked by C++ instead of us having to keep track of the actual amount of roomtext manually.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
