### PR TITLE
Refactor entities, blocks, linecross, and textboxes to not use the 'active' attribute system and to not have separate length-trackers

### DIFF
--- a/desktop_version/src/BlockV.cpp
+++ b/desktop_version/src/BlockV.cpp
@@ -7,7 +7,6 @@ blockclass::blockclass()
 
 void blockclass::clear()
 {
-	active = false;
 	type = 0;
 	trigger = 0;
 
@@ -33,4 +32,69 @@ void blockclass::rectset(const int xi, const int yi, const int wi, const int hi)
 	rect.y = yi;
 	rect.w = wi;
 	rect.h = hi;
+}
+
+void blockclass::setblockcolour(std::string col)
+{
+	if (col == "cyan")
+	{
+		r = 164;
+		g = 164;
+		b = 255;
+	}
+	else if (col == "red")
+	{
+		r = 255;
+		g = 60;
+		b = 60;
+	}
+	else if (col == "green")
+	{
+		r = 144;
+		g = 255;
+		b = 144;
+	}
+	else if (col == "yellow")
+	{
+		r = 255;
+		g = 255;
+		b = 134;
+	}
+	else if (col == "blue")
+	{
+		r = 95;
+		g = 95;
+		b = 255;
+	}
+	else if (col == "purple")
+	{
+		r = 255;
+		g = 134;
+		b = 255;
+	}
+	else if (col == "white")
+	{
+		r = 244;
+		g = 244;
+		b = 244;
+	}
+	else if (col == "gray")
+	{
+		r = 174;
+		g = 174;
+		b = 174;
+	}
+	else if (col == "orange")
+	{
+		r = 255;
+		g = 130;
+		b = 20;
+	}
+	else
+	{
+		//use a gray
+		r = 174;
+		g = 174;
+		b = 174;
+	}
 }

--- a/desktop_version/src/BlockV.h
+++ b/desktop_version/src/BlockV.h
@@ -12,9 +12,10 @@ public:
     void clear();
 
     void rectset(const int xi, const int yi, const int wi, const int hi);
+
+    void setblockcolour(std::string col);
 public:
     //Fundamentals
-    bool active;
     SDL_Rect rect;
     int type;
     int trigger;

--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -8,7 +8,6 @@ entclass::entclass()
 void entclass::clear()
 {
 	// Set all values to a default, required for creating a new entity
-	active = false;
 	invis = false;
 	type = 0;
 	size = 0;
@@ -85,4 +84,501 @@ bool entclass::outside()
 		return true;
 	}
 	return false;
+}
+
+void entclass::setenemyroom(int rx, int ry)
+{
+    //Simple function to initilise simple enemies
+    rx -= 100;
+    ry -= 100;
+    switch(rn(rx, ry))
+    {
+        //Space Station 1
+    case rn(12, 3):  //Security Drone
+        tile = 36;
+        colour = 8;
+        animate = 1;
+        break;
+    case rn(13, 3):  //Wavelengths
+        tile = 32;
+        colour = 7;
+        animate = 1;
+        w = 32;
+        break;
+    case rn(15, 3):  //Traffic
+        tile = 28;
+        colour = 6;
+        animate = 1;
+        w = 22;
+        h = 32;
+        break;
+    case rn(12, 5):  //The Yes Men
+        tile = 40;
+        colour = 9;
+        animate = 1;
+        w = 20;
+        h = 20;
+        break;
+    case rn(13, 6):  //Hunchbacked Guards
+        tile = 44;
+        colour = 8;
+        animate = 1;
+        w = 16;
+        h = 20;
+        break;
+    case rn(13, 4):  //Communication Station
+        harmful = false;
+        if (xp == 256)
+        {
+            //transmittor
+            tile = 104;
+            colour = 4;
+            animate = 7;
+            w = 16;
+            h = 16;
+            xp -= 24;
+            yp -= 16;
+        }
+        else
+        {
+            //radar dish
+            tile =124;
+            colour = 4;
+            animate = 6;
+            w = 32;
+            h = 32;
+            cx = 4;
+            size = 9;
+            xp -= 4;
+            yp -= 32;
+        }
+
+        break;
+        //The Lab
+    case rn(4, 0):
+        tile = 78;
+        colour = 7;
+        animate = 1;
+        w = 16;
+        h = 16;
+        break;
+    case rn(2, 0):
+        tile = 88;
+        colour = 11;
+        animate = 1;
+        w = 16;
+        h = 16;
+        break;
+        //Space Station 2
+    case rn(14, 11):
+        colour = 17;
+        break; //Lies
+    case rn(16, 11):
+        colour = 8;
+        break; //Lies
+    case rn(13, 10):
+        colour = 11;
+        break; //Factory
+    case rn(13, 9):
+        colour = 9;
+        break; //Factory
+    case rn(13, 8):
+        colour = 8;
+        break; //Factory
+    case rn(11, 13): //Truth
+        tile = 64;
+        colour = 7;
+        animate = 100;
+        w = 44;
+        h = 10;
+        size = 10;
+        break;
+    case rn(17, 7): //Brass sent us under the top
+        tile =82;
+        colour = 8;
+        animate = 5;
+        w = 28;
+        h = 32;
+        cx = 4;
+        break;
+    case rn(10, 7): // (deception)
+        tile = 92;
+        colour = 6;
+        animate = 1;
+        w = 16;
+        h = 16;
+        break;
+    case rn(14, 13): // (chose poorly)
+        tile = 56;
+        colour = 6;
+        animate = 1;
+        w = 15;
+        h = 24;
+        break;
+    case rn(13, 12): // (backsliders)
+        tile = 164;
+        colour = 7;
+        animate = 1;
+        w = 16;
+        h = 16;
+        break;
+    case rn(14, 8): // (wheel of fortune room)
+        tile = 116;
+        colour = 12;
+        animate = 1;
+        w = 32;
+        h = 32;
+        break;
+    case rn(16, 9): // (seeing dollar signs)
+        tile = 68;
+        colour = 7;
+        animate = 1;
+        w = 16;
+        h = 16;
+        break;
+    case rn(16, 7): // (tomb of mad carew)
+        tile = 106;
+        colour = 7;
+        animate = 2;
+        w = 24;
+        h = 25;
+        break;
+        //Warp Zone
+    case rn(15, 2): // (numbers)
+        tile = 100;
+        colour = 6;
+        animate = 1;
+        w = 32;
+        h = 14;
+        yp += 1;
+        break;
+    case rn(16, 2): // (Manequins)
+        tile = 52;
+        colour = 7;
+        animate = 5;
+        w = 16;
+        h = 25;
+        yp -= 4;
+        break;
+    case rn(18, 0): // (Obey)
+        tile = 51;
+        colour = 11;
+        animate = 100;
+        w = 30;
+        h = 14;
+        break;
+    case rn(19, 1): // Ascending and Descending
+        tile = 48;
+        colour = 9;
+        animate = 5;
+        w = 16;
+        h = 16;
+        break;
+    case rn(19, 2): // Shockwave Rider
+        tile = 176;
+        colour = 6;
+        animate = 1;
+        w = 16;
+        h = 16;
+        break;
+    case rn(18, 3): // Mind the gap
+        tile = 168;
+        colour = 7;
+        animate = 1;
+        w = 16;
+        h = 16;
+        break;
+    case rn(17, 3): // Edge Games
+        if (yp ==96)
+        {
+            tile = 160;
+            colour = 8;
+            animate = 1;
+            w = 16;
+            h = 16;
+        }
+        else
+        {
+            tile = 156;
+            colour = 8;
+            animate = 1;
+            w = 16;
+            h = 16;
+        }
+        break;
+    case rn(16, 0): // I love you
+        tile = 112;
+        colour = 8;
+        animate = 5;
+        w = 16;
+        h = 16;
+        break;
+    case rn(14, 2): // That's why I have to kill you
+        tile = 114;
+        colour = 6;
+        animate = 5;
+        w = 16;
+        h = 16;
+        break;
+    case rn(18, 2): // Thinking with Portals
+        //depends on direction
+        if (xp ==88)
+        {
+            tile = 54+12;
+            colour = 12;
+            animate = 100;
+            w = 60;
+            h = 16;
+            size = 10;
+        }
+        else
+        {
+            tile = 54;
+            colour = 12;
+            animate = 100;
+            w = 60;
+            h = 16;
+            size = 10;
+        }
+        break;
+        //Final level
+    case rn(50-100, 53-100):  //The Yes Men
+        tile = 40;
+        colour = 9;
+        animate = 1;
+        w = 20;
+        h = 20;
+        break;
+    case rn(48-100, 51-100):  //Wavelengths
+        tile = 32;
+        colour = 7;
+        animate = 1;
+        w = 32;
+        break;
+    case rn(43-100,52-100): // Ascending and Descending
+        tile = 48;
+        colour = 9;
+        animate = 5;
+        w = 16;
+        h = 16;
+        break;
+    case rn(46-100,51-100): //kids his age
+        tile = 88;
+        colour = 11;
+        animate = 1;
+        w = 16;
+        h = 16;
+        break;
+    case rn(43-100,51-100): // Mind the gap
+        tile = 168;
+        colour = 7;
+        animate = 1;
+        w = 16;
+        h = 16;
+        break;
+    case rn(44-100,51-100): // vertigo?
+        tile = 172;
+        colour = 7;
+        animate = 100;
+        w = 32;
+        h = 32;
+        break;
+    case rn(44-100,52-100): // (backsliders)
+        tile = 164;
+        colour = 7;
+        animate = 1;
+        w = 16;
+        h = 16;
+        break;
+    case rn(43-100, 56-100): //Intermission 1
+        tile = 88;
+        colour = 21;
+        animate = 1;
+        w = 16;
+        h = 16;
+        break;
+    case rn(45-100, 56-100): //Intermission 1
+        tile = 88;
+        colour = 21;
+        animate = 1;
+        w = 16;
+        h = 16;
+        break;
+        //The elephant
+    case rn(11, 9):
+    case rn(12, 9):
+    case rn(11, 8):
+    case rn(12, 8):
+        tile = 0;
+        colour = 102;
+        animate = 0;
+        w = 464;
+        h = 320;
+        size = 11;
+        harmful = false;
+        break;
+    }
+}
+
+void entclass::setenemy(int t)
+{
+    switch (t)
+    {
+    case 0:
+        //lies emitter
+        switch ((int) para)
+        {
+        case 0:
+            tile = 60;
+            animate = 2;
+            colour = 6;
+            behave = 10;
+            w = 32;
+            h = 32;
+            x1 = -200;
+            break;
+        case 1:
+            yp += 10;
+            tile = 63;
+            animate = 100; //LIES
+            colour = 6;
+            behave = 11;
+            para = 9; //destroyed when outside
+            x1 = -200;
+            x2 = 400;
+            w = 26;
+            h = 10;
+            cx = 1;
+            cy = 1;
+            break;
+        case 2:
+            tile = 62;
+            animate = 100;
+            colour = 6;
+            behave = -1;
+            w = 32;
+            h = 32;
+            break;
+        }
+        break;
+    case 1:
+        //FACTORY emitter
+        switch ((int) para)
+        {
+        case 0:
+            tile = 72;
+            animate = 3;
+            size = 9;
+            colour = 6;
+            behave = 12;
+            w = 64;
+            h = 40;
+            cx = 0;
+            cy = 24;
+            break;
+        case 1:
+            xp += 4;
+            yp -= 4;
+            tile = 76;
+            animate = 100; // Clouds
+            colour = 6;
+            behave = 13;
+            para = -6; //destroyed when outside
+            x2 = 400;
+            w = 32;
+            h = 12;
+            cx = 0;
+            cy = 6;
+            break;
+        case 2:
+            tile = 77;
+            animate = 100;
+            colour = 6;
+            behave = -1;
+            w = 32;
+            h = 16;
+            break;
+        }
+        break;
+    }
+}
+
+void entclass::settreadmillcolour(int rx, int ry)
+{
+    rx -= 100;
+    ry -= 100;
+    rx += 50 - 12;
+    ry += 50 - 14;   //Space Station
+
+    tile = 20; //default as blue
+    switch(rn(rx, ry))
+    {
+    case rn(52, 48):
+        tile = 791;
+        break; //Cyan
+
+    case rn(49, 47):
+        tile = 24;
+        break; //Yellow
+    case rn(56, 44):
+        tile = 24;
+        break; //Yellow
+    case rn(54, 49):
+        tile = 24;
+        break; //Yellow
+
+    case rn(49, 49):
+        tile = 36;
+        break; //Green
+    case rn(55, 44):
+        tile = 36;
+        break; //Green
+    case rn(54, 43):
+        tile = 36;
+        break; //Green
+    case rn(53, 49):
+        tile = 36;
+        break; //Green
+    case rn(54, 45):
+        tile = 711;
+        break; //Green (special)
+    case rn(51, 48):
+        tile = 711;
+        break; //Green (special)
+
+    case rn(50, 49):
+        tile = 28;
+        break; //Purple
+    case rn(54, 44):
+        tile = 28;
+        break; //Purple
+    case rn(49, 42):
+        tile = 28;
+        break; //Purple
+    case rn(55, 43):
+        tile = 28;
+        break; //Purple
+    case rn(54, 47):
+        tile = 28;
+        break; //Purple
+    case rn(53, 48):
+        tile = 28;
+        break; //Purple
+
+    case rn(51, 47):
+        tile = 32;
+        break; //Red
+    case rn(52, 49):
+        tile = 32;
+        break; //Red
+    case rn(48, 43):
+        tile = 32;
+        break; //Red
+    case rn(55, 47):
+        tile = 32;
+        break; //Red
+    case rn(54, 48):
+        tile = 32;
+        break; //Red
+    }
 }

--- a/desktop_version/src/Ent.h
+++ b/desktop_version/src/Ent.h
@@ -1,6 +1,8 @@
 #ifndef ENT_H
 #define ENT_H
 
+#define rn(rx, ry) ((rx) + ((ry) * 100))
+
 class entclass
 {
 public:
@@ -10,9 +12,14 @@ public:
 
     bool outside();
 
+    void setenemyroom(int rx, int ry);
+
+    void setenemy(int t);
+
+    void settreadmillcolour(int rx, int ry);
 public:
     //Fundamentals
-    bool active, invis;
+    bool invis;
     int type, size, tile, rule;
     int state, statedelay;
     int behave, animate;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -42,9 +42,6 @@ bool entityclass::checktowerspikes(int t, mapclass& map)
 
 void entityclass::init()
 {
-    nentity = 0;
-    nblocks = 0;
-
     skipblocks = false;
     skipdirblocks = false;
     platformtile = 0;
@@ -69,13 +66,8 @@ void entityclass::init()
     }
 
     flags.resize(100);
-    blocks.resize(500);
-    entities.resize(200);
-    linecrosskludge.resize(100);
     collect.resize(100);
     customcollect.resize(100);
-
-    nlinecrosskludge = 0;
 }
 
 void entityclass::resetallflags()
@@ -118,71 +110,6 @@ void entityclass::changeflag( int t, int s )
     flags[t] = s;
 }
 
-void entityclass::setblockcolour( int t, std::string col )
-{
-    if (col == "cyan")
-    {
-        blocks[t].r = 164;
-        blocks[t].g = 164;
-        blocks[t].b = 255;
-    }
-    else if (col == "red")
-    {
-        blocks[t].r = 255;
-        blocks[t].g = 60;
-        blocks[t].b = 60;
-    }
-    else if (col == "green")
-    {
-        blocks[t].r = 144;
-        blocks[t].g = 255;
-        blocks[t].b = 144;
-    }
-    else if (col == "yellow")
-    {
-        blocks[t].r = 255;
-        blocks[t].g = 255;
-        blocks[t].b = 134;
-    }
-    else if (col == "blue")
-    {
-        blocks[t].r = 95;
-        blocks[t].g = 95;
-        blocks[t].b = 255;
-    }
-    else if (col == "purple")
-    {
-        blocks[t].r = 255;
-        blocks[t].g = 134;
-        blocks[t].b = 255;
-    }
-    else if (col == "white")
-    {
-        blocks[t].r = 244;
-        blocks[t].g = 244;
-        blocks[t].b = 244;
-    }
-    else if (col == "gray")
-    {
-        blocks[t].r = 174;
-        blocks[t].g = 174;
-        blocks[t].b = 174;
-    }
-    else if (col == "orange")
-    {
-        blocks[t].r = 255;
-        blocks[t].g = 130;
-        blocks[t].b = 20;
-    }
-    else
-    {
-        //use a gray
-        blocks[t].r = 174;
-        blocks[t].g = 174;
-        blocks[t].b = 174;
-    }
-}
-
 int entityclass::swncolour( int t )
 {
     //given colour t, return colour in setcol
@@ -198,14 +125,11 @@ int entityclass::swncolour( int t )
 void entityclass::swnenemiescol( int t )
 {
     //change the colour of all SWN enemies to the current one
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
-        if (entities[i].active)
+        if (entities[i].type == 23)
         {
-            if (entities[i].type == 23)
-            {
-                entities[i].colour = swncolour(t);
-            }
+            entities[i].colour = swncolour(t);
         }
     }
 }
