### PR TITLE
Write unlock.vvv when pressing Alt+F4

### DIFF
--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -575,6 +575,7 @@ int main(int argc, char *argv[])
     //SDL_FreeSurface( gameScreen );
 
     //Quit SDL
+    game.savestats(map, graphics);
     NETWORK_shutdown();
     SDL_Quit();
     FILESYSTEM_deinit();


### PR DESCRIPTION
## Changes:

* **Write `unlock.vvv` when pressing Alt+F4**

  Previously, the only way to guarantee that the game actually saved your `unlock.vvv` after changing an option, was to ensure you pressed ACTION on the "quit game" menu option.

  This makes Alt+F4 graceful in that pressing it will also save `unlock.vvv`, as it should. Now truly UN-graceful ways of exiting the game, such as SIGSEGV, SIGABRT, or `pkill -9` or `pkill -15` will not save `unlock.vvv`, as should be the case.

  I just realized I'm mixing Windows idioms ("Alt+F4") and Unix idioms ("SIGSEGV", "`pkill`"). Whoops.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
