### PR TITLE
Fix unfocusing the game while in fullscreen mode

### DIFF
--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -248,6 +248,7 @@ void KeyPoll::Poll()
 					SDL_SetWindowFullscreen(window, 0);
 				}
 				SDL_DisableScreenSaver();
+				resetWindow = true;
 			}
 			else if (evt.window.event == SDL_WINDOWEVENT_FOCUS_LOST)
 			{
@@ -260,16 +261,19 @@ void KeyPoll::Poll()
 					);
 				}
 				SDL_EnableScreenSaver();
+				resetWindow = true;
 			}
 
 			/* Mouse Focus */
 			else if (evt.window.event == SDL_WINDOWEVENT_ENTER)
 			{
 				SDL_DisableScreenSaver();
+				resetWindow = true;
 			}
 			else if (evt.window.event == SDL_WINDOWEVENT_LEAVE)
 			{
 				SDL_EnableScreenSaver();
+				resetWindow = true;
 			}
 		}
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -553,11 +553,11 @@ int main(int argc, char *argv[])
             Mix_Volume(-1,MIX_MAX_VOLUME);
         }
 
-		if(key.resetWindow)
-		{
-			key.resetWindow = false;
-			gameScreen.ResizeScreen(-1, -1);
-		}
+        if (key.resetWindow)
+        {
+            key.resetWindow = false;
+            gameScreen.ResizeScreen(-1, -1);
+        }
 
         music.processmusic();
         graphics.processfade();


### PR DESCRIPTION
## Changes:

* **Fix unfocusing the game while in fullscreen mode**

  If you Alt+Tabbed while in fullscreen mode, the game would stay in fullscreen instead of switching to windowed, but there was a chance it would EITHER use the same internal resolution which would mismatch the window resolution (don't know when exactly this happens, but still) and stay being in an actual windowed mode, OR switch between fullscreen/windowed every other time you re-focused the window, which is annoying.

  Now, whenever you Alt+Tab in fullscreen, the game will be in windowed mode, and then when you re-focus it will go back to fullscreen. Consistently.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