@@ -857,376 +781,328 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
 
 void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*= 0*/ )
 {
-    if(nblocks == 0)
-    {
-        //If there are no active blocks, Z=0;
-        k = 0;
-        nblocks++;
-    }
-    else
-    {
-        int i = 0;
-        k = -1;
-        while (i < nblocks)
-        {
-            if (!blocks[i].active)
-            {
-                k = i;
-                i = nblocks;
-            }
-            i++;
-        }
-        if (k == -1)
-        {
-            k = nblocks;
-            nblocks++;
-        }
-    }
+    //'k' is used in entityclass::updateentities() for entity type 12... even though this is createblock()
+    k = blocks.size();
 
-    blocks[k].clear();
-    blocks[k].active = true;
+    blockclass block;
+
     switch(t)
     {
     case BLOCK: //Block
-        blocks[k].type = BLOCK;
-        blocks[k].xp = xp;
-        blocks[k].yp = yp;
-        blocks[k].wp = w;
-        blocks[k].hp = h;
-        blocks[k].rectset(xp, yp, w, h);
-
-        nblocks++;
+        block.type = BLOCK;
+        block.xp = xp;
+        block.yp = yp;
+        block.wp = w;
+        block.hp = h;
+        block.rectset(xp, yp, w, h);
         break;
     case TRIGGER: //Trigger
-        blocks[k].type = TRIGGER;
-        blocks[k].x = xp;
-        blocks[k].y = yp;
-        blocks[k].wp = w;
-        blocks[k].hp = h;
-        blocks[k].rectset(xp, yp, w, h);
-        blocks[k].trigger = trig;
-
-        nblocks++;
+        block.type = TRIGGER;
+        block.x = xp;
+        block.y = yp;
+        block.wp = w;
+        block.hp = h;
+        block.rectset(xp, yp, w, h);
+        block.trigger = trig;
         break;
     case DAMAGE: //Damage
-        blocks[k].type = DAMAGE;
-        blocks[k].x = xp;
-        blocks[k].y = yp;
-        blocks[k].wp = w;
-        blocks[k].hp = h;
-        blocks[k].rectset(xp, yp, w, h);
-
-        nblocks++;
+        block.type = DAMAGE;
+        block.x = xp;
+        block.y = yp;
+        block.wp = w;
+        block.hp = h;
+        block.rectset(xp, yp, w, h);
         break;
     case DIRECTIONAL: //Directional
-        blocks[k].type = DIRECTIONAL;
-        blocks[k].x = xp;
-        blocks[k].y = yp;
-        blocks[k].wp = w;
-        blocks[k].hp = h;
-        blocks[k].rectset(xp, yp, w, h);
-        blocks[k].trigger = trig;
-
-        nblocks++;
+        block.type = DIRECTIONAL;
+        block.x = xp;
+        block.y = yp;
+        block.wp = w;
+        block.hp = h;
+        block.rectset(xp, yp, w, h);
+        block.trigger = trig;
         break;
     case SAFE: //Safe block
-        blocks[k].type = SAFE;
-        blocks[k].xp = xp;
-        blocks[k].yp = yp;
-        blocks[k].wp = w;
-        blocks[k].hp = h;
-        blocks[k].rectset(xp, yp, w, h);
-
-        nblocks++;
+        block.type = SAFE;
+        block.xp = xp;
+        block.yp = yp;
+        block.wp = w;
+        block.hp = h;
+        block.rectset(xp, yp, w, h);
         break;
     case ACTIVITY: //Activity Zone
-        blocks[k].type = ACTIVITY;
-        blocks[k].x = xp;
-        blocks[k].y = yp;
-        blocks[k].wp = w;
-        blocks[k].hp = h;
-        blocks[k].rectset(xp, yp, w, h);
+        block.type = ACTIVITY;
+        block.x = xp;
+        block.y = yp;
+        block.wp = w;
+        block.hp = h;
+        block.rectset(xp, yp, w, h);
 
         //Ok, each and every activity zone in the game is initilised here. "Trig" in this case is a variable that
         //assigns all the details.
         switch(trig)
         {
         case 0: //testing zone
-            blocks[k].prompt = "Press ENTER to explode";
-            blocks[k].script = "intro";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to explode";
+            block.script = "intro";
+            block.setblockcolour("orange");
             trig=1;
             break;
         case 1:
-            blocks[k].prompt = "Press ENTER to talk to Violet";
-            blocks[k].script = "talkpurple";
-            setblockcolour(k, "purple");
+            block.prompt = "Press ENTER to talk to Violet";
+            block.script = "talkpurple";
+            block.setblockcolour("purple");
             trig=0;
             break;
         case 2:
-            blocks[k].prompt = "Press ENTER to talk to Vitellary";
-            blocks[k].script = "talkyellow";
-            setblockcolour(k, "yellow");
+            block.prompt = "Press ENTER to talk to Vitellary";
+            block.script = "talkyellow";
+            block.setblockcolour("yellow");
             trig=0;
             break;
         case 3:
-            blocks[k].prompt = "Press ENTER to talk to Vermilion";
-            blocks[k].script = "talkred";
-            setblockcolour(k, "red");
+            block.prompt = "Press ENTER to talk to Vermilion";
+            block.script = "talkred";
+            block.setblockcolour("red");
             trig=0;
             break;
         case 4:
-            blocks[k].prompt = "Press ENTER to talk to Verdigris";
-            blocks[k].script = "talkgreen";
-            setblockcolour(k, "green");
+            block.prompt = "Press ENTER to talk to Verdigris";
+            block.script = "talkgreen";
+            block.setblockcolour("green");
             trig=0;
             break;
         case 5:
-            blocks[k].prompt = "Press ENTER to talk to Victoria";
-            blocks[k].script = "talkblue";
-            setblockcolour(k, "blue");
+            block.prompt = "Press ENTER to talk to Victoria";
+            block.script = "talkblue";
+            block.setblockcolour("blue");
             trig=0;
             break;
         case 6:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_station_1";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_station_1";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 7:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_outside_1";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_outside_1";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 8:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_outside_2";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_outside_2";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 9:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_outside_3";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_outside_3";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 10:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_outside_4";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_outside_4";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 11:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_outside_5";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_outside_5";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 12:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_outside_6";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_outside_6";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 13:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_finallevel";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_finallevel";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 14:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_station_2";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_station_2";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 15:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_station_3";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_station_3";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 16:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_station_4";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_station_4";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 17:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_warp_1";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_warp_1";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 18:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_warp_2";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_warp_2";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 19:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_lab_1";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_lab_1";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 20:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_lab_2";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_lab_2";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 21:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_secretlab";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_secretlab";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 22:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_shipcomputer";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_shipcomputer";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 23:
-            blocks[k].prompt = "Press ENTER to activate terminals";
-            blocks[k].script = "terminal_radio";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminals";
+            block.script = "terminal_radio";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 24:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_jukebox";
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_jukebox";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 25:
-            blocks[k].prompt = "Passion for Exploring";
-            blocks[k].script = "terminal_juke1";
-            setblockcolour(k, "orange");
+            block.prompt = "Passion for Exploring";
+            block.script = "terminal_juke1";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 26:
-            blocks[k].prompt = "Pushing Onwards";
-            blocks[k].script = "terminal_juke2";
-            setblockcolour(k, "orange");
+            block.prompt = "Pushing Onwards";
+            block.script = "terminal_juke2";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 27:
-            blocks[k].prompt = "Positive Force";
-            blocks[k].script = "terminal_juke3";
-            setblockcolour(k, "orange");
+            block.prompt = "Positive Force";
+            block.script = "terminal_juke3";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 28:
-            blocks[k].prompt = "Presenting VVVVVV";
-            blocks[k].script = "terminal_juke4";
-            setblockcolour(k, "orange");
+            block.prompt = "Presenting VVVVVV";
+            block.script = "terminal_juke4";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 29:
-            blocks[k].prompt = "Potential for Anything";
-            blocks[k].script = "terminal_juke5";
-            setblockcolour(k, "orange");
+            block.prompt = "Potential for Anything";
+            block.script = "terminal_juke5";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 30:
-            blocks[k].prompt = "Predestined Fate";
-            blocks[k].script = "terminal_juke6";
-            setblockcolour(k, "orange");
+            block.prompt = "Predestined Fate";
+            block.script = "terminal_juke6";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 31:
-            blocks[k].prompt = "Pipe Dream";
-            blocks[k].script = "terminal_juke7";
-            setblockcolour(k, "orange");
+            block.prompt = "Pipe Dream";
+            block.script = "terminal_juke7";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 32:
-            blocks[k].prompt = "Popular Potpourri";
-            blocks[k].script = "terminal_juke8";
-            setblockcolour(k, "orange");
+            block.prompt = "Popular Potpourri";
+            block.script = "terminal_juke8";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 33:
-            blocks[k].prompt = "Pressure Cooker";
-            blocks[k].script = "terminal_juke9";
-            setblockcolour(k, "orange");
+            block.prompt = "Pressure Cooker";
+            block.script = "terminal_juke9";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 34:
-            blocks[k].prompt = "ecroF evitisoP";
-            blocks[k].script = "terminal_juke10";
-            setblockcolour(k, "orange");
+            block.prompt = "ecroF evitisoP";
+            block.script = "terminal_juke10";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 35:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "custom_"+customscript;
-            setblockcolour(k, "orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "custom_"+customscript;
+            block.setblockcolour("orange");
             trig=0;
             break;
         }
-        nblocks++;
         break;
     }
+
+    blocks.push_back(block);
 }
 
 void entityclass::removeallblocks()
 {
-    for(int i=0; i<nblocks; i++) blocks[i].clear();
-    nblocks=0;
+    blocks.clear();
 }
 
-void entityclass::removeblock( int t )
+void entityclass::removeblock(int t)
 {
-    blocks[t].clear();
-    int i = nblocks - 1;
-    while (i >= 0 && !(blocks[i].active))
+    blocks.erase(blocks.begin() + t);
+}
+
+void entityclass::removeblockat(int x, int y)
+{
+    for (size_t i = 0; i < blocks.size(); i++)
     {
-        nblocks--;
-        i--;
+        if (blocks[i].xp == x && blocks[i].yp == y) removeblock_iter(i);
     }
 }
 
-void entityclass::removeblockat( int x, int y )
+void entityclass::removetrigger(int t)
 {
-    for (int i = 0; i < nblocks; i++)
+    for (size_t i = 0; i < blocks.size(); i++)
     {
-        if(blocks[i].xp == int(x) && blocks[i].yp == int(y)) removeblock(i);
+        if (blocks[i].type == TRIGGER && blocks[i].trigger == t) removeblock_iter(i);
     }
 }
 
-void entityclass::removetrigger( int t )
+void entityclass::removeentity(int t)
 {
-    for(int i=0; i<nblocks; i++)
-    {
-        if(blocks[i].type == TRIGGER)
-        {
-            if (blocks[i].trigger == t)
-            {
-                blocks[i].active = false;
-                removeblock(i);
-            }
-        }
-    }
+    entities.erase(entities.begin() + t);
 }
 
-void entityclass::copylinecross( int t )
+void entityclass::copylinecross(int t)
 {
     //Copy entity t into the first free linecrosskludge entity
-    linecrosskludge[nlinecrosskludge].clear();
-    linecrosskludge[nlinecrosskludge].xp = entities[t].xp;
-    linecrosskludge[nlinecrosskludge].yp = entities[t].yp;
-    linecrosskludge[nlinecrosskludge].w = entities[t].w;
-    linecrosskludge[nlinecrosskludge].onentity = entities[t].onentity;
-    linecrosskludge[nlinecrosskludge].state = entities[t].state;
-    linecrosskludge[nlinecrosskludge].life = entities[t].life;
-    nlinecrosskludge++;
+    linecrosskludge.push_back(entities[t]);
 }
 
-void entityclass::revertlinecross( int t, int s )
+void entityclass::revertlinecross(int t, int s)
 {
     //Restore entity t info from linecrossing s
     entities[t].onentity = linecrosskludge[s].onentity;
@@ -1234,13 +1110,13 @@ void entityclass::revertlinecross( int t, int s )
     entities[t].life = linecrosskludge[s].life;
 }
 
-bool entityclass::gridmatch( int p1, int p2, int p3, int p4, int p11, int p21, int p31, int p41 )
+bool entityclass::gridmatch(int p1, int p2, int p3, int p4, int p11, int p21, int p31, int p41)
 {
     if (p1 == p11 && p2 == p21 && p3 == p31 && p4 == p41) return true;
     return false;
 }
 
-int entityclass::crewcolour( int t )
+int entityclass::crewcolour(int t)
 {
     //Return the colour of the indexed crewmate
     switch(t)
@@ -1267,536 +1143,10 @@ int entityclass::crewcolour( int t )
     return 0;
 }
 
-void entityclass::setenemyroom( int t, int rx, int ry )
+void entityclass::createentity(Game& game, float xp, float yp, int t, float vx /*= 0*/, float vy /*= 0*/, int p1 /*= 0*/, int p2 /*= 0*/, int p3 /*= 320*/, int p4 /*= 240 */)
 {
-    //Simple function to initilise simple enemies
-    rx -= 100;
-    ry -= 100;
-    switch(rn(rx, ry))
-    {
-        //Space Station 1
-    case rn(12, 3):  //Security Drone
-        entities[t].tile = 36;
-        entities[t].colour = 8;
-        entities[t].animate = 1;
-        break;
-    case rn(13, 3):  //Wavelengths
-        entities[t].tile = 32;
-        entities[t].colour = 7;
-        entities[t].animate = 1;
-        entities[t].w = 32;
-        break;
-    case rn(15, 3):  //Traffic
-        entities[t].tile = 28;
-        entities[t].colour = 6;
-        entities[t].animate = 1;
-        entities[t].w = 22;
-        entities[t].h = 32;
-        break;
-    case rn(12, 5):  //The Yes Men
-        entities[t].tile = 40;
-        entities[t].colour = 9;
-        entities[t].animate = 1;
-        entities[t].w = 20;
-        entities[t].h = 20;
-        break;
-    case rn(13, 6):  //Hunchbacked Guards
-        entities[t].tile = 44;
-        entities[t].colour = 8;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 20;
-        break;
-    case rn(13, 4):  //Communication Station
-        entities[t].harmful = false;
-        if (entities[t].xp == 256)
-        {
-            //transmittor
-            entities[t].tile = 104;
-            entities[t].colour = 4;
-            entities[t].animate = 7;
-            entities[t].w = 16;
-            entities[t].h = 16;
-            entities[t].xp -= 24;
-            entities[t].yp -= 16;
-        }
-        else
-        {
-            //radar dish
-            entities[t].tile =124;
-            entities[t].colour = 4;
-            entities[t].animate = 6;
-            entities[t].w = 32;
-            entities[t].h = 32;
-            entities[t].cx = 4;
-            entities[t].size = 9;
-            entities[t].xp -= 4;
-            entities[t].yp -= 32;
-        }
-
-        break;
-        //The Lab
-    case rn(4, 0):
-        entities[t].tile = 78;
-        entities[t].colour = 7;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(2, 0):
-        entities[t].tile = 88;
-        entities[t].colour = 11;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-        //Space Station 2
-    case rn(14, 11):
-        entities[t].colour = 17;
-        break; //Lies
-    case rn(16, 11):
-        entities[t].colour = 8;
-        break; //Lies
-    case rn(13, 10):
-        entities[t].colour = 11;
-        break; //Factory
-    case rn(13, 9):
-        entities[t].colour = 9;
-        break; //Factory
-    case rn(13, 8):
-        entities[t].colour = 8;
-        break; //Factory
-    case rn(11, 13): //Truth
-        entities[t].tile = 64;
-        entities[t].colour = 7;
-        entities[t].animate = 100;
-        entities[t].w = 44;
-        entities[t].h = 10;
-        entities[t].size = 10;
-        break;
-    case rn(17, 7): //Brass sent us under the top
-        entities[t].tile =82;
-        entities[t].colour = 8;
-        entities[t].animate = 5;
-        entities[t].w = 28;
-        entities[t].h = 32;
-        entities[t].cx = 4;
-        break;
-    case rn(10, 7): // (deception)
-        entities[t].tile = 92;
-        entities[t].colour = 6;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(14, 13): // (chose poorly)
-        entities[t].tile = 56;
-        entities[t].colour = 6;
-        entities[t].animate = 1;
-        entities[t].w = 15;
-        entities[t].h = 24;
-        break;
-    case rn(13, 12): // (backsliders)
-        entities[t].tile = 164;
-        entities[t].colour = 7;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(14, 8): // (wheel of fortune room)
-        entities[t].tile = 116;
-        entities[t].colour = 12;
-        entities[t].animate = 1;
-        entities[t].w = 32;
-        entities[t].h = 32;
-        break;
-    case rn(16, 9): // (seeing dollar signs)
-        entities[t].tile = 68;
-        entities[t].colour = 7;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(16, 7): // (tomb of mad carew)
-        entities[t].tile = 106;
-        entities[t].colour = 7;
-        entities[t].animate = 2;
-        entities[t].w = 24;
-        entities[t].h = 25;
-        break;
-        //Warp Zone
-    case rn(15, 2): // (numbers)
-        entities[t].tile = 100;
-        entities[t].colour = 6;
-        entities[t].animate = 1;
-        entities[t].w = 32;
-        entities[t].h = 14;
-        entities[t].yp += 1;
-        break;
-    case rn(16, 2): // (Manequins)
-        entities[t].tile = 52;
-        entities[t].colour = 7;
-        entities[t].animate = 5;
-        entities[t].w = 16;
-        entities[t].h = 25;
-        entities[t].yp -= 4;
-        break;
-    case rn(18, 0): // (Obey)
-        entities[t].tile = 51;
-        entities[t].colour = 11;
-        entities[t].animate = 100;
-        entities[t].w = 30;
-        entities[t].h = 14;
-        break;
-    case rn(19, 1): // Ascending and Descending
-        entities[t].tile = 48;
-        entities[t].colour = 9;
-        entities[t].animate = 5;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(19, 2): // Shockwave Rider
-        entities[t].tile = 176;
-        entities[t].colour = 6;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(18, 3): // Mind the gap
-        entities[t].tile = 168;
-        entities[t].colour = 7;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(17, 3): // Edge Games
-        if (entities[t].yp ==96)
-        {
-            entities[t].tile = 160;
-            entities[t].colour = 8;
-            entities[t].animate = 1;
-            entities[t].w = 16;
-            entities[t].h = 16;
-        }
-        else
-        {
-            entities[t].tile = 156;
-            entities[t].colour = 8;
-            entities[t].animate = 1;
-            entities[t].w = 16;
-            entities[t].h = 16;
-        }
-        break;
-    case rn(16, 0): // I love you
-        entities[t].tile = 112;
-        entities[t].colour = 8;
-        entities[t].animate = 5;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(14, 2): // That's why I have to kill you
-        entities[t].tile = 114;
-        entities[t].colour = 6;
-        entities[t].animate = 5;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(18, 2): // Thinking with Portals
-        //depends on direction
-        if (entities[t].xp ==88)
-        {
-            entities[t].tile = 54+12;
-            entities[t].colour = 12;
-            entities[t].animate = 100;
-            entities[t].w = 60;
-            entities[t].h = 16;
-            entities[t].size = 10;
-        }
-        else
-        {
-            entities[t].tile = 54;
-            entities[t].colour = 12;
-            entities[t].animate = 100;
-            entities[t].w = 60;
-            entities[t].h = 16;
-            entities[t].size = 10;
-        }
-        break;
-        //Final level
-    case rn(50-100, 53-100):  //The Yes Men
-        entities[t].tile = 40;
-        entities[t].colour = 9;
-        entities[t].animate = 1;
-        entities[t].w = 20;
-        entities[t].h = 20;
-        break;
-    case rn(48-100, 51-100):  //Wavelengths
-        entities[t].tile = 32;
-        entities[t].colour = 7;
-        entities[t].animate = 1;
-        entities[t].w = 32;
-        break;
-    case rn(43-100,52-100): // Ascending and Descending
-        entities[t].tile = 48;
-        entities[t].colour = 9;
-        entities[t].animate = 5;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(46-100,51-100): //kids his age
-        entities[t].tile = 88;
-        entities[t].colour = 11;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(43-100,51-100): // Mind the gap
-        entities[t].tile = 168;
-        entities[t].colour = 7;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(44-100,51-100): // vertigo?
-        entities[t].tile = 172;
-        entities[t].colour = 7;
-        entities[t].animate = 100;
-        entities[t].w = 32;
-        entities[t].h = 32;
-        break;
-    case rn(44-100,52-100): // (backsliders)
-        entities[t].tile = 164;
-        entities[t].colour = 7;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(43-100, 56-100): //Intermission 1
-        entities[t].tile = 88;
-        entities[t].colour = 21;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(45-100, 56-100): //Intermission 1
-        entities[t].tile = 88;
-        entities[t].colour = 21;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-        //The elephant
-    case rn(11, 9):
-    case rn(12, 9):
-    case rn(11, 8):
-    case rn(12, 8):
-        entities[t].tile = 0;
-        entities[t].colour = 102;
-        entities[t].animate = 0;
-        entities[t].w = 464;
-        entities[t].h = 320;
-        entities[t].size = 11;
-        entities[t].harmful = false;
-        break;
-    }
-}
-
-void entityclass::setenemy( int t, int r )
-{
-    switch(t)
-    {
-    case 0:
-        //lies emitter
-        if( (entities[r].para)==0)
-        {
-            entities[r].tile = 60;
-            entities[r].animate = 2;
-            entities[r].colour = 6;
-            entities[r].behave = 10;
-            entities[r].w = 32;
-            entities[r].h = 32;
-            entities[r].x1 = -200;
-        }
-        else if ( (entities[r].para) == 1)
-        {
-            entities[r].yp += 10;
-            entities[r].tile = 63;
-            entities[r].animate = 100; //LIES
-            entities[r].colour = 6;
-            entities[r].behave = 11;
-            entities[r].para = 9; //destroyed when outside
-            entities[r].x1 = -200;
-            entities[r].x2 = 400;
-            entities[r].w = 26;
-            entities[r].h = 10;
-            entities[r].cx = 1;
-            entities[r].cy = 1;
-        }
-        else if ( (entities[r].para) == 2)
-        {
-            entities[r].tile = 62;
-            entities[r].animate = 100;
-            entities[r].colour = 6;
-            entities[r].behave = -1;
-            entities[r].w = 32;
-            entities[r].h = 32;
-        }
-        break;
-    case 1:
-        //FACTORY emitter
-        if( (entities[r].para)==0)
-        {
-            entities[r].tile = 72;
-            entities[r].animate = 3;
-            entities[r].size = 9;
-            entities[r].colour = 6;
-            entities[r].behave = 12;
-            entities[r].w = 64;
-            entities[r].h = 40;
-            entities[r].cx = 0;
-            entities[r].cy = 24;
-        }
-        else if ( (entities[r].para) == 1)
-        {
-            entities[r].xp += 4;
-            entities[r].yp -= 4;
-            entities[r].tile = 76;
-            entities[r].animate = 100; // Clouds
-            entities[r].colour = 6;
-            entities[r].behave = 13;
-            entities[r].para = -6; //destroyed when outside
-            entities[r].x2 = 400;
-            entities[r].w = 32;
-            entities[r].h = 12;
-            entities[r].cx = 0;
-            entities[r].cy = 6;
-        }
-        else if ( (entities[r].para) == 2)
-        {
-            entities[r].tile = 77;
-            entities[r].animate = 100;
-            entities[r].colour = 6;
-            entities[r].behave = -1;
-            entities[r].w = 32;
-            entities[r].h = 16;
-        }
-        break;
-    default:
-        break;
-    }
-}
-
-void entityclass::settreadmillcolour( int t, int rx, int ry )
-{
-    rx -= 100;
-    ry -= 100;
-    rx += 50 - 12;
-    ry += 50 - 14;   //Space Station
-
-    entities[t].tile = 20; //default as blue
-    switch(rn(rx, ry))
-    {
-    case rn(52, 48):
-        entities[t].tile = 791;
-        break; //Cyan
-
-    case rn(49, 47):
-        entities[t].tile = 24;
-        break; //Yellow
-    case rn(56, 44):
-        entities[t].tile = 24;
-        break; //Yellow
-    case rn(54, 49):
-        entities[t].tile = 24;
-        break; //Yellow
-
-    case rn(49, 49):
-        entities[t].tile = 36;
-        break; //Green
-    case rn(55, 44):
-        entities[t].tile = 36;
-        break; //Green
-    case rn(54, 43):
-        entities[t].tile = 36;
-        break; //Green
-    case rn(53, 49):
-        entities[t].tile = 36;
-        break; //Green
-    case rn(54, 45):
-        entities[t].tile = 711;
-        break; //Green (special)
-    case rn(51, 48):
-        entities[t].tile = 711;
-        break; //Green (special)
-
-    case rn(50, 49):
-        entities[t].tile = 28;
-        break; //Purple
-    case rn(54, 44):
-        entities[t].tile = 28;
-        break; //Purple
-    case rn(49, 42):
-        entities[t].tile = 28;
-        break; //Purple
-    case rn(55, 43):
-        entities[t].tile = 28;
-        break; //Purple
-    case rn(54, 47):
-        entities[t].tile = 28;
-        break; //Purple
-    case rn(53, 48):
-        entities[t].tile = 28;
-        break; //Purple
-
-    case rn(51, 47):
-        entities[t].tile = 32;
-        break; //Red
-    case rn(52, 49):
-        entities[t].tile = 32;
-        break; //Red
-    case rn(48, 43):
-        entities[t].tile = 32;
-        break; //Red
-    case rn(55, 47):
-        entities[t].tile = 32;
-        break; //Red
-    case rn(54, 48):
-        entities[t].tile = 32;
-        break; //Red
-    default:
-        return;
-        break;
-    }
-}
-
-void entityclass::createentity( Game& game, float xp, float yp, int t, float vx /*= 0*/, float vy /*= 0*/, int p1 /*= 0*/, int p2 /*= 0*/, int p3 /*= 320*/, int p4 /*= 240 */ )
-{
-    //Find the first inactive case z that we can use to index the new entity
-    if (nentity == 0)
-    {
-        //If there are no active entities, Z=0;
-        k = 0;
-        nentity++;
-    }
-    else
-    {
-        int i = 0;
-        k = -1;
-        while (i < nentity)
-        {
-            if (!entities[i].active)
-            {
-                k = i;
-                i = nentity;
-            }
-            i++;
-        }
-        if (k == -1)
-        {
-            k = nentity;
-            nentity++;
-        }
-    }
+    //'k' is used in entityclass::updateentities() for entity type 12
+    k = entities.size();
 
     //Size 0 is a sprite
     //Size 1 is a tile
@@ -1813,565 +1163,521 @@ void entityclass::createentity( Game& game, float xp, float yp, int t, float vx 
     //Rule 4 is a horizontal line, 5 is vertical
     //Rule 6 is a crew member
 
-    entities[k].clear();
-    entities[k].active = true;
-    entities[k].type = t;
+    entclass entity;
+    entity.type = t;
     switch(t)
     {
     case 0: //Player
-        entities[k].rule = 0; //Playable character
-        entities[k].tile = 0;
-        entities[k].colour = 0;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cx = 6;
-        entities[k].cy = 2;
-        entities[k].w = 12;
-        entities[k].h = 21;
-        entities[k].dir = 1;
+        entity.rule = 0; //Playable character
+        entity.tile = 0;
+        entity.colour = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cx = 6;
+        entity.cy = 2;
+        entity.w = 12;
+        entity.h = 21;
+        entity.dir = 1;
 
-        if( (vx)==1) entities[k].invis = true;
+        if (vx == 1) entity.invis = true;
 
-        entities[k].gravity = true;
+        entity.gravity = true;
         break;
     case 1: //Simple enemy, bouncing off the walls
-        entities[k].rule = 1;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].behave = vx;
-        entities[k].para = vy;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].cx = 0;
-        entities[k].cy = 0;
+        entity.rule = 1;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.behave = vx;
+        entity.para = vy;
+        entity.w = 16;
+        entity.h = 16;
+        entity.cx = 0;
+        entity.cy = 0;
 
-        entities[k].x1 = p1;
-        entities[k].y1 = p2;
-        entities[k].x2 = p3;
-        entities[k].y2 = p4;
+        entity.x1 = p1;
+        entity.y1 = p2;
+        entity.x2 = p3;
+        entity.y2 = p4;
 
-        entities[k].harmful = true;
+        entity.harmful = true;
         //Exact appearance depends entirely on location, assigned here:
-        /*
-        }else if (game.roomx == 50 && game.roomy == 52) {
-        entities[k].tile = 48; entities[k].colour = 6;
-        entities[k].w = 32;	entities[k].h = 27;
-        entities[k].animate = 1;
-        //ok, for space station 2
-        */
-        entities[k].tile = 24;
-        entities[k].animate = 0;
-        entities[k].colour = 8;
+        entity.tile = 24;
+        entity.animate = 0;
+        entity.colour = 8;
 
         if  (game.roomy == 111 && (game.roomx >= 113 && game.roomx <= 117))
         {
-            setenemy(0, k);
-            setenemyroom(k, game.roomx, game.roomy); //For colour
+            entity.setenemy(0);
+            entity.setenemyroom(game.roomx, game.roomy); //For colour
         }
         else if  (game.roomx == 113 && (game.roomy <= 110 && game.roomy >= 108))
         {
-            setenemy(1, k);
-            setenemyroom(k, game.roomx, game.roomy); //For colour
+            entity.setenemy(1);
+            entity.setenemyroom(game.roomx, game.roomy); //For colour
         }
         else if (game.roomx == 113 && game.roomy == 107)
         {
             //MAVVERRRICK
-            entities[k].tile = 96;
-            entities[k].colour = 6;
-            entities[k].size = 9;
-            entities[k].w = 64;
-            entities[k].h = 44;
-            entities[k].animate = 4;
+            entity.tile = 96;
+            entity.colour = 6;
+            entity.size = 9;
+            entity.w = 64;
+            entity.h = 44;
+            entity.animate = 4;
         }
         else
         {
-            setenemyroom(k, game.roomx, game.roomy);
+            entity.setenemyroom(game.roomx, game.roomy);
         }
-
-        //}else{*/
-        /*
-        entities[k].tile = 24;
-        entities[k].animate = 0;
-        entities[k].colour = 8;
-        //for warpzone:
-        if (game.roomx == 51 && game.roomy == 51) entities[k].colour = 6;
-        if (game.roomx == 52 && game.roomy == 51) entities[k].colour = 7;
-        if (game.roomx == 54 && game.roomy == 49) entities[k].colour = 11;
-        if (game.roomx == 55 && game.roomy == 50) entities[k].colour = 9;
-        if (game.roomx == 55 && game.roomy == 51) entities[k].colour = 6;
-        if (game.roomx == 54 && game.roomy == 51) entities[k].colour = 12;
-        if (game.roomx == 54 && game.roomy == 52) entities[k].colour = 7;
-        if (game.roomx == 53 && game.roomy == 52) entities[k].colour = 8;
-        if (game.roomx == 51 && game.roomy == 52) entities[k].colour = 6;
-        if (game.roomx == 52 && game.roomy == 49) entities[k].colour = 8;
-        //}
-        */
         break;
     case 2: //A moving platform
-        entities[k].rule = 2;
-        entities[k].type = 1;
-        entities[k].size = 2;
-        entities[k].tile = 1;
+        entity.rule = 2;
+        entity.type = 1;
+        entity.size = 2;
+        entity.tile = 1;
 
         if (customplatformtile > 0){
-            entities[k].tile = customplatformtile;
+            entity.tile = customplatformtile;
         }else if (platformtile > 0) {
-						entities[k].tile = platformtile;
+            entity.tile = platformtile;
         }else{
           //appearance again depends on location
-          if (gridmatch(p1, p2, p3, p4, 100, 70, 320, 160)) entities[k].tile = 616;
-          if (gridmatch(p1, p2, p3, p4, 72, 0, 248, 240)) entities[k].tile = 610;
-          if (gridmatch(p1, p2, p3, p4, -20, 0, 320, 240)) entities[k].tile = 413;
+          if (gridmatch(p1, p2, p3, p4, 100, 70, 320, 160)) entity.tile = 616;
+          if (gridmatch(p1, p2, p3, p4, 72, 0, 248, 240)) entity.tile = 610;
+          if (gridmatch(p1, p2, p3, p4, -20, 0, 320, 240)) entity.tile = 413;
 
-          if (gridmatch(p1, p2, p3, p4, -96, -72, 400, 312)) entities[k].tile = 26;
-          if (gridmatch(p1, p2, p3, p4, -32, -40, 352, 264)) entities[k].tile = 27;
+          if (gridmatch(p1, p2, p3, p4, -96, -72, 400, 312)) entity.tile = 26;
+          if (gridmatch(p1, p2, p3, p4, -32, -40, 352, 264)) entity.tile = 27;
         }
 
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 32;
-        entities[k].h = 8;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 32;
+        entity.h = 8;
 
-		if (int(vx) <= 1) vertplatforms = true;
-		if (int(vx) >= 2  && int(vx) <= 5) horplatforms = true;
-		if (int(vx) == 14 || int(vx) == 15) horplatforms = true; //special case for last part of Space Station
-		if (int(vx) >= 6  && int(vx) <= 7) vertplatforms = true;
+        if (int(vx) <= 1) vertplatforms = true;
+        if (int(vx) >= 2  && int(vx) <= 5) horplatforms = true;
+        if (int(vx) == 14 || int(vx) == 15) horplatforms = true; //special case for last part of Space Station
+        if (int(vx) >= 6  && int(vx) <= 7) vertplatforms = true;
 
         if (int(vx) >= 10  && int(vx) <= 11)
         {
             //Double sized threadmills
-            entities[k].w = 64;
-            entities[k].h = 8;
+            entity.w = 64;
+            entity.h = 8;
             vx -= 2;
-            entities[k].size = 8;
+            entity.size = 8;
         }
 
-        entities[k].behave = vx;
-        entities[k].para = vy;
+        entity.behave = vx;
+        entity.para = vy;
 
         if (int(vx) >= 8  && int(vx) <= 9)
         {
             horplatforms = true; //threadmill!
-            entities[k].animate = 10;
-            if(customplatformtile>0){
-              entities[k].tile = customplatformtile+4;
-              if (int(vx) == 8) entities[k].tile += 4;
-              if (int(vx) == 9) entities[k].animate = 11;
-            }else{
-              settreadmillcolour(k, game.roomx, game.roomy);
-              if (int(vx) == 8) entities[k].tile += 40;
-              if (int(vx) == 9) entities[k].animate = 11;
+            entity.animate = 10;
+            if (customplatformtile > 0)
+            {
+                entity.tile = customplatformtile + 4;
+                if (int(vx) == 8) entity.tile += 4;
+                if (int(vx) == 9) entity.animate = 11;
+            }
+            else
+            {
+                entity.settreadmillcolour(game.roomx, game.roomy);
+                if (int(vx) == 8) entity.tile += 40;
+                if (int(vx) == 9) entity.animate = 11;
             }
         }
         else
         {
-            entities[k].animate = 100;
+            entity.animate = 100;
         }
 
-        entities[k].x1 = p1;
-        entities[k].y1 = p2;
-        entities[k].x2 = p3;
-        entities[k].y2 = p4;
+        entity.x1 = p1;
+        entity.y1 = p2;
+        entity.x2 = p3;
+        entity.y2 = p4;
 
-        entities[k].isplatform = true;
+        entity.isplatform = true;
 
         createblock(0, xp, yp, 32, 8);
         break;
     case 3: //Disappearing platforms
-        entities[k].rule = 3;
-        entities[k].type = 2;
-        entities[k].size = 2;
-        entities[k].tile = 2;
+        entity.rule = 3;
+        entity.type = 2;
+        entity.size = 2;
+        entity.tile = 2;
         //appearance again depends on location
-        if(customplatformtile>0)
+        if (customplatformtile > 0)
         {
-          entities[k].tile=customplatformtile;
+            entity.tile = customplatformtile;
         }
         else if (vx > 0)
         {
-            entities[k].tile = int(vx);
+            entity.tile = vx;
         }
         else
         {
-            if(game.roomx==49 && game.roomy==52) entities[k].tile = 18;
-            if (game.roomx == 50 && game.roomy == 52) entities[k].tile = 22;
+            if (game.roomx == 49 && game.roomy == 52) entity.tile = 18;
+            if (game.roomx == 50 && game.roomy == 52) entity.tile = 22;
         }
 
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cy = -1;
-        entities[k].w = 32;
-        entities[k].h = 10;
-        entities[k].behave = vx;
-        entities[k].para = vy;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cy = -1;
+        entity.w = 32;
+        entity.h = 10;
+        entity.behave = vx;
+        entity.para = vy;
+        entity.onentity = 1;
+        entity.animate = 100;
 
         createblock(0, xp, yp, 32, 8);
         break;
     case 4: //Breakable blocks
-        entities[k].rule = 6;
-        entities[k].type = 3;
-        entities[k].size = 1;
-        entities[k].tile = 10;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cy = -1;
-        entities[k].w = 8;
-        entities[k].h = 10;
-        entities[k].behave = vx;
-        entities[k].para = vy;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
+        entity.rule = 6;
+        entity.type = 3;
+        entity.size = 1;
+        entity.tile = 10;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cy = -1;
+        entity.w = 8;
+        entity.h = 10;
+        entity.behave = vx;
+        entity.para = vy;
+        entity.onentity = 1;
+        entity.animate = 100;
 
         createblock(0, xp, yp, 8, 8);
         break;
     case 5: //Gravity Tokens
-        entities[k].rule = 3;
-        entities[k].type = 4;
-        entities[k].size = 0;
-        entities[k].tile = 11;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].behave = vx;
-        entities[k].para = vy;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
+        entity.rule = 3;
+        entity.type = 4;
+        entity.size = 0;
+        entity.tile = 11;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.behave = vx;
+        entity.para = vy;
+        entity.onentity = 1;
+        entity.animate = 100;
         break;
     case 6: //Decorative particles
-        entities[k].rule = 2;
-        entities[k].type = 5;  //Particles
-        entities[k].colour = 1;
-        entities[k].size = 3;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].vx = vx;
-        entities[k].vy = vy;
+        entity.rule = 2;
+        entity.type = 5;  //Particles
+        entity.colour = 1;
+        entity.size = 3;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.vx = vx;
+        entity.vy = vy;
 
-        entities[k].life = 12;
+        entity.life = 12;
         break;
     case 7: //Decorative particles
-        entities[k].rule = 2;
-        entities[k].type = 5;  //Particles
-        entities[k].colour = 2;
-        entities[k].size = 3;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].vx = vx;
-        entities[k].vy = vy;
+        entity.rule = 2;
+        entity.type = 5;  //Particles
+        entity.colour = 2;
+        entity.size = 3;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.vx = vx;
+        entity.vy = vy;
 
-        entities[k].life = 12;
+        entity.life = 12;
         break;
     case 8: //Small collectibles
-        entities[k].rule = 3;
-        entities[k].type = 6;
-        entities[k].size = 4;
-        entities[k].tile = 48;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 8;
-        entities[k].h = 8;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
+        entity.rule = 3;
+        entity.type = 6;
+        entity.size = 4;
+        entity.tile = 48;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 8;
+        entity.h = 8;
+        entity.onentity = 1;
+        entity.animate = 100;
 
         //Check if it's already been collected
-        entities[k].para = vx;
-        if (collect[vx] == 1) entities[k].active = false;
+        entity.para = vx;
+        if (collect[vx] == 1) return;
         break;
     case 9: //Something Shiny
-        entities[k].rule = 3;
-        entities[k].type = 7;
-        entities[k].size = 0;
-        entities[k].tile = 22;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].colour = 3;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
+        entity.rule = 3;
+        entity.type = 7;
+        entity.size = 0;
+        entity.tile = 22;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.colour = 3;
+        entity.onentity = 1;
+        entity.animate = 100;
 
         //Check if it's already been collected
-        entities[k].para = vx;
-        if (collect[vx] == 1) entities[k].active = false;
+        entity.para = vx;
+        if (collect[vx] == 1) return;
         break;
     case 10: //Savepoint
-        entities[k].rule = 3;
-        entities[k].type = 8;
-        entities[k].size = 0;
-        entities[k].tile = 20 + vx;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].colour = 4;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
-        entities[k].para = vy;
+        entity.rule = 3;
+        entity.type = 8;
+        entity.size = 0;
+        entity.tile = 20 + vx;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.colour = 4;
+        entity.onentity = 1;
+        entity.animate = 100;
+        entity.para = vy;
 
-        if (game.savepoint ==  (vy))
+        if (game.savepoint == vy)
         {
-            entities[k].colour = 5;
-            entities[k].onentity = 0;
+            entity.colour = 5;
+            entity.onentity = 0;
         }
 
-        if (game.nodeathmode)
-        {
-            entities[k].active = false;
-        }
+        if (game.nodeathmode) return;
         break;
     case 11: //Horizontal Gravity Line
-        entities[k].rule = 4;
-        entities[k].type = 9;
-        entities[k].size = 5;
-        entities[k].life = 0;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = vx;
-        entities[k].h = 1;
-        entities[k].onentity = 1;
+        entity.rule = 4;
+        entity.type = 9;
+        entity.size = 5;
+        entity.life = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = vx;
+        entity.h = 1;
+        entity.onentity = 1;
         break;
     case 12: //Vertical Gravity Line
-        entities[k].rule = 5;
-        entities[k].type = 10;
-        entities[k].size = 6;
-        entities[k].life = 0;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 1;
-        entities[k].h = vx;
-        //entities[k].colour = 0;
-        entities[k].onentity = 1;
+        entity.rule = 5;
+        entity.type = 10;
+        entity.size = 6;
+        entity.life = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 1;
+        entity.h = vx;
+        entity.onentity = 1;
         break;
     case 13: //Warp token
-        entities[k].rule = 3;
-        entities[k].type = 11;
-        entities[k].size = 0;
-        entities[k].tile = 18;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].colour = 10;
-        entities[k].onentity = 1;
-        entities[k].animate = 2;
+        entity.rule = 3;
+        entity.type = 11;
+        entity.size = 0;
+        entity.tile = 18;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.colour = 10;
+        entity.onentity = 1;
+        entity.animate = 2;
         //Added in port, hope it doesn't break anything
-        entities[k].behave = vx;
-        entities[k].para = vy;
+        entity.behave = vx;
+        entity.para = vy;
         break;
     case 14: // Teleporter
-        entities[k].rule = 3;
-        entities[k].type = 100;
-        entities[k].size = 7;
-        entities[k].tile = 1; //inactive
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 96;
-        entities[k].h = 96;
-        entities[k].colour = 100;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
-        entities[k].para = vy;
-
-        //we'll init it's activeness here later
-        /*if (game.savepoint == vy) {
-        entities[k].colour = 5;
-        entities[k].onentity = 0;
-        }*/
+        entity.rule = 3;
+        entity.type = 100;
+        entity.size = 7;
+        entity.tile = 1; //inactive
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 96;
+        entity.h = 96;
+        entity.colour = 100;
+        entity.onentity = 1;
+        entity.animate = 100;
+        entity.para = vy;
         break;
     case 15: // Crew Member (warp zone)
-        entities[k].rule = 6;
-        entities[k].type = 12; //A special case!
-        entities[k].tile = 144;
-        entities[k].colour = 13; //144 for sad :(
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cx = 6;
-        entities[k].cy = 2;
-        entities[k].w = 12;
-        entities[k].h = 21;
-        entities[k].dir = 0;
+        entity.rule = 6;
+        entity.type = 12; //A special case!
+        entity.tile = 144;
+        entity.colour = 13; //144 for sad :(
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cx = 6;
+        entity.cy = 2;
+        entity.w = 12;
+        entity.h = 21;
+        entity.dir = 0;
 
-        entities[k].state = vx;
+        entity.state = vx;
 
-        entities[k].gravity = true;
+        entity.gravity = true;
         break;
     case 16: // Crew Member, upside down (space station)
-        entities[k].rule = 7;
-        entities[k].type = 12; //A special case!
-        entities[k].tile = 144+6;
-        entities[k].colour = 14; //144 for sad (upside down+12):(
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cx = 6;
-        entities[k].cy = 2;
-        entities[k].w = 12;
-        entities[k].h = 21;
-        entities[k].dir = 1;
+        entity.rule = 7;
+        entity.type = 12; //A special case!
+        entity.tile = 144+6;
+        entity.colour = 14; //144 for sad (upside down+12):(
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cx = 6;
+        entity.cy = 2;
+        entity.w = 12;
+        entity.h = 21;
+        entity.dir = 1;
 
-        entities[k].state = vx;
+        entity.state = vx;
 
-        entities[k].gravity = true;
+        entity.gravity = true;
         break;
     case 17: // Crew Member (Lab)
-        entities[k].rule = 6;
-        entities[k].type = 12; //A special case!
-        entities[k].tile = 144;
-        entities[k].colour = 16; //144 for sad :(
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cx = 6;
-        entities[k].cy = 2;
-        entities[k].w = 12;
-        entities[k].h = 21;
-        entities[k].dir = 1;
+        entity.rule = 6;
+        entity.type = 12; //A special case!
+        entity.tile = 144;
+        entity.colour = 16; //144 for sad :(
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cx = 6;
+        entity.cy = 2;
+        entity.w = 12;
+        entity.h = 21;
+        entity.dir = 1;
 
-        entities[k].state = vx;
+        entity.state = vx;
 
-        entities[k].gravity = true;
+        entity.gravity = true;
         break;
     case 18: // Crew Member (Ship)
         //This is the scriping crewmember
-        entities[k].rule = 6;
-        entities[k].type = 12; //A special case!
-        entities[k].colour = vx;
+        entity.rule = 6;
+        entity.type = 12; //A special case!
+        entity.colour = vx;
         if (int(vy) == 0)
         {
-            entities[k].tile = 0;
+            entity.tile = 0;
         }
         else
         {
-            entities[k].tile = 144;
+            entity.tile = 144;
         }
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cx = 6;
-        entities[k].cy = 2;
-        entities[k].w = 12;
-        entities[k].h = 21;
-        entities[k].dir = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cx = 6;
+        entity.cy = 2;
+        entity.w = 12;
+        entity.h = 21;
+        entity.dir = 0;
 
-        entities[k].state = p1;
-        entities[k].para = p2;
+        entity.state = p1;
+        entity.para = p2;
 
         if (p1 == 17)
         {
-            entities[k].dir = p2;
+            entity.dir = p2;
         }
 
-        entities[k].gravity = true;
+        entity.gravity = true;
         break;
     case 19: // Crew Member (Ship) More tests!
-        entities[k].rule = 6;
-        entities[k].type = 12; //A special case!
-        entities[k].tile = 0;
-        entities[k].colour = 6; //54 for sad :(
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cx = 6;
-        entities[k].cy = 2;
-        entities[k].w = 12;
-        entities[k].h = 21;
-        entities[k].dir = 1;
+        entity.rule = 6;
+        entity.type = 12; //A special case!
+        entity.tile = 0;
+        entity.colour = 6; //54 for sad :(
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cx = 6;
+        entity.cy = 2;
+        entity.w = 12;
+        entity.h = 21;
+        entity.dir = 1;
 
-        entities[k].state = vx;
+        entity.state = vx;
 
-        entities[k].gravity = true;
+        entity.gravity = true;
         break;
     case 20: //Terminal
-        entities[k].rule = 3;
-        entities[k].type = 13;
-        entities[k].size = 0;
-        entities[k].tile = 16 + vx;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].colour = 4;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
-        entities[k].para = vy;
-
-        /*if (game.savepoint == vy) {
-        entities[k].colour = 5;
-        entities[k].onentity = 0;
-        }*/
+        entity.rule = 3;
+        entity.type = 13;
+        entity.size = 0;
+        entity.tile = 16 + vx;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.colour = 4;
+        entity.onentity = 1;
+        entity.animate = 100;
+        entity.para = vy;
         break;
     case 21: //as above, except doesn't highlight
-        entities[k].rule = 3;
-        entities[k].type = 13;
-        entities[k].size = 0;
-        entities[k].tile = 16 + vx;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].colour = 4;
-        entities[k].onentity = 0;
-        entities[k].animate = 100;
-        entities[k].para = vy;
-
-        /*if (game.savepoint == vy) {
-        entities[k].colour = 5;
-        entities[k].onentity = 0;
-        }*/
+        entity.rule = 3;
+        entity.type = 13;
+        entity.size = 0;
+        entity.tile = 16 + vx;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.colour = 4;
+        entity.onentity = 0;
+        entity.animate = 100;
+        entity.para = vy;
         break;
     case 22: //Fake trinkets, only appear if you've collected them
-        entities[k].rule = 3;
-        entities[k].type = 7;
-        entities[k].size = 0;
-        entities[k].tile = 22;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].colour = 3;
-        entities[k].onentity = 0;
-        entities[k].animate = 100;
+        entity.rule = 3;
+        entity.type = 7;
+        entity.size = 0;
+        entity.tile = 22;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.colour = 3;
+        entity.onentity = 0;
+        entity.animate = 100;
 
         //Check if it's already been collected
-        entities[k].para = vx;
-        if (collect[ (vx)] == 0) entities[k].active = false;
+        entity.para = vx;
+        if (collect[vx] == 0) return;
         break;
     case 23: //SWN Enemies
         //Given a different behavior, these enemies are especially for SWN mode and disappear outside the screen.
-        entities[k].rule = 1;
-        entities[k].type = 23;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].behave = vx;
-        entities[k].para = vy;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].cx = 0;
-        entities[k].cy = 0;
+        entity.rule = 1;
+        entity.type = 23;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.behave = vx;
+        entity.para = vy;
+        entity.w = 16;
+        entity.h = 16;
+        entity.cx = 0;
+        entity.cy = 0;
 
-        entities[k].x1 = -2000;
-        entities[k].y1 = -100;
-        entities[k].x2 = 5200;
-        entities[k].y2 = 340;
+        entity.x1 = -2000;
+        entity.y1 = -100;
+        entity.x2 = 5200;
+        entity.y2 = 340;
 
-        entities[k].harmful = true;
+        entity.harmful = true;
 
         //initilise tiles here based on behavior
-        entities[k].size = 12; //don't wrap around
-        entities[k].colour = 21;
-        entities[k].tile = 78; //default case
-        entities[k].animate = 1;
+        entity.size = 12; //don't wrap around
+        entity.colour = 21;
+        entity.tile = 78; //default case
+        entity.animate = 1;
         if (game.swngame == 1)
         {
             //set colour based on current state
-            entities[k].colour = swncolour(game.swncolstate);
+            entity.colour = swncolour(game.swncolstate);
         }
         break;
     case 24: // Super Crew Member
         //This special crewmember is way more advanced than the usual kind, and can interact with game objects
-        entities[k].rule = 6;
-        entities[k].type = 14; //A special case!
-        entities[k].colour = vx;
-        if( (vx)==16)
+        entity.rule = 6;
+        entity.type = 14; //A special case!
+        entity.colour = vx;
+        if (int(vx) == 16)
         {
             //victoria is sad!
             if (int(vy) == 2) vy = 1;
@@ -2382,205 +1688,193 @@ void entityclass::createentity( Game& game, float xp, float yp, int t, float vx 
         }
         if (int(vy) == 0)
         {
-            entities[k].tile = 0;
+            entity.tile = 0;
         }
         else
         {
-            entities[k].tile = 144;
+            entity.tile = 144;
         }
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cx = 6;
-        entities[k].cy = 2;
-        entities[k].w = 12;
-        entities[k].h = 21;
-        entities[k].dir = 1;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cx = 6;
+        entity.cy = 2;
+        entity.w = 12;
+        entity.h = 21;
+        entity.dir = 1;
 
-        entities[k].x1 = -2000;
-        entities[k].y1 = -100;
-        entities[k].x2 = 5200;
-        entities[k].y2 = 340;
+        entity.x1 = -2000;
+        entity.y1 = -100;
+        entity.x2 = 5200;
+        entity.y2 = 340;
 
-        entities[k].state = p1;
-        entities[k].para = p2;
+        entity.state = p1;
+        entity.para = p2;
 
         if (p1 == 17)
         {
-            entities[k].dir = p2;
+            entity.dir = p2;
         }
 
-        entities[k].gravity = true;
+        entity.gravity = true;
         break;
     case 25: //Trophies
-        entities[k].rule = 3;
-        entities[k].type = 15;
-        entities[k].size = 0;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].colour = 4;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
-        entities[k].para = vy;
+        entity.rule = 3;
+        entity.type = 15;
+        entity.size = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.colour = 4;
+        entity.onentity = 1;
+        entity.animate = 100;
+        entity.para = vy;
 
         //Decide tile here based on given achievement: both whether you have them and what they are
         //default is just a trophy base:
-        entities[k].tile = 180 + vx;
-        switch(int(vy))
+        entity.tile = 180 + vx;
+        switch (int(vy))
         {
         case 1:
-            if(game.bestrank[0]>=3)
+            if (game.bestrank[0] >= 3)
             {
-                entities[k].tile = 184 + vx;
-                entities[k].colour = 31;
+                entity.tile = 184 + vx;
+                entity.colour = 31;
             }
             break;
         case 2:
-            if(game.bestrank[1]>=3)
+            if (game.bestrank[1] >= 3)
             {
-                entities[k].tile = 186 + vx;
-                entities[k].colour = 35;
+                entity.tile = 186 + vx;
+                entity.colour = 35;
             }
             break;
         case 3:
-            if(game.bestrank[2]>=3)
+            if (game.bestrank[2] >= 3)
             {
-                entities[k].tile = 184 + vx;
-                entities[k].colour = 33;
+                entity.tile = 184 + vx;
+                entity.colour = 33;
             }
             break;
         case 4:
-            if(game.bestrank[3]>=3)
+            if (game.bestrank[3] >= 3)
             {
-                entities[k].tile = 184 + vx;
-                entities[k].colour = 32;
+                entity.tile = 184 + vx;
+                entity.colour = 32;
             }
             break;
         case 5:
-            if(game.bestrank[4]>=3)
+            if (game.bestrank[4] >= 3)
             {
-                entities[k].tile = 184 + vx;
-                entities[k].colour = 34;
+                entity.tile = 184 + vx;
+                entity.colour = 34;
             }
             break;
         case 6:
-            if(game.bestrank[5]>=3)
+            if (game.bestrank[5] >= 3)
             {
-                entities[k].tile = 184 + vx;
-                entities[k].colour = 30;
+                entity.tile = 184 + vx;
+                entity.colour = 30;
             }
             break;
 
         case 7:
-            if(game.unlock[5])
+            if (game.unlock[5])
             {
-                entities[k].tile = 188 + vx;
-                entities[k].colour = 37;
-                entities[k].h += 3;
+                entity.tile = 188 + vx;
+                entity.colour = 37;
+                entity.h += 3;
             }
             break;
         case 8:
-            if(game.unlock[19])
+            if (game.unlock[19])
             {
-                entities[k].tile = 188 + vx;
-                entities[k].colour = 37;
-                entities[k].h += 3;
+                entity.tile = 188 + vx;
+                entity.colour = 37;
+                entity.h += 3;
             }
             break;
 
         case 9:
-            if (game.bestgamedeaths > -1)
+            if (game.bestgamedeaths > -1 && game.bestgamedeaths <= 50)
             {
-                if (game.bestgamedeaths <= 50)
-                {
-                    entities[k].tile = 182 + vx;
-                    entities[k].colour = 40;
-                }
+                entity.tile = 182 + vx;
+                entity.colour = 40;
             }
             break;
         case 10:
-            if (game.bestgamedeaths > -1)
+            if (game.bestgamedeaths > -1 && game.bestgamedeaths <= 100)
             {
-                if (game.bestgamedeaths <= 100)
-                {
-                    entities[k].tile = 182 + vx;
-                    entities[k].colour = 36;
-                }
+                entity.tile = 182 + vx;
+                entity.colour = 36;
             }
             break;
         case 11:
-            if (game.bestgamedeaths > -1)
+            if (game.bestgamedeaths > -1 && game.bestgamedeaths <= 250)
             {
-                if (game.bestgamedeaths <= 250)
-                {
-                    entities[k].tile = 182 + vx;
-                    entities[k].colour = 38;
-                }
+                entity.tile = 182 + vx;
+                entity.colour = 38;
             }
             break;
         case 12:
-            if (game.bestgamedeaths > -1)
+            if (game.bestgamedeaths > -1 && game.bestgamedeaths <= 500)
             {
-                if (game.bestgamedeaths <= 500)
-                {
-                    entities[k].tile = 182 + vx;
-                    entities[k].colour = 39;
-                }
+                entity.tile = 182 + vx;
+                entity.colour = 39;
             }
             break;
 
         case 13:
-            if(game.swnbestrank>=1)
+            if (game.swnbestrank >= 1)
             {
-                entities[k].tile = 182 + vx;
-                entities[k].colour = 39;
+                entity.tile = 182 + vx;
+                entity.colour = 39;
             }
             break;
         case 14:
-            if(game.swnbestrank>=2)
+            if (game.swnbestrank >= 2)
             {
-                entities[k].tile =  (182 + vx);
-                entities[k].colour = 39;
+                entity.tile = 182 + vx;
+                entity.colour = 39;
             }
             break;
         case 15:
-            if(game.swnbestrank>=3)
+            if (game.swnbestrank >= 3)
             {
-                entities[k].tile =  (182 + vx);
-                entities[k].colour = 39;
+                entity.tile = 182 + vx;
+                entity.colour = 39;
             }
             break;
         case 16:
-            if(game.swnbestrank>=4)
+            if (game.swnbestrank >= 4)
             {
-                entities[k].tile =  (182 + vx);
-                entities[k].colour = 38;
+                entity.tile = 182 + vx;
+                entity.colour = 38;
             }
             break;
         case 17:
-            if(game.swnbestrank>=5)
+            if (game.swnbestrank >= 5)
             {
-                entities[k].tile =  (182 + vx);
-                entities[k].colour = 36;
+                entity.tile = 182 + vx;
+                entity.colour = 36;
             }
             break;
         case 18:
-            if(game.swnbestrank>=6)
+            if (game.swnbestrank >= 6)
             {
-                entities[k].tile =  (182 + vx);
-                entities[k].colour = 40;
+                entity.tile = 182 + vx;
+                entity.colour = 40;
             }
             break;
 
         case 19:
-            if(game.unlock[20])
+            if (game.unlock[20])
             {
-                entities[k].tile = 3;
-                entities[k].colour = 102;
-                entities[k].size = 13;
-                entities[k].xp -= 64;
-                entities[k].yp -= 128;
+                entity.tile = 3;
+                entity.colour = 102;
+                entity.size = 13;
+                entity.xp -= 64;
+                entity.yp -= 128;
             }
             break;
 
@@ -2588,1324 +1882,1279 @@ void entityclass::createentity( Game& game, float xp, float yp, int t, float vx 
 
         break;
     case 26: //Epilogue super warp token
-        entities[k].rule = 3;
-        entities[k].type = 11;
-        entities[k].size = 0;
-        entities[k].tile = 18;
-        entities[k].xp =  (xp);
-        entities[k].yp =  (yp);
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].colour = 3;
-        entities[k].onentity = 0;
-        entities[k].animate = 100;
-        entities[k].para = vy;
-        entities[k].size = 13;
+        entity.rule = 3;
+        entity.type = 11;
+        entity.size = 0;
+        entity.tile = 18;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.colour = 3;
+        entity.onentity = 0;
+        entity.animate = 100;
+        entity.para = vy;
+        entity.size = 13;
         break;
 
     case 51: //Vertical Warp Line
-        entities[k].rule = 5;
-        entities[k].type = 51;
-        entities[k].size = 6;
-        entities[k].life = 0;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 1;
-        entities[k].h = vx;
-        //entities[k].colour = 0;
-        entities[k].onentity = 1;
-        entities[k].invis=true;
+        entity.rule = 5;
+        entity.type = 51;
+        entity.size = 6;
+        entity.life = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 1;
+        entity.h = vx;
+        entity.onentity = 1;
+        entity.invis = true;
         if (map.custommode) customwarpmode = true;
         break;
       case 52: //Vertical Warp Line
-        entities[k].rule = 5;
-        entities[k].type = 52;
-        entities[k].size = 6;
-        entities[k].life = 0;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 1;
-        entities[k].h = vx;
-        //entities[k].colour = 0;
-        entities[k].onentity = 1;
-        entities[k].invis=true;
+        entity.rule = 5;
+        entity.type = 52;
+        entity.size = 6;
+        entity.life = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 1;
+        entity.h = vx;
+        entity.onentity = 1;
+        entity.invis = true;
         if (map.custommode) customwarpmode = true;
         break;
       case 53: //Horizontal Warp Line
-        entities[k].rule = 7;
-        entities[k].type = 53;
-        entities[k].size = 5;
-        entities[k].life = 0;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = vx;
-        entities[k].h = 1;
-        entities[k].onentity = 1;
-        entities[k].invis=true;
+        entity.rule = 7;
+        entity.type = 53;
+        entity.size = 5;
+        entity.life = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = vx;
+        entity.h = 1;
+        entity.onentity = 1;
+        entity.invis = true;
         if (map.custommode) customwarpmode = true;
         break;
       case 54: //Horizontal Warp Line
-        entities[k].rule = 7;
-        entities[k].type = 54;
-        entities[k].size = 5;
-        entities[k].life = 0;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = vx;
-        entities[k].h = 1;
-        entities[k].onentity = 1;
-        entities[k].invis=true;
+        entity.rule = 7;
+        entity.type = 54;
+        entity.size = 5;
+        entity.life = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = vx;
+        entity.h = 1;
+        entity.onentity = 1;
+        entity.invis = true;
         if (map.custommode) customwarpmode = true;
         break;
       case 55: // Crew Member (custom, collectable)
         //1 - position in array
         //2 - colour
-        entities[k].rule = 3;
-        entities[k].type = 55;
-        if(customcrewmoods[int(vy)]==1){
-          entities[k].tile = 144;
-        }else{
-          entities[k].tile = 0;
+        entity.rule = 3;
+        entity.type = 55;
+        if (customcrewmoods[int(vy)] == 1)
+        {
+            entity.tile = 144;
         }
-        entities[k].colour = crewcolour(int(vy));
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cx = 6;
-        entities[k].cy = 2;
-        entities[k].w = 12;
-        entities[k].h = 21;
-        entities[k].dir = 0;
+        else
+        {
+            entity.tile = 0;
+        }
+        entity.colour = crewcolour(vy);
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cx = 6;
+        entity.cy = 2;
+        entity.w = 12;
+        entity.h = 21;
+        entity.dir = 0;
 
-        entities[k].state = 0;
-        entities[k].onentity = 1;
-        //entities[k].state = vx;
+        entity.state = 0;
+        entity.onentity = 1;
 
-        entities[k].gravity = true;
+        entity.gravity = true;
 
         //Check if it's already been collected
-        entities[k].para = vx;
-        if (customcollect[vx] == 1) entities[k].active = false;
+        entity.para = vx;
+        if (customcollect[int(vx)] == 1) return;
         break;
       case 56: //Custom enemy
-        entities[k].rule = 1;
-        entities[k].type = 1;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].behave = vx;
-        entities[k].para = vy;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].cx = 0;
-        entities[k].cy = 0;
+        entity.rule = 1;
+        entity.type = 1;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.behave = vx;
+        entity.para = vy;
+        entity.w = 16;
+        entity.h = 16;
+        entity.cx = 0;
+        entity.cy = 0;
 
-        entities[k].x1 = p1;
-        entities[k].y1 = p2;
-        entities[k].x2 = p3;
-        entities[k].y2 = p4;
+        entity.x1 = p1;
+        entity.y1 = p2;
+        entity.x2 = p3;
+        entity.y2 = p4;
 
-        entities[k].harmful = true;
+        entity.harmful = true;
 
-        switch(customenemy){
-          case 0: setenemyroom(k, 4+100, 0+100); break;
-          case 1: setenemyroom(k, 2+100, 0+100); break;
-          case 2: setenemyroom(k, 12+100, 3+100); break;
-          case 3: setenemyroom(k, 13+100, 12+100); break;
-          case 4: setenemyroom(k, 16+100, 9+100); break;
-          case 5: setenemyroom(k, 19+100, 1+100); break;
-          case 6: setenemyroom(k, 19+100, 2+100); break;
-          case 7: setenemyroom(k, 18+100, 3+100); break;
-          case 8: setenemyroom(k, 16+100, 0+100); break;
-          case 9: setenemyroom(k, 14+100, 2+100); break;
-          default: setenemyroom(k, 4+100, 0+100); break;
+        switch (customenemy) {
+            case 0: entity.setenemyroom(4+100, 0+100); break;
+            case 1: entity.setenemyroom(2+100, 0+100); break;
+            case 2: entity.setenemyroom(12+100, 3+100); break;
+            case 3: entity.setenemyroom(13+100, 12+100); break;
+            case 4: entity.setenemyroom(16+100, 9+100); break;
+            case 5: entity.setenemyroom(19+100, 1+100); break;
+            case 6: entity.setenemyroom(19+100, 2+100); break;
+            case 7: entity.setenemyroom(18+100, 3+100); break;
+            case 8: entity.setenemyroom(16+100, 0+100); break;
+            case 9: entity.setenemyroom(14+100, 2+100); break;
+            default: entity.setenemyroom(4+100, 0+100); break;
         }
 
         //Set colour based on room tile
-         //Set custom colours
-        if(customplatformtile>0){
-          int entcol=(customplatformtile/12);
-          switch(entcol){
-            //RED
-            case 3: case 7: case 12: case 23: case 28:
-            case 34: case 42: case 48: case 58:
-              entities[k].colour = 6; break;
-            //GREEN
-            case 5: case 9: case 22: case 25: case 29:
-            case 31: case 38: case 46: case 52: case 53:
-              entities[k].colour = 7; break;
-            //BLUE
-            case 1: case 6: case 14: case 27: case 33:
-            case 44: case 50: case 57:
-              entities[k].colour = 12; break;
-            //YELLOW
-            case 4: case 17: case 24: case 30: case 37:
-            case 45: case 51: case 55:
-              entities[k].colour = 9; break;
-            //PURPLE
-            case 2: case 11: case 15: case 19: case 32:
-            case 36: case 49:
-              entities[k].colour = 20; break;
-            //CYAN
-            case 8: case 10: case 13: case 18: case 26:
-            case 35: case 41: case 47: case 54:
-              entities[k].colour = 11; break;
-            //PINK
-            case 16: case 20: case 39: case 43: case 56:
-              entities[k].colour = 8; break;
-            //ORANGE
-            case 21: case 40:
-              entities[k].colour = 17; break;
-            default:
-              entities[k].colour = 6;
-            break;
+        //Set custom colours
+        if (customplatformtile > 0) {
+          int entcol = customplatformtile / 12;
+          switch (entcol)
+          {
+              //RED
+              case 3: case 7: case 12: case 23: case 28:
+              case 34: case 42: case 48: case 58:
+                  entity.colour = 6; break;
+              //GREEN
+              case 5: case 9: case 22: case 25: case 29:
+              case 31: case 38: case 46: case 52: case 53:
+                  entity.colour = 7; break;
+              //BLUE
+              case 1: case 6: case 14: case 27: case 33:
+              case 44: case 50: case 57:
+                  entity.colour = 12; break;
+              //YELLOW
+              case 4: case 17: case 24: case 30: case 37:
+              case 45: case 51: case 55:
+                  entity.colour = 9; break;
+              //PURPLE
+              case 2: case 11: case 15: case 19: case 32:
+              case 36: case 49:
+                  entity.colour = 20; break;
+              //CYAN
+              case 8: case 10: case 13: case 18: case 26:
+              case 35: case 41: case 47: case 54:
+                  entity.colour = 11; break;
+              //PINK
+              case 16: case 20: case 39: case 43: case 56:
+                  entity.colour = 8; break;
+              //ORANGE
+              case 21: case 40:
+                  entity.colour = 17; break;
+              default:
+                  entity.colour = 6; break;
           }
         }
 
         break;
     }
+
+    entities.push_back(entity);
 }
 
-bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musicclass& music )
+bool entityclass::updateentities(int i, UtilityClass& help, Game& game, musicclass& music)
 {
-    if(entities[i].active)
+    if (entities[i].statedelay <= 0)
     {
-        if(entities[i].statedelay<=0)
+        switch (entities[i].type)
         {
-            switch(entities[i].type)
+        case 0:  //Player
+            break;
+        case 1:  //Movement behaviors
+            //Enemies can have a number of different behaviors:
+            switch (entities[i].behave)
             {
-            case 0:  //Player
-                if (entities[i].state == 0)
+            case 0: //Bounce, Start moving down
+                if (entities[i].state == 0)   //Init
                 {
+                    entities[i].state = 3;
+                    updateentities(i, help, game, music);
+                }
+                else if (entities[i].state == 1)
+                {
+                    if (entities[i].outside()) entities[i].state = entities[i].onwall;
+                }
+                else if (entities[i].state == 2)
+                {
+                    entities[i].vy = -entities[i].para;
+                    entities[i].onwall = 3;
+                    entities[i].state = 1;
+                }
+                else if (entities[i].state == 3)
+                {
+                    entities[i].vy = entities[i].para;
+                    entities[i].onwall = 2;
+                    entities[i].state = 1;
                 }
                 break;
-            case 1:  //Movement behaviors
-                //Enemies can have a number of different behaviors:
-                switch(entities[i].behave)
+            case 1: //Bounce, Start moving up
+                if (entities[i].state == 0)   //Init
                 {
-                case 0: //Bounce, Start moving down
-                    if (entities[i].state == 0)   //Init
+                    entities[i].state = 2;
+                    updateentities(i, help, game, music);
+                }
+                else if (entities[i].state == 1)
+                {
+                    if (entities[i].outside()) entities[i].state = entities[i].onwall;
+                }
+                else if (entities[i].state == 2)
+                {
+                    entities[i].vy = -entities[i].para;
+                    entities[i].onwall = 3;
+                    entities[i].state = 1;
+                }
+                else if (entities[i].state == 3)
+                {
+                    entities[i].vy = entities[i].para;
+                    entities[i].onwall = 2;
+                    entities[i].state = 1;
+                }
+                break;
+            case 2: //Bounce, Start moving left
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].state = 3;
+                    updateentities(i, help, game, music);
+                }
+                else if (entities[i].state == 1)
+                {
+                    if (entities[i].outside()) entities[i].state = entities[i].onwall;
+                }
+                else if (entities[i].state == 2)
+                {
+                    entities[i].vx = entities[i].para;
+                    entities[i].onwall = 3;
+                    entities[i].state = 1;
+                }
+                else if (entities[i].state == 3)
+                {
+                    entities[i].vx = -entities[i].para;
+                    entities[i].onwall = 2;
+                    entities[i].state = 1;
+                }
+                break;
+            case 3: //Bounce, Start moving right
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].state = 3;
+                    updateentities(i, help, game, music);
+                }
+                else if (entities[i].state == 1)
+                {
+                    if (entities[i].outside()) entities[i].state = entities[i].onwall;
+                }
+                else if (entities[i].state == 2)
+                {
+                    entities[i].vx = -entities[i].para;
+                    entities[i].onwall = 3;
+                    entities[i].state = 1;
+                }
+                else if (entities[i].state == 3)
+                {
+                    entities[i].vx = entities[i].para;
+                    entities[i].onwall = 2;
+                    entities[i].state = 1;
+                }
+                break;
+            case 4: //Always move left
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].vx = entities[i].para;
+                }
+                break;
+            case 5: //Always move right
+                if (entities[i].state == 0)
+                {
+                    //Init
+                    entities[i].vx = static_cast<int>(entities[i].para);
+                    entities[i].state = 1;
+                    entities[i].onwall = 2;
+                }
+                else if (entities[i].state == 2)
+                {
+                    entities[i].vx = 0;
+                    entities[i].onwall = 0;
+                    entities[i].xp -=  static_cast<int>(entities[i].para);
+                    entities[i].statedelay=8;
+                    entities[i].state=0;
+                }
+                break;
+            case 6: //Always move up
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].vy = static_cast<int>(entities[i].para);
+                    entities[i].state = 1;
+                    entities[i].onwall = 2;
+                }
+                else if (entities[i].state == 2)
+                {
+                    entities[i].vy = static_cast<int>(-entities[i].para);
+                    entities[i].onwall = 0;
+                    entities[i].yp -=  (entities[i].para);
+                    entities[i].statedelay=8;
+                    entities[i].state=0;
+                }
+                break;
+            case 7: //Always move down
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].vx = static_cast<int>(entities[i].para);
+                }
+                break;
+            case 8:
+            case 9:
+                //Threadmill: don't move, just impart velocity
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].vx = 0;
+                    entities[i].state = 1;
+                    entities[i].onwall = 0;
+                }
+                break;
+            case 10:
+                //Emitter: shoot an enemy every so often
+                if (entities[i].state == 0)
+                {
+                    createentity(game, entities[i].xp+28, entities[i].yp, 1, 10, 1);
+                    entities[i].state = 1;
+                    entities[i].statedelay = 12;
+                }
+                else if (entities[i].state == 1)
+                {
+                    entities[i].state = 0;
+                }
+                break;
+            case 11: //Always move right, destroy when outside screen
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].vx = entities[i].para;
+                    entities[i].state = 1;
+                }
+                else if (entities[i].state == 1)
+                {
+                    if (entities[i].xp >= 335
+                    || (game.roomx == 117 && entities[i].xp >= (33*8)-32)) //collector for LIES
                     {
-                        entities[i].state = 3;
-                        updateentities(i, help, game, music);
+                        removeentity(i);
                     }
-                    else if (entities[i].state == 1)
+                }
+                break;
+            case 12:
+                //Emitter: shoot an enemy every so often (up)
+                if (entities[i].state == 0)
+                {
+                    createentity(game, entities[i].xp, entities[i].yp, 1, 12, 1);
+                    entities[i].state = 1;
+                    entities[i].statedelay = 16;
+                }
+                else if (entities[i].state == 1)
+                {
+                    entities[i].state = 0;
+                }
+                break;
+            case 13: //Always move up, destroy when outside screen
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].vy = entities[i].para;
+                    entities[i].state = 1;
+                }
+                else if (entities[i].state == 1)
+                {
+                    if (entities[i].yp <= -60
+                    || (game.roomy == 108 && entities[i].yp <= 60)) //collector for factory
                     {
-                        if (entities[i].outside()) entities[i].state = entities[i].onwall;
+                        removeentity(i);
                     }
-                    else if (entities[i].state == 2)
+                }
+                break;
+            case 14: //Very special hack: as two, but doesn't move in specific circumstances
+                if (entities[i].state == 0)   //Init
+                {
+                    for (size_t j = 0; j < entities.size(); j++)
                     {
-                        entities[i].vy = -entities[i].para;
-                        entities[i].onwall = 3;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 3)
-                    {
-                        entities[i].vy = entities[i].para;
-                        entities[i].onwall = 2;
-                        entities[i].state = 1;
-                    }
-                    break;
-                case 1: //Bounce, Start moving up
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].state = 2;
-                        updateentities(i, help, game, music);
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].outside()) entities[i].state = entities[i].onwall;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vy = -entities[i].para;
-                        entities[i].onwall = 3;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 3)
-                    {
-                        entities[i].vy = entities[i].para;
-                        entities[i].onwall = 2;
-                        entities[i].state = 1;
-                    }
-                    break;
-                case 2: //Bounce, Start moving left
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].state = 3;
-                        updateentities(i, help, game, music);
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].outside()) entities[i].state = entities[i].onwall;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vx = entities[i].para;
-                        entities[i].onwall = 3;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 3)
-                    {
-                        entities[i].vx = -entities[i].para;
-                        entities[i].onwall = 2;
-                        entities[i].state = 1;
-                    }
-                    break;
-                case 3: //Bounce, Start moving right
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].state = 3;
-                        updateentities(i, help, game, music);
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].outside()) entities[i].state = entities[i].onwall;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vx = -entities[i].para;
-                        entities[i].onwall = 3;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 3)
-                    {
-                        entities[i].vx = entities[i].para;
-                        entities[i].onwall = 2;
-                        entities[i].state = 1;
-                    }
-                    break;
-                case 4: //Always move left
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].vx = entities[i].para;
-                    }
-                    break;
-                case 5: //Always move right
-                    if (entities[i].state == 0)
-                    {
-                        //Init
-                        entities[i].vx = static_cast<int>(entities[i].para);
-                        entities[i].state = 1;
-                        entities[i].onwall = 2;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vx = 0;
-                        entities[i].onwall = 0;
-                        entities[i].xp -=  static_cast<int>(entities[i].para);
-                        entities[i].statedelay=8;
-                        entities[i].state=0;
-                    }
-                    break;
-                case 6: //Always move up
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].vy = static_cast<int>(entities[i].para);
-                        entities[i].state = 1;
-                        entities[i].onwall = 2;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vy = static_cast<int>(-entities[i].para);
-                        entities[i].onwall = 0;
-                        entities[i].yp -=  (entities[i].para);
-                        entities[i].statedelay=8;
-                        entities[i].state=0;
-                    }
-                    break;
-                case 7: //Always move down
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].vx = static_cast<int>(entities[i].para);
-                    }
-                    break;
-                case 8:
-                case 9:
-                    //Threadmill: don't move, just impart velocity
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].vx = 0;
-                        entities[i].state = 1;
-                        entities[i].onwall = 0;
-                    }
-                    break;
-                case 10:
-                    //Emitter: shoot an enemy every so often
-                    if (entities[i].state == 0)
-                    {
-                        createentity(game, entities[i].xp+28, entities[i].yp, 1, 10, 1);
-                        entities[i].state = 1;
-                        entities[i].statedelay = 12;
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        entities[i].state = 0;
-                    }
-                    break;
-                case 11: //Always move right, destroy when outside screen
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].vx = entities[i].para;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].xp >= 335) entities[i].active = false;
-                        if (game.roomx == 117)
+                        if (entities[j].type == 2 && entities[j].state== 3 && entities[j].xp == (entities[i].xp-32) )
                         {
-                            if (entities[i].xp >= (33*8)-32) entities[i].active = false;
-                            //collector for LIES
-                        }
-                    }
-                    break;
-                case 12:
-                    //Emitter: shoot an enemy every so often (up)
-                    if (entities[i].state == 0)
-                    {
-                        createentity(game, entities[i].xp, entities[i].yp, 1, 12, 1);
-                        entities[i].state = 1;
-                        entities[i].statedelay = 16;
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        entities[i].state = 0;
-                    }
-                    break;
-                case 13: //Always move up, destroy when outside screen
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].vy = entities[i].para;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].yp <= -60) entities[i].active = false;
-                        if (game.roomy == 108)
-                        {
-                            if (entities[i].yp <= 60) entities[i].active = false;
-                            //collector for factory
-                        }
-                    }
-                    break;
-                case 14: //Very special hack: as two, but doesn't move in specific circumstances
-                    if (entities[i].state == 0)   //Init
-                    {
-                        for (int j = 0; j < nentity; j++)
-                        {
-                            if (entities[j].type == 2 && entities[j].state== 3 && entities[j].xp == (entities[i].xp-32) )
-                            {
-                                entities[i].state = 3;
-                                updateentities(i, help, game, music);
-                            }
-                        }
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].outside()) entities[i].state = entities[i].onwall;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vx = entities[i].para;
-                        entities[i].onwall = 3;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 3)
-                    {
-                        entities[i].vx = -entities[i].para;
-                        entities[i].onwall = 2;
-                        entities[i].state = 1;
-                    }
-                    break;
-                case 15: //As above, but for 3!
-                    if (entities[i].state == 0)   //Init
-                    {
-                        for (int j = 0; j < nentity; j++)
-                        {
-                            if (entities[j].type == 2 && entities[j].state==3 && entities[j].xp==entities[i].xp+32)
-                            {
-                                entities[i].state = 3;
-                                updateentities(i, help, game, music);
-                            }
-                        }
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].outside()) entities[i].state = entities[i].onwall;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vx = -entities[i].para;
-                        entities[i].onwall = 3;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 3)
-                    {
-                        entities[i].vx = entities[i].para;
-                        entities[i].onwall = 2;
-                        entities[i].state = 1;
-                    }
-                    break;
-                case 16: //MAVERICK BUS FOLLOWS HIS OWN RULES
-                    if (entities[i].state == 0)   //Init
-                    {
-                        //first, y position
-                        if (entities[getplayer()].yp > 14 * 8)
-                        {
-                            entities[i].tile = 120;
-                            entities[i].yp = (28*8)-62;
-                        }
-                        else
-                        {
-                            entities[i].tile = 96;
-                            entities[i].yp = 24;
-                        }
-                        //now, x position
-                        if (entities[getplayer()].xp > 20 * 8)
-                        {
-                            //approach from the left
-                            entities[i].xp = -64;
-                            entities[i].state = 2;
-                            updateentities(i, help, game, music); //right
-                        }
-                        else
-                        {
-                            //approach from the left
-                            entities[i].xp = 320;
                             entities[i].state = 3;
-                            updateentities(i, help, game, music); //left
+                            updateentities(i, help, game, music);
                         }
-
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].outside()) entities[i].state = entities[i].onwall;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vx = int(entities[i].para);
-                        entities[i].onwall = 3;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 3)
-                    {
-                        entities[i].vx = int(-entities[i].para);
-                        entities[i].onwall = 2;
-                        entities[i].state = 1;
-                    }
-                    break;
-                case 17: //Special for ASCII Snake (left)
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].statedelay = 6;
-                        entities[i].xp -=  int(entities[i].para);
-                    }
-                    break;
-                case 18: //Special for ASCII Snake (right)
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].statedelay = 6;
-                        entities[i].xp += int(entities[i].para);
-                    }
-                    break;
-                }
-                break;
-            case 2: //Disappearing platforms
-                //wait for collision
-                if (entities[i].state == 1)
-                {
-                    entities[i].life = 12;
-                    entities[i].state = 2;
-                    entities[i].onentity = 0;
-
-                    music.playef(7,10);
-                }
-                else if (entities[i].state == 2)
-                {
-                    entities[i].life--;
-                    if (entities[i].life % 3 == 0) entities[i].tile++;
-                    if (entities[i].life <= 0)
-                    {
-                        removeblockat(entities[i].xp, entities[i].yp);
-                        entities[i].state = 3;// = false;
-                        entities[i].invis = true;
-                    }
-                }
-                else if (entities[i].state == 3)
-                {
-                    //wait until recharged!
-                }
-                else if (entities[i].state == 4)
-                {
-                    //restart!
-                    createblock(0, entities[i].xp, entities[i].yp, 32, 8);
-                    entities[i].state = 4;
-                    entities[i].invis = false;
-                    entities[i].tile--;
-                    entities[i].state++;
-                    entities[i].onentity = 1;
-                }
-                else if (entities[i].state == 5)
-                {
-                    entities[i].life+=3;
-                    if (entities[i].life % 3 == 0) entities[i].tile--;
-                    if (entities[i].life >= 12)
-                    {
-                        entities[i].life = 12;
-                        entities[i].state = 0;
-                        entities[i].tile++;
-                    }
-                }
-                break;
-            case 3: //Breakable blocks
-                //Only counts if vy of player entity is non zero
-                if (entities[i].state == 1)
-                {
-                    // int j = getplayer();
-                    //if (entities[j].vy > 0.5 && (entities[j].yp+entities[j].h<=entities[i].yp+6)) {
-                    entities[i].life = 4;
-                    entities[i].state = 2;
-                    entities[i].onentity = 0;
-                    music.playef(6,10);
-                    /*}else if (entities[j].vy <= -0.5  && (entities[j].yp>=entities[i].yp+2)) {
-                    entities[i].life = 4;
-                    entities[i].state = 2; entities[i].onentity = 0;
-                    }else {
-                    entities[i].state = 0;
-                    }*/
-                }
-                else if (entities[i].state == 2)
-                {
-                    entities[i].life--;
-                    entities[i].tile++;
-                    if (entities[i].life <= 0)
-                    {
-                        removeblockat(entities[i].xp, entities[i].yp);
-                        entities[i].active = false;
-                    }
-                }
-                break;
-            case 4: //Gravity token
-                //wait for collision
-                if (entities[i].state == 1)
-                {
-                    entities[i].active = false;
-                    game.gravitycontrol = (game.gravitycontrol + 1) % 2;
-
-                }
-                break;
-            case 5:  //Particle sprays
-                if (entities[i].state == 0)
-                {
-                    entities[i].life--;
-                    if (entities[i].life < 0) entities[i].active = false;
-                }
-                break;
-            case 6: //Small pickup
-                //wait for collision
-                if (entities[i].state == 1)
-                {
-                    game.coins++;
-                    music.playef(4,10);
-                    collect[entities[i].para] = 1;
-
-                    entities[i].active = false;
-                }
-                break;
-            case 7: //Found a trinket
-                //wait for collision
-                if (entities[i].state == 1)
-                {
-                    game.trinkets++;
-                    if (game.intimetrial)
-                    {
-                        collect[entities[i].para] = 1;
-                        music.playef(25,10);
-                    }
-                    else
-                    {
-                        game.state = 1000;
-                        //music.haltdasmusik();
-                        if(music.currentsong!=-1) music.silencedasmusik();
-                        music.playef(3,10);
-                        collect[entities[i].para] = 1;
-                        if (game.trinkets > game.stat_trinkets)
-                        {
-                            game.stat_trinkets = game.trinkets;
-                        }
-                    }
-
-                    entities[i].active = false;
-                }
-                break;
-            case 8: //Savepoints
-                //wait for collision
-                if (entities[i].state == 1)
-                {
-                    //First, deactivate all other savepoints
-                    for (int j = 0; j < nentity; j++)
-                    {
-                        if (entities[j].type == 8 && entities[j].active)
-                        {
-                            entities[j].colour = 4;
-                            entities[j].onentity = 1;
-                        }
-                    }
-                    entities[i].colour = 5;
-                    entities[i].onentity = 0;
-                    game.savepoint = entities[i].para;
-                    music.playef(5,10);
-
-                    game.savex = entities[i].xp - 4;
-
-                    if (entities[i].tile == 20)
-                    {
-                        game.savey = entities[i].yp - 1;
-                        game.savegc = 1;
-                    }
-                    else if (entities[i].tile == 21)
-                    {
-                        game.savey = entities[i].yp-8;
-                        game.savegc = 0;
-                    }
-
-                    game.saverx = game.roomx;
-                    game.savery = game.roomy;
-                    game.savedir = entities[getplayer()].dir;
-                    entities[i].state = 0;
-                }
-                break;
-            case 9: //Gravity Lines
-                if (entities[i].state == 1)
-                {
-                    entities[i].life--;
-                    entities[i].onentity = 0;
-
-                    if (entities[i].life <= 0)
-                    {
-                        entities[i].state = 0;
-                        entities[i].onentity = 1;
-                    }
-                }
-                break;
-            case 10: //Vertical gravity Lines
-                if (entities[i].state == 1)
-                {
-                    entities[i].onentity = 3;
-                    entities[i].state = 2;
-
-
-                    music.playef(8,10);
-                    game.gravitycontrol = (game.gravitycontrol + 1) % 2;
-                    game.totalflips++;
-                    temp = getplayer();
-                    if (game.gravitycontrol == 0)
-                    {
-                        if (entities[temp].vy < 3) entities[temp].vy = 3;
-                    }
-                    else
-                    {
-                        if (entities[temp].vy > -3) entities[temp].vy = -3;
-                    }
-                }
-                else if (entities[i].state == 2)
-                {
-                    entities[i].life--;
-                    if (entities[i].life <= 0)
-                    {
-                        entities[i].state = 0;
-                        entities[i].onentity = 1;
-                    }
-                }
-                else if (entities[i].state == 3)
-                {
-                    entities[i].state = 2;
-                    entities[i].life = 4;
-                    entities[i].onentity = 3;
-                }
-                else if (entities[i].state == 4)
-                {
-                    //Special case for room initilisations: As state one, except without the reversal
-                    entities[i].onentity = 3;
-                    entities[i].state = 2;
-                }
-                break;
-            case 11: //Warp point
-                //wait for collision
-                if (entities[i].state == 1)
-                {
-                    //Depending on the room the warp point is in, teleport to a new location!
-                    entities[i].onentity = 0;
-                    //play a sound or somefink
-                    music.playef(10);
-                    game.teleport = true;
-
-                    game.edteleportent = i;
-                    //for the multiple room:
-                    if (int(entities[i].xp) == 12*8) game.teleportxpos = 1;
-                    if (int(entities[i].xp) == 5*8) game.teleportxpos = 2;
-                    if (int(entities[i].xp) == 28*8) game.teleportxpos = 3;
-                    if (int(entities[i].xp) == 21*8) game.teleportxpos = 4;
-                }
-                break;
-            case 12: //Crew member
-                //Somewhat complex AI: exactly what they do depends on room, location, state etc
-                //At state 0, do nothing at all.
-                if (entities[i].state == 1)
-                {
-                    //happy!
-                    if (entities[k].rule == 6)	entities[k].tile = 0;
-                    if (entities[k].rule == 7)	entities[k].tile = 6;
-                    //Stay close to the hero!
-                    int j = getplayer();
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[j].xp > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-
-                    //Special rules:
-                    if (game.roomx == 110 && game.roomy == 105)
-                    {
-                        if (entities[i].xp < 155)
-                        {
-                            if (entities[i].ax < 0) entities[i].ax = 0;
-                        }
-                    }
-                }
-                else if (entities[i].state == 2)
-                {
-                    //Basic rules, don't change expression
-                    int j = getplayer();
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[j].xp > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-                }
-                else if (entities[i].state == 10)
-                {
-                    //Everything from 10 on is for cutscenes
-                    //Basic rules, don't change expression
-                    int j = getplayer();
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[j].xp > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-                }
-                else if (entities[i].state == 11)
-                {
-                    //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                    int j=getcrewman(1); //purple
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[j].xp > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-                }
-                else if (entities[i].state == 12)
-                {
-                    //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                    int j=getcrewman(2); //yellow
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[j].xp > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-                }
-                else if (entities[i].state == 13)
-                {
-                    //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                    int j=getcrewman(3); //red
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[j].xp > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-                }
-                else if (entities[i].state == 14)
-                {
-                    //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                    int j=getcrewman(4); //green
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[j].xp > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-                }
-                else if (entities[i].state == 15)
-                {
-                    //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                    int j=getcrewman(5); //blue
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[j].xp > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-                }
-                else if (entities[i].state == 16)
-                {
-                    //Follow a position: given an x coordinate, seek it out.
-                    if (entities[i].para > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[i].para < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[i].para > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[i].para < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-                }
-                else if (entities[i].state == 17)
-                {
-                    //stand still
-                }
-                else if (entities[i].state == 18)
-                {
-                    //Stand still and face the player
-                    int j = getplayer();
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-                }
-                else if (entities[i].state == 19)
-                {
-                    //Walk right off the screen after time t
-                    if (entities[i].para <= 0)
-                    {
-                        entities[i].dir = 1;
-                        entities[i].ax = 3;
-                    }
-                    else
-                    {
-                        entities[i].para--;
-                    }
-                }
-                else if (entities[i].state == 20)
-                {
-                    //Panic! For briefing script
-                    if (entities[i].life == 0)
-                    {
-                        //walk left for a bit
-                        entities[i].ax = 0;
-                        if (40 > entities[i].xp + 5)
-                        {
-                            entities[i].dir = 1;
-                        }
-                        else if (40 < entities[i].xp - 5)
-                        {
-                            entities[i].dir = 0;
-                        }
-
-                        if (40 > entities[i].xp + 45)
-                        {
-                            entities[i].ax = 3;
-                        }
-                        else if (40 < entities[i].xp - 45)
-                        {
-                            entities[i].ax = -3;
-                        }
-                        if ( (entities[i].ax) == 0)
-                        {
-                            entities[i].life = 1;
-                            entities[i].para = 30;
-                        }
-                    }
-                    else	if (entities[i].life == 1)
-                    {
-                        //Stand around for a bit
-                        entities[i].para--;
-                        if (entities[i].para <= 0)
-                        {
-                            entities[i].life++;
-                        }
-                    }
-                    else if (entities[i].life == 2)
-                    {
-                        //walk right for a bit
-                        entities[i].ax = 0;
-                        if (280 > entities[i].xp + 5)
-                        {
-                            entities[i].dir = 1;
-                        }
-                        else if (280 < entities[i].xp - 5)
-                        {
-                            entities[i].dir = 0;
-                        }
-
-                        if (280 > entities[i].xp + 45)
-                        {
-                            entities[i].ax = 3;
-                        }
-                        else if (280 < entities[i].xp - 45)
-                        {
-                            entities[i].ax = -3;
-                        }
-                        if ( (entities[i].ax) == 0)
-                        {
-                            entities[i].life = 3;
-                            entities[i].para = 30;
-                        }
-                    }
-                    else	if (entities[i].life == 3)
-                    {
-                        //Stand around for a bit
-                        entities[i].para--;
-                        if (entities[i].para <= 0)
-                        {
-                            entities[i].life=0;
-                        }
-                    }
-                }
-                break;
-            case 13: //Terminals (very similar to savepoints)
-                //wait for collision
-                if (entities[i].state == 1)
-                {
-                    entities[i].colour = 5;
-                    entities[i].onentity = 0;
-                    music.playef(17,10);
-
-                    entities[i].state = 0;
-                }
-                break;
-            case 14: //Super Crew member
-                //Actually needs less complex AI than the scripting crewmember
-                if (entities[i].state == 0)
-                {
-                    //follow player, but only if he's on the floor!
-                    int j = getplayer();
-                    if(entities[j].onground>0)
-                    {
-                        if (entities[j].xp > entities[i].xp + 5)
-                        {
-                            entities[i].dir = 1;
-                        }
-                        else if (entities[j].xp>15 && entities[j].xp < entities[i].xp - 5)
-                        {
-                            entities[i].dir = 0;
-                        }
-
-                        if (entities[j].xp > entities[i].xp + 45)
-                        {
-                            entities[i].ax = 3;
-                        }
-                        else if (entities[j].xp < entities[i].xp - 45)
-                        {
-                            entities[i].ax = -3;
-                        }
-                        if (entities[i].ax < 0 && entities[i].xp < 60)
-                        {
-                            entities[i].ax = 0;
-                        }
-                    }
-                    else
-                    {
-                        if (entities[j].xp > entities[i].xp + 5)
-                        {
-                            entities[i].dir = 1;
-                        }
-                        else if (entities[j].xp < entities[i].xp - 5)
-                        {
-                            entities[i].dir = 0;
-                        }
-
-                        entities[i].ax = 0;
-                    }
-
-                    if (entities[i].xp > 240)
-                    {
-                        entities[i].ax = 3;
-                        entities[i].dir = 1;
-                    }
-                    if (entities[i].xp >= 310)
-                    {
-                        game.scmprogress++;
-                        entities[i].active = false;
-                    }
-                }
-                break;
-            case 15: //Trophy
-                //wait for collision
-                if (entities[i].state == 1)
-                {
-                    trophytext+=2;
-                    if (trophytext > 30) trophytext = 30;
-                    trophytype = entities[i].para;
-
-                    entities[i].state = 0;
-                }
-                break;
-            case 23:
-                //swn game!
-                switch(entities[i].behave)
-                {
-                case 0:
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].vx = 7;
-                        if (entities[i].xp > 320) entities[i].active = false;
-                    }
-                    break;
-                case 1:
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].vx = -7;
-                        if (entities[i].xp <-20) entities[i].active = false;
-                    }
-                    break;
-                }
-                break;
-
-            case 51: //Vertical warp line
-                if (entities[i].state == 2){
-                  int j=getplayer();
-                  if(entities[j].xp<=307){
-                    customwarpmodevon=false;
-                    entities[i].state = 0;
-                  }
-                }else if (entities[i].state == 1)
-                {
-                  entities[i].state = 2;
-                  entities[i].statedelay = 2;
-                  entities[i].onentity = 1;
-                  customwarpmodevon=true;
-                }
-                break;
-            case 52: //Vertical warp line
-                if (entities[i].state == 2){
-                  int j=getplayer();
-                  if(entities[j].xp<=307){
-                    customwarpmodevon=false;
-                    entities[i].state = 0;
-                  }
-                }else if (entities[i].state == 1)
-                {
-                  entities[i].state = 2;
-                  entities[i].statedelay = 2;
-                  entities[i].onentity = 1;
-                  customwarpmodevon=true;
-                }
-                break;
-              case 53: //Warp lines Horizonal
-                if (entities[i].state == 2){
-                  customwarpmodehon=false;
-                  entities[i].state = 0;
-                }else if (entities[i].state == 1)
-                {
-                  entities[i].state = 2;
-                  entities[i].statedelay = 2;
-                  entities[i].onentity = 1;
-                  customwarpmodehon=true;
-                }
-                break;
-                case 54: //Warp lines Horizonal
-                if (entities[i].state == 2){
-                  customwarpmodehon=false;
-                  entities[i].state = 0;
-                }else if (entities[i].state == 1)
-                {
-                   entities[i].state = 2;
-                   entities[i].statedelay = 2;
-                   entities[i].onentity = 1;
-                   customwarpmodehon=true;
-                }
-                break;
-              case 55: //Collectable crewmate
-                //wait for collision
-                if (entities[i].state == 0)
-                {
-                    //Basic rules, don't change expression
-                    int j = getplayer();
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
                     }
                 }
                 else if (entities[i].state == 1)
                 {
-                    game.crewmates++;
-                    if (game.intimetrial)
-                    {
-                        customcollect[entities[i].para] = 1;
-                        music.playef(27,10);
-                    }
-                    else
-                    {
-                        game.state = 1010;
-                        //music.haltdasmusik();
-                        if(music.currentsong!=-1) music.silencedasmusik();
-                        music.playef(27,10);
-                        customcollect[entities[i].para] = 1;
-                    }
-
-                    entities[i].active = false;
-                }
-                break;
-            case 100: //The teleporter
-                if (entities[i].state == 1)
-                {
-                    //if inactive, activate!
-                    if (entities[i].tile == 1)
-                    {
-                        music.playef(18, 10);
-                        entities[i].onentity = 0;
-                        entities[i].tile = 2;
-                        entities[i].colour = 101;
-                        if(!game.intimetrial && !game.nodeathmode)
-                        {
-                            game.state = 2000;
-                            game.statedelay = 0;
-                        }
-
-                        game.activetele = true;
-                        game.teleblock.x = entities[i].xp - 32;
-                        game.teleblock.y = entities[i].yp - 32;
-                        game.teleblock.w = 160;
-                        game.teleblock.h = 160;
-
-
-                        //Alright, let's set this as our savepoint too
-                        //First, deactivate all other savepoints
-                        for (int j = 0; j < nentity; j++)
-                        {
-                            if (entities[j].type == 8 && entities[j].active)
-                            {
-                                entities[j].colour = 4;
-                                entities[j].onentity = 1;
-                            }
-                        }
-                        game.savepoint = static_cast<int>(entities[i].para);
-                        game.savex = entities[i].xp + 44;
-                        game.savey = entities[i].yp + 44;
-                        game.savegc = 0;
-
-                        game.saverx = game.roomx;
-                        game.savery = game.roomy;
-                        game.savedir = entities[getplayer()].dir;
-                        entities[i].state = 0;
-                    }
-
-                    entities[i].state = 0;
+                    if (entities[i].outside()) entities[i].state = entities[i].onwall;
                 }
                 else if (entities[i].state == 2)
                 {
-                    //Initilise the teleporter without changing the game state or playing sound
+                    entities[i].vx = entities[i].para;
+                    entities[i].onwall = 3;
+                    entities[i].state = 1;
+                }
+                else if (entities[i].state == 3)
+                {
+                    entities[i].vx = -entities[i].para;
+                    entities[i].onwall = 2;
+                    entities[i].state = 1;
+                }
+                break;
+            case 15: //As above, but for 3!
+                if (entities[i].state == 0)   //Init
+                {
+                    for (size_t j = 0; j < entities.size(); j++)
+                    {
+                        if (entities[j].type == 2 && entities[j].state==3 && entities[j].xp==entities[i].xp+32)
+                        {
+                            entities[i].state = 3;
+                            updateentities(i, help, game, music);
+                        }
+                    }
+                }
+                else if (entities[i].state == 1)
+                {
+                    if (entities[i].outside()) entities[i].state = entities[i].onwall;
+                }
+                else if (entities[i].state == 2)
+                {
+                    entities[i].vx = -entities[i].para;
+                    entities[i].onwall = 3;
+                    entities[i].state = 1;
+                }
+                else if (entities[i].state == 3)
+                {
+                    entities[i].vx = entities[i].para;
+                    entities[i].onwall = 2;
+                    entities[i].state = 1;
+                }
+                break;
+            case 16: //MAVERICK BUS FOLLOWS HIS OWN RULES
+                if (entities[i].state == 0)   //Init
+                {
+                    //first, y position
+                    if (entities[getplayer()].yp > 14 * 8)
+                    {
+                        entities[i].tile = 120;
+                        entities[i].yp = (28*8)-62;
+                    }
+                    else
+                    {
+                        entities[i].tile = 96;
+                        entities[i].yp = 24;
+                    }
+                    //now, x position
+                    if (entities[getplayer()].xp > 20 * 8)
+                    {
+                        //approach from the left
+                        entities[i].xp = -64;
+                        entities[i].state = 2;
+                        updateentities(i, help, game, music); //right
+                    }
+                    else
+                    {
+                        //approach from the left
+                        entities[i].xp = 320;
+                        entities[i].state = 3;
+                        updateentities(i, help, game, music); //left
+                    }
+
+                }
+                else if (entities[i].state == 1)
+                {
+                    if (entities[i].outside()) entities[i].state = entities[i].onwall;
+                }
+                else if (entities[i].state == 2)
+                {
+                    entities[i].vx = int(entities[i].para);
+                    entities[i].onwall = 3;
+                    entities[i].state = 1;
+                }
+                else if (entities[i].state == 3)
+                {
+                    entities[i].vx = int(-entities[i].para);
+                    entities[i].onwall = 2;
+                    entities[i].state = 1;
+                }
+                break;
+            case 17: //Special for ASCII Snake (left)
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].statedelay = 6;
+                    entities[i].xp -=  int(entities[i].para);
+                }
+                break;
+            case 18: //Special for ASCII Snake (right)
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].statedelay = 6;
+                    entities[i].xp += int(entities[i].para);
+                }
+                break;
+            }
+            break;
+        case 2: //Disappearing platforms
+            //wait for collision
+            if (entities[i].state == 1)
+            {
+                entities[i].life = 12;
+                entities[i].state = 2;
+                entities[i].onentity = 0;
+
+                music.playef(7,10);
+            }
+            else if (entities[i].state == 2)
+            {
+                entities[i].life--;
+                if (entities[i].life % 3 == 0) entities[i].tile++;
+                if (entities[i].life <= 0)
+                {
+                    removeblockat(entities[i].xp, entities[i].yp);
+                    entities[i].state = 3;// = false;
+                    entities[i].invis = true;
+                }
+            }
+            else if (entities[i].state == 3)
+            {
+                //wait until recharged!
+            }
+            else if (entities[i].state == 4)
+            {
+                //restart!
+                createblock(0, entities[i].xp, entities[i].yp, 32, 8);
+                entities[i].state = 4;
+                entities[i].invis = false;
+                entities[i].tile--;
+                entities[i].state++;
+                entities[i].onentity = 1;
+            }
+            else if (entities[i].state == 5)
+            {
+                entities[i].life+=3;
+                if (entities[i].life % 3 == 0) entities[i].tile--;
+                if (entities[i].life >= 12)
+                {
+                    entities[i].life = 12;
+                    entities[i].state = 0;
+                    entities[i].tile++;
+                }
+            }
+            break;
+        case 3: //Breakable blocks
+            //Only counts if vy of player entity is non zero
+            if (entities[i].state == 1)
+            {
+                // int j = getplayer();
+                //if (entities[j].vy > 0.5 && (entities[j].yp+entities[j].h<=entities[i].yp+6)) {
+                entities[i].life = 4;
+                entities[i].state = 2;
+                entities[i].onentity = 0;
+                music.playef(6,10);
+                /*}else if (entities[j].vy <= -0.5  && (entities[j].yp>=entities[i].yp+2)) {
+                entities[i].life = 4;
+                entities[i].state = 2; entities[i].onentity = 0;
+                }else {
+                entities[i].state = 0;
+                }*/
+            }
+            else if (entities[i].state == 2)
+            {
+                entities[i].life--;
+                entities[i].tile++;
+                if (entities[i].life <= 0)
+                {
+                    removeblockat(entities[i].xp, entities[i].yp);
+                    removeentity(i);
+                }
+            }
+            break;
+        case 4: //Gravity token
+            //wait for collision
+            if (entities[i].state == 1)
+            {
+                removeentity(i);
+                game.gravitycontrol = (game.gravitycontrol + 1) % 2;
+
+            }
+            break;
+        case 5:  //Particle sprays
+            if (entities[i].state == 0)
+            {
+                entities[i].life--;
+                if (entities[i].life < 0) removeentity(i);
+            }
+            break;
+        case 6: //Small pickup
+            //wait for collision
+            if (entities[i].state == 1)
+            {
+                game.coins++;
+                music.playef(4,10);
+                collect[entities[i].para] = 1;
+
+                removeentity(i);
+            }
+            break;
+        case 7: //Found a trinket
+            //wait for collision
+            if (entities[i].state == 1)
+            {
+                game.trinkets++;
+                if (game.intimetrial)
+                {
+                    collect[entities[i].para] = 1;
+                    music.playef(25,10);
+                }
+                else
+                {
+                    game.state = 1000;
+                    //music.haltdasmusik();
+                    if(music.currentsong!=-1) music.silencedasmusik();
+                    music.playef(3,10);
+                    collect[entities[i].para] = 1;
+                    if (game.trinkets > game.stat_trinkets)
+                    {
+                        game.stat_trinkets = game.trinkets;
+                    }
+                }
+
+                removeentity(i);
+            }
+            break;
+        case 8: //Savepoints
+            //wait for collision
+            if (entities[i].state == 1)
+            {
+                //First, deactivate all other savepoints
+                for (size_t j = 0; j < entities.size(); j++)
+                {
+                    if (entities[j].type == 8)
+                    {
+                        entities[j].colour = 4;
+                        entities[j].onentity = 1;
+                    }
+                }
+                entities[i].colour = 5;
+                entities[i].onentity = 0;
+                game.savepoint = entities[i].para;
+                music.playef(5,10);
+
+                game.savex = entities[i].xp - 4;
+
+                if (entities[i].tile == 20)
+                {
+                    game.savey = entities[i].yp - 1;
+                    game.savegc = 1;
+                }
+                else if (entities[i].tile == 21)
+                {
+                    game.savey = entities[i].yp-8;
+                    game.savegc = 0;
+                }
+
+                game.saverx = game.roomx;
+                game.savery = game.roomy;
+                game.savedir = entities[getplayer()].dir;
+                entities[i].state = 0;
+            }
+            break;
+        case 9: //Gravity Lines
+            if (entities[i].state == 1)
+            {
+                entities[i].life--;
+                entities[i].onentity = 0;
+
+                if (entities[i].life <= 0)
+                {
+                    entities[i].state = 0;
+                    entities[i].onentity = 1;
+                }
+            }
+            break;
+        case 10: //Vertical gravity Lines
+            if (entities[i].state == 1)
+            {
+                entities[i].onentity = 3;
+                entities[i].state = 2;
+
+
+                music.playef(8,10);
+                game.gravitycontrol = (game.gravitycontrol + 1) % 2;
+                game.totalflips++;
+                temp = getplayer();
+                if (game.gravitycontrol == 0)
+                {
+                    if (entities[temp].vy < 3) entities[temp].vy = 3;
+                }
+                else
+                {
+                    if (entities[temp].vy > -3) entities[temp].vy = -3;
+                }
+            }
+            else if (entities[i].state == 2)
+            {
+                entities[i].life--;
+                if (entities[i].life <= 0)
+                {
+                    entities[i].state = 0;
+                    entities[i].onentity = 1;
+                }
+            }
+            else if (entities[i].state == 3)
+            {
+                entities[i].state = 2;
+                entities[i].life = 4;
+                entities[i].onentity = 3;
+            }
+            else if (entities[i].state == 4)
+            {
+                //Special case for room initilisations: As state one, except without the reversal
+                entities[i].onentity = 3;
+                entities[i].state = 2;
+            }
+            break;
+        case 11: //Warp point
+            //wait for collision
+            if (entities[i].state == 1)
+            {
+                //Depending on the room the warp point is in, teleport to a new location!
+                entities[i].onentity = 0;
+                //play a sound or somefink
+                music.playef(10);
+                game.teleport = true;
+
+                game.edteleportent = i;
+                //for the multiple room:
+                if (int(entities[i].xp) == 12*8) game.teleportxpos = 1;
+                if (int(entities[i].xp) == 5*8) game.teleportxpos = 2;
+                if (int(entities[i].xp) == 28*8) game.teleportxpos = 3;
+                if (int(entities[i].xp) == 21*8) game.teleportxpos = 4;
+            }
+            break;
+        case 12: //Crew member
+            //Somewhat complex AI: exactly what they do depends on room, location, state etc
+            //At state 0, do nothing at all.
+            if (entities[i].state == 1)
+            {
+                //happy!
+                if (entities[k].rule == 6)	entities[k].tile = 0;
+                if (entities[k].rule == 7)	entities[k].tile = 6;
+                //Stay close to the hero!
+                int j = getplayer();
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[j].xp > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[j].xp < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+
+                //Special rules:
+                if (game.roomx == 110 && game.roomy == 105
+                && entities[i].xp < 155 && entities[i].ax < 0)
+                {
+                    entities[i].ax = 0;
+                }
+            }
+            else if (entities[i].state == 2)
+            {
+                //Basic rules, don't change expression
+                int j = getplayer();
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[j].xp > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[j].xp < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+            }
+            else if (entities[i].state == 10)
+            {
+                //Everything from 10 on is for cutscenes
+                //Basic rules, don't change expression
+                int j = getplayer();
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[j].xp > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[j].xp < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+            }
+            else if (entities[i].state == 11)
+            {
+                //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
+                int j=getcrewman(1); //purple
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[j].xp > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[j].xp < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+            }
+            else if (entities[i].state == 12)
+            {
+                //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
+                int j=getcrewman(2); //yellow
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[j].xp > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[j].xp < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+            }
+            else if (entities[i].state == 13)
+            {
+                //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
+                int j=getcrewman(3); //red
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[j].xp > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[j].xp < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+            }
+            else if (entities[i].state == 14)
+            {
+                //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
+                int j=getcrewman(4); //green
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[j].xp > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[j].xp < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+            }
+            else if (entities[i].state == 15)
+            {
+                //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
+                int j=getcrewman(5); //blue
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[j].xp > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[j].xp < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+            }
+            else if (entities[i].state == 16)
+            {
+                //Follow a position: given an x coordinate, seek it out.
+                if (entities[i].para > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[i].para < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[i].para > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[i].para < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+            }
+            else if (entities[i].state == 17)
+            {
+                //stand still
+            }
+            else if (entities[i].state == 18)
+            {
+                //Stand still and face the player
+                int j = getplayer();
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+            }
+            else if (entities[i].state == 19)
+            {
+                //Walk right off the screen after time t
+                if (entities[i].para <= 0)
+                {
+                    entities[i].dir = 1;
+                    entities[i].ax = 3;
+                }
+                else
+                {
+                    entities[i].para--;
+                }
+            }
+            else if (entities[i].state == 20)
+            {
+                //Panic! For briefing script
+                if (entities[i].life == 0)
+                {
+                    //walk left for a bit
+                    entities[i].ax = 0;
+                    if (40 > entities[i].xp + 5)
+                    {
+                        entities[i].dir = 1;
+                    }
+                    else if (40 < entities[i].xp - 5)
+                    {
+                        entities[i].dir = 0;
+                    }
+
+                    if (40 > entities[i].xp + 45)
+                    {
+                        entities[i].ax = 3;
+                    }
+                    else if (40 < entities[i].xp - 45)
+                    {
+                        entities[i].ax = -3;
+                    }
+                    if ( (entities[i].ax) == 0)
+                    {
+                        entities[i].life = 1;
+                        entities[i].para = 30;
+                    }
+                }
+                else	if (entities[i].life == 1)
+                {
+                    //Stand around for a bit
+                    entities[i].para--;
+                    if (entities[i].para <= 0)
+                    {
+                        entities[i].life++;
+                    }
+                }
+                else if (entities[i].life == 2)
+                {
+                    //walk right for a bit
+                    entities[i].ax = 0;
+                    if (280 > entities[i].xp + 5)
+                    {
+                        entities[i].dir = 1;
+                    }
+                    else if (280 < entities[i].xp - 5)
+                    {
+                        entities[i].dir = 0;
+                    }
+
+                    if (280 > entities[i].xp + 45)
+                    {
+                        entities[i].ax = 3;
+                    }
+                    else if (280 < entities[i].xp - 45)
+                    {
+                        entities[i].ax = -3;
+                    }
+                    if ( (entities[i].ax) == 0)
+                    {
+                        entities[i].life = 3;
+                        entities[i].para = 30;
+                    }
+                }
+                else	if (entities[i].life == 3)
+                {
+                    //Stand around for a bit
+                    entities[i].para--;
+                    if (entities[i].para <= 0)
+                    {
+                        entities[i].life=0;
+                    }
+                }
+            }
+            break;
+        case 13: //Terminals (very similar to savepoints)
+            //wait for collision
+            if (entities[i].state == 1)
+            {
+                entities[i].colour = 5;
+                entities[i].onentity = 0;
+                music.playef(17,10);
+
+                entities[i].state = 0;
+            }
+            break;
+        case 14: //Super Crew member
+            //Actually needs less complex AI than the scripting crewmember
+            if (entities[i].state == 0)
+            {
+                //follow player, but only if he's on the floor!
+                int j = getplayer();
+                if(entities[j].onground>0)
+                {
+                    if (entities[j].xp > entities[i].xp + 5)
+                    {
+                        entities[i].dir = 1;
+                    }
+                    else if (entities[j].xp>15 && entities[j].xp < entities[i].xp - 5)
+                    {
+                        entities[i].dir = 0;
+                    }
+
+                    if (entities[j].xp > entities[i].xp + 45)
+                    {
+                        entities[i].ax = 3;
+                    }
+                    else if (entities[j].xp < entities[i].xp - 45)
+                    {
+                        entities[i].ax = -3;
+                    }
+                    if (entities[i].ax < 0 && entities[i].xp < 60)
+                    {
+                        entities[i].ax = 0;
+                    }
+                }
+                else
+                {
+                    if (entities[j].xp > entities[i].xp + 5)
+                    {
+                        entities[i].dir = 1;
+                    }
+                    else if (entities[j].xp < entities[i].xp - 5)
+                    {
+                        entities[i].dir = 0;
+                    }
+
+                    entities[i].ax = 0;
+                }
+
+                if (entities[i].xp > 240)
+                {
+                    entities[i].ax = 3;
+                    entities[i].dir = 1;
+                }
+                if (entities[i].xp >= 310)
+                {
+                    game.scmprogress++;
+                    removeentity(i);
+                }
+            }
+            break;
+        case 15: //Trophy
+            //wait for collision
+            if (entities[i].state == 1)
+            {
+                trophytext+=2;
+                if (trophytext > 30) trophytext = 30;
+                trophytype = entities[i].para;
+
+                entities[i].state = 0;
+            }
+            break;
+        case 23:
+            //swn game!
+            switch(entities[i].behave)
+            {
+            case 0:
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].vx = 7;
+                    if (entities[i].xp > 320) removeentity(i);
+                }
+                break;
+            case 1:
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].vx = -7;
+                    if (entities[i].xp < -20) removeentity(i);
+                }
+                break;
+            }
+            break;
+
+        case 51: //Vertical warp line
+            if (entities[i].state == 2){
+              int j=getplayer();
+              if(entities[j].xp<=307){
+                customwarpmodevon=false;
+                entities[i].state = 0;
+              }
+            }else if (entities[i].state == 1)
+            {
+              entities[i].state = 2;
+              entities[i].statedelay = 2;
+              entities[i].onentity = 1;
+              customwarpmodevon=true;
+            }
+            break;
+        case 52: //Vertical warp line
+            if (entities[i].state == 2){
+              int j=getplayer();
+              if(entities[j].xp<=307){
+                customwarpmodevon=false;
+                entities[i].state = 0;
+              }
+            }else if (entities[i].state == 1)
+            {
+              entities[i].state = 2;
+              entities[i].statedelay = 2;
+              entities[i].onentity = 1;
+              customwarpmodevon=true;
+            }
+            break;
+          case 53: //Warp lines Horizonal
+            if (entities[i].state == 2){
+              customwarpmodehon=false;
+              entities[i].state = 0;
+            }else if (entities[i].state == 1)
+            {
+              entities[i].state = 2;
+              entities[i].statedelay = 2;
+              entities[i].onentity = 1;
+              customwarpmodehon=true;
+            }
+            break;
+            case 54: //Warp lines Horizonal
+            if (entities[i].state == 2){
+              customwarpmodehon=false;
+              entities[i].state = 0;
+            }else if (entities[i].state == 1)
+            {
+               entities[i].state = 2;
+               entities[i].statedelay = 2;
+               entities[i].onentity = 1;
+               customwarpmodehon=true;
+            }
+            break;
+          case 55: //Collectable crewmate
+            //wait for collision
+            if (entities[i].state == 0)
+            {
+                //Basic rules, don't change expression
+                int j = getplayer();
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+            }
+            else if (entities[i].state == 1)
+            {
+                game.crewmates++;
+                if (game.intimetrial)
+                {
+                    customcollect[entities[i].para] = 1;
+                    music.playef(27,10);
+                }
+                else
+                {
+                    game.state = 1010;
+                    if (music.currentsong!=-1) music.silencedasmusik();
+                    music.playef(27,10);
+                    customcollect[entities[i].para] = 1;
+                }
+
+                removeentity(i);
+            }
+            break;
+        case 100: //The teleporter
+            if (entities[i].state == 1)
+            {
+                //if inactive, activate!
+                if (entities[i].tile == 1)
+                {
+                    music.playef(18, 10);
                     entities[i].onentity = 0;
-                    entities[i].tile = 6;
-                    entities[i].colour = 102;
+                    entities[i].tile = 2;
+                    entities[i].colour = 101;
+                    if(!game.intimetrial && !game.nodeathmode)
+                    {
+                        game.state = 2000;
+                        game.statedelay = 0;
+                    }
 
                     game.activetele = true;
                     game.teleblock.x = entities[i].xp - 32;
@@ -3913,18 +3162,54 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     game.teleblock.w = 160;
                     game.teleblock.h = 160;
 
+
+                    //Alright, let's set this as our savepoint too
+                    //First, deactivate all other savepoints
+                    for (size_t j = 0; j < entities.size(); j++)
+                    {
+                        if (entities[j].type == 8)
+                        {
+                            entities[j].colour = 4;
+                            entities[j].onentity = 1;
+                        }
+                    }
+                    game.savepoint = static_cast<int>(entities[i].para);
+                    game.savex = entities[i].xp + 44;
+                    game.savey = entities[i].yp + 44;
+                    game.savegc = 0;
+
+                    game.saverx = game.roomx;
+                    game.savery = game.roomy;
+                    game.savedir = entities[getplayer()].dir;
                     entities[i].state = 0;
                 }
-                break;
+
+                entities[i].state = 0;
             }
-        }
-        else
-        {
-            entities[i].statedelay--;
-            if (entities[i].statedelay < 0)
+            else if (entities[i].state == 2)
             {
-                entities[i].statedelay = 0;
+                //Initilise the teleporter without changing the game state or playing sound
+                entities[i].onentity = 0;
+                entities[i].tile = 6;
+                entities[i].colour = 102;
+
+                game.activetele = true;
+                game.teleblock.x = entities[i].xp - 32;
+                game.teleblock.y = entities[i].yp - 32;
+                game.teleblock.w = 160;
+                game.teleblock.h = 160;
+
+                entities[i].state = 0;
             }
+            break;
+        }
+    }
+    else
+    {
+        entities[i].statedelay--;
+        if (entities[i].statedelay < 0)
+        {
+            entities[i].statedelay = 0;
         }
     }
 
@@ -3933,391 +3218,375 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
 
 void entityclass::animateentities( int _i, Game& game, UtilityClass& help )
 {
-    if(entities[_i].active)
+    if(entities[_i].statedelay < 1)
     {
-        if(entities[_i].statedelay < 1)
+        switch(entities[_i].type)
         {
-            switch(entities[_i].type)
+        case 0:
+            entities[_i].framedelay--;
+            if(entities[_i].dir==1)
+            {
+                entities[_i].drawframe=entities[_i].tile;
+            }
+            else
+            {
+                entities[_i].drawframe=entities[_i].tile+3;
+            }
+
+            if(entities[_i].onground>0 || entities[_i].onroof>0)
+            {
+                if(entities[_i].vx > 0.00f || entities[_i].vx < -0.00f)
+                {
+                    //Walking
+                    if(entities[_i].framedelay<=1)
+                    {
+                        entities[_i].framedelay=4;
+                        entities[_i].walkingframe++;
+                    }
+                    if (entities[_i].walkingframe >=2) entities[_i].walkingframe=0;
+                    entities[_i].drawframe += entities[_i].walkingframe + 1;
+                }
+
+                if (entities[_i].onroof > 0) entities[_i].drawframe += 6;
+            }
+            else
+            {
+                entities[_i].drawframe ++;
+                if (game.gravitycontrol == 1)
+                {
+                    entities[_i].drawframe += 6;
+                }
+            }
+
+            if (game.deathseq > -1)
+            {
+                entities[_i].drawframe=13;
+                if (entities[_i].dir == 1) entities[_i].drawframe = 12;
+                if (game.gravitycontrol == 1) entities[_i].drawframe += 2;
+            }
+            break;
+        case 1:
+        case 23:
+            //Variable animation
+            switch(entities[_i].animate)
             {
             case 0:
+                //Simple oscilation
                 entities[_i].framedelay--;
-                if(entities[_i].dir==1)
+                if(entities[_i].framedelay<=0)
                 {
-                    entities[_i].drawframe=entities[_i].tile;
-                }
-                else
-                {
-                    entities[_i].drawframe=entities[_i].tile+3;
-                }
-
-                if(entities[_i].onground>0 || entities[_i].onroof>0)
-                {
-                    if(entities[_i].vx > 0.00f || entities[_i].vx < -0.00f)
+                    entities[_i].framedelay = 8;
+                    if(entities[_i].actionframe==0)
                     {
-                        //Walking
-                        if(entities[_i].framedelay<=1)
-                        {
-                            entities[_i].framedelay=4;
-                            entities[_i].walkingframe++;
-                        }
-                        if (entities[_i].walkingframe >=2) entities[_i].walkingframe=0;
-                        entities[_i].drawframe += entities[_i].walkingframe + 1;
-                    }
-
-                    if (entities[_i].onroof > 0) entities[_i].drawframe += 6;
-                }
-                else
-                {
-                    entities[_i].drawframe ++;
-                    if (game.gravitycontrol == 1)
-                    {
-                        entities[_i].drawframe += 6;
-                    }
-                }
-
-                if (game.deathseq > -1)
-                {
-                    entities[_i].drawframe=13;
-                    if (entities[_i].dir == 1) entities[_i].drawframe = 12;
-                    if (game.gravitycontrol == 1) entities[_i].drawframe += 2;
-                }
-                break;
-            case 1:
-            case 23:
-                //Variable animation
-                switch(entities[_i].animate)
-                {
-                case 0:
-                    //Simple oscilation
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 8;
-                        if(entities[_i].actionframe==0)
-                        {
-                            entities[_i].walkingframe++;
-                            if (entities[_i].walkingframe == 4)
-                            {
-                                entities[_i].walkingframe = 2;
-                                entities[_i].actionframe = 1;
-                            }
-                        }
-                        else
-                        {
-                            entities[_i].walkingframe--;
-                            if (entities[_i].walkingframe == -1)
-                            {
-                                entities[_i].walkingframe = 1;
-                                entities[_i].actionframe = 0;
-                            }
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                    break;
-                case 1:
-                    //Simple Loop
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 8;
                         entities[_i].walkingframe++;
                         if (entities[_i].walkingframe == 4)
                         {
-                            entities[_i].walkingframe = 0;
+                            entities[_i].walkingframe = 2;
+                            entities[_i].actionframe = 1;
                         }
                     }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                    break;
-                case 2:
-                    //Simpler Loop (just two frames)
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
+                    else
                     {
-                        entities[_i].framedelay = 2;
-                        entities[_i].walkingframe++;
-                        if (entities[_i].walkingframe == 2)
-                        {
-                            entities[_i].walkingframe = 0;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                    break;
-                case 3:
-                    //Simpler Loop (just two frames, but double sized)
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 2;
-                        entities[_i].walkingframe++;
-                        if (entities[_i].walkingframe == 2)
-                        {
-                            entities[_i].walkingframe = 0;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += (entities[_i].walkingframe*2);
-                    break;
-                case 4:
-                    //Simpler Loop (just two frames, but double sized) (as above but slower)
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 6;
-                        entities[_i].walkingframe++;
-                        if (entities[_i].walkingframe == 2)
-                        {
-                            entities[_i].walkingframe = 0;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += (entities[_i].walkingframe*2);
-                    break;
-                case 5:
-                    //Simpler Loop (just two frames) (slower)
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 6;
-                        entities[_i].walkingframe++;
-                        if (entities[_i].walkingframe == 2)
-                        {
-                            entities[_i].walkingframe = 0;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                    break;
-                case 6:
-                    //Normal Loop (four frames, double sized)
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 4;
-                        entities[_i].walkingframe++;
-                        if (entities[_i].walkingframe == 4)
-                        {
-                            entities[_i].walkingframe = 0;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += (entities[_i].walkingframe*2);
-                    break;
-                case 7:
-                    //Simpler Loop (just two frames) (slower) (with directions!)
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 6;
-                        entities[_i].walkingframe++;
-                        if (entities[_i].walkingframe == 2)
-                        {
-                            entities[_i].walkingframe = 0;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-
-                    if (entities[_i].vx > 0.000f ) entities[_i].drawframe += 2;
-                    break;
-                case 10:
-                    //Threadmill left
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 3;//(6-entities[_i].para);
                         entities[_i].walkingframe--;
                         if (entities[_i].walkingframe == -1)
                         {
-                            entities[_i].walkingframe = 3;
+                            entities[_i].walkingframe = 1;
+                            entities[_i].actionframe = 0;
                         }
                     }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                    break;
-                case 11:
-                    //Threadmill right
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 3;//(6-entities[_i].para);
-                        entities[_i].walkingframe++;
-                        if (entities[_i].walkingframe == 4)
-                        {
-                            entities[_i].walkingframe = 0;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                    break;
-                case 100:
-                    //Simple case for no animation (platforms, etc)
-                    entities[_i].drawframe = entities[_i].tile;
-                    break;
-                default:
-                    entities[_i].drawframe = entities[_i].tile;
-                    break;
                 }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
+                break;
+            case 1:
+                //Simple Loop
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 8;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 4)
+                    {
+                        entities[_i].walkingframe = 0;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
+                break;
+            case 2:
+                //Simpler Loop (just two frames)
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 2;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 2)
+                    {
+                        entities[_i].walkingframe = 0;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
+                break;
+            case 3:
+                //Simpler Loop (just two frames, but double sized)
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 2;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 2)
+                    {
+                        entities[_i].walkingframe = 0;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += (entities[_i].walkingframe*2);
+                break;
+            case 4:
+                //Simpler Loop (just two frames, but double sized) (as above but slower)
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 6;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 2)
+                    {
+                        entities[_i].walkingframe = 0;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += (entities[_i].walkingframe*2);
+                break;
+            case 5:
+                //Simpler Loop (just two frames) (slower)
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 6;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 2)
+                    {
+                        entities[_i].walkingframe = 0;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
+                break;
+            case 6:
+                //Normal Loop (four frames, double sized)
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 4;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 4)
+                    {
+                        entities[_i].walkingframe = 0;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += (entities[_i].walkingframe*2);
+                break;
+            case 7:
+                //Simpler Loop (just two frames) (slower) (with directions!)
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 6;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 2)
+                    {
+                        entities[_i].walkingframe = 0;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
+
+                if (entities[_i].vx > 0.000f ) entities[_i].drawframe += 2;
+                break;
+            case 10:
+                //Threadmill left
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 3;
+                    entities[_i].walkingframe--;
+                    if (entities[_i].walkingframe == -1)
+                    {
+                        entities[_i].walkingframe = 3;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
                 break;
             case 11:
-                entities[_i].drawframe = entities[_i].tile;
-                if(entities[_i].animate==2)
-                {
-                    //Simpler Loop (just two frames)
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 10;
-                        entities[_i].walkingframe++;
-                        if (entities[_i].walkingframe == 2)
-                        {
-                            entities[_i].walkingframe = 0;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                }
-                break;
-            case 12:
-            case 55:
-            case 14: //Crew member! Very similar to hero
+                //Threadmill right
                 entities[_i].framedelay--;
-                if(entities[_i].dir==1)
+                if(entities[_i].framedelay<=0)
                 {
-                    entities[_i].drawframe=entities[_i].tile;
-                }
-                else
-                {
-                    entities[_i].drawframe=entities[_i].tile+3;
-                }
-
-                if(entities[_i].onground>0 || entities[_i].onroof>0)
-                {
-                    if(entities[_i].vx > 0.0000f || entities[_i].vx < -0.000f)
+                    entities[_i].framedelay = 3;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 4)
                     {
-                        //Walking
-                        if(entities[_i].framedelay<=0)
-                        {
-                            entities[_i].framedelay=4;
-                            entities[_i].walkingframe++;
-                        }
-                        if (entities[_i].walkingframe >=2) entities[_i].walkingframe=0;
-                        entities[_i].drawframe += entities[_i].walkingframe + 1;
+                        entities[_i].walkingframe = 0;
                     }
-
-                    //if (entities[_i].onroof > 0) entities[_i].drawframe += 6;
-                }
-                else
-                {
-                    entities[_i].drawframe ++;
-                    //if (game.gravitycontrol == 1) {
-                    //	entities[_i].drawframe += 6;
-                    //}
                 }
 
-                if (game.deathseq > -1)
-                {
-                    entities[_i].drawframe=13;
-                    if (entities[_i].dir == 1) entities[_i].drawframe = 12;
-                    if (entities[_i].rule == 7) entities[_i].drawframe += 2;
-                    //if (game.gravitycontrol == 1) entities[_i].drawframe += 2;
-                }
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
                 break;
-            case 100: //the teleporter!
-                if (entities[_i].tile == 1)
-                {
-                    //it's inactive
-                    entities[_i].drawframe = entities[_i].tile;
-                }
-                else if (entities[_i].tile == 2)
-                {
-                    entities[_i].drawframe = entities[_i].tile;
-
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 1;
-                        entities[_i].walkingframe = int(fRandom() * 6);
-                        if (entities[_i].walkingframe >= 4)
-                        {
-                            entities[_i].walkingframe = -1;
-                            entities[_i].framedelay = 4;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                }
-                else if (entities[_i].tile == 6)
-                {
-                    //faster!
-                    entities[_i].drawframe = entities[_i].tile;
-
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 2;
-                        entities[_i].walkingframe = int(fRandom() * 6);
-                        if (entities[_i].walkingframe >= 4)
-                        {
-                            entities[_i].walkingframe = -5;
-                            entities[_i].framedelay = 4;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                }
+            case 100:
+                //Simple case for no animation (platforms, etc)
+                entities[_i].drawframe = entities[_i].tile;
                 break;
             default:
                 entities[_i].drawframe = entities[_i].tile;
                 break;
             }
+            break;
+        case 11:
+            entities[_i].drawframe = entities[_i].tile;
+            if(entities[_i].animate==2)
+            {
+                //Simpler Loop (just two frames)
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 10;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 2)
+                    {
+                        entities[_i].walkingframe = 0;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
+            }
+            break;
+        case 12:
+        case 55:
+        case 14: //Crew member! Very similar to hero
+            entities[_i].framedelay--;
+            if(entities[_i].dir==1)
+            {
+                entities[_i].drawframe=entities[_i].tile;
+            }
+            else
+            {
+                entities[_i].drawframe=entities[_i].tile+3;
+            }
+
+            if(entities[_i].onground>0 || entities[_i].onroof>0)
+            {
+                if(entities[_i].vx > 0.0000f || entities[_i].vx < -0.000f)
+                {
+                    //Walking
+                    if(entities[_i].framedelay<=0)
+                    {
+                        entities[_i].framedelay=4;
+                        entities[_i].walkingframe++;
+                    }
+                    if (entities[_i].walkingframe >=2) entities[_i].walkingframe=0;
+                    entities[_i].drawframe += entities[_i].walkingframe + 1;
+                }
+            }
+            else
+            {
+                entities[_i].drawframe ++;
+            }
+
+            if (game.deathseq > -1)
+            {
+                entities[_i].drawframe=13;
+                if (entities[_i].dir == 1) entities[_i].drawframe = 12;
+                if (entities[_i].rule == 7) entities[_i].drawframe += 2;
+            }
+            break;
+        case 100: //the teleporter!
+            if (entities[_i].tile == 1)
+            {
+                //it's inactive
+                entities[_i].drawframe = entities[_i].tile;
+            }
+            else if (entities[_i].tile == 2)
+            {
+                entities[_i].drawframe = entities[_i].tile;
+
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 1;
+                    entities[_i].walkingframe = int(fRandom() * 6);
+                    if (entities[_i].walkingframe >= 4)
+                    {
+                        entities[_i].walkingframe = -1;
+                        entities[_i].framedelay = 4;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
+            }
+            else if (entities[_i].tile == 6)
+            {
+                //faster!
+                entities[_i].drawframe = entities[_i].tile;
+
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 2;
+                    entities[_i].walkingframe = int(fRandom() * 6);
+                    if (entities[_i].walkingframe >= 4)
+                    {
+                        entities[_i].walkingframe = -5;
+                        entities[_i].framedelay = 4;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
+            }
+            break;
+        default:
+            entities[_i].drawframe = entities[_i].tile;
+            break;
         }
-        else
-        {
-            //entities[_i].statedelay--;
-            if (entities[_i].statedelay < 0) entities[_i].statedelay = 0;
-        }
+    }
+    else
+    {
+        if (entities[_i].statedelay < 0) entities[_i].statedelay = 0;
     }
 }
 
-bool entityclass::gettype( int t )
+bool entityclass::gettype(int t)
 {
     //Returns true is there is an entity of type t onscreen
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
-        if(entities[i].type==t)
-        {
-            return true;
-        }
+        if (entities[i].type == t) return true;
     }
 
     return false;
 }
 
-int entityclass::getcompanion( int t )
+int entityclass::getcompanion(int t)
 {
     //Returns the index of the companion with rule t
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
-        if(entities[i].rule==6 || entities[i].rule==7)
-        {
-            return i;
-        }
+        if (entities[i].rule == 6 || entities[i].rule == 7) return i;
     }
 
     return -1;
@@ -4326,12 +3595,9 @@ int entityclass::getcompanion( int t )
 int entityclass::getplayer()
 {
     //Returns the index of the first player entity
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
-        if(entities[i].type==0)
-        {
-            return i;
-        }
+        if (entities[i].type == 0) return i;
     }
 
     return -1;
@@ -4340,9 +3606,40 @@ int entityclass::getplayer()
 int entityclass::getscm()
 {
     //Returns the supercrewmate
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
-        if(entities[i].type==14)
+        if (entities[i].type==14) return i;
+    }
+
+    return 0;
+}
+
+int entityclass::getlineat(int t)
+{
+    //Get the entity which is a horizontal line at height t (for SWN game)
+    for (size_t i = 0; i < entities.size(); i++)
+    {
+        if (entities[i].size == 5 && entities[i].yp == t) return i;
+    }
+
+    return 0;
+}
+
+int entityclass::getcrewman(int t)
+{
+    //Returns the index of the crewman with colour index given by t
+    if (t == 0) t = 0;
+    if (t == 1) t = 20;
+    if (t == 2) t = 14;
+    if (t == 3) t = 15;
+    if (t == 4) t = 13;
+    if (t == 5) t = 16;
+
+    for (size_t i = 0; i < entities.size(); i++)
+    {
+        if ((entities[i].type == 12 || entities[i].type == 14)
+        && (entities[i].rule == 6 || entities[i].rule == 7)
+        && entities[i].colour==t)
         {
             return i;
         }
@@ -4351,24 +3648,7 @@ int entityclass::getscm()
     return 0;
 }
 
-int entityclass::getlineat( int t )
-{
-    //Get the entity which is a horizontal line at height t (for SWN game)
-    for (int i = 0; i < nentity; i++)
-    {
-        if (entities[i].size == 5)
-        {
-            if (entities[i].yp == t)
-            {
-                return i;
-            }
-        }
-    }
-
-    return 0;
-}
-
-int entityclass::getcrewman( int t )
+int entityclass::getcustomcrewman(int t)
 {
     //Returns the index of the crewman with colour index given by t
     if (t == 0) t = 0;
@@ -4378,40 +3658,9 @@ int entityclass::getcrewman( int t )
     if (t == 4) t = 13;
     if (t == 5) t = 16;
 
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
-        if ((entities[i].type == 12 || entities[i].type == 14)
-        && (entities[i].rule == 6 || entities[i].rule == 7))
-        {
-            if(entities[i].colour==t)
-            {
-                return i;
-            }
-        }
-    }
-
-    return 0;
-}
-
-int entityclass::getcustomcrewman( int t )
-{
-    //Returns the index of the crewman with colour index given by t
-    if (t == 0) t = 0;
-    if (t == 1) t = 20;
-    if (t == 2) t = 14;
-    if (t == 3) t = 15;
-    if (t == 4) t = 13;
-    if (t == 5) t = 16;
-
-    for (int i = 0; i < nentity; i++)
-    {
-        if (entities[i].type == 55)
-        {
-            if(entities[i].colour==t)
-            {
-                return i;
-            }
-        }
+        if (entities[i].type == 55 && entities[i].colour==t) return i;
     }
 
     return 0;
@@ -4419,12 +3668,9 @@ int entityclass::getcustomcrewman( int t )
 
 int entityclass::getteleporter()
 {
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
-        if(entities[i].type==100 && entities[i].active)
-        {
-            return i;
-        }
+        if (entities[i].type == 100) return i;
     }
 
     return -1;
@@ -4468,9 +3714,9 @@ bool entityclass::entitycollide( int a, int b )
 bool entityclass::checkdirectional( int t )
 {
     //Returns true if player entity (rule 0) moving in dir t through directional block
-    for(int i=0; i < nentity; i++)
+    for (size_t i=0; i < entities.size(); i++)
     {
-        if(entities[i].rule==0)
+        if (entities[i].rule==0)
         {
             tempx = entities[i].xp + entities[i].cx;
             tempy = entities[i].yp + entities[i].cy;
@@ -4478,14 +3724,12 @@ bool entityclass::checkdirectional( int t )
             temph = entities[i].h;
             rectset(tempx, tempy, tempw, temph);
 
-            for (int j=0; j<nblocks; j++)
+            for (size_t j = 0; j < blocks.size(); j++)
             {
-                if (blocks[j].type == DIRECTIONAL && blocks[j].active)
+                if (blocks[j].type == DIRECTIONAL
+                && UtilityClass::intersects(blocks[j].rect, temprect))
                 {
-                    if(UtilityClass::intersects(blocks[j].rect,temprect))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
         }
@@ -4496,9 +3740,9 @@ bool entityclass::checkdirectional( int t )
 bool entityclass::checkdamage()
 {
     //Returns true if player entity (rule 0) collides with a damagepoint
-    for(int i=0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
-        if(entities[i].rule==0)
+        if (entities[i].rule == 0)
         {
             tempx = entities[i].xp + entities[i].cx;
             tempy = entities[i].yp + entities[i].cy;
@@ -4506,14 +3750,12 @@ bool entityclass::checkdamage()
             temph = entities[i].h;
             rectset(tempx, tempy, tempw, temph);
 
-            for (int j=0; j<nblocks; j++)
+            for (size_t j = 0; j < blocks.size(); j++)
             {
-                if (blocks[j].type == DAMAGE && blocks[j].active)
+                if (blocks[j].type == DAMAGE
+                && UtilityClass::intersects(blocks[j].rect, temprect))
                 {
-                    if(UtilityClass::intersects(blocks[j].rect, temprect))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
         }
@@ -4524,9 +3766,9 @@ bool entityclass::checkdamage()
 bool entityclass::scmcheckdamage()
 {
     //Returns true if supercrewmate collides with a damagepoint
-    for(int i=0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
-        if(entities[i].type==14)
+        if (entities[i].type==14)
         {
             tempx = entities[i].xp + entities[i].cx;
             tempy = entities[i].yp + entities[i].cy;
@@ -4534,14 +3776,12 @@ bool entityclass::scmcheckdamage()
             temph = entities[i].h;
             rectset(tempx, tempy, tempw, temph);
 
-            for (int j=0; j<nblocks; j++)
+            for (size_t j = 0; j < blocks.size(); j++)
             {
-                if (blocks[j].type == DAMAGE && blocks[j].active)
+                if (blocks[j].type == DAMAGE
+                && UtilityClass::intersects(blocks[j].rect, temprect))
                 {
-                    if(UtilityClass::intersects(blocks[j].rect, temprect))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
         }
@@ -4549,7 +3789,7 @@ bool entityclass::scmcheckdamage()
     return false;
 }
 
-void entityclass::settemprect( int t )
+void entityclass::settemprect(int t)
 {
     //setup entity t in temprect
     tempx = entities[t].xp + entities[t].cx;
@@ -4562,9 +3802,9 @@ void entityclass::settemprect( int t )
 int entityclass::checktrigger()
 {
     //Returns an int player entity (rule 0) collides with a trigger
-    for(int i=0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
-        if(entities[i].rule==0)
+        if (entities[i].rule == 0)
         {
             tempx = entities[i].xp + entities[i].cx;
             tempy = entities[i].yp + entities[i].cy;
@@ -4572,15 +3812,13 @@ int entityclass::checktrigger()
             temph = entities[i].h;
             rectset(tempx, tempy, tempw, temph);
 
-            for (int j=0; j<nblocks; j++)
+            for (size_t j=0; j<blocks.size(); j++)
             {
-                if (blocks[j].type == TRIGGER && blocks[j].active)
+                if (blocks[j].type == TRIGGER
+                && UtilityClass::intersects(blocks[j].rect, temprect))
                 {
-                    if (UtilityClass::intersects(blocks[j].rect, temprect))
-                    {
-                        activetrigger = blocks[j].trigger;
-                        return blocks[j].trigger;
-                    }
+                    activetrigger = blocks[j].trigger;
+                    return blocks[j].trigger;
                 }
             }
         }
@@ -4591,9 +3829,9 @@ int entityclass::checktrigger()
 int entityclass::checkactivity()
 {
     //Returns an int player entity (rule 0) collides with an activity
-    for(int i=0; i < nentity; i++)
+    for (size_t i=0; i < entities.size(); i++)
     {
-        if(entities[i].rule==0)
+        if (entities[i].rule == 0)
         {
             tempx = entities[i].xp + entities[i].cx;
             tempy = entities[i].yp + entities[i].cy;
@@ -4601,14 +3839,12 @@ int entityclass::checkactivity()
             temph = entities[i].h;
             rectset(tempx, tempy, tempw, temph);
 
-            for (int j=0; j<nblocks; j++)
+            for (size_t j = 0; j < blocks.size(); j++)
             {
-                if (blocks[j].type == ACTIVITY && blocks[j].active)
+                if (blocks[j].type == ACTIVITY
+                && UtilityClass::intersects(blocks[j].rect, temprect))
                 {
-                    if (UtilityClass::intersects(blocks[j].rect, temprect))
-                    {
-                        return j;
-                    }
+                    return j;
                 }
             }
         }
@@ -4616,13 +3852,13 @@ int entityclass::checkactivity()
     return -1;
 }
 
-int entityclass::getgridpoint( int t )
+int entityclass::getgridpoint(int t)
 {
     t = (t - (t % 8)) / 8;
     return t;
 }
 
-bool entityclass::cblocks( int t )
+bool entityclass::cblocks(int t)
 {
     tempx = entities[t].xp + entities[t].cx;
     tempy = entities[t].yp + entities[t].cy;
@@ -4636,19 +3872,14 @@ bool entityclass::cblocks( int t )
 bool entityclass::checkplatform()
 {
     //Return true if rectset intersects a moving platform, setups px & py to the platform x & y
-    for (int i = 0; i < nblocks; i++)
+    for (size_t i = 0; i < blocks.size(); i++)
     {
-        if (blocks[i].active)
+        if (blocks[i].type == BLOCK
+        && UtilityClass::intersects(blocks[i].rect, temprect))
         {
-            if (blocks[i].type == BLOCK)
-            {
-                if (UtilityClass::intersects(blocks[i].rect, temprect))
-                {
-                    px = blocks[i].xp;
-                    py = blocks[i].yp;
-                    return true;
-                }
-            }
+            px = blocks[i].xp;
+            py = blocks[i].yp;
+            return true;
         }
     }
     return false;
@@ -4656,35 +3887,32 @@ bool entityclass::checkplatform()
 
 bool entityclass::checkblocks()
 {
-    for (int i = 0; i < nblocks; i++)
+    for (size_t i = 0; i < blocks.size(); i++)
     {
-        if (blocks[i].active)
+        if(!skipdirblocks)
         {
-            if(!skipdirblocks)
+            if (blocks[i].type == DIRECTIONAL)
             {
-                if (blocks[i].type == DIRECTIONAL)
-                {
-                    if (dy > 0 && blocks[i].trigger == 0) if (UtilityClass::intersects(blocks[i].rect, temprect)) return true;
-                    if (dy <= 0 && blocks[i].trigger == 1) if (UtilityClass::intersects(blocks[i].rect, temprect)) return true;
-                    if (dx > 0 && blocks[i].trigger == 2) if (UtilityClass::intersects(blocks[i].rect, temprect)) return true;
-                    if (dx <= 0 && blocks[i].trigger == 3) if (UtilityClass::intersects(blocks[i].rect, temprect)) return true;
-                }
+                if (dy > 0 && blocks[i].trigger == 0) if (UtilityClass::intersects(blocks[i].rect, temprect)) return true;
+                if (dy <= 0 && blocks[i].trigger == 1) if (UtilityClass::intersects(blocks[i].rect, temprect)) return true;
+                if (dx > 0 && blocks[i].trigger == 2) if (UtilityClass::intersects(blocks[i].rect, temprect)) return true;
+                if (dx <= 0 && blocks[i].trigger == 3) if (UtilityClass::intersects(blocks[i].rect, temprect)) return true;
             }
-            if (blocks[i].type == BLOCK)
+        }
+        if (blocks[i].type == BLOCK)
+        {
+            if (UtilityClass::intersects(blocks[i].rect, temprect))
+            {
+                return true;
+            }
+        }
+        if (blocks[i].type == SAFE)
+        {
+            if( (dr)==1)
             {
                 if (UtilityClass::intersects(blocks[i].rect, temprect))
                 {
                     return true;
-                }
-            }
-            if (blocks[i].type == SAFE)
-            {
-                if( (dr)==1)
-                {
-                    if (UtilityClass::intersects(blocks[i].rect, temprect))
-                    {
-                        return true;
-                    }
                 }
             }
         }
@@ -4742,30 +3970,22 @@ bool entityclass::checkwall( mapclass& map )
 float entityclass::hplatformat()
 {
     //Returns first entity of horizontal platform at (px, py), -1000 otherwise.
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
-        if (entities[i].active)
+        if (entities[i].rule == 2 && entities[i].behave >= 2
+        && entities[i].xp == px && entities[i].yp == py)
         {
-            if (entities[i].rule == 2)
+            if (entities[i].behave == 8)   //threadmill!
             {
-                if (entities[i].behave >= 2)
-                {
-                    if (entities[i].xp == px && entities[i].yp == py)
-                    {
-                        if (entities[i].behave == 8)   //threadmill!
-                        {
-                            return entities[i].para;
-                        }
-                        else if(entities[i].behave == 9)    //threadmill!
-                        {
-                            return -entities[i].para;
-                        }
-                        else
-                        {
-                            return entities[i].vx;
-                        }
-                    }
-                }
+                return entities[i].para;
+            }
+            else if(entities[i].behave == 9)    //threadmill!
+            {
+                return -entities[i].para;
+            }
+            else
+            {
+                return entities[i].vx;
             }
         }
     }
@@ -5063,16 +4283,6 @@ void entityclass::applyfriction( int t, float xrate, float yrate )
     if (std::abs(entities[t].vy) < yrate) entities[t].vy = 0.0f;
 }
 
-void entityclass::cleanup()
-{
-    int i = nentity - 1;
-    while (i >= 0 && !entities[i].active)
-    {
-        nentity--;
-        i--;
-    }
-}
-
 void entityclass::updateentitylogic( int t, Game& game )
 {
     entities[t].oldxp = entities[t].xp;
@@ -5221,223 +4431,202 @@ void entityclass::hormovingplatformfix( int t, mapclass& map )
 }
 
 void entityclass::customwarplinecheck(int i) {
-		//Turns on obj.customwarpmodevon and obj.customwarpmodehon if player collides
-		//with warp lines
-			
-	if (entities[i].active) {
-		//We test entity to entity
-		for (int j = 0; j < nentity; j++) {
-			if (entities[j].active && i != j) {//Active
-				if (entities[i].rule == 0 && entities[j].rule == 5) { //Player vs vertical line!
-					if (entities[j].type == 51 || entities[j].type == 52) {								
-						if (entitywarpvlinecollide(i, j)) {	
-							customwarpmodevon = true;
-						}
-					}
-				}
-						
-				if (entities[i].rule == 0 && entities[j].rule == 7){   //Player vs horizontal WARP line
-					if (entities[j].type == 53 || entities[j].type == 54) {								
-						if (entitywarphlinecollide(i, j)) {
-							customwarpmodehon = true;
-						}
-					}
-				}
-			}
-		}
-	}
+    //Turns on obj.customwarpmodevon and obj.customwarpmodehon if player collides
+    //with warp lines
+
+    //We test entity to entity
+    for (int j = 0; j < (int) entities.size(); j++)
+    {
+        if (i != j)
+        {
+            if (entities[i].rule == 0 && entities[j].rule == 5 //Player vs vertical line!
+            && (entities[j].type == 51 || entities[j].type == 52)
+            && entitywarpvlinecollide(i, j))
+            {
+                customwarpmodevon = true;
+            }
+
+            if (entities[i].rule == 0 && entities[j].rule == 7 //Player vs horizontal WARP line
+            && (entities[j].type == 53 || entities[j].type == 54)
+            && entitywarphlinecollide(i, j))
+            {
+                customwarpmodehon = true;
+            }
+        }
+    }
 }
 
 void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& map, musicclass& music )
 {
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
-        if (entities[i].active)
+        //We test entity to entity
+        for (size_t j = 0; j < entities.size(); j++)
         {
-            //We test entity to entity
-            for (int j = 0; j < nentity; j++)
+            if (i != j)
             {
-                if (entities[j].active && i!=j)  //Active
+                if (entities[i].rule == 0 && entities[j].rule == 1 && entities[j].harmful)
                 {
-                    if (entities[i].rule == 0 && entities[j].rule == 1 && entities[j].harmful)
+                    //player i hits enemy or enemy bullet j
+                    if (entitycollide(i, j) && !map.invincibility)
                     {
-                        //player i hits enemy or enemy bullet j
-                        if (entitycollide(i, j) && !map.invincibility)
+                        if (entities[i].size == 0 && (entities[j].size == 0 || entities[j].size == 12))
                         {
-                            if (entities[i].size == 0 && (entities[j].size == 0 || entities[j].size == 12))
+                            //They're both sprites, so do a per pixel collision
+                            colpoint1.x = entities[i].xp;
+                            colpoint1.y = entities[i].yp;
+                            colpoint2.x = entities[j].xp;
+                            colpoint2.y = entities[j].yp;
+                            if (dwgfx.flipmode)
                             {
-                                //They're both sprites, so do a per pixel collision
-                                colpoint1.x = entities[i].xp;
-                                colpoint1.y = entities[i].yp;
-                                colpoint2.x = entities[j].xp;
-                                colpoint2.y = entities[j].yp;
-                                if (dwgfx.flipmode)
+                                if (dwgfx.Hitest(dwgfx.flipsprites[entities[i].drawframe],
+                                                 colpoint1, 1, dwgfx.flipsprites[entities[j].drawframe], colpoint2, 1))
                                 {
-                                    if (dwgfx.Hitest(dwgfx.flipsprites[entities[i].drawframe],
-                                                     colpoint1, 1, dwgfx.flipsprites[entities[j].drawframe], colpoint2, 1))
-                                    {
-                                        //Do the collision stuff
-                                        game.deathseq = 30;
-                                    }
-                                }
-                                else
-                                {
-                                    if (dwgfx.Hitest(dwgfx.sprites[entities[i].drawframe],
-                                                     colpoint1, 1, dwgfx.sprites[entities[j].drawframe], colpoint2, 1) )
-                                    {
-                                        //Do the collision stuff
-                                        game.deathseq = 30;
-                                    }
+                                    //Do the collision stuff
+                                    game.deathseq = 30;
                                 }
                             }
                             else
                             {
-                                //Ok, then we just assume a normal bounding box collision
-                                game.deathseq = 30;
+                                if (dwgfx.Hitest(dwgfx.sprites[entities[i].drawframe],
+                                                 colpoint1, 1, dwgfx.sprites[entities[j].drawframe], colpoint2, 1) )
+                                {
+                                    //Do the collision stuff
+                                    game.deathseq = 30;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            //Ok, then we just assume a normal bounding box collision
+                            game.deathseq = 30;
+                        }
+                    }
+                }
+                if (entities[i].rule == 0 && entities[j].rule == 2)   //Moving platforms
+                {
+                    if (entitycollide(i, j)) removeblockat(entities[j].xp, entities[j].yp);
+                }
+                if (entities[i].rule == 0 && entities[j].rule == 3)   //Entity to entity
+                {
+                    if(entities[j].onentity>0)
+                    {
+                        if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
+                    }
+                }
+                if (entities[i].rule == 0 && entities[j].rule == 4)   //Player vs horizontal line!
+                {
+                    if(game.deathseq==-1)
+                    {
+                        //Here we compare the player's old position versus his new one versus the line.
+                        //All points either be above or below it. Otherwise, there was a collision this frame.
+                        if (entities[j].onentity > 0)
+                        {
+                            if (entityhlinecollide(i, j))
+                            {
+                                music.playef(8,10);
+                                game.gravitycontrol = (game.gravitycontrol + 1) % 2;
+                                game.totalflips++;
+                                if (game.gravitycontrol == 0)
+                                {
+                                    if (entities[i].vy < 1) entities[i].vy = 1;
+                                }
+                                else
+                                {
+                                    if (entities[i].vy > -1) entities[i].vy = -1;
+                                }
+
+                                entities[j].state = entities[j].onentity;
+                                entities[j].life = 6;
                             }
                         }
                     }
-                    if (entities[i].rule == 0 && entities[j].rule == 2)   //Moving platforms
-                    {
-                        if (entitycollide(i, j)) removeblockat(entities[j].xp, entities[j].yp);
-                    }
-                    if (entities[i].rule == 0 && entities[j].rule == 3)   //Entity to entity
+                }
+                if (entities[i].rule == 0 && entities[j].rule == 5)   //Player vs vertical line!
+                {
+                    if(game.deathseq==-1)
                     {
                         if(entities[j].onentity>0)
                         {
-                            if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
-                        }
-                    }
-                    if (entities[i].rule == 0 && entities[j].rule == 4)   //Player vs horizontal line!
-                    {
-                        if(game.deathseq==-1)
-                        {
-                            //Here we compare the player's old position versus his new one versus the line.
-                            //All points either be above or below it. Otherwise, there was a collision this frame.
-                            if (entities[j].onentity > 0)
+                            if (entityvlinecollide(i, j))
                             {
-                                if (entityhlinecollide(i, j))
-                                {
-                                    music.playef(8,10);
-                                    game.gravitycontrol = (game.gravitycontrol + 1) % 2;
-                                    game.totalflips++;
-                                    if (game.gravitycontrol == 0)
-                                    {
-                                        if (entities[i].vy < 1) entities[i].vy = 1;
-                                    }
-                                    else
-                                    {
-                                        if (entities[i].vy > -1) entities[i].vy = -1;
-                                    }
-
-                                    entities[j].state = entities[j].onentity;
-                                    entities[j].life = 6;
-                                }
+                                entities[j].state = entities[j].onentity;
+                                entities[j].life = 4;
                             }
                         }
                     }
-                    if (entities[i].rule == 0 && entities[j].rule == 5)   //Player vs vertical line!
+                }
+                if (entities[i].rule == 0 && entities[j].rule == 6)   //Player versus crumbly blocks! Special case
+                {
+                    if (entities[j].onentity > 0)
                     {
-                        if(game.deathseq==-1)
+                        //ok; only check the actual collision if they're in a close proximity
+                        temp = entities[i].yp - entities[j].yp;
+                        if (temp < 30 || temp > -30)
                         {
-                            if(entities[j].onentity>0)
-                            {
-                                if (entityvlinecollide(i, j))
-                                {
-                                    entities[j].state = entities[j].onentity;
-                                    entities[j].life = 4;
-                                }
-                            }
-                        }
-                    }
-                    if (entities[i].rule == 0 && entities[j].rule == 6)   //Player versus crumbly blocks! Special case
-                    {
-                        if (entities[j].onentity > 0)
-                        {
-                            //ok; only check the actual collision if they're in a close proximity
-                            temp = entities[i].yp - entities[j].yp;
+                            temp = entities[i].xp - entities[j].xp;
                             if (temp < 30 || temp > -30)
                             {
-                                temp = entities[i].xp - entities[j].xp;
-                                if (temp < 30 || temp > -30)
-                                {
-                                    if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
-                                }
+                                if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
                             }
                         }
                     }
-										/*
-                    if (entities[i].rule == 0 && entities[j].rule == 7)   //Player vs horizontal WARP line
+                }
+                if (game.supercrewmate)
+                {
+                    //some extra collisions
+                    if (entities[i].type == 14)   //i is the supercrewmate
                     {
-                        if(game.deathseq==-1)
+                        if (entities[j].rule == 1 && entities[j].harmful)  //j is a harmful enemy
                         {
-                            if(entities[j].onentity>0)
+                            //player i hits enemy or enemy bullet j
+                            if (entitycollide(i, j) && !map.invincibility)
                             {
-                                if (entityhlinecollide(i, j))
+                                if (entities[i].size == 0 && entities[j].size == 0)
                                 {
-                                    entities[j].state = entities[j].onentity;
-                                    entities[j].life = 4;
-                                }
-                            }
-                        }
-                    }
-										*/
-                    if (game.supercrewmate)
-                    {
-                        //some extra collisions
-                        if (entities[i].type == 14)   //i is the supercrewmate
-                        {
-                            if (entities[j].rule == 1 && entities[j].harmful)  //j is a harmful enemy
-                            {
-                                //player i hits enemy or enemy bullet j
-                                if (entitycollide(i, j) && !map.invincibility)
-                                {
-                                    if (entities[i].size == 0 && entities[j].size == 0)
+                                    //They're both sprites, so do a per pixel collision
+                                    colpoint1.x = entities[i].xp;
+                                    colpoint1.y = entities[i].yp;
+                                    colpoint2.x = entities[j].xp;
+                                    colpoint2.y = entities[j].yp;
+                                    if (dwgfx.flipmode)
                                     {
-                                        //They're both sprites, so do a per pixel collision
-                                        colpoint1.x = entities[i].xp;
-                                        colpoint1.y = entities[i].yp;
-                                        colpoint2.x = entities[j].xp;
-                                        colpoint2.y = entities[j].yp;
-                                        if (dwgfx.flipmode)
+                                        if (dwgfx.Hitest(dwgfx.flipsprites[entities[i].drawframe],
+                                                         colpoint1, 1, dwgfx.flipsprites[entities[j].drawframe], colpoint2, 1))
                                         {
-                                            if (dwgfx.Hitest(dwgfx.flipsprites[entities[i].drawframe],
-                                                             colpoint1, 1, dwgfx.flipsprites[entities[j].drawframe], colpoint2, 1))
-                                            {
-                                                //Do the collision stuff
-                                                game.deathseq = 30;
-                                                game.scmhurt = true;
-                                            }
-                                        }
-                                        else
-                                        {
-                                            if (dwgfx.Hitest(dwgfx.sprites[entities[i].drawframe],
-                                                             colpoint1, 1, dwgfx.sprites[entities[j].drawframe], colpoint2, 1))
-                                            {
-                                                //Do the collision stuff
-                                                game.deathseq = 30;
-                                                game.scmhurt = true;
-                                            }
+                                            //Do the collision stuff
+                                            game.deathseq = 30;
+                                            game.scmhurt = true;
                                         }
                                     }
                                     else
                                     {
-                                        //Ok, then we just assume a normal bounding box collision
-                                        game.deathseq = 30;
-                                        game.scmhurt = true;
+                                        if (dwgfx.Hitest(dwgfx.sprites[entities[i].drawframe],
+                                                         colpoint1, 1, dwgfx.sprites[entities[j].drawframe], colpoint2, 1))
+                                        {
+                                            //Do the collision stuff
+                                            game.deathseq = 30;
+                                            game.scmhurt = true;
+                                        }
                                     }
                                 }
-                            }
-                            if (entities[j].rule == 2)   //Moving platforms
-                            {
-                                if (entitycollide(i, j)) removeblockat(entities[j].xp, entities[j].yp);
-                            }
-                            if (entities[j].type == 8 && entities[j].rule == 3)   //Entity to entity (well, checkpoints anyway!)
-                            {
-                                if(entities[j].onentity>0)
+                                else
                                 {
-                                    if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
+                                    //Ok, then we just assume a normal bounding box collision
+                                    game.deathseq = 30;
+                                    game.scmhurt = true;
                                 }
+                            }
+                        }
+                        if (entities[j].rule == 2)   //Moving platforms
+                        {
+                            if (entitycollide(i, j)) removeblockat(entities[j].xp, entities[j].yp);
+                        }
+                        if (entities[j].type == 8 && entities[j].rule == 3)   //Entity to entity (well, checkpoints anyway!)
+                        {
+                            if(entities[j].onentity>0)
+                            {
+                                if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
                             }
                         }
                     }

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -8,7 +8,8 @@
 #include <vector>
 #include <string>
 
-#define		rn( rx,  ry) ((rx) + ((ry) * 100))
+#define removeblock_iter(index) { obj.removeblock(index); index--; }
+#define removeentity_iter(index) { obj.removeentity(index); index--; }
 
 enum
 {
@@ -60,8 +61,6 @@ public:
         createblock(DAMAGE, 312, -8, 16, 260);
     }
 
-    void setblockcolour(int t, std::string col);
-
     int swncolour(int t );
 
     void swnenemiescol(int t);
@@ -80,6 +79,8 @@ public:
 
     void removetrigger(int t);
 
+    void removeentity(int t);
+
     void copylinecross(int t);
 
     void revertlinecross(int t, int s);
@@ -87,12 +88,6 @@ public:
     bool gridmatch(int p1, int p2, int p3, int p4, int p11, int p21, int p31, int p41);
 
     int crewcolour(int t);
-
-    void setenemyroom(int t, int rx, int ry);
-
-    void setenemy(int t, int r);
-
-    void settreadmillcolour(int t, int rx, int ry);
 
     void createentity(Game& game, float xp, float yp, int t, float vx = 0, float vy = 0,
                       int p1 = 0, int p2 = 0, int p3 = 320, int p4 = 240 );
@@ -175,8 +170,6 @@ public:
 
     void applyfriction(int t, float xrate, float yrate);
 
-    void cleanup();
-
     void updateentitylogic(int t, Game& game);
 
 
@@ -193,10 +186,7 @@ public:
 
     std::vector<entclass> entities;
 
-    int nentity;
-
     std::vector<entclass> linecrosskludge;
-    int nlinecrosskludge;
 
     point colpoint1, colpoint2;
 
@@ -218,7 +208,6 @@ public:
     std::vector<int> collect;
     std::vector<int> customcollect;
 
-    int nblocks;
     bool skipblocks, skipdirblocks;
 
     int platformtile;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -2319,7 +2319,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             i = obj.getcompanion(companion);
             if(i>-1)
             {
-                obj.entities[i].active = false;
+                obj.removeentity(i);
             }
 
             i = obj.getteleporter();

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -94,10 +94,6 @@ void Graphics::init()
     menuoffset = 0;
     resumegamemode = false;
 
-    //Textboxes!
-    textbox.resize(30);
-    ntextbox = 0;
-
     //Fading stuff
     fadebars.resize(15);
 
@@ -596,146 +592,149 @@ void Graphics::drawtowertile3( int x, int y, int t, int off )
     BlitSurfaceStandard(tiles3[t+(off*30)], NULL, towerbuffer, &rect);
 }
 
-void Graphics::drawgui( UtilityClass& help )
+void Graphics::drawgui(UtilityClass& help)
 {
-    textboxcleanup();
     //Draw all the textboxes to the screen
-    for (int i = 0; i<ntextbox; i++)
+    for (size_t i = 0; i < textbox.size(); i++)
     {
         //This routine also updates the textboxs
         textbox[i].update();
-        if (textbox[i].active)
+        if (textbox[i].tm == 2 && textbox[i].tl <= 0.5)
         {
-            if (textbox[i].r == 0 && textbox[i].g == 0 && textbox[i].b == 0)
+            textbox.erase(textbox.begin() + i);
+            i--;
+            continue;
+        }
+
+        if (textbox[i].r == 0 && textbox[i].g == 0 && textbox[i].b == 0)
+        {
+            if(flipmode)
             {
-                if(flipmode)
+                for (j = 0; j < (int) textbox[i].line.size(); j++)
                 {
-                    for (j = 0; j < textbox[i].numlines; j++)
-                    {
-                        Print(textbox[i].xp + 8, textbox[i].yp + (textbox[i].numlines*8) - (j * 8), textbox[i].line[j], 196, 196, 255 - help.glow);
-                    }
-                }
-                else
-                {
-                    for (j = 0; j < textbox[i].numlines; j++)
-                    {
-                        Print(textbox[i].xp + 8, textbox[i].yp + 8 + (j * 8), textbox[i].line[j], 196, 196, 255 - help.glow);
-                    }
+                    Print(textbox[i].xp + 8, textbox[i].yp + (textbox[i].line.size()*8) - (j * 8), textbox[i].line[j], 196, 196, 255 - help.glow);
                 }
             }
             else
             {
-
-                FillRect(backBuffer,textbox[i].textrect, textbox[i].r/6, textbox[i].g/6, textbox[i].b / 6 );
-
-                drawcoloredtile(textbox[i].xp, textbox[i].yp, 40, textbox[i].r, textbox[i].g, textbox[i].b);
-                drawcoloredtile(textbox[i].xp+textbox[i].w-8, textbox[i].yp, 42, textbox[i].r, textbox[i].g, textbox[i].b);
-                drawcoloredtile(textbox[i].xp, textbox[i].yp+textbox[i].h-8, 45, textbox[i].r, textbox[i].g, textbox[i].b);
-                drawcoloredtile(textbox[i].xp+textbox[i].w-8, textbox[i].yp+textbox[i].h-8, 47, textbox[i].r, textbox[i].g, textbox[i].b);
-                for (int k = 0; k < textbox[i].lw; k++)
+                for (j = 0; j < (int) textbox[i].line.size(); j++)
                 {
-                    drawcoloredtile(textbox[i].xp + 8 + (k * 8), textbox[i].yp, 41, textbox[i].r, textbox[i].g, textbox[i].b);
-                    drawcoloredtile(textbox[i].xp + 8 + (k * 8), textbox[i].yp+textbox[i].h-8, 46, textbox[i].r, textbox[i].g, textbox[i].b);
-                }
-                for (int k = 0; k < textbox[i].numlines; k++)
-                {
-                    drawcoloredtile(textbox[i].xp, textbox[i].yp + 8 + (k * 8), 43, textbox[i].r, textbox[i].g, textbox[i].b);
-                    drawcoloredtile(textbox[i].xp + textbox[i].w-8, textbox[i].yp + 8 + (k * 8), 44, textbox[i].r, textbox[i].g, textbox[i].b);
-                }
-
-                if(flipmode)
-                {
-                    for (j = 0; j < textbox[i].numlines; j++)
-                    {
-                        Print(textbox[i].xp + 8, textbox[i].yp  + (textbox[i].numlines*8) - (j * 8), textbox[i].line[j], textbox[i].r, textbox[i].g, textbox[i].b);
-                    }
-                }
-                else
-                {
-                    for (j = 0; j < textbox[i].numlines; j++)
-                    {
-                        Print(textbox[i].xp + 8, textbox[i].yp +8 + (j * 8), textbox[i].line[j], textbox[i].r, textbox[i].g, textbox[i].b);
-                    }
+                    Print(textbox[i].xp + 8, textbox[i].yp + 8 + (j * 8), textbox[i].line[j], 196, 196, 255 - help.glow);
                 }
             }
+        }
+        else
+        {
 
-            if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].r == 165)
+            FillRect(backBuffer,textbox[i].textrect, textbox[i].r/6, textbox[i].g/6, textbox[i].b / 6 );
+
+            drawcoloredtile(textbox[i].xp, textbox[i].yp, 40, textbox[i].r, textbox[i].g, textbox[i].b);
+            drawcoloredtile(textbox[i].xp+textbox[i].w-8, textbox[i].yp, 42, textbox[i].r, textbox[i].g, textbox[i].b);
+            drawcoloredtile(textbox[i].xp, textbox[i].yp+textbox[i].h-8, 45, textbox[i].r, textbox[i].g, textbox[i].b);
+            drawcoloredtile(textbox[i].xp+textbox[i].w-8, textbox[i].yp+textbox[i].h-8, 47, textbox[i].r, textbox[i].g, textbox[i].b);
+            for (int k = 0; k < textbox[i].lw; k++)
             {
-                if (flipmode)
-                {
-                    drawimage(5, 0, 180, true);
-                }
-                else
-                {
-                    drawimage(0, 0, 12, true);
-                }
+                drawcoloredtile(textbox[i].xp + 8 + (k * 8), textbox[i].yp, 41, textbox[i].r, textbox[i].g, textbox[i].b);
+                drawcoloredtile(textbox[i].xp + 8 + (k * 8), textbox[i].yp+textbox[i].h-8, 46, textbox[i].r, textbox[i].g, textbox[i].b);
             }
-            else if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].g == 165)
+            for (size_t k = 0; k < textbox[i].line.size(); k++)
             {
-                if (flipmode)
+                drawcoloredtile(textbox[i].xp, textbox[i].yp + 8 + (k * 8), 43, textbox[i].r, textbox[i].g, textbox[i].b);
+                drawcoloredtile(textbox[i].xp + textbox[i].w-8, textbox[i].yp + 8 + (k * 8), 44, textbox[i].r, textbox[i].g, textbox[i].b);
+            }
+
+            if(flipmode)
+            {
+                for (j = 0; j < (int) textbox[i].line.size(); j++)
                 {
-                    drawimage(6, 0, 180, true);
-                }
-                else
-                {
-                    drawimage(4, 0, 12, true);
+                    Print(textbox[i].xp + 8, textbox[i].yp  + (textbox[i].line.size()*8) - (j * 8), textbox[i].line[j], textbox[i].r, textbox[i].g, textbox[i].b);
                 }
             }
+            else
+            {
+                for (j = 0; j < (int) textbox[i].line.size(); j++)
+                {
+                    Print(textbox[i].xp + 8, textbox[i].yp +8 + (j * 8), textbox[i].line[j], textbox[i].r, textbox[i].g, textbox[i].b);
+                }
+            }
+        }
+
+        if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].r == 165)
+        {
             if (flipmode)
             {
-                if (textbox[i].r == 175 && textbox[i].g == 175)
-                {
-                    //purple guy
-                    drawsprite(80 - 6, 64 + 48 + 4, 6, 220- help.glow/4 - int(fRandom()*20), 120- help.glow/4, 210 - help.glow/4);
-                }
-                else if (textbox[i].r == 175 && textbox[i].b == 175)
-                {
-                    //red guy
-                    drawsprite(80 - 6, 64 + 48+ 4, 6, 255 - help.glow/8, 70 - help.glow/4, 70 - help.glow / 4);
-                }
-                else if (textbox[i].r == 175)
-                {
-                    //green guy
-                    drawsprite(80 - 6, 64 + 48 + 4, 6, 120 - help.glow / 4 - int(fRandom() * 20), 220 - help.glow / 4, 120 - help.glow / 4);
-                }
-                else if (textbox[i].g == 175)
-                {
-                    //yellow guy
-                    drawsprite(80 - 6, 64 + 48+ 4, 6, 220- help.glow/4 - int(fRandom()*20), 210 - help.glow/4, 120- help.glow/4);
-                }
-                else if (textbox[i].b == 175)
-                {
-                    //blue guy
-                    drawsprite(80 - 6, 64 + 48+ 4, 6, 75, 75, 255- help.glow/4 - int(fRandom()*20));
-                }
+                drawimage(5, 0, 180, true);
             }
             else
             {
-                if (textbox[i].r == 175 && textbox[i].g == 175)
-                {
-                    //purple guy
-                    drawsprite(80 - 6, 64 + 32 + 4, 0, 220- help.glow/4 - int(fRandom()*20), 120- help.glow/4, 210 - help.glow/4);
-                }
-                else if (textbox[i].r == 175 && textbox[i].b == 175)
-                {
-                    //red guy
-                    drawsprite(80 - 6, 64 + 32 + 4, 0, 255 - help.glow/8, 70 - help.glow/4, 70 - help.glow / 4);
-                }
-                else if (textbox[i].r == 175)
-                {
-                    //green guy
-                    drawsprite(80 - 6, 64 + 32 + 4, 0, 120 - help.glow / 4 - int(fRandom() * 20), 220 - help.glow / 4, 120 - help.glow / 4);
-                }
-                else if (textbox[i].g == 175)
-                {
-                    //yellow guy
-                    drawsprite(80 - 6, 64 + 32 + 4, 0, 220- help.glow/4 - int(fRandom()*20), 210 - help.glow/4, 120- help.glow/4);
-                }
-                else if (textbox[i].b == 175)
-                {
-                    //blue guy
-                    drawsprite(80 - 6, 64 + 32 + 4, 0, 75, 75, 255- help.glow/4 - int(fRandom()*20));
-                }
+                drawimage(0, 0, 12, true);
+            }
+        }
+        else if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].g == 165)
+        {
+            if (flipmode)
+            {
+                drawimage(6, 0, 180, true);
+            }
+            else
+            {
+                drawimage(4, 0, 12, true);
+            }
+        }
+        if (flipmode)
+        {
+            if (textbox[i].r == 175 && textbox[i].g == 175)
+            {
+                //purple guy
+                drawsprite(80 - 6, 64 + 48 + 4, 6, 220- help.glow/4 - int(fRandom()*20), 120- help.glow/4, 210 - help.glow/4);
+            }
+            else if (textbox[i].r == 175 && textbox[i].b == 175)
+            {
+                //red guy
+                drawsprite(80 - 6, 64 + 48+ 4, 6, 255 - help.glow/8, 70 - help.glow/4, 70 - help.glow / 4);
+            }
+            else if (textbox[i].r == 175)
+            {
+                //green guy
+                drawsprite(80 - 6, 64 + 48 + 4, 6, 120 - help.glow / 4 - int(fRandom() * 20), 220 - help.glow / 4, 120 - help.glow / 4);
+            }
+            else if (textbox[i].g == 175)
+            {
+                //yellow guy
+                drawsprite(80 - 6, 64 + 48+ 4, 6, 220- help.glow/4 - int(fRandom()*20), 210 - help.glow/4, 120- help.glow/4);
+            }
+            else if (textbox[i].b == 175)
+            {
+                //blue guy
+                drawsprite(80 - 6, 64 + 48+ 4, 6, 75, 75, 255- help.glow/4 - int(fRandom()*20));
+            }
+        }
+        else
+        {
+            if (textbox[i].r == 175 && textbox[i].g == 175)
+            {
+                //purple guy
+                drawsprite(80 - 6, 64 + 32 + 4, 0, 220- help.glow/4 - int(fRandom()*20), 120- help.glow/4, 210 - help.glow/4);
+            }
+            else if (textbox[i].r == 175 && textbox[i].b == 175)
+            {
+                //red guy
+                drawsprite(80 - 6, 64 + 32 + 4, 0, 255 - help.glow/8, 70 - help.glow/4, 70 - help.glow / 4);
+            }
+            else if (textbox[i].r == 175)
+            {
+                //green guy
+                drawsprite(80 - 6, 64 + 32 + 4, 0, 120 - help.glow / 4 - int(fRandom() * 20), 220 - help.glow / 4, 120 - help.glow / 4);
+            }
+            else if (textbox[i].g == 175)
+            {
+                //yellow guy
+                drawsprite(80 - 6, 64 + 32 + 4, 0, 220- help.glow/4 - int(fRandom()*20), 210 - help.glow/4, 120- help.glow/4);
+            }
+            else if (textbox[i].b == 175)
+            {
+                //blue guy
+                drawsprite(80 - 6, 64 + 32 + 4, 0, 75, 75, 255- help.glow/4 - int(fRandom()*20));
             }
         }
     }
@@ -991,7 +990,7 @@ void Graphics::drawtextbox( int x, int y, int w, int h, int r, int g, int b )
 void Graphics::textboxactive()
 {
     //Remove all but the most recent textbox
-    for (int i = 0; i < ntextbox; i++)
+    for (int i = 0; i < (int) textbox.size(); i++)
     {
         if (m != i) textbox[i].remove();
     }
@@ -1000,7 +999,7 @@ void Graphics::textboxactive()
 void Graphics::textboxremovefast()
 {
     //Remove all textboxes
-    for (int i = 0; i < ntextbox; i++)
+    for (size_t i = 0; i < textbox.size(); i++)
     {
         textbox[i].removefast();
     }
@@ -1009,7 +1008,7 @@ void Graphics::textboxremovefast()
 void Graphics::textboxremove()
 {
     //Remove all textboxes
-    for (int i = 0; i < ntextbox; i++)
+    for (size_t i = 0; i < textbox.size(); i++)
     {
         textbox[i].remove();
     }
@@ -1031,38 +1030,23 @@ void Graphics::textboxadjust()
 }
 
 
-void Graphics::createtextbox( std::string t, int xp, int yp, int r/*= 255*/, int g/*= 255*/, int b /*= 255*/ )
+void Graphics::createtextbox(std::string t, int xp, int yp, int r /*= 255*/, int g /*= 255*/, int b /*= 255*/)
 {
+    m = textbox.size();
 
-    if(ntextbox == 0)
+    if ((int) textbox.size() < 20)
     {
-        //If there are no active textboxes, Z=0;
-        m = 0;
-        ntextbox++;
-    }
-    else
-    {
-        /*i = 0; m = -1;
-        while (i < ntextbox) {
-        if (!textbox[i].active) {	m = i; i = ntextbox;}
-        i++;
-        }
-        if (m == -1) {m = ntextbox; ntextbox++;}
-        */
-        m = ntextbox;
-        ntextbox++;
-    }
+        textboxclass text;
 
-    if(m<20)
-    {
-        textbox[m].clear();
-        textbox[m].line[0] = t;
-        textbox[m].xp = xp;
+        text.line.push_back(t);
+        text.xp = xp;
         int length = utf8::unchecked::distance(t.begin(), t.end());
-        if (xp == -1) textbox[m].xp = 160 - (((length / 2) + 1) * 8);
-        textbox[m].yp = yp;
-        textbox[m].initcol(r, g, b);
-        textbox[m].resize();
+        if (xp == -1) text.xp = 160 - (((length / 2) + 1) * 8);
+        text.yp = yp;
+        text.initcol(r, g, b);
+        text.resize();
+
+        textbox.push_back(text);
     }
 }
 
@@ -1448,11 +1432,11 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
 
     SDL_Rect drawRect;
 
-	trinketcolset = false;
+    trinketcolset = false;
 
-    for (int i = obj.nentity - 1; i >= 0; i--)
+    for (int i = obj.entities.size() - 1; i >= 0; i--)
     {
-        if (!obj.entities[i].invis && obj.entities[i].active)
+        if (!obj.entities[i].invis)
         {
             if (obj.entities[i].size == 0)
             {
@@ -2491,13 +2475,13 @@ void Graphics::drawtowerentities( mapclass& map, entityclass& obj, UtilityClass&
     point tpoint;
     SDL_Rect trect;
 
-    for (int i = obj.nentity - 1; i >= 0; i--)
+    for (int i = obj.entities.size() - 1; i >= 0; i--)
     {
-        if (!obj.entities[i].invis && obj.entities[i].active)
+        if (!obj.entities[i].invis)
         {
             if (obj.entities[i].size == 0)        // Sprites
             {
-				trinketcolset = false;
+                trinketcolset = false;
                 tpoint.x = obj.entities[i].xp;
                 tpoint.y = obj.entities[i].yp-map.ypos;
                 setcol(obj.entities[i].colour, help);
@@ -2960,16 +2944,6 @@ void Graphics::setwarprect( int a, int b, int c, int d )
 	warprect.w = c;
 	warprect.h = d;
 }
-
-	void Graphics::textboxcleanup()
-	{
-		int i = ntextbox - 1;
-		while (i >= 0 && !textbox[i].active)
-		{
-			ntextbox--;
-			i--;
-		}
-	}
 
 void Graphics::textboxcenter()
 {

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -57,8 +57,6 @@ public:
 
 	void createtextbox(std::string t, int xp, int yp, int r= 255, int g= 255, int b = 255);
 
-	void textboxcleanup();
-
 	void textboxcenter();
 
 	void textboxcenterx();
@@ -271,7 +269,6 @@ public:
 	int trinketr, trinketg, trinketb;
 
 	std::vector <textboxclass> textbox;
-	int ntextbox;
 
 	bool showcutscenebars;
 	int cutscenebarspos;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1972,6 +1972,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
             {
                 script.load(obj.blocks[game.activeactivity].script);
                 obj.removeblock(game.activeactivity);
+                game.activeactivity = -1;
             }
         }else{
           game.gamestate = EDITORMODE;
@@ -1999,7 +2000,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 #endif
 
     //Entity type 0 is player controled
-    for (int ie = 0; ie < obj.nentity; ++ie)
+    for (size_t ie = 0; ie < obj.entities.size(); ++ie)
     {
         if (obj.entities[ie].rule == 0)
         {
@@ -2101,6 +2102,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
                         {
                             script.load(obj.blocks[game.activeactivity].script);
                             obj.removeblock(game.activeactivity);
+                            game.activeactivity = -1;
                         }
                     }
                     else if (game.swnmode == 1 && game.swngame == 1)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -30,7 +30,6 @@ scriptclass::scriptclass()
 	r = 0;
 	textx = 0;
 	texty = 0;
-	txtnumlines = 0;
 }
 
 void scriptclass::clearcustom(){
@@ -142,19 +141,26 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 	#endif
 			if (words[0] == "destroy")
 			{
-				if(words[1]=="gravitylines"){
-				  for(int edi=0; edi<obj.nentity; edi++){
-				    if(obj.entities[edi].type==9) obj.entities[edi].active=false;
-				    if(obj.entities[edi].type==10) obj.entities[edi].active=false;
-				  }
-				}else if(words[1]=="warptokens"){
-				  for(int edi=0; edi<obj.nentity; edi++){
-				    if(obj.entities[edi].type==11) obj.entities[edi].active=false;
-          }
-				}else if(words[1]=="platforms"){
-				  for(int edi=0; edi<obj.nentity; edi++){
-				    if(obj.entities[edi].rule==2 && obj.entities[edi].animate==100) obj.entities[edi].active=false;
-          }
+				if (words[1] == "gravitylines")
+				{
+					for (size_t edi = 0; edi < obj.entities.size(); edi++) {
+						if (obj.entities[edi].type == 9) removeentity_iter(edi);
+						if (obj.entities[edi].type == 10) removeentity_iter(edi);
+					}
+				}
+				else if (words[1] == "warptokens")
+				{
+					for (size_t edi = 0; edi < obj.entities.size(); edi++)
+					{
+						if (obj.entities[edi].type == 11) removeentity_iter(edi);
+					}
+				}
+				else if (words[1] == "platforms")
+				{
+					for (size_t edi = 0; edi < obj.entities.size(); edi++)
+					{
+						if (obj.entities[edi].rule == 2 && obj.entities[edi].animate == 100) removeentity_iter(edi);
+					}
 				}
 			}
 			if (words[0] == "customiftrinkets")
@@ -376,11 +382,11 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				texty = ss_toi(words[3]);
 
 				//Number of lines for the textbox!
-				txtnumlines = ss_toi(words[4]);
-				for (int i = 0; i < txtnumlines; i++)
+				txt.clear();
+				for (int i = 0; i < ss_toi(words[4]); i++)
 				{
 					position++;
-					txt[i] = commands[position];
+					txt.push_back(commands[position]);
 				}
 			}
 			else if (words[0] == "position")
@@ -450,12 +456,12 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 					if (j == 1)    //left
 					{
 						textx = obj.entities[i].xp -10000; //tells the box to be oriented correctly later
-						texty = obj.entities[i].yp - 16 - (txtnumlines*8);
+						texty = obj.entities[i].yp - 16 - (txt.size()*8);
 					}
 					else if (j == 0)     //Right
 					{
 						textx = obj.entities[i].xp - 16;
-						texty = obj.entities[i].yp - 18 - (txtnumlines * 8);
+						texty = obj.entities[i].yp - 18 - (txt.size() * 8);
 					}
 				}
 				else
@@ -547,12 +553,12 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 					if (j == 1)    //left
 					{
 						textx = obj.entities[i].xp -10000; //tells the box to be oriented correctly later
-						texty = obj.entities[i].yp - 16 - (txtnumlines*8);
+						texty = obj.entities[i].yp - 16 - (txt.size()*8);
 					}
 					else if (j == 0)     //Right
 					{
 						textx = obj.entities[i].xp - 16;
-						texty = obj.entities[i].yp - 18 - (txtnumlines * 8);
+						texty = obj.entities[i].yp - 18 - (txt.size() * 8);
 					}
 				}
 				else
@@ -575,15 +581,15 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "flipme")
 			{
-				if(dwgfx.flipmode) texty += 2*(120 - texty) - 8*(txtnumlines+2);
+				if(dwgfx.flipmode) texty += 2*(120 - texty) - 8*(txt.size()+2);
 			}
 			else if (words[0] == "speak_active")
 			{
 				//Ok, actually display the textbox we've initilised now!
 				dwgfx.createtextbox(txt[0], textx, texty, r, g, b);
-				if (txtnumlines > 1)
+				if ((int) txt.size() > 1)
 				{
-					for (i = 1; i < txtnumlines; i++)
+					for (i = 1; i < (int) txt.size(); i++)
 					{
 						dwgfx.addline(txt[i]);
 					}
@@ -626,9 +632,9 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			{
 				//Exactly as above, except don't make the textbox active (so we can use multiple textboxes)
 				dwgfx.createtextbox(txt[0], textx, texty, r, g, b);
-				if (txtnumlines > 1)
+				if ((int) txt.size() > 1)
 				{
-					for (i = 1; i < txtnumlines; i++)
+					for (i = 1; i < (int) txt.size(); i++)
 					{
 						dwgfx.addline(txt[i]);
 					}
@@ -1655,9 +1661,9 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "jukebox")
 			{
-				for (j = 0; j < obj.nentity; j++)
+				for (j = 0; j < (int) obj.entities.size(); j++)
 				{
-					if (obj.entities[j].type == 13 && obj.entities[j].active)
+					if (obj.entities[j].type == 13)
 					{
 						obj.entities[j].colour = 4;
 					}
@@ -1665,7 +1671,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				if (ss_toi(words[1]) == 1)
 				{
 					obj.createblock(5, 88 - 4, 80, 20, 16, 25);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 88 && obj.entities[j].yp==80)
 						{
@@ -1676,7 +1682,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				else if (ss_toi(words[1]) == 2)
 				{
 					obj.createblock(5, 128 - 4, 80, 20, 16, 26);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 128 && obj.entities[j].yp==80)
 						{
@@ -1687,7 +1693,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				else if (ss_toi(words[1]) == 3)
 				{
 					obj.createblock(5, 176 - 4, 80, 20, 16, 27);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 176 && obj.entities[j].yp==80)
 						{
@@ -1698,7 +1704,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				else if (ss_toi(words[1]) == 4)
 				{
 					obj.createblock(5, 216 - 4, 80, 20, 16, 28);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 216 && obj.entities[j].yp==80)
 						{
@@ -1709,7 +1715,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				else if (ss_toi(words[1]) == 5)
 				{
 					obj.createblock(5, 88 - 4, 128, 20, 16, 29);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 88 && obj.entities[j].yp==128)
 						{
@@ -1720,7 +1726,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				else if (ss_toi(words[1]) == 6)
 				{
 					obj.createblock(5, 176 - 4, 128, 20, 16, 30);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 176 && obj.entities[j].yp==128)
 						{
@@ -1731,7 +1737,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				else if (ss_toi(words[1]) == 7)
 				{
 					obj.createblock(5, 40 - 4, 40, 20, 16, 31);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 40 && obj.entities[j].yp==40)
 						{
@@ -1742,7 +1748,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				else if (ss_toi(words[1]) == 8)
 				{
 					obj.createblock(5, 216 - 4, 128, 20, 16, 32);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 216 && obj.entities[j].yp==128)
 						{
@@ -1753,7 +1759,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				else if (ss_toi(words[1]) == 9)
 				{
 					obj.createblock(5, 128 - 4, 128, 20, 16, 33);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 128 && obj.entities[j].yp==128)
 						{
@@ -1764,7 +1770,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				else if (ss_toi(words[1]) == 10)
 				{
 					obj.createblock(5, 264 - 4, 40, 20, 16, 34);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 264 && obj.entities[j].yp==40)
 						{
@@ -1962,7 +1968,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "everybodysad")
 			{
-				for (i = 0; i < obj.nentity; i++)
+				for (i = 0; i < (int) obj.entities.size(); i++)
 				{
 					if (obj.entities[i].rule == 6 || obj.entities[i].rule == 0)
 					{
@@ -2023,12 +2029,12 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				switch(ss_toi(words[1]))
 				{
 				case 1:
-					txtnumlines = 1;
+					txt.resize(1);
 
 					txt[0] = "I'm worried about " + game.unrescued() + ", Doctor!";
 					break;
 				case 2:
-					txtnumlines = 3;
+					txt.resize(3);
 
 					if (game.crewrescued() < 5)
 					{
@@ -2037,7 +2043,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 					}
 					else
 					{
-						txtnumlines = 2;
+						txt.resize(2);
 						txt[1] = "to helping you find " + game.unrescued() + "!";
 					}
 					break;
@@ -2538,7 +2544,7 @@ void scriptclass::resetgametomenu( Graphics& dwgfx, Game& game,mapclass& map, en
 {
 	game.gamestate = TITLEMODE;
 	dwgfx.flipmode = false;
-	obj.nentity = 0;
+	obj.entities.clear();
 	dwgfx.fademode = 4;
 	game.createmenu("gameover");
 }
@@ -2558,7 +2564,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		//set flipmode
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
 
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2581,7 +2587,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		//set flipmode
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
 
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2603,7 +2609,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		//set flipmode
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
 
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2642,7 +2648,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2670,7 +2676,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2698,7 +2704,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2726,7 +2732,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2754,7 +2760,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2788,7 +2794,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2813,7 +2819,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		//set flipmode
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
 
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2842,7 +2848,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		//set flipmode
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
 
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2878,7 +2884,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		//set flipmode
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
 
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2913,7 +2919,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		//set flipmode
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2948,7 +2954,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		//set flipmode
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2983,7 +2989,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		//set flipmode
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3018,7 +3024,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		//set flipmode
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3050,7 +3056,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		//set flipmode
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3082,7 +3088,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		//set flipmode
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3114,7 +3120,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		//set flipmode
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3146,7 +3152,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		//set flipmode
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3169,7 +3175,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3206,7 +3212,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		//set flipmode
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
 
-		if(obj.nentity==0)
+		if (obj.entities.empty())
 		{
 			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3245,7 +3251,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
     //set flipmode
     if (dwgfx.setflipmode) dwgfx.flipmode = true;
 
-    if(obj.nentity==0)
+    if (obj.entities.empty())
     {
       obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
     }
@@ -3291,7 +3297,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
     //set flipmode
     if (dwgfx.setflipmode) dwgfx.flipmode = true;
 
-    if(obj.nentity==0)
+    if (obj.entities.empty())
     {
       obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
     }

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -63,7 +63,6 @@ public:
     int textx;
     int texty;
     int r,g,b;
-    int txtnumlines;
 
     //Misc
     int i, j, k;

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -9,40 +9,28 @@ textboxclass::textboxclass()
 void textboxclass::firstcreate()
 {
     //Like clear, only it creates the actual arrays, etc
-    for (int iter = 0; iter < 10; iter++)
-    {
-        std::string t;
-        t = "";
-        line.push_back(t);
-    }
+    line.clear();
     x = 0;
     y = 0;
     w = 0;
     h = 0;
-    numlines = 0;
     lw = 0;
     tl = 0;
     tm = 0;
-    active = false;
     timer = 0;
 }
 
 void textboxclass::clear()
 {
     //Set all values to a default, required for creating a new entity
-    for (size_t iter = 0; iter < line.size(); iter++)
-    {
-        line[iter]="";
-    }
+    line.clear();
     xp = 0;
     yp = 0;
     w = 0;
     h = 0;
-    numlines = 1;
     lw = 0;
     tl = 0;
     tm = 0;
-    active = true;
     timer = 0;
 }
 
@@ -105,7 +93,7 @@ void textboxclass::update()
         if (tl <= 0.5)
         {
             tl = 0.5;
-            active = false;
+            //This textbox will now be actually removed by drawgui
         }
         setcol(int(tr * tl), int(tg * tl), int(tb * tl));
     }
@@ -132,7 +120,7 @@ void textboxclass::resize()
 {
     //Set the width and height to the correct sizes
     max = 0;
-    for (int iter = 0; iter < numlines; iter++)
+    for (size_t iter = 0; iter < line.size(); iter++)
     {
         unsigned int len = utf8::unchecked::distance(line[iter].begin(), line[iter].end());
         if (len > (unsigned int)max) max = len;
@@ -140,7 +128,7 @@ void textboxclass::resize()
 
     lw = max;
     w = (max +2) * 8;
-    h = (numlines + 2) * 8;
+    h = (line.size() + 2) * 8;
     textrect.x = xp;
     textrect.y = yp;
     textrect.w = w;
@@ -149,8 +137,7 @@ void textboxclass::resize()
 
 void textboxclass::addline(std::string t)
 {
-    line[numlines] = t;
-    numlines++;
+    line.push_back(t);
     resize();
-    if (numlines >= 12) numlines = 0;
+    if ((int) line.size() >= 12) line.clear();
 }

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -36,12 +36,11 @@ public:
 public:
     //Fundamentals
     std::vector<std::string> line;
-    int xp, yp, lw, w, h, numlines;
+    int xp, yp, lw, w, h;
     int x,y;
     int r,g,b;
     int tr,tg,tb;
     SDL_Rect textrect;
-    bool active;
     int timer;
 
     float tl;

--- a/desktop_version/src/WarpClass.cpp
+++ b/desktop_version/src/WarpClass.cpp
@@ -931,10 +931,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		warpy = true;
 		rcol = 5;
 
-		obj.entities[obj.nentity].active = true;
-		obj.nentity++;
 		obj.createentity(game, 14 * 8, (8 * 8) + 4, 14); //Teleporter!
-		obj.entities[obj.nentity - 2].active = false;
 
 		if(game.intimetrial)
 		{

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -1496,7 +1496,7 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
 
         if(!game.completestop)
         {
-            for (int i = 0; i < obj.nentity; i++)
+            for (size_t i = 0; i < obj.entities.size(); i++)
             {
                 //Is this entity on the ground? (needed for jumping)
                 if (obj.entitycollidefloor(map, i))
@@ -1525,11 +1525,6 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
         dwgfx.drawentities(map, obj, help);
     }
 
-    /*for(int i=0; i<obj.nblocks; i++){
-    if (obj.blocks[i].active) {
-    		dwgfx.backbuffer.fillRect(obj.blocks[i].rect, 0xDDDDDD);
-    }
-      }*/
     //dwgfx.drawminimap(game, map);
 
     if(map.extrarow==0 || (map.custommode && map.roomname!=""))
@@ -1826,7 +1821,7 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
 
     //Detail entity info for debuging
     /*
-    for (int i = 0; i < obj.nentity; i++) {
+    for (int i = 0; i < obj.entities.size(); i++) {
     	game.tempstring =help.String(obj.entities[i].type) +", (" +help.String(obj.entities[i].xp) + "," +help.String(obj.entities[i].yp) + ")";
     	game.tempstring += " state:" +obj.entities[i].state + ", delay:" + obj.entities[i].statedelay;
     	dwgfx.Print(5, 5 + i * 8, game.tempstring, 255, 255, 255);
@@ -2755,7 +2750,7 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
 
     if(!game.completestop)
     {
-        for (int i = 0; i < obj.nentity; i++)
+        for (size_t i = 0; i < obj.entities.size(); i++)
         {
             //Is this entity on the ground? (needed for jumping)
             if (obj.entitycollidefloor(map, i))
@@ -2786,11 +2781,6 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
     dwgfx.drawtowerspikes(map);
 
 
-    /*for(int i=0; i<obj.nblocks; i++){
-    if (obj.blocks[i].active) {
-    		dwgfx.backbuffer.fillRect(obj.blocks[i].rect, 0xDDDDDD);
-    }
-      }*/
     dwgfx.cutscenebars();
     BlitSurfaceStandard(dwgfx.backBuffer, NULL, dwgfx.tempBuffer, NULL);
 


### PR DESCRIPTION
## Changes:

### Summary

This patch removes the variables `nentity`, `nblocks`, `nlinecrosskludge`, and `ntextbox` from `entityclass` (and `Graphics`) in favor of using `entities.size()`, `blocks.size()`, `linecrosskludge.size()`, and `textbox.size()`, which are amount-tracking methods handled automatically by C++. Furthermore, entities, blocks, and textboxes no longer have an `active` attribute, and if an entity, block, or textbox exists, it is always guaranteed to be real and not fake, unlike the previous system using the `active` attribute.

As a bonus, `numlines` is removed from `textboxclass` and `txtnumlines` is removed from `scriptclass` in favor of using `line.size()` and `txt.size()` respectively.

Doing these things not only makes code maintenance easier, but it also makes debugging easier, even when it's not explicitly related to working on the codebase. I'm a fan of attaching GDB to VVVVVV and printing out various things to debug issues in my custom levels, ever since I discovered that the Linux and macOS versions have debug symbols (thanks @flibitijibibo!), but unfortunately whenever I do something like `print obj.blocks`, that means I get 500 slots, most of which are not even real, because from the point of view of C++ there are 500 slots in obj.blocks. Then whenever I'm using my brain to analyze a given slot, I always have to make sure that its `active` is set to true before I do any thinking, else it's not real and I'm just wasting time, which is always an annoyance.

Furthermore, this patch also fixes segfaults resulting from Undefined Behavior in a few custom levels, most notably Unshackled v1.2.

&#x200b;

The function `entityclass::setblockcolour()` has been moved to now be on the `blockclass` itself, so it is now `blockclass::setblockcolour()`. So instead of `entityclass::setblockcolour()` taking in the index of the block whose color you want to set, you simply take the block and call its `setblockcolour()` method. Same thing for `entityclass::setenemyroom()`, `entityclass::setenemy()`, and `entityclass::settreadmillcolour()` - they are now on the entclass as `entclass::setenemyroom()`, `entclass::setenemy()`, and `entclass::settreadmillcolour()`, respectively.

For the `linecrosskludge` handling, instead of copying only specific attributes, I've decided to just copy the full attributes of each object instead. I'm pretty sure it doesn't affect anything, and I've checked.

I also took the opportunity to clean up some formatting and code style, such as using a case-switch for checking `para` in `entclass::setenemy()` instead of an `if`-`else if` chain, cleaning up some mixed indentation, removing commented-out code from earlier development of this game, removing unnecessary int casts in assignments (they definitely should be kept in comparisons, though, and any assignment expression more complicated than `a = b`), collapsing double-nested if-statements by putting them together into one with an "and" (the biggest offenders of this were `entityclass::hplatformat()` and `entityclass::customwarplinecheck()`), and fixing spacing.

The biggest code cleanup (besides the removal of the `active` system) is that I've added a formal function to remove an entity, `entityclass::removeentity()`. I found it weird that there's an `entityclass::removeblock()` but no `entityclass::removeentity()`. And in this patch I use `entityclass::removeentity()` in place of setting the `active` attribute of an entity to false.

Furthermore, this makes functions like `entityclass::cleanup()` unnecessary, nor the equivalent for blocks that never actually got formalized into a function and just got copy-pasted everywhere, which is typical of this game. Thus `entityclass::cleanup()` has been removed due to it no longer being necessary, since we no longer manually keep track of the actual amount of active entities separately, so there's no way that the amount of entities will desync with the actual amount of entities. The same thing has been done for blocks, removing that copy-pasted equivalent for blocks from everywhere it was copy-pasted.

&#x200b;

There are now macros `removeentity_iter()` and `removeblock_iter()` to remove an entity or a block while iterating through `obj.entities` or `obj.blocks`. It assumes that `obj.entities.size()` or `obj.blocks.size()` will always decrease by one, and that you're not iterating through these vectors backwards. I think most of the time those assumptions are sound.

Although, iterating backwards avoids the above problem entirely. Luckily, the game already does iterate backwards in the cases where I can't simply decrement the index when removing an entity, which is in `entityclass::updateentities()`. I was a bit spooked, however, when `entityclass::updateentities()` called itself. Apparently it's just a way to re-update an entity, because each entity doesn't actually have its own update method, and instead it's just all conflated into one giant function (not unlike the rest of the game's code). I had to make sure that each entity type's update code that called `entityclass::updateentities()` didn't also call `removeentity()`, or else it could result in removing the wrong entity. Fortunately, this was the case, and I could rest easy once again.

&#x200b;

One of the concerns I had while writing this patch was that there would be some behavior dependent on the game forgetting to check the `active` attribute of an object before doing something. As far as I can tell, there are no such exploits except in very contrived almost-fictional scenarios. For example, `getcrewman()` didn't check the `active` attribute, which could theoretically lead to the game targeting a deactivated crewmate instead of a real one, but there's no way to deactivate crewmates without `gotoroom`, which deactivates all entities (and runs `entityclass::cleanup()`, fixing said theoretical issue) anyway.

However, see a few paragraphs below for a real (but trivial) case where the game forgot to check the `active` attribute of the current active activity zone, that I fixed.

In VVVVVV: Community Edition, there's a `destroy(crewmates)` command, which can be used to deactivate a crewmate and thus *could* create the above issue, but I want such issues to be fixed anyway. Hence, this patch removing the need to check the `active` attribute, because now if you have an entity object, it's guaranteed to be actually real and not fake.

&#x200b;

There's a curious oddity in `WarpClass.cpp` for the room Murdering Twinmaker. Apparently, the game adds one deactivated entity before adding the teleporter, so the teleporter is separated from the rest of the entities by one entity. I'm not sure for what purpose this was done - if the teleporter here was being referenced by a hardcoded index somewhere else in the code, it would break if you came back here after rescuing Verdigris.

Given that my new system means you simply cannot have deactivated entities in between other active entities, and that I have no idea what this oddity means, I've decided to not keep this oddity.

&#x200b;

While working on this patch, I found that the game was not setting `game.activeactivity` to -1 after pressing Enter on a given activity zone and removing it. This meant that the game was still referencing the prompt and color of a deactivated activity zone, which isn't *technically* undefined behavior but is pretty much in the same vein as it, and got turned into *actual* undefined behavior when I was working on this patch, causing segfaults.

The previous behavior was that when you pressed Enter on an activity zone, the rendering of the prompt afterwards was simply solid black, but this behavior was actually a bug. It was referencing a deactivated block that had its `clear()` method called on it, which is why it was solid black! So now when you press Enter on an activity zone, the prompt will nicely fade out and won't suddenly turn to black and then after a few frames disappear just as suddenly.

As you can see, removing this whole `active` system not only means better-working code in general, but also exposing (and fixing) certain lurking bugs in the game that wouldn't have otherwise been brought to light!

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
