### PR TITLE
Stop passing 'graphics', 'map', 'obj', 'music', 'key', and 'help' everywhere

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -3,7 +3,7 @@
 #include "Map.h"
 #include "UtilityClass.h"
 
-bool entityclass::checktowerspikes(int t, mapclass& map)
+bool entityclass::checktowerspikes(int t)
 {
     tempx = entities[t].xp + entities[t].cx;
     tempy = entities[t].yp + entities[t].cy;
@@ -210,19 +210,19 @@ void entityclass::swnenemiescol( int t )
     }
 }
 
-void entityclass::gravcreate( Game& game, int ypos, int dir, int xoff /*= 0*/, int yoff /*= 0*/ )
+void entityclass::gravcreate(int ypos, int dir, int xoff /*= 0*/, int yoff /*= 0*/)
 {
     if (dir == 0)
     {
-        createentity(game, -150 - xoff, 58 + (ypos * 20)+yoff, 23, 0, 0);
+        createentity(-150 - xoff, 58 + (ypos * 20)+yoff, 23, 0, 0);
     }
     else
     {
-        createentity(game, 320+150 + xoff, 58 + (ypos * 20)+yoff, 23, 1, 0);
+        createentity(320+150 + xoff, 58 + (ypos * 20)+yoff, 23, 1, 0);
     }
 }
 
-void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
+void entityclass::generateswnwave(int t)
 {
     //generate a wave for the SWN game
     if(game.swndelay<=0)
@@ -308,7 +308,7 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                 if (game.deathcounts - game.swndeaths > 25) game.swndelay += 4;
                 break;
             case 1:
-                createentity(game, -150, 58 + (int(fRandom() * 6) * 20), 23, 0, 0);
+                createentity(-150, 58 + (int(fRandom() * 6) * 20), 23, 0, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 break;
@@ -331,52 +331,52 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                         game.swnstate2++;
                     }
                 }
-                createentity(game, -150, 58 + (int(game.swnstate2) * 20), 23, 0, 0);
+                createentity(-150, 58 + (int(game.swnstate2) * 20), 23, 0, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 break;
             case 3:
-                createentity(game, 320+150, 58 + (int(fRandom() * 6) * 20), 23, 1, 0);
+                createentity(320+150, 58 + (int(fRandom() * 6) * 20), 23, 1, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 break;
             case 4:
                 //left and right compliments
                 game.swnstate2 = int(fRandom() * 6);
-                createentity(game, -150, 58 + (game.swnstate2  * 20), 23, 0, 0);
-                createentity(game, 320+150, 58 + ((5-game.swnstate2) * 20), 23, 1, 0);
+                createentity(-150, 58 + (game.swnstate2  * 20), 23, 0, 0);
+                createentity(320+150, 58 + ((5-game.swnstate2) * 20), 23, 1, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 game.swnstate2 = 0;
                 break;
             case 5:
                 //Top and bottom
-                createentity(game, -150, 58, 23, 0, 0);
-                createentity(game, -150, 58 + (5 * 20), 23, 0, 0);
+                createentity(-150, 58, 23, 0, 0);
+                createentity(-150, 58 + (5 * 20), 23, 0, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 game.swnstate2 = 1;
                 break;
             case 6:
                 //Middle
-                createentity(game, -150, 58 + (2 * 20), 23, 0, 0);
-                createentity(game, -150, 58 + (3 * 20), 23, 0, 0);
+                createentity(-150, 58 + (2 * 20), 23, 0, 0);
+                createentity(-150, 58 + (3 * 20), 23, 0, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 game.swnstate2 = 0;
                 break;
             case 7:
                 //Top and bottom
-                createentity(game, 320+150, 58, 23, 1, 0);
-                createentity(game, 320+150, 58 + (5 * 20), 23, 1, 0);
+                createentity(320+150, 58, 23, 1, 0);
+                createentity(320+150, 58 + (5 * 20), 23, 1, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 game.swnstate2 = 1;
                 break;
             case 8:
                 //Middle
-                createentity(game, 320+150, 58 + (2 * 20), 23, 1, 0);
-                createentity(game, 320+150, 58 + (3 * 20), 23, 1, 0);
+                createentity(320+150, 58 + (2 * 20), 23, 1, 0);
+                createentity(320+150, 58 + (3 * 20), 23, 1, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 game.swnstate2 = 0;
@@ -400,7 +400,7 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                         game.swnstate2++;
                     }
                 }
-                createentity(game, 320 + 150, 58 + (int(game.swnstate2) * 20), 23, 1, 0);
+                createentity(320 + 150, 58 + (int(game.swnstate2) * 20), 23, 1, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 break;
@@ -567,16 +567,16 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                 game.swnstate2 = 0;
                 break;
             case 10:
-                gravcreate(game, 0, 0);
-                gravcreate(game, 1, 0);
-                gravcreate(game, 2, 0);
+                gravcreate(0, 0);
+                gravcreate(1, 0);
+                gravcreate(2, 0);
                 game.swnstate++;
                 game.swndelay = 10; //return to decision state
                 break;
             case 11:
-                gravcreate(game, 3, 0);
-                gravcreate(game, 4, 0);
-                gravcreate(game, 5, 0);
+                gravcreate(3, 0);
+                gravcreate(4, 0);
+                gravcreate(5, 0);
                 game.swnstate2++;
                 if(game.swnstate2==3)
                 {
@@ -590,16 +590,16 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                 }
                 break;
             case 12:
-                gravcreate(game, 0, 1);
-                gravcreate(game, 1, 1);
-                gravcreate(game, 2, 1);
+                gravcreate(0, 1);
+                gravcreate(1, 1);
+                gravcreate(2, 1);
                 game.swnstate++;
                 game.swndelay = 10; //return to decision state
                 break;
             case 13:
-                gravcreate(game, 3, 1);
-                gravcreate(game, 4, 1);
-                gravcreate(game, 5, 1);
+                gravcreate(3, 1);
+                gravcreate(4, 1);
+                gravcreate(5, 1);
                 game.swnstate2++;
                 if(game.swnstate2==3)
                 {
@@ -613,43 +613,43 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                 }
                 break;
             case 14:
-                gravcreate(game, 0, 0, 0);
-                gravcreate(game, 5, 1, 0);
+                gravcreate(0, 0, 0);
+                gravcreate(5, 1, 0);
 
                 game.swnstate++;
                 game.swndelay = 20; //return to decision state
                 break;
             case 15:
-                gravcreate(game, 1, 0);
-                gravcreate(game, 4, 1);
+                gravcreate(1, 0);
+                gravcreate(4, 1);
 
                 game.swnstate++;
                 game.swndelay = 20; //return to decision state
                 break;
             case 16:
-                gravcreate(game, 2, 0);
-                gravcreate(game, 3, 1);
+                gravcreate(2, 0);
+                gravcreate(3, 1);
 
                 game.swnstate++;
                 game.swndelay = 20; //return to decision state
                 break;
             case 17:
-                gravcreate(game, 3, 0);
-                gravcreate(game, 2, 1);
+                gravcreate(3, 0);
+                gravcreate(2, 1);
 
                 game.swnstate++;
                 game.swndelay = 20; //return to decision state
                 break;
             case 18:
-                gravcreate(game, 4, 0);
-                gravcreate(game, 1, 1);
+                gravcreate(4, 0);
+                gravcreate(1, 1);
 
                 game.swnstate++;
                 game.swndelay = 20; //return to decision state
                 break;
             case 19:
-                gravcreate(game, 5, 0);
-                gravcreate(game, 0, 1);
+                gravcreate(5, 0);
+                gravcreate(0, 1);
 
                 game.swnstate=0;
                 game.swndelay = 20; //return to decision state
@@ -674,7 +674,7 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                         game.swnstate2++;
                     }
                 }
-                createentity(game, -150, 58 + (int(game.swnstate2) * 20), 23, 0, 0);
+                createentity(-150, 58 + (int(game.swnstate2) * 20), 23, 0, 0);
                 if(game.swnstate4<=6)
                 {
                     game.swnstate = 20;
@@ -706,7 +706,7 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                         game.swnstate2++;
                     }
                 }
-                createentity(game, 320+150, 58 + (int(game.swnstate2) * 20), 23, 1, 0);
+                createentity(320+150, 58 + (int(game.swnstate2) * 20), 23, 1, 0);
                 if(game.swnstate4<=6)
                 {
                     game.swnstate = 21;
@@ -722,8 +722,8 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                 game.swnstate4++;
                 //left and right compliments
                 game.swnstate2 = int(fRandom() * 6);
-                createentity(game, -150, 58 + (game.swnstate2  * 20), 23, 0, 0);
-                createentity(game, 320 + 150, 58 + ((5 - game.swnstate2) * 20), 23, 1, 0);
+                createentity(-150, 58 + (game.swnstate2  * 20), 23, 0, 0);
+                createentity(320 + 150, 58 + ((5 - game.swnstate2) * 20), 23, 1, 0);
                 if(game.swnstate4<=12)
                 {
                     game.swnstate = 22;
@@ -737,53 +737,53 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                 game.swnstate2 = 0;
                 break;
             case 23:
-                gravcreate(game, 1, 0);
-                gravcreate(game, 2, 0, 15);
-                gravcreate(game, 2, 0, -15);
-                gravcreate(game, 3, 0, 15);
-                gravcreate(game, 3, 0, -15);
-                gravcreate(game, 4, 0);
+                gravcreate(1, 0);
+                gravcreate(2, 0, 15);
+                gravcreate(2, 0, -15);
+                gravcreate(3, 0, 15);
+                gravcreate(3, 0, -15);
+                gravcreate(4, 0);
                 game.swnstate = 0;
                 game.swndelay = 15; //return to decision state
                 break;
             case 24:
-                gravcreate(game, 1, 1);
-                gravcreate(game, 2, 1, 15);
-                gravcreate(game, 2, 1, -15);
-                gravcreate(game, 3, 1, 15);
-                gravcreate(game, 3, 1, -15);
-                gravcreate(game, 4, 1);
+                gravcreate(1, 1);
+                gravcreate(2, 1, 15);
+                gravcreate(2, 1, -15);
+                gravcreate(3, 1, 15);
+                gravcreate(3, 1, -15);
+                gravcreate(4, 1);
                 game.swnstate = 0;
                 game.swndelay = 15; //return to decision state
                 break;
             case 25:
-                gravcreate(game, 0, 0);
-                gravcreate(game, 1, 1,0,10);
-                gravcreate(game, 4, 1,0,-10);
-                gravcreate(game, 5, 0);
+                gravcreate(0, 0);
+                gravcreate(1, 1,0,10);
+                gravcreate(4, 1,0,-10);
+                gravcreate(5, 0);
                 game.swnstate = 0;
                 game.swndelay = 20; //return to decision state
                 break;
             case 26:
-                gravcreate(game, 0, 1, 0);
-                gravcreate(game, 1, 1, 10);
-                gravcreate(game, 4, 1, 40);
-                gravcreate(game, 5, 1, 50);
+                gravcreate(0, 1, 0);
+                gravcreate(1, 1, 10);
+                gravcreate(4, 1, 40);
+                gravcreate(5, 1, 50);
                 game.swnstate = 0;
                 game.swndelay = 20; //return to decision state
                 break;
             case 27:
-                gravcreate(game, 0, 0, 0);
-                gravcreate(game, 1, 0, 10);
-                gravcreate(game, 4, 0, 40);
-                gravcreate(game, 5, 0, 50);
+                gravcreate(0, 0, 0);
+                gravcreate(1, 0, 10);
+                gravcreate(4, 0, 40);
+                gravcreate(5, 0, 50);
                 game.swnstate = 0;
                 game.swndelay = 20; //return to decision state
                 break;
             case 28:
                 game.swnstate4++;
                 game.swnstate2 = int(fRandom() * 6);
-                createentity(game, -150, 58 + (game.swnstate2  * 20), 23, 0, 0);
+                createentity(-150, 58 + (game.swnstate2  * 20), 23, 0, 0);
                 if(game.swnstate4<=6)
                 {
                     game.swnstate = 28;
@@ -799,7 +799,7 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
             case 29:
                 game.swnstate4++;
                 game.swnstate2 = int(fRandom() * 6);
-                gravcreate(game, game.swnstate2, 1);
+                gravcreate(game.swnstate2, 1);
                 if(game.swnstate4<=6)
                 {
                     game.swnstate = 29;
@@ -815,8 +815,8 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
             case 30:
                 game.swnstate4++;
                 game.swnstate2 = int(fRandom() * 3);
-                gravcreate(game, game.swnstate2, 0);
-                gravcreate(game, 5-game.swnstate2, 0);
+                gravcreate(game.swnstate2, 0);
+                gravcreate(5-game.swnstate2, 0);
                 if(game.swnstate4<=2)
                 {
                     game.swnstate = 30;
@@ -832,8 +832,8 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
             case 31:
                 game.swnstate4++;
                 game.swnstate2 = int(fRandom() * 3);
-                gravcreate(game, game.swnstate2, 1);
-                gravcreate(game, 5-game.swnstate2, 1);
+                gravcreate(game.swnstate2, 1);
+                gravcreate(5-game.swnstate2, 1);
                 if(game.swnstate4<=2)
                 {
                     game.swnstate = 31;
@@ -1769,7 +1769,7 @@ void entityclass::settreadmillcolour( int t, int rx, int ry )
     }
 }
 
-void entityclass::createentity( Game& game, float xp, float yp, int t, float vx /*= 0*/, float vy /*= 0*/, int p1 /*= 0*/, int p2 /*= 0*/, int p3 /*= 320*/, int p4 /*= 240 */ )
+void entityclass::createentity(float xp, float yp, int t, float vx /*= 0*/, float vy /*= 0*/, int p1 /*= 0*/, int p2 /*= 0*/, int p3 /*= 320*/, int p4 /*= 240 */)
 {
     //Find the first inactive case z that we can use to index the new entity
     if (nentity == 0)
@@ -2764,7 +2764,7 @@ void entityclass::createentity( Game& game, float xp, float yp, int t, float vx 
     }
 }
 
-bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musicclass& music )
+bool entityclass::updateentities(int i)
 {
     if(entities[i].active)
     {
@@ -2785,7 +2785,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     if (entities[i].state == 0)   //Init
                     {
                         entities[i].state = 3;
-                        updateentities(i, help, game, music);
+                        updateentities(i);
                     }
                     else if (entities[i].state == 1)
                     {
@@ -2808,7 +2808,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     if (entities[i].state == 0)   //Init
                     {
                         entities[i].state = 2;
-                        updateentities(i, help, game, music);
+                        updateentities(i);
                     }
                     else if (entities[i].state == 1)
                     {
@@ -2831,7 +2831,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     if (entities[i].state == 0)   //Init
                     {
                         entities[i].state = 3;
-                        updateentities(i, help, game, music);
+                        updateentities(i);
                     }
                     else if (entities[i].state == 1)
                     {
@@ -2854,7 +2854,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     if (entities[i].state == 0)   //Init
                     {
                         entities[i].state = 3;
-                        updateentities(i, help, game, music);
+                        updateentities(i);
                     }
                     else if (entities[i].state == 1)
                     {
@@ -2932,7 +2932,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     //Emitter: shoot an enemy every so often
                     if (entities[i].state == 0)
                     {
-                        createentity(game, entities[i].xp+28, entities[i].yp, 1, 10, 1);
+                        createentity(entities[i].xp+28, entities[i].yp, 1, 10, 1);
                         entities[i].state = 1;
                         entities[i].statedelay = 12;
                     }
@@ -2961,7 +2961,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     //Emitter: shoot an enemy every so often (up)
                     if (entities[i].state == 0)
                     {
-                        createentity(game, entities[i].xp, entities[i].yp, 1, 12, 1);
+                        createentity(entities[i].xp, entities[i].yp, 1, 12, 1);
                         entities[i].state = 1;
                         entities[i].statedelay = 16;
                     }
@@ -2994,7 +2994,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                             if (entities[j].type == 2 && entities[j].state== 3 && entities[j].xp == (entities[i].xp-32) )
                             {
                                 entities[i].state = 3;
-                                updateentities(i, help, game, music);
+                                updateentities(i);
                             }
                         }
                     }
@@ -3023,7 +3023,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                             if (entities[j].type == 2 && entities[j].state==3 && entities[j].xp==entities[i].xp+32)
                             {
                                 entities[i].state = 3;
-                                updateentities(i, help, game, music);
+                                updateentities(i);
                             }
                         }
                     }
@@ -3064,14 +3064,14 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                             //approach from the left
                             entities[i].xp = -64;
                             entities[i].state = 2;
-                            updateentities(i, help, game, music); //right
+                            updateentities(i); //right
                         }
                         else
                         {
                             //approach from the left
                             entities[i].xp = 320;
                             entities[i].state = 3;
-                            updateentities(i, help, game, music); //left
+                            updateentities(i); //left
                         }
 
                     }
@@ -3931,7 +3931,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
     return true;
 }
 
-void entityclass::animateentities( int _i, Game& game, UtilityClass& help )
+void entityclass::animateentities(int _i)
 {
     if(entities[_i].active)
     {
@@ -4309,7 +4309,7 @@ bool entityclass::gettype( int t )
     return false;
 }
 
-int entityclass::getcompanion( int t )
+int entityclass::getcompanion()
 {
     //Returns the index of the companion with rule t
     for (int i = 0; i < nentity; i++)
@@ -4461,11 +4461,11 @@ bool entityclass::entitycollide( int a, int b )
     temph = entities[b].h;
     rect2set(tempx, tempy, tempw, temph);
 
-    if (UtilityClass::intersects(temprect, temprect2)) return true;
+    if (help.intersects(temprect, temprect2)) return true;
     return false;
 }
 
-bool entityclass::checkdirectional( int t )
+bool entityclass::checkdirectional()
 {
     //Returns true if player entity (rule 0) moving in dir t through directional block
     for(int i=0; i < nentity; i++)
@@ -4482,7 +4482,7 @@ bool entityclass::checkdirectional( int t )
             {
                 if (blocks[j].type == DIRECTIONAL && blocks[j].active)
                 {
-                    if(UtilityClass::intersects(blocks[j].rect,temprect))
+                    if(help.intersects(blocks[j].rect,temprect))
                     {
                         return true;
                     }
@@ -4510,7 +4510,7 @@ bool entityclass::checkdamage()
             {
                 if (blocks[j].type == DAMAGE && blocks[j].active)
                 {
-                    if(UtilityClass::intersects(blocks[j].rect, temprect))
+                    if(help.intersects(blocks[j].rect, temprect))
                     {
                         return true;
                     }
@@ -4538,7 +4538,7 @@ bool entityclass::scmcheckdamage()
             {
                 if (blocks[j].type == DAMAGE && blocks[j].active)
                 {
-                    if(UtilityClass::intersects(blocks[j].rect, temprect))
+                    if(help.intersects(blocks[j].rect, temprect))
                     {
                         return true;
                     }
@@ -4576,7 +4576,7 @@ int entityclass::checktrigger()
             {
                 if (blocks[j].type == TRIGGER && blocks[j].active)
                 {
-                    if (UtilityClass::intersects(blocks[j].rect, temprect))
+                    if (help.intersects(blocks[j].rect, temprect))
                     {
                         activetrigger = blocks[j].trigger;
                         return blocks[j].trigger;
@@ -4605,7 +4605,7 @@ int entityclass::checkactivity()
             {
                 if (blocks[j].type == ACTIVITY && blocks[j].active)
                 {
-                    if (UtilityClass::intersects(blocks[j].rect, temprect))
+                    if (help.intersects(blocks[j].rect, temprect))
                     {
                         return j;
                     }
@@ -4642,7 +4642,7 @@ bool entityclass::checkplatform()
         {
             if (blocks[i].type == BLOCK)
             {
-                if (UtilityClass::intersects(blocks[i].rect, temprect))
+                if (help.intersects(blocks[i].rect, temprect))
                 {
                     px = blocks[i].xp;
                     py = blocks[i].yp;
@@ -4664,15 +4664,15 @@ bool entityclass::checkblocks()
             {
                 if (blocks[i].type == DIRECTIONAL)
                 {
-                    if (dy > 0 && blocks[i].trigger == 0) if (UtilityClass::intersects(blocks[i].rect, temprect)) return true;
-                    if (dy <= 0 && blocks[i].trigger == 1) if (UtilityClass::intersects(blocks[i].rect, temprect)) return true;
-                    if (dx > 0 && blocks[i].trigger == 2) if (UtilityClass::intersects(blocks[i].rect, temprect)) return true;
-                    if (dx <= 0 && blocks[i].trigger == 3) if (UtilityClass::intersects(blocks[i].rect, temprect)) return true;
+                    if (dy > 0 && blocks[i].trigger == 0) if (help.intersects(blocks[i].rect, temprect)) return true;
+                    if (dy <= 0 && blocks[i].trigger == 1) if (help.intersects(blocks[i].rect, temprect)) return true;
+                    if (dx > 0 && blocks[i].trigger == 2) if (help.intersects(blocks[i].rect, temprect)) return true;
+                    if (dx <= 0 && blocks[i].trigger == 3) if (help.intersects(blocks[i].rect, temprect)) return true;
                 }
             }
             if (blocks[i].type == BLOCK)
             {
-                if (UtilityClass::intersects(blocks[i].rect, temprect))
+                if (help.intersects(blocks[i].rect, temprect))
                 {
                     return true;
                 }
@@ -4681,7 +4681,7 @@ bool entityclass::checkblocks()
             {
                 if( (dr)==1)
                 {
-                    if (UtilityClass::intersects(blocks[i].rect, temprect))
+                    if (help.intersects(blocks[i].rect, temprect))
                     {
                         return true;
                     }
@@ -4692,7 +4692,7 @@ bool entityclass::checkblocks()
     return false;
 }
 
-bool entityclass::checkwall( mapclass& map )
+bool entityclass::checkwall()
 {
     //Returns true if entity setup in temprect collides with a wall
     //used for proper collision functions; you can't just, like, call it
@@ -4882,7 +4882,7 @@ bool entityclass::entitywarpvlinecollide(int t, int l) {
 	return false;
 }
 
-float entityclass::entitycollideplatformroof( mapclass& map, int t )
+float entityclass::entitycollideplatformroof(int t)
 {
     tempx = entities[t].xp + entities[t].cx;
     tempy = entities[t].yp + entities[t].cy -1;
@@ -4898,7 +4898,7 @@ float entityclass::entitycollideplatformroof( mapclass& map, int t )
     return -1000;
 }
 
-float entityclass::entitycollideplatformfloor( mapclass& map, int t )
+float entityclass::entitycollideplatformfloor(int t)
 {
     tempx = entities[t].xp + entities[t].cx;
     tempy = entities[t].yp + entities[t].cy + 1;
@@ -4914,7 +4914,7 @@ float entityclass::entitycollideplatformfloor( mapclass& map, int t )
     return -1000;
 }
 
-bool entityclass::entitycollidefloor( mapclass& map, int t )
+bool entityclass::entitycollidefloor(int t)
 {
     //see? like here, for example!
     tempx = entities[t].xp + entities[t].cx;
@@ -4923,11 +4923,11 @@ bool entityclass::entitycollidefloor( mapclass& map, int t )
     temph = entities[t].h;
     rectset(tempx, tempy, tempw, temph);
 
-    if (checkwall(map)) return true;
+    if (checkwall()) return true;
     return false;
 }
 
-bool entityclass::entitycollideroof( mapclass& map, int t )
+bool entityclass::entitycollideroof(int t)
 {
     //and here!
     tempx = entities[t].xp + entities[t].cx;
@@ -4936,11 +4936,11 @@ bool entityclass::entitycollideroof( mapclass& map, int t )
     temph = entities[t].h;
     rectset(tempx, tempy, tempw, temph);
 
-    if (checkwall(map)) return true;
+    if (checkwall()) return true;
     return false;
 }
 
-bool entityclass::testwallsx( int t, mapclass& map, int tx, int ty )
+bool entityclass::testwallsx(int t, int tx, int ty)
 {
     tempx = tx + entities[t].cx;
     tempy = ty + entities[t].cy;
@@ -4963,19 +4963,19 @@ bool entityclass::testwallsx( int t, mapclass& map, int tx, int ty )
     dr = entities[t].rule;
 
     //Ok, now we check walls
-    if (checkwall(map))
+    if (checkwall())
     {
         if (entities[t].vx > 1.0f)
         {
             entities[t].vx--;
             entities[t].newxp = entities[t].xp + entities[t].vx;
-            return testwallsx(t, map, entities[t].newxp, entities[t].yp);
+            return testwallsx(t, entities[t].newxp, entities[t].yp);
         }
         else if (entities[t].vx < -1.0f)
         {
             entities[t].vx++;
             entities[t].newxp = entities[t].xp + entities[t].vx;
-            return testwallsx(t, map, entities[t].newxp, entities[t].yp);
+            return testwallsx(t, entities[t].newxp, entities[t].yp);
         }
         else
         {
@@ -4986,7 +4986,7 @@ bool entityclass::testwallsx( int t, mapclass& map, int tx, int ty )
     return true;
 }
 
-bool entityclass::testwallsy( int t, mapclass& map, float tx, float ty )
+bool entityclass::testwallsy(int t, float tx, float ty)
 {
     tempx = static_cast<int>(tx) + entities[t].cx;
     tempy = static_cast<int>(ty) + entities[t].cy;
@@ -5010,19 +5010,19 @@ bool entityclass::testwallsy( int t, mapclass& map, float tx, float ty )
     dr = entities[t].rule;
 
     //Ok, now we check walls
-    if (checkwall(map))
+    if (checkwall())
     {
         if (entities[t].vy > 1)
         {
             entities[t].vy--;
             entities[t].newyp = int(entities[t].yp + entities[t].vy);
-            return testwallsy(t, map, entities[t].xp, entities[t].newyp);
+            return testwallsy(t, entities[t].xp, entities[t].newyp);
         }
         else if (entities[t].vy < -1)
         {
             entities[t].vy++;
             entities[t].newyp = int(entities[t].yp + entities[t].vy);
-            return testwallsy(t, map, entities[t].xp, entities[t].newyp);
+            return testwallsy(t, entities[t].xp, entities[t].newyp);
         }
         else
         {
@@ -5073,7 +5073,7 @@ void entityclass::cleanup()
     }
 }
 
-void entityclass::updateentitylogic( int t, Game& game )
+void entityclass::updateentitylogic(int t)
 {
     entities[t].oldxp = entities[t].xp;
     entities[t].oldyp = entities[t].yp;
@@ -5110,9 +5110,9 @@ void entityclass::updateentitylogic( int t, Game& game )
     entities[t].newyp = entities[t].yp + entities[t].vy;
 }
 
-void entityclass::entitymapcollision( int t, mapclass& map )
+void entityclass::entitymapcollision(int t)
 {
-    if (testwallsx(t, map, entities[t].newxp, entities[t].yp))
+    if (testwallsx(t, entities[t].newxp, entities[t].yp))
     {
         entities[t].xp = entities[t].newxp;
     }
@@ -5121,7 +5121,7 @@ void entityclass::entitymapcollision( int t, mapclass& map )
         if (entities[t].onwall > 0) entities[t].state = entities[t].onwall;
         if (entities[t].onxwall > 0) entities[t].state = entities[t].onxwall;
     }
-    if (testwallsy(t, map, entities[t].xp, entities[t].newyp))
+    if (testwallsy(t, entities[t].xp, entities[t].newyp))
     {
         entities[t].yp = entities[t].newyp;
     }
@@ -5133,7 +5133,7 @@ void entityclass::entitymapcollision( int t, mapclass& map )
     }
 }
 
-void entityclass::movingplatformfix( int t, mapclass& map )
+void entityclass::movingplatformfix(int t)
 {
     //If this intersects the player, then we move the player along it
     int j = getplayer();
@@ -5146,7 +5146,7 @@ void entityclass::movingplatformfix( int t, mapclass& map )
             entities[j].yp = entities[j].yp - int(entities[j].vy);
             entities[j].vy = entities[t].vy;
             entities[j].newyp = entities[j].yp + int(entities[j].vy);
-            if (testwallsy(j, map, entities[j].xp, entities[j].newyp))
+            if (testwallsy(j, entities[j].xp, entities[j].newyp))
             {
                  if (entities[t].vy > 0)
                 {
@@ -5169,7 +5169,7 @@ void entityclass::movingplatformfix( int t, mapclass& map )
     }
 }
 
-void entityclass::scmmovingplatformfix( int t, mapclass& map )
+void entityclass::scmmovingplatformfix(int t)
 {
     //If this intersects the SuperCrewMate, then we move them along it
     int j = getscm();
@@ -5182,7 +5182,7 @@ void entityclass::scmmovingplatformfix( int t, mapclass& map )
             entities[j].yp = entities[j].yp -  (entities[j].vy);
             entities[j].vy = entities[t].vy;
             entities[j].newyp = static_cast<float>(entities[j].yp) + entities[j].vy;
-            if (testwallsy(j, map, entities[j].xp, entities[j].newyp))
+            if (testwallsy(j, entities[j].xp, entities[j].newyp))
             {
                 if (entities[t].vy > 0)
                 {
@@ -5205,7 +5205,7 @@ void entityclass::scmmovingplatformfix( int t, mapclass& map )
     }
 }
 
-void entityclass::hormovingplatformfix( int t, mapclass& map )
+void entityclass::hormovingplatformfix(int t)
 {
     //If this intersects the player, then we move the player along it
     //for horizontal platforms, this is simplier
@@ -5248,7 +5248,7 @@ void entityclass::customwarplinecheck(int i) {
 	}
 }
 
-void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& map, musicclass& music )
+void entityclass::entitycollisioncheck()
 {
     for (int i = 0; i < nentity; i++)
     {
@@ -5271,10 +5271,10 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
                                 colpoint1.y = entities[i].yp;
                                 colpoint2.x = entities[j].xp;
                                 colpoint2.y = entities[j].yp;
-                                if (dwgfx.flipmode)
+                                if (graphics.flipmode)
                                 {
-                                    if (dwgfx.Hitest(dwgfx.flipsprites[entities[i].drawframe],
-                                                     colpoint1, 1, dwgfx.flipsprites[entities[j].drawframe], colpoint2, 1))
+                                    if (graphics.Hitest(graphics.flipsprites[entities[i].drawframe],
+                                                     colpoint1, graphics.flipsprites[entities[j].drawframe], colpoint2))
                                     {
                                         //Do the collision stuff
                                         game.deathseq = 30;
@@ -5282,8 +5282,8 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
                                 }
                                 else
                                 {
-                                    if (dwgfx.Hitest(dwgfx.sprites[entities[i].drawframe],
-                                                     colpoint1, 1, dwgfx.sprites[entities[j].drawframe], colpoint2, 1) )
+                                    if (graphics.Hitest(graphics.sprites[entities[i].drawframe],
+                                                     colpoint1, graphics.sprites[entities[j].drawframe], colpoint2) )
                                     {
                                         //Do the collision stuff
                                         game.deathseq = 30;
@@ -5399,10 +5399,10 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
                                         colpoint1.y = entities[i].yp;
                                         colpoint2.x = entities[j].xp;
                                         colpoint2.y = entities[j].yp;
-                                        if (dwgfx.flipmode)
+                                        if (graphics.flipmode)
                                         {
-                                            if (dwgfx.Hitest(dwgfx.flipsprites[entities[i].drawframe],
-                                                             colpoint1, 1, dwgfx.flipsprites[entities[j].drawframe], colpoint2, 1))
+                                            if (graphics.Hitest(graphics.flipsprites[entities[i].drawframe],
+                                                             colpoint1, graphics.flipsprites[entities[j].drawframe], colpoint2))
                                             {
                                                 //Do the collision stuff
                                                 game.deathseq = 30;
@@ -5411,8 +5411,8 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
                                         }
                                         else
                                         {
-                                            if (dwgfx.Hitest(dwgfx.sprites[entities[i].drawframe],
-                                                             colpoint1, 1, dwgfx.sprites[entities[j].drawframe], colpoint2, 1))
+                                            if (graphics.Hitest(graphics.sprites[entities[i].drawframe],
+                                                             colpoint1, graphics.sprites[entities[j].drawframe], colpoint2))
                                             {
                                                 //Do the collision stuff
                                                 game.deathseq = 30;
@@ -5449,7 +5449,7 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
     //can't have the player being stuck...
     int j = getplayer();
     skipdirblocks = true;
-    if (!testwallsx(j, map, entities[j].xp, entities[j].yp))
+    if (!testwallsx(j, entities[j].xp, entities[j].yp))
     {
         //Let's try to get out...
         if (entities[j].rule == 0)
@@ -5471,7 +5471,7 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
     {
         j = getscm();
         skipdirblocks = true;
-        if (!testwallsx(j, map, entities[j].xp, entities[j].yp))
+        if (!testwallsx(j, entities[j].xp, entities[j].yp))
         {
             //Let's try to get out...
             if(game.gravitycontrol==0)

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -66,9 +66,9 @@ public:
 
     void swnenemiescol(int t);
 
-    void gravcreate(Game& game, int ypos, int dir, int xoff = 0, int yoff = 0);
+    void gravcreate(int ypos, int dir, int xoff = 0, int yoff = 0);
 
-    void generateswnwave(Game& game, UtilityClass& help, int t);
+    void generateswnwave(int t);
 
     void createblock(int t, int xp, int yp, int w, int h, int trig = 0);
 
@@ -94,16 +94,16 @@ public:
 
     void settreadmillcolour(int t, int rx, int ry);
 
-    void createentity(Game& game, float xp, float yp, int t, float vx = 0, float vy = 0,
+    void createentity(float xp, float yp, int t, float vx = 0, float vy = 0,
                       int p1 = 0, int p2 = 0, int p3 = 320, int p4 = 240 );
 
-    bool updateentities(int i, UtilityClass& help, Game& game, musicclass& music);
+    bool updateentities(int i);
 
-    void animateentities(int i, Game& game, UtilityClass& help);
+    void animateentities(int i);
 
     bool gettype(int t);
 
-    int getcompanion(int t);
+    int getcompanion();
 
     int getplayer();
 
@@ -122,7 +122,7 @@ public:
 
     bool entitycollide(int a, int b);
 
-    bool checkdirectional(int t);
+    bool checkdirectional();
 
     bool checkdamage();
 
@@ -142,9 +142,9 @@ public:
 
     bool checkblocks();
 
-    bool checktowerspikes(int t, mapclass& map);
+    bool checktowerspikes(int t);
 
-    bool checkwall(mapclass& map);
+    bool checkwall();
 
     float hplatformat();
 
@@ -153,23 +153,23 @@ public:
     bool entityhlinecollide(int t, int l);
 
     bool entityvlinecollide(int t, int l);
-		
-		bool entitywarphlinecollide(int t, int l);
-		bool entitywarpvlinecollide(int t, int l);
 
-		void customwarplinecheck(int i);
+    bool entitywarphlinecollide(int t, int l);
+    bool entitywarpvlinecollide(int t, int l);
 
-    float entitycollideplatformroof(mapclass& map, int t);
+    void customwarplinecheck(int i);
 
-    float entitycollideplatformfloor(mapclass& map, int t);
+    float entitycollideplatformroof(int t);
 
-    bool entitycollidefloor(mapclass& map, int t);
+    float entitycollideplatformfloor(int t);
 
-    bool entitycollideroof(mapclass& map, int t);
+    bool entitycollidefloor(int t);
 
-    bool testwallsx(int t, mapclass& map, int tx, int ty);
+    bool entitycollideroof(int t);
 
-	bool testwallsy(int t, mapclass& map, float tx, float ty);
+    bool testwallsx(int t, int tx, int ty);
+
+    bool testwallsy(int t, float tx, float ty);
 
     void fixfriction(int t, float xfix, float xrate, float yrate);
 
@@ -177,18 +177,18 @@ public:
 
     void cleanup();
 
-    void updateentitylogic(int t, Game& game);
+    void updateentitylogic(int t);
 
 
-    void entitymapcollision(int t, mapclass& map);
+    void entitymapcollision(int t);
 
-    void movingplatformfix(int t, mapclass& map);
+    void movingplatformfix(int t);
 
-    void scmmovingplatformfix(int t, mapclass& map);
+    void scmmovingplatformfix(int t);
 
-    void hormovingplatformfix(int t, mapclass& map);
+    void hormovingplatformfix(int t);
 
-    void entitycollisioncheck(Graphics& dwgfx, Game& game, mapclass& map, musicclass& music);
+    void entitycollisioncheck();
 
 
     std::vector<entclass> entities;

--- a/desktop_version/src/Finalclass.cpp
+++ b/desktop_version/src/Finalclass.cpp
@@ -2,7 +2,7 @@
 
 #include "MakeAndPlay.h"
 
-std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entityclass& obj)
+std::vector<std::string> finalclass::loadlevel(int rx, int ry)
 {
 	int t;
 
@@ -13,7 +13,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 	warpx = false;
 	warpy = false;
 
-	roomname = "Untitled room ["+UtilityClass::String(rx) + "," + UtilityClass::String(ry)+"]";
+	roomname = "Untitled room ["+help.String(rx) + "," + help.String(ry)+"]";
 
 	switch(t)
 	{
@@ -50,11 +50,11 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,220,0,0,0,0,0,0,0,218,98,98,98,98,98,98,98,98,98,98,98");
 		tmap.push_back("98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,220,0,0,0,0,0,0,0,218,98,98,98,98,98,98,98,98,98,98,98");
 
-		obj.createentity(game, 163, 32, 12, 168);  // (vertical gravity line)
-		obj.createentity(game, 99, 32, 12, 168);  // (vertical gravity line)
-		obj.createentity(game, 227, 32, 12, 168);  // (vertical gravity line)
-		obj.createentity(game, 35, 32, 12, 168);  // (vertical gravity line)
-		obj.createentity(game, 291, 32, 12, 168);  // (vertical gravity line)
+		obj.createentity(163, 32, 12, 168);  // (vertical gravity line)
+		obj.createentity(99, 32, 12, 168);  // (vertical gravity line)
+		obj.createentity(227, 32, 12, 168);  // (vertical gravity line)
+		obj.createentity(35, 32, 12, 168);  // (vertical gravity line)
+		obj.createentity(291, 32, 12, 168);  // (vertical gravity line)
 
 		warpx = true;
 		roomname = "1954 World Cup Vinyl";
@@ -92,12 +92,12 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,178,179,179,180,0,0,0,0,0,0,0,178,179,179,180,0,0,0,0,0,0,0,178,179,179,180,0,0,0,0,0,0,0,218,98,220,740");
 		tmap.push_back("0,0,0,218,98,98,220,0,0,0,0,0,0,0,218,98,98,220,0,0,0,0,0,0,0,218,98,98,220,0,0,0,0,0,0,0,218,98,220,740");
 
-		obj.createentity(game, -8, 116, 11, 40);  // (horizontal gravity line)
-		obj.createentity(game, 48, 116, 11, 184);  // (horizontal gravity line)
-		obj.createentity(game, 32, 88, 10, 1, 51500);  // (savepoint)
-		obj.createentity(game, 32, 128, 10, 0, 51501);  // (savepoint)
-		obj.createentity(game, 256, 88, 10, 1, 51502);  // (savepoint)
-		obj.createentity(game, 256, 128, 10, 0, 51503);  // (savepoint)
+		obj.createentity(-8, 116, 11, 40);  // (horizontal gravity line)
+		obj.createentity(48, 116, 11, 184);  // (horizontal gravity line)
+		obj.createentity(32, 88, 10, 1, 51500);  // (savepoint)
+		obj.createentity(32, 128, 10, 0, 51501);  // (savepoint)
+		obj.createentity(256, 88, 10, 1, 51502);  // (savepoint)
+		obj.createentity(256, 128, 10, 0, 51503);  // (savepoint)
 		warpy = true;
 		roomname = "The V Stooges";
 		break;
@@ -135,10 +135,10 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,50,178,179,179,180,49,0,0,0,0,0,0,0,0,50,178,179,179,180,49,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,50,218,98,98,220,49,0,0,0,0,0,0,0,0,50,218,98,98,220,49,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 116, 11, 40);  // (horizontal gravity line)
-		obj.createentity(game, 288, 116, 11, 32);  // (horizontal gravity line)
-		obj.createentity(game, 64, 116, 11, 64);  // (horizontal gravity line)
-		obj.createentity(game, 192, 116, 11, 64);  // (horizontal gravity line)
+		obj.createentity(-8, 116, 11, 40);  // (horizontal gravity line)
+		obj.createentity(288, 116, 11, 32);  // (horizontal gravity line)
+		obj.createentity(64, 116, 11, 64);  // (horizontal gravity line)
+		obj.createentity(192, 116, 11, 64);  // (horizontal gravity line)
 
 		warpy = true;
 		roomname = "glitch";
@@ -176,13 +176,13 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 116, 11, 40);  // (horizontal gravity line)
-		obj.createentity(game, 48, 116, 11, 224);  // (horizontal gravity line)
-		obj.createentity(game, 288, 116, 11, 32);  // (horizontal gravity line)
-		obj.createentity(game, 56, 88, 1, 3, 10);  // Enemy
-		obj.createentity(game, 248-16, 128, 1, 2, 10);  // Enemy
-		obj.createentity(game, 272, 168, 10, 0, 51480);  // (savepoint)
-		obj.createentity(game, 32, 48, 10, 1, 51481);  // (savepoint)
+		obj.createentity(-8, 116, 11, 40);  // (horizontal gravity line)
+		obj.createentity(48, 116, 11, 224);  // (horizontal gravity line)
+		obj.createentity(288, 116, 11, 32);  // (horizontal gravity line)
+		obj.createentity(56, 88, 1, 3, 10);  // Enemy
+		obj.createentity(248-16, 128, 1, 2, 10);  // Enemy
+		obj.createentity(272, 168, 10, 0, 51480);  // (savepoint)
+		obj.createentity(32, 48, 10, 1, 51481);  // (savepoint)
 
 		warpy = true;
 		roomname = "glitch";
@@ -220,11 +220,11 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,218,220,0,0,0,0,0,0,218,220,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,218,220,0,0,0,0,0,0,218,220,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 148, 11, 104);  // (horizontal gravity line)
-		obj.createentity(game, -8, 84, 11, 80);  // (horizontal gravity line)
-		obj.createentity(game, 176, 116, 11, 144);  // (horizontal gravity line)
-		obj.createentity(game, 128, 96, 10, 0, 51470);  // (savepoint)
-		obj.createentity(game, 128, 56, 10, 1, 51471);  // (savepoint)
+		obj.createentity(-8, 148, 11, 104);  // (horizontal gravity line)
+		obj.createentity(-8, 84, 11, 80);  // (horizontal gravity line)
+		obj.createentity(176, 116, 11, 144);  // (horizontal gravity line)
+		obj.createentity(128, 96, 10, 0, 51470);  // (savepoint)
+		obj.createentity(128, 56, 10, 1, 51471);  // (savepoint)
 
 		warpy = true;
 		roomname = "change";
@@ -262,13 +262,13 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 84, 11, 328);  // (horizontal gravity line)
-		obj.createentity(game, -8, 148, 11, 328);  // (horizontal gravity line)
-		obj.createentity(game, 96, 120, 1, 2, 4);  // Enemy
-		obj.createentity(game, 144, 96, 1, 2, 4);  // Enemy
-		obj.createentity(game, 192, 120, 1, 2, 4);  // Enemy
-		obj.createentity(game, 240, 96, 1, 2, 4);  // Enemy
-		obj.createentity(game, 288, 120, 1, 2, 4);  // Enemy
+		obj.createentity(-8, 84, 11, 328);  // (horizontal gravity line)
+		obj.createentity(-8, 148, 11, 328);  // (horizontal gravity line)
+		obj.createentity(96, 120, 1, 2, 4);  // Enemy
+		obj.createentity(144, 96, 1, 2, 4);  // Enemy
+		obj.createentity(192, 120, 1, 2, 4);  // Enemy
+		obj.createentity(240, 96, 1, 2, 4);  // Enemy
+		obj.createentity(288, 120, 1, 2, 4);  // Enemy
 
 		warpy = true;
 		roomname = "change";
@@ -306,10 +306,10 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,218,220,0,0,0,0,0,0,218,220,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,218,220,0,0,0,0,0,0,218,220,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 248, 84, 11, 72);  // (horizontal gravity line)
-		obj.createentity(game, 224, 148, 11, 96);  // (horizontal gravity line)
-		obj.createentity(game, 176, 56, 10, 1, 51450);  // (savepoint)
-		obj.createentity(game, 176, 96, 10, 0, 51451);  // (savepoint)
+		obj.createentity(248, 84, 11, 72);  // (horizontal gravity line)
+		obj.createentity(224, 148, 11, 96);  // (horizontal gravity line)
+		obj.createentity(176, 56, 10, 1, 51450);  // (savepoint)
+		obj.createentity(176, 96, 10, 0, 51451);  // (savepoint)
 
 		warpy = true;
 		roomname = "change";
@@ -348,19 +348,19 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 64+32-8, 32-16, 1, 0, 7, 0, -48, 320, 312);  // Enemy, bounded
-		obj.createentity(game, 96+32-8, 32-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 128+32-8, 32-16, 1, 0, 7, 0, -40, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 160+32-8, 32-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 192+32-8, 32-16, 1, 0, 7, 0, -64, 320, 336);  // Enemy, bounded
-		obj.createentity(game, 64+32-8, 64-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 64+32-8, 96-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 64+32-8, 128-16, 1, 0, 7, 0, -64, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 64+32-8, 160-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 192+32-8, 128-16+8, 1, 0, 7, 0, -64, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 192+32-8, 160-16+8, 1, 0, 7, 0, -80, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 192+32-8, 192-16+8, 1, 0, 7, 0, -80, 320, 304);  // Enemy, bounded
-		obj.createentity(game, 192+32-8, 192+24, 1, 0, 7, 0, -80, 320, 304);  // Enemy, bounded
+		obj.createentity(64+32-8, 32-16, 1, 0, 7, 0, -48, 320, 312);  // Enemy, bounded
+		obj.createentity(96+32-8, 32-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
+		obj.createentity(128+32-8, 32-16, 1, 0, 7, 0, -40, 320, 320);  // Enemy, bounded
+		obj.createentity(160+32-8, 32-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
+		obj.createentity(192+32-8, 32-16, 1, 0, 7, 0, -64, 320, 336);  // Enemy, bounded
+		obj.createentity(64+32-8, 64-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
+		obj.createentity(64+32-8, 96-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
+		obj.createentity(64+32-8, 128-16, 1, 0, 7, 0, -64, 320, 320);  // Enemy, bounded
+		obj.createentity(64+32-8, 160-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
+		obj.createentity(192+32-8, 128-16+8, 1, 0, 7, 0, -64, 320, 320);  // Enemy, bounded
+		obj.createentity(192+32-8, 160-16+8, 1, 0, 7, 0, -80, 320, 320);  // Enemy, bounded
+		obj.createentity(192+32-8, 192-16+8, 1, 0, 7, 0, -80, 320, 304);  // Enemy, bounded
+		obj.createentity(192+32-8, 192+24, 1, 0, 7, 0, -80, 320, 304);  // Enemy, bounded
 
 		warpy = true;
 		roomname = "Vertigo";
@@ -398,17 +398,17 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,178,179,180,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,218,98,220,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 155, 24, 12, 184);  // (vertical gravity line)
-		obj.createentity(game, 120, 152, 1, 1, 8, 0, -56, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 104, 136, 1, 1, 8, 0, -64, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 88, 120, 1, 1, 8, 0, -56, 320, 312);  // Enemy, bounded
-		obj.createentity(game, 72, 104, 1, 1, 8, 0, -56, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 56, 88, 1, 1, 8, 0, -48, 320, 328);  // Enemy, bounded
-		obj.createentity(game, 176, 56, 1, 0, 8, 0, -64, 320, 288);  // Enemy, bounded
-		obj.createentity(game, 192, 72, 1, 0, 8, 0, -48, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 208, 88, 1, 0, 8, 0, -72, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 224, 104, 1, 0, 8, 0, -56, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 240, 120, 1, 0, 8, 0, -48, 320, 296);  // Enemy, bounded
+		obj.createentity(155, 24, 12, 184);  // (vertical gravity line)
+		obj.createentity(120, 152, 1, 1, 8, 0, -56, 320, 296);  // Enemy, bounded
+		obj.createentity(104, 136, 1, 1, 8, 0, -64, 320, 296);  // Enemy, bounded
+		obj.createentity(88, 120, 1, 1, 8, 0, -56, 320, 312);  // Enemy, bounded
+		obj.createentity(72, 104, 1, 1, 8, 0, -56, 320, 296);  // Enemy, bounded
+		obj.createentity(56, 88, 1, 1, 8, 0, -48, 320, 328);  // Enemy, bounded
+		obj.createentity(176, 56, 1, 0, 8, 0, -64, 320, 288);  // Enemy, bounded
+		obj.createentity(192, 72, 1, 0, 8, 0, -48, 320, 296);  // Enemy, bounded
+		obj.createentity(208, 88, 1, 0, 8, 0, -72, 320, 296);  // Enemy, bounded
+		obj.createentity(224, 104, 1, 0, 8, 0, -56, 320, 296);  // Enemy, bounded
+		obj.createentity(240, 120, 1, 0, 8, 0, -48, 320, 296);  // Enemy, bounded
 
 		warpy = true;
 		roomname = "The Voon Show";
@@ -446,9 +446,9 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,218,98,220,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,218,98,220,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 168, 72, 10, 0, 51420);  // (savepoint)
-		obj.createentity(game, 24, 60, 11, 120);  // (horizontal gravity line)
-		obj.createentity(game, 24, 148, 11, 120);  // (horizontal gravity line)
+		obj.createentity(168, 72, 10, 0, 51420);  // (savepoint)
+		obj.createentity(24, 60, 11, 120);  // (horizontal gravity line)
+		obj.createentity(24, 148, 11, 120);  // (horizontal gravity line)
 
 		warpy = true;
 		roomname = "glitch";
@@ -487,11 +487,11 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,740,218,98,220,0,0,0,0,0,218,220,0,0,0,0,0,0,0,0,0,0,0,218,98,220,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 		tmap.push_back("740,740,218,98,220,0,0,0,0,0,218,220,178,179,179,179,179,179,179,179,179,179,180,218,98,220,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 
-		obj.createentity(game, 280, 120, 10, 1, 51410);  // (savepoint)
-		obj.createentity(game, 40, 28, 11, 192);  // (horizontal gravity line)
-		obj.createentity(game, 96, 204, 11, 88);  // (horizontal gravity line)
-		obj.createentity(game, 144, 156, 11, 88);  // (horizontal gravity line)
-		obj.createentity(game, 96, 92, 11, 88);  // (horizontal gravity line)
+		obj.createentity(280, 120, 10, 1, 51410);  // (savepoint)
+		obj.createentity(40, 28, 11, 192);  // (horizontal gravity line)
+		obj.createentity(96, 204, 11, 88);  // (horizontal gravity line)
+		obj.createentity(144, 156, 11, 88);  // (horizontal gravity line)
+		obj.createentity(96, 92, 11, 88);  // (horizontal gravity line)
 
 		warpx = true;
 		roomname = "1950 Silverstone Grand V";
@@ -530,8 +530,8 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,740,218,98,220,0,0,0,0,0,218,98,220,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 		tmap.push_back("740,740,218,98,220,0,0,0,0,0,218,98,220,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 
-		obj.createentity(game, 264, 168, 10, 1, 52410);  // (savepoint)
-		obj.createentity(game, 152, 112, 20, 1);  // (terminal)
+		obj.createentity(264, 168, 10, 1, 52410);  // (savepoint)
+		obj.createentity(152, 112, 20, 1);  // (terminal)
 
 		if(obj.flags[72] == 0)
 		{
@@ -617,12 +617,12 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220,178,179,179,180,218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220");
 		tmap.push_back("218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220");
 
-		obj.createentity(game, 264, 176, 10, 1, 52430);  // (savepoint)
-		obj.createentity(game, 96, 180, 11, 96);  // (horizontal gravity line)
-		obj.createentity(game, 160, 52, 11, 96);  // (horizontal gravity line)
-		obj.createentity(game, 240, 136, 1, 2, 8);  // Enemy
-		obj.createentity(game, 96, 88, 1, 3, 8);  // Enemy
-		obj.createentity(game, 72, 32, 10, 0, 52431);  // (savepoint)
+		obj.createentity(264, 176, 10, 1, 52430);  // (savepoint)
+		obj.createentity(96, 180, 11, 96);  // (horizontal gravity line)
+		obj.createentity(160, 52, 11, 96);  // (horizontal gravity line)
+		obj.createentity(240, 136, 1, 2, 8);  // Enemy
+		obj.createentity(96, 88, 1, 3, 8);  // Enemy
+		obj.createentity(72, 32, 10, 0, 52431);  // (savepoint)
 		roomname = "Upstairs, Downstairs";
 		break;
 
@@ -659,21 +659,20 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("98,98,98,98,98,98,220,218,220,218,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,220,218,98,98");
 		tmap.push_back("98,98,98,98,98,98,220,218,220,218,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,220,218,98,98");
 
-		obj.createentity(game, 64, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 192, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 32, 112, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(64, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(192, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(32, 112, 2, 9, 4);  //Threadmill, <<<
 
-		obj.createentity(game, 0, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 104, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(0, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 104, 2, 8, 4);  //Threadmill, >>>
 
-		obj.createentity(game, 80+8, 128, 1, 0, 5, 0, 120, 320, 200);  // Enemy, bounded
-		obj.createentity(game, 128+16, 168, 1, 1, 5, 0, 120, 320, 200);  // Enemy, bounded
-		obj.createentity(game, 176+24, 128, 1, 0, 5, 0, 120, 320, 200);  // Enemy, bounded
-		//obj.createentity(game, 224, 168, 1, 1, 5, 0, 120, 320, 200);  // Enemy, bounded
-		obj.createentity(game, 24, 184, 10, 1, 52440);  // (savepoint)
+		obj.createentity(80+8, 128, 1, 0, 5, 0, 120, 320, 200);  // Enemy, bounded
+		obj.createentity(128+16, 168, 1, 1, 5, 0, 120, 320, 200);  // Enemy, bounded
+		obj.createentity(176+24, 128, 1, 0, 5, 0, 120, 320, 200);  // Enemy, bounded
+		obj.createentity(24, 184, 10, 1, 52440);  // (savepoint)
 		roomname = "Timeslip";
 		break;
 
@@ -709,10 +708,10 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,218,98,220,218,98,220,740,740,218,98,220,218,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,220,218,98,220,740,740,740,740,740,740,740");
 		tmap.push_back("740,218,98,220,218,98,220,740,740,218,98,220,218,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,220,218,98,220,740,740,740,740,740,740,740");
 
-		obj.createentity(game, 40, 176, 10, 1, 52450);  // (savepoint)
-		obj.createentity(game, 80, 156, 11, 176);  // (horizontal gravity line)
-		obj.createentity(game, 128, 88, 10, 1, 52451);  // (savepoint)
-		obj.createentity(game, 160, 76, 11, 96);  // (horizontal gravity line)
+		obj.createentity(40, 176, 10, 1, 52450);  // (savepoint)
+		obj.createentity(80, 156, 11, 176);  // (horizontal gravity line)
+		obj.createentity(128, 88, 10, 1, 52451);  // (savepoint)
+		obj.createentity(160, 76, 11, 96);  // (horizontal gravity line)
 		roomname = "Three's Company";
 		break;
 
@@ -748,12 +747,12 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,218,98,220,178,179,179,179,179,179,179,179,180,218,220,178,179,179,179,179,179,179,179,179,179,179,179,180,218,98,220,740,740,740,740,740,740,740,740,740");
 		tmap.push_back("740,218,98,220,218,98,98,98,98,98,98,98,220,218,220,218,98,98,98,98,98,98,98,98,98,98,98,220,218,98,220,740,740,740,740,740,740,740,740,740");
 
-		obj.createentity(game, 68-4, 56,  2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 132-4, 56,  2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 44, 192, 3);  //Disappearing Platform
-		obj.createentity(game, 92, 104, 3);  //Disappearing Platform
-		obj.createentity(game, 120, 192, 2, 3, 6);  // Platform
-		obj.createentity(game, 264, 48, 2, 2, 6);  // Platform
+		obj.createentity(68-4, 56,  2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(132-4, 56,  2, 9, 4);  //Threadmill, <<<
+		obj.createentity(44, 192, 3);  //Disappearing Platform
+		obj.createentity(92, 104, 3);  //Disappearing Platform
+		obj.createentity(120, 192, 2, 3, 6);  // Platform
+		obj.createentity(264, 48, 2, 2, 6);  // Platform
 		roomname = "Cosmic Creepers";
 		break;
 
@@ -789,12 +788,12 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("179,179,179,179,179,179,179,179,179,180,6,6,6,6,6,6,6,6,6,6,6,6,178,179,180,6,6,6,6,6,6,6,6,6,6,6,6,178,179,179");
 		tmap.push_back("98,98,98,98,98,98,98,98,98,220,178,179,179,179,179,179,179,179,179,179,179,180,218,98,220,178,179,179,179,179,179,179,179,179,179,179,180,218,98,98");
 
-		obj.createentity(game, 16, 112, 10, 1, 52480);  // (savepoint)
-		obj.createentity(game, 67, 24, 12, 96);  // (vertical gravity line)
-		obj.createentity(game, 243, 112, 12, 104);  // (vertical gravity line)
-		obj.createentity(game, 288, 104, 10, 0, 52481);  // (savepoint)
-		obj.createentity(game, 187, 24, 12, 80);  // (vertical gravity line)
-		obj.createentity(game, 123, 128, 12, 88);  // (vertical gravity line)
+		obj.createentity(16, 112, 10, 1, 52480);  // (savepoint)
+		obj.createentity(67, 24, 12, 96);  // (vertical gravity line)
+		obj.createentity(243, 112, 12, 104);  // (vertical gravity line)
+		obj.createentity(288, 104, 10, 0, 52481);  // (savepoint)
+		obj.createentity(187, 24, 12, 80);  // (vertical gravity line)
+		obj.createentity(123, 128, 12, 88);  // (vertical gravity line)
 
 		roomname = "The Villi People";
 		break;
@@ -831,16 +830,16 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("98,220,0,0,0,218,98,98,98,98,220,218,98,98,98,98,98,220,218,98,220,740,740,740,740,740,740,740,740,740,218,98,220,218,98,98,98,98,98,98");
 		tmap.push_back("98,220,0,0,0,218,98,98,98,98,220,218,98,98,98,98,98,220,218,98,220,740,740,740,740,740,740,740,740,740,218,98,220,218,98,98,98,98,98,98");
 
-		obj.createentity(game, 192, 56, 10, 1, 53500);  // (savepoint)
-		obj.createentity(game, 288, 104, 10, 0, 53501);  // (savepoint)
+		obj.createentity(192, 56, 10, 1, 53500);  // (savepoint)
+		obj.createentity(288, 104, 10, 0, 53501);  // (savepoint)
 
-		obj.createentity(game, 168, 96, 1, 0, 5);  // Enemy
-		obj.createentity(game, 184+2, 104, 1, 0, 5);  // Enemy
-		obj.createentity(game, 200+4, 112, 1, 0, 5);  // Enemy
+		obj.createentity(168, 96, 1, 0, 5);  // Enemy
+		obj.createentity(184+2, 104, 1, 0, 5);  // Enemy
+		obj.createentity(200+4, 112, 1, 0, 5);  // Enemy
 
-		obj.createentity(game, 88, 176-4, 1, 1, 5);  // Enemy
-		obj.createentity(game, 104+2, 168-4, 1, 1, 5);  // Enemy
-		obj.createentity(game, 120 + 4, 160 - 4, 1, 1, 5);  // Enemy
+		obj.createentity(88, 176-4, 1, 1, 5);  // Enemy
+		obj.createentity(104+2, 168-4, 1, 1, 5);  // Enemy
+		obj.createentity(120 + 4, 160 - 4, 1, 1, 5);  // Enemy
 
 		warpx = true;
 		roomname = "change";
@@ -878,13 +877,13 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259");
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 
-		obj.createentity(game, 24, 88, 10, 1, 54500);  // (savepoint)
-		obj.createentity(game, 280, 184, 10, 1, 54501);  // (savepoint)
-		obj.createentity(game, 56, 44, 11, 56);  // (horizontal gravity line)
-		obj.createentity(game, 131, 72, 12, 64);  // (vertical gravity line)
-		obj.createentity(game, 144, 36, 11, 48);  // (horizontal gravity line)
-		obj.createentity(game, 211, 80, 12, 56);  // (vertical gravity line)
-		obj.createentity(game, 224, 52, 11, 80);  // (horizontal gravity line)
+		obj.createentity(24, 88, 10, 1, 54500);  // (savepoint)
+		obj.createentity(280, 184, 10, 1, 54501);  // (savepoint)
+		obj.createentity(56, 44, 11, 56);  // (horizontal gravity line)
+		obj.createentity(131, 72, 12, 64);  // (vertical gravity line)
+		obj.createentity(144, 36, 11, 48);  // (horizontal gravity line)
+		obj.createentity(211, 80, 12, 56);  // (vertical gravity line)
+		obj.createentity(224, 52, 11, 80);  // (horizontal gravity line)
 
 		warpx = true;
 		roomname = "change";
@@ -923,14 +922,14 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 
-		obj.createentity(game, 16, 48, 10, 1, 53520);  // (savepoint)
-		obj.createentity(game, 96, 144, 3);  //Disappearing Platform
-		obj.createentity(game, 128, 144, 3);  //Disappearing Platform
-		obj.createentity(game, 160, 144, 3);  //Disappearing Platform
-		obj.createentity(game, 208, 80, 3);  //Disappearing Platform
-		obj.createentity(game, 240, 80, 3);  //Disappearing Platform
-		obj.createentity(game, 272, 80, 3);  //Disappearing Platform
-		obj.createentity(game, 304, 80, 3);  //Disappearing Platform
+		obj.createentity(16, 48, 10, 1, 53520);  // (savepoint)
+		obj.createentity(96, 144, 3);  //Disappearing Platform
+		obj.createentity(128, 144, 3);  //Disappearing Platform
+		obj.createentity(160, 144, 3);  //Disappearing Platform
+		obj.createentity(208, 80, 3);  //Disappearing Platform
+		obj.createentity(240, 80, 3);  //Disappearing Platform
+		obj.createentity(272, 80, 3);  //Disappearing Platform
+		obj.createentity(304, 80, 3);  //Disappearing Platform
 		roomname = "The Last Straw";
 		break;
 
@@ -966,16 +965,16 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,6,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 
-		obj.createentity(game, 0, 80, 3);  //Disappearing Platform
-		obj.createentity(game, 288, 88, 3);  //Disappearing Platform
-		obj.createentity(game, 32, 80, 3);  //Disappearing Platform
-		obj.createentity(game, 64, 136, 3);  //Disappearing Platform
-		obj.createentity(game, 96, 136, 3);  //Disappearing Platform
-		obj.createentity(game, 224, 144, 3);  //Disappearing Platform
-		obj.createentity(game, 192, 144, 3);  //Disappearing Platform
-		obj.createentity(game, 256, 88, 3);  //Disappearing Platform
-		obj.createentity(game, 128, 88, 3);  //Disappearing Platform
-		obj.createentity(game, 160, 88, 3);  //Disappearing Platform
+		obj.createentity(0, 80, 3);  //Disappearing Platform
+		obj.createentity(288, 88, 3);  //Disappearing Platform
+		obj.createentity(32, 80, 3);  //Disappearing Platform
+		obj.createentity(64, 136, 3);  //Disappearing Platform
+		obj.createentity(96, 136, 3);  //Disappearing Platform
+		obj.createentity(224, 144, 3);  //Disappearing Platform
+		obj.createentity(192, 144, 3);  //Disappearing Platform
+		obj.createentity(256, 88, 3);  //Disappearing Platform
+		obj.createentity(128, 88, 3);  //Disappearing Platform
+		obj.createentity(160, 88, 3);  //Disappearing Platform
 		roomname = "W";
 		break;
 
@@ -1011,10 +1010,10 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 
-		obj.createentity(game, 0, 88, 3);  //Disappearing Platform
-		obj.createentity(game, 32, 88, 3);  //Disappearing Platform
-		obj.createentity(game, 64, 88, 3);  //Disappearing Platform
-		obj.createentity(game, 120, 128, 9, 19);  // (shiny trinket)
+		obj.createentity(0, 88, 3);  //Disappearing Platform
+		obj.createentity(32, 88, 3);  //Disappearing Platform
+		obj.createentity(64, 88, 3);  //Disappearing Platform
+		obj.createentity(120, 128, 9, 19);  // (shiny trinket)
 
 		roomname="V";
 		break;
@@ -1311,11 +1310,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,178,179,180,218,98,220,218,98,220,218,98,220,218,98,220,218,98,220,740,740,740,740,740,740");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,218,98,220,218,98,220,218,98,220,218,98,220,218,98,220,218,98,220,740,740,740,740,740,740");
 
-		obj.createentity(game, 264, 32, 10, 0, 54480);  // (savepoint)
-
-		/*if(!game.nocutscenes && obj.flags[71]==0){
-		obj.createblock(1, 72, 0, 320, 240, 49);
-		}*/
+		obj.createentity(264, 32, 10, 0, 54480);  // (savepoint)
 
 		warpy = true;
 		roomname = "Regular Service Will Return Shortly";
@@ -1353,7 +1348,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,740,740,218,98,220,0,0,218,220,0,0,218,98,220,0,0,0,0,218,220,0,0,0,0,218,98,220,0,0,218,220,0,0,218,98,98,98,98,98");
 		tmap.push_back("740,740,740,218,98,220,0,0,218,220,0,0,218,98,220,0,0,0,0,218,220,0,0,0,0,218,98,220,0,0,218,220,0,0,218,98,98,98,98,98");
 
-		obj.createentity(game, 120, 116, 11, 80);  // (horizontal gravity line)
+		obj.createentity(120, 116, 11, 80);  // (horizontal gravity line)
 		warpy = true;
 		roomname = "Origami Room";
 		break;
@@ -1392,7 +1387,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("12,12,12,12,12,12,12,15,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,16,12");
 		tmap.push_back("12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12");
 
-		obj.createentity(game, 40, 80, 10, 1, 50500);  // (savepoint)
+		obj.createentity(40, 80, 10, 1, 50500);  // (savepoint)
 
 		roomname = "Teleporter Divot";
 		break;
@@ -1429,14 +1424,14 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12");
 		tmap.push_back("12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12");
 
-		obj.createentity(game, 16, 112, 10, 1, 50520);  // (savepoint)
+		obj.createentity(16, 112, 10, 1, 50520);  // (savepoint)
 		roomname = "Seeing Red";
 
 		if(!game.intimetrial)
 		{
 			if(game.companion==0 && obj.flags[8]==0 && !game.crewstats[3])   //also need to check if he's rescued in a previous game
 			{
-				obj.createentity(game, 264, 185, 18, 15, 1, 17, 0);
+				obj.createentity(264, 185, 18, 15, 1, 17, 0);
 				obj.createblock(1, 26*8, 0, 32, 240, 36);
 			}
 		}
@@ -1474,7 +1469,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12");
 		tmap.push_back("12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12");
 
-		obj.createentity(game, 128-16, 80-32, 14); //Teleporter!
+		obj.createentity(128-16, 80-32, 14); //Teleporter!
 		roomname = "Building Apport";
 
 		if(game.intimetrial)
@@ -1589,8 +1584,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
 
-		//obj.createentity(game, -8, 84-32, 11, 328);  // (horizontal gravity line)
-		obj.createentity(game, -8, 148 + 32, 11, 328);  // (horizontal gravity line)
+		obj.createentity(-8, 148 + 32, 11, 328);  // (horizontal gravity line)
 
 		obj.createblock(1, -10, 84 - 16, 340, 32, 10); //create the second line!
 
@@ -1630,28 +1624,28 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("219,218,98,220,0,0,0,0,218,98,220,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 		tmap.push_back("219,218,98,220,0,0,0,0,218,98,220,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 
-		obj.createentity(game, 264, 176, 10, 1, 51530);  // (savepoint)
+		obj.createentity(264, 176, 10, 1, 51530);  // (savepoint)
 
 		if(game.companion==0)   //also need to check if he's rescued in a previous game
 		{
 			if (game.lastsaved == 2)
 			{
-				obj.createentity(game, 112, 169, 18, 14, 0, 17, 1);
+				obj.createentity(112, 169, 18, 14, 0, 17, 1);
 				obj.createblock(1, 22 * 8, 16*8, 32, 240, 37);
 			}
 			else if (game.lastsaved ==3)
 			{
-				obj.createentity(game, 112, 169, 18, 15, 0, 17, 1);
+				obj.createentity(112, 169, 18, 15, 0, 17, 1);
 				obj.createblock(1, 22 * 8, 16*8, 32, 240, 38);
 			}
 			else if (game.lastsaved == 4)
 			{
-				obj.createentity(game, 112, 169, 18, 13, 0, 17, 1);
+				obj.createentity(112, 169, 18, 13, 0, 17, 1);
 				obj.createblock(1, 22 * 8, 16*8, 32, 240, 39);
 			}
 			else
 			{
-				obj.createentity(game, 112, 169, 18, 16, 1, 17, 1);
+				obj.createentity(112, 169, 18, 16, 1, 17, 1);
 				obj.createblock(1, 22 * 8, 16*8, 32, 240, 40);
 			}
 		}
@@ -1695,7 +1689,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("219,219,219,219,219,219,219,219,218,98,220,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 		tmap.push_back("219,219,219,219,219,219,219,219,218,98,220,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 
-		obj.createentity(game, (22 * 8)+4, (9 * 8) + 4, 14); //Teleporter!
+		obj.createentity((22 * 8)+4, (9 * 8) + 4, 14); //Teleporter!
 
 		roomname = "House of Mirrors";
 		warpx = true;
@@ -1734,8 +1728,6 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,218,98,220,0,218,98,98,220,0,218,98,98,98,220,0,218,98,98,98,98,220,0,218,98,99,259,259,259,259,259");
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,218,98,220,0,218,98,98,220,0,218,98,98,98,220,0,218,98,98,98,98,220,0,218,98,220,219,219,219,219,219");
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,218,98,220,0,218,98,98,220,0,218,98,98,98,220,0,218,98,98,98,98,220,0,218,98,220,219,219,219,219,219");
-
-		//obj.createentity(game, 164, 96, 10, 1, 56410);  // (savepoint)
 
 		warpy = true;
 		roomname = "Now Take My Lead";
@@ -1820,9 +1812,9 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		{
 			obj.createblock(1, 20, 0, 32, 240, 13); //scene 2
 		}
-		obj.createentity(game, 104, 120, 1, 0, 3);  // Enemy
-		obj.createentity(game, 168, 176, 1, 1, 3);  // Enemy
-		obj.createentity(game, 232, 120, 1, 0, 3);  // Enemy
+		obj.createentity(104, 120, 1, 0, 3);  // Enemy
+		obj.createentity(168, 176, 1, 1, 3);  // Enemy
+		obj.createentity(232, 120, 1, 0, 3);  // Enemy
 
 		warpy = true;
 		roomname = "Don't Get Ahead of Yourself!";
@@ -1860,7 +1852,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("259,259,259,259,259,259,259,259,259,259,259,259,259,100,98,220,218,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98");
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,219,219,219,218,98,220,218,98,99,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259");
 
-		obj.createentity(game, 144, 40, 10, 1, 56440);  // (savepoint)
+		obj.createentity(144, 40, 10, 1, 56440);  // (savepoint)
 
 		if(!game.nodeathmode)
 		{
@@ -1904,8 +1896,8 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98");
 		tmap.push_back("259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259");
 
-		obj.createentity(game, 104, 152, 1, 0, 3);  // Enemy
-		obj.createentity(game, 200, 152, 1, 0, 3);  // Enemy
+		obj.createentity(104, 152, 1, 0, 3);  // Enemy
+		obj.createentity(200, 152, 1, 0, 3);  // Enemy
 
 		roomname = "Must I Do Everything For You?";
 		warpy = true;
@@ -1944,7 +1936,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98");
 		tmap.push_back("259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259");
 
-		obj.createentity(game, 56, 192, 10, 1, 56460);  // (savepoint)
+		obj.createentity(56, 192, 10, 1, 56460);  // (savepoint)
 
 		if(!game.nodeathmode)
 		{
@@ -1987,7 +1979,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,220,6,6,6,6,218,98,98,220,218,98,220,219,219,219,219,219,219,219,219,219,219,219");
 		tmap.push_back("259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,100,98,220,178,179,179,180,218,98,98,220,218,98,220,219,219,219,219,219,219,219,219,219,219,219");
 
-		obj.createentity(game, 144, 64, 2, 0, 2, 144, 64, 176, 216);  // Platform, bounded
+		obj.createentity(144, 64, 2, 0, 2, 144, 64, 176, 216);  // Platform, bounded
 
 		roomname = "...But Not Too Close";
 		warpy = true;
@@ -2061,7 +2053,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 
-		obj.createentity(game, 152, 176, 10, 1, 56490);  // (savepoint)
+		obj.createentity(152, 176, 10, 1, 56490);  // (savepoint)
 		if(!game.nodeathmode)
 		{
 			obj.createblock(1, 200, 0, 32, 240, 44); //scene 3
@@ -2102,9 +2094,9 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("219,219,219,219,219,219,218,98,220,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,218,98,98,220,218,98");
 		tmap.push_back("219,219,219,219,219,219,218,98,220,178,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,180,218,98,98,220,218,98");
 
-		obj.createentity(game, 88, 200, 2, 1, 4, 88, 128, 216, 208);  // Platform, bounded
-		obj.createentity(game, 136, 136, 2, 0, 4, 88, 128, 216, 208);  // Platform, bounded
-		obj.createentity(game, 184, 200, 2, 1, 4, 88, 128, 216, 208);  // Platform, bounded
+		obj.createentity(88, 200, 2, 1, 4, 88, 128, 216, 208);  // Platform, bounded
+		obj.createentity(136, 136, 2, 0, 4, 88, 128, 216, 208);  // Platform, bounded
+		obj.createentity(184, 200, 2, 1, 4, 88, 128, 216, 208);  // Platform, bounded
 
 		roomname = "...Not as I Do";
 		warpy = true;
@@ -2142,7 +2134,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 
-		obj.createentity(game, 192, 136, 10, 1, 56510);  // (savepoint)
+		obj.createentity(192, 136, 10, 1, 56510);  // (savepoint)
 		if(!game.nodeathmode)
 		{
 			obj.createblock(1, 80, 0, 32, 240, 45); //scene 3
@@ -2183,13 +2175,13 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("219,218,98,220,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,218,98,220,219");
 		tmap.push_back("219,218,98,220,178,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,180,218,98,220,219");
 
-		obj.createentity(game, 48, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
-		obj.createentity(game, 80, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
-		obj.createentity(game, 112, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
-		obj.createentity(game, 144, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
-		obj.createentity(game, 176, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
-		obj.createentity(game, 208, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
-		obj.createentity(game, 240, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
+		obj.createentity(48, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
+		obj.createentity(80, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
+		obj.createentity(112, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
+		obj.createentity(144, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
+		obj.createentity(176, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
+		obj.createentity(208, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
+		obj.createentity(240, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
 
 		roomname = "Do Try To Keep Up";
 		warpy = true;
@@ -2227,7 +2219,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("219,219,219,219,219,218,98,220,218,98,99,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259");
 		tmap.push_back("219,219,219,219,219,218,98,220,218,98,220,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 
-		obj.createentity(game, 72, 72, 10, 1, 56530);  // (savepoint)
+		obj.createentity(72, 72, 10, 1, 56530);  // (savepoint)
 
 		roomname = "You're Falling Behind";
 		warpy = true;
@@ -2265,7 +2257,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259");
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 
-		obj.createentity(game, (18 * 8) + 4, (10 * 8) + 4, 14); //Teleporter!
+		obj.createentity((18 * 8) + 4, (10 * 8) + 4, 14); //Teleporter!
 
 		if(!game.nodeathmode)
 		{

--- a/desktop_version/src/Finalclass.h
+++ b/desktop_version/src/Finalclass.h
@@ -10,7 +10,7 @@
 class finalclass
 {
 public:
-    std::vector<std::string> loadlevel(int rx, int ry, Game& game, entityclass& obj);
+    std::vector<std::string> loadlevel(int rx, int ry);
 
     std::string roomname;
     int coin, rcol;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -268,7 +268,6 @@ void Game::init(void)
     hardestroomdeaths = 0;
     currentroomdeaths=0;
 
-    sfpsmode = false; //by default, play at 30 fps
     inertia = 1.1f;
     swnmode = false;
     swntimer = 0;
@@ -297,13 +296,11 @@ void Game::init(void)
     TiXmlDocument doc;
     if (!FILESYSTEM_loadTiXmlDocument("saves/qsave.vvv", &doc))
     {
-        quickcookieexists = false;
         quicksummary = "";
         printf("Quick Save Not Found\n");
     }
     else
     {
-        quickcookieexists = true;
         TiXmlHandle hDoc(&doc);
         TiXmlElement* pElem;
         TiXmlHandle hRoot(0);
@@ -335,13 +332,11 @@ void Game::init(void)
     TiXmlDocument docTele;
     if (!FILESYSTEM_loadTiXmlDocument("saves/tsave.vvv", &docTele))
     {
-        telecookieexists = false;
         telesummary = "";
         printf("Teleporter Save Not Found\n");
     }
     else
     {
-        telecookieexists = true;
         TiXmlHandle hDoc(&docTele);
         TiXmlElement* pElem;
         TiXmlHandle hRoot(0);
@@ -373,18 +368,6 @@ void Game::init(void)
         }
     }
 
-    //if (telecookie.data.savex == undefined) {
-    // telecookieexists = false; telesummary = "";
-    //} else {
-    // telecookieexists = true; telesummary = telecookie.data.summary;
-    //}
-
-    //if (quickcookie.data.savex == undefined) {
-    // quickcookieexists = false; quicksummary = "";
-    //} else {
-    // quickcookieexists = true; quicksummary = quickcookie.data.summary;
-    //}
-
     screenshake = flashlight = 0 ;
 
     stat_trinkets = 0;
@@ -393,7 +376,6 @@ void Game::init(void)
     teststring = "TEST = True";
     state = 1;
     statedelay = 0;
-    //updatestate(dwgfx, map, obj, help, music);
 
     skipfakeload = false;
 
@@ -503,7 +485,7 @@ Game::~Game(void)
 {
 }
 
-void Game::lifesequence( entityclass& obj )
+void Game::lifesequence()
 {
     if (lifeseq > 0)
     {
@@ -664,13 +646,13 @@ void Game::savecustomlevelstats()
 
     if(numcustomlevelstats>=200)numcustomlevelstats=199;
     msg = new TiXmlElement( "numcustomlevelstats" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(numcustomlevelstats).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(numcustomlevelstats).c_str() ));
     msgs->LinkEndChild( msg );
 
     std::string customlevelscorestr;
     for(int i = 0; i < numcustomlevelstats; i++ )
     {
-        customlevelscorestr += UtilityClass::String(customlevelscore[i]) + ",";
+        customlevelscorestr += help.String(customlevelscore[i]) + ",";
     }
     msg = new TiXmlElement( "customlevelscore" );
     msg->LinkEndChild( new TiXmlText( customlevelscorestr.c_str() ));
@@ -696,16 +678,15 @@ void Game::savecustomlevelstats()
     }
 }
 
-void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void Game::updatestate()
 {
     int i;
     statedelay--;
-    if(statedelay<=0){
-		  statedelay=0;
-			glitchrunkludge=false;
-		}
     if (statedelay <= 0)
     {
+        statedelay=0;
+        glitchrunkludge=false;
+
         switch(state)
         {
         case 0:
@@ -720,24 +701,20 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             advancetext = true;
             hascontrol = false;
             state = 3;
-            dwgfx.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            dwgfx.addline("intro to story!");
+            graphics.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
+            graphics.addline("intro to story!");
             //Oh no! what happen to rest of crew etc crash into dimension
             break;
         case 4:
             //End of opening cutscene for now
-            dwgfx.createtextbox("  Press arrow keys or WASD to move  ", -1, 195, 174, 174, 174);
-            dwgfx.textboxtimer(60);
+            graphics.createtextbox("  Press arrow keys or WASD to move  ", -1, 195, 174, 174, 174);
+            graphics.textboxtimer(60);
             state = 0;
             break;
         case 5:
             //Demo over
             advancetext = true;
             hascontrol = false;
-            /*dwgfx.createtextbox("   Prototype Complete    ", 50, 80, 164, 164, 255);
-            dwgfx.addline("Congrats! More Info Soon!");
-            dwgfx.textboxcenter();
-            */
 
             startscript = true;
             newscript="returntohub";
@@ -746,7 +723,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             break;
         case 7:
             //End of opening cutscene for now
-            dwgfx.textboxremove();
+            graphics.textboxremove();
             hascontrol = true;
             advancetext = false;
             state = 0;
@@ -757,9 +734,9 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (obj.flags[13] == 0)
             {
                 obj.changeflag(13, 1);
-                dwgfx.createtextbox("  Press ENTER to view map  ", -1, 155, 174, 174, 174);
-                dwgfx.addline("      and quicksave");
-                dwgfx.textboxtimer(60);
+                graphics.createtextbox("  Press ENTER to view map  ", -1, 155, 174, 174, 174);
+                graphics.addline("      and quicksave");
+                graphics.textboxtimer(60);
             }
             state = 0;
             break;
@@ -808,49 +785,49 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 11:
             //Intermission 1 instructional textbox, depends on last saved
-            dwgfx.textboxremovefast();
-            dwgfx.createtextbox("   When you're NOT standing on   ", -1, 3, 174, 174, 174);
-            if (dwgfx.flipmode)
+            graphics.textboxremovefast();
+            graphics.createtextbox("   When you're NOT standing on   ", -1, 3, 174, 174, 174);
+            if (graphics.flipmode)
             {
                 if (lastsaved == 2)
                 {
-                    dwgfx.addline("   the ceiling, Vitellary will");
+                    graphics.addline("   the ceiling, Vitellary will");
                 }
                 else if (lastsaved == 3)
                 {
-                    dwgfx.addline("   the ceiling, Vermilion will");
+                    graphics.addline("   the ceiling, Vermilion will");
                 }
                 else if (lastsaved == 4)
                 {
-                    dwgfx.addline("   the ceiling, Verdigris will");
+                    graphics.addline("   the ceiling, Verdigris will");
                 }
                 else if (lastsaved == 5)
                 {
-                    dwgfx.addline("   the ceiling, Victoria will");
+                    graphics.addline("   the ceiling, Victoria will");
                 }
             }
             else
             {
                 if (lastsaved == 2)
                 {
-                    dwgfx.addline("    the floor, Vitellary will");
+                    graphics.addline("    the floor, Vitellary will");
                 }
                 else if (lastsaved == 3)
                 {
-                    dwgfx.addline("    the floor, Vermilion will");
+                    graphics.addline("    the floor, Vermilion will");
                 }
                 else if (lastsaved == 4)
                 {
-                    dwgfx.addline("    the floor, Verdigris will");
+                    graphics.addline("    the floor, Verdigris will");
                 }
                 else if (lastsaved == 5)
                 {
-                    dwgfx.addline("    the floor, Victoria will");
+                    graphics.addline("    the floor, Victoria will");
                 }
             }
 
-            dwgfx.addline("     stop and wait for you.");
-            dwgfx.textboxtimer(180);
+            graphics.addline("     stop and wait for you.");
+            graphics.textboxtimer(180);
             state = 0;
             break;
         case 12:
@@ -859,53 +836,53 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (obj.flags[61] == 0)
             {
                 obj.changeflag(61, 1);
-                dwgfx.textboxremovefast();
-                dwgfx.createtextbox("  You can't continue to the next   ", -1, 8, 174, 174, 174);
+                graphics.textboxremovefast();
+                graphics.createtextbox("  You can't continue to the next   ", -1, 8, 174, 174, 174);
                 if (lastsaved == 5)
                 {
-                    dwgfx.addline("  room until she is safely across. ");
+                    graphics.addline("  room until she is safely across. ");
                 }
                 else
                 {
-                    dwgfx.addline("  room until he is safely across.  ");
+                    graphics.addline("  room until he is safely across.  ");
                 }
-                dwgfx.textboxtimer(120);
+                graphics.textboxtimer(120);
             }
             state = 0;
             break;
         case 13:
             //textbox removal
             obj.removetrigger(13);
-            dwgfx.textboxremovefast();
+            graphics.textboxremovefast();
             state = 0;
             break;
         case 14:
             //Intermission 1 instructional textbox, depends on last saved
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox(" When you're standing on the ceiling, ", -1, 3, 174, 174, 174);
+                graphics.createtextbox(" When you're standing on the ceiling, ", -1, 3, 174, 174, 174);
             }
             else
             {
-                dwgfx.createtextbox(" When you're standing on the floor, ", -1, 3, 174, 174, 174);
+                graphics.createtextbox(" When you're standing on the floor, ", -1, 3, 174, 174, 174);
             }
             if (lastsaved == 2)
             {
-                dwgfx.addline(" Vitellary will try to walk to you. ");
+                graphics.addline(" Vitellary will try to walk to you. ");
             }
             else if (lastsaved == 3)
             {
-                dwgfx.addline(" Vermilion will try to walk to you. ");
+                graphics.addline(" Vermilion will try to walk to you. ");
             }
             else if (lastsaved == 4)
             {
-                dwgfx.addline(" Verdigris will try to walk to you. ");
+                graphics.addline(" Verdigris will try to walk to you. ");
             }
             else if (lastsaved == 5)
             {
-                dwgfx.addline(" Victoria will try to walk to you. ");
+                graphics.addline(" Victoria will try to walk to you. ");
             }
-            dwgfx.textboxtimer(280);
+            graphics.textboxtimer(280);
 
             state = 0;
             break;
@@ -928,9 +905,9 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
         case 17:
             //Arrow key tutorial
             obj.removetrigger(17);
-            dwgfx.createtextbox(" If you prefer, you can press UP or ", -1, 195, 174, 174, 174);
-            dwgfx.addline("   DOWN instead of ACTION to flip.");
-            dwgfx.textboxtimer(100);
+            graphics.createtextbox(" If you prefer, you can press UP or ", -1, 195, 174, 174, 174);
+            graphics.addline("   DOWN instead of ACTION to flip.");
+            graphics.textboxtimer(100);
             state = 0;
             break;
 
@@ -939,7 +916,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             {
                 obj.changeflag(1, 1);
                 state = 0;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
             }
             obj.removetrigger(20);
             break;
@@ -948,18 +925,18 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             {
                 obj.changeflag(2, 1);
                 state = 0;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
             }
             obj.removetrigger(21);
             break;
         case 22:
             if (obj.flags[3] == 0)
             {
-                dwgfx.textboxremovefast();
+                graphics.textboxremovefast();
                 obj.changeflag(3, 1);
                 state = 0;
-                dwgfx.createtextbox("  Press ACTION to flip  ", -1, 25, 174, 174, 174);
-                dwgfx.textboxtimer(60);
+                graphics.createtextbox("  Press ACTION to flip  ", -1, 25, 174, 174, 174);
+                graphics.textboxtimer(60);
             }
             obj.removetrigger(22);
             break;
@@ -1299,54 +1276,54 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 50:
             music.playef(15, 10);
-            dwgfx.createtextbox("Help! Can anyone hear", 35, 15, 255, 134, 255);
-            dwgfx.addline("this message?");
-            dwgfx.textboxtimer(60);
+            graphics.createtextbox("Help! Can anyone hear", 35, 15, 255, 134, 255);
+            graphics.addline("this message?");
+            graphics.textboxtimer(60);
             state++;
             statedelay = 100;
             break;
         case 51:
             music.playef(15, 10);
-            dwgfx.createtextbox("Verdigris? Are you out", 30, 12, 255, 134, 255);
-            dwgfx.addline("there? Are you ok?");
-            dwgfx.textboxtimer(60);
+            graphics.createtextbox("Verdigris? Are you out", 30, 12, 255, 134, 255);
+            graphics.addline("there? Are you ok?");
+            graphics.textboxtimer(60);
             state++;
             statedelay = 100;
             break;
         case 52:
             music.playef(15, 10);
-            dwgfx.createtextbox("Please help us! We've crashed", 5, 22, 255, 134, 255);
-            dwgfx.addline("and need assistance!");
-            dwgfx.textboxtimer(60);
+            graphics.createtextbox("Please help us! We've crashed", 5, 22, 255, 134, 255);
+            graphics.addline("and need assistance!");
+            graphics.textboxtimer(60);
             state++;
             statedelay = 100;
             break;
         case 53:
             music.playef(15, 10);
-            dwgfx.createtextbox("Hello? Anyone out there?", 40, 15, 255, 134, 255);
-            dwgfx.textboxtimer(60);
+            graphics.createtextbox("Hello? Anyone out there?", 40, 15, 255, 134, 255);
+            graphics.textboxtimer(60);
             state++;
             statedelay = 100;
             break;
         case 54:
             music.playef(15, 10);
-            dwgfx.createtextbox("This is Doctor Violet from the", 5, 8, 255, 134, 255);
-            dwgfx.addline("D.S.S. Souleye! Please respond!");
-            dwgfx.textboxtimer(60);
+            graphics.createtextbox("This is Doctor Violet from the", 5, 8, 255, 134, 255);
+            graphics.addline("D.S.S. Souleye! Please respond!");
+            graphics.textboxtimer(60);
             state++;
             statedelay = 100;
             break;
         case 55:
             music.playef(15, 10);
-            dwgfx.createtextbox("Please... Anyone...", 45, 14, 255, 134, 255);
-            dwgfx.textboxtimer(60);
+            graphics.createtextbox("Please... Anyone...", 45, 14, 255, 134, 255);
+            graphics.textboxtimer(60);
             state++;
             statedelay = 100;
             break;
         case 56:
             music.playef(15, 10);
-            dwgfx.createtextbox("Please be alright, everyone...", 25, 18, 255, 134, 255);
-            dwgfx.textboxtimer(60);
+            graphics.createtextbox("Please be alright, everyone...", 25, 18, 255, 134, 255);
+            graphics.textboxtimer(60);
             state=50;
             statedelay = 100;
             break;
@@ -1354,15 +1331,15 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 80:
             //Used to return to menu from the game
-            if(dwgfx.fademode == 1)	state++;
+            if(graphics.fademode == 1) state++;
             break;
         case 81:
             gamestate = 1;
-            dwgfx.fademode = 4;
+            graphics.fademode = 4;
             music.play(6);
-            dwgfx.backgrounddrawn = false;
+            graphics.backgrounddrawn = false;
             map.tdrawback = true;
-            dwgfx.flipmode = false;
+            graphics.flipmode = false;
             createmenu("mainmenu");
             state = 0;
             break;
@@ -1392,31 +1369,32 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (timetrialrank > bestrank[timetriallevel] || bestrank[timetriallevel]==-1)
             {
                 bestrank[timetriallevel] = timetrialrank;
-								if(timetrialrank>=3){
-									if(timetriallevel==0) NETWORK_unlockAchievement("vvvvvvtimetrial_station1_fixed");
-									if(timetriallevel==1) NETWORK_unlockAchievement("vvvvvvtimetrial_lab_fixed");
-									if(timetriallevel==2) NETWORK_unlockAchievement("vvvvvvtimetrial_tower_fixed");
-									if(timetriallevel==3) NETWORK_unlockAchievement("vvvvvvtimetrial_station2_fixed");
-									if(timetriallevel==4) NETWORK_unlockAchievement("vvvvvvtimetrial_warp_fixed");
-									if(timetriallevel==5) NETWORK_unlockAchievement("vvvvvvtimetrial_final_fixed");
-								}
+                if (timetrialrank >= 3)
+                {
+                    if (timetriallevel == 0) NETWORK_unlockAchievement("vvvvvvtimetrial_station1_fixed");
+                    if (timetriallevel == 1) NETWORK_unlockAchievement("vvvvvvtimetrial_lab_fixed");
+                    if (timetriallevel == 2) NETWORK_unlockAchievement("vvvvvvtimetrial_tower_fixed");
+                    if (timetriallevel == 3) NETWORK_unlockAchievement("vvvvvvtimetrial_station2_fixed");
+                    if (timetriallevel == 4) NETWORK_unlockAchievement("vvvvvvtimetrial_warp_fixed");
+                    if (timetriallevel == 5) NETWORK_unlockAchievement("vvvvvvtimetrial_final_fixed");
+                }
             }
 
-            savestats(map, dwgfx);
+            savestats();
 
-            dwgfx.fademode = 2;
+            graphics.fademode = 2;
             music.fadeout();
             state++;
             break;
         case 83:
             frames--;
-            if(dwgfx.fademode == 1)	state++;
+            if (graphics.fademode == 1) state++;
             break;
         case 84:
-            dwgfx.flipmode = false;
+            graphics.flipmode = false;
             gamestate = 1;
-            dwgfx.fademode = 4;
-            dwgfx.backgrounddrawn = true;
+            graphics.fademode = 4;
+            graphics.backgrounddrawn = true;
             map.tdrawback = true;
             createmenu("timetrialcomplete");
             state = 0;
@@ -1491,11 +1469,11 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 96:
             //Used to return to gravitron to game
-            if(dwgfx.fademode == 1)	state++;
+            if(graphics.fademode == 1) state++;
             break;
         case 97:
             gamestate = 0;
-            dwgfx.fademode = 4;
+            graphics.fademode = 4;
             startscript = true;
             newscript="returntolab";
             state = 0;
@@ -1534,59 +1512,59 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
 
             companion = 6;
-            i = obj.getcompanion(6);
+            i = obj.getcompanion();
             obj.entities[i].tile = 0;
             obj.entities[i].state = 1;
 
             advancetext = true;
             hascontrol = false;
 
-            dwgfx.createtextbox("Captain! I've been so worried!", 60, 90, 164, 255, 164);
+            graphics.createtextbox("Captain! I've been so worried!", 60, 90, 164, 255, 164);
             state++;
             music.playef(12, 10);
         }
         break;
         case 104:
-            dwgfx.createtextbox("I'm glad you're ok!", 135, 152, 164, 164, 255);
+            graphics.createtextbox("I'm glad you're ok!", 135, 152, 164, 164, 255);
             state++;
             music.playef(11, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
             break;
         case 106:
         {
-            dwgfx.createtextbox("I've been trying to find a", 74, 70, 164, 255, 164);
-            dwgfx.addline("way out, but I keep going");
-            dwgfx.addline("around in circles...");
+            graphics.createtextbox("I've been trying to find a", 74, 70, 164, 255, 164);
+            graphics.addline("way out, but I keep going");
+            graphics.addline("around in circles...");
             state++;
             music.playef(2, 10);
-            dwgfx.textboxactive();
-            i = obj.getcompanion(6);
+            graphics.textboxactive();
+            i = obj.getcompanion();
             obj.entities[i].tile = 54;
             obj.entities[i].state = 0;
         }
         break;
         case 108:
-            dwgfx.createtextbox("Don't worry! I have a", 125, 152, 164, 164, 255);
-            dwgfx.addline("teleporter key!");
+            graphics.createtextbox("Don't worry! I have a", 125, 152, 164, 164, 255);
+            graphics.addline("teleporter key!");
             state++;
             music.playef(11, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
             break;
         case 110:
         {
 
-            i = obj.getcompanion(6);
+            i = obj.getcompanion();
             obj.entities[i].tile = 0;
             obj.entities[i].state = 1;
-            dwgfx.createtextbox("Follow me!", 185, 154, 164, 164, 255);
+            graphics.createtextbox("Follow me!", 185, 154, 164, 164, 255);
             state++;
             music.playef(11, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
 
         }
         break;
         case 112:
-            dwgfx.textboxremove();
+            graphics.textboxremove();
             hascontrol = true;
             advancetext = false;
 
@@ -1607,13 +1585,13 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             advancetext = true;
             hascontrol = false;
 
-            dwgfx.createtextbox("Sorry Eurogamers! Teleporting around", 60 - 20, 200, 255, 64, 64);
-            dwgfx.addline("the map doesn't work in this version!");
-            dwgfx.textboxcenterx();
+            graphics.createtextbox("Sorry Eurogamers! Teleporting around", 60 - 20, 200, 255, 64, 64);
+            graphics.addline("the map doesn't work in this version!");
+            graphics.textboxcenterx();
             state++;
             break;
         case 118:
-            dwgfx.textboxremove();
+            graphics.textboxremove();
             hascontrol = true;
             advancetext = false;
 
@@ -1650,50 +1628,50 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
         break;
         case 122:
             companion = 7;
-            i = obj.getcompanion(7);
+            i = obj.getcompanion();
             obj.entities[i].tile = 6;
             obj.entities[i].state = 1;
 
             advancetext = true;
             hascontrol = false;
 
-            dwgfx.createtextbox("Captain! You're ok!", 60-10, 90-40, 255, 255, 134);
+            graphics.createtextbox("Captain! You're ok!", 60-10, 90-40, 255, 255, 134);
             state++;
             music.playef(14, 10);
             break;
         case 124:
-            dwgfx.createtextbox("I've found a teleporter, but", 60-20, 90 - 40, 255, 255, 134);
-            dwgfx.addline("I can't get it to go anywhere...");
+            graphics.createtextbox("I've found a teleporter, but", 60-20, 90 - 40, 255, 255, 134);
+            graphics.addline("I can't get it to go anywhere...");
             state++;
             music.playef(2, 10);
-            dwgfx.textboxactive();
-            i = obj.getcompanion(7);	//obj.entities[i].tile = 66;	obj.entities[i].state = 0;
+            graphics.textboxactive();
+            i = obj.getcompanion();
             break;
         case 126:
-            dwgfx.createtextbox("I can help with that!", 125, 152-40, 164, 164, 255);
+            graphics.createtextbox("I can help with that!", 125, 152-40, 164, 164, 255);
             state++;
             music.playef(11, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
             break;
         case 128:
-            dwgfx.createtextbox("I have the teleporter", 130, 152-35, 164, 164, 255);
-            dwgfx.addline("codex for our ship!");
+            graphics.createtextbox("I have the teleporter", 130, 152-35, 164, 164, 255);
+            graphics.addline("codex for our ship!");
             state++;
             music.playef(11, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
             break;
 
         case 130:
-            dwgfx.createtextbox("Yey! Let's go home!", 60-30, 90-35, 255, 255, 134);
+            graphics.createtextbox("Yey! Let's go home!", 60-30, 90-35, 255, 255, 134);
             state++;
             music.playef(14, 10);
-            dwgfx.textboxactive();
-            i = obj.getcompanion(7);
+            graphics.textboxactive();
+            i = obj.getcompanion();
             obj.entities[i].tile = 6;
             obj.entities[i].state = 1;
             break;
         case 132:
-            dwgfx.textboxremove();
+            graphics.textboxremove();
             hascontrol = true;
             advancetext = false;
 
@@ -1947,7 +1925,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             break;
 
         case 1000:
-            dwgfx.showcutscenebars = true;
+            graphics.showcutscenebars = true;
             hascontrol = false;
             completestop = true;
             state++;
@@ -1957,56 +1935,55 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             //Found a trinket!
             advancetext = true;
             state++;
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("        Congratulations!       ", 50, 105, 174, 174, 174);
-                dwgfx.addline("");
-                dwgfx.addline("You have found a shiny trinket!");
-                dwgfx.textboxcenterx();
+                graphics.createtextbox("        Congratulations!       ", 50, 105, 174, 174, 174);
+                graphics.addline("");
+                graphics.addline("You have found a shiny trinket!");
+                graphics.textboxcenterx();
 
                 if(map.custommode)
                 {
-                    dwgfx.createtextbox(" " + help.number(trinkets) + " out of " + help.number(map.customtrinkets)+ " ", 50, 65, 174, 174, 174);
-                    dwgfx.textboxcenterx();
+                    graphics.createtextbox(" " + help.number(trinkets) + " out of " + help.number(map.customtrinkets)+ " ", 50, 65, 174, 174, 174);
+                    graphics.textboxcenterx();
                 }
                 else
                 {
-                    dwgfx.createtextbox(" " + help.number(trinkets) + " out of Twenty ", 50, 65, 174, 174, 174);
-                    dwgfx.textboxcenterx();
+                    graphics.createtextbox(" " + help.number(trinkets) + " out of Twenty ", 50, 65, 174, 174, 174);
+                    graphics.textboxcenterx();
                 }
             }
             else
             {
-                dwgfx.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
-                dwgfx.addline("");
-                dwgfx.addline("You have found a shiny trinket!");
-                dwgfx.textboxcenterx();
+                graphics.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
+                graphics.addline("");
+                graphics.addline("You have found a shiny trinket!");
+                graphics.textboxcenterx();
 
                 if(map.custommode)
                 {
-                    dwgfx.createtextbox(" " + help.number(trinkets) + " out of " + help.number(map.customtrinkets)+ " ", 50, 135, 174, 174, 174);
-                    dwgfx.textboxcenterx();
+                    graphics.createtextbox(" " + help.number(trinkets) + " out of " + help.number(map.customtrinkets)+ " ", 50, 135, 174, 174, 174);
+                    graphics.textboxcenterx();
                 }
                 else
                 {
-                    dwgfx.createtextbox(" " + help.number(trinkets) + " out of Twenty ", 50, 135, 174, 174, 174);
-                    dwgfx.textboxcenterx();
+                    graphics.createtextbox(" " + help.number(trinkets) + " out of Twenty ", 50, 135, 174, 174, 174);
+                    graphics.textboxcenterx();
                 }
             }
             break;
         case 1003:
-            dwgfx.textboxremove();
+            graphics.textboxremove();
             hascontrol = true;
             advancetext = false;
             completestop = false;
             state = 0;
-            //music.play(music.resumesong);
             if(!muted && music.currentsong>-1) music.fadeMusicVolumeIn(3000);
-            dwgfx.showcutscenebars = false;
+            graphics.showcutscenebars = false;
             break;
 
         case 1010:
-            dwgfx.showcutscenebars = true;
+            graphics.showcutscenebars = true;
             hascontrol = false;
             completestop = true;
             state++;
@@ -2016,53 +1993,53 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             //Found a crewmate!
             advancetext = true;
             state++;
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("        Congratulations!       ", 50, 105, 174, 174, 174);
-                dwgfx.addline("");
-                dwgfx.addline("You have found a lost crewmate!");
-                dwgfx.textboxcenterx();
+                graphics.createtextbox("        Congratulations!       ", 50, 105, 174, 174, 174);
+                graphics.addline("");
+                graphics.addline("You have found a lost crewmate!");
+                graphics.textboxcenterx();
 
-                if(int(map.customcrewmates-crewmates)==0)
+                if (map.customcrewmates - crewmates == 0)
                 {
-                    dwgfx.createtextbox("     All crewmates rescued!    ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox("     All crewmates rescued!    ", 50, 65, 174, 174, 174);
                 }
-                else if(map.customcrewmates-crewmates==1)
+                else if (map.customcrewmates - crewmates == 1)
                 {
-                    dwgfx.createtextbox("    " + help.number(int(map.customcrewmates-crewmates))+ " remains    ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox("    " + help.number(int(map.customcrewmates-crewmates))+ " remains    ", 50, 65, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox("     " + help.number(int(map.customcrewmates-crewmates))+ " remain    ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox("     " + help.number(int(map.customcrewmates-crewmates))+ " remain    ", 50, 65, 174, 174, 174);
                 }
-                dwgfx.textboxcenterx();
+                graphics.textboxcenterx();
 
             }
             else
             {
-                dwgfx.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
-                dwgfx.addline("");
-                dwgfx.addline("You have found a lost crewmate!");
-                dwgfx.textboxcenterx();
+                graphics.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
+                graphics.addline("");
+                graphics.addline("You have found a lost crewmate!");
+                graphics.textboxcenterx();
 
-                if(int(map.customcrewmates-crewmates)==0)
+                if (map.customcrewmates - crewmates == 0)
                 {
-                    dwgfx.createtextbox("     All crewmates rescued!    ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox("     All crewmates rescued!    ", 50, 135, 174, 174, 174);
                 }
-                else if(map.customcrewmates-crewmates==1)
+                else if (map.customcrewmates - crewmates == 1)
                 {
-                    dwgfx.createtextbox("    " + help.number(int(map.customcrewmates-crewmates))+ " remains    ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox("    " + help.number(int(map.customcrewmates-crewmates))+ " remains    ", 50, 135, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox("     " + help.number(int(map.customcrewmates-crewmates))+ " remain    ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox("     " + help.number(int(map.customcrewmates-crewmates))+ " remain    ", 50, 135, 174, 174, 174);
                 }
-                dwgfx.textboxcenterx();
+                graphics.textboxcenterx();
             }
             break;
 #if !defined(NO_CUSTOM_LEVELS)
         case 1013:
-            dwgfx.textboxremove();
+            graphics.textboxremove();
             hascontrol = true;
             advancetext = false;
             completestop = false;
@@ -2072,36 +2049,36 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             {
                 if(map.custommodeforreal)
                 {
-                    dwgfx.fademode = 2;
-                    if(!muted && ed.levmusic>0) music.fadeMusicVolumeIn(3000);
-                    if(ed.levmusic>0) music.fadeout();
-                    state=1014;
+                    graphics.fademode = 2;
+                    if (!muted && ed.levmusic > 0) music.fadeMusicVolumeIn(3000);
+                    if (ed.levmusic > 0) music.fadeout();
+                    state = 1014;
                 }
                 else
                 {
                     gamestate = EDITORMODE;
-                    dwgfx.backgrounddrawn=false;
-                    if(!muted && ed.levmusic>0) music.fadeMusicVolumeIn(3000);
-                    if(ed.levmusic>0) music.fadeout();
+                    graphics.backgrounddrawn = false;
+                    if (!muted && ed.levmusic > 0) music.fadeMusicVolumeIn(3000);
+                    if (ed.levmusic > 0) music.fadeout();
                 }
             }
             else
             {
-                if(!muted && ed.levmusic>0) music.fadeMusicVolumeIn(3000);
+                if (!muted && ed.levmusic > 0) music.fadeMusicVolumeIn(3000);
             }
-            dwgfx.showcutscenebars = false;
+            graphics.showcutscenebars = false;
             break;
 #endif
         case 1014:
             frames--;
-            if(dwgfx.fademode == 1)	state++;
+            if(graphics.fademode == 1) state++;
             break;
         case 1015:
-            dwgfx.flipmode = false;
+            graphics.flipmode = false;
             gamestate = TITLEMODE;
-            dwgfx.fademode = 4;
+            graphics.fademode = 4;
             music.play(6);
-            dwgfx.backgrounddrawn = true;
+            graphics.backgrounddrawn = true;
             map.tdrawback = true;
             //Update level stats
             if(map.customcrewmates-crewmates==0)
@@ -2130,16 +2107,16 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             }
             else
             {
-                savetele(map, obj, music);
-                if (dwgfx.flipmode)
+                savetele();
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox("    Game Saved    ", -1, 202, 174, 174, 174);
-                    dwgfx.textboxtimer(25);
+                    graphics.createtextbox("    Game Saved    ", -1, 202, 174, 174, 174);
+                    graphics.textboxtimer(25);
                 }
                 else
                 {
-                    dwgfx.createtextbox("    Game Saved    ", -1, 12, 174, 174, 174);
-                    dwgfx.textboxtimer(25);
+                    graphics.createtextbox("    Game Saved    ", -1, 12, 174, 174, 174);
+                    graphics.textboxtimer(25);
                 }
                 state = 0;
             }
@@ -2223,21 +2200,21 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
         case 2510:
             advancetext = true;
             hascontrol = false;
-            dwgfx.createtextbox("Hello?", 125+24, 152-20, 164, 164, 255);
+            graphics.createtextbox("Hello?", 125+24, 152-20, 164, 164, 255);
             state++;
             music.playef(11, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
             break;
         case 2512:
             advancetext = true;
             hascontrol = false;
-            dwgfx.createtextbox("Is anyone there?", 125+8, 152-24, 164, 164, 255);
+            graphics.createtextbox("Is anyone there?", 125+8, 152-24, 164, 164, 255);
             state++;
             music.playef(11, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
             break;
         case 2514:
-            dwgfx.textboxremove();
+            graphics.textboxremove();
             hascontrol = true;
             advancetext = false;
 
@@ -2317,7 +2294,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             obj.entities[i].colour = 0;
             obj.entities[i].invis = true;
 
-            i = obj.getcompanion(companion);
+            i = obj.getcompanion();
             if(i>-1)
             {
                 obj.entities[i].active = false;
@@ -2330,48 +2307,42 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 3006:
             //Level complete! (warp zone)
-            unlocknum(4, map, dwgfx);
+            unlocknum(4);
             lastsaved = 4;
             music.play(0);
             state++;
             statedelay = 75;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 180, 165, 165, 255);
+                graphics.createtextbox("", -1, 180, 165, 165, 255);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 12, 165, 165, 255);
+                graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
-            //dwgfx.addline("      Level Complete!      ");
-            dwgfx.addline("                                   ");
-            dwgfx.addline("");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            graphics.addline("                                   ");
+            graphics.addline("");
+            graphics.addline("");
+            graphics.textboxcenterx();
 
-            /*												advancetext = true;
-            hascontrol = false;
-            state = 3;
-            dwgfx.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            dwgfx.addline("intro to story!");*/
             break;
         case 3007:
             state++;
             statedelay = 45;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 104, 175,174,174);
+                graphics.createtextbox("", -1, 104, 175,174,174);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 64+8+16, 175,174,174);
+                graphics.createtextbox("", -1, 64+8+16, 175,174,174);
             }
-            dwgfx.addline("     You have rescued  ");
-            dwgfx.addline("      a crew member!   ");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            graphics.addline("     You have rescued  ");
+            graphics.addline("      a crew member!   ");
+            graphics.addline("");
+            graphics.textboxcenterx();
             break;
         case 3008:
             state++;
@@ -2381,60 +2352,60 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (temp == 1)
             {
                 tempstring = "  One remains  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else if (temp > 0)
             {
                 tempstring = "  " + help.number(temp) + " remain  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else
             {
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
                 }
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3009:
             state++;
             statedelay = 0;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
             }
             else
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3010:
             if (jumppressed)
             {
                 state++;
                 statedelay = 30;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
             }
             break;
         case 3011:
@@ -2444,49 +2415,42 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 3020:
             //Level complete! (Space Station 2)
-            unlocknum(3, map, dwgfx);
+            unlocknum(3);
             lastsaved = 2;
             music.play(0);
             state++;
             statedelay = 75;
 
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 180, 165, 165, 255);
+                graphics.createtextbox("", -1, 180, 165, 165, 255);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 12, 165, 165, 255);
+                graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
-            //dwgfx.addline("      Level Complete!      ");
-            dwgfx.addline("                                   ");
-            dwgfx.addline("");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
-
-            /*												advancetext = true;
-            hascontrol = false;
-            state = 3;
-            dwgfx.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            dwgfx.addline("intro to story!");*/
+            graphics.addline("                                   ");
+            graphics.addline("");
+            graphics.addline("");
+            graphics.textboxcenterx();
             break;
         case 3021:
             state++;
             statedelay = 45;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 104, 174,175,174);
+                graphics.createtextbox("", -1, 104, 174,175,174);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 64+8+16, 174,175,174);
+                graphics.createtextbox("", -1, 64+8+16, 174,175,174);
             }
-            dwgfx.addline("     You have rescued  ");
-            dwgfx.addline("      a crew member!   ");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            graphics.addline("     You have rescued  ");
+            graphics.addline("      a crew member!   ");
+            graphics.addline("");
+            graphics.textboxcenterx();
             break;
         case 3022:
             state++;
@@ -2496,60 +2460,60 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (temp == 1)
             {
                 tempstring = "  One remains  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else if (temp > 0)
             {
                 tempstring = "  " + help.number(temp) + " remain  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else
             {
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
                 }
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3023:
             state++;
             statedelay = 0;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
             }
             else
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3024:
             if (jumppressed)
             {
                 state++;
                 statedelay = 30;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
             }
             break;
         case 3025:
@@ -2559,48 +2523,41 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 3040:
             //Level complete! (Lab)
-            unlocknum(1, map, dwgfx);
+            unlocknum(1);
             lastsaved = 5;
             music.play(0);
             state++;
             statedelay = 75;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 180, 165, 165, 255);
+                graphics.createtextbox("", -1, 180, 165, 165, 255);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 12, 165, 165, 255);
+                graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
-            //dwgfx.addline("      Level Complete!      ");
-            dwgfx.addline("                                   ");
-            dwgfx.addline("");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
-
-            /*												advancetext = true;
-            hascontrol = false;
-            state = 3;
-            dwgfx.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            dwgfx.addline("intro to story!");*/
+            graphics.addline("                                   ");
+            graphics.addline("");
+            graphics.addline("");
+            graphics.textboxcenterx();
             break;
         case 3041:
             state++;
             statedelay = 45;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 104, 174,174,175);
+                graphics.createtextbox("", -1, 104, 174,174,175);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 64+8+16, 174,174,175);
+                graphics.createtextbox("", -1, 64+8+16, 174,174,175);
             }
-            dwgfx.addline("     You have rescued  ");
-            dwgfx.addline("      a crew member!   ");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            graphics.addline("     You have rescued  ");
+            graphics.addline("      a crew member!   ");
+            graphics.addline("");
+            graphics.textboxcenterx();
             break;
         case 3042:
             state++;
@@ -2610,60 +2567,60 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (temp == 1)
             {
                 tempstring = "  One remains  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else if (temp > 0)
             {
                 tempstring = "  " + help.number(temp) + " remain  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else
             {
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
                 }
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3043:
             state++;
             statedelay = 0;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
             }
             else
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3044:
             if (jumppressed)
             {
                 state++;
                 statedelay = 30;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
             }
             break;
         case 3045:
@@ -2673,49 +2630,42 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 3050:
             //Level complete! (Space Station 1)
-            unlocknum(0, map, dwgfx);
+            unlocknum(0);
             lastsaved = 1;
             music.play(0);
             state++;
             statedelay = 75;
 
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 180, 165, 165, 255);
+                graphics.createtextbox("", -1, 180, 165, 165, 255);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 12, 165, 165, 255);
+                graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
-            //dwgfx.addline("      Level Complete!      ");
-            dwgfx.addline("                                   ");
-            dwgfx.addline("");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
-
-            /*												advancetext = true;
-            hascontrol = false;
-            state = 3;
-            dwgfx.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            dwgfx.addline("intro to story!");*/
+            graphics.addline("                                   ");
+            graphics.addline("");
+            graphics.addline("");
+            graphics.textboxcenterx();
             break;
         case 3051:
             state++;
             statedelay = 45;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 104, 175,175,174);
+                graphics.createtextbox("", -1, 104, 175,175,174);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 64+8+16, 175,175,174);
+                graphics.createtextbox("", -1, 64+8+16, 175,175,174);
             }
-            dwgfx.addline("     You have rescued  ");
-            dwgfx.addline("      a crew member!   ");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            graphics.addline("     You have rescued  ");
+            graphics.addline("      a crew member!   ");
+            graphics.addline("");
+            graphics.textboxcenterx();
             break;
         case 3052:
             state++;
@@ -2725,71 +2675,71 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (temp == 1)
             {
                 tempstring = "  One remains  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else if (temp > 0)
             {
                 tempstring = "  " + help.number(temp) + " remain  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else
             {
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
                 }
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3053:
             state++;
             statedelay = 0;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
             }
             else
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3054:
             if (jumppressed)
             {
                 state++;
                 statedelay = 30;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
                 crewstats[1] = 0; //Set violet's rescue script to 0 to make the next bit easier
                 teleportscript = "";
             }
             break;
         case 3055:
-            dwgfx.fademode = 2;
+            graphics.fademode = 2;
             state++;
             statedelay = 10;
             break;
         case 3056:
-            if(dwgfx.fademode==1)
+            if(graphics.fademode==1)
             {
                 startscript = true;
                 if (nocutscenes)
@@ -2807,48 +2757,41 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 3060:
             //Level complete! (Tower)
-            unlocknum(2, map, dwgfx);
+            unlocknum(2);
             lastsaved = 3;
             music.play(0);
             state++;
             statedelay = 75;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 180, 165, 165, 255);
+                graphics.createtextbox("", -1, 180, 165, 165, 255);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 12, 165, 165, 255);
+                graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
-            //dwgfx.addline("      Level Complete!      ");
-            dwgfx.addline("                                   ");
-            dwgfx.addline("");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
-
-            /*												advancetext = true;
-            hascontrol = false;
-            state = 3;
-            dwgfx.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            dwgfx.addline("intro to story!");*/
+            graphics.addline("                                   ");
+            graphics.addline("");
+            graphics.addline("");
+            graphics.textboxcenterx();
             break;
         case 3061:
             state++;
             statedelay = 45;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 104, 175,174,175);
+                graphics.createtextbox("", -1, 104, 175,174,175);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 64+8+16, 175,174,175);
+                graphics.createtextbox("", -1, 64+8+16, 175,174,175);
             }
-            dwgfx.addline("     You have rescued  ");
-            dwgfx.addline("      a crew member!   ");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            graphics.addline("     You have rescued  ");
+            graphics.addline("      a crew member!   ");
+            graphics.addline("");
+            graphics.textboxcenterx();
             break;
         case 3062:
             state++;
@@ -2858,60 +2801,60 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (temp == 1)
             {
                 tempstring = "  One remains  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else if (temp > 0)
             {
                 tempstring = "  " + help.number(temp) + " remain  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else
             {
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
                 }
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3063:
             state++;
             statedelay = 0;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
             }
             else
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3064:
             if (jumppressed)
             {
                 state++;
                 statedelay = 30;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
             }
             break;
         case 3065:
@@ -2921,11 +2864,11 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
 
         case 3070:
-            dwgfx.fademode = 2;
+            graphics.fademode = 2;
             state++;
             break;
         case 3071:
-            if (dwgfx.fademode == 1) state++;
+            if (graphics.fademode == 1) state++;
             break;
         case 3072:
             //Ok, we need to adjust some flags based on who've we've rescued. Some of there conversation options
@@ -3000,25 +2943,25 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             //returning from an intermission, very like 3070
             if (inintermission)
             {
-                dwgfx.fademode = 2;
+                graphics.fademode = 2;
                 companion = 0;
                 state=3100;
             }
             else
             {
-                unlocknum(7, map, dwgfx);
-                dwgfx.fademode = 2;
+                unlocknum(7);
+                graphics.fademode = 2;
                 companion = 0;
                 state++;
             }
             break;
         case 3081:
-            if (dwgfx.fademode == 1) state++;
+            if (graphics.fademode == 1) state++;
             break;
         case 3082:
             map.finalmode = false;
             startscript = true;
-            newscript="regularreturn";
+            newscript = "regularreturn";
             state = 0;
             break;
 
@@ -3030,45 +2973,42 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
                 companion = 0;
                 supercrewmate = false;
                 state++;
-                dwgfx.fademode = 2;
+                graphics.fademode = 2;
                 music.fadeout();
-                state=3100;
+                state = 3100;
             }
             else
             {
-                unlocknum(6, map, dwgfx);
-                dwgfx.fademode = 2;
+                unlocknum(6);
+                graphics.fademode = 2;
                 companion = 0;
                 supercrewmate = false;
                 state++;
             }
             break;
         case 3086:
-            if (dwgfx.fademode == 1) state++;
+            if (graphics.fademode == 1) state++;
             break;
         case 3087:
             map.finalmode = false;
             startscript = true;
-            newscript="regularreturn";
+            newscript = "regularreturn";
             state = 0;
             break;
 
         case 3100:
-            if(dwgfx.fademode == 1)	state++;
+            if (graphics.fademode == 1) state++;
             break;
         case 3101:
-            dwgfx.flipmode = false;
+            graphics.flipmode = false;
             gamestate = 1;
-            dwgfx.fademode = 4;
-            dwgfx.backgrounddrawn = true;
+            graphics.fademode = 4;
+            graphics.backgrounddrawn = true;
             map.tdrawback = true;
             createmenu("play");
             music.play(6);
             state = 0;
             break;
-
-            //startscript = true;	newscript="returntohub";
-            //state = 0;
 
             /*case 3025:
             if (recording == 1) {
@@ -3077,17 +3017,17 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             help.toclipboard(recordstring);
             }
             test = true; teststring = recordstring;
-            dwgfx.createtextbox("   Congratulations!    ", 50, 80, 164, 164, 255);
-            dwgfx.addline("");
-            dwgfx.addline("Your play of this level has");
-            dwgfx.addline("been copied to the clipboard.");
-            dwgfx.addline("");
-            dwgfx.addline("Please consider pasting and");
-            dwgfx.addline("sending it to me! Even if you");
-            dwgfx.addline("made a lot of mistakes - knowing");
-            dwgfx.addline("exactly where people are having");
-            dwgfx.addline("trouble is extremely useful!");
-            dwgfx.textboxcenter();
+            graphics.createtextbox("   Congratulations!    ", 50, 80, 164, 164, 255);
+            graphics.addline("");
+            graphics.addline("Your play of this level has");
+            graphics.addline("been copied to the clipboard.");
+            graphics.addline("");
+            graphics.addline("Please consider pasting and");
+            graphics.addline("sending it to me! Even if you");
+            graphics.addline("made a lot of mistakes - knowing");
+            graphics.addline("exactly where people are having");
+            graphics.addline("trouble is extremely useful!");
+            graphics.textboxcenter();
             state = 0;
             break;*/
 
@@ -3099,54 +3039,54 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             break;
         case 3501:
             //Game complete!
-						NETWORK_unlockAchievement("vvvvvvgamecomplete");
-            unlocknum(5, map, dwgfx);
+            NETWORK_unlockAchievement("vvvvvvgamecomplete");
+            unlocknum(5);
             crewstats[0] = true;
             state++;
             statedelay = 75;
             music.play(7);
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 180, 164, 165, 255);
+                graphics.createtextbox("", -1, 180, 164, 165, 255);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 12, 164, 165, 255);
+                graphics.createtextbox("", -1, 12, 164, 165, 255);
             }
-            dwgfx.addline("                                   ");
-            dwgfx.addline("");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            graphics.addline("                                   ");
+            graphics.addline("");
+            graphics.addline("");
+            graphics.textboxcenterx();
             break;
         case 3502:
             state++;
             statedelay = 45+15;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 175-24, 0, 0, 0);
+                graphics.createtextbox("  All Crew Members Rescued!  ", -1, 175-24, 0, 0, 0);
             }
             else
             {
-                dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 64, 0, 0, 0);
+                graphics.createtextbox("  All Crew Members Rescued!  ", -1, 64, 0, 0, 0);
             }
-            savetime = timestring(help);
+            savetime = timestring();
             break;
         case 3503:
             state++;
             statedelay = 45;
 
             tempstring = help.number(trinkets);
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("Trinkets Found:", 48, 155-24, 0,0,0);
-                dwgfx.createtextbox(tempstring, 180, 155-24, 0, 0, 0);
+                graphics.createtextbox("Trinkets Found:", 48, 155-24, 0,0,0);
+                graphics.createtextbox(tempstring, 180, 155-24, 0, 0, 0);
             }
             else
             {
-                dwgfx.createtextbox("Trinkets Found:", 48, 84, 0,0,0);
-                dwgfx.createtextbox(tempstring, 180, 84, 0, 0, 0);
+                graphics.createtextbox("Trinkets Found:", 48, 84, 0,0,0);
+                graphics.createtextbox(tempstring, 180, 84, 0, 0, 0);
             }
             break;
         case 3504:
@@ -3154,84 +3094,84 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 45+15;
 
             tempstring = savetime;
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("   Game Time:", 64, 143-24, 0,0,0);
-                dwgfx.createtextbox(tempstring, 180, 143-24, 0, 0, 0);
+                graphics.createtextbox("   Game Time:", 64, 143-24, 0,0,0);
+                graphics.createtextbox(tempstring, 180, 143-24, 0, 0, 0);
             }
             else
             {
-                dwgfx.createtextbox("   Game Time:", 64, 96, 0,0,0);
-                dwgfx.createtextbox(tempstring, 180, 96, 0, 0, 0);
+                graphics.createtextbox("   Game Time:", 64, 96, 0,0,0);
+                graphics.createtextbox(tempstring, 180, 96, 0, 0, 0);
             }
             break;
         case 3505:
             state++;
             statedelay = 45;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox(" Total Flips:", 64, 116-24, 0,0,0);
-                dwgfx.createtextbox(help.String(totalflips), 180, 116-24, 0, 0, 0);
+                graphics.createtextbox(" Total Flips:", 64, 116-24, 0,0,0);
+                graphics.createtextbox(help.String(totalflips), 180, 116-24, 0, 0, 0);
             }
             else
             {
-                dwgfx.createtextbox(" Total Flips:", 64, 123, 0,0,0);
-                dwgfx.createtextbox(help.String(totalflips), 180, 123, 0, 0, 0);
+                graphics.createtextbox(" Total Flips:", 64, 123, 0,0,0);
+                graphics.createtextbox(help.String(totalflips), 180, 123, 0, 0, 0);
             }
             break;
         case 3506:
             state++;
             statedelay = 45+15;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("Total Deaths:", 64, 104-24, 0,0,0);
-                dwgfx.createtextbox(help.String(deathcounts), 180, 104-24, 0, 0, 0);
+                graphics.createtextbox("Total Deaths:", 64, 104-24, 0,0,0);
+                graphics.createtextbox(help.String(deathcounts), 180, 104-24, 0, 0, 0);
             }
             else
             {
-                dwgfx.createtextbox("Total Deaths:", 64, 135, 0,0,0);
-                dwgfx.createtextbox(help.String(deathcounts), 180, 135, 0, 0, 0);
+                graphics.createtextbox("Total Deaths:", 64, 135, 0,0,0);
+                graphics.createtextbox(help.String(deathcounts), 180, 135, 0, 0, 0);
             }
             break;
         case 3507:
             state++;
             statedelay = 45+15;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
                 tempstring = "Hardest Room (with " + help.String(hardestroomdeaths) + " deaths)";
-                dwgfx.createtextbox(tempstring, -1, 81-24, 0,0,0);
-                dwgfx.createtextbox(hardestroom, -1, 69-24, 0, 0, 0);
+                graphics.createtextbox(tempstring, -1, 81-24, 0,0,0);
+                graphics.createtextbox(hardestroom, -1, 69-24, 0, 0, 0);
             }
             else
             {
                 tempstring = "Hardest Room (with " + help.String(hardestroomdeaths) + " deaths)";
-                dwgfx.createtextbox(tempstring, -1, 158, 0,0,0);
-                dwgfx.createtextbox(hardestroom, -1, 170, 0, 0, 0);
+                graphics.createtextbox(tempstring, -1, 158, 0,0,0);
+                graphics.createtextbox(hardestroom, -1, 170, 0, 0, 0);
             }
             break;
         case 3508:
             state++;
             statedelay = 0;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
             }
             else
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3509:
             if (jumppressed)
             {
                 state++;
                 statedelay = 30;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
             }
             break;
         case 3510:
@@ -3255,26 +3195,18 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
                 }
             }
 
-						if (bestgamedeaths > -1) {
-							if (bestgamedeaths <= 500) {
-							  NETWORK_unlockAchievement("vvvvvvcomplete500");
-							}
-							if (bestgamedeaths <= 250) {
-								NETWORK_unlockAchievement("vvvvvvcomplete250");
-							}
-							if (bestgamedeaths <= 100) {
-								NETWORK_unlockAchievement("vvvvvvcomplete100");
-							}
-							if (bestgamedeaths <= 50) {
-								NETWORK_unlockAchievement("vvvvvvcomplete50");
-							}
-						}
-						
+        if (bestgamedeaths > -1) {
+            if (bestgamedeaths <= 500) NETWORK_unlockAchievement("vvvvvvcomplete500");
+            if (bestgamedeaths <= 250) NETWORK_unlockAchievement("vvvvvvcomplete250");
+            if (bestgamedeaths <= 100) NETWORK_unlockAchievement("vvvvvvcomplete100");
+            if (bestgamedeaths <= 50) NETWORK_unlockAchievement("vvvvvvcomplete50");
+        }
 
-            savestats(map, dwgfx);
+
+            savestats();
             if (nodeathmode)
             {
-								NETWORK_unlockAchievement("vvvvvvmaster"); //bloody hell
+                NETWORK_unlockAchievement("vvvvvvmaster"); //bloody hell
                 unlock[20] = true;
                 state = 3520;
                 statedelay = 0;
@@ -3335,18 +3267,18 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 60;
             break;
         case 3516:
-            dwgfx.fademode = 2;
+            graphics.fademode = 2;
             state++;
             break;
         case 3517:
-            if (dwgfx.fademode == 1)
+            if (graphics.fademode == 1)
             {
                 state++;
                 statedelay = 30;
             }
             break;
         case 3518:
-            dwgfx.fademode = 4;
+            graphics.fademode = 4;
             state = 0;
             statedelay = 30;
             //music.play(5);
@@ -3360,7 +3292,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             map.finalx = 100;
             map.finaly = 100;
 
-            dwgfx.cutscenebarspos = 320;
+            graphics.cutscenebarspos = 320;
 
             teleport_to_new_area = true;
             teleportscript = "gamecomplete";
@@ -3371,17 +3303,17 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             hascontrol = false;
             crewstats[0] = true;
 
-            dwgfx.fademode = 2;
+            graphics.fademode = 2;
             state++;
             break;
         case 3521:
-            if(dwgfx.fademode == 1)	state++;
+            if (graphics.fademode == 1) state++;
             break;
         case 3522:
-            dwgfx.flipmode = false;
+            graphics.flipmode = false;
             gamestate = 1;
-            dwgfx.fademode = 4;
-            dwgfx.backgrounddrawn = true;
+            graphics.fademode = 4;
+            graphics.backgrounddrawn = true;
             map.tdrawback = true;
             createmenu("nodeathmodecomplete");
             state = 0;
@@ -3506,7 +3438,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             }
             else
             {
-                savetele(map, obj, music);
+                savetele();
             }
             i = obj.getteleporter();
             activetele = true;
@@ -4151,7 +4083,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
     }
 }
 
-void Game::gethardestroom( mapclass& map )
+void Game::gethardestroom()
 {
     if (currentroomdeaths > hardestroomdeaths)
     {
@@ -4187,7 +4119,7 @@ void Game::gethardestroom( mapclass& map )
     }
 }
 
-void Game::deletestats( mapclass& map, Graphics& dwgfx )
+void Game::deletestats()
 {
     for (int i = 0; i < 25; i++)
     {
@@ -4201,12 +4133,12 @@ void Game::deletestats( mapclass& map, Graphics& dwgfx )
         bestlives[i] = -1;
         bestrank[i] = -1;
     }
-    dwgfx.setflipmode = false;
+    graphics.setflipmode = false;
     stat_trinkets = 0;
-    savestats(map, dwgfx);
+    savestats();
 }
 
-void Game::unlocknum( int t, mapclass& map, Graphics& dwgfx )
+void Game::unlocknum(int t)
 {
     if (map.custommode)
     {
@@ -4215,16 +4147,15 @@ void Game::unlocknum( int t, mapclass& map, Graphics& dwgfx )
     }
 
     unlock[t] = true;
-    savestats(map, dwgfx);
+    savestats();
 }
 
-void Game::loadstats( mapclass& map, Graphics& dwgfx )
+void Game::loadstats()
 {
-    // TODO loadstats
     TiXmlDocument doc;
     if (!FILESYSTEM_loadTiXmlDocument("saves/unlock.vvv", &doc))
     {
-        savestats(map, dwgfx);
+        savestats();
         printf("No Stats found. Assuming a new player\n");
     }
 
@@ -4390,7 +4321,7 @@ void Game::loadstats( mapclass& map, Graphics& dwgfx )
 
         if (pKey == "setflipmode")
         {
-            dwgfx.setflipmode = atoi(pText);
+            graphics.setflipmode = atoi(pText);
         }
 
         if (pKey == "invincibility")
@@ -4440,16 +4371,19 @@ void Game::loadstats( mapclass& map, Graphics& dwgfx )
         if (pKey == "advanced_smoothing")
         {
             fullScreenEffect_badSignal = atoi(pText);
-            dwgfx.screenbuffer->badSignalEffect = fullScreenEffect_badSignal;
+            graphics.screenbuffer->badSignalEffect = fullScreenEffect_badSignal;
         }
 
-				if (pKey == "usingmmmmmm")
+        if (pKey == "usingmmmmmm")
         {
-					if(atoi(pText)>0){
-            usingmmmmmm = 1;
-					}else{
-					  usingmmmmmm = 0;
-					}
+            if (atoi(pText) > 0)
+            {
+                usingmmmmmm = 1;
+            }
+            else
+            {
+                usingmmmmmm = 0;
+            }
         }
 
         if (pKey == "skipfakeload")
@@ -4459,68 +4393,68 @@ void Game::loadstats( mapclass& map, Graphics& dwgfx )
 
         if (pKey == "notextoutline")
         {
-            dwgfx.notextoutline = atoi(pText);
+            graphics.notextoutline = atoi(pText);
         }
 
         if (pKey == "translucentroomname")
         {
-            dwgfx.translucentroomname = atoi(pText);
+            graphics.translucentroomname = atoi(pText);
         }
 
         if (pKey == "showmousecursor")
         {
-            dwgfx.showmousecursor = atoi(pText);
+            graphics.showmousecursor = atoi(pText);
         }
 
-		if (pKey == "flipButton")
-		{
-			SDL_GameControllerButton newButton;
-			if (GetButtonFromString(pText, &newButton))
-			{
-				controllerButton_flip.push_back(newButton);
-			}
-		}
+        if (pKey == "flipButton")
+        {
+            SDL_GameControllerButton newButton;
+            if (GetButtonFromString(pText, &newButton))
+            {
+                controllerButton_flip.push_back(newButton);
+            }
+        }
 
-		if (pKey == "enterButton")
-		{
-			SDL_GameControllerButton newButton;
-			if (GetButtonFromString(pText, &newButton))
-			{
-				controllerButton_map.push_back(newButton);
-			}
-		}
+        if (pKey == "enterButton")
+        {
+            SDL_GameControllerButton newButton;
+            if (GetButtonFromString(pText, &newButton))
+            {
+                controllerButton_map.push_back(newButton);
+            }
+        }
 
-		if (pKey == "escButton")
-		{
-			SDL_GameControllerButton newButton;
-			if (GetButtonFromString(pText, &newButton))
-			{
-				controllerButton_esc.push_back(newButton);
-			}
-		}
+        if (pKey == "escButton")
+        {
+            SDL_GameControllerButton newButton;
+            if (GetButtonFromString(pText, &newButton))
+            {
+                controllerButton_esc.push_back(newButton);
+            }
+        }
 
-		if (pKey == "controllerSensitivity")
-		{
-			controllerSensitivity = atoi(pText);
-		}
+        if (pKey == "controllerSensitivity")
+        {
+            controllerSensitivity = atoi(pText);
+        }
 
     }
 
-    if(fullscreen)
+    if (fullscreen)
     {
-        dwgfx.screenbuffer->toggleFullScreen();
+        graphics.screenbuffer->toggleFullScreen();
     }
-    for (int i = 0; i < stretchMode; i += 1)
+    for (int i = 0; i < stretchMode; i++)
     {
-        dwgfx.screenbuffer->toggleStretchMode();
+        graphics.screenbuffer->toggleStretchMode();
     }
     if (useLinearFilter)
     {
-        dwgfx.screenbuffer->toggleLinearFilter();
+        graphics.screenbuffer->toggleLinearFilter();
     }
-    dwgfx.screenbuffer->ResizeScreen(width, height);
+    graphics.screenbuffer->ResizeScreen(width, height);
 
-    if (dwgfx.showmousecursor == true)
+    if (graphics.showmousecursor == true)
     {
         SDL_ShowCursor(SDL_ENABLE);
     }
@@ -4542,7 +4476,7 @@ void Game::loadstats( mapclass& map, Graphics& dwgfx )
     }
 }
 
-void Game::savestats( mapclass& _map, Graphics& _dwgfx )
+void Game::savestats()
 {
     TiXmlDocument doc;
     TiXmlElement* msg;
@@ -4562,7 +4496,7 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
     std::string s_unlock;
     for(size_t i = 0; i < unlock.size(); i++ )
     {
-        s_unlock += UtilityClass::String(unlock[i]) + ",";
+        s_unlock += help.String(unlock[i]) + ",";
     }
     msg = new TiXmlElement( "unlock" );
     msg->LinkEndChild( new TiXmlText( s_unlock.c_str() ));
@@ -4571,7 +4505,7 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
     std::string s_unlocknotify;
     for(size_t i = 0; i < unlocknotify.size(); i++ )
     {
-        s_unlocknotify += UtilityClass::String(unlocknotify[i]) + ",";
+        s_unlocknotify += help.String(unlocknotify[i]) + ",";
     }
     msg = new TiXmlElement( "unlocknotify" );
     msg->LinkEndChild( new TiXmlText( s_unlocknotify.c_str() ));
@@ -4580,7 +4514,7 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
     std::string s_besttimes;
     for(size_t i = 0; i < besttrinkets.size(); i++ )
     {
-        s_besttimes += UtilityClass::String(besttimes[i]) + ",";
+        s_besttimes += help.String(besttimes[i]) + ",";
     }
     msg = new TiXmlElement( "besttimes" );
     msg->LinkEndChild( new TiXmlText( s_besttimes.c_str() ));
@@ -4589,7 +4523,7 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
     std::string s_besttrinkets;
     for(size_t i = 0; i < besttrinkets.size(); i++ )
     {
-        s_besttrinkets += UtilityClass::String(besttrinkets[i]) + ",";
+        s_besttrinkets += help.String(besttrinkets[i]) + ",";
     }
     msg = new TiXmlElement( "besttrinkets" );
     msg->LinkEndChild( new TiXmlText( s_besttrinkets.c_str() ));
@@ -4598,7 +4532,7 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
     std::string s_bestlives;
     for(size_t i = 0; i < bestlives.size(); i++ )
     {
-        s_bestlives += UtilityClass::String(bestlives[i]) + ",";
+        s_bestlives += help.String(bestlives[i]) + ",";
     }
     msg = new TiXmlElement( "bestlives" );
     msg->LinkEndChild( new TiXmlText( s_bestlives.c_str() ));
@@ -4607,7 +4541,7 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
     std::string s_bestrank;
     for(size_t i = 0; i < bestrank.size(); i++ )
     {
-        s_bestrank += UtilityClass::String(bestrank[i]) + ",";
+        s_bestrank += help.String(bestrank[i]) + ",";
     }
     msg = new TiXmlElement( "bestrank" );
     msg->LinkEndChild( new TiXmlText( s_bestrank.c_str() ));
@@ -4635,7 +4569,7 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
     dataNode->LinkEndChild( msg );
 
     int width, height;
-    _dwgfx.screenbuffer->GetWindowSize(&width, &height);
+    graphics.screenbuffer->GetWindowSize(&width, &height);
     msg = new TiXmlElement( "window_width" );
     msg->LinkEndChild( new TiXmlText( tu.String(width).c_str()));
     dataNode->LinkEndChild( msg );
@@ -4652,11 +4586,11 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "setflipmode" );
-    msg->LinkEndChild( new TiXmlText( tu.String(_dwgfx.setflipmode).c_str()));
+    msg->LinkEndChild( new TiXmlText( tu.String(graphics.setflipmode).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "invincibility" );
-    msg->LinkEndChild( new TiXmlText( tu.String(_map.invincibility).c_str()));
+    msg->LinkEndChild( new TiXmlText( tu.String(map.invincibility).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "slowdown" );
@@ -4680,7 +4614,6 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
     msg->LinkEndChild( new TiXmlText( tu.String(fullScreenEffect_badSignal).c_str()));
     dataNode->LinkEndChild( msg );
 
-		
     msg = new TiXmlElement( "usingmmmmmm" );
     msg->LinkEndChild( new TiXmlText( tu.String(usingmmmmmm).c_str()));
     dataNode->LinkEndChild( msg );
@@ -4690,15 +4623,15 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
     dataNode->LinkEndChild(msg);
 
     msg = new TiXmlElement("notextoutline");
-    msg->LinkEndChild(new TiXmlText(tu.String((int) _dwgfx.notextoutline).c_str()));
+    msg->LinkEndChild(new TiXmlText(tu.String((int) graphics.notextoutline).c_str()));
     dataNode->LinkEndChild(msg);
 
     msg = new TiXmlElement("translucentroomname");
-    msg->LinkEndChild(new TiXmlText(tu.String((int) _dwgfx.translucentroomname).c_str()));
+    msg->LinkEndChild(new TiXmlText(tu.String((int) graphics.translucentroomname).c_str()));
     dataNode->LinkEndChild(msg);
 
     msg = new TiXmlElement("showmousecursor");
-    msg->LinkEndChild(new TiXmlText(tu.String((int)_dwgfx.showmousecursor).c_str()));
+    msg->LinkEndChild(new TiXmlText(tu.String((int)graphics.showmousecursor).c_str()));
     dataNode->LinkEndChild(msg);
 
     for (size_t i = 0; i < controllerButton_flip.size(); i += 1)
@@ -4720,14 +4653,14 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
         dataNode->LinkEndChild(msg);
     }
 
-	msg = new TiXmlElement( "controllerSensitivity" );
-	msg->LinkEndChild( new TiXmlText( tu.String(controllerSensitivity).c_str()));
-	dataNode->LinkEndChild( msg );
+    msg = new TiXmlElement( "controllerSensitivity" );
+    msg->LinkEndChild( new TiXmlText( tu.String(controllerSensitivity).c_str()));
+    dataNode->LinkEndChild( msg );
 
     FILESYSTEM_saveTiXmlDocument("saves/unlock.vvv", &doc);
 }
 
-void Game::customstart( entityclass& obj, musicclass& music )
+void Game::customstart()
 {
     jumpheld = true;
 
@@ -4738,24 +4671,18 @@ void Game::customstart( entityclass& obj, musicclass& music )
 
     savegc = edsavegc;
     savedir = edsavedir; //Worldmap Start
-    //savex = 6 * 8; savey = 15 * 8; saverx = 46; savery = 54; savegc = 0; savedir = 1; //Final Level Current
     savepoint = 0;
     gravitycontrol = savegc;
 
     coins = 0;
     trinkets = 0;
 
-    //state = 2; deathseq = -1; lifeseq = 10; //Not dead, in game initilisation state
     state = 0;
     deathseq = -1;
     lifeseq = 0;
-
-    //let's teleport in!
-    //state = 2500;
-    //if (!nocutscenes) music.play(5);
 }
 
-void Game::start( entityclass& obj, musicclass& music )
+void Game::start()
 {
     jumpheld = true;
 
@@ -4765,24 +4692,20 @@ void Game::start( entityclass& obj, musicclass& music )
     savery = 110;
     savegc = 0;
     savedir = 1; //Worldmap Start
-    //savex = 6 * 8; savey = 15 * 8; saverx = 46; savery = 54; savegc = 0; savedir = 1; //Final Level Current
     savepoint = 0;
     gravitycontrol = savegc;
 
     coins = 0;
     trinkets = 0;
 
-    //state = 2; deathseq = -1; lifeseq = 10; //Not dead, in game initilisation state
     state = 0;
     deathseq = -1;
     lifeseq = 0;
 
-    //let's teleport in!
-    //state = 2500;
     if (!nocutscenes) music.play(5);
 }
 
-void Game::deathsequence( mapclass& map, entityclass& obj, musicclass& music )
+void Game::deathsequence()
 {
     int i;
     if (supercrewmate && scmhurt)
@@ -4833,7 +4756,7 @@ void Game::deathsequence( mapclass& map, entityclass& obj, musicclass& music )
     }
 }
 
-void Game::startspecial( int t, entityclass& obj, musicclass& music )
+void Game::startspecial(int t)
 {
     jumpheld = true;
 
@@ -4874,7 +4797,7 @@ void Game::startspecial( int t, entityclass& obj, musicclass& music )
     lifeseq = 0;
 }
 
-void Game::starttrial( int t, entityclass& obj, musicclass& music )
+void Game::starttrial(int t)
 {
     jumpheld = true;
 
@@ -4950,7 +4873,7 @@ void Game::starttrial( int t, entityclass& obj, musicclass& music )
     lifeseq = 0;
 }
 
-void Game::loadquick( mapclass& map, entityclass& obj, musicclass& music )
+void Game::loadquick()
 {
     TiXmlDocument doc;
     if (!FILESYSTEM_loadTiXmlDocument("saves/qsave.vvv", &doc)) return;
@@ -5171,7 +5094,7 @@ void Game::loadquick( mapclass& map, entityclass& obj, musicclass& music )
 
 }
 
-void Game::customloadquick(std::string savfile, mapclass& map, entityclass& obj, musicclass& music )
+void Game::customloadquick(std::string savfile)
 {
     std::string levelfile = savfile.substr(7);
     TiXmlDocument doc;
@@ -5428,45 +5351,15 @@ void Game::customloadquick(std::string savfile, mapclass& map, entityclass& obj,
 
 }
 
-//TODO load summary
-void Game::loadsummary( mapclass& map, UtilityClass& help )
+void Game::loadsummary()
 {
-    //quickcookie = SharedObject.getLocal("dwvvvvvv_quick");
-    //telecookie = SharedObject.getLocal("dwvvvvvv_tele");
-
-    //if (telecookie.data.savex == undefined) {
-    //	telecookieexists = false; telesummary = "";
-    //} else {
-    //	telecookieexists = true; telesummary = telecookie.data.summary;
-    //	tele_gametime = giventimestring(telecookie.data.hours, telecookie.data.minutes, telecookie.data.seconds, help);
-    //	tele_trinkets = telecookie.data.trinkets;
-    //	tele_currentarea = map.currentarea(map.area(telecookie.data.savex, telecookie.data.savey));
-
-    //	summary_crewstats = telecookie.data.crewstats.slice();
-    //	tele_crewstats = summary_crewstats.slice();
-    //}
-
-    //if (quickcookie.data.savex == undefined) {
-    //	quickcookieexists = false; quicksummary = "";
-    //} else {
-    //	quickcookieexists = true; quicksummary = quickcookie.data.summary;
-    //	quick_gametime = giventimestring(quickcookie.data.hours, quickcookie.data.minutes, quickcookie.data.seconds, help);
-    //	quick_trinkets = quickcookie.data.trinkets;
-    //	quick_currentarea = map.currentarea(map.area(quickcookie.data.savex, quickcookie.data.savey));
-
-    //	summary_crewstats = quickcookie.data.crewstats.slice();
-    //	quick_crewstats = summary_crewstats.slice();
-    //}
-
     TiXmlDocument docTele;
     if (!FILESYSTEM_loadTiXmlDocument("saves/tsave.vvv", &docTele))
     {
-        telecookieexists = false;
         telesummary = "";
     }
     else
     {
-        telecookieexists = true;
         TiXmlHandle hDoc(&docTele);
         TiXmlElement* pElem;
         TiXmlHandle hRoot(0);
@@ -5545,19 +5438,17 @@ void Game::loadsummary( mapclass& map, UtilityClass& help )
             }
 
         }
-        tele_gametime = giventimestring(l_hours,l_minute, l_second,help);
+        tele_gametime = giventimestring(l_hours,l_minute, l_second);
         tele_currentarea = map.currentarea(map.area(l_saveX, l_saveY));
     }
 
     TiXmlDocument doc;
     if (!FILESYSTEM_loadTiXmlDocument("saves/qsave.vvv", &doc))
     {
-        quickcookieexists = false;
         quicksummary = "";
     }
     else
     {
-        quickcookieexists = true;
         TiXmlHandle hDoc(&doc);
         TiXmlElement* pElem;
         TiXmlHandle hRoot(0);
@@ -5637,7 +5528,7 @@ void Game::loadsummary( mapclass& map, UtilityClass& help )
 
         }
 
-        quick_gametime = giventimestring(l_hours,l_minute, l_second,help);
+        quick_gametime = giventimestring(l_hours,l_minute, l_second);
         quick_currentarea = map.currentarea(map.area(l_saveX, l_saveY));
     }
 
@@ -5645,7 +5536,7 @@ void Game::loadsummary( mapclass& map, UtilityClass& help )
 
 }
 
-void Game::initteleportermode( mapclass& map )
+void Game::initteleportermode()
 {
     //Set the teleporter variable to the right position!
     teleport_to_teleporter = 0;
@@ -5659,13 +5550,9 @@ void Game::initteleportermode( mapclass& map )
     }
 }
 
-void Game::savetele( mapclass& map, entityclass& obj, musicclass& music )
+void Game::savetele()
 {
     //TODO make this code a bit cleaner.
-
-    //telecookie = SharedObject.getLocal("dwvvvvvv_tele");
-    //Save to the telesave cookie
-    telecookieexists = true;
 
     if (map.custommode)
     {
@@ -5690,23 +5577,11 @@ void Game::savetele( mapclass& map, entityclass& obj, musicclass& music )
 
 
     //Flags, map and stats
-    //savestate[1].explored = map.explored.slice();
-    //savestate[1].flags = obj.flags.slice();
-    //savestate[1].crewstats = crewstats.slice();
-    //savestate[1].collect = obj.collect.slice();
-
-    //telecookie.data.worldmap = savestate[1].explored.slice();
-    //telecookie.data.flags = savestate[1].flags.slice();
-    //telecookie.data.crewstats = savestate[1].crewstats.slice();
-    //telecookie.data.collect = savestate[1].collect.slice();
-
-    //telecookie.data.finalmode = map.finalmode;
-    //telecookie.data.finalstretch = map.finalstretch;
 
     std::string mapExplored;
     for(size_t i = 0; i < map.explored.size(); i++ )
     {
-        mapExplored += UtilityClass::String(map.explored[i]) + ",";
+        mapExplored += help.String(map.explored[i]) + ",";
     }
     msg = new TiXmlElement( "worldmap" );
     msg->LinkEndChild( new TiXmlText( mapExplored.c_str() ));
@@ -5715,7 +5590,7 @@ void Game::savetele( mapclass& map, entityclass& obj, musicclass& music )
     std::string flags;
     for(size_t i = 0; i < obj.flags.size(); i++ )
     {
-        flags += UtilityClass::String(obj.flags[i]) + ",";
+        flags += help.String(obj.flags[i]) + ",";
     }
     msg = new TiXmlElement( "flags" );
     msg->LinkEndChild( new TiXmlText( flags.c_str() ));
@@ -5724,7 +5599,7 @@ void Game::savetele( mapclass& map, entityclass& obj, musicclass& music )
     std::string crewstatsString;
     for(size_t i = 0; i < crewstats.size(); i++ )
     {
-        crewstatsString += UtilityClass::String(crewstats[i]) + ",";
+        crewstatsString += help.String(crewstats[i]) + ",";
     }
     msg = new TiXmlElement( "crewstats" );
     msg->LinkEndChild( new TiXmlText( crewstatsString.c_str() ));
@@ -5733,90 +5608,67 @@ void Game::savetele( mapclass& map, entityclass& obj, musicclass& music )
     std::string collect;
     for(size_t i = 0; i < obj.collect.size(); i++ )
     {
-        collect += UtilityClass::String(obj.collect[i]) + ",";
+        collect += help.String(obj.collect[i]) + ",";
     }
     msg = new TiXmlElement( "collect" );
     msg->LinkEndChild( new TiXmlText( collect.c_str() ));
     msgs->LinkEndChild( msg );
 
-    //telecookie.data.finalx = map.finalx;
-    //telecookie.data.finaly = map.finaly;
     //Position
-    //telecookie.data.savex = savex;
-    //telecookie.data.savey = savey;
 
     msg = new TiXmlElement( "finalx" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(map.finalx).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(map.finalx).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "finaly" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(map.finaly).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(map.finaly).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savex" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savex).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savex).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savey" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savey).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savey).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "saverx" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(saverx).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(saverx).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savery" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savery).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savery).c_str() ));
     msgs->LinkEndChild( msg );
 
-    //telecookie.data.saverx = saverx;
-    //telecookie.data.savery = savery;
-    //telecookie.data.savegc = savegc;
-    //telecookie.data.savedir = savedir;
-    //telecookie.data.savepoint = savepoint;
-    //telecookie.data.trinkets = trinkets;
-
     msg = new TiXmlElement( "savegc" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savegc).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savegc).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savedir" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savedir).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savedir).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savepoint" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savepoint).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savepoint).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "trinkets" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(trinkets).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(trinkets).c_str() ));
     msgs->LinkEndChild( msg );
 
 
-    //if (music.nicechange != -1) {
-    //telecookie.data.currentsong = music.nicechange;
-    //}else{
-    //telecookie.data.currentsong = music.currentsong;
-    //}
-    //telecookie.data.teleportscript = teleportscript;
-
     //Special stats
-    //telecookie.data.companion = companion;
-    //telecookie.data.lastsaved = lastsaved;
-    //telecookie.data.supercrewmate = supercrewmate;
-    //telecookie.data.scmprogress = scmprogress;
-    //telecookie.data.scmmoveme = scmmoveme;
 
     if(music.nicefade==1)
     {
         msg = new TiXmlElement( "currentsong" );
-        msg->LinkEndChild( new TiXmlText( UtilityClass::String(music.nicechange).c_str() ));
+        msg->LinkEndChild( new TiXmlText( help.String(music.nicechange).c_str() ));
         msgs->LinkEndChild( msg );
     }
     else
     {
         msg = new TiXmlElement( "currentsong" );
-        msg->LinkEndChild( new TiXmlText( UtilityClass::String(music.currentsong).c_str() ));
+        msg->LinkEndChild( new TiXmlText( help.String(music.currentsong).c_str() ));
         msgs->LinkEndChild( msg );
     }
 
@@ -5824,62 +5676,50 @@ void Game::savetele( mapclass& map, entityclass& obj, musicclass& music )
     msg->LinkEndChild( new TiXmlText( teleportscript.c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "companion" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(companion).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(companion).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "lastsaved" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(lastsaved).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(lastsaved).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "supercrewmate" );
     msg->LinkEndChild( new TiXmlText( BoolToString(supercrewmate) ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "scmprogress" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(scmprogress).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(scmprogress).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "scmmoveme" );
     msg->LinkEndChild( new TiXmlText( BoolToString(scmmoveme) ));
     msgs->LinkEndChild( msg );
 
 
-    //telecookie.data.frames = frames; telecookie.data.seconds = seconds;
-    //telecookie.data.minutes = minutes; telecookie.data.hours = hours;
-
-    //telecookie.data.deathcounts = deathcounts;
-    //telecookie.data.totalflips = totalflips;
-    //telecookie.data.hardestroom = hardestroom; telecookie.data.hardestroomdeaths = hardestroomdeaths;
-
-    //savearea = map.currentarea(map.area(roomx, roomy))
-    //telecookie.data.summary = savearea + ", " + timestring(help);
-    //telesummary = telecookie.data.summary;
-
-
     msg = new TiXmlElement( "frames" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(frames).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(frames).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "seconds" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(seconds).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(seconds).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "minutes" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(minutes).c_str()) );
+    msg->LinkEndChild( new TiXmlText( help.String(minutes).c_str()) );
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "hours" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(hours).c_str()) );
+    msg->LinkEndChild( new TiXmlText( help.String(hours).c_str()) );
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "deathcounts" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(deathcounts).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(deathcounts).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "totalflips" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(totalflips).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(totalflips).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "hardestroom" );
     msg->LinkEndChild( new TiXmlText( hardestroom.c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "hardestroomdeaths" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(hardestroomdeaths).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(hardestroomdeaths).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "finalmode" );
@@ -5891,8 +5731,7 @@ void Game::savetele( mapclass& map, entityclass& obj, musicclass& music )
 
 
     msg = new TiXmlElement( "summary" );
-    UtilityClass tempUtil;
-    std::string summary = savearea + ", " + timestring(tempUtil);
+    std::string summary = savearea + ", " + timestring();
     msg->LinkEndChild( new TiXmlText( summary.c_str() ));
     msgs->LinkEndChild( msg );
 
@@ -5912,10 +5751,8 @@ void Game::savetele( mapclass& map, entityclass& obj, musicclass& music )
 }
 
 
-void Game::savequick( mapclass& map, entityclass& obj, musicclass& music )
+void Game::savequick()
 {
-    quickcookieexists = true;
-
     if (map.custommode)
     {
         //Don't trash save data!
@@ -5939,23 +5776,11 @@ void Game::savequick( mapclass& map, entityclass& obj, musicclass& music )
 
 
     //Flags, map and stats
-    //savestate[1].explored = map.explored.slice();
-    //savestate[1].flags = obj.flags.slice();
-    //savestate[1].crewstats = crewstats.slice();
-    //savestate[1].collect = obj.collect.slice();
-
-    //telecookie.data.worldmap = savestate[1].explored.slice();
-    //telecookie.data.flags = savestate[1].flags.slice();
-    //telecookie.data.crewstats = savestate[1].crewstats.slice();
-    //telecookie.data.collect = savestate[1].collect.slice();
-
-    //telecookie.data.finalmode = map.finalmode;
-    //telecookie.data.finalstretch = map.finalstretch;
 
     std::string mapExplored;
     for(size_t i = 0; i < map.explored.size(); i++ )
     {
-        mapExplored += UtilityClass::String(map.explored[i]) + ",";
+        mapExplored += help.String(map.explored[i]) + ",";
     }
     msg = new TiXmlElement( "worldmap" );
     msg->LinkEndChild( new TiXmlText( mapExplored.c_str() ));
@@ -5964,7 +5789,7 @@ void Game::savequick( mapclass& map, entityclass& obj, musicclass& music )
     std::string flags;
     for(size_t i = 0; i < obj.flags.size(); i++ )
     {
-        flags += UtilityClass::String(obj.flags[i]) + ",";
+        flags += help.String(obj.flags[i]) + ",";
     }
     msg = new TiXmlElement( "flags" );
     msg->LinkEndChild( new TiXmlText( flags.c_str() ));
@@ -5973,7 +5798,7 @@ void Game::savequick( mapclass& map, entityclass& obj, musicclass& music )
     std::string crewstatsString;
     for(size_t i = 0; i < crewstats.size(); i++ )
     {
-        crewstatsString += UtilityClass::String(crewstats[i]) + ",";
+        crewstatsString += help.String(crewstats[i]) + ",";
     }
     msg = new TiXmlElement( "crewstats" );
     msg->LinkEndChild( new TiXmlText( crewstatsString.c_str() ));
@@ -5982,89 +5807,66 @@ void Game::savequick( mapclass& map, entityclass& obj, musicclass& music )
     std::string collect;
     for(size_t i = 0; i < obj.collect.size(); i++ )
     {
-        collect += UtilityClass::String(obj.collect[i]) + ",";
+        collect += help.String(obj.collect[i]) + ",";
     }
     msg = new TiXmlElement( "collect" );
     msg->LinkEndChild( new TiXmlText( collect.c_str() ));
     msgs->LinkEndChild( msg );
 
-    //telecookie.data.finalx = map.finalx;
-    //telecookie.data.finaly = map.finaly;
     //Position
-    //telecookie.data.savex = savex;
-    //telecookie.data.savey = savey;
 
     msg = new TiXmlElement( "finalx" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(map.finalx).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(map.finalx).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "finaly" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(map.finaly).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(map.finaly).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savex" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savex).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savex).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savey" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savey).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savey).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "saverx" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(saverx).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(saverx).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savery" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savery).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savery).c_str() ));
     msgs->LinkEndChild( msg );
 
-    //telecookie.data.saverx = saverx;
-    //telecookie.data.savery = savery;
-    //telecookie.data.savegc = savegc;
-    //telecookie.data.savedir = savedir;
-    //telecookie.data.savepoint = savepoint;
-    //telecookie.data.trinkets = trinkets;
-
     msg = new TiXmlElement( "savegc" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savegc).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savegc).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savedir" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savedir).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savedir).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savepoint" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savepoint).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savepoint).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "trinkets" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(trinkets).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(trinkets).c_str() ));
     msgs->LinkEndChild( msg );
 
 
-    //if (music.nicechange != -1) {
-    //telecookie.data.currentsong = music.nicechange;
-    //}else{
-    //telecookie.data.currentsong = music.currentsong;
-    //}
-    //telecookie.data.teleportscript = teleportscript;
-
     //Special stats
-    //telecookie.data.companion = companion;
-    //telecookie.data.lastsaved = lastsaved;
-    //telecookie.data.supercrewmate = supercrewmate;
-    //telecookie.data.scmprogress = scmprogress;
-    //telecookie.data.scmmoveme = scmmoveme;
     if(music.nicefade==1)
     {
         msg = new TiXmlElement( "currentsong" );
-        msg->LinkEndChild( new TiXmlText( UtilityClass::String(music.nicechange).c_str() ));
+        msg->LinkEndChild( new TiXmlText( help.String(music.nicechange).c_str() ));
         msgs->LinkEndChild( msg );
     }
     else
     {
         msg = new TiXmlElement( "currentsong" );
-        msg->LinkEndChild( new TiXmlText( UtilityClass::String(music.currentsong).c_str() ));
+        msg->LinkEndChild( new TiXmlText( help.String(music.currentsong).c_str() ));
         msgs->LinkEndChild( msg );
     }
 
@@ -6072,26 +5874,23 @@ void Game::savequick( mapclass& map, entityclass& obj, musicclass& music )
     msg->LinkEndChild( new TiXmlText( teleportscript.c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "companion" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(companion).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(companion).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "lastsaved" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(lastsaved).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(lastsaved).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "supercrewmate" );
     msg->LinkEndChild( new TiXmlText( BoolToString(supercrewmate) ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "scmprogress" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(scmprogress).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(scmprogress).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "scmmoveme" );
     msg->LinkEndChild( new TiXmlText( BoolToString(scmmoveme) ));
     msgs->LinkEndChild( msg );
 
-
-    //telecookie.data.finalmode = map.finalmode;
-    //telecookie.data.finalstretch = map.finalstretch;
 
     msg = new TiXmlElement( "finalmode" );
     msg->LinkEndChild( new TiXmlText( BoolToString(map.finalmode) ));
@@ -6100,55 +5899,41 @@ void Game::savequick( mapclass& map, entityclass& obj, musicclass& music )
     msg->LinkEndChild( new TiXmlText( BoolToString(map.finalstretch) ));
     msgs->LinkEndChild( msg );
 
-    //telecookie.data.frames = frames; telecookie.data.seconds = seconds;
-    //telecookie.data.minutes = minutes; telecookie.data.hours = hours;
-
-    //telecookie.data.deathcounts = deathcounts;
-    //telecookie.data.totalflips = totalflips;
-    //telecookie.data.hardestroom = hardestroom; telecookie.data.hardestroomdeaths = hardestroomdeaths;
-
-    //savearea = map.currentarea(map.area(roomx, roomy))
-    //telecookie.data.summary = savearea + ", " + timestring(help);
-    //telesummary = telecookie.data.summary;
-
 
     msg = new TiXmlElement( "frames" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(frames).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(frames).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "seconds" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(seconds).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(seconds).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "minutes" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(minutes).c_str()) );
+    msg->LinkEndChild( new TiXmlText( help.String(minutes).c_str()) );
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "hours" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(hours).c_str()) );
+    msg->LinkEndChild( new TiXmlText( help.String(hours).c_str()) );
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "deathcounts" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(deathcounts).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(deathcounts).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "totalflips" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(totalflips).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(totalflips).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "hardestroom" );
     msg->LinkEndChild( new TiXmlText( hardestroom.c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "hardestroomdeaths" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(hardestroomdeaths).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(hardestroomdeaths).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "summary" );
-    UtilityClass tempUtil;
-    std::string summary = savearea + ", " + timestring(tempUtil);
+    std::string summary = savearea + ", " + timestring();
     msg->LinkEndChild( new TiXmlText( summary.c_str() ));
     msgs->LinkEndChild( msg );
 
     quicksummary = summary;
-    //telecookie.flush();
-    //telecookie.close();
 
     if(FILESYSTEM_saveTiXmlDocument("saves/qsave.vvv", &doc))
     {
@@ -6162,10 +5947,8 @@ void Game::savequick( mapclass& map, entityclass& obj, musicclass& music )
 
 }
 
-void Game::customsavequick(std::string savfile, mapclass& map, entityclass& obj, musicclass& music )
+void Game::customsavequick(std::string savfile)
 {
-    quickcookieexists = true;
-
     TiXmlDocument doc;
     TiXmlElement* msg;
     TiXmlDeclaration* decl = new TiXmlDeclaration( "1.0", "", "" );
@@ -6183,23 +5966,11 @@ void Game::customsavequick(std::string savfile, mapclass& map, entityclass& obj,
 
 
     //Flags, map and stats
-    //savestate[1].explored = map.explored.slice();
-    //savestate[1].flags = obj.flags.slice();
-    //savestate[1].crewstats = crewstats.slice();
-    //savestate[1].collect = obj.collect.slice();
-
-    //telecookie.data.worldmap = savestate[1].explored.slice();
-    //telecookie.data.flags = savestate[1].flags.slice();
-    //telecookie.data.crewstats = savestate[1].crewstats.slice();
-    //telecookie.data.collect = savestate[1].collect.slice();
-
-    //telecookie.data.finalmode = map.finalmode;
-    //telecookie.data.finalstretch = map.finalstretch;
 
     std::string mapExplored;
     for(size_t i = 0; i < map.explored.size(); i++ )
     {
-        mapExplored += UtilityClass::String(map.explored[i]) + ",";
+        mapExplored += help.String(map.explored[i]) + ",";
     }
     msg = new TiXmlElement( "worldmap" );
     msg->LinkEndChild( new TiXmlText( mapExplored.c_str() ));
@@ -6208,7 +5979,7 @@ void Game::customsavequick(std::string savfile, mapclass& map, entityclass& obj,
     std::string flags;
     for(size_t i = 0; i < obj.flags.size(); i++ )
     {
-        flags += UtilityClass::String(obj.flags[i]) + ",";
+        flags += help.String(obj.flags[i]) + ",";
     }
     msg = new TiXmlElement( "flags" );
     msg->LinkEndChild( new TiXmlText( flags.c_str() ));
@@ -6217,7 +5988,7 @@ void Game::customsavequick(std::string savfile, mapclass& map, entityclass& obj,
     std::string moods;
     for(int i = 0; i < 6; i++ )
     {
-        moods += UtilityClass::String(obj.customcrewmoods[i]) + ",";
+        moods += help.String(obj.customcrewmoods[i]) + ",";
     }
     msg = new TiXmlElement( "moods" );
     msg->LinkEndChild( new TiXmlText( moods.c_str() ));
@@ -6226,7 +5997,7 @@ void Game::customsavequick(std::string savfile, mapclass& map, entityclass& obj,
     std::string crewstatsString;
     for(size_t i = 0; i < crewstats.size(); i++ )
     {
-        crewstatsString += UtilityClass::String(crewstats[i]) + ",";
+        crewstatsString += help.String(crewstats[i]) + ",";
     }
     msg = new TiXmlElement( "crewstats" );
     msg->LinkEndChild( new TiXmlText( crewstatsString.c_str() ));
@@ -6235,7 +6006,7 @@ void Game::customsavequick(std::string savfile, mapclass& map, entityclass& obj,
     std::string collect;
     for(size_t i = 0; i < obj.collect.size(); i++ )
     {
-        collect += UtilityClass::String(obj.collect[i]) + ",";
+        collect += help.String(obj.collect[i]) + ",";
     }
     msg = new TiXmlElement( "collect" );
     msg->LinkEndChild( new TiXmlText( collect.c_str() ));
@@ -6244,93 +6015,70 @@ void Game::customsavequick(std::string savfile, mapclass& map, entityclass& obj,
     std::string customcollect;
     for(size_t i = 0; i < obj.customcollect.size(); i++ )
     {
-        customcollect += UtilityClass::String(obj.customcollect[i]) + ",";
+        customcollect += help.String(obj.customcollect[i]) + ",";
     }
     msg = new TiXmlElement( "customcollect" );
     msg->LinkEndChild( new TiXmlText( customcollect.c_str() ));
     msgs->LinkEndChild( msg );
 
-    //telecookie.data.finalx = map.finalx;
-    //telecookie.data.finaly = map.finaly;
     //Position
-    //telecookie.data.savex = savex;
-    //telecookie.data.savey = savey;
 
     msg = new TiXmlElement( "finalx" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(map.finalx).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(map.finalx).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "finaly" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(map.finaly).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(map.finaly).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savex" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savex).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savex).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savey" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savey).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savey).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "saverx" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(saverx).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(saverx).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savery" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savery).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savery).c_str() ));
     msgs->LinkEndChild( msg );
 
-    //telecookie.data.saverx = saverx;
-    //telecookie.data.savery = savery;
-    //telecookie.data.savegc = savegc;
-    //telecookie.data.savedir = savedir;
-    //telecookie.data.savepoint = savepoint;
-    //telecookie.data.trinkets = trinkets;
-
     msg = new TiXmlElement( "savegc" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savegc).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savegc).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savedir" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savedir).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savedir).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savepoint" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savepoint).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savepoint).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "trinkets" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(trinkets).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(trinkets).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "crewmates" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(crewmates).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(crewmates).c_str() ));
     msgs->LinkEndChild( msg );
 
 
-    //if (music.nicechange != -1) {
-    //telecookie.data.currentsong = music.nicechange;
-    //}else{
-    //telecookie.data.currentsong = music.currentsong;
-    //}
-    //telecookie.data.teleportscript = teleportscript;
-
     //Special stats
-    //telecookie.data.companion = companion;
-    //telecookie.data.lastsaved = lastsaved;
-    //telecookie.data.supercrewmate = supercrewmate;
-    //telecookie.data.scmprogress = scmprogress;
-    //telecookie.data.scmmoveme = scmmoveme;
     if(music.nicefade==1)
     {
         msg = new TiXmlElement( "currentsong" );
-        msg->LinkEndChild( new TiXmlText( UtilityClass::String(music.nicechange).c_str() ));
+        msg->LinkEndChild( new TiXmlText( help.String(music.nicechange).c_str() ));
         msgs->LinkEndChild( msg );
     }
     else
     {
         msg = new TiXmlElement( "currentsong" );
-        msg->LinkEndChild( new TiXmlText( UtilityClass::String(music.currentsong).c_str() ));
+        msg->LinkEndChild( new TiXmlText( help.String(music.currentsong).c_str() ));
         msgs->LinkEndChild( msg );
     }
 
@@ -6338,62 +6086,50 @@ void Game::customsavequick(std::string savfile, mapclass& map, entityclass& obj,
     msg->LinkEndChild( new TiXmlText( teleportscript.c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "companion" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(companion).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(companion).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "lastsaved" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(lastsaved).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(lastsaved).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "supercrewmate" );
     msg->LinkEndChild( new TiXmlText( BoolToString(supercrewmate) ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "scmprogress" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(scmprogress).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(scmprogress).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "scmmoveme" );
     msg->LinkEndChild( new TiXmlText( BoolToString(scmmoveme) ));
     msgs->LinkEndChild( msg );
 
 
-    //telecookie.data.frames = frames; telecookie.data.seconds = seconds;
-    //telecookie.data.minutes = minutes; telecookie.data.hours = hours;
-
-    //telecookie.data.deathcounts = deathcounts;
-    //telecookie.data.totalflips = totalflips;
-    //telecookie.data.hardestroom = hardestroom; telecookie.data.hardestroomdeaths = hardestroomdeaths;
-
-    //savearea = map.currentarea(map.area(roomx, roomy))
-    //telecookie.data.summary = savearea + ", " + timestring(help);
-    //telesummary = telecookie.data.summary;
-
-
     msg = new TiXmlElement( "frames" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(frames).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(frames).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "seconds" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(seconds).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(seconds).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "minutes" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(minutes).c_str()) );
+    msg->LinkEndChild( new TiXmlText( help.String(minutes).c_str()) );
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "hours" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(hours).c_str()) );
+    msg->LinkEndChild( new TiXmlText( help.String(hours).c_str()) );
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "deathcounts" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(deathcounts).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(deathcounts).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "totalflips" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(totalflips).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(totalflips).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "hardestroom" );
     msg->LinkEndChild( new TiXmlText( hardestroom.c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "hardestroomdeaths" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(hardestroomdeaths).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(hardestroomdeaths).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "showminimap" );
@@ -6401,14 +6137,11 @@ void Game::customsavequick(std::string savfile, mapclass& map, entityclass& obj,
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "summary" );
-    UtilityClass tempUtil;
-    std::string summary = savearea + ", " + timestring(tempUtil);
+    std::string summary = savearea + ", " + timestring();
     msg->LinkEndChild( new TiXmlText( summary.c_str() ));
     msgs->LinkEndChild( msg );
 
     customquicksummary = summary;
-    //telecookie.flush();
-    //telecookie.close();
 
     std::string levelfile = savfile.substr(7);
     if(FILESYSTEM_saveTiXmlDocument(("saves/"+levelfile+".vvv").c_str(), &doc))
@@ -6423,7 +6156,7 @@ void Game::customsavequick(std::string savfile, mapclass& map, entityclass& obj,
 }
 
 
-void Game::loadtele( mapclass& map, entityclass& obj, musicclass& music )
+void Game::loadtele()
 {
     TiXmlDocument doc;
     if (!FILESYSTEM_loadTiXmlDocument("saves/tsave.vvv", &doc)) return;
@@ -6700,7 +6433,7 @@ teststring = os.str();
 	}
 }
 
-std::string Game::giventimestring( int hrs, int min, int sec, UtilityClass& help )
+std::string Game::giventimestring(int hrs, int min, int sec)
 {
     tempstring = "";
     if (hrs > 0)
@@ -6711,7 +6444,7 @@ std::string Game::giventimestring( int hrs, int min, int sec, UtilityClass& help
     return tempstring;
 }
 
-std::string Game::timestring( UtilityClass& help )
+std::string Game::timestring()
 {
     tempstring = "";
     if (hours > 0)
@@ -6722,7 +6455,7 @@ std::string Game::timestring( UtilityClass& help )
     return tempstring;
 }
 
-std::string Game::partimestring( UtilityClass& help )
+std::string Game::partimestring()
 {
     //given par time in seconds:
     tempstring = "";
@@ -6737,7 +6470,7 @@ std::string Game::partimestring( UtilityClass& help )
     return tempstring;
 }
 
-std::string Game::resulttimestring( UtilityClass& help )
+std::string Game::resulttimestring()
 {
     //given result time in seconds:
     tempstring = "";
@@ -6753,7 +6486,7 @@ std::string Game::resulttimestring( UtilityClass& help )
     return tempstring;
 }
 
-std::string Game::timetstring( int t, UtilityClass& help )
+std::string Game::timetstring(int t)
 {
     //given par time in seconds:
     tempstring = "";
@@ -7753,7 +7486,6 @@ void Game::deletequick()
         printf("Error deleting file\n");
 
     quicksummary = "";
-    quickcookieexists = false;
 }
 
 void Game::deletetele()
@@ -7762,7 +7494,6 @@ void Game::deletetele()
         printf("Error deleting file\n");
 
     telesummary = "";
-    telecookieexists = false;
 }
 
 void Game::swnpenalty()

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -37,83 +37,65 @@ public:
 
     void resetgameclock();
 
-    void customsavequick(std::string savfile, mapclass& map, entityclass& obj, musicclass& music);
-    void savequick(mapclass& map, entityclass& obj, musicclass& music);
+    void customsavequick(std::string savfile);
+    void savequick();
 
     void gameclock();
 
-    std::string giventimestring(int hrs, int min, int sec, UtilityClass& help );
+    std::string giventimestring(int hrs, int min, int sec);
 
-    std::string  timestring(UtilityClass& help);
+    std::string timestring();
 
-    std::string partimestring(UtilityClass& help);
+    std::string partimestring();
 
-    std::string resulttimestring(UtilityClass& help);
+    std::string resulttimestring();
 
-    std::string timetstring(int t, UtilityClass& help);
+    std::string timetstring(int t);
 
     void  createmenu(std::string t);
 
-    void lifesequence(entityclass& obj);
+    void lifesequence();
 
-    void gethardestroom(mapclass& map);
+    void gethardestroom();
 
-    void updatestate(Graphics& dwgfx, mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music);
+    void updatestate();
 
-    void unlocknum(int t, mapclass& map, Graphics& dwgfx);
+    void unlocknum(int t);
 
-    void loadstats(mapclass& map, Graphics& dwgfx);
+    void loadstats();
 
-    void  savestats(mapclass& map, Graphics& dwgfx);
+    void savestats();
 
-    void deletestats(mapclass& map, Graphics& dwgfx);
+    void deletestats();
 
     void deletequick();
 
-    void savetele(mapclass& map, entityclass& obj, musicclass& music);
+    void savetele();
 
-    void loadtele(mapclass& map, entityclass& obj, musicclass& music);
+    void loadtele();
 
     void deletetele();
 
-    void customstart(entityclass& obj, musicclass& music );
+    void customstart();
 
-    void start(entityclass& obj, musicclass& music );
+    void start();
 
-    void startspecial(int t, entityclass& obj, musicclass& music);
+    void startspecial(int t);
 
-    void starttrial(int t, entityclass& obj, musicclass& music);
-
-    void telegotoship()
-    {
-        //Special function to move the telesave to the ship teleporter.
-        //telecookie.data.savex = 13*8;
-        //telecookie.data.savey = 129;
-        //telecookie.data.saverx = 102;
-        //telecookie.data.savery = 111;
-        //telecookie.data.savegc = 0;
-        //telecookie.data.savedir = 1;
-        //telecookie.data.savepoint = 0;
-
-        //telecookie.data.currentsong = 4;
-        //telecookie.data.companion = 0;
-
-        //telecookie.data.finalmode = false;
-        //telecookie.data.finalstretch = false;
-    }
+    void starttrial(int t);
 
     void swnpenalty();
 
-    void deathsequence(mapclass& map, entityclass& obj, musicclass& music);
+    void deathsequence();
 
-    void customloadquick(std::string savfile, mapclass& map, entityclass& obj, musicclass& music);
-    void loadquick(mapclass& map, entityclass& obj, musicclass& music);
+    void customloadquick(std::string savfile);
+    void loadquick();
 
-    void loadsummary(mapclass& map, UtilityClass& help);
+    void loadsummary();
 
-    void initteleportermode(mapclass& map);
+    void initteleportermode();
 
-	std::string saveFilePath;
+    std::string saveFilePath;
 
 
     int door_left;
@@ -134,9 +116,9 @@ public:
     //State logic stuff
     int state, statedelay;
 
-		bool glitchrunkludge;
+    bool glitchrunkludge;
 
-		int usingmmmmmm;
+    int usingmmmmmm;
 
     int gamestate;
     bool hascontrol, jumpheld;
@@ -146,20 +128,19 @@ public:
     bool infocus;
     bool muted;
     int mutebutton;
-	private:
+private:
     float m_globalVol;
 
-	public:
+public:
 
     int tapleft, tapright;
 
     //Menu interaction stuff
     bool mapheld;
     int menupage;
-    //public var crewstats:Array = new Array();
     int lastsaved;
     int deathcounts;
-	int timerStartTime;
+    int timerStartTime;
 
     int frames, seconds, minutes, hours;
     bool gamesaved;
@@ -193,9 +174,6 @@ public:
     int creditposx, creditposy, creditposdelay;
 
 
-    //60 fps mode!
-    bool sfpsmode;
-
     //Sine Wave Ninja Minigame
     bool swnmode;
     int swngame, swnstate, swnstate2, swnstate3, swnstate4, swndelay, swndeaths;
@@ -207,7 +185,7 @@ public:
     int scmprogress;
 
     //Accessibility Options
-    bool  colourblindmode;
+    bool colourblindmode;
     bool noflashingmode;
     int slowdown;
     Uint32 gameframerate;
@@ -260,9 +238,6 @@ public:
     std::vector<int>bestlives;
     std::vector<int> bestrank;
 
-    bool telecookieexists;
-    bool quickcookieexists;
-
     std::string tele_gametime;
     int tele_trinkets;
     std::string tele_currentarea;
@@ -311,9 +286,9 @@ public:
 
     bool advanced_mode;
     bool fullScreenEffect_badSignal;
-	bool useLinearFilter;
-	int stretchMode;
-	int controllerSensitivity;
+    bool useLinearFilter;
+    int stretchMode;
+    int controllerSensitivity;
 
     //Screenrecording stuff, for beta/trailer
     int recording;
@@ -356,9 +331,9 @@ public:
     bool customlevelstatsloaded;
 
 
-	std::vector<SDL_GameControllerButton> controllerButton_map;
-	std::vector<SDL_GameControllerButton> controllerButton_flip;
-	std::vector<SDL_GameControllerButton> controllerButton_esc;
+    std::vector<SDL_GameControllerButton> controllerButton_map;
+    std::vector<SDL_GameControllerButton> controllerButton_flip;
+    std::vector<SDL_GameControllerButton> controllerButton_esc;
 
     bool skipfakeload;
 };

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -25,12 +25,9 @@ void Graphics::init()
 
 
     //We initialise a few things
-    //updatebackground = true;
 
 
-    //ct = new ColorTransform(0, 0, 0, 1, 255, 255, 255, 1); //Set to white
-
-	linestate = 0;
+    linestate = 0;
 
 
     trinketcolset = false;
@@ -41,10 +38,6 @@ void Graphics::init()
 
     flipmode = false;
     setflipmode = false;
-    //flipmatrix.scale(1, -1);
-    //flipmatrix.translate(0, 240);
-    //flipfontmatrix.scale(1, -1);	flipfontmatrix.translate(0, 8);
-    //flipfontmatrix2.scale(1, -1);	flipfontmatrix2.translate(0, 9);
 
     //Background inits
     for (int i = 0; i < 50; i++)
@@ -154,14 +147,13 @@ Graphics::~Graphics()
 
 }
 
-void Graphics::drawspritesetcol(int x, int y, int t, int c, UtilityClass& help)
+void Graphics::drawspritesetcol(int x, int y, int t, int c)
 {
     SDL_Rect rect;
-    setRect(rect,x,y,sprites_rect.w,sprites_rect.h);
-    setcol(c, help);
+    setRect(rect, x, y, sprites_rect.w, sprites_rect.h);
+    setcol(c);
 
-    BlitSurfaceColoured(sprites[t],NULL,backBuffer, &rect, ct);
-    //.copyPixels(sprites[t], sprites_rect, backbuffer, tpoint);
+    BlitSurfaceColoured(sprites[t], NULL, backBuffer, &rect, ct);
 }
 
 void Graphics::Makebfont()
@@ -556,22 +548,19 @@ void Graphics::drawsprite( int x, int y, int t, int r, int g,  int b )
     BlitSurfaceColoured(sprites[t], NULL, backBuffer, &rect, ct);
 }
 
-void Graphics::drawtile( int x, int y, int t, int r, int g,  int b )
+void Graphics::drawtile(int x, int y, int t)
 {
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
     BlitSurfaceStandard(tiles[t], NULL, backBuffer, &rect);
 }
 
-
-void Graphics::drawtile2( int x, int y, int t, int r, int g,  int b )
+void Graphics::drawtile2(int x, int y, int t)
 {
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
     BlitSurfaceStandard(tiles2[t], NULL, backBuffer, &rect);
 }
 
-
-
-void Graphics::drawtile3( int x, int y, int t, int off )
+void Graphics::drawtile3(int x, int y, int t, int off)
 {
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
     BlitSurfaceStandard(tiles3[t+(off*30)], NULL, backBuffer, &rect);
@@ -596,7 +585,7 @@ void Graphics::drawtowertile3( int x, int y, int t, int off )
     BlitSurfaceStandard(tiles3[t+(off*30)], NULL, towerbuffer, &rect);
 }
 
-void Graphics::drawgui( UtilityClass& help )
+void Graphics::drawgui()
 {
     textboxcleanup();
     //Draw all the textboxes to the screen
@@ -843,7 +832,7 @@ void Graphics::cutscenebars()
     }
 }
 
-void Graphics::drawcrewman( int x, int y, int t, bool act, UtilityClass& help, bool noshift /*=false*/ )
+void Graphics::drawcrewman(int x, int y, int t, bool act, bool noshift /*=false*/ )
 {
     if (!act)
     {
@@ -851,22 +840,22 @@ void Graphics::drawcrewman( int x, int y, int t, bool act, UtilityClass& help, b
         {
             if (flipmode)
             {
-                drawspritesetcol(x, y, 14, 19, help);
+                drawspritesetcol(x, y, 14, 19);
             }
             else
             {
-                drawspritesetcol(x, y, 12, 19, help);
+                drawspritesetcol(x, y, 12, 19);
             }
         }
         else
         {
             if (flipmode)
             {
-                drawspritesetcol(x - 8, y, 14, 19, help);
+                drawspritesetcol(x - 8, y, 14, 19);
             }
             else
             {
-                drawspritesetcol(x - 8, y, 12, 19, help);
+                drawspritesetcol(x - 8, y, 12, 19);
             }
         }
     }
@@ -877,22 +866,22 @@ void Graphics::drawcrewman( int x, int y, int t, bool act, UtilityClass& help, b
         switch(t)
         {
         case 0:
-            drawspritesetcol(x, y, crewframe, 0 , help);
+            drawspritesetcol(x, y, crewframe, 0);
             break;
         case 1:
-            drawspritesetcol(x, y, crewframe, 20, help);
+            drawspritesetcol(x, y, crewframe, 20);
             break;
         case 2:
-            drawspritesetcol(x, y, crewframe, 14, help);
+            drawspritesetcol(x, y, crewframe, 14);
             break;
         case 3:
-            drawspritesetcol(x, y, crewframe, 15, help);
+            drawspritesetcol(x, y, crewframe, 15);
             break;
         case 4:
-            drawspritesetcol(x, y, crewframe, 13, help);
+            drawspritesetcol(x, y, crewframe, 13);
             break;
         case 5:
-            drawspritesetcol(x, y, crewframe, 16, help);
+            drawspritesetcol(x, y, crewframe, 16);
             break;
         }
 
@@ -1135,7 +1124,7 @@ void Graphics::processfade()
     }
 }
 
-void Graphics::drawmenu( Game& game, int cr, int cg, int cb, int division /*= 30*/ )
+void Graphics::drawmenu(int cr, int cg, int cb, int division /*= 30*/ )
 {
     for (int i = 0; i < game.nummenuoptions; i++)
     {
@@ -1173,7 +1162,7 @@ void Graphics::drawmenu( Game& game, int cr, int cg, int cb, int division /*= 30
     }
 }
 
-void Graphics::drawlevelmenu( Game& game, int cr, int cg, int cb, int division /*= 30*/ )
+void Graphics::drawlevelmenu(int cr, int cg, int cb, int division /*= 30*/ )
 {
     for (int i = 0; i < game.nummenuoptions; i++)
     {
@@ -1253,7 +1242,7 @@ void Graphics::drawcoloredtile( int x, int y, int t, int r, int g, int b )
 }
 
 
-bool Graphics::Hitest(SDL_Surface* surface1, point p1, int col, SDL_Surface* surface2, point p2, int col2)
+bool Graphics::Hitest(SDL_Surface* surface1, point p1, SDL_Surface* surface2, point p2)
 {
 
     //find rectangle where they intersect:
@@ -1299,7 +1288,7 @@ bool Graphics::Hitest(SDL_Surface* surface1, point p1, int col, SDL_Surface* sur
 
 }
 
-void Graphics::drawgravityline( int t, entityclass& obj )
+void Graphics::drawgravityline(int t)
 {
     if (obj.entities[t].life == 0)
     {
@@ -1343,7 +1332,7 @@ void Graphics::drawgravityline( int t, entityclass& obj )
     }
 }
 
-void Graphics::drawtrophytext( entityclass& obj, UtilityClass& help )
+void Graphics::drawtrophytext()
 {
     int temp, temp2, temp3;
 
@@ -1430,7 +1419,7 @@ void Graphics::drawtrophytext( entityclass& obj, UtilityClass& help )
     }
 }
 
-void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help )
+void Graphics::drawentities()
 {
     //Update line colours!
     if (linedelay <= 0)
@@ -1448,7 +1437,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
 
     SDL_Rect drawRect;
 
-	trinketcolset = false;
+    trinketcolset = false;
 
     for (int i = obj.nentity - 1; i >= 0; i--)
     {
@@ -1462,7 +1451,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
                     //
-                    setcol(obj.entities[i].colour, help);
+                    setcol(obj.entities[i].colour);
                     //flipsprites[obj.entities[i].drawframe].colorTransform(sprites_rect, ct);
                     drawRect = sprites_rect;
                     drawRect.x += tpoint.x;
@@ -1514,7 +1503,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
                     //
-                    setcol(obj.entities[i].colour, help);
+                    setcol(obj.entities[i].colour);
                     //sprites[obj.entities[i].drawframe].colorTransform(sprites_rect, ct);
 
                     drawRect = sprites_rect;
@@ -1624,7 +1613,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                 line_rect.y = obj.entities[i].yp;
                 line_rect.w = obj.entities[i].w;
                 line_rect.h = 1;
-                drawgravityline(i, obj);
+                drawgravityline(i);
             }
             else if (obj.entities[i].size == 6)    //Vertical Line
             {
@@ -1632,15 +1621,15 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                 line_rect.y = obj.entities[i].yp;
                 line_rect.w = 1;
                 line_rect.h = obj.entities[i].h;
-                drawgravityline(i, obj);
+                drawgravityline(i);
             }
             else if (obj.entities[i].size == 7)    //Teleporter
             {
-                drawtele(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].drawframe, obj.entities[i].colour, help);
+                drawtele(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].drawframe, obj.entities[i].colour);
             }
             else if (obj.entities[i].size == 8)    // Special: Moving platform, 8 tiles
             {
-				//TODO check this is correct game breaking moving paltform
+                //TODO check this is correct game breaking moving paltform
                 tpoint.x = obj.entities[i].xp;
                 tpoint.y = obj.entities[i].yp;
                 drawRect = sprites_rect;
@@ -1685,7 +1674,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
             {
                 if (flipmode)
                 {
-                    setcol(obj.entities[i].colour, help);
+                    setcol(obj.entities[i].colour);
 
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
@@ -1721,7 +1710,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                 }
                 else
                 {
-                    setcol(obj.entities[i].colour, help);
+                    setcol(obj.entities[i].colour);
 
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
@@ -1760,7 +1749,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
             {
                 if (flipmode)
                 {
-                    setcol(obj.entities[i].colour, help);
+                    setcol(obj.entities[i].colour);
 
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
@@ -1780,7 +1769,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                 }
                 else
                 {
-                    setcol(obj.entities[i].colour, help);
+                    setcol(obj.entities[i].colour);
 
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
@@ -1801,8 +1790,8 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
             }
             else if (obj.entities[i].size == 11)    //The fucking elephant
             {
-				//TODO elephant bug
-                setcol(obj.entities[i].colour, help);
+                //TODO elephant bug
+                setcol(obj.entities[i].colour);
                 drawimagecol(3, obj.entities[i].xp, obj.entities[i].yp);
             }
             else if (obj.entities[i].size == 12)         // Regular sprites that don't wrap
@@ -1812,7 +1801,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                     //forget this for a minute;
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
-                    setcol(obj.entities[i].colour, help);
+                    setcol(obj.entities[i].colour);
                     //
 
                     drawRect = sprites_rect;
@@ -1833,7 +1822,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                         }
 
                         tpoint.y = tpoint.y+4;
-                        setcol(23, help);
+                        setcol(23);
 
                         drawRect = tiles_rect;
                         drawRect.x += tpoint.x;
@@ -1853,7 +1842,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                         }
 
                         tpoint.y = tpoint.y+4;
-                        setcol(23, help);
+                        setcol(23);
                         //
 
                         drawRect = tiles_rect;
@@ -1866,7 +1855,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                 {
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
-                    setcol(obj.entities[i].colour, help);
+                    setcol(obj.entities[i].colour);
                     //
                     drawRect = sprites_rect;
                     drawRect.x += tpoint.x;
@@ -1888,7 +1877,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                         }
 
                         tpoint.y = tpoint.y+4;
-                        setcol(23, help);
+                        setcol(23);
 
 
                         drawRect = tiles_rect;
@@ -1909,7 +1898,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                         }
 
                         tpoint.y = tpoint.y+4;
-                        setcol(23, help);
+                        setcol(23);
                         //
 
                         drawRect = tiles_rect;
@@ -1923,45 +1912,32 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
             {
                  //Special for epilogue: huge hero!
 
-                	if (flipmode) {
+                if (flipmode) {
+                    FillRect(tempBuffer, 0x000000);
 
-
-
-                		//scaleMatrix.scale(6, 6);
-                		//bigbuffer.fillRect(bigbuffer.rect, 0x000000);
-						FillRect(tempBuffer, 0x000000);
-
-                		tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
-                		setcol(obj.entities[i].colour, help);
-                		//flipsprites[obj.entities[i].drawframe].colorTransform(sprites_rect, ct);
-                		//bigbuffer.copyPixels(flipsprites[obj.entities[i].drawframe], sprites_rect, new Point(0, 0));
-						SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), sprites_rect.x, sprites_rect.y   };
-						SDL_Surface* TempSurface = ScaleSurface( flipsprites[obj.entities[i].drawframe], 6* sprites_rect.w,6* sprites_rect.w );
-						BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
-						SDL_FreeSurface(TempSurface);
-                		//scaleMatrix.translate(-obj.entities[i].xp, -obj.entities[i].yp);
-                	}
-					else
-					{
-						//TODO checkthis
-						tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
-						setcol(obj.entities[i].colour, help);
-						//flipsprites[obj.entities[i].drawframe].colorTransform(sprites_rect, ct);
-						//bigbuffer.copyPixels(flipsprites[obj.entities[i].drawframe], sprites_rect, new Point(0, 0));
-						SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
-						SDL_Surface* TempSurface = ScaleSurface( flipsprites[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
-						BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
-						SDL_FreeSurface(TempSurface);
-                	}
-
-
-
+                    tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
+                    setcol(obj.entities[i].colour);
+                    SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), sprites_rect.x, sprites_rect.y   };
+                    SDL_Surface* TempSurface = ScaleSurface( flipsprites[obj.entities[i].drawframe], 6* sprites_rect.w,6* sprites_rect.w );
+                    BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
+                    SDL_FreeSurface(TempSurface);
+                }
+                else
+                {
+                    //TODO checkthis
+                    tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
+                    setcol(obj.entities[i].colour);
+                    SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
+                    SDL_Surface* TempSurface = ScaleSurface( flipsprites[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
+                    BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
+                    SDL_FreeSurface(TempSurface);
+                }
             }
         }
     }
 }
 
-void Graphics::drawbackground( int t, mapclass& map )
+void Graphics::drawbackground(int t)
 {
     int temp = 0;
 
@@ -2366,7 +2342,7 @@ void Graphics::drawbackground( int t, mapclass& map )
     }
 }
 
-void Graphics::drawmap( mapclass& map )
+void Graphics::drawmap()
 {
     ///TODO forground once;
     if (!foregrounddrawn)
@@ -2405,51 +2381,52 @@ void Graphics::drawmap( mapclass& map )
         foregrounddrawn = true;
     }
     OverlaySurfaceKeyed(foregroundBuffer, backBuffer, 0x00000000);
-    //SDL_BlitSurface(foregroundBuffer, NULL, backBuffer, NULL);
-
 }
 
-void Graphics::drawfinalmap(mapclass & map)
+void Graphics::drawfinalmap()
 {
-	//Update colour cycling for final level
-	if (map.final_colormode) {
-		map.final_aniframedelay--;
-		if(map.final_aniframedelay==0)
-		{
-			foregrounddrawn=false;
-		}
-		if (map.final_aniframedelay <= 0) {
-			map.final_aniframedelay = 2;
-			map.final_aniframe++;
-			if (map.final_aniframe >= 4)
-				map.final_aniframe = 0;
-		}
-	}
+    //Update colour cycling for final level
+    if (map.final_colormode)
+    {
+        map.final_aniframedelay--;
+        if (map.final_aniframedelay == 0) foregrounddrawn=false;
+        if (map.final_aniframedelay <= 0)
+    {
+            map.final_aniframedelay = 2;
+            map.final_aniframe++;
+            if (map.final_aniframe >= 4) map.final_aniframe = 0;
+        }
+    }
 
-	if (!foregrounddrawn) {
-		FillRect(foregroundBuffer, 0x00000000);
-		if(map.tileset==0){
-			for (int j = 0; j < 29+map.extrarow; j++) {
-				for (int i = 0; i < 40; i++) {
-					if((map.contents[i + map.vmult[j]])>0)
-						drawforetile(i * 8, j * 8, map.finalat(i,j));
-				}
-			}
-		}else if (map.tileset == 1) {
-			for (int j = 0; j < 29+map.extrarow; j++) {
-				for (int i = 0; i < 40; i++) {
-					if((map.contents[i + map.vmult[j]])>0)
-						drawforetile2(i * 8, j * 8, map.finalat(i,j));
-				}
-			}
-		}
-		foregrounddrawn=true;
-	}
+    if (!foregrounddrawn) {
+        FillRect(foregroundBuffer, 0x00000000);
+        if (map.tileset == 0)
+        {
+            for (int j = 0; j < 29+map.extrarow; j++)
+            {
+                for (int i = 0; i < 40; i++)
+                {
+                    if ((map.contents[i + map.vmult[j]])>0) drawforetile(i * 8, j * 8, map.finalat(i,j));
+                }
+            }
+        }
+        else if (map.tileset == 1)
+        {
+            for (int j = 0; j < 29+map.extrarow; j++)
+            {
+                for (int i = 0; i < 40; i++)
+                {
+                    if ((map.contents[i + map.vmult[j]])>0) drawforetile2(i * 8, j * 8, map.finalat(i,j));
+                }
+            }
+        }
+        foregrounddrawn=true;
+    }
 
-	OverlaySurfaceKeyed(foregroundBuffer, backBuffer, 0x00000000);
+    OverlaySurfaceKeyed(foregroundBuffer, backBuffer, 0x00000000);
 }
 
-void Graphics::drawtowermap( mapclass& map )
+void Graphics::drawtowermap()
 {
     int temp;
     for (int j = 0; j < 30; j++)
@@ -2462,7 +2439,7 @@ void Graphics::drawtowermap( mapclass& map )
     }
 }
 
-void Graphics::drawtowermap_nobackground( mapclass& map )
+void Graphics::drawtowermap_nobackground()
 {
     int temp;
     for (j = 0; j < 30; j++)
@@ -2475,7 +2452,7 @@ void Graphics::drawtowermap_nobackground( mapclass& map )
     }
 }
 
-void Graphics::drawtowerentities( mapclass& map, entityclass& obj, UtilityClass& help )
+void Graphics::drawtowerentities()
 {
     //Update line colours!
     if (linedelay <= 0)
@@ -2497,10 +2474,10 @@ void Graphics::drawtowerentities( mapclass& map, entityclass& obj, UtilityClass&
         {
             if (obj.entities[i].size == 0)        // Sprites
             {
-				trinketcolset = false;
+                trinketcolset = false;
                 tpoint.x = obj.entities[i].xp;
                 tpoint.y = obj.entities[i].yp-map.ypos;
-                setcol(obj.entities[i].colour, help);
+                setcol(obj.entities[i].colour);
                 setRect(trect, tpoint.x, tpoint.y, sprites_rect.w, sprites_rect.h);
                 BlitSurfaceColoured(sprites[obj.entities[i].drawframe], NULL, backBuffer, &trect, ct);
                 //screenwrapping!
@@ -2573,7 +2550,7 @@ void Graphics::drawtowerentities( mapclass& map, entityclass& obj, UtilityClass&
                 line_rect.y = obj.entities[i].yp-map.ypos;
                 line_rect.w = obj.entities[i].w;
                 line_rect.h = 1;
-                drawgravityline(i, obj);
+                drawgravityline(i);
             }
             else if (obj.entities[i].size == 6)    //Vertical Line
             {
@@ -2581,13 +2558,13 @@ void Graphics::drawtowerentities( mapclass& map, entityclass& obj, UtilityClass&
                 line_rect.y = obj.entities[i].yp-map.ypos;
                 line_rect.w = 1;
                 line_rect.h = obj.entities[i].h;
-                drawgravityline(i, obj);
+                drawgravityline(i);
             }
         }
     }
 }
 
-void Graphics::drawtowerspikes( mapclass& map )
+void Graphics::drawtowerspikes()
 {
     for (int i = 0; i < 40; i++)
     {
@@ -2596,7 +2573,7 @@ void Graphics::drawtowerspikes( mapclass& map )
     }
 }
 
-void Graphics::drawtowerbackgroundsolo( mapclass& map )
+void Graphics::drawtowerbackgroundsolo()
 {
     if (map.bypos < 0)
     {
@@ -2633,9 +2610,8 @@ void Graphics::drawtowerbackgroundsolo( mapclass& map )
     }
 }
 
-void Graphics::drawtowerbackground( mapclass& map )
+void Graphics::drawtowerbackground()
 {
-    //TODO
     int temp;
 
     if (map.bypos < 0) map.bypos += 120 * 8;
@@ -2676,7 +2652,7 @@ void Graphics::drawtowerbackground( mapclass& map )
     }
 }
 
-void Graphics::setcol( int t, UtilityClass& help )
+void Graphics::setcol(int t)
 {
 	int temp;
 
@@ -2880,10 +2856,6 @@ void Graphics::setcol( int t, UtilityClass& help )
 
 void Graphics::menuoffrender()
 {
-	//TODO
-	//screenbuffer.lock();
-	//screenbuffer.copyPixels(menubuffer, menubuffer.rect, tl, null, null, false);
-	//screenbuffer->UpdateScreen(menubuffer,NULL);
 	SDL_Rect offsetRect1;
 	setRect (offsetRect1, 0, 0, backBuffer->w ,backBuffer->h);
 
@@ -2919,14 +2891,10 @@ void Graphics::menuoffrender()
 		BlitSurfaceStandard(menubuffer,NULL,backBuffer,&offsetRect);
 	}
 
-	//screenbuffer.unlock();
 	SDL_Rect rect;
 	setRect(rect, 0, 0, backBuffer->w, backBuffer->h);
 	screenbuffer->UpdateScreen(backBuffer,&rect);
-	//backbuffer.lock();
-	//backbuffer.fillRect(backbuffer.rect, 0x000000);
 	FillRect(backBuffer, 0x000000);
-	//backbuffer.unlock();
 }
 
 void Graphics::drawhuetile( int x, int y, int t, int c )
@@ -3023,15 +2991,8 @@ void Graphics::flashlight()
 void Graphics::screenshake()
 {
 	point tpoint;
-	//screenbuffer.lock();
 	if(flipmode)
 	{
-		//	tpoint.x = int((Math.random() * 7) - 4); tpoint.y = int((Math.random() * 7) - 4);
-		//	flipmatrix.translate(tpoint.x, tpoint.y);
-		//	screenbuffer.draw(backbuffer, flipmatrix);
-		//	flipmatrix.translate(-tpoint.x, -tpoint.y);
-
-		screenbuffer->ClearScreen(0x000);
 		tpoint.x =  (fRandom() * 7) - 4;
 		tpoint.y =  (fRandom() * 7) - 4;
 		SDL_Rect shakeRect;
@@ -3042,24 +3003,14 @@ void Graphics::screenshake()
 	}
 	else
 	{
-		//FillRect(screenbuffer, 0x000);
-		//SDL_Rect rect;
-		//setRect(rect, blackBars/2, 0, screenbuffer->w, screenbuffer->h);
-		//SDL_BlitSurface(backBuffer, NULL, screenbuffer, &rect);
-		screenbuffer->ClearScreen(0x000);
 		tpoint.x =  static_cast<Sint32>((fRandom() * 7) - 4);
 		tpoint.y =  static_cast<Sint32>((fRandom() * 7) - 4);
 		SDL_Rect shakeRect;
 		setRect(shakeRect,tpoint.x, tpoint.y, backBuffer->w, backBuffer->h);
 		screenbuffer->UpdateScreen( backBuffer, &shakeRect);
-		// screenbuffer.copyPixels(backbuffer, backbuffer.rect, tpoint, null, null, false);
 	}
-	//screenbuffer.unlock();
 
-	//backbuffer.lock();
 	FillRect(backBuffer, 0x000000 );
-	//backbuffer.fillRect(backbuffer.rect, 0x000000);
-	//backbuffer.unlock();
 }
 
 void Graphics::render()
@@ -3145,7 +3096,7 @@ void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool
 	}
 }
 
-void Graphics::drawtele(int x, int y, int t, int c, UtilityClass& help)
+void Graphics::drawtele(int x, int y, int t, int c)
 {
 	setcolreal(getRGB(16,16,16));
 
@@ -3153,7 +3104,7 @@ void Graphics::drawtele(int x, int y, int t, int c, UtilityClass& help)
 	setRect(telerect, x , y, tele_rect.w, tele_rect.h );
 	BlitSurfaceColoured(tele[0], NULL, backBuffer, &telerect, ct);
 
-	setcol(c, help);
+	setcol(c);
 	if (t > 9) t = 8;
 	if (t < 0) t = 0;
 
@@ -3196,13 +3147,6 @@ Uint32 Graphics::RGBf(int r, int g, int b)
 void Graphics::setcolreal(Uint32 t)
 {
 	ct.colour = t;
-}
-
-void Graphics::drawtile(int x, int y, int t)
-{
-	SDL_Rect drawRect;
-	setRect(drawRect,x,y, tiles_rect.w, tiles_rect.h  );
-	BlitSurfaceStandard(tiles[t] ,NULL, backBuffer,&drawRect);
 }
 
 void Graphics::drawforetile(int x, int y, int t)

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -36,7 +36,7 @@ public:
 
 	void drawhuetile(int x, int y, int t, int c);
 
-	void drawgravityline(int t, entityclass& obj);
+	void drawgravityline(int t);
 
 	void MakeTileArray();
 
@@ -46,8 +46,8 @@ public:
 
 	void drawcoloredtile(int x, int y, int t, int r, int g, int b);
 
-	void drawmenu(Game& game, int cr, int cg, int cb, int division = 30);
-	void drawlevelmenu(Game& game, int cr, int cg, int cb, int division = 30);
+	void drawmenu(int cr, int cg, int cb, int division = 30);
+	void drawlevelmenu(int cr, int cg, int cb, int division = 30);
 
 	void processfade();
 
@@ -88,7 +88,7 @@ public:
 	void drawpixeltextbox(int x, int y, int w, int h, int w2, int h2, int r, int g, int b, int xo, int yo);
 	void drawcustompixeltextbox(int x, int y, int w, int h, int w2, int h2, int r, int g, int b, int xo, int yo);
 
-	void drawcrewman(int x, int y, int t, bool act, UtilityClass& help, bool noshift =false);
+	void drawcrewman(int x, int y, int t, bool act, bool noshift =false);
 
 	int crewcolour(const int t);
 
@@ -100,7 +100,7 @@ public:
 
 	void drawimagecol(int t, int xp, int yp, int r, int g, int b, bool cent= false);
 
-	void drawgui(UtilityClass& help);
+	void drawgui();
 
 	void drawsprite(int x, int y, int t, int r, int g, int b);
 
@@ -126,7 +126,7 @@ public:
 
 	int len(std::string t);
 	void bigprint( int _x, int _y, std::string _s, int r, int g, int b, bool cen = false, int sc = 2 );
-	void drawspritesetcol(int x, int y, int t, int c, UtilityClass& help);
+	void drawspritesetcol(int x, int y, int t, int c);
 
 
 	void flashlight();
@@ -134,16 +134,16 @@ public:
 
 	void render();
 
-	bool Hitest(SDL_Surface* surface1, point p1, int col, SDL_Surface* surface2, point p2, int col2);
+	bool Hitest(SDL_Surface* surface1, point p1, SDL_Surface* surface2, point p2);
 
-	void drawentities(mapclass& map, entityclass& obj, UtilityClass& help);
+	void drawentities();
 
-	void drawtrophytext(entityclass&, UtilityClass& help);
+	void drawtrophytext();
 
 	void bigrprint(int x, int y, std::string& t, int r, int g, int b, bool cen = false, float sc = 2);
 
 
-	void drawtele(int x, int y, int t, int c, UtilityClass& help);
+	void drawtele(int x, int y, int t, int c);
 
 	Uint32 getRGBA(Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
@@ -160,17 +160,15 @@ public:
 
 	void setcolreal(Uint32 t);
 
-	void drawbackground(int t, mapclass& map);
-	void drawtile3( int x, int y, int t, int off );
+	void drawbackground(int t);
+	void drawtile3(int x, int y, int t, int off);
 	void drawentcolours( int x, int y, int t);
-	void drawtile2( int x, int y, int t, int r, int g, int b );
-	void drawtile( int x, int y, int t, int r, int g, int b );
-	void drawtowertile( int x, int y, int t );
-	void drawtowertile3( int x, int y, int t, int off );
-
+	void drawtile2(int x, int y, int t);
 	void drawtile(int x, int y, int t);
+	void drawtowertile(int x, int y, int t);
+	void drawtowertile3(int x, int y, int t, int off);
 
-	void drawmap(mapclass& map);
+	void drawmap();
 
 	void drawforetile(int x, int y, int t);
 
@@ -180,25 +178,25 @@ public:
 
 	void drawrect(int x, int y, int w, int h, int r, int g, int b);
 
-	void drawtowermap(mapclass& map);
+	void drawtowermap();
 
-	void drawtowermap_nobackground(mapclass& map);
+	void drawtowermap_nobackground();
 
-	void drawtowerspikes(mapclass& map);
+	void drawtowerspikes();
 
-	void drawtowerentities(mapclass& map, entityclass& obj, UtilityClass& help);
+	void drawtowerentities();
 
 	bool onscreen(int t);
 
-	void drawtowerbackgroundsolo(mapclass& map);
+	void drawtowerbackgroundsolo();
 
 
 	void menuoffrender();
 
-	void drawtowerbackground(mapclass& map);
+	void drawtowerbackground();
 
-	void setcol(int t, UtilityClass& help);
-	void drawfinalmap(mapclass & map);
+	void setcol(int t);
+	void drawfinalmap();
 
 	colourTransform ct;
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -9,111 +9,108 @@
 
 extern scriptclass script;
 
-// Found in titlerender.cpp
-void updategraphicsmode(Game& game, Graphics& dwgfx);
-
-void updatebuttonmappings(Game& game, KeyPoll& key, musicclass& music, int bind)
+void updatebuttonmappings(int bind)
 {
-	for (
-		SDL_GameControllerButton i = SDL_CONTROLLER_BUTTON_A;
-		i < SDL_CONTROLLER_BUTTON_DPAD_UP;
-		i = (SDL_GameControllerButton) (i + 1)
-	) {
-		if (key.isDown(i))
-		{
-			bool dupe = false;
-			if (bind == 1)
-			{
-				for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
-				{
-					if (i == game.controllerButton_flip[j])
-					{
-						dupe = true;
-					}
-				}
-				if (!dupe)
-				{
-					game.controllerButton_flip.push_back(i);
-					music.playef(11, 10);
-				}
-				for (size_t j = 0; j < game.controllerButton_map.size(); j += 1)
-				{
-					if (i == game.controllerButton_map[j])
-					{
-						game.controllerButton_map.erase(game.controllerButton_map.begin() + j);
-					}
-				}
-				for (size_t j = 0; j < game.controllerButton_esc.size(); j += 1)
-				{
-					if (i == game.controllerButton_esc[j])
-					{
-						game.controllerButton_esc.erase(game.controllerButton_esc.begin() + j);
-					}
-				}
-			}
-			if (bind == 2)
-			{
-				for (size_t j = 0; j < game.controllerButton_map.size(); j += 1)
-				{
-					if (i == game.controllerButton_map[j])
-					{
-						dupe = true;
-					}
-				}
-				if (!dupe)
-				{
-					game.controllerButton_map.push_back(i);
-					music.playef(11, 10);
-				}
-				for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
-				{
-					if (i == game.controllerButton_flip[j])
-					{
-						game.controllerButton_flip.erase(game.controllerButton_flip.begin() + j);
-					}
-				}
-				for (size_t j = 0; j < game.controllerButton_esc.size(); j += 1)
-				{
-					if (i == game.controllerButton_esc[j])
-					{
-						game.controllerButton_esc.erase(game.controllerButton_esc.begin() + j);
-					}
-				}
-			}
-			if (bind == 3)
-			{
-				for (size_t j = 0; j < game.controllerButton_esc.size(); j += 1)
-				{
-					if (i == game.controllerButton_esc[j])
-					{
-						dupe = true;
-					}
-				}
-				if (!dupe)
-				{
-					game.controllerButton_esc.push_back(i);
-					music.playef(11, 10);
-				}
-				for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
-				{
-					if (i == game.controllerButton_flip[j])
-					{
-						game.controllerButton_flip.erase(game.controllerButton_flip.begin() + j);
-					}
-				}
-				for (size_t j = 0; j < game.controllerButton_map.size(); j += 1)
-				{
-					if (i == game.controllerButton_map[j])
-					{
-						game.controllerButton_map.erase(game.controllerButton_map.begin() + j);
-					}
-				}
-			}
-		}
-	}
+    for (
+        SDL_GameControllerButton i = SDL_CONTROLLER_BUTTON_A;
+        i < SDL_CONTROLLER_BUTTON_DPAD_UP;
+        i = (SDL_GameControllerButton) (i + 1)
+    ) {
+        if (key.isDown(i))
+        {
+            bool dupe = false;
+            if (bind == 1)
+            {
+                for (size_t j = 0; j < game.controllerButton_flip.size(); j++)
+                {
+                    if (i == game.controllerButton_flip[j])
+                    {
+                        dupe = true;
+                    }
+                }
+                if (!dupe)
+                {
+                    game.controllerButton_flip.push_back(i);
+                    music.playef(11, 10);
+                }
+                for (size_t j = 0; j < game.controllerButton_map.size(); j++)
+                {
+                    if (i == game.controllerButton_map[j])
+                    {
+                        game.controllerButton_map.erase(game.controllerButton_map.begin() + j);
+                    }
+                }
+                for (size_t j = 0; j < game.controllerButton_esc.size(); j++)
+                {
+                    if (i == game.controllerButton_esc[j])
+                    {
+                        game.controllerButton_esc.erase(game.controllerButton_esc.begin() + j);
+                    }
+                }
+            }
+            if (bind == 2)
+            {
+                for (size_t j = 0; j < game.controllerButton_map.size(); j++)
+                {
+                    if (i == game.controllerButton_map[j])
+                    {
+                        dupe = true;
+                    }
+                }
+                if (!dupe)
+                {
+                    game.controllerButton_map.push_back(i);
+                    music.playef(11, 10);
+                }
+                for (size_t j = 0; j < game.controllerButton_flip.size(); j++)
+                {
+                    if (i == game.controllerButton_flip[j])
+                    {
+                        game.controllerButton_flip.erase(game.controllerButton_flip.begin() + j);
+                    }
+                }
+                for (size_t j = 0; j < game.controllerButton_esc.size(); j++)
+                {
+                    if (i == game.controllerButton_esc[j])
+                    {
+                        game.controllerButton_esc.erase(game.controllerButton_esc.begin() + j);
+                    }
+                }
+            }
+            if (bind == 3)
+            {
+                for (size_t j = 0; j < game.controllerButton_esc.size(); j++)
+                {
+                    if (i == game.controllerButton_esc[j])
+                    {
+                        dupe = true;
+                    }
+                }
+                if (!dupe)
+                {
+                    game.controllerButton_esc.push_back(i);
+                    music.playef(11, 10);
+                }
+                for (size_t j = 0; j < game.controllerButton_flip.size(); j++)
+                {
+                    if (i == game.controllerButton_flip[j])
+                    {
+                        game.controllerButton_flip.erase(game.controllerButton_flip.begin() + j);
+                    }
+                }
+                for (size_t j = 0; j < game.controllerButton_map.size(); j++)
+                {
+                    if (i == game.controllerButton_map[j])
+                    {
+                        game.controllerButton_map.erase(game.controllerButton_map.begin() + j);
+                    }
+                }
+            }
+        }
+    }
 }
 
-void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, UtilityClass& help, musicclass& music)
+void titleinput()
 {
     //game.mx = (mouseX / 4);
     //game.my = (mouseY / 4);
@@ -126,9 +123,9 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
     game.press_action = false;
     game.press_map = false;
 
-    if (dwgfx.flipmode)
+    if (graphics.flipmode)
     {
-		//GAMEPAD TODO
+        //GAMEPAD TODO
         if (key.isDown(KEYBOARD_LEFT) || key.isDown(KEYBOARD_DOWN) || key.isDown(KEYBOARD_a) ||  key.isDown(KEYBOARD_s) || key.controllerWantsRight(true)) game.press_left = true;
         if (key.isDown(KEYBOARD_RIGHT) || key.isDown(KEYBOARD_UP)  || key.isDown(KEYBOARD_d) ||  key.isDown(KEYBOARD_w) || key.controllerWantsLeft(true)) game.press_right = true;
     }
@@ -141,7 +138,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
         if (key.isDown(KEYBOARD_RIGHT) || key.isDown(KEYBOARD_DOWN)  || key.isDown(KEYBOARD_d) ||  key.isDown(KEYBOARD_s) || key.controllerWantsRight(true))
         {
             game.press_right = true;
-		}
+        }
     }
     if (key.isDown(KEYBOARD_z) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v) || key.isDown(game.controllerButton_flip)) game.press_action = true;
     //|| key.isDown(KEYBOARD_UP) || key.isDown(KEYBOARD_DOWN)) game.press_action = true; //on menus, up and down don't work as action
@@ -151,48 +148,12 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
     if (!game.press_action && !game.press_left && !game.press_right) game.jumpheld = false;
     if (!game.press_map) game.mapheld = false;
 
-    if (!game.jumpheld && dwgfx.fademode==0)
+    if (!game.jumpheld && graphics.fademode==0)
     {
         if (game.press_action || game.press_left || game.press_right || game.press_map)
         {
             game.jumpheld = true;
         }
-
-        /*
-        if (game.press_left) {
-        game.mainmenu--;
-        }else if (game.press_right) {
-        game.mainmenu++;
-        }
-
-        if (game.mainmenu < 0) game.mainmenu = 2;
-        if (game.mainmenu > 2 ) game.mainmenu = 0;
-        */
-
-
-        /*
-        if (game.press_action) {
-        if (!game.menustart) {
-        game.menustart = true;
-        music.play(6);
-        music.playef(18, 10);
-        game.screenshake = 10;
-        game.flashlight = 5;
-        }else{
-        if(game.mainmenu==0){
-        dwgfx.fademode = 2;
-        }else if (game.mainmenu == 1) {
-        if (game.telesummary != "") {
-        dwgfx.fademode = 2;
-        }
-        }else if (game.mainmenu == 2) {
-        if (game.quicksummary != "") {
-        dwgfx.fademode = 2;
-        }
-        }
-        }
-        }
-        */
 
         if (key.isDown(27) && game.currentmenuname != "youwannaquit" && game.menustart)
         {
@@ -233,9 +194,9 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
             {
                 if (game.currentmenuname == "mainmenu")
                 {
-								
-            #if defined(MAKEANDPLAY)
-				   if (game.currentmenuoption == 0)
+
+#if defined(MAKEANDPLAY)
+                    if (game.currentmenuoption == 0)
                     {
                       //Bring you to the normal playmenu
                         music.playef(11, 10);
@@ -255,14 +216,14 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                         music.playef(11, 10);
                         game.createmenu("options");
 
-												//Add extra menu for mmmmmm mod
-												if(music.mmmmmm){
-													game.menuoptions[3] = "soundtrack";
-													game.menuoptionsactive[3] = true;
-													game.menuoptions[4] = "return";
-													game.menuoptionsactive[4] = true;
-													game.nummenuoptions = 5;
-												}
+                    //Add extra menu for mmmmmm mod
+                    if(music.mmmmmm){
+                        game.menuoptions[3] = "soundtrack";
+                        game.menuoptionsactive[3] = true;
+                        game.menuoptions[4] = "return";
+                        game.menuoptionsactive[4] = true;
+                        game.nummenuoptions = 5;
+                    }
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 3)
@@ -270,11 +231,11 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                         //bye!
                         music.playef(2, 10);
                         game.mainmenu = 100;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                 }
-            #elif !defined(MAKEANDPLAY)
-                #if defined(NO_CUSTOM_LEVELS)
+#elif !defined(MAKEANDPLAY)
+  #if defined(NO_CUSTOM_LEVELS)
                     if (game.currentmenuoption == 0)
                     {
                         //Play
@@ -282,7 +243,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                         {
                             //No saves exist, just start a new game
                             game.mainmenu = 0;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else
                         {
@@ -327,7 +288,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                         //bye!
                         music.playef(2, 10);
                         game.mainmenu = 100;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                 #else
                     if (game.currentmenuoption == 0)
@@ -337,7 +298,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                         {
                             //No saves exist, just start a new game
                             game.mainmenu = 0;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else
                         {
@@ -389,7 +350,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                         //bye!
                         music.playef(2, 10);
                         game.mainmenu = 100;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
             #endif
                 }
@@ -425,7 +386,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                     TiXmlDocument doc;
 	                  if (!FILESYSTEM_loadTiXmlDocument(name.c_str(), &doc)){
 	                    game.mainmenu = 22;
-                      dwgfx.fademode = 2;
+                      graphics.fademode = 2;
 	                  }else{
                       game.createmenu("quickloadlevel");
                       map.nexttowercolour();
@@ -437,10 +398,10 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                 {
                   if(game.currentmenuoption==0){//continue save
                     game.mainmenu = 23;
-                    dwgfx.fademode = 2;
+                    graphics.fademode = 2;
                   }else if(game.currentmenuoption==1){
 	                  game.mainmenu = 22;
-                    dwgfx.fademode = 2;
+                    graphics.fademode = 2;
                   }else if(game.currentmenuoption==2){
                     music.playef(11, 10);
                     game.levelpage=0;
@@ -464,7 +425,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                     //LEVEL EDITOR HOOK
                     music.playef(11, 10);
                     game.mainmenu = 20;
-                    dwgfx.fademode = 2;
+                    graphics.fademode = 2;
                     ed.filename="";
                   }/*else if(game.currentmenuoption==2){
                     music.playef(11, 10);
@@ -508,26 +469,23 @@ SDL_assert(0 && "Remove open level dir");
                 {
                   if (game.currentmenuoption == 0){
                     music.playef(11, 10);
-                    dwgfx.screenbuffer->toggleFullScreen();
+                    graphics.screenbuffer->toggleFullScreen();
                     game.fullscreen = !game.fullscreen;
-                    updategraphicsmode(game, dwgfx);
-                    game.savestats(map, dwgfx);
+                    game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 0;
                   }else if (game.currentmenuoption == 1){
                     music.playef(11, 10);
-                    dwgfx.screenbuffer->toggleStretchMode();
+                    graphics.screenbuffer->toggleStretchMode();
                     game.stretchMode = (game.stretchMode + 1) % 3;
-                    updategraphicsmode(game, dwgfx);
-                    game.savestats(map, dwgfx);
+                    game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 1;
                   }else if (game.currentmenuoption == 2){
                     music.playef(11, 10);
-                    dwgfx.screenbuffer->toggleLinearFilter();
+                    graphics.screenbuffer->toggleLinearFilter();
                     game.useLinearFilter = !game.useLinearFilter;
-                    updategraphicsmode(game, dwgfx);
-                    game.savestats(map, dwgfx);
+                    game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 2;
                   }else if (game.currentmenuoption == 3){
@@ -535,21 +493,20 @@ SDL_assert(0 && "Remove open level dir");
                       music.playef(11, 10);
                       game.fullScreenEffect_badSignal = !game.fullScreenEffect_badSignal;
                       //Hook the analogue thing in here: ABCDEFG
-                      updategraphicsmode(game, dwgfx);
-					  dwgfx.screenbuffer->badSignalEffect= !dwgfx.screenbuffer->badSignalEffect;
-                      game.savestats(map, dwgfx);
+                      graphics.screenbuffer->badSignalEffect= !graphics.screenbuffer->badSignalEffect;
+                      game.savestats();
                       game.createmenu("graphicoptions");
                       game.currentmenuoption = 3;
                   }else if (game.currentmenuoption == 4) {
                       //toggle mouse cursor
                       music.playef(11, 10);
-                      if (dwgfx.showmousecursor == true) {
+                      if (graphics.showmousecursor == true) {
                           SDL_ShowCursor(SDL_DISABLE);
-                          dwgfx.showmousecursor = false;
+                          graphics.showmousecursor = false;
                       }
                       else {
                           SDL_ShowCursor(SDL_ENABLE);
-                          dwgfx.showmousecursor = true;
+                          graphics.showmousecursor = true;
                       }
                   }
                   else
@@ -559,122 +516,6 @@ SDL_assert(0 && "Remove open level dir");
                       game.createmenu("mainmenu");
                       map.nexttowercolour();
                   }
-
-                  /* //Old stuff
-                    if (game.advanced_mode)
-                    {
-                        if (game.currentmenuoption == 0)
-                        {
-                            //toggle fullscreen
-                            dwgfx.screenbuffer->toggleFullScreen();
-                            music.playef(11, 10);
-                            if (game.fullscreen)
-                            {
-                                game.fullscreen = false;
-                            }
-                            else
-                            {
-                                game.fullscreen = true;
-                            }
-                            updategraphicsmode(game, dwgfx);
-                            game.savestats(map, dwgfx);
-                            game.createmenu("graphicoptions");
-                        }
-                        else if (game.currentmenuoption == 1)
-                        {
-                            //enable acceleration: if in fullscreen, go back to window first
-                            music.playef(11, 10);
-                            game.advanced_mode = false;
-                            if (game.fullscreen)
-                            {
-                                game.fullscreen = false;
-                                updategraphicsmode(game, dwgfx);
-                                game.fullscreen = true;
-                            }
-                            updategraphicsmode(game, dwgfx);
-
-                            game.savestats(map, dwgfx);
-                            game.createmenu("graphicoptions");
-                            game.currentmenuoption = 1;
-                        }
-                        else if (game.currentmenuoption == 2)
-                        {
-                            //change scaling mode
-                            music.playef(11, 10);
-                            game.advanced_scaling = (game.advanced_scaling + 1) % 5;
-                            dwgfx.screenbuffer->ResizeScreen(320 *game.advanced_scaling,240*game.advanced_scaling );
-                            dwgfx.screenbuffer->SetScale(game.advanced_scaling);
-                            updategraphicsmode(game, dwgfx);
-
-                            game.savestats(map, dwgfx);
-                            game.createmenu("graphicoptions");
-                            game.currentmenuoption = 2;
-                        }
-                        else if (game.currentmenuoption == 3)
-                        {
-                            //change smoothing
-                            music.playef(11, 10);
-                            game.advanced_smoothing = !game.advanced_smoothing;
-                            updategraphicsmode(game, dwgfx);
-
-                            game.savestats(map, dwgfx);
-                            game.createmenu("graphicoptions");
-                            game.currentmenuoption = 3;
-                        }
-                        else
-                        {
-                            //back
-                            music.playef(11, 10);
-                            game.createmenu("mainmenu");
-                            map.nexttowercolour();
-                        }
-                    }
-                    else
-                    {
-                        if (game.currentmenuoption == 0)
-                        {
-                            dwgfx.screenbuffer->toggleFullScreen();
-                            //toggle fullscreen
-                            music.playef(11, 10);
-                            if (game.fullscreen)
-                            {
-                                game.fullscreen = false;
-                            }
-                            else
-                            {
-                                game.fullscreen = true;
-                            }
-                            updategraphicsmode(game, dwgfx);
-
-                            game.savestats(map, dwgfx);
-                            game.createmenu("graphicoptions");
-                        }
-                        else if (game.currentmenuoption == 1)
-                        {
-                            //disable acceleration: if in fullscreen, go back to window first
-                            music.playef(11, 10);
-                            game.advanced_mode = true;
-                            if (game.fullscreen)
-                            {
-                                game.fullscreen = false;
-                                updategraphicsmode(game, dwgfx);
-                                game.fullscreen = true;
-                            }
-                            updategraphicsmode(game, dwgfx);
-
-                            game.savestats(map, dwgfx);
-                            game.createmenu("graphicoptions");
-                            game.currentmenuoption = 1;
-                        }
-                        else
-                        {
-                            //back
-                            music.playef(11, 10);
-                            game.createmenu("mainmenu");
-                            map.nexttowercolour();
-                        }
-                    }
-                    */
                 }
                 else if (game.currentmenuname == "youwannaquit")
                 {
@@ -683,7 +524,7 @@ SDL_assert(0 && "Remove open level dir");
                         //bye!
                         music.playef(2, 10);
                         game.mainmenu = 100;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else
                     {
@@ -707,7 +548,7 @@ SDL_assert(0 && "Remove open level dir");
                         map.invincibility = !map.invincibility;
                         //game.deletequick();
                         //game.deletetele();
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         music.playef(11, 10);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 3;
@@ -741,7 +582,7 @@ SDL_assert(0 && "Remove open level dir");
                         //back
                         game.gameframerate=34;
                         game.slowdown = 30;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         music.playef(11, 10);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 4;
@@ -751,7 +592,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.gameframerate=41;
                         game.slowdown = 24;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         music.playef(11, 10);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 4;
@@ -761,7 +602,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.gameframerate=55;
                         game.slowdown = 18;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         music.playef(11, 10);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 4;
@@ -771,7 +612,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.gameframerate=83;
                         game.slowdown = 12;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         music.playef(11, 10);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 4;
@@ -784,7 +625,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         //disable animated backgrounds
                         game.colourblindmode = !game.colourblindmode;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         map.tdrawback = true;
                         music.playef(11, 10);
                     }
@@ -792,7 +633,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         //disable screeneffects
                         game.noflashingmode = !game.noflashingmode;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         if (!game.noflashingmode)
                         {
                             music.playef(18, 10);
@@ -805,8 +646,8 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 2)
                     {
                         //disable text outline
-                        dwgfx.notextoutline = !dwgfx.notextoutline;
-                        game.savestats(map, dwgfx);
+                        graphics.notextoutline = !graphics.notextoutline;
+                        game.savestats();
                         music.playef(11, 10);
                     }
                     else if (game.currentmenuoption == 3)
@@ -839,7 +680,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 6)
                     {
                         // toggle translucent roomname BG
-                        dwgfx.translucentroomname = !dwgfx.translucentroomname;
+                        graphics.translucentroomname = !graphics.translucentroomname;
                         music.playef(11, 10);
                     }
                     else if (game.currentmenuoption == 7)
@@ -848,22 +689,22 @@ SDL_assert(0 && "Remove open level dir");
                         music.playef(11, 10);
                         game.createmenu("options");
 
-												//Add extra menu for mmmmmm mod
-												if(music.mmmmmm){
-													#if defined(MAKEANDPLAY)
-														game.menuoptions[3] = "soundtrack";
-														game.menuoptionsactive[3] = true;
-														game.menuoptions[4] = "return";
-														game.menuoptionsactive[4] = true;
-														game.nummenuoptions = 5;
-													#elif !defined(MAKEANDPLAY)
-														game.menuoptions[4] = "soundtrack";
-														game.menuoptionsactive[4] = true;
-														game.menuoptions[5] = "return";
-														game.menuoptionsactive[5] = true;
-														game.nummenuoptions = 6;
-													#endif
-												}
+                        //Add extra menu for mmmmmm mod
+                        if(music.mmmmmm){
+#if defined(MAKEANDPLAY)
+                            game.menuoptions[3] = "soundtrack";
+                            game.menuoptionsactive[3] = true;
+                            game.menuoptions[4] = "return";
+                            game.menuoptionsactive[4] = true;
+                            game.nummenuoptions = 5;
+#elif !defined(MAKEANDPLAY)
+                            game.menuoptions[4] = "soundtrack";
+                            game.menuoptionsactive[4] = true;
+                            game.menuoptions[5] = "return";
+                            game.menuoptionsactive[5] = true;
+                            game.nummenuoptions = 6;
+#endif
+}
 
                         map.nexttowercolour();
                     }
@@ -875,23 +716,22 @@ SDL_assert(0 && "Remove open level dir");
                 }
                 else if (game.currentmenuname == "options")
                 {
-								
-				#if defined(MAKEANDPLAY)
-				if (game.currentmenuoption == 0)
+#if defined(MAKEANDPLAY)
+                    if (game.currentmenuoption == 0)
                     {
                         //accessibility options
                         music.playef(11, 10);
                         game.createmenu("accessibility");
                         map.nexttowercolour();
                     }
-                   
-					else if (game.currentmenuoption == 1)
-					{
-						//clear data menu
-						music.playef(11, 10);
-						game.createmenu("controller");
-						map.nexttowercolour();
-					}
+
+                    else if (game.currentmenuoption == 1)
+                    {
+                        //clear data menu
+                        music.playef(11, 10);
+                        game.createmenu("controller");
+                        map.nexttowercolour();
+                    }
                     else if (game.currentmenuoption == 2)
                     {
                         //clear data menu
@@ -900,40 +740,39 @@ SDL_assert(0 && "Remove open level dir");
                         map.nexttowercolour();
                     }
 
-										if(music.mmmmmm){
-											if (game.currentmenuoption == 3)
-											{
-													//**** TOGGLE MMMMMM
-													if(game.usingmmmmmm > 0){
-														game.usingmmmmmm=0;
-													}else{
-														game.usingmmmmmm=1;
-													}
-													music.usingmmmmmm = !music.usingmmmmmm;
-													music.playef(11, 10);
-													music.play(6);
-													game.savestats(map, dwgfx);
-													game.createmenu("mainmenu");
-													map.nexttowercolour();
-											}
-											if (game.currentmenuoption == 4)
-											{
-													//back
-													music.playef(11, 10);
-													game.createmenu("mainmenu");
-													map.nexttowercolour();
-											}
-										}else{
-											if (game.currentmenuoption == 3)
-											{
-													//back
-													music.playef(11, 10);
-													game.createmenu("mainmenu");
-													map.nexttowercolour();
-											}
-										}
-                    
-				#elif !defined(MAKEANDPLAY)
+                    if(music.mmmmmm){
+                        if (game.currentmenuoption == 3)
+                        {
+                            //**** TOGGLE MMMMMM
+                            if(game.usingmmmmmm > 0){
+                                game.usingmmmmmm=0;
+                            }else{
+                                game.usingmmmmmm=1;
+                            }
+                            music.usingmmmmmm = !music.usingmmmmmm;
+                            music.playef(11, 10);
+                            music.play(6);
+                            game.savestats();
+                            game.createmenu("mainmenu");
+                            map.nexttowercolour();
+                        }
+                        if (game.currentmenuoption == 4)
+                        {
+                            //back
+                            music.playef(11, 10);
+                            game.createmenu("mainmenu");
+                            map.nexttowercolour();
+                        }
+                    }else{
+                        if (game.currentmenuoption == 3)
+                        {
+                            //back
+                            music.playef(11, 10);
+                            game.createmenu("mainmenu");
+                            map.nexttowercolour();
+                        }
+                    }
+#elif !defined(MAKEANDPLAY)
                     if (game.currentmenuoption == 0)
                     {
                         //accessibility options
@@ -948,13 +787,13 @@ SDL_assert(0 && "Remove open level dir");
                         game.createmenu("unlockmenu");
                         map.nexttowercolour();
                     }
-					else if (game.currentmenuoption == 2)
-					{
-						//clear data menu
-						music.playef(11, 10);
-						game.createmenu("controller");
-						map.nexttowercolour();
-					}
+                    else if (game.currentmenuoption == 2)
+                    {
+                        //clear data menu
+                        music.playef(11, 10);
+                        game.createmenu("controller");
+                        map.nexttowercolour();
+                    }
                     else if (game.currentmenuoption == 3)
                     {
                         //clear data menu
@@ -962,40 +801,40 @@ SDL_assert(0 && "Remove open level dir");
                         game.createmenu("cleardatamenu");
                         map.nexttowercolour();
                     }
-                    
-										if(music.mmmmmm){
-											if (game.currentmenuoption == 4)
-											{
-													//**** TOGGLE MMMMMM
-													if(game.usingmmmmmm > 0){
-														game.usingmmmmmm=0;
-													}else{
-														game.usingmmmmmm=1;
-													}
-													music.usingmmmmmm = !music.usingmmmmmm;
-													music.playef(11, 10);
-													music.play(6);
-													game.savestats(map, dwgfx);
-													game.createmenu("mainmenu");
-													map.nexttowercolour();
-											}
-											if (game.currentmenuoption == 5)
-											{
-													//back
-													music.playef(11, 10);
-													game.createmenu("mainmenu");
-													map.nexttowercolour();
-											}
-										}else{
-											if (game.currentmenuoption == 4)
-											{
-													//back
-													music.playef(11, 10);
-													game.createmenu("mainmenu");
-													map.nexttowercolour();
-											}
-										}
-										#endif
+
+                    if(music.mmmmmm){
+                        if (game.currentmenuoption == 4)
+                        {
+                            //**** TOGGLE MMMMMM
+                            if(game.usingmmmmmm > 0){
+                                game.usingmmmmmm=0;
+                            }else{
+                                game.usingmmmmmm=1;
+                            }
+                            music.usingmmmmmm = !music.usingmmmmmm;
+                            music.playef(11, 10);
+                            music.play(6);
+                            game.savestats();
+                            game.createmenu("mainmenu");
+                            map.nexttowercolour();
+                        }
+                        if (game.currentmenuoption == 5)
+                        {
+                            //back
+                            music.playef(11, 10);
+                            game.createmenu("mainmenu");
+                            map.nexttowercolour();
+                        }
+                    }else{
+                        if (game.currentmenuoption == 4)
+                        {
+                            //back
+                            music.playef(11, 10);
+                            game.createmenu("mainmenu");
+                            map.nexttowercolour();
+                        }
+                    }
+#endif
                 }
                 else if (game.currentmenuname == "unlockmenutrials")
                 {
@@ -1004,7 +843,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.unlock[9] = true;
                         game.unlocknotify[9] = true;
                         music.playef(11, 10);
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 0;
                     }
@@ -1013,7 +852,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.unlock[10] = true;
                         game.unlocknotify[10] = true;
                         music.playef(11, 10);
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 1;
                     }
@@ -1022,7 +861,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.unlock[11] = true;
                         game.unlocknotify[11] = true;
                         music.playef(11, 10);
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 2;
                     }
@@ -1031,7 +870,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.unlock[12] = true;
                         game.unlocknotify[12] = true;
                         music.playef(11, 10);
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 3;
                     }
@@ -1040,7 +879,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.unlock[13] = true;
                         game.unlocknotify[13] = true;
                         music.playef(11, 10);
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 4;
                     }
@@ -1049,7 +888,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.unlock[14] = true;
                         game.unlocknotify[14] = true;
                         music.playef(11, 10);
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 5;
                     }
@@ -1078,7 +917,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.unlocknotify[16] = true;
                         game.unlock[6] = true;
                         game.unlock[7] = true;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenu");
                         game.currentmenuoption = 1;
                     }
@@ -1088,7 +927,7 @@ SDL_assert(0 && "Remove open level dir");
                         music.playef(11, 10);
                         game.unlock[17] = true;
                         game.unlocknotify[17] = true;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenu");
                         game.currentmenuoption = 2;
                     }
@@ -1098,7 +937,7 @@ SDL_assert(0 && "Remove open level dir");
                         music.playef(11, 10);
                         game.unlock[18] = true;
                         game.unlocknotify[18] = true;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenu");
                         game.currentmenuoption = 3;
                     }
@@ -1107,7 +946,7 @@ SDL_assert(0 && "Remove open level dir");
                         //unlock jukebox
                         music.playef(11, 10);
                         game.stat_trinkets = 20;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenu");
                         game.currentmenuoption = 4;
                     }
@@ -1117,7 +956,7 @@ SDL_assert(0 && "Remove open level dir");
                         music.playef(11, 10);
                         game.unlock[8] = true;
                         game.unlocknotify[8] = true;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenu");
                         game.currentmenuoption = 5;
                     }
@@ -1301,19 +1140,19 @@ SDL_assert(0 && "Remove open level dir");
                         {
                             //You at least have a quicksave, or you couldn't have gotten here
                             game.mainmenu = 2;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else if (game.quicksummary == "")
                         {
                             //You at least have a telesave, or you couldn't have gotten here
                             game.mainmenu = 1;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else
                         {
                             //go to a menu!
                             music.playef(11, 10);
-                            game.loadsummary(map, help); //Prepare save slots to display
+                            game.loadsummary(); //Prepare save slots to display
                             game.createmenu("continue");
                             map.settowercolour(3);
                         }
@@ -1351,32 +1190,32 @@ SDL_assert(0 && "Remove open level dir");
                         {
                             //You at least have a quicksave, or you couldn't have gotten here
                             game.mainmenu = 2;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else if (game.quicksummary == "")
                         {
                             //You at least have a telesave, or you couldn't have gotten here
                             game.mainmenu = 1;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else
                         {
                             //go to a menu!
                             music.playef(11, 10);
-                            game.loadsummary(map, help); //Prepare save slots to display
+                            game.loadsummary(); //Prepare save slots to display
                             game.createmenu("continue");
                             map.settowercolour(3);
                         }
                     }
                     else if (game.currentmenuoption == 1)
                     {
-										  if(!map.invincibility){
-                        game.mainmenu = 11;
-                        dwgfx.fademode = 2;
-											}else{
+                        if(!map.invincibility){
+                            game.mainmenu = 11;
+                            graphics.fademode = 2;
+                        }else{
                         //Can't do yet! play sad sound
                         music.playef(2, 10);
-											}
+                        }
                     }
                     else if (game.currentmenuoption == 2)
                     {
@@ -1406,7 +1245,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         //yep
                         game.mainmenu = 0;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                         game.deletequick();
                         game.deletetele();
                     }
@@ -1419,41 +1258,41 @@ SDL_assert(0 && "Remove open level dir");
                     }
                 }
 
-				else if (game.currentmenuname == "controller")
-				{
-					if (game.currentmenuoption == 0)
-					{
-						game.controllerSensitivity++;
-						music.playef(11, 10);
-						if(game.controllerSensitivity > 4)
-						{
-							game.controllerSensitivity = 0;
-						}
-					}
+                else if (game.currentmenuname == "controller")
+                {
+                    if (game.currentmenuoption == 0)
+                    {
+                        game.controllerSensitivity++;
+                        music.playef(11, 10);
+                        if(game.controllerSensitivity > 4)
+                        {
+                            game.controllerSensitivity = 0;
+                        }
+                    }
 
-					if (game.currentmenuoption == 4)
-					{
-						music.playef(11, 10);
-						game.createmenu("options");
+                    if (game.currentmenuoption == 4)
+                    {
+                        music.playef(11, 10);
+                        game.createmenu("options");
 
-						//Add extra menu for mmmmmm mod
-						if(music.mmmmmm){
-							#if defined(MAKEANDPLAY)
-								game.menuoptions[3] = "soundtrack";
-								game.menuoptionsactive[3] = true;
-								game.menuoptions[4] = "return";
-								game.menuoptionsactive[4] = true;
-								game.nummenuoptions = 5;
-							#elif !defined(MAKEANDPLAY)
-								game.menuoptions[4] = "soundtrack";
-								game.menuoptionsactive[4] = true;
-								game.menuoptions[5] = "return";
-								game.menuoptionsactive[5] = true;
-								game.nummenuoptions = 6;
-							#endif
-						}
-					}
-				}
+                        //Add extra menu for mmmmmm mod
+                        if(music.mmmmmm){
+#if defined(MAKEANDPLAY)
+                            game.menuoptions[3] = "soundtrack";
+                            game.menuoptionsactive[3] = true;
+                            game.menuoptions[4] = "return";
+                            game.menuoptionsactive[4] = true;
+                            game.nummenuoptions = 5;
+#elif !defined(MAKEANDPLAY)
+                            game.menuoptions[4] = "soundtrack";
+                            game.menuoptionsactive[4] = true;
+                            game.menuoptions[5] = "return";
+                            game.menuoptionsactive[5] = true;
+                            game.nummenuoptions = 6;
+#endif
+                        }
+                    }
+                }
                 else if (game.currentmenuname == "cleardatamenu")
                 {
                     if (game.currentmenuoption == 0)
@@ -1462,22 +1301,22 @@ SDL_assert(0 && "Remove open level dir");
                         music.playef(11, 10);
                         game.createmenu("options");
 
-												//Add extra menu for mmmmmm mod
-												if(music.mmmmmm){
-													#if defined(MAKEANDPLAY)
-														game.menuoptions[3] = "soundtrack";
-														game.menuoptionsactive[3] = true;
-														game.menuoptions[4] = "return";
-														game.menuoptionsactive[4] = true;
-														game.nummenuoptions = 5;
-													#elif !defined(MAKEANDPLAY)
-														game.menuoptions[4] = "soundtrack";
-														game.menuoptionsactive[4] = true;
-														game.menuoptions[5] = "return";
-														game.menuoptionsactive[5] = true;
-														game.nummenuoptions = 6;
-													#endif
-												}
+                        //Add extra menu for mmmmmm mod
+                        if(music.mmmmmm){
+#if defined(MAKEANDPLAY)
+                            game.menuoptions[3] = "soundtrack";
+                            game.menuoptionsactive[3] = true;
+                            game.menuoptions[4] = "return";
+                            game.menuoptionsactive[4] = true;
+                            game.nummenuoptions = 5;
+#elif !defined(MAKEANDPLAY)
+                            game.menuoptions[4] = "soundtrack";
+                            game.menuoptionsactive[4] = true;
+                            game.menuoptions[5] = "return";
+                            game.menuoptionsactive[5] = true;
+                            game.nummenuoptions = 6;
+#endif
+                        }
                         map.nexttowercolour();
                     }
                     else
@@ -1486,7 +1325,7 @@ SDL_assert(0 && "Remove open level dir");
                         music.playef(23, 10);
                         game.deletequick();
                         game.deletetele();
-                        game.deletestats(map, dwgfx);
+                        game.deletestats();
                         game.flashlight = 5;
                         game.screenshake = 15;
                         game.createmenu("mainmenu");
@@ -1519,7 +1358,7 @@ SDL_assert(0 && "Remove open level dir");
                         music.playef(18, 10);
                         game.screenshake = 10;
                         game.flashlight = 5;
-                        dwgfx.setflipmode = !dwgfx.setflipmode;
+                        graphics.setflipmode = !graphics.setflipmode;
                         game.savemystats = true;
                     }
                     else if (game.currentmenuoption == 4)
@@ -1540,12 +1379,12 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)   //start no death mode, disabling cutscenes
                     {
                         game.mainmenu = 10;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 1)
                     {
                         game.mainmenu = 9;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 2)
                     {
@@ -1560,12 +1399,12 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         game.mainmenu = 1;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 1)
                     {
                         game.mainmenu = 2;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 2)
                     {
@@ -1604,22 +1443,22 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         game.mainmenu = 12;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 1)
                     {
                         game.mainmenu = 13;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 2)
                     {
                         game.mainmenu = 14;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 3)
                     {
                         game.mainmenu = 15;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 4)
                     {
@@ -1634,22 +1473,22 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         game.mainmenu = 16;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 1)
                     {
                         game.mainmenu = 17;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 2)
                     {
                         game.mainmenu = 18;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 3)
                     {
                         game.mainmenu = 19;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 4)
                     {
@@ -1687,32 +1526,32 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0 && game.unlock[9])   //space station 1
                     {
                         game.mainmenu = 3;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 1 && game.unlock[10])    //lab
                     {
                         game.mainmenu = 4;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 2 && game.unlock[11])    //tower
                     {
                         game.mainmenu = 5;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 3 && game.unlock[12])    //station 2
                     {
                         game.mainmenu = 6;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 4 && game.unlock[13])    //warp
                     {
                         game.mainmenu = 7;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 5 && game.unlock[14])    //final
                     {
                         game.mainmenu = 8;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 6)    //go to the time trial menu
                     {
@@ -1743,32 +1582,32 @@ SDL_assert(0 && "Remove open level dir");
                         if (game.timetriallevel == 0)   //space station 1
                         {
                             game.mainmenu = 3;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else if (game.timetriallevel == 1)    //lab
                         {
                             game.mainmenu = 4;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else if (game.timetriallevel == 2)    //tower
                         {
                             game.mainmenu = 5;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else if (game.timetriallevel == 3)    //station 2
                         {
                             game.mainmenu = 6;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else if (game.timetriallevel == 4)    //warp
                         {
                             game.mainmenu = 7;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else if (game.timetriallevel == 5)    //final
                         {
                             game.mainmenu = 8;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                     }
                 }
@@ -1789,17 +1628,18 @@ SDL_assert(0 && "Remove open level dir");
                 game.currentmenuoption < 4 &&
                 key.controllerButtonDown()      )
         {
-            updatebuttonmappings(game, key, music, game.currentmenuoption);
+            updatebuttonmappings(game.currentmenuoption);
         }
 
     }
 
-    if (dwgfx.fademode == 1)
-        script.startgamemode(game.mainmenu, key, dwgfx, game, map, obj, help, music);
+    if (graphics.fademode == 1)
+    {
+        script.startgamemode(game.mainmenu);
+    }
 }
 
-void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-               entityclass& obj, UtilityClass& help, musicclass& music)
+void gameinput()
 {
     //TODO mouse input
     //game.mx = (mouseX / 2);
@@ -1922,41 +1762,11 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 
     if (!game.press_map) game.mapheld = false;
 
-    /*
-    if (key.isDown("1".charCodeAt(0))) {
-    dwgfx.screen.width = 640;
-    dwgfx.screen.height = 480;
-    setstage(640,480);
-    }
-    if (key.isDown("2".charCodeAt(0))) {
-    dwgfx.screen.width = 960;
-    dwgfx.screen.height = 720;
-    setstage(960,720);
-    }
-    if (key.isDown("3".charCodeAt(0))) {
-    dwgfx.screen.width = 1280;
-    dwgfx.screen.height = 960;
-    setstage(1280,960);
-    }
-    */
-    /*game.test = true;
-    game.teststring = String(game.inertia);
-    if (key.isDown("1".charCodeAt(0))) game.inertia = 0.5;
-    if (key.isDown("2".charCodeAt(0))) game.inertia = 0.6;
-    if (key.isDown("3".charCodeAt(0))) game.inertia = 0.7;
-    if (key.isDown("4".charCodeAt(0))) game.inertia = 0.8;
-    if (key.isDown("5".charCodeAt(0))) game.inertia = 0.9;
-    if (key.isDown("6".charCodeAt(0))) game.inertia = 1;
-    if (key.isDown("7".charCodeAt(0))) game.inertia = 1.1;
-    if (key.isDown("8".charCodeAt(0))) game.inertia = 1.2;
-    if (key.isDown("9".charCodeAt(0))) game.inertia = 1.3;
-    if (key.isDown("0".charCodeAt(0))) game.inertia = 1.4;*/
-
-    if (game.intimetrial && dwgfx.fademode == 1 && game.quickrestartkludge)
+    if (game.intimetrial && graphics.fademode == 1 && game.quickrestartkludge)
     {
         //restart the time trial
         game.quickrestartkludge = false;
-        script.startgamemode(game.timetriallevel + 3, key, dwgfx, game, map, obj, help, music);
+        script.startgamemode(game.timetriallevel + 3);
         game.deathseq = -1;
         game.completestop = false;
     }
@@ -1976,14 +1786,14 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         }else{
           game.gamestate = EDITORMODE;
 
-          dwgfx.textboxremove();
+          graphics.textboxremove();
           game.hascontrol = true;
           game.advancetext = false;
           game.completestop = false;
           game.state = 0;
-			    dwgfx.showcutscenebars = false;
+          graphics.showcutscenebars = false;
 
-          dwgfx.backgrounddrawn=false;
+          graphics.backgrounddrawn=false;
           music.fadeout();
           //If warpdir() is used during playtesting, we need to set it back after!
           for (int j = 0; j < ed.maxheight; j++)
@@ -2003,26 +1813,8 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
     {
         if (obj.entities[ie].rule == 0)
         {
-            //game.test = true;
-            //game.teststring = "player(" + String(int(obj.entities[i])) + "," + String(int(obj.entities[i].yp)) + ")"
-            //  + ", mouse(" + String(int(game.mx)) + "," + String(int(game.my)) + ")";
             if (game.hascontrol && game.deathseq == -1 && game.lifeseq <= 5)
             {
-                /*
-                if (key.isDown(8)) {
-                script.load("returntohub");
-                }
-                */
-                /*
-                if (key.isDown(27)) {
-                game.state = 0;
-                dwgfx.textboxremove();
-
-                map.tdrawback = true;
-                music.haltdasmusik();
-                game.gamestate = TITLEMODE;
-                }
-                */
 
                 if (game.press_map && !game.mapheld)
                 {
@@ -2030,7 +1822,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 
                     if (game.activetele && game.readytotele > 20 && !game.intimetrial)
                     {
-                        if(!dwgfx.flipmode)
+                        if(!graphics.flipmode)
                         {
                             obj.flags[73] = 1; //Flip mode test
                         }
@@ -2060,30 +1852,26 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
                             {
                                 //Alright, normal teleporting
                                 game.gamestate = 5;
-                                dwgfx.menuoffset = 240; //actually this should count the roomname
-                                if (map.extrarow) dwgfx.menuoffset -= 10;
-                                //dwgfx.menubuffer.copyPixels(dwgfx.screenbuffer, dwgfx.screenbuffer.rect, dwgfx.tl, null, null, false);
+                                graphics.menuoffset = 240; //actually this should count the roomname
+                                if (map.extrarow) graphics.menuoffset -= 10;
 
-                                //TODO TESTHIS
-                                //dwgfx.screenbuffer->UpdateScreen(dwgfx.menubuffer, NULL);
-								BlitSurfaceStandard(dwgfx.menubuffer,NULL,dwgfx.backBuffer, NULL);
+                                BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
 
-                                dwgfx.resumegamemode = false;
+                                graphics.resumegamemode = false;
 
                                 game.useteleporter = true;
-                                game.initteleportermode(map);
+                                game.initteleportermode();
                             }
                             else
                             {
-                                //trace(game.recordstring);
                                 //We're teleporting! Yey!
                                 game.activetele = false;
                                 game.hascontrol = false;
-                                music.fadeout(); //Uncomment this when it's working!
+                                music.fadeout();
 
                                 int player = obj.getplayer();
                                 obj.entities[player].colour = 102;
-                                int companion = obj.getcompanion(game.companion);
+                                int companion = obj.getcompanion();
                                 if(companion>-1) obj.entities[companion].colour = 102;
 
                                 int teleporter = obj.getteleporter();
@@ -2110,38 +1898,35 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
                         //Quit menu, same conditions as in game menu
                         game.gamestate = MAPMODE;
                         game.gamesaved = false;
-                        dwgfx.resumegamemode = false;
+                        graphics.resumegamemode = false;
                         game.menupage = 20; // The Map Page
-                        //dwgfx.menubuffer.copyPixels(dwgfx.screenbuffer, dwgfx.screenbuffer.rect, dwgfx.tl, null, null, false);
-                        //dwgfx.screenbuffer->UpdateScreen(dwgfx.menubuffer, NULL);
-														BlitSurfaceStandard(dwgfx.menubuffer,NULL,dwgfx.backBuffer, NULL);
-                        dwgfx.menuoffset = 240; //actually this should count the roomname
-                        if (map.extrarow) dwgfx.menuoffset -= 10;
+                        BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
+                        graphics.menuoffset = 240; //actually this should count the roomname
+                        if (map.extrarow) graphics.menuoffset -= 10;
                     }
-                    else if (game.intimetrial && dwgfx.fademode==0)
+                    else if (game.intimetrial && graphics.fademode==0)
                     {
                         //Quick restart of time trial
-                        script.hardreset(key, dwgfx, game, map, obj, help, music);
-                        if (dwgfx.setflipmode) dwgfx.flipmode = true;
-                        dwgfx.fademode = 2;
+                        script.hardreset();
+                        if (graphics.setflipmode) graphics.flipmode = true;
+                        graphics.fademode = 2;
                         game.completestop = true;
                         music.fadeout();
                         game.intimetrial = true;
                         game.quickrestartkludge = true;
                     }
-                    else if (dwgfx.fademode==0)
+                    else if (graphics.fademode==0)
                     {
                         //Normal map screen, do transition later
                         game.gamestate = MAPMODE;
                         map.cursordelay = 0;
                         map.cursorstate = 0;
                         game.gamesaved = false;
-                        dwgfx.resumegamemode = false;
+                        graphics.resumegamemode = false;
                         game.menupage = 0; // The Map Page
-														BlitSurfaceStandard(dwgfx.menubuffer,NULL,dwgfx.backBuffer, NULL);
-                        //dwgfx.screenbuffer->UpdateScreen(dwgfx.menubuffer, NULL);
-                        dwgfx.menuoffset = 240; //actually this should count the roomname
-                        if (map.extrarow) dwgfx.menuoffset -= 10;
+                        BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
+                        graphics.menuoffset = 240; //actually this should count the roomname
+                        if (map.extrarow) graphics.menuoffset -= 10;
                     }
                 }
 
@@ -2151,20 +1936,17 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
                     //Quit menu, same conditions as in game menu
                     game.gamestate = MAPMODE;
                     game.gamesaved = false;
-                    dwgfx.resumegamemode = false;
+                    graphics.resumegamemode = false;
                     game.menupage = 10; // The Map Page
 
-                    //dwgfx.menubuffer.copyPixels(dwgfx.screenbuffer, dwgfx.screenbuffer.rect, dwgfx.tl, NULL, NULL, false);
-
-                    //dwgfx.screenbuffer->UpdateScreen(dwgfx.menubuffer, NULL);
-													BlitSurfaceStandard(dwgfx.menubuffer,NULL,dwgfx.backBuffer, NULL);
-                    dwgfx.menuoffset = 240; //actually this should count the roomname
-                    if (map.extrarow) dwgfx.menuoffset -= 10;
+                    BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
+                    graphics.menuoffset = 240; //actually this should count the roomname
+                    if (map.extrarow) graphics.menuoffset -= 10;
                 }
 
                 if (key.keymap[SDLK_r] && game.deathseq<=0)// && map.custommode) //Have fun glitchrunners!
                 {
-                	game.deathseq = 30;
+                    game.deathseq = 30;
                 }
 
                 if (game.press_left)
@@ -2267,8 +2049,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
     }
 }
 
-void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-              entityclass& obj, UtilityClass& help, musicclass& music)
+void mapinput()
 {
     //TODO Mouse Input!
     //game.mx = (mouseX / 2);
@@ -2279,9 +2060,9 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
     game.press_action = false;
     game.press_map = false;
 
-    if(dwgfx.menuoffset==0)
+    if(graphics.menuoffset==0)
     {
-        if (dwgfx.flipmode)
+        if (graphics.flipmode)
         {
             if (key.isDown(KEYBOARD_LEFT) || key.isDown(KEYBOARD_DOWN) || key.isDown(KEYBOARD_a) ||  key.isDown(KEYBOARD_s) || key.controllerWantsLeft(false) ) game.press_left = true;
             if (key.isDown(KEYBOARD_RIGHT) || key.isDown(KEYBOARD_UP) || key.isDown(KEYBOARD_d) ||  key.isDown(KEYBOARD_w) || key.controllerWantsRight(false)) game.press_right = true;
@@ -2336,14 +2117,14 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         if(game.press_map && game.menupage < 10)
         {
             //Normal map screen, do transition later
-            dwgfx.resumegamemode = true;
+            graphics.resumegamemode = true;
         }
     }
 
-    if (dwgfx.fademode == 1)
+    if (graphics.fademode == 1)
     {
-        FillRect(dwgfx.menubuffer, 0x000000);
-        dwgfx.resumegamemode = true;
+        FillRect(graphics.menubuffer, 0x000000);
+        graphics.resumegamemode = true;
         obj.removeallblocks();
         game.menukludge = false;
         if (game.menupage >= 20)
@@ -2377,7 +2158,7 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         if (game.menupage == 1 && obj.flags[67] == 1 && game.press_action && !game.insecretlab && !map.custommode)
         {
             //Warp back to the ship
-            dwgfx.resumegamemode = true;
+            graphics.resumegamemode = true;
 
             game.teleport_to_x = 2;
             game.teleport_to_y = 11;
@@ -2403,41 +2184,41 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
             music.playef(18, 10);
             game.gamesaved = true;
 
-            game.savetime = game.timestring(help);
+            game.savetime = game.timestring();
             game.savearea = map.currentarea(map.area(game.roomx, game.roomy));
             game.savetrinkets = game.trinkets;
 
             if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111) game.savearea = "The Ship";
 
-        #if !defined(NO_CUSTOM_LEVELS)
+#if !defined(NO_CUSTOM_LEVELS)
             if(map.custommodeforreal)
             {
-              game.customsavequick(ed.ListOfMetaData[game.playcustomlevel].filename, map, obj, music);
+              game.customsavequick(ed.ListOfMetaData[game.playcustomlevel].filename);
             }
             else
-        #endif
+#endif
             {
-              game.savequick(map, obj, music);
+              game.savequick();
             }
         }
 
         if (game.menupage == 10 && game.press_action)
         {
             //return to game
-            dwgfx.resumegamemode = true;
+            graphics.resumegamemode = true;
         }
         if (game.menupage == 11 && game.press_action)
         {
             //quit to menu
-            if (dwgfx.fademode == 0)
+            if (graphics.fademode == 0)
             {
-				//Kill contents of offset render buffer, since we do that for some reason.
-				//This fixes an apparent frame flicker.
-				FillRect(dwgfx.tempBuffer, 0x000000);
+                //Kill contents of offset render buffer, since we do that for some reason.
+                //This fixes an apparent frame flicker.
+                FillRect(graphics.tempBuffer, 0x000000);
                 if (game.intimetrial || game.insecretlab || game.nodeathmode) game.menukludge = true;
-                script.hardreset(key, dwgfx, game, map, obj, help, music);
-                if(dwgfx.setflipmode) dwgfx.flipmode = true;
-                dwgfx.fademode = 2;
+                script.hardreset();
+                if(graphics.setflipmode) graphics.flipmode = true;
+                graphics.fademode = 2;
                 music.fadeout();
                 map.nexttowercolour();
             }
@@ -2446,15 +2227,15 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         if (game.menupage == 20 && game.press_action)
         {
             //return to game
-            dwgfx.resumegamemode = true;
+            graphics.resumegamemode = true;
         }
         if (game.menupage == 21 && game.press_action)
         {
             //quit to menu
-            if (dwgfx.fademode == 0)
+            if (graphics.fademode == 0)
             {
                 game.swnmode = false;
-                dwgfx.fademode = 2;
+                graphics.fademode = 2;
                 music.fadeout();
             }
         }
@@ -2471,8 +2252,7 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
     }
 }
 
-void teleporterinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                     entityclass& obj, UtilityClass& help, musicclass& music)
+void teleporterinput()
 {
     //Todo Mouseinput!
     //game.mx = (mouseX / 2);
@@ -2485,7 +2265,7 @@ void teleporterinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
     game.press_action = false;
     game.press_map = false;
 
-    if(dwgfx.menuoffset==0)
+    if(graphics.menuoffset==0)
     {
         if (key.isDown(KEYBOARD_LEFT)|| key.isDown(KEYBOARD_a) || key.controllerWantsLeft(false) ) game.press_left = true;
         if (key.isDown(KEYBOARD_RIGHT) || key.isDown(KEYBOARD_d)|| key.controllerWantsRight(false) ) game.press_right = true;
@@ -2546,12 +2326,12 @@ void teleporterinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
             if (game.roomx == tempx + 100 && game.roomy == tempy + 100)
             {
                 //cancel!
-                dwgfx.resumegamemode = true;
+                graphics.resumegamemode = true;
             }
             else
             {
                 //teleport
-                dwgfx.resumegamemode = true;
+                graphics.resumegamemode = true;
                 game.teleport_to_x = tempx;
                 game.teleport_to_y = tempy;
 
@@ -2574,8 +2354,7 @@ void teleporterinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
     }
 }
 
-void gamecompleteinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                       entityclass& obj, UtilityClass& help, musicclass& music)
+void gamecompleteinput()
 {
     //game.mx = (mouseX / 2);
     //game.my = (mouseY / 2);
@@ -2590,9 +2369,9 @@ void gamecompleteinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         game.creditposition -= 6;
         if (game.creditposition <= -game.creditmaxposition)
         {
-            if(dwgfx.fademode==0)
+            if(graphics.fademode==0)
             {
-                dwgfx.fademode = 2;
+                graphics.fademode = 2;
             }
             game.creditposition = -game.creditmaxposition;
         }
@@ -2611,16 +2390,15 @@ void gamecompleteinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         if(game.press_map)
         {
             //Return to game
-            if(dwgfx.fademode==0)
+            if(graphics.fademode==0)
             {
-                dwgfx.fademode = 2;
+                graphics.fademode = 2;
             }
         }
     }
 }
 
-void gamecompleteinput2(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                        entityclass& obj, UtilityClass& help, musicclass& music)
+void gamecompleteinput2()
 {
     //TODO Mouse Input!
     //game.mx = (mouseX / 2);
@@ -2638,9 +2416,9 @@ void gamecompleteinput2(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map
         game.creditposx++;
         if (game.creditposy >= 30)
         {
-            if(dwgfx.fademode==0)
+            if(graphics.fademode==0)
             {
-                dwgfx.fademode = 2;
+                graphics.fademode = 2;
                 music.fadeout();
             }
         }
@@ -2654,9 +2432,9 @@ void gamecompleteinput2(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map
         if(game.press_map)
         {
             //Return to game
-            if(dwgfx.fademode==0)
+            if(graphics.fademode==0)
             {
-                dwgfx.fademode = 2;
+                graphics.fademode = 2;
                 music.fadeout();
             }
         }

--- a/desktop_version/src/Input.h
+++ b/desktop_version/src/Input.h
@@ -9,22 +9,16 @@
 #include "Music.h"
 #include "Map.h"
 
-void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game,
-                entityclass& obj, UtilityClass& help, musicclass& music);
+void titleinput();
 
-void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-               entityclass& obj, UtilityClass& help, musicclass& music);
+void gameinput();
 
-void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-              entityclass& obj, UtilityClass& help, musicclass& music);
+void mapinput();
 
-void teleporterinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                     entityclass& obj, UtilityClass& help, musicclass& music);
+void teleporterinput();
 
-void gamecompleteinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                       entityclass& obj, UtilityClass& help, musicclass& music);
+void gamecompleteinput();
 
-void gamecompleteinput2(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                        entityclass& obj, UtilityClass& help, musicclass& music);
+void gamecompleteinput2();
 
 #endif /* INPUT_H */

--- a/desktop_version/src/Labclass.cpp
+++ b/desktop_version/src/Labclass.cpp
@@ -2,7 +2,7 @@
 
 #include "MakeAndPlay.h"
 
-std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entityclass& obj)
+std::vector<std::string> labclass::loadlevel(int rx, int ry)
 {
 	int t;
 
@@ -23,7 +23,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 	std::vector<std::string> tmap;
 	coin = 0;
 	rcol = 0;
-	roomname = "Untitled room ["+UtilityClass::String(rx) + "," + UtilityClass::String(ry)+"]";
+	roomname = "Untitled room ["+help.String(rx) + "," + help.String(ry)+"]";
 
 	switch(t)
 	{
@@ -61,7 +61,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("283,283,324,364,364,364,364,364,364,364,364,364,364,364,364,364,364,364,364,364,364,364,364,364,325,283,405,0,0,0,0,0,0,403,283,283,283,283,283,283");
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,405,0,0,0,0,0,0,403,283,283,283,283,283,283");
 
-		obj.createentity(game, 232, 24, 10, 0, 250500);  // (savepoint)
+		obj.createentity(232, 24, 10, 0, 250500);  // (savepoint)
 
 		if(game.intimetrial)
 		{
@@ -104,7 +104,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("280,280,280,280,280,280,280,280,280,280,280,280,280,321,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,322,280");
 		tmap.push_back("280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280");
 
-		obj.createentity(game, 112, 180, 11, 192);  // (horizontal gravity line)
+		obj.createentity(112, 180, 11, 192);  // (horizontal gravity line)
 		rcol = 0;
 
 		roomname = "It's Perfectly Safe";
@@ -142,8 +142,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,414,0,0,0,0,0,0,0,412,292,292,292,292");
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,414,0,0,0,0,0,0,0,412,292,292,292,292");
 
-		obj.createentity(game, 96, 124, 11, 120);  // (horizontal gravity line)
-		obj.createentity(game, 248, 48, 10, 0, 251490);  // (savepoint)
+		obj.createentity(96, 124, 11, 120);  // (horizontal gravity line)
+		obj.createentity(248, 48, 10, 0, 251490);  // (savepoint)
 		rcol = 4;
 
 		roomname = "Rascasse";
@@ -181,11 +181,11 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("286,286,286,286,286,286,286,327,367,367,367,367,367,367,367,367,328,286,286,327,367,367,367,367,367,367,367,367,328,286,286,286,286,286,286,286,286,286,286,286");
 		tmap.push_back("286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 
-		obj.createentity(game, 248, 136, 10, 1, 252490);  // (savepoint)
-		obj.createentity(game, 16, 68, 11, 64);  // (horizontal gravity line)
-		obj.createentity(game, 112, 68, 11, 64);  // (horizontal gravity line)
-		obj.createentity(game, 64, 164, 11, 64);  // (horizontal gravity line)
-		obj.createentity(game, 160, 164, 11, 64);  // (horizontal gravity line)
+		obj.createentity(248, 136, 10, 1, 252490);  // (savepoint)
+		obj.createentity(16, 68, 11, 64);  // (horizontal gravity line)
+		obj.createentity(112, 68, 11, 64);  // (horizontal gravity line)
+		obj.createentity(64, 164, 11, 64);  // (horizontal gravity line)
+		obj.createentity(160, 164, 11, 64);  // (horizontal gravity line)
 		rcol = 2;
 
 		roomname = "Keep Going";
@@ -223,10 +223,10 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("289,411,0,0,0,0,0,0,0,0,0,409,289,289,289,289,289,289,330,370,370,370,370,370,331,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289");
 		tmap.push_back("289,411,0,0,0,0,0,0,0,0,0,409,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289");
 
-		obj.createentity(game, 280, 136, 10, 1, 252480);  // (savepoint)
-		obj.createentity(game, 48, 52, 11, 104);  // (horizontal gravity line)
-		obj.createentity(game, 192, 52, 11, 104);  // (horizontal gravity line)
-		obj.createentity(game, 152, 196, 11, 40);  // (horizontal gravity line)
+		obj.createentity(280, 136, 10, 1, 252480);  // (savepoint)
+		obj.createentity(48, 52, 11, 104);  // (horizontal gravity line)
+		obj.createentity(192, 52, 11, 104);  // (horizontal gravity line)
+		obj.createentity(152, 196, 11, 40);  // (horizontal gravity line)
 		rcol=3;
 
 		roomname = "Single-slit Experiment";
@@ -265,9 +265,9 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295");
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295");
 
-		obj.createentity(game, 32, 128, 10, 1, 253480);  // (savepoint)
-		obj.createentity(game, 187, 88, 12, 56);  // (vertical gravity line)
-		obj.createentity(game, 107, 88, 12, 56);  // (vertical gravity line)
+		obj.createentity(32, 128, 10, 1, 253480);  // (savepoint)
+		obj.createentity(187, 88, 12, 56);  // (vertical gravity line)
+		obj.createentity(107, 88, 12, 56);  // (vertical gravity line)
 		rcol = 5;
 
 		roomname = "Don't Flip Out";
@@ -305,12 +305,12 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 
-		obj.createentity(game, 43, 88, 12, 56);  // (vertical gravity line)
-		obj.createentity(game, 123, 88, 12, 56);  // (vertical gravity line)
-		obj.createentity(game, 203, 88, 12, 56);  // (vertical gravity line)
-		obj.createentity(game, 283, 88, 12, 56);  // (vertical gravity line)
+		obj.createentity(43, 88, 12, 56);  // (vertical gravity line)
+		obj.createentity(123, 88, 12, 56);  // (vertical gravity line)
+		obj.createentity(203, 88, 12, 56);  // (vertical gravity line)
+		obj.createentity(283, 88, 12, 56);  // (vertical gravity line)
 
-		obj.createentity(game, 156, 128, 20, 1);  // (terminal)
+		obj.createentity(156, 128, 20, 1);  // (terminal)
 		obj.createblock(5, 156-8, 128, 20, 16, 19);
 		rcol = 1;
 
@@ -349,8 +349,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,411,69,69,69,69,69,69,69,69");
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,330,370,370,370,370,370,370,370,370");
 
-		obj.createentity(game, 96, 192, 10, 1, 253500);  // (savepoint)
-		obj.createentity(game, 163, 32, 12, 168);  // (vertical gravity line)
+		obj.createentity(96, 192, 10, 1, 253500);  // (savepoint)
+		obj.createentity(163, 32, 12, 168);  // (vertical gravity line)
 		rcol = 3;
 
 		roomname = "Double-slit Experiment";
@@ -388,10 +388,10 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,406,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 		tmap.push_back("367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,328,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 
-		obj.createentity(game, 264, 104, 10, 1, 253510);  // (savepoint)
-		obj.createentity(game, 131, 120, 12, 96);  // (vertical gravity line)
-		obj.createentity(game, 187, 16, 12, 96);  // (vertical gravity line)
-		obj.createentity(game, 40, 112, 10, 0, 253511);  // (savepoint)
+		obj.createentity(264, 104, 10, 1, 253510);  // (savepoint)
+		obj.createentity(131, 120, 12, 96);  // (vertical gravity line)
+		obj.createentity(187, 16, 12, 96);  // (vertical gravity line)
+		obj.createentity(40, 112, 10, 0, 253511);  // (savepoint)
 		rcol = 2;
 		roomname = "They Call Him Flipper";
 		break;
@@ -428,8 +428,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,333,373,373,373,373,373,334,292,292,292,333,373,373,373,373,373,334,292,292,292,292,292,292,292,292,292,292");
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 
-		obj.createentity(game, 24, 184, 10, 1, 253520);  // (savepoint)
-		obj.createentity(game, 64, 164, 11, 200);  // (horizontal gravity line)
+		obj.createentity(24, 184, 10, 1, 253520);  // (savepoint)
+		obj.createentity(64, 164, 11, 200);  // (horizontal gravity line)
 		rcol = 4;
 		roomname = "Three's a Crowd";
 		break;
@@ -466,10 +466,10 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("286,286,286,286,286,286,286,408,0,0,0,0,0,0,366,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,328,286,286,286,286,286");
 		tmap.push_back("286,286,286,286,286,286,286,408,0,0,0,0,0,0,406,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 
-		obj.createentity(game, 195, 24, 12, 80);  // (vertical gravity line)
-		obj.createentity(game, 195, 128, 12, 80);  // (vertical gravity line)
-		obj.createentity(game, 80, 120, 10, 0, 252520);  // (savepoint)
-		obj.createentity(game, 80, 96, 10, 1, 252521);  // (savepoint)
+		obj.createentity(195, 24, 12, 80);  // (vertical gravity line)
+		obj.createentity(195, 128, 12, 80);  // (vertical gravity line)
+		obj.createentity(80, 120, 10, 0, 252520);  // (savepoint)
+		obj.createentity(80, 96, 10, 1, 252521);  // (savepoint)
 		rcol = 2;
 		roomname = "Hitting the Apex";
 		break;
@@ -506,10 +506,10 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("280,321,362,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,360,322,280,280,280,280,280,280,280");
 		tmap.push_back("280,280,321,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,322,280,280,280,280,280,280,280,280");
 
-		obj.createentity(game, 24, 188, 11, 224);  // (horizontal gravity line)
-		obj.createentity(game, 280, 96, 10, 1, 252510);  // (savepoint)
+		obj.createentity(24, 188, 11, 224);  // (horizontal gravity line)
+		obj.createentity(280, 96, 10, 1, 252510);  // (savepoint)
 
-		obj.createentity(game, 204, 32, 20, 0);  // (terminal)
+		obj.createentity(204, 32, 20, 0);  // (terminal)
 		obj.createblock(5, 204-8, 32, 20, 16, 20);
 		rcol=0;
 
@@ -549,8 +549,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("292,414,59,0,0,0,0,0,0,0,0,0,0,0,0,0,0,60,412,292,292,333,373,373,373,373,373,373,373,373,373,373,373,373,373,373,334,292,292,292");
 		tmap.push_back("292,414,59,0,0,0,0,0,0,0,0,0,0,0,0,0,0,60,412,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 
-		obj.createentity(game, 24, 44, 11, 112);  // (horizontal gravity line)
-		obj.createentity(game, 176, 180, 11, 112);  // (horizontal gravity line)
+		obj.createentity(24, 44, 11, 112);  // (horizontal gravity line)
+		obj.createentity(176, 180, 11, 112);  // (horizontal gravity line)
 		rcol = 4;
 		roomname = "Thorny Exchange";
 		break;
@@ -587,10 +587,10 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("283,283,324,365,65,65,65,65,65,65,65,65,65,65,65,65,65,65,363,325,405,53,0,0,0,0,0,0,0,0,0,0,0,0,0,0,54,403,283,283");
 		tmap.push_back("283,283,283,324,364,364,364,364,364,364,364,364,364,364,364,364,364,364,325,283,405,53,0,0,0,0,0,0,0,0,0,0,0,0,0,0,54,403,283,283");
 
-		obj.createentity(game, 32, 28, 11, 296);  // (horizontal gravity line)
-		obj.createentity(game, 32, 196, 11, 112);  // (horizontal gravity line)
-		obj.createentity(game, 128, 100, 11, 160);  // (horizontal gravity line)
-		obj.createentity(game, 88, 112, 10, 0, 250510);  // (savepoint)
+		obj.createentity(32, 28, 11, 296);  // (horizontal gravity line)
+		obj.createentity(32, 196, 11, 112);  // (horizontal gravity line)
+		obj.createentity(128, 100, 11, 160);  // (horizontal gravity line)
+		obj.createentity(88, 112, 10, 0, 250510);  // (savepoint)
 		roomname = "Brought to you by the letter G";
 		rcol = 1;
 		break;
@@ -627,8 +627,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("286,286,286,286,286,286,286,286,408,55,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("286,286,286,286,286,286,286,286,408,55,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 28, 11, 336);  // (horizontal gravity line)
-		obj.createentity(game, 32, 72, 10, 1, 250520);  // (savepoint)
+		obj.createentity(-8, 28, 11, 336);  // (horizontal gravity line)
+		obj.createentity(32, 72, 10, 1, 250520);  // (savepoint)
 		rcol=2;
 
 		roomname = "Free Your Mind";
@@ -666,7 +666,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280");
 		tmap.push_back("280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280");
 
-		obj.createentity(game, 80, 180, 11, 248);  // (horizontal gravity line)
+		obj.createentity(80, 180, 11, 248);  // (horizontal gravity line)
 		rcol=0;
 		roomname = "I Changed My Mind, Thelma...";
 		break;
@@ -703,8 +703,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 
-		obj.createentity(game, -8, 180, 11, 208);  // (horizontal gravity line)
-		obj.createentity(game, 240, 180, 11, 88);  // (horizontal gravity line)
+		obj.createentity(-8, 180, 11, 208);  // (horizontal gravity line)
+		obj.createentity(240, 180, 11, 88);  // (horizontal gravity line)
 		rcol=4;
 
 		roomname = "Indirect Jump Vector";
@@ -742,7 +742,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,62,415,295,417,61,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,62,415,295,417,61,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 28, 11, 336);  // (horizontal gravity line)
+		obj.createentity(-8, 28, 11, 336);  // (horizontal gravity line)
 		rcol=5;
 
 		roomname = "In a Single Bound";
@@ -780,9 +780,9 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("0,0,0,0,0,0,0,0,0,54,403,283,405,53,0,0,0,0,0,0,0,0,0,0,0,0,54,403,283,405,53,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,54,403,283,405,53,0,0,0,0,0,0,0,0,0,0,0,0,54,403,283,405,53,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 28, 11, 80);  // (horizontal gravity line)
-		obj.createentity(game, 112, 28, 11, 96);  // (horizontal gravity line)
-		obj.createentity(game, 248, 28, 11, 80);  // (horizontal gravity line)
+		obj.createentity(-8, 28, 11, 80);  // (horizontal gravity line)
+		obj.createentity(112, 28, 11, 96);  // (horizontal gravity line)
+		obj.createentity(248, 28, 11, 80);  // (horizontal gravity line)
 		rcol=1;
 
 		roomname = "Barani, Barani";
@@ -821,9 +821,9 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 		tmap.push_back("286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 
-		obj.createentity(game, -8, 180, 11, 80);  // (horizontal gravity line)
-		obj.createentity(game, 112, 180, 11, 96);  // (horizontal gravity line)
-		obj.createentity(game, 248, 180, 11, 80);  // (horizontal gravity line)
+		obj.createentity(-8, 180, 11, 80);  // (horizontal gravity line)
+		obj.createentity(112, 180, 11, 96);  // (horizontal gravity line)
+		obj.createentity(248, 180, 11, 80);  // (horizontal gravity line)
 		rcol=2;
 
 		roomname = "Safety Dance";
@@ -861,7 +861,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,58,409,411,0,0,0,0,0,0,409,289,289,289");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,58,409,411,0,0,0,0,0,0,409,289,289,289");
 
-		obj.createentity(game, -8, 28, 11, 40);  // (horizontal gravity line)
+		obj.createentity(-8, 28, 11, 40);  // (horizontal gravity line)
 
 		rcol=3;
 		roomname = "Heady Heights";
@@ -900,13 +900,11 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("295,295,295,295,295,295,417,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,62,415,295");
 
 
-		obj.createentity(game, 160, 176, 10, 0, 249550);  // (savepoint)
-		obj.createentity(game, 224, 68, 11, 72);  // (horizontal gravity line)
+		obj.createentity(160, 176, 10, 0, 249550);  // (savepoint)
+		obj.createentity(224, 68, 11, 72);  // (horizontal gravity line)
 
 
-		//obj.createentity(game, 224, 192, 10, 0, 249550);  // (savepoint)
-
-		if(!game.intimetrial) obj.createentity(game, (12 * 8)-4, (6 * 8) + 4, 14); //Teleporter!
+		if(!game.intimetrial) obj.createentity((12 * 8)-4, (6 * 8) + 4, 14); //Teleporter!
 		rcol = 5;
 
 		roomname = "Entanglement Generator";
@@ -945,7 +943,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,402,0,0,0,0,0,0,400,280,280,280");
 		tmap.push_back("280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,402,0,0,0,0,0,0,400,280,280,280");
 
-		obj.createentity(game, -8, 180, 11, 224);  // (horizontal gravity line)
+		obj.createentity(-8, 180, 11, 224);  // (horizontal gravity line)
 
 		rcol = 0;
 		roomname = "Exhausted?";
@@ -984,8 +982,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,414,59,0,0,0,0,0,0,0,60,412,292,414,0,0,0,0,0,0,412,292,292,292");
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,414,59,0,0,0,0,0,0,0,60,412,292,414,0,0,0,0,0,0,412,292,292,292");
 
-		obj.createentity(game, 32, 64, 9, 10);  // (shiny trinket)
-		obj.createentity(game, 120, 72, 10, 1, 252550);  // (savepoint)
+		obj.createentity(32, 64, 9, 10);  // (shiny trinket)
+		obj.createentity(120, 72, 10, 1, 252550);  // (savepoint)
 		rcol = 4;
 
 		roomname = "The Tantalizing Trinket";
@@ -1023,10 +1021,10 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("283,283,283,283,283,283,283,283,324,365,65,65,65,65,65,65,65,65,0,0,0,0,0,0,0,0,54,403,283,405,0,0,0,0,0,0,403,283,283,283");
 		tmap.push_back("283,283,283,283,283,283,283,283,283,324,364,364,364,364,364,364,364,365,53,0,0,0,0,0,0,0,54,403,283,405,0,0,0,0,0,0,403,283,283,283");
 
-		obj.createentity(game, 272, 144, 10, 1, 253550);  // (savepoint)
-		obj.createentity(game, 152, 116, 11, 56);  // (horizontal gravity line)
-		obj.createentity(game, 139, 16, 12, 72);  // (vertical gravity line)
-		obj.createentity(game, 139, 144, 12, 72);  // (vertical gravity line)
+		obj.createentity(272, 144, 10, 1, 253550);  // (savepoint)
+		obj.createentity(152, 116, 11, 56);  // (horizontal gravity line)
+		obj.createentity(139, 16, 12, 72);  // (vertical gravity line)
+		obj.createentity(139, 144, 12, 72);  // (vertical gravity line)
 		rcol=1;
 
 		roomname = "The Bernoulli Principle";
@@ -1064,9 +1062,9 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295");
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295");
 
-		obj.createentity(game, 216, 144, 10, 1, 254550);  // (savepoint)
-		obj.createentity(game, -8, 60, 11, 136);  // (horizontal gravity line)
-		obj.createentity(game, -8, 172, 11, 136);  // (horizontal gravity line)
+		obj.createentity(216, 144, 10, 1, 254550);  // (savepoint)
+		obj.createentity(-8, 60, 11, 136);  // (horizontal gravity line)
+		obj.createentity(-8, 172, 11, 136);  // (horizontal gravity line)
 		rcol = 5;
 
 		roomname = "Standing Wave";
@@ -1104,8 +1102,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,406,286,286,286,286,286,286,286,286,286,286,286");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,406,286,286,286,286,286,286,286,286,286,286,286");
 
-		obj.createentity(game, -8, 60, 11, 336);  // (horizontal gravity line)
-		obj.createentity(game, -8, 172, 11, 336);  // (horizontal gravity line)
+		obj.createentity(-8, 60, 11, 336);  // (horizontal gravity line)
+		obj.createentity(-8, 172, 11, 336);  // (horizontal gravity line)
 		rcol=2;
 
 		obj.fatal_top();
@@ -1144,14 +1142,14 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 60, 11, 120);  // (horizontal gravity line)
-		obj.createentity(game, -8, 172, 11, 40);  // (horizontal gravity line)
-		obj.createentity(game, 264, 72, 10, 0, 254530);  // (savepoint)
-		obj.createentity(game, 40, 144, 10, 1, 254531);  // (savepoint)
-		obj.createentity(game, 160, 60, 11, 48);  // (horizontal gravity line)
-		obj.createentity(game, 288, 60, 11, 40);  // (horizontal gravity line)
-		obj.createentity(game, 112, 172, 11, 48);  // (horizontal gravity line)
-		obj.createentity(game, 208, 172, 11, 120);  // (horizontal gravity line)
+		obj.createentity(-8, 60, 11, 120);  // (horizontal gravity line)
+		obj.createentity(-8, 172, 11, 40);  // (horizontal gravity line)
+		obj.createentity(264, 72, 10, 0, 254530);  // (savepoint)
+		obj.createentity(40, 144, 10, 1, 254531);  // (savepoint)
+		obj.createentity(160, 60, 11, 48);  // (horizontal gravity line)
+		obj.createentity(288, 60, 11, 40);  // (horizontal gravity line)
+		obj.createentity(112, 172, 11, 48);  // (horizontal gravity line)
+		obj.createentity(208, 172, 11, 120);  // (horizontal gravity line)
 		rcol=3;
 
 		obj.fatal_top();
@@ -1190,11 +1188,11 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 60, 11, 336);  // (horizontal gravity line)
-		obj.createentity(game, -8, 172, 11, 336);  // (horizontal gravity line)
-		obj.createentity(game, 72, 64, 1, 0, 8, 72, 64, 248, 168);  // Enemy, bounded
-		obj.createentity(game, 232, 64, 1, 0, 8, 72, 64, 248, 168);  // Enemy, bounded
-		obj.createentity(game, 152, 152, 1, 1, 8, 72, 64, 248, 168);  // Enemy, bounded
+		obj.createentity(-8, 60, 11, 336);  // (horizontal gravity line)
+		obj.createentity(-8, 172, 11, 336);  // (horizontal gravity line)
+		obj.createentity(72, 64, 1, 0, 8, 72, 64, 248, 168);  // Enemy, bounded
+		obj.createentity(232, 64, 1, 0, 8, 72, 64, 248, 168);  // Enemy, bounded
+		obj.createentity(152, 152, 1, 1, 8, 72, 64, 248, 168);  // Enemy, bounded
 
 		obj.fatal_top();
 		roomname = "Vibrating String Problem";
@@ -1233,11 +1231,11 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 176, 60, 11, 152);  // (horizontal gravity line)
-		obj.createentity(game, 176, 172, 11, 152);  // (horizontal gravity line)
-		obj.createentity(game, -8, 84, 11, 160);  // (horizontal gravity line)
-		obj.createentity(game, -8, 148, 11, 160);  // (horizontal gravity line)
-		obj.createentity(game, 160-4, 120, 10, 1, 254510);  // (savepoint)
+		obj.createentity(176, 60, 11, 152);  // (horizontal gravity line)
+		obj.createentity(176, 172, 11, 152);  // (horizontal gravity line)
+		obj.createentity(-8, 84, 11, 160);  // (horizontal gravity line)
+		obj.createentity(-8, 148, 11, 160);  // (horizontal gravity line)
+		obj.createentity(160-4, 120, 10, 1, 254510);  // (savepoint)
 		rcol=1;
 
 		obj.fatal_top();
@@ -1276,11 +1274,11 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 84, 11, 336);  // (horizontal gravity line)
-		obj.createentity(game, -8, 148, 11, 336);  // (horizontal gravity line)
-		obj.createentity(game, 88, 96, 1, 3, 3);  // Enemy
-		obj.createentity(game, 40, 120, 1, 3, 3);  // Enemy
-		obj.createentity(game, 136, 120, 1, 3, 3);  // Enemy
+		obj.createentity(-8, 84, 11, 336);  // (horizontal gravity line)
+		obj.createentity(-8, 148, 11, 336);  // (horizontal gravity line)
+		obj.createentity(88, 96, 1, 3, 3);  // Enemy
+		obj.createentity(40, 120, 1, 3, 3);  // Enemy
+		obj.createentity(136, 120, 1, 3, 3);  // Enemy
 		rcol = 0;
 
 		obj.fatal_top();
@@ -1320,10 +1318,10 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("286,286,286,286,408,55,0,0,0,0,0,0,56,430,55,0,0,0,0,0,0,56,430,55,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("286,286,286,286,408,55,0,0,0,0,0,0,56,430,55,0,0,0,0,0,0,56,430,55,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 264, 84, 11, 64);  // (horizontal gravity line)
-		obj.createentity(game, 240+4, 96, 10, 0, 254490);  // (savepoint)
-		obj.createentity(game, 48, 28, 11, 192);  // (horizontal gravity line)
-		obj.createentity(game, 120, 148, 11, 208);  // (horizontal gravity line)
+		obj.createentity(264, 84, 11, 64);  // (horizontal gravity line)
+		obj.createentity(240+4, 96, 10, 0, 254490);  // (savepoint)
+		obj.createentity(48, 28, 11, 192);  // (horizontal gravity line)
+		obj.createentity(120, 148, 11, 208);  // (horizontal gravity line)
 		rcol=2;
 
 		roomname = "I'm Sorry";
@@ -1362,8 +1360,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 
-		obj.createentity(game, 48, 156, 11, 200);  // (horizontal gravity line)
-		obj.createentity(game, 216, 56, 10, 0, 255490);  // (savepoint)
+		obj.createentity(48, 156, 11, 200);  // (horizontal gravity line)
+		obj.createentity(216, 56, 10, 0, 255490);  // (savepoint)
 		rcol=4;
 
 		roomname = "Please Forgive Me!";
@@ -1401,10 +1399,10 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 
-		obj.createentity(game, 131, 48, 12, 152);  // (vertical gravity line)
-		obj.createentity(game, 179, 48, 12, 152);  // (vertical gravity line)
-		obj.createentity(game, 227, 48, 12, 152);  // (vertical gravity line)
-		obj.createentity(game, 275, 48, 12, 152);  // (vertical gravity line)
+		obj.createentity(131, 48, 12, 152);  // (vertical gravity line)
+		obj.createentity(179, 48, 12, 152);  // (vertical gravity line)
+		obj.createentity(227, 48, 12, 152);  // (vertical gravity line)
+		obj.createentity(275, 48, 12, 152);  // (vertical gravity line)
 		rcol=1;
 
 		roomname = "Playing Foosball";
@@ -1442,17 +1440,17 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295");
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295");
 
-		obj.createentity(game, 91, 168, 12, 32);  // (vertical gravity line)
-		obj.createentity(game, 139, 80, 12, 120);  // (vertical gravity line)
-		obj.createentity(game, 235, 104, 12, 96);  // (vertical gravity line)
-		obj.createentity(game, 187, 144, 12, 56);  // (vertical gravity line)
-		obj.createentity(game, 43, 48, 12, 152);  // (vertical gravity line)
-		obj.createentity(game, 91, 48, 12, 112);  // (vertical gravity line)
-		obj.createentity(game, 139, 48, 12, 24);  // (vertical gravity line)
-		obj.createentity(game, 187, 48, 12, 88);  // (vertical gravity line)
-		obj.createentity(game, 235, 48, 12, 48);  // (vertical gravity line)
-		obj.createentity(game, 283, 48, 12, 152);  // (vertical gravity line)
-		obj.createentity(game, 8, 48, 10, 0, 255510);  // (savepoint)
+		obj.createentity(91, 168, 12, 32);  // (vertical gravity line)
+		obj.createentity(139, 80, 12, 120);  // (vertical gravity line)
+		obj.createentity(235, 104, 12, 96);  // (vertical gravity line)
+		obj.createentity(187, 144, 12, 56);  // (vertical gravity line)
+		obj.createentity(43, 48, 12, 152);  // (vertical gravity line)
+		obj.createentity(91, 48, 12, 112);  // (vertical gravity line)
+		obj.createentity(139, 48, 12, 24);  // (vertical gravity line)
+		obj.createentity(187, 48, 12, 88);  // (vertical gravity line)
+		obj.createentity(235, 48, 12, 48);  // (vertical gravity line)
+		obj.createentity(283, 48, 12, 152);  // (vertical gravity line)
+		obj.createentity(8, 48, 10, 0, 255510);  // (savepoint)
 		rcol=5;
 
 		roomname = "A Difficult Chord";
@@ -1490,11 +1488,11 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,402,51,0,0,0,0,0,52,400,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280");
 		tmap.push_back("280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,402,51,0,0,0,0,0,52,400,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280");
 
-		obj.createentity(game, 16, 184, 10, 1, 255520);  // (savepoint)
-		obj.createentity(game, 131, 88, 12, 96);  // (vertical gravity line)
-		obj.createentity(game, 208, 180, 11, 40);  // (horizontal gravity line)
-		obj.createentity(game, 67, 56, 12, 80);  // (vertical gravity line)
-		obj.createentity(game, 195, 56, 12, 80);  // (vertical gravity line)
+		obj.createentity(16, 184, 10, 1, 255520);  // (savepoint)
+		obj.createentity(131, 88, 12, 96);  // (vertical gravity line)
+		obj.createentity(208, 180, 11, 40);  // (horizontal gravity line)
+		obj.createentity(67, 56, 12, 80);  // (vertical gravity line)
+		obj.createentity(195, 56, 12, 80);  // (vertical gravity line)
 		rcol = 0;
 
 		roomname = "The Living Dead End";
@@ -1605,13 +1603,13 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("280,280,280,280,280,280,280,280,402,0,0,0,0,0,400,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280");
 		tmap.push_back("280,280,280,280,280,280,280,280,402,0,0,0,0,0,400,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280");
 
-		obj.createentity(game, 267, 24, 12, 184);  // (vertical gravity line)
-		obj.createentity(game, 16, 24, 9,  9);  // (shiny trinket)
-		obj.createentity(game, 187, 24, 12, 64);  // (vertical gravity line)
-		obj.createentity(game, 104, 124, 11, 80);  // (horizontal gravity line)
-		obj.createentity(game, 48, 72, 10, 1, 252500);  // (savepoint)
-		obj.createentity(game, 224, 72, 10, 1, 252501);  // (savepoint)
-		obj.createentity(game, 99, 24, 12, 80);  // (vertical gravity line)
+		obj.createentity(267, 24, 12, 184);  // (vertical gravity line)
+		obj.createentity(16, 24, 9,  9);  // (shiny trinket)
+		obj.createentity(187, 24, 12, 64);  // (vertical gravity line)
+		obj.createentity(104, 124, 11, 80);  // (horizontal gravity line)
+		obj.createentity(48, 72, 10, 1, 252500);  // (savepoint)
+		obj.createentity(224, 72, 10, 1, 252501);  // (savepoint)
+		obj.createentity(99, 24, 12, 80);  // (vertical gravity line)
 		rcol=0;
 
 		roomname = "Young Man, It's Worth the Challenge";
@@ -1686,7 +1684,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("289,289,289,289,289,330,371,446,447,288,286,327,367,367,367,367,328,286,287,447,448,369,331,289,289,289,289,289,289,289,289,289,289,289,289,289,289,330,370,370");
 		tmap.push_back("289,289,289,289,289,289,330,370,371,406,286,286,286,286,286,286,286,286,408,369,370,331,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289");
 
-		obj.createentity(game, 104, 128, 9, 11);  // (shiny trinket)
+		obj.createentity(104, 128, 9, 11);  // (shiny trinket)
 		rcol = 6;
 
 		roomname = "Purest Unobtainium";
@@ -1725,7 +1723,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("295,295,295,295,295,417,0,415,295,295,417,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,415,295,295,295,295");
 		tmap.push_back("295,295,295,295,295,417,0,415,295,295,336,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,337,295,295,295,295");
 
-		obj.createentity(game, 112, 184, 10, 1, 258520);  // (savepoint)
+		obj.createentity(112, 184, 10, 1, 258520);  // (savepoint)
 		rcol = 5;
 
 		roomname = "I Smell Ozone";
@@ -1768,7 +1766,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		{
 			if(game.companion==0 && obj.flags[9]==0 &&  !game.crewstats[5])   //also need to check if he's rescued in a previous game
 			{
-				obj.createentity(game, 32, 177, 18, 16, 1, 17, 1);
+				obj.createentity(32, 177, 18, 16, 1, 17, 1);
 				obj.createblock(1, 24*8, 0, 32, 240, 33);
 			}
 		}
@@ -1811,7 +1809,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		rcol=3;
 
 
-		obj.createentity(game, (10 * 8)-4, (8 * 8) + 4, 14); //Teleporter!
+		obj.createentity((10 * 8)-4, (8 * 8) + 4, 14); //Teleporter!
 
 		if(game.intimetrial)
 		{

--- a/desktop_version/src/Labclass.h
+++ b/desktop_version/src/Labclass.h
@@ -10,7 +10,7 @@
 class labclass
 {
 public:
-    std::vector<std::string>  loadlevel(int rx, int ry , Game& game, entityclass& obj);
+    std::vector<std::string>  loadlevel(int rx, int ry);
 
     std::string roomname;
     int coin, rcol;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -5,7 +5,7 @@
 extern int temp;
 extern scriptclass script;
 
-void titlelogic( Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help, musicclass& music, mapclass& map)
+void titlelogic()
 {
     //Misc
     //map.updatetowerglow();
@@ -38,19 +38,19 @@ void titlelogic( Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& he
     }
 }
 
-void maplogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help)
+void maplogic()
 {
     //Misc
     help.updateglow();
 }
 
 
-void gamecompletelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help)
+void gamecompletelogic()
 {
     //Misc
     map.updatetowerglow();
     help.updateglow();
-    dwgfx.crewframe = 0;
+    graphics.crewframe = 0;
 
     map.tdrawback = true;
 
@@ -66,18 +66,18 @@ void gamecompletelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclas
         map.bscroll = +1;
     }
 
-    if (dwgfx.fademode == 1)
+    if (graphics.fademode == 1)
     {
         //Fix some graphical things
-        dwgfx.showcutscenebars = false;
-        dwgfx.cutscenebarspos = 0;
+        graphics.showcutscenebars = false;
+        graphics.cutscenebarspos = 0;
         //Return to game
         game.gamestate = 7;
-        dwgfx.fademode = 4;
+        graphics.fademode = 4;
     }
 }
 
-void gamecompletelogic2(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help)
+void gamecompletelogic2()
 {
     //Misc
     map.updatetowerglow();
@@ -95,32 +95,22 @@ void gamecompletelogic2(Graphics& dwgfx, Game& game, entityclass& obj,  musiccla
             if (game.creditposy > 30) game.creditposy = 30;
         }
     }
-    /*
-    game.creditposition--;
-    if (game.creditposition <= -1650) {
-    game.creditposition = -1650;
-    map.bscroll = 0;
-    }else {
-    map.bypos += 1; map.bscroll = +1;
-    }
-    */
 
-    if (dwgfx.fademode == 1)
+    if (graphics.fademode == 1)
     {
         //Fix some graphical things
-        dwgfx.showcutscenebars = false;
-        dwgfx.cutscenebarspos = 0;
+        graphics.showcutscenebars = false;
+        graphics.cutscenebarspos = 0;
         //Fix the save thingy
         game.deletequick();
         int tmp=music.currentsong;
         music.currentsong=4;
-        game.savetele(map,obj,music);
+        game.savetele();
         music.currentsong=tmp;
-        game.telegotoship();
         //Return to game
         map.colstate = 10;
         game.gamestate = 1;
-        dwgfx.fademode = 4;
+        graphics.fademode = 4;
         music.playef(18, 10);
         game.createmenu("gamecompletecontinue");
         map.nexttowercolour();
@@ -128,7 +118,7 @@ void gamecompletelogic2(Graphics& dwgfx, Game& game, entityclass& obj,  musiccla
 }
 
 
-void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help)
+void towerlogic()
 {
     //Logic for the tower level
     map.updatetowerglow();
@@ -254,7 +244,7 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
         {
             if (map.resumedelay <= 0)
             {
-                game.lifesequence(obj);
+                game.lifesequence();
                 if (game.lifeseq == 0) map.cameramode = 1;
             }
             else
@@ -268,17 +258,17 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
     {
         map.colsuperstate = 1;
         map.cameramode = 2;
-        game.deathsequence(map, obj, music);
+        game.deathsequence();
         game.deathseq--;
         if (game.deathseq <= 0)
         {
             if (game.nodeathmode)
             {
                 game.deathseq = 1;
-                game.gethardestroom(map);
+                game.gethardestroom();
                 //start depressing sequence here...
-                if (game.gameoverdelay <= -10 && dwgfx.fademode==0) dwgfx.fademode = 2;
-                if (dwgfx.fademode == 1) script.resetgametomenu(dwgfx, game, map, obj, help, music);
+                if (game.gameoverdelay <= -10 && graphics.fademode==0) graphics.fademode = 2;
+                if (graphics.fademode == 1) script.resetgametomenu();
             }
             else
             {
@@ -289,15 +279,15 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
                 }
 
                 game.gravitycontrol = game.savegc;
-                dwgfx.textboxremove();
-                map.resetplayer(dwgfx, game, obj, music);
+                graphics.textboxremove();
+                map.resetplayer();
             }
         }
     }
     else
     {
         //State machine for game logic
-        game.updatestate(dwgfx, map, obj, help, music);
+        game.updatestate();
 
 
         //Time trial stuff
@@ -362,21 +352,15 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
         {
             for (int i = obj.nentity - 1; i >= 0;  i--)
             {
-                //Remove old platform
-                //if (obj.entities[i].isplatform) obj.removeblockat(obj.entities[i].xp, obj.entities[i].yp);
-
-                obj.updateentities(i, help, game, music);                // Behavioral logic
-                obj.updateentitylogic(i, game);                          // Basic Physics
-                obj.entitymapcollision(i, map);                          // Collisions with walls
-
-                //Create new platform
-                //if (obj.entities[i].isplatform) obj.movingplatformfix(i, map);
+                obj.updateentities(i);                             // Behavioral logic
+                obj.updateentitylogic(i);                          // Basic Physics
+                obj.entitymapcollision(i);                         // Collisions with walls
             }
 
-            obj.entitycollisioncheck(dwgfx, game, map, music);         // Check ent v ent collisions, update states
+            obj.entitycollisioncheck();         // Check ent v ent collisions, update states
             //special for tower: is the player touching any spike blocks?
             int player = obj.getplayer();
-            if(obj.checktowerspikes(player, map) && dwgfx.fademode==0)
+            if(obj.checktowerspikes(player) && graphics.fademode==0)
             {
                 game.deathseq = 30;
             }
@@ -391,13 +375,13 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
                     if (game.door_left > -2 && obj.entities[player].xp < -14)
                     {
                         obj.entities[player].xp += 320;
-                        map.gotoroom(48, 52, dwgfx, game, obj, music);
+                        map.gotoroom(48, 52);
                     }
                     if (game.door_right > -2 && obj.entities[player].xp >= 308)
                     {
                         obj.entities[player].xp -= 320;
                         obj.entities[player].yp -= (71*8);
-                        map.gotoroom(game.roomx + 1, game.roomy+1, dwgfx, game, obj, music);
+                        map.gotoroom(game.roomx + 1, game.roomy+1);
                     }
                 }
                 else
@@ -410,18 +394,18 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
                         {
                             obj.entities[player].xp += 320;
                             obj.entities[player].yp -= (71 * 8);
-                            map.gotoroom(50, 54, dwgfx, game, obj, music);
+                            map.gotoroom(50, 54);
                         }
                         else
                         {
                             obj.entities[player].xp += 320;
-                            map.gotoroom(50, 53, dwgfx, game, obj, music);
+                            map.gotoroom(50, 53);
                         }
                     }
                     if (game.door_right > -2 && obj.entities[player].xp >= 308)
                     {
                         obj.entities[player].xp -= 320;
-                        map.gotoroom(52, 53, dwgfx, game, obj, music);
+                        map.gotoroom(52, 53);
                     }
                 }
             }
@@ -453,12 +437,12 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
                     {
                         obj.entities[player].xp += 320;
                         obj.entities[player].yp -= (671 * 8);
-                        map.gotoroom(108, 109, dwgfx, game, obj, music);
+                        map.gotoroom(108, 109);
                     }
                     if (game.door_right > -2 && obj.entities[player].xp >= 308)
                     {
                         obj.entities[player].xp -= 320;
-                        map.gotoroom(110, 104, dwgfx, game, obj, music);
+                        map.gotoroom(110, 104);
                     }
                 }
             }
@@ -523,10 +507,10 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
         //Looping around, room change conditions!
     }
 
-    if (game.teleport_to_new_area) script.teleport(dwgfx, game, map,	obj, help, music);
+    if (game.teleport_to_new_area) script.teleport();
 }
 
-void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help)
+void gamelogic()
 {
     //Misc
     help.updateglow();
@@ -571,7 +555,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
         obj.upset = 0;
     }
 
-    game.lifesequence(obj);
+    game.lifesequence();
 
 
     if (game.deathseq != -1)
@@ -607,14 +591,14 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             {
                 //ok, unfortunate case where the disappearing platform hasn't fully disappeared. Accept a little
                 //graphical uglyness to avoid breaking the room!
-                while (obj.entities[i].state == 2) obj.updateentities(i, help, game, music);
+                while (obj.entities[i].state == 2) obj.updateentities(i);
                 obj.entities[i].state = 4;
             }
             else if (map.finalstretch && obj.entities[i].type == 2)
             {
                 //TODO: }else if (map.finallevel && map.finalstretch && obj.entities[i].type == 2) {
                 //for the final level. probably something 99% of players won't see.
-                while (obj.entities[i].state == 2) obj.updateentities(i, help, game, music);
+                while (obj.entities[i].state == 2) obj.updateentities(i);
                 obj.entities[i].state = 4;
             }
             else if (obj.entities[i].type == 23 && game.swnmode && game.deathseq<15)
@@ -647,17 +631,17 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             }
         }
 
-        game.deathsequence(map, obj, music);
+        game.deathsequence();
         game.deathseq--;
         if (game.deathseq <= 0)
         {
             if (game.nodeathmode)
             {
                 game.deathseq = 1;
-                game.gethardestroom(map);
+                game.gethardestroom();
                 //start depressing sequence here...
-                if (game.gameoverdelay <= -10 && dwgfx.fademode==0) dwgfx.fademode = 2;
-                if (dwgfx.fademode == 1) script.resetgametomenu(dwgfx, game, map, obj, help, music);
+                if (game.gameoverdelay <= -10 && graphics.fademode==0) graphics.fademode = 2;
+                if (graphics.fademode == 1) script.resetgametomenu();
             }
             else
             {
@@ -672,13 +656,13 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     }
                 }
 
-                game.gethardestroom(map);
+                game.gethardestroom();
                 game.hascontrol = true;
 
 
                 game.gravitycontrol = game.savegc;
-                dwgfx.textboxremove();
-                map.resetplayer(dwgfx, game, obj, music);
+                graphics.textboxremove();
+                map.resetplayer();
             }
         }
     }
@@ -700,7 +684,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                             temp = 1+int(fRandom() * 6);
                             if (temp == map.final_mapcol) temp = (temp + 1) % 6;
                             if (temp == 0) temp = 6;
-                            map.changefinalcol(temp, obj,game);
+                            map.changefinalcol(temp);
                         }
                         else if (map.final_colorframe == 2)
                         {
@@ -708,14 +692,14 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                             temp = 1+int(fRandom() * 6);
                             if (temp == map.final_mapcol) temp = (temp + 1) % 6;
                             if (temp == 0) temp = 6;
-                            map.changefinalcol(temp, obj,game);
+                            map.changefinalcol(temp);
                         }
                     }
                 }
             }
         }
         //State machine for game logic
-        game.updatestate(dwgfx, map, obj, help, music);
+        game.updatestate();
         if (game.startscript)
         {
             script.load(game.newscript);
@@ -750,7 +734,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 }
                 else
                 {
-                    obj.generateswnwave(game, help, 0);
+                    obj.generateswnwave(0);
                 }
             }
             else if(game.swngame==1)   //super gravitron game
@@ -763,7 +747,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     game.swnrank = 1;
                     if (game.swnbestrank < 1)
                     {
-												NETWORK_unlockAchievement("vvvvvvsupgrav5");
+                        NETWORK_unlockAchievement("vvvvvvsupgrav5");
                         game.swnbestrank = 1;
                         game.swnmessage = 2+30;
                         music.playef(26, 10);
@@ -774,7 +758,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     game.swnrank = 2;
                     if (game.swnbestrank < 2)
                     {
-												NETWORK_unlockAchievement("vvvvvvsupgrav10");
+                        NETWORK_unlockAchievement("vvvvvvsupgrav10");
                         game.swnbestrank = 2;
                         game.swnmessage = 2+30;
                         music.playef(26, 10);
@@ -785,7 +769,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     game.swnrank = 3;
                     if (game.swnbestrank < 3)
                     {
-												NETWORK_unlockAchievement("vvvvvvsupgrav15");
+                        NETWORK_unlockAchievement("vvvvvvsupgrav15");
                         game.swnbestrank = 3;
                         game.swnmessage = 2+30;
                         music.playef(26, 10);
@@ -796,7 +780,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     game.swnrank = 4;
                     if (game.swnbestrank < 4)
                     {
-												NETWORK_unlockAchievement("vvvvvvsupgrav20");
+                        NETWORK_unlockAchievement("vvvvvvsupgrav20");
                         game.swnbestrank = 4;
                         game.swnmessage = 2+30;
                         music.playef(26, 10);
@@ -807,7 +791,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     game.swnrank = 5;
                     if (game.swnbestrank < 5)
                     {
-												NETWORK_unlockAchievement("vvvvvvsupgrav30");
+                        NETWORK_unlockAchievement("vvvvvvsupgrav30");
                         game.swnbestrank = 5;
                         game.swnmessage = 2+30;
                         music.playef(26, 10);
@@ -818,21 +802,21 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     game.swnrank = 6;
                     if (game.swnbestrank < 6)
                     {
-												NETWORK_unlockAchievement("vvvvvvsupgrav60");
+                        NETWORK_unlockAchievement("vvvvvvsupgrav60");
                         game.swnbestrank = 6;
                         game.swnmessage = 2+30;
                         music.playef(26, 10);
                     }
                 }
 
-                obj.generateswnwave(game, help, 1);
+                obj.generateswnwave(1);
 
                 game.swncoldelay--;
                 if(game.swncoldelay<=0)
                 {
                     game.swncolstate = (game.swncolstate+1)%6;
                     game.swncoldelay = 30;
-                    dwgfx.rcol = game.swncolstate;
+                    graphics.rcol = game.swncolstate;
                     obj.swnenemiescol(game.swncolstate);
                 }
             }
@@ -859,7 +843,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             else if (game.swngame == 4)    //create top line
             {
                 game.swngame = 3;
-                obj.createentity(game, -8, 84 - 32, 11, 8);  // (horizontal gravity line)
+                obj.createentity(-8, 84 - 32, 11, 8);  // (horizontal gravity line)
                 music.niceplay(2);
                 game.swndeaths = game.deathcounts;
             }
@@ -965,19 +949,19 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                         {
                             obj.removeblockat(obj.entities[i].xp, obj.entities[i].yp);
 
-                            obj.updateentities(i, help, game, music);                // Behavioral logic
-                            obj.updateentitylogic(i, game);                          // Basic Physics
-                            obj.entitymapcollision(i, map);                          // Collisions with walls
+                            obj.updateentities(i);                             // Behavioral logic
+                            obj.updateentitylogic(i);                          // Basic Physics
+                            obj.entitymapcollision(i);                         // Collisions with walls
 
                             obj.createblock(0, obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
                             if (game.supercrewmate)
                             {
-                                obj.movingplatformfix(i, map);
-                                obj.scmmovingplatformfix(i, map);
+                                obj.movingplatformfix(i);
+                                obj.scmmovingplatformfix(i);
                             }
                             else
                             {
-                                obj.movingplatformfix(i, map);
+                                obj.movingplatformfix(i);
                             }
                         }
                     }
@@ -994,29 +978,29 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                         {
                             obj.removeblockat(obj.entities[ie].xp, obj.entities[ie].yp);
 
-                            obj.updateentities(ie, help, game, music);                // Behavioral logic
-                            obj.updateentitylogic(ie, game);                          // Basic Physics
-                            obj.entitymapcollision(ie, map);                          // Collisions with walls
+                            obj.updateentities(ie);                             // Behavioral logic
+                            obj.updateentitylogic(ie);                          // Basic Physics
+                            obj.entitymapcollision(ie);                         // Collisions with walls
 
-                            obj.hormovingplatformfix(ie, map);
+                            obj.hormovingplatformfix(ie);
                         }
                     }
                 }
                 //is the player standing on a moving platform?
                 int i = obj.getplayer();
-                float j = obj.entitycollideplatformfloor(map, i);
+                float j = obj.entitycollideplatformfloor(i);
                 if (j > -1000)
                 {
                     obj.entities[i].newxp = obj.entities[i].xp + j;
-                    obj.entitymapcollision(i, map);
+                    obj.entitymapcollision(i);
                 }
                 else
                 {
-                    j = obj.entitycollideplatformroof(map, i);
+                    j = obj.entitycollideplatformroof(i);
                     if (j > -1000)
                     {
                         obj.entities[i].newxp = obj.entities[i].xp + j;
-                        obj.entitymapcollision(i, map);
+                        obj.entitymapcollision(i);
                     }
                 }
             }
@@ -1025,13 +1009,13 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             {
                 if (!obj.entities[ie].isplatform)
                 {
-                    obj.updateentities(ie, help, game, music);          // Behavioral logic
-                    obj.updateentitylogic(ie, game);                    // Basic Physics
-                    obj.entitymapcollision(ie, map);                    // Collisions with walls
+                    obj.updateentities(ie);                       // Behavioral logic
+                    obj.updateentitylogic(ie);                    // Basic Physics
+                    obj.entitymapcollision(ie);                   // Collisions with walls
                 }
             }
 
-            obj.entitycollisioncheck(dwgfx, game, map, music);         // Check ent v ent collisions, update states
+            obj.entitycollisioncheck();         // Check ent v ent collisions, update states
         }
 
         //now! let's clean up removed entities
@@ -1145,12 +1129,12 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             if (game.door_down > -2 && obj.entities[player].yp >= 238)
             {
                 obj.entities[player].yp -= 240;
-                map.gotoroom(game.roomx, game.roomy + 1, dwgfx, game, obj, music);
+                map.gotoroom(game.roomx, game.roomy + 1);
             }
             if (game.door_up > -2 && obj.entities[player].yp < -2)
             {
                 obj.entities[player].yp += 240;
-                map.gotoroom(game.roomx, game.roomy - 1, dwgfx, game, obj, music);
+                map.gotoroom(game.roomx, game.roomy - 1);
             }
         }
         else if (map.warpy)
@@ -1197,12 +1181,12 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             if (game.door_left > -2 && obj.entities[player].xp < -14)
             {
                 obj.entities[player].xp += 320;
-                map.gotoroom(game.roomx - 1, game.roomy, dwgfx, game, obj, music);
+                map.gotoroom(game.roomx - 1, game.roomy);
             }
             if (game.door_right > -2 && obj.entities[player].xp >= 308)
             {
                 obj.entities[player].xp -= 320;
-                map.gotoroom(game.roomx + 1, game.roomy, dwgfx, game, obj, music);
+                map.gotoroom(game.roomx + 1, game.roomy);
             }
         }
         else
@@ -1212,22 +1196,22 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             if (game.door_down > -2 && obj.entities[player].yp >= 238)
             {
                 obj.entities[player].yp -= 240;
-                map.gotoroom(game.roomx, game.roomy + 1, dwgfx, game, obj, music);
+                map.gotoroom(game.roomx, game.roomy + 1);
             }
             if (game.door_up > -2 && obj.entities[player].yp < -2)
             {
                 obj.entities[player].yp += 240;
-                map.gotoroom(game.roomx, game.roomy - 1, dwgfx, game, obj, music);
+                map.gotoroom(game.roomx, game.roomy - 1);
             }
             if (game.door_left > -2 && obj.entities[player].xp < -14)
             {
                 obj.entities[player].xp += 320;
-                map.gotoroom(game.roomx - 1, game.roomy, dwgfx, game, obj, music);
+                map.gotoroom(game.roomx - 1, game.roomy);
             }
             if (game.door_right > -2 && obj.entities[player].xp >= 308)
             {
                 obj.entities[player].xp -= 320;
-                map.gotoroom(game.roomx + 1, game.roomy, dwgfx, game, obj, music);
+                map.gotoroom(game.roomx + 1, game.roomy);
             }
         }
 
@@ -1241,7 +1225,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
               edi2 = (edi-(edi%40))/40;
               edj2 = (edj-(edj%30))/30;
 
-              map.warpto(100+edi2, 100+edj2, obj.getplayer(), edi%40, (edj%30)+2, dwgfx, game, obj, music);
+              map.warpto(100+edi2, 100+edj2, obj.getplayer(), edi%40, (edj%30)+2);
               game.teleport = false;
 
               if (game.teleport == false)
@@ -1257,56 +1241,56 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
               {
                   int i = obj.getplayer();
                   obj.entities[i].yp = 225;
-                  map.gotoroom(119, 100, dwgfx, game, obj, music);
+                  map.gotoroom(119, 100);
                   game.teleport = false;
               }
               else if (game.roomx == 119 && game.roomy == 100)
               {
                   int i = obj.getplayer();
                   obj.entities[i].yp = 225;
-                  map.gotoroom(119, 103, dwgfx, game, obj, music);
+                  map.gotoroom(119, 103);
                   game.teleport = false;
               }
               else if (game.roomx == 119 && game.roomy == 103)
               {
                   int i = obj.getplayer();
                   obj.entities[i].xp = 0;
-                  map.gotoroom(116, 103, dwgfx, game, obj, music);
+                  map.gotoroom(116, 103);
                   game.teleport = false;
               }
               else if (game.roomx == 116 && game.roomy == 103)
               {
                   int i = obj.getplayer();
                   obj.entities[i].yp = 225;
-                  map.gotoroom(116, 100, dwgfx, game, obj, music);
+                  map.gotoroom(116, 100);
                   game.teleport = false;
               }
               else if (game.roomx == 116 && game.roomy == 100)
               {
                   int i = obj.getplayer();
                   obj.entities[i].xp = 0;
-                  map.gotoroom(114, 102, dwgfx, game, obj, music);
+                  map.gotoroom(114, 102);
                   game.teleport = false;
               }
               else if (game.roomx == 114 && game.roomy == 102)
               {
                   int i = obj.getplayer();
                   obj.entities[i].yp = 225;
-                  map.gotoroom(113, 100, dwgfx, game, obj, music);
+                  map.gotoroom(113, 100);
                   game.teleport = false;
               }
               else if (game.roomx == 116 && game.roomy == 104)
               {
                   //pre warp zone here
-                  map.warpto(107, 101, obj.getplayer(), 14, 16, dwgfx, game, obj, music);
+                  map.warpto(107, 101, obj.getplayer(), 14, 16);
               }
               else if (game.roomx == 107 && game.roomy == 101)
               {
-                  map.warpto(105, 119, obj.getplayer(), 5, 26, dwgfx, game, obj, music);
+                  map.warpto(105, 119, obj.getplayer(), 5, 26);
               }
               else if (game.roomx == 105 && game.roomy == 118)
               {
-                  map.warpto(101, 111, obj.getplayer(), 34, 6, dwgfx, game, obj, music);
+                  map.warpto(101, 111, obj.getplayer(), 34, 6);
               }
               else if (game.roomx == 101 && game.roomy == 111)
               {
@@ -1314,31 +1298,31 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                   switch(game.teleportxpos)
                   {
                   case 1:
-                      map.warpto(108, 108, obj.getplayer(), 4, 27, dwgfx, game, obj, music);
+                      map.warpto(108, 108, obj.getplayer(), 4, 27);
                       break;
                   case 2:
-                      map.warpto(101, 111, obj.getplayer(), 12, 27, dwgfx, game, obj, music);
+                      map.warpto(101, 111, obj.getplayer(), 12, 27);
                       break;
                   case 3:
-                      map.warpto(119, 111, obj.getplayer(), 31, 7, dwgfx, game, obj, music);
+                      map.warpto(119, 111, obj.getplayer(), 31, 7);
                       break;
                   case 4:
-                      map.warpto(114, 117, obj.getplayer(), 19, 16, dwgfx, game, obj, music);
+                      map.warpto(114, 117, obj.getplayer(), 19, 16);
                       break;
                   }
               }
               else if (game.roomx == 108 && game.roomy == 106)
               {
-                  map.warpto(119, 111, obj.getplayer(), 4, 27, dwgfx, game, obj, music);
+                  map.warpto(119, 111, obj.getplayer(), 4, 27);
               }
               else if (game.roomx == 100 && game.roomy == 111)
               {
-                  map.warpto(101, 111, obj.getplayer(), 24, 6, dwgfx, game, obj, music);
+                  map.warpto(101, 111, obj.getplayer(), 24, 6);
               }
               else if (game.roomx == 119 && game.roomy == 107)
               {
                   //Secret lab, to super gravitron
-                  map.warpto(119, 108, obj.getplayer(), 19, 10, dwgfx, game, obj, music);
+                  map.warpto(119, 108, obj.getplayer(), 19, 10);
               }
               if (game.teleport == false)
               {
@@ -1360,8 +1344,8 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             switch(game.companion)
             {
             case 6:
-                obj.createentity(game, obj.entities[i].xp, 121.0f, 15.0f,1);  //Y=121, the floor in that particular place!
-                j = obj.getcompanion(6);
+                obj.createentity(obj.entities[i].xp, 121.0f, 15.0f,1);  //Y=121, the floor in that particular place!
+                j = obj.getcompanion();
                 obj.entities[j].vx = obj.entities[i].vx;
                 obj.entities[j].dir = obj.entities[i].dir;
                 break;
@@ -1370,13 +1354,13 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 {
                     if (game.roomx == 110)
                     {
-                        obj.createentity(game, 320, 86, 16, 1);  //Y=86, the ROOF in that particular place!
+                        obj.createentity(320, 86, 16, 1);  //Y=86, the ROOF in that particular place!
                     }
                     else
                     {
-                        obj.createentity(game, obj.entities[i].xp, 86.0f, 16.0f, 1);  //Y=86, the ROOF in that particular place!
+                        obj.createentity(obj.entities[i].xp, 86.0f, 16.0f, 1);  //Y=86, the ROOF in that particular place!
                     }
-                    j = obj.getcompanion(7);
+                    j = obj.getcompanion();
                     obj.entities[j].vx = obj.entities[i].vx;
                     obj.entities[j].dir = obj.entities[i].dir;
                 }
@@ -1386,15 +1370,15 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 {
                     if (game.roomx == 102)
                     {
-                        obj.createentity(game, 310, 177, 17, 1);
-                        j = obj.getcompanion(8);
+                        obj.createentity(310, 177, 17, 1);
+                        j = obj.getcompanion();
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
                     }
                     else
                     {
-                        obj.createentity(game, obj.entities[i].xp, 177.0f, 17.0f, 1);
-                        j = obj.getcompanion(8);
+                        obj.createentity(obj.entities[i].xp, 177.0f, 17.0f, 1);
+                        j = obj.getcompanion();
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
                     }
@@ -1405,13 +1389,13 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 {
                     if (game.roomx == 110 && obj.entities[i].xp<20)
                     {
-                        obj.createentity(game, 100, 185, 18, 15, 0, 1);
+                        obj.createentity(100, 185, 18, 15, 0, 1);
                     }
                     else
                     {
-                        obj.createentity(game, obj.entities[i].xp, 185.0f, 18.0f, 15, 0, 1);
+                        obj.createentity(obj.entities[i].xp, 185.0f, 18.0f, 15, 0, 1);
                     }
-                    j = obj.getcompanion(9);
+                    j = obj.getcompanion();
                     obj.entities[j].vx = obj.entities[i].vx;
                     obj.entities[j].dir = obj.entities[i].dir;
                 }
@@ -1422,26 +1406,26 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 {
                     if (obj.flags[59] == 0)
                     {
-                        obj.createentity(game, 225.0f, 169.0f, 18, dwgfx.crewcolour(game.lastsaved), 0, 10);
-                        j = obj.getcompanion(10);
+                        obj.createentity(225.0f, 169.0f, 18, graphics.crewcolour(game.lastsaved), 0, 10);
+                        j = obj.getcompanion();
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
                     }
                 }
-                else	if (game.roomy >= 52)
+                else if (game.roomy >= 52)
                 {
                     if (obj.flags[59] == 1)
                     {
-                        obj.createentity(game, 160.0f, 177.0f, 18, dwgfx.crewcolour(game.lastsaved), 0, 18, 1);
-                        j = obj.getcompanion(10);
+                        obj.createentity(160.0f, 177.0f, 18, graphics.crewcolour(game.lastsaved), 0, 18, 1);
+                        j = obj.getcompanion();
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
                     }
                     else
                     {
                         obj.flags[59] = 1;
-                        obj.createentity(game, obj.entities[i].xp, -20.0f, 18.0f, dwgfx.crewcolour(game.lastsaved), 0, 10, 0);
-                        j = obj.getcompanion(10);
+                        obj.createentity(obj.entities[i].xp, -20.0f, 18.0f, graphics.crewcolour(game.lastsaved), 0, 10, 0);
+                        j = obj.getcompanion();
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
                     }
@@ -1449,60 +1433,59 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 break;
             case 11:
                 //Intermission 1: We're using the SuperCrewMate instead!
-                //obj.createentity(game, obj.entities[i].xp, obj.entities[i].yp, 24, dwgfx.crewcolour(game.lastsaved));
                 if(game.roomx-41==game.scmprogress)
                 {
                     switch(game.scmprogress)
                     {
                     case 0:
-                        obj.createentity(game, 76, 161, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(76, 161, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 1:
-                        obj.createentity(game, 10, 169, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 169, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 2:
-                        obj.createentity(game, 10, 177, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 177, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 3:
                         if (game.scmmoveme)
                         {
-                            obj.createentity(game, obj.entities[obj.getplayer()].xp, 185, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                            obj.createentity(obj.entities[obj.getplayer()].xp, 185, 24, graphics.crewcolour(game.lastsaved), 2);
                             game.scmmoveme = false;
                         }
                         else
                         {
-                            obj.createentity(game, 10, 177, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                            obj.createentity(10, 177, 24, graphics.crewcolour(game.lastsaved), 2);
                         }
                         break;
                     case 4:
-                        obj.createentity(game, 10, 185, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 185, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 5:
-                        obj.createentity(game, 10, 185, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 185, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 6:
-                        obj.createentity(game, 10, 185, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 185, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 7:
-                        obj.createentity(game, 10, 41, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 41, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 8:
-                        obj.createentity(game, 10, 169, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 169, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 9:
-                        obj.createentity(game, 10, 169, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 169, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 10:
-                        obj.createentity(game, 10, 129, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 129, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 11:
-                        obj.createentity(game, 10, 129, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 129, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 12:
-                        obj.createentity(game, 10, 65, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 65, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 13:
-                        obj.createentity(game, 10, 177, 24, dwgfx.crewcolour(game.lastsaved));
+                        obj.createentity(10, 177, 24, graphics.crewcolour(game.lastsaved));
                         break;
                     }
                 }
@@ -1544,5 +1527,5 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
     }
 
     if (game.teleport_to_new_area)
-        script.teleport(dwgfx, game, map,	obj, help, music);
+        script.teleport();
 }

--- a/desktop_version/src/Logic.h
+++ b/desktop_version/src/Logic.h
@@ -8,16 +8,16 @@
 #include "Music.h"
 #include "Map.h"
 
-void titlelogic(Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help, musicclass& music, mapclass& map);
+void titlelogic();
 
-void maplogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help);
+void maplogic();
 
-void gamecompletelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help);
+void gamecompletelogic();
 
-void gamecompletelogic2(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help);
+void gamecompletelogic2();
 
-void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help);
+void towerlogic();
 
-void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help);
+void gamelogic();
 
 #endif /* LOGIC_H */

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -515,7 +515,7 @@ int mapclass::maptiletoenemycol(int t)
 	return 11;
 }
 
-void mapclass::changefinalcol(int t, entityclass& obj, Game& game)
+void mapclass::changefinalcol(int t)
 {
 	//change the map to colour t - for the game's final stretch.
 	//First up, the tiles. This is just a setting:
@@ -819,12 +819,12 @@ void mapclass::showship()
 	explored[4 + (11 * 20)] = 1;
 }
 
-void mapclass::resetplayer(Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music)
+void mapclass::resetplayer()
 {
 	bool was_in_tower = towermode;
 	if (game.roomx != game.saverx || game.roomy != game.savery)
 	{
-		gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		gotoroom(game.saverx, game.savery);
 	}
 
 	game.deathseq = -1;
@@ -876,16 +876,16 @@ void mapclass::resetplayer(Graphics& dwgfx, Game& game, entityclass& obj, musicc
 	}
 }
 
-void mapclass::warpto(int rx, int ry , int t, int tx, int ty, Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music)
+void mapclass::warpto(int rx, int ry, int t, int tx, int ty)
 {
-	gotoroom(rx, ry, dwgfx, game, obj, music);
+	gotoroom(rx, ry);
 	game.teleport = false;
 	obj.entities[t].xp = tx * 8;
 	obj.entities[t].yp = (ty * 8) - obj.entities[t].h;
 	game.gravitycontrol = 0;
 }
 
-void mapclass::gotoroom(int rx, int ry, Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music)
+void mapclass::gotoroom(int rx, int ry)
 {
 	//First, destroy the current room
 	obj.removeallblocks();
@@ -999,7 +999,7 @@ void mapclass::gotoroom(int rx, int ry, Graphics& dwgfx, Game& game, entityclass
 		if (game.roomx == 107 && game.roomy == 109) music.niceplay(4);
 		if (game.roomx == 108 && game.roomy == 109)
 		{
-			if (dwgfx.setflipmode)
+			if (graphics.setflipmode)
 			{
 				music.niceplay(9);
 			}
@@ -1010,7 +1010,7 @@ void mapclass::gotoroom(int rx, int ry, Graphics& dwgfx, Game& game, entityclass
 		}
 		if (game.roomx == 109)
 		{
-			if (dwgfx.setflipmode)
+			if (graphics.setflipmode)
 			{
 				music.niceplay(9);
 			}
@@ -1053,7 +1053,7 @@ void mapclass::gotoroom(int rx, int ry, Graphics& dwgfx, Game& game, entityclass
 		if (game.roomx == 104 && game.roomy == 112) music.niceplay(4);
 	}
 	temp = rx + (ry * 100);
-	loadlevel(game.roomx, game.roomy, dwgfx, game, obj, music);
+	loadlevel(game.roomx, game.roomy);
 
 
 	//Do we need to reload the background?
@@ -1061,9 +1061,9 @@ void mapclass::gotoroom(int rx, int ry, Graphics& dwgfx, Game& game, entityclass
 
 	if(redrawbg)
 	{
-		dwgfx.backgrounddrawn = false; //Used for background caching speedup
+		graphics.backgrounddrawn = false; //Used for background caching speedup
 	}
-	dwgfx.foregrounddrawn = false; //Used for background caching speedup
+	graphics.foregrounddrawn = false; //Used for background caching speedup
 
 	game.prevroomx = game.roomx;
 	game.prevroomy = game.roomy;
@@ -1174,11 +1174,9 @@ std::string mapclass::currentarea(int t)
 	return "???";
 }
 
-void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music)
+void mapclass::loadlevel(int rx, int ry)
 {
 	int t;
-	//t = rx + (ry * 100);
-	//roomname = "[UNTITLED] (" + String(rx)+","+String(ry)+")";
 	if (!finalmode)
 	{
 		explored[rx - 100 + ((ry - 100) * 20)] = 1;
@@ -1287,13 +1285,13 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 						{
 							//in the secret lab! Crazy background!
 							background = 2;
-							if (rx == 116 && ry == 105) dwgfx.rcol = 1;
-							if (rx == 117 && ry == 105) dwgfx.rcol = 5;
-							if (rx == 118 && ry == 105) dwgfx.rcol = 4;
-							if (rx == 117 && ry == 106) dwgfx.rcol = 2;
-							if (rx == 118 && ry == 106) dwgfx.rcol = 0;
-							if (rx == 119 && ry == 106) dwgfx.rcol = 3;
-							if (rx == 119 && ry == 107) dwgfx.rcol = 1;
+							if (rx == 116 && ry == 105) graphics.rcol = 1;
+							if (rx == 117 && ry == 105) graphics.rcol = 5;
+							if (rx == 118 && ry == 105) graphics.rcol = 4;
+							if (rx == 117 && ry == 106) graphics.rcol = 2;
+							if (rx == 118 && ry == 106) graphics.rcol = 0;
+							if (rx == 119 && ry == 106) graphics.rcol = 3;
+							if (rx == 119 && ry == 107) graphics.rcol = 1;
 						}
 					}
 				}
@@ -1304,7 +1302,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 	if (rx == 119 && ry == 108 && !custommode)
 	{
 		background = 5;
-		dwgfx.rcol = 3;
+		graphics.rcol = 3;
 		warpx = true;
 		warpy = true;
 	}
@@ -1312,11 +1310,11 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 	switch(t)
 	{
 	case 0:
-			#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY)
 	case 1: //World Map
 		tileset = 1;
 		extrarow = 1;
-		tmap = otherlevel.loadlevel(rx, ry, game, obj);
+		tmap = otherlevel.loadlevel(rx, ry);
 		fillcontent(tmap);
 		roomname = otherlevel.roomname;
 		tileset = otherlevel.roomtileset;
@@ -1329,12 +1327,12 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		}
 		break;
 	case 2: //The Lab
-		tmap = lablevel.loadlevel(rx, ry, game, obj);
+		tmap = lablevel.loadlevel(rx, ry);
 		fillcontent(tmap);
 		roomname = lablevel.roomname;
 		tileset = 1;
 		background = 2;
-		dwgfx.rcol = lablevel.rcol;
+		graphics.rcol = lablevel.rcol;
 		break;
 	case 3: //The Tower
 		tdrawback = true;
@@ -1347,41 +1345,40 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		tileset = 1;
 		background = 3;
 		towermode = true;
-		//bypos = 0; ypos = 0; cameramode = 0;
 
 		//All the entities for here are just loaded here; it's essentially one room after all
 
 
-		obj.createentity(game, 48, 5456, 10, 1, 505007); // (savepoint)
-		obj.createentity(game, 224, 4528, 10, 1, 505017); // (savepoint)
-		obj.createentity(game, 232, 4168, 10, 0, 505027); // (savepoint)
-		obj.createentity(game, 280, 3816, 10, 1, 505037); // (savepoint)
-		obj.createentity(game, 152, 3552, 10, 1, 505047); // (savepoint)
-		obj.createentity(game, 216, 3280, 10, 0, 505057); // (savepoint)
-		obj.createentity(game, 216, 4808, 10, 1, 505067); // (savepoint)
-		obj.createentity(game, 72, 3096, 10, 0, 505077); // (savepoint)
-		obj.createentity(game, 176, 2600, 10, 0, 505087); // (savepoint)
-		obj.createentity(game, 216, 2392, 10, 0, 505097); // (savepoint)
-		obj.createentity(game, 152, 1184, 10, 1, 505107); // (savepoint)
-		obj.createentity(game, 152, 912, 10, 1, 505117); // (savepoint)
-		obj.createentity(game, 152, 536, 10, 1, 505127); // (savepoint)
-		obj.createentity(game, 120, 5136, 10, 0, 505137); // (savepoint)
-		obj.createentity(game, 144, 1824, 10, 0, 505147); // (savepoint)
-		obj.createentity(game, 72, 2904, 10, 0, 505157); // (savepoint)
-		obj.createentity(game, 224, 1648, 10, 1, 505167); // (savepoint)
-		obj.createentity(game, 112, 5280, 10, 1, 50517); // (savepoint)
+		obj.createentity(48, 5456, 10, 1, 505007); // (savepoint)
+		obj.createentity(224, 4528, 10, 1, 505017); // (savepoint)
+		obj.createentity(232, 4168, 10, 0, 505027); // (savepoint)
+		obj.createentity(280, 3816, 10, 1, 505037); // (savepoint)
+		obj.createentity(152, 3552, 10, 1, 505047); // (savepoint)
+		obj.createentity(216, 3280, 10, 0, 505057); // (savepoint)
+		obj.createentity(216, 4808, 10, 1, 505067); // (savepoint)
+		obj.createentity(72, 3096, 10, 0, 505077); // (savepoint)
+		obj.createentity(176, 2600, 10, 0, 505087); // (savepoint)
+		obj.createentity(216, 2392, 10, 0, 505097); // (savepoint)
+		obj.createentity(152, 1184, 10, 1, 505107); // (savepoint)
+		obj.createentity(152, 912, 10, 1, 505117); // (savepoint)
+		obj.createentity(152, 536, 10, 1, 505127); // (savepoint)
+		obj.createentity(120, 5136, 10, 0, 505137); // (savepoint)
+		obj.createentity(144, 1824, 10, 0, 505147); // (savepoint)
+		obj.createentity(72, 2904, 10, 0, 505157); // (savepoint)
+		obj.createentity(224, 1648, 10, 1, 505167); // (savepoint)
+		obj.createentity(112, 5280, 10, 1, 50517); // (savepoint)
 
-		obj.createentity(game, 24, 4216, 9, 7); // (shiny trinket)
-		obj.createentity(game, 280, 3216, 9, 8); // (shiny trinket)
+		obj.createentity(24, 4216, 9, 7); // (shiny trinket)
+		obj.createentity(280, 3216, 9, 8); // (shiny trinket)
 		break;
 	case 4: //The Warpzone
-		tmap = warplevel.loadlevel(rx, ry, game, obj);
+		tmap = warplevel.loadlevel(rx, ry);
 		fillcontent(tmap);
 		roomname = warplevel.roomname;
 		tileset = 1;
 		background = 3;
-		dwgfx.rcol = warplevel.rcol;
-		dwgfx.backgrounddrawn = false;
+		graphics.rcol = warplevel.rcol;
+		graphics.backgrounddrawn = false;
 
 		warpx = warplevel.warpx;
 		warpy = warplevel.warpy;
@@ -1391,19 +1388,19 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		if (warpx && warpy) background = 5;
 		break;
 	case 5: //Space station
-		tmap = spacestation2.loadlevel(rx, ry, game, obj);
+		tmap = spacestation2.loadlevel(rx, ry);
 		fillcontent(tmap);
 		roomname = spacestation2.roomname;
 		tileset = 0;
 		break;
 	case 6: //final level
-		tmap = finallevel.loadlevel(finalx, finaly, game, obj);
+		tmap = finallevel.loadlevel(finalx, finaly);
 		fillcontent(tmap);
 		roomname = finallevel.roomname;
 		tileset = 1;
 		background = 3;
-		dwgfx.rcol = finallevel.rcol;
-		dwgfx.backgrounddrawn = false;
+		graphics.rcol = finallevel.rcol;
+		graphics.backgrounddrawn = false;
 
 		if (finalstretch)
 		{
@@ -1419,8 +1416,8 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			if (warpx && warpy) background = 5;
 		}
 
-		dwgfx.rcol = 6;
-		changefinalcol(final_mapcol, obj, game);
+		graphics.rcol = 6;
+		changefinalcol(final_mapcol);
 		break;
 	case 7: //Final Level, Tower 1
 		tdrawback = true;
@@ -1484,19 +1481,19 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 
 		tower.loadminitower2();
 
-		obj.createentity(game, 56, 556, 11, 136); // (horizontal gravity line)
-		obj.createentity(game, 184, 592, 10, 0, 50500); // (savepoint)
-		obj.createentity(game, 184, 644, 11, 88); // (horizontal gravity line)
-		obj.createentity(game, 56, 460, 11, 136); // (horizontal gravity line)
-		obj.createentity(game, 216, 440, 10, 0, 50501); // (savepoint)
-		obj.createentity(game, 104, 508, 11, 168); // (horizontal gravity line)
-		obj.createentity(game, 219, 264, 12, 56); // (vertical gravity line)
-		obj.createentity(game, 120, 332, 11, 96); // (horizontal gravity line)
-		obj.createentity(game, 219, 344, 12, 56); // (vertical gravity line)
-		obj.createentity(game, 224, 332, 11, 48); // (horizontal gravity line)
-		obj.createentity(game, 56, 212, 11, 144); // (horizontal gravity line)
-		obj.createentity(game, 32, 20, 11, 96); // (horizontal gravity line)
-		obj.createentity(game, 72, 156, 11, 200); // (horizontal gravity line)
+		obj.createentity(56, 556, 11, 136); // (horizontal gravity line)
+		obj.createentity(184, 592, 10, 0, 50500); // (savepoint)
+		obj.createentity(184, 644, 11, 88); // (horizontal gravity line)
+		obj.createentity(56, 460, 11, 136); // (horizontal gravity line)
+		obj.createentity(216, 440, 10, 0, 50501); // (savepoint)
+		obj.createentity(104, 508, 11, 168); // (horizontal gravity line)
+		obj.createentity(219, 264, 12, 56); // (vertical gravity line)
+		obj.createentity(120, 332, 11, 96); // (horizontal gravity line)
+		obj.createentity(219, 344, 12, 56); // (vertical gravity line)
+		obj.createentity(224, 332, 11, 48); // (horizontal gravity line)
+		obj.createentity(56, 212, 11, 144); // (horizontal gravity line)
+		obj.createentity(32, 20, 11, 96); // (horizontal gravity line)
+		obj.createentity(72, 156, 11, 200); // (horizontal gravity line)
 
 		int i = obj.getplayer();
 		obj.entities[i].yp += (71 * 8);
@@ -1527,19 +1524,19 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 
 		tower.loadminitower2();
 
-		obj.createentity(game, 56, 556, 11, 136); // (horizontal gravity line)
-		obj.createentity(game, 184, 592, 10, 0, 50500); // (savepoint)
-		obj.createentity(game, 184, 644, 11, 88); // (horizontal gravity line)
-		obj.createentity(game, 56, 460, 11, 136); // (horizontal gravity line)
-		obj.createentity(game, 216, 440, 10, 0, 50501); // (savepoint)
-		obj.createentity(game, 104, 508, 11, 168); // (horizontal gravity line)
-		obj.createentity(game, 219, 264, 12, 56); // (vertical gravity line)
-		obj.createentity(game, 120, 332, 11, 96); // (horizontal gravity line)
-		obj.createentity(game, 219, 344, 12, 56); // (vertical gravity line)
-		obj.createentity(game, 224, 332, 11, 48); // (horizontal gravity line)
-		obj.createentity(game, 56, 212, 11, 144); // (horizontal gravity line)
-		obj.createentity(game, 32, 20, 11, 96); // (horizontal gravity line)
-		obj.createentity(game, 72, 156, 11, 200); // (horizontal gravity line)
+		obj.createentity(56, 556, 11, 136); // (horizontal gravity line)
+		obj.createentity(184, 592, 10, 0, 50500); // (savepoint)
+		obj.createentity(184, 644, 11, 88); // (horizontal gravity line)
+		obj.createentity(56, 460, 11, 136); // (horizontal gravity line)
+		obj.createentity(216, 440, 10, 0, 50501); // (savepoint)
+		obj.createentity(104, 508, 11, 168); // (horizontal gravity line)
+		obj.createentity(219, 264, 12, 56); // (vertical gravity line)
+		obj.createentity(120, 332, 11, 96); // (horizontal gravity line)
+		obj.createentity(219, 344, 12, 56); // (vertical gravity line)
+		obj.createentity(224, 332, 11, 48); // (horizontal gravity line)
+		obj.createentity(56, 212, 11, 144); // (horizontal gravity line)
+		obj.createentity(32, 20, 11, 96); // (horizontal gravity line)
+		obj.createentity(72, 156, 11, 200); // (horizontal gravity line)
 
 		ypos = 0;
 		bypos = 0;
@@ -1550,7 +1547,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		break;
 	case 11: //Tower Hallways //Content is held in final level routine
 	{
-		tmap = finallevel.loadlevel(rx, ry, game, obj);
+		tmap = finallevel.loadlevel(rx, ry);
 		fillcontent(tmap);
 		roomname = finallevel.roomname;
 		tileset = 2;
@@ -1571,7 +1568,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		}
 	}
 		break;
-					#endif
+#endif
 #if !defined(NO_CUSTOM_LEVELS)
 	case 12: //Custom level
 		int curlevel=(rx-100)+((ry-100)*ed.maxwidth);
@@ -1589,7 +1586,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			case 2: //Lab
 			tileset = 1;
 			background = 2;
-			dwgfx.rcol = ed.level[curlevel].tilecol;
+			graphics.rcol = ed.level[curlevel].tilecol;
 			break;
 			case 3: //Warp Zone/intermission
 			tileset = 1;
@@ -1608,21 +1605,21 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		//If screen warping, then override all that:
 		bool redrawbg = game.roomx != game.prevroomx || game.roomy != game.prevroomy;
 		if(redrawbg){
-			dwgfx.backgrounddrawn = false;
+			graphics.backgrounddrawn = false;
 		}
 		if(ed.level[curlevel].warpdir>0){
 			if(ed.level[curlevel].warpdir==1){
 			warpx=true;
 			background=3;
-			dwgfx.rcol = ed.getwarpbackground(rx-100,ry-100);
+			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
 			}else if(ed.level[curlevel].warpdir==2){
 			warpy=true;
 			background=4;
-			dwgfx.rcol = ed.getwarpbackground(rx-100,ry-100);
+			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
 			}else if(ed.level[curlevel].warpdir==3){
 			warpx=true; warpy=true;
 			background = 5;
-			dwgfx.rcol = ed.getwarpbackground(rx-100,ry-100);
+			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
 			}
 		}
 
@@ -1663,8 +1660,8 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 				if(warpy){ if(by1==0 && by2==240){ by1=-100; by2=340; } }
 
 				obj.customenemy=ed.level[tsx+((ed.maxwidth)*tsy)].enemytype;
-				obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 56,
-								 edentity[edi].p1, 4, bx1, by1, bx2, by2);
+				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 56,
+					edentity[edi].p1, 4, bx1, by1, bx2, by2);
 				break;
 				case 2: //Platforms and Threadmills
 				if(edentity[edi].p1<=4){
@@ -1677,36 +1674,36 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 					if(warpx){ if(bx1==0 && bx2==320){ bx1=-100; bx2=420; } }
 					if(warpy){ if(by1==0 && by2==240){ by1=-100; by2=340; } }
 
-					obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 2,
-									 edentity[edi].p1, ed.level[rx-100+((ry-100)*ed.mapwidth)].platv, bx1, by1, bx2, by2);
+					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 2,
+						edentity[edi].p1, ed.level[rx-100+((ry-100)*ed.mapwidth)].platv, bx1, by1, bx2, by2);
 				}else if(edentity[edi].p1>=5 && edentity[edi].p1<=8){ //Threadmill
-					obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 2,
-									 edentity[edi].p1+3, 4);
+					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 2,
+						edentity[edi].p1+3, 4);
 				}
 				break;
 				case 3: //Disappearing platforms
-				obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 3);
+				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 3);
 				break;
 				case 9:
-				obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 9, ed.findtrinket(edi));
+				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 9, ed.findtrinket(edi));
 				break;
 				case 10: //Checkpoints
-				obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 10,
-								edentity[edi].p1,((rx+(ry*100))*20)+tempcheckpoints);
+				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 10,
+					edentity[edi].p1,((rx+(ry*100))*20)+tempcheckpoints);
 				tempcheckpoints++;
 				break;
 				case 11: //Gravity Lines
 				if(edentity[edi].p1==0){ //Horizontal
-					obj.createentity(game, (edentity[edi].p2*8),(edentity[edi].y*8)- ((ry-100)*30*8)+4, 11, edentity[edi].p3);
+					obj.createentity((edentity[edi].p2*8),(edentity[edi].y*8)- ((ry-100)*30*8)+4, 11, edentity[edi].p3);
 				}else{ //Vertical
-					obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8)+3,(edentity[edi].p2*8), 12, edentity[edi].p3);
+					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8)+3,(edentity[edi].p2*8), 12, edentity[edi].p3);
 				}
 				break;
 				case 13: //Warp Tokens
-				obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 13, edentity[edi].p1, edentity[edi].p2);
+				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 13, edentity[edi].p1, edentity[edi].p2);
 				break;
 				case 15: //Collectable crewmate
-				obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8)-4,(edentity[edi].y*8)- ((ry-100)*30*8)+1, 55, ed.findcrewmate(edi), edentity[edi].p1, edentity[edi].p2);
+				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8)-4,(edentity[edi].y*8)- ((ry-100)*30*8)+1, 55, ed.findcrewmate(edi), edentity[edi].p1, edentity[edi].p2);
 				break;
 				case 17: //Roomtext!
 				{
@@ -1720,7 +1717,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 				}
 				case 18: //Terminals
 				obj.customscript=edentity[edi].scriptname;
-				obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8)+8, 20, 1);
+				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8)+8, 20, 1);
 				obj.createblock(5, (edentity[edi].x*8)- ((rx-100)*40*8)-8, (edentity[edi].y*8)- ((ry-100)*30*8)+8, 20, 16, 35);
 				break;
 				case 19: //Script Box
@@ -1732,13 +1729,13 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 				case 50: //Warp Lines
 				obj.customwarpmode=true;
 				if(edentity[edi].p1==0){ //
-					obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8)+4,(edentity[edi].p2*8), 51, edentity[edi].p3);
+					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8)+4,(edentity[edi].p2*8), 51, edentity[edi].p3);
 				}else if(edentity[edi].p1==1){ //Horizontal, right
-					obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8)+4,(edentity[edi].p2*8), 52, edentity[edi].p3);
+					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8)+4,(edentity[edi].p2*8), 52, edentity[edi].p3);
 				}else if(edentity[edi].p1==2){ //Vertical, top
-					obj.createentity(game, (edentity[edi].p2*8),(edentity[edi].y*8)- ((ry-100)*30*8)+7, 53, edentity[edi].p3);
+					obj.createentity((edentity[edi].p2*8),(edentity[edi].y*8)- ((ry-100)*30*8)+7, 53, edentity[edi].p3);
 				}else if(edentity[edi].p1==3){
-					obj.createentity(game, (edentity[edi].p2*8),(edentity[edi].y*8)- ((ry-100)*30*8), 54, edentity[edi].p3);
+					obj.createentity((edentity[edi].p2*8),(edentity[edi].y*8)- ((ry-100)*30*8), 54, edentity[edi].p3);
 				}
 				break;
 			}
@@ -1833,7 +1830,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 				if (contents[i + vmult[j]] == 10)
 				{
 					contents[i + vmult[j]] = 0;
-					obj.createentity(game, i * 8, j * 8, 4);
+					obj.createentity(i * 8, j * 8, 4);
 				}
 				//Directional blocks
 				if (contents[i + vmult[j]] >= 14 && contents[i + vmult[j]] <= 17)
@@ -1877,7 +1874,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		{
 			if (game.crewstats[3] && !game.crewstats[4])
 			{
-				obj.createentity(game, 87, 105, 18, 15, 0, 18);
+				obj.createentity(87, 105, 18, 15, 0, 18);
 				obj.createblock(5, 87-32, 0, 32+32+32, 240, 3);
 			}
 		}
@@ -1885,7 +1882,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		{
 			if (game.crewstats[3] && !game.crewstats[5])
 			{
-				obj.createentity(game, 140, 137, 18, 15, 0, 18);
+				obj.createentity(140, 137, 18, 15, 0, 18);
 				obj.createblock(5, 140-32, 0, 32+32+32, 240, 3);
 			}
 		}
@@ -1893,7 +1890,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		{
 			if (game.crewstats[3] && !game.crewstats[2])
 			{
-				obj.createentity(game, 235, 81, 18, 15, 0, 18);
+				obj.createentity(235, 81, 18, 15, 0, 18);
 				obj.createblock(5, 235-32, 0, 32+32+32, 240, 3);
 			}
 		}
@@ -1905,7 +1902,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			{
 				if(game.crewrescued()>4 && game.crewrescued()!=6)
 				{
-					obj.createentity(game, 175, 121, 18, 13, 0, 18);
+					obj.createentity(175, 121, 18, 13, 0, 18);
 					obj.createblock(5, 175-32, 0, 32+32+32, 240, 4);
 				}
 			}
@@ -1916,7 +1913,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			{
 				if(game.crewrescued()<=4 && game.crewrescued()!=6)
 				{
-					obj.createentity(game, 53, 161, 18, 13, 1, 18);
+					obj.createentity(53, 161, 18, 13, 1, 18);
 					obj.createblock(5, 53-32, 0, 32+32+32, 240, 4);
 				}
 			}
@@ -1929,7 +1926,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			if (game.crewstats[3])
 			{
 				//If so, red will always be at his post
-				obj.createentity(game, 107, 121, 18, 15, 0, 18);
+				obj.createentity(107, 121, 18, 15, 0, 18);
 				//What script do we use?
 				obj.createblock(5, 107-32, 0, 32+32+32, 240, 3);
 			}
@@ -1940,7 +1937,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			//First: is he rescued?
 			if (game.crewstats[2])
 			{
-				obj.createentity(game, 198, 105, 18, 14, 0, 18);
+				obj.createentity(198, 105, 18, 14, 0, 18);
 				//What script do we use?
 				obj.createblock(5, 198-32, 0, 32+32+32, 240, 2);
 			}
@@ -1951,7 +1948,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			//First: is he rescued?
 			if (game.crewstats[4])
 			{
-				obj.createentity(game, 242, 177, 18, 13, 0, 18);
+				obj.createentity(242, 177, 18, 13, 0, 18);
 				//What script do we use?
 				obj.createblock(5, 242-32, 177-20, 32+32+32, 40, 4);
 			}
@@ -1962,7 +1959,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			//First: is she rescued?
 			if (game.crewstats[1])
 			{
-				obj.createentity(game, 140, 177, 18, 20, 0, 18);
+				obj.createentity(140, 177, 18, 20, 0, 18);
 				//What script do we use?
 				obj.createblock(5, 140-32, 0, 32+32+32, 240, 1);
 			}
@@ -1974,7 +1971,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			if (game.crewstats[5])
 			{
 				//A slight varation - she's upside down
-				obj.createentity(game, 249, 62, 18, 16, 0, 18);
+				obj.createentity(249, 62, 18, 16, 0, 18);
 				j = obj.getcrewman(5);
 				obj.entities[j].rule = 7;
 				obj.entities[j].tile +=6;

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -44,7 +44,7 @@ public:
 
     int maptiletoenemycol(int t);
 
-    void changefinalcol(int t, entityclass& obj, Game& game);
+    void changefinalcol(int t);
 
     void setcol(const int r1, const int g1, const int b1 , const int r2, const  int g2, const int b2, const int c);
 
@@ -73,15 +73,15 @@ public:
 
     void showship();
 
-    void resetplayer(Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music);
+    void resetplayer();
 
-    void warpto(int rx, int ry , int t, int tx, int ty,  Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music);
+    void warpto(int rx, int ry , int t, int tx, int ty);
 
-    void gotoroom(int rx, int ry, Graphics& dwgfx,  Game& game, entityclass& obj, musicclass& music);
+    void gotoroom(int rx, int ry);
 
     std::string currentarea(int t);
 
-    void loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music);
+    void loadlevel(int rx, int ry);
 
 
     std::vector <int> roomdeaths;

--- a/desktop_version/src/Otherlevel.cpp
+++ b/desktop_version/src/Otherlevel.cpp
@@ -11,7 +11,7 @@ void otherlevelclass::addline(std::string t)
 	roomtext.push_back(text);
 }
 
-std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game, entityclass& obj)
+std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry)
 {
 	int t;
 	roomtileset = 1;
@@ -61,8 +61,8 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("486,486,486,486,486,486,486,486,486,608,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,606,486,486,486,486,486,486");
 		tmap.push_back("486,486,486,486,486,486,486,486,486,608,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,606,486,486,486,486,486,486");
 
-		obj.createentity(game, 72, 32, 14); //Teleporter!
-		obj.createentity(game, 216, 144, 20, 1);
+		obj.createentity(72, 32, 14); //Teleporter!
+		obj.createentity(216, 144, 20, 1);
 
 		obj.createblock(5, 216-4, 144, 20, 16, 8);
 		break;
@@ -372,7 +372,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 
-		obj.createentity(game, 152, 144, 10, 1, 9000);  // (savepoint)
+		obj.createentity(152, 144, 10, 1, 9000);  // (savepoint)
 		break;
 
 	case rn(0,10):
@@ -408,7 +408,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 
-		obj.createentity(game, 224, 96, 10, 0, 10000);  // (savepoint)
+		obj.createentity(224, 96, 10, 0, 10000);  // (savepoint)
 		break;
 
 	case rn(0,11):
@@ -444,7 +444,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 
-		obj.createentity(game, 56, 32, 13); //Warp Token
+		obj.createentity(56, 32, 13); //Warp Token
 
 		break;
 
@@ -617,7 +617,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 
-		obj.createentity(game, 120, 40, 14); //Teleporter!
+		obj.createentity(120, 40, 14); //Teleporter!
 		break;
 
 	case rn(0,17):
@@ -755,7 +755,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,603,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,603,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 
-		obj.createentity(game, 144, 136, 10, 1, 4010);  // (savepoint)
+		obj.createentity(144, 136, 10, 1, 4010);  // (savepoint)
 		break;
 
 	case rn(1,5):
@@ -791,7 +791,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 
-		obj.createentity(game, 88, 104, 10, 1, 106010);  // (savepoint)
+		obj.createentity(88, 104, 10, 1, 106010);  // (savepoint)
 		break;
 
 	case rn(1,6):
@@ -895,7 +895,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,605,236,116,116,116,116,116,116,116,116,116,116,116,116,116,116,116,116");
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,605,236,116,116,116,116,116,116,116,116,116,116,116,116,116,116,116,116");
 
-		obj.createentity(game, 152, 64, 10, 0, 9010);  // (savepoint)
+		obj.createentity(152, 64, 10, 0, 9010);  // (savepoint)
 		break;
 
 	case rn(1,10):
@@ -931,7 +931,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 
-		obj.createentity(game, 208, 120, 9, 15);  // (shiny trinket)
+		obj.createentity(208, 120, 9, 15);  // (shiny trinket)
 		break;
 
 	case rn(1,11):
@@ -967,13 +967,13 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 
-		obj.createentity(game, 40, 192, 13); //Warp Token
-		obj.createentity(game, 168, 136, 13); //Warp Token
-		obj.createentity(game, 224, 136, 13); //Warp Token
+		obj.createentity(40, 192, 13); //Warp Token
+		obj.createentity(168, 136, 13); //Warp Token
+		obj.createentity(224, 136, 13); //Warp Token
 
 
 
-		obj.createentity(game, 96, 80, 13); //Warp Token
+		obj.createentity(96, 80, 13); //Warp Token
 
 		break;
 
@@ -1044,7 +1044,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 
-		obj.createentity(game, 112, 152, 10, 1, 13010);  // (savepoint)
+		obj.createentity(112, 152, 10, 1, 13010);  // (savepoint)
 		break;
 
 	case rn(1,14):
@@ -1148,7 +1148,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,617,415,295,295,295,295,295");
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,617,415,295,295,295,295,295");
 
-		obj.createentity(game, 280, 120, 10, 1, 16010);  // (savepoint)
+		obj.createentity(280, 120, 10, 1, 16010);  // (savepoint)
 		break;
 
 	case rn(2,2):
@@ -1184,7 +1184,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("483,483,483,483,483,483,483,483,483,605,49,0,0,0,0,0,0,50,603,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 		tmap.push_back("483,483,483,483,483,483,483,483,483,605,49,0,0,0,0,0,0,50,603,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 
-		obj.createentity(game, 56, 32, 10, 1, 2020);  // (savepoint)
+		obj.createentity(56, 32, 10, 1, 2020);  // (savepoint)
 		break;
 
 	case rn(2,3):
@@ -1288,7 +1288,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 40, 88, 10, 1, 6020);  // (savepoint)
+		obj.createentity(40, 88, 10, 1, 6020);  // (savepoint)
 		break;
 
 	case rn(2,8):
@@ -1394,26 +1394,26 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 			tmap.push_back("113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113");
 			tmap.push_back("113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113");
 
-			obj.createentity(game, 40, 32, 22, 0);  // (shiny trinket)
-			obj.createentity(game, 64, 32, 22, 1);  // (shiny trinket)
-			obj.createentity(game, 88, 32, 22, 2);  // (shiny trinket)
-			obj.createentity(game, 40, 80, 22, 3);  // (shiny trinket)
-			obj.createentity(game, 64, 80, 22, 4);  // (shiny trinket)
-			obj.createentity(game, 88, 80, 22, 5);  // (shiny trinket)
-			obj.createentity(game, 112, 80, 22, 6);  // (shiny trinket)
-			obj.createentity(game, 40, 128, 22, 7);  // (shiny trinket)
-			obj.createentity(game, 64, 128, 22, 8);  // (shiny trinket)
-			obj.createentity(game, 88, 128, 22, 9);  // (shiny trinket)
-			obj.createentity(game, 112, 128, 22, 10);  // (shiny trinket)
-			obj.createentity(game, 136, 128, 22, 11);  // (shiny trinket)
-			obj.createentity(game, 40, 176, 22, 12);  // (shiny trinket)
-			obj.createentity(game, 64, 176, 22, 13);  // (shiny trinket)
-			obj.createentity(game, 88, 176, 22, 14);  // (shiny trinket)
-			obj.createentity(game, 112, 176, 22, 15);  // (shiny trinket)
-			obj.createentity(game, 136, 176, 22, 16);  // (shiny trinket)
-			obj.createentity(game, 112, 32, 22, 17);  // (shiny trinket)
-			obj.createentity(game, 136, 80, 22, 18);  // (shiny trinket)
-			obj.createentity(game, 136, 32, 22, 19);  // (shiny trinket)
+			obj.createentity(40, 32, 22, 0);  // (shiny trinket)
+			obj.createentity(64, 32, 22, 1);  // (shiny trinket)
+			obj.createentity(88, 32, 22, 2);  // (shiny trinket)
+			obj.createentity(40, 80, 22, 3);  // (shiny trinket)
+			obj.createentity(64, 80, 22, 4);  // (shiny trinket)
+			obj.createentity(88, 80, 22, 5);  // (shiny trinket)
+			obj.createentity(112, 80, 22, 6);  // (shiny trinket)
+			obj.createentity(40, 128, 22, 7);  // (shiny trinket)
+			obj.createentity(64, 128, 22, 8);  // (shiny trinket)
+			obj.createentity(88, 128, 22, 9);  // (shiny trinket)
+			obj.createentity(112, 128, 22, 10);  // (shiny trinket)
+			obj.createentity(136, 128, 22, 11);  // (shiny trinket)
+			obj.createentity(40, 176, 22, 12);  // (shiny trinket)
+			obj.createentity(64, 176, 22, 13);  // (shiny trinket)
+			obj.createentity(88, 176, 22, 14);  // (shiny trinket)
+			obj.createentity(112, 176, 22, 15);  // (shiny trinket)
+			obj.createentity(136, 176, 22, 16);  // (shiny trinket)
+			obj.createentity(112, 32, 22, 17);  // (shiny trinket)
+			obj.createentity(136, 80, 22, 18);  // (shiny trinket)
+			obj.createentity(136, 32, 22, 19);  // (shiny trinket)
 
 			if(!game.nocutscenes && obj.flags[70]==0)
 			{
@@ -1454,7 +1454,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 			tmap.push_back("113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113");
 			tmap.push_back("113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113");
 
-			obj.createentity(game, 90, 52, 26, 0);  // (super warp)
+			obj.createentity(90, 52, 26, 0);  // (super warp)
 		}
 
 		break;
@@ -1492,7 +1492,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104");
 		tmap.push_back("104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104");
 
-		obj.createentity(game, 64, 64, 14); //Teleporter!
+		obj.createentity(64, 64, 14); //Teleporter!
 		break;
 
 	case rn(2,12):
@@ -1630,7 +1630,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 		tmap.push_back("489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 
-		obj.createentity(game, 240, 96, 10, 0, 15020);  // (savepoint)
+		obj.createentity(240, 96, 10, 0, 15020);  // (savepoint)
 		break;
 
 	case rn(3,2):
@@ -1666,7 +1666,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,620,0,0,0,0,618,498,498");
 		tmap.push_back("498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,620,0,0,0,0,618,498,498");
 
-		obj.createentity(game, 152, 96, 9, 16);  // (shiny trinket)
+		obj.createentity(152, 96, 9, 16);  // (shiny trinket)
 		break;
 
 	case rn(3,3):
@@ -1702,7 +1702,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501");
 		tmap.push_back("501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501");
 
-		obj.createentity(game, 24, 192, 10, 1, 3030);  // (savepoint)
+		obj.createentity(24, 192, 10, 1, 3030);  // (savepoint)
 		break;
 
 	case rn(3,5):
@@ -1874,7 +1874,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101");
 		tmap.push_back("101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101");
 
-		obj.createentity(game, 248, 168, 10, 1, 9030);  // (savepoint)
+		obj.createentity(248, 168, 10, 1, 9030);  // (savepoint)
 		break;
 
 	case rn(3,10):
@@ -1910,65 +1910,65 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,223,741,741,741,741,741,741,221,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101");
 		tmap.push_back("101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,223,741,741,741,741,741,741,221,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101");
 
-		obj.createentity(game, 88, 80, 21, 1); //Terminal	// UU Brothers
+		obj.createentity(88, 80, 21, 1); //Terminal	// UU Brothers
 		obj.createblock(5, 88 - 4, 80, 20, 16, 25);
 
 		if(game.stat_trinkets>=5)
 		{
-			obj.createentity(game, 128, 80, 21, 1); //Terminal
+			obj.createentity(128, 80, 21, 1); //Terminal
 			obj.createblock(5, 128 - 4, 80, 20, 16, 26);
 		}
 
 		if(game.stat_trinkets>=8)
 		{
-			obj.createentity(game, 176, 80, 21, 1); //Terminal
+			obj.createentity(176, 80, 21, 1); //Terminal
 			obj.createblock(5, 176 - 4, 80, 20, 16, 27);
 		}
 
 		if(game.stat_trinkets>=10)
 		{
-			obj.createentity(game, 216, 80, 21, 1); //Terminal
+			obj.createentity(216, 80, 21, 1); //Terminal
 			obj.createblock(5, 216 - 4, 80, 20, 16, 28);
 		}
 
 		if(game.stat_trinkets>=12)
 		{
-			obj.createentity(game, 88, 128, 21, 0); //Terminal
+			obj.createentity(88, 128, 21, 0); //Terminal
 			obj.createblock(5, 88 - 4, 128, 20, 16, 29);
 		}
 
 		if(game.stat_trinkets>=14)
 		{
-			obj.createentity(game, 128, 128, 21, 0); //Terminal
+			obj.createentity(128, 128, 21, 0); //Terminal
 			obj.createblock(5, 128 - 4, 128, 20, 16, 33);
 		}
 
 		if(game.stat_trinkets>=16)
 		{
-			obj.createentity(game, 176, 128, 21, 0); //Terminal
+			obj.createentity(176, 128, 21, 0); //Terminal
 			obj.createblock(5, 176 - 4, 128, 20, 16, 30);
 		}
 
 		if(game.stat_trinkets>=18)
 		{
-			obj.createentity(game, 216, 128, 21, 0); //Terminal
+			obj.createentity(216, 128, 21, 0); //Terminal
 			obj.createblock(5, 216 - 4, 128, 20, 16, 32);
 		}
 
 		//Special cases
 		if(game.stat_trinkets>=20)
 		{
-			obj.createentity(game, 40, 40, 21, 0); //Terminal
+			obj.createentity(40, 40, 21, 0); //Terminal
 			obj.createblock(5, 40 - 4, 40, 20, 16, 31);
 		}
 
 		if(game.stat_trinkets>=20)
 		{
-			obj.createentity(game, 264, 40, 21, 0); //Terminal
+			obj.createentity(264, 40, 21, 0); //Terminal
 			obj.createblock(5, 264 - 4, 40, 20, 16, 34);
 		}
 
-		obj.createentity(game, 152, 40, 21, 0); //Terminal (jukebox instructions)
+		obj.createentity(152, 40, 21, 0); //Terminal (jukebox instructions)
 		obj.createblock(5, 152 - 4, 40, 20, 16, 24);
 		break;
 
@@ -2039,7 +2039,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,692,0,0,0,0,0,612,492,492,492,492,492,492,492,492,492,492,492,492,492,492,614,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,692,0,0,0,0,0,612,492,492,492,492,492,492,492,492,492,492,492,492,492,492,614,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 128, 160, 10, 1, 113030);  // (savepoint)
+		obj.createentity(128, 160, 10, 1, 113030);  // (savepoint)
 		break;
 
 
@@ -2076,7 +2076,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,605,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,605,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 192, 96, 10, 0, 114030);  // (savepoint)
+		obj.createentity(192, 96, 10, 0, 114030);  // (savepoint)
 		break;
 
 	case rn(3,14):
@@ -2282,12 +2282,12 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110");
 		tmap.push_back("110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110");
 
-		obj.createentity(game, 256, 120, 20, 1); //Terminal Ship computer
+		obj.createentity(256, 120, 20, 1); //Terminal Ship computer
 		obj.createblock(5, 256 - 4, 120, 20, 16, 22);
 
-		obj.createentity(game, 256, 184, 20, 1); //Terminal
-		obj.createentity(game, 232, 184, 20, 1); //Terminal
-		obj.createentity(game, 208, 184, 20, 1); //Terminal
+		obj.createentity(256, 184, 20, 1); //Terminal
+		obj.createentity(232, 184, 20, 1); //Terminal
+		obj.createentity(208, 184, 20, 1); //Terminal
 		obj.createblock(5, 208 + 4, 184, 56, 16, 23);
 		break;
 
@@ -2392,7 +2392,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,689,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,609,489,489,489,489,489,489,489,489,489,489,489");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,689,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,609,489,489,489,489,489,489,489,489,489,489,489");
 
-		obj.createentity(game, 248, 112, 10, 1, 114040);  // (savepoint)
+		obj.createentity(248, 112, 10, 1, 114040);  // (savepoint)
 		break;
 
 	case rn(4,14):
@@ -2428,7 +2428,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,614,0,0,0,0,0,612,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,614,0,0,0,0,0,612,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 
-		obj.createentity(game, 104, 176, 10, 1, 115040);  // (savepoint)
+		obj.createentity(104, 176, 10, 1, 115040);  // (savepoint)
 		break;
 
 	case rn(4,15):
@@ -2464,7 +2464,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 
-		obj.createentity(game, 16, 40, 10, 1, 15040);  // (savepoint)
+		obj.createentity(16, 40, 10, 1, 15040);  // (savepoint)
 		break;
 
 	case rn(5,2):
@@ -2534,7 +2534,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,614,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,614,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 272, 128, 10, 0, 3050);  // (savepoint)
+		obj.createentity(272, 128, 10, 0, 3050);  // (savepoint)
 		break;
 
 	case rn(5,4):
@@ -2876,7 +2876,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 
-		obj.createentity(game, 184, 176, 10, 1, 13050);  // (savepoint)
+		obj.createentity(184, 176, 10, 1, 13050);  // (savepoint)
 		break;
 
 	case rn(5,14):
@@ -2947,7 +2947,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("486,486,486,486,486,486,486,486,527,567,568,0,0,686,0,0,606,486,486,486,486,486,486,486,527,568,0,0,0,0,0,566,567,528,486,486,486,486,486,486");
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,527,567,567,567,567,567,528,486,486,486,486,486,486,486,486,527,567,567,567,567,567,528,486,486,486,486,486,486,486,486");
 
-		obj.createentity(game, 72, 16, 9, 14);  // (shiny trinket)
+		obj.createentity(72, 16, 9, 14);  // (shiny trinket)
 		break;
 
 	case rn(5,18):
@@ -2983,7 +2983,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("489,489,611,0,0,0,0,609,489,489,611,0,0,0,0,609,489,489,611,0,0,0,0,609,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 		tmap.push_back("489,489,611,0,0,0,0,609,489,489,611,0,0,0,0,609,489,489,611,0,0,0,0,609,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 
-		obj.createentity(game, 224, 160, 13); //Warp Token
+		obj.createentity(224, 160, 13); //Warp Token
 
 		break;
 
@@ -3054,7 +3054,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 152, 152, 10, 0, 103060);  // (savepoint)
+		obj.createentity(152, 152, 10, 0, 103060);  // (savepoint)
 		break;
 
 	case rn(6,4):
@@ -3090,7 +3090,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,603,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,603,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 
-		obj.createentity(game, 128, 120, 10, 1, 4060);  // (savepoint)
+		obj.createentity(128, 120, 10, 1, 4060);  // (savepoint)
 		break;
 
 	case rn(6,5):
@@ -3194,7 +3194,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 		tmap.push_back("489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 
-		obj.createentity(game, 64, 88, 10, 1, 7060);  // (savepoint)
+		obj.createentity(64, 88, 10, 1, 7060);  // (savepoint)
 		break;
 
 	case rn(6,8):
@@ -3298,7 +3298,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,618,498,498,498,498,498,498,498,498,498");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,618,498,498,498,498,498,498,498,498,498");
 
-		obj.createentity(game, 152, 128, 10, 0, 10060);  // (savepoint)
+		obj.createentity(152, 128, 10, 0, 10060);  // (savepoint)
 		break;
 
 	case rn(6,11):
@@ -3473,11 +3473,11 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 
 		if(!game.intimetrial)
 		{
-			obj.createentity(game, 96, 48, 20, 1);//Terminal
+			obj.createentity(96, 48, 20, 1);//Terminal
 			obj.createblock(5, 96 - 4, 48, 20, 16, 12);
 		}
 
-		obj.createentity(game, 128, 216, 10, 1, 116061);  // (savepoint)
+		obj.createentity(128, 216, 10, 1, 116061);  // (savepoint)
 		break;
 
 	case rn(6,18):
@@ -3581,7 +3581,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486");
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486");
 
-		obj.createentity(game, 192, 104, 13); //Warp Token
+		obj.createentity(192, 104, 13); //Warp Token
 
 		break;
 
@@ -3618,7 +3618,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 88, 136, 10, 0, 103070);  // (savepoint)
+		obj.createentity(88, 136, 10, 0, 103070);  // (savepoint)
 		break;
 
 	case rn(7,3):
@@ -3688,7 +3688,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,527,567,567,567,528,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486");
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486");
 
-		obj.createentity(game, 208, 128, 10, 1, 4070);  // (savepoint)
+		obj.createentity(208, 128, 10, 1, 4070);  // (savepoint)
 		break;
 
 	case rn(7,5):
@@ -3860,7 +3860,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 
-		obj.createentity(game, 64, 112, 14); //Teleporter!
+		obj.createentity(64, 112, 14); //Teleporter!
 		break;
 
 	case rn(7,10):
@@ -3964,7 +3964,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,524,564,564,564,564,564,564,564,564,564,564,564,564,564,564,564,525,483,483,483,483,483,483,483,483,483,483,483");
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 
-		obj.createentity(game, 48, 192, 10, 1, 14070);  // (savepoint)
+		obj.createentity(48, 192, 10, 1, 14070);  // (savepoint)
 		break;
 
 	case rn(8,0):
@@ -4170,7 +4170,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 
-		obj.createentity(game, 80, 40, 10, 1, 5080);  // (savepoint)
+		obj.createentity(80, 40, 10, 1, 5080);  // (savepoint)
 		break;
 
 	case rn(8,6):
@@ -4206,7 +4206,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("489,489,489,489,489,489,611,0,0,0,0,609,489,489,489,489,611,0,0,0,0,0,0,609,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 		tmap.push_back("489,489,489,489,489,489,611,0,0,0,0,609,489,489,489,489,611,0,0,0,0,0,0,609,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 
-		obj.createentity(game, 96, 72, 13); //Warp Token
+		obj.createentity(96, 72, 13); //Warp Token
 
 		break;
 
@@ -4345,8 +4345,8 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,603,483,483,483,483");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,603,483,483,483,483");
 
-		obj.createentity(game, 176, 40, 14); //Teleporter!
-		obj.createentity(game, 120, 128, 20, 1);  // (terminal)
+		obj.createentity(176, 40, 14); //Teleporter!
+		obj.createentity(120, 128, 20, 1);  // (terminal)
 
 		obj.createblock(5, 120-4, 128, 20, 16, 7);
 		break;
@@ -4452,7 +4452,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("492,492,614,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,612,492,492");
 		tmap.push_back("492,492,614,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,612,492,492");
 
-		obj.createentity(game, 40, 152, 10, 1, 14080);  // (savepoint)
+		obj.createentity(40, 152, 10, 1, 14080);  // (savepoint)
 		break;
 
 	case rn(8,15):
@@ -4522,7 +4522,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("489,489,489,489,611,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,609,489,489,489,489");
 		tmap.push_back("489,489,489,489,611,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,609,489,489,489,489");
 
-		obj.createentity(game, 152, 80, 10, 1, 16080);  // (savepoint)
+		obj.createentity(152, 80, 10, 1, 16080);  // (savepoint)
 		break;
 
 	case rn(8,17):
@@ -4796,7 +4796,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,417,698,698,698,698,698,698,698,698,698,698,698,698,698,698,698,698,415,295,295,295,295,295,295,295,295,295,295,295");
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,417,698,698,698,698,698,698,698,698,698,698,698,698,698,698,698,698,415,295,295,295,295,295,295,295,295,295,295,295");
 
-		obj.createentity(game, 80, 40, 9, 17);  // (shiny trinket)
+		obj.createentity(80, 40, 9, 17);  // (shiny trinket)
 		roomtileset = 0; // (Use space station tileset)
 		break;
 
@@ -4942,7 +4942,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("516,516,638,0,0,0,630,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510");
 		tmap.push_back("516,516,638,0,0,0,630,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510");
 
-		obj.createentity(game, 184, 176, 10, 1, 12100);  // (savepoint)
+		obj.createentity(184, 176, 10, 1, 12100);  // (savepoint)
 		roomtileset = 0; // (Use space station tileset)
 		break;
 
@@ -5085,7 +5085,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486");
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486");
 
-		obj.createentity(game, 216, 72, 10, 1, 16100);  // (savepoint)
+		obj.createentity(216, 72, 10, 1, 16100);  // (savepoint)
 		break;
 
 	case rn(10,17):
@@ -5189,7 +5189,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,623,0,0,0,0,0,621,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501");
 		tmap.push_back("501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,623,0,0,0,0,0,621,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501");
 
-		obj.createentity(game, 40, 112, 9, 13);  // (shiny trinket)
+		obj.createentity(40, 112, 9, 13);  // (shiny trinket)
 		break;
 
 	case rn(11,0):
@@ -5362,7 +5362,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("495,495,617,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
 
-		obj.createentity(game, (8 * 8), (12 * 8), 1, 0, 0, -10000, -10000, 10000, 100000);  // Enemy
+		obj.createentity((8 * 8), (12 * 8), 1, 0, 0, -10000, -10000, 10000, 100000);  // Enemy
 		obj.nearelephant = true;
 
 		roomtileset = 0; // (Use space station tileset)
@@ -5402,7 +5402,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310");
 
 
-		obj.createentity(game, 8 * 8, -248 + (12 * 8), 1, 0, 0, -10000, -10000, 10000, 100000);  // Enemy
+		obj.createentity(8 * 8, -248 + (12 * 8), 1, 0, 0, -10000, -10000, 10000, 100000);  // Enemy
 		obj.nearelephant = true;
 
 		roomtileset = 0; // (Use space station tileset)
@@ -5716,10 +5716,10 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,412,292,292,414,698,698,698,412,292,292,292");
 
 
-		obj.createentity(game, -328 + (8 * 8), (12 * 8), 1, 0, 0, -10000, -10000, 10000, 100000);  // Enemy
+		obj.createentity(-328 + (8 * 8), (12 * 8), 1, 0, 0, -10000, -10000, 10000, 100000);  // Enemy
 		obj.nearelephant = true;
 
-		obj.createentity(game, 240, 72, 10, 1, 8120);  // (savepoint)
+		obj.createentity(240, 72, 10, 1, 8120);  // (savepoint)
 		roomtileset = 0; // (Use space station tileset)
 		break;
 
@@ -5757,7 +5757,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,217,689,689,689,215,95,95,95");
 
 
-		obj.createentity(game, -328 + (8 * 8), -248 + (12 * 8), 1, 0, 0, -10000, -10000, 10000, 100000);  // Enemy
+		obj.createentity(-328 + (8 * 8), -248 + (12 * 8), 1, 0, 0, -10000, -10000, 10000, 100000);  // Enemy
 		obj.nearelephant = true;
 
 		roomtileset = 0; // (Use space station tileset)
@@ -6003,7 +6003,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 
-		obj.createentity(game, 48, 96, 14); //Teleporter!
+		obj.createentity(48, 96, 14); //Teleporter!
 		break;
 
 	case rn(13,14):
@@ -6039,7 +6039,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 280, 32, 20, 1); //terminal
+		obj.createentity(280, 32, 20, 1); //terminal
 		obj.createblock(5, 280-4, 32, 20, 16, 9);
 
 		roomtileset = 0; // (Use space station tileset)
@@ -6112,7 +6112,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 
-		obj.createentity(game, 80, 104, 10, 1, 16130);  // (savepoint)
+		obj.createentity(80, 104, 10, 1, 16130);  // (savepoint)
 		break;
 
 	case rn(13,17):
@@ -6148,7 +6148,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,617,0,0,0,0,0,0,0,0,615,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,617,0,0,0,0,0,0,0,0,615,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 
-		obj.createentity(game, 240, 128, 10, 1, 17130);  // (savepoint)
+		obj.createentity(240, 128, 10, 1, 17130);  // (savepoint)
 		break;
 
 	case rn(13,18):
@@ -6390,8 +6390,8 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 
-		obj.createentity(game, 176, 72, 14); //Teleporter!
-		obj.createentity(game, 88, 160, 20, 1);//terminal
+		obj.createentity(176, 72, 14); //Teleporter!
+		obj.createentity(88, 160, 20, 1);//terminal
 
 		obj.createblock(5, 88-4, 160, 20, 16, 11);
 		break;
@@ -6533,7 +6533,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,608,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,608,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 88, 96, 10, 0, 18150);  // (savepoint)
+		obj.createentity(88, 96, 10, 0, 18150);  // (savepoint)
 		break;
 
 	case rn(15,19):
@@ -6603,7 +6603,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 
-		obj.createentity(game, 72, 120, 13); //Warp Token
+		obj.createentity(72, 120, 13); //Warp Token
 
 		break;
 
@@ -6641,7 +6641,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
 		roomtileset = 0; // (Use space station tileset)
-		obj.createentity(game, 176, 152, 10, 1, 14160);  // (savepoint)
+		obj.createentity(176, 152, 10, 1, 14160);  // (savepoint)
 		break;
 
 	case rn(16,17):
@@ -6779,8 +6779,8 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,617,680,680,680,680,680,680,615,495,495,495,495,495");
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,617,680,680,680,680,680,680,615,495,495,495,495,495");
 
-		obj.createentity(game, 40, 40, 14); //Teleporter!
-		obj.createentity(game, 192, 120, 20, 1);//terminal
+		obj.createentity(40, 40, 14); //Teleporter!
+		obj.createentity(192, 120, 20, 1);//terminal
 
 		obj.createblock(5, 192-4, 120, 20, 16, 10);
 		roomtileset = 0; // (Use space station tileset)
@@ -6961,7 +6961,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 112, 72, 14); //Teleporter!
+		obj.createentity(112, 72, 14); //Teleporter!
 		break;
 
 	case rn(17,18):
@@ -7031,7 +7031,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486");
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486");
 
-		obj.createentity(game, 152, 152, 10, 0, 19170);  // (savepoint)
+		obj.createentity(152, 152, 10, 0, 19170);  // (savepoint)
 		break;
 
 	case rn(18,4):
@@ -7102,7 +7102,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
 		roomtileset = 0; // (Use space station tileset)
-		obj.createentity(game, 104, 152, 10, 1, 15180);  // (savepoint)
+		obj.createentity(104, 152, 10, 1, 15180);  // (savepoint)
 		break;
 
 	case rn(18,17):
@@ -7206,7 +7206,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("564,564,564,564,564,564,565,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("483,483,483,483,483,483,605,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 192, 176, 10, 1, 105190);  // (savepoint)
+		obj.createentity(192, 176, 10, 1, 105190);  // (savepoint)
 		break;
 
 	case rn(19,5):
@@ -7242,7 +7242,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 
-		obj.createentity(game, 40, 192, 10, 1, 106190);  // (savepoint)
+		obj.createentity(40, 192, 10, 1, 106190);  // (savepoint)
 		break;
 
 
@@ -7313,7 +7313,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498");
 		tmap.push_back("498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498");
 
-		obj.createentity(game, 72, 168, 10, 1, 111190);  // (savepoint)
+		obj.createentity(72, 168, 10, 1, 111190);  // (savepoint)
 		break;
 
 	case rn(19,11):
@@ -7451,7 +7451,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("489,489,489,489,489,489,611,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,609,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 		tmap.push_back("489,489,489,489,489,489,611,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,609,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 
-		obj.createentity(game, 80, 144, 10, 1, 14190);  // (savepoint)
+		obj.createentity(80, 144, 10, 1, 14190);  // (savepoint)
 		break;
 
 	case rn(19,15):
@@ -7555,7 +7555,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,615,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,615,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 
-		obj.createentity(game, 168, 88, 10, 1, 17190);  // (savepoint)
+		obj.createentity(168, 88, 10, 1, 17190);  // (savepoint)
 		break;
 
 	case rn(19,18):
@@ -7802,23 +7802,23 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,414,0,0,0,0,0,0,0,412,292,292,292,292,292,292,292,292,292,292,292");
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,414,0,0,0,0,0,0,0,412,292,292,292,292,292,292,292,292,292,292,292");
 
-		obj.createentity(game, 256, 88, 21, 1); //Terminal
-		obj.createentity(game, 128, 88, 21, 1); //Terminal
-		obj.createentity(game, 104, 88, 21, 1); //Terminal
-		obj.createentity(game, 80, 88, 21, 1); //Terminal
-		obj.createentity(game, 128, 128, 21, 0); //Terminal
-		obj.createentity(game, 128, 192, 21, 1); //Terminal
-		obj.createentity(game, 104, 192, 21, 1); //Terminal
-		obj.createentity(game, 80, 192, 21, 1); //Terminal
+		obj.createentity(256, 88, 21, 1); //Terminal
+		obj.createentity(128, 88, 21, 1); //Terminal
+		obj.createentity(104, 88, 21, 1); //Terminal
+		obj.createentity(80, 88, 21, 1); //Terminal
+		obj.createentity(128, 128, 21, 0); //Terminal
+		obj.createentity(128, 192, 21, 1); //Terminal
+		obj.createentity(104, 192, 21, 1); //Terminal
+		obj.createentity(80, 192, 21, 1); //Terminal
 
 		if(game.insecretlab)
 		{
 			//vitellary
-			obj.createentity(game, 231, 81, 18, 14, 0, 18);
+			obj.createentity(231, 81, 18, 14, 0, 18);
 			obj.createblock(5, 231- 32, 0, 32 + 32 + 32, 240, 2);
 
 			//violet
-			obj.createentity(game,83, 126, 18, 20, 0, 18);
+			obj.createentity(83, 126, 18, 20, 0, 18);
 			obj.entities[obj.getcrewman(1)].rule = 7;
 			obj.entities[obj.getcrewman(1)].tile +=6;
 			obj.createblock(5, 83 - 32, 0, 32 + 32 + 32, 240, 1);
@@ -7858,27 +7858,27 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295");
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295");
 
-		obj.createentity(game, 96, 48, 25, 0, 1); //Terminal
-		obj.createentity(game, 128, 48, 25, 0, 2); //Terminal
-		obj.createentity(game, 160, 48, 25, 0, 3); //Terminal
-		obj.createentity(game, 192, 48, 25, 0, 4); //Terminal
-		obj.createentity(game, 224, 48, 25, 0, 5); //Terminal
-		obj.createentity(game, 256, 48, 25, 0, 6); //Terminal
+		obj.createentity(96, 48, 25, 0, 1); //Terminal
+		obj.createentity(128, 48, 25, 0, 2); //Terminal
+		obj.createentity(160, 48, 25, 0, 3); //Terminal
+		obj.createentity(192, 48, 25, 0, 4); //Terminal
+		obj.createentity(224, 48, 25, 0, 5); //Terminal
+		obj.createentity(256, 48, 25, 0, 6); //Terminal
 
-		obj.createentity(game, 96, 88, 25, 1, 13); //Terminal
-		obj.createentity(game, 128, 88, 25, 1, 14); //Terminal
-		obj.createentity(game, 160, 88, 25, 1, 15); //Terminal
-		obj.createentity(game, 192, 88, 25, 1, 16); //Terminal
-		obj.createentity(game, 224, 88, 25, 1, 17); //Terminal
-		obj.createentity(game, 256, 88, 25, 1, 18); //Terminal
+		obj.createentity(96, 88, 25, 1, 13); //Terminal
+		obj.createentity(128, 88, 25, 1, 14); //Terminal
+		obj.createentity(160, 88, 25, 1, 15); //Terminal
+		obj.createentity(192, 88, 25, 1, 16); //Terminal
+		obj.createentity(224, 88, 25, 1, 17); //Terminal
+		obj.createentity(256, 88, 25, 1, 18); //Terminal
 
-		obj.createentity(game, 96, 128-3, 25, 0, 7); //Terminal
-		obj.createentity(game, 96, 168, 25, 1, 8); //Terminal
+		obj.createentity(96, 128-3, 25, 0, 7); //Terminal
+		obj.createentity(96, 168, 25, 1, 8); //Terminal
 
-		obj.createentity(game, 160, 128, 25, 0, 12); //Terminal
-		obj.createentity(game, 192, 128, 25, 0, 11); //Terminal
-		obj.createentity(game, 224, 128, 25, 0, 10); //Terminal
-		obj.createentity(game, 256, 128, 25, 0, 9); //Terminal
+		obj.createentity(160, 128, 25, 0, 12); //Terminal
+		obj.createentity(192, 128, 25, 0, 11); //Terminal
+		obj.createentity(224, 128, 25, 0, 10); //Terminal
+		obj.createentity(256, 128, 25, 0, 9); //Terminal
 		break;
 
 	case rn(16,5):
@@ -7914,8 +7914,8 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 
-		obj.createentity(game, 152, 168, 25, 0, 20); //Terminal
-		obj.createentity(game, 152, 168, 25, 0, 19); //Terminal
+		obj.createentity(152, 168, 25, 0, 20); //Terminal
+		obj.createentity(152, 168, 25, 0, 19); //Terminal
 		break;
 
 	case rn(19,6):
@@ -7951,21 +7951,21 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,411,0,0,0,0,0,0,409,289,289,289");
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,411,0,0,0,0,0,0,409,289,289,289");
 
-		obj.createentity(game, 216, 176, 21, 1); //Terminal
-		obj.createentity(game, 192, 176, 21, 1); //Terminal
-		obj.createentity(game, 168, 176, 21, 1); //Terminal
-		obj.createentity(game, 144, 176, 21, 1); //Terminal
-		obj.createentity(game, 88, 96, 21, 1); //Terminal
-		obj.createentity(game, 112, 96, 21, 1); //Terminal
-		obj.createentity(game, 136, 96, 21, 1); //Terminal
-		obj.createentity(game, 160, 96, 21, 1); //Terminal
+		obj.createentity(216, 176, 21, 1); //Terminal
+		obj.createentity(192, 176, 21, 1); //Terminal
+		obj.createentity(168, 176, 21, 1); //Terminal
+		obj.createentity(144, 176, 21, 1); //Terminal
+		obj.createentity(88, 96, 21, 1); //Terminal
+		obj.createentity(112, 96, 21, 1); //Terminal
+		obj.createentity(136, 96, 21, 1); //Terminal
+		obj.createentity(160, 96, 21, 1); //Terminal
 
 		//vertigris:
-		obj.createentity(game, 100, 169, 18, 13, 0, 18);
+		obj.createentity(100, 169, 18, 13, 0, 18);
 		obj.createblock(5, 100 - 16, 0, 32 + 32, 240, 4);
 
 		//victoria:
-		obj.createentity(game, 193, 89, 18, 16, 0, 18);
+		obj.createentity(193, 89, 18, 16, 0, 18);
 		obj.createblock(5, 193-16, 0, 32+32, 240, 5);
 		break;
 
@@ -8003,12 +8003,12 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 
-		obj.createentity(game, 72, 192, 13);  // (shiny trinket)
-		obj.createentity(game, 112, 144, 20, 1);  // (terminal)
+		obj.createentity(72, 192, 13);  // (shiny trinket)
+		obj.createentity(112, 144, 20, 1);  // (terminal)
 		obj.createblock(5, 112 - 4, 144, 20, 16, 21);
 
 		//vermilion
-		obj.createentity(game, 186, 137, 18, 15, 0, 18);
+		obj.createentity(186, 137, 18, 15, 0, 18);
 		obj.createblock(5, 186 - 32, 0, 32 + 32 + 32, 240, 3);
 
 		//naughty corner!
@@ -8051,8 +8051,8 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 
-		obj.createentity(game, -8, 84-32, 11, 328+8);  // (horizontal gravity line)
-		obj.createentity(game, -8, 148 + 32, 11, 328+8);  // (horizontal gravity line)
+		obj.createentity(-8, 84-32, 11, 328+8);  // (horizontal gravity line)
+		obj.createentity(-8, 148 + 32, 11, 328+8);  // (horizontal gravity line)
 		obj.createblock(1, -10, 84 - 16, 340, 32, 9); //start the game
 		break;
 

--- a/desktop_version/src/Otherlevel.h
+++ b/desktop_version/src/Otherlevel.h
@@ -27,7 +27,7 @@ public:
     };
 
     void addline(std::string t);
-    std::vector<std::string> loadlevel(int rx, int ry , Game& game, entityclass& obj);
+    std::vector<std::string> loadlevel(int rx, int ry);
 
     std::string roomname;
 

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -230,8 +230,3 @@ void Screen::toggleLinearFilter()
 		240
 	);
 }
-
-void Screen::ClearScreen( int colour )
-{
-    //FillRect(m_screen, colour) ;
-}

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -12,7 +12,6 @@ public:
 	void GetWindowSize(int* x, int* y);
 
 	void UpdateScreen(SDL_Surface* buffer, SDL_Rect* rect);
-	void ClearScreen(int colour);
 	void FlipScreen();
 
 	const SDL_PixelFormat* GetFormat();

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -68,7 +68,7 @@ void scriptclass::tokenize( std::string t )
 	}
 }
 
-void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void scriptclass::run()
 {
 	while(running && scriptdelay<=0 && !game.pausescript)
 	{
@@ -100,7 +100,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         int curlevel=temprx+(ed.maxwidth*(tempry));
 			  ed.level[curlevel].warpdir=ss_toi(words[3]);
 			  //If screen warping, then override all that:
-        dwgfx.backgrounddrawn = false;
+        graphics.backgrounddrawn = false;
 
         //Do we update our own room?
         if(game.roomx-100==temprx && game.roomy-100==tempry){
@@ -111,7 +111,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
             if(ed.level[curlevel].tileset==2){
               //Lab
               map.background = 2;
-              dwgfx.rcol = ed.level[curlevel].tilecol;
+              graphics.rcol = ed.level[curlevel].tilecol;
             }else if(ed.level[curlevel].tileset==3){
               //Warp Zone
               map.background = 6;
@@ -119,15 +119,15 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
           }else if(ed.level[curlevel].warpdir==1){
             map.warpx=true;
             map.background=3;
-            dwgfx.rcol = ed.getwarpbackground(temprx,tempry);
+            graphics.rcol = ed.getwarpbackground(temprx,tempry);
           }else if(ed.level[curlevel].warpdir==2){
             map.warpy=true;
             map.background=4;
-            dwgfx.rcol = ed.getwarpbackground(temprx,tempry);
+            graphics.rcol = ed.getwarpbackground(temprx,tempry);
           }else if(ed.level[curlevel].warpdir==3){
             map.warpx=true; map.warpy=true;
             map.background = 5;
-            dwgfx.rcol = ed.getwarpbackground(temprx,tempry);
+            graphics.rcol = ed.getwarpbackground(temprx,tempry);
           }
         }
 			}
@@ -282,21 +282,21 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			if (words[0] == "gotoroom")
 			{
 				//USAGE: gotoroom(x,y) (manually add 100)
-				map.gotoroom(ss_toi(words[1])+100, ss_toi(words[2])+100, dwgfx, game, obj, music);
+				map.gotoroom(ss_toi(words[1])+100, ss_toi(words[2])+100);
 			}
 			if (words[0] == "cutscene")
 			{
-				dwgfx.showcutscenebars = true;
+				graphics.showcutscenebars = true;
 			}
 			if (words[0] == "endcutscene")
 			{
-				dwgfx.showcutscenebars = false;
+				graphics.showcutscenebars = false;
 			}
 			if (words[0] == "untilbars")
 			{
-				if (dwgfx.showcutscenebars)
+				if (graphics.showcutscenebars)
 				{
-					if (dwgfx.cutscenebarspos < 360)
+					if (graphics.cutscenebarspos < 360)
 					{
 						scriptdelay = 1;
 						position--;
@@ -304,7 +304,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				}
 				else
 				{
-					if (dwgfx.cutscenebarspos > 0)
+					if (graphics.cutscenebarspos > 0)
 					{
 						scriptdelay = 1;
 						position--;
@@ -575,17 +575,17 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "flipme")
 			{
-				if(dwgfx.flipmode) texty += 2*(120 - texty) - 8*(txtnumlines+2);
+				if(graphics.flipmode) texty += 2*(120 - texty) - 8*(txtnumlines+2);
 			}
 			else if (words[0] == "speak_active")
 			{
 				//Ok, actually display the textbox we've initilised now!
-				dwgfx.createtextbox(txt[0], textx, texty, r, g, b);
+				graphics.createtextbox(txt[0], textx, texty, r, g, b);
 				if (txtnumlines > 1)
 				{
 					for (i = 1; i < txtnumlines; i++)
 					{
-						dwgfx.addline(txt[i]);
+						graphics.addline(txt[i]);
 					}
 				}
 
@@ -594,23 +594,23 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				{
 					//position to the left of the player
 					textx += 10000;
-					textx -= dwgfx.textboxwidth();
+					textx -= graphics.textboxwidth();
 					textx += 16;
-					dwgfx.textboxmoveto(textx);
+					graphics.textboxmoveto(textx);
 				}
 
 				if (textx == -500 || textx == -1)
 				{
-					dwgfx.textboxcenterx();
+					graphics.textboxcenterx();
 				}
 
 				if (texty == -500)
 				{
-					dwgfx.textboxcentery();
+					graphics.textboxcentery();
 				}
 
-				dwgfx.textboxadjust();
-				dwgfx.textboxactive();
+				graphics.textboxadjust();
+				graphics.textboxactive();
 
 				if (!game.backgroundtext)
 				{
@@ -625,12 +625,12 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			else if (words[0] == "speak")
 			{
 				//Exactly as above, except don't make the textbox active (so we can use multiple textboxes)
-				dwgfx.createtextbox(txt[0], textx, texty, r, g, b);
+				graphics.createtextbox(txt[0], textx, texty, r, g, b);
 				if (txtnumlines > 1)
 				{
 					for (i = 1; i < txtnumlines; i++)
 					{
-						dwgfx.addline(txt[i]);
+						graphics.addline(txt[i]);
 					}
 				}
 
@@ -639,23 +639,23 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				{
 					//position to the left of the player
 					textx += 10000;
-					textx -= dwgfx.textboxwidth();
+					textx -= graphics.textboxwidth();
 					textx += 16;
-					dwgfx.textboxmoveto(textx);
+					graphics.textboxmoveto(textx);
 				}
 
 				if (textx == -500 || textx == -1)
 				{
-					dwgfx.textboxcenterx();
+					graphics.textboxcenterx();
 				}
 
 				if (texty == -500)
 				{
-					dwgfx.textboxcentery();
+					graphics.textboxcentery();
 				}
 
-				dwgfx.textboxadjust();
-				//dwgfx.textboxactive();
+				graphics.textboxadjust();
+				//graphics.textboxactive();
 
 				if (!game.backgroundtext)
 				{
@@ -669,13 +669,13 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "endtext")
 			{
-				dwgfx.textboxremove();
+				graphics.textboxremove();
 				game.hascontrol = true;
 				game.advancetext = false;
 			}
 			else if (words[0] == "endtextfast")
 			{
-				dwgfx.textboxremovefast();
+				graphics.textboxremovefast();
 				game.hascontrol = true;
 				game.advancetext = false;
 			}
@@ -719,7 +719,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "createentity")
 			{
-				obj.createentity(game, ss_toi(words[1]), ss_toi(words[2]), ss_toi(words[3]), ss_toi(words[4]), ss_toi(words[5]));
+				obj.createentity(ss_toi(words[1]), ss_toi(words[2]), ss_toi(words[3]), ss_toi(words[4]), ss_toi(words[5]));
 			}
 			else if (words[0] == "createcrewman")
 			{
@@ -788,11 +788,11 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 
 				if (ss_toi(words[5]) >= 16)
 				{
-					obj.createentity(game, ss_toi(words[1]), ss_toi(words[2]), 18, r, ss_toi(words[4]), ss_toi(words[5]), ss_toi(words[6]));
+					obj.createentity(ss_toi(words[1]), ss_toi(words[2]), 18, r, ss_toi(words[4]), ss_toi(words[5]), ss_toi(words[6]));
 				}
 				else
 				{
-					obj.createentity(game, ss_toi(words[1]), ss_toi(words[2]), 18, r, ss_toi(words[4]), ss_toi(words[5]));
+					obj.createentity(ss_toi(words[1]), ss_toi(words[2]), 18, r, ss_toi(words[4]), ss_toi(words[5]));
 				}
 			}
 			else if (words[0] == "changemood")
@@ -1263,7 +1263,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "textboxactive")
 			{
-				dwgfx.textboxactive();
+				graphics.textboxactive();
 			}
 			else if (words[0] == "gamemode")
 			{
@@ -1271,17 +1271,16 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				{
 					//TODO this draw the teleporter screen. This is a problem. :(
 					game.gamestate = 5;
-					dwgfx.menuoffset = 240; //actually this should count the roomname
-					if (map.extrarow) dwgfx.menuoffset -= 10;
-					//dwgfx.menubuffer.copyPixels(dwgfx.screenbuffer, dwgfx.screenbuffer.rect, dwgfx.tl, null, null, false);
+					graphics.menuoffset = 240; //actually this should count the roomname
+					if (map.extrarow) graphics.menuoffset -= 10;
 
-					dwgfx.resumegamemode = false;
+					graphics.resumegamemode = false;
 
 					game.useteleporter = false; //good heavens don't actually use it
 				}
 				else if (words[1] == "game")
 				{
-					dwgfx.resumegamemode = true;
+					graphics.resumegamemode = true;
 				}
 			}
 			else if (words[0] == "ifexplored")
@@ -1432,20 +1431,20 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "befadein")
 			{
-				dwgfx.fadeamount = 0;
-				dwgfx.fademode= 0;
+				graphics.fadeamount = 0;
+				graphics.fademode= 0;
 			}
 			else if (words[0] == "fadein")
 			{
-				dwgfx.fademode = 4;
+				graphics.fademode = 4;
 			}
 			else if (words[0] == "fadeout")
 			{
-				dwgfx.fademode = 2;
+				graphics.fademode = 2;
 			}
 			else if (words[0] == "untilfade")
 			{
-				if (dwgfx.fademode>1)
+				if (graphics.fademode>1)
 				{
 					scriptdelay = 1;
 					position--;
@@ -1464,7 +1463,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			{
 				map.resetnames();
 				map.resetmap();
-				map.resetplayer(dwgfx, game, obj, music);
+				map.resetplayer();
 				map.tdrawback = true;
 
 				obj.resetallflags();
@@ -1510,7 +1509,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			else if (words[0] == "rollcredits")
 			{
 				game.gamestate = 6;
-				dwgfx.fademode = 4;
+				graphics.fademode = 4;
 				game.creditposition = 0;
 			}
 			else if (words[0] == "finalmode")
@@ -1520,7 +1519,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				map.finaly = ss_toi(words[2]);
 				game.roomx = map.finalx;
 				game.roomy = map.finaly;
-				map.gotoroom(game.roomx, game.roomy, dwgfx, game, obj, music);
+				map.gotoroom(game.roomx, game.roomy);
 			}
 			else if (words[0] == "rescued")
 			{
@@ -1812,22 +1811,22 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				i = 215;
 				if (game.crewstats[2] && game.lastsaved!=2)
 				{
-					obj.createentity(game, i, 153, 18, 14, 0, 17, 0);
+					obj.createentity(i, 153, 18, 14, 0, 17, 0);
 					i += 25;
 				}
 				if (game.crewstats[3] && game.lastsaved!=3)
 				{
-					obj.createentity(game, i, 153, 18, 15, 0, 17, 0);
+					obj.createentity(i, 153, 18, 15, 0, 17, 0);
 					i += 25;
 				}
 				if (game.crewstats[4] && game.lastsaved!=4)
 				{
-					obj.createentity(game, i, 153, 18, 13, 0, 17, 0);
+					obj.createentity(i, 153, 18, 13, 0, 17, 0);
 					i += 25;
 				}
 				if (game.crewstats[5] && game.lastsaved!=5)
 				{
-					obj.createentity(game, i, 153, 18, 16, 0, 17, 0);
+					obj.createentity(i, 153, 18, 16, 0, 17, 0);
 					i += 25;
 				}
 			}
@@ -1887,12 +1886,12 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				game.trinkets++;
 				obj.collect[ss_toi(words[1])] = 1;
 
-				dwgfx.textboxremovefast();
+				graphics.textboxremovefast();
 
-				dwgfx.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
-				dwgfx.addline("");
-				dwgfx.addline("You have found a shiny trinket!");
-				dwgfx.textboxcenterx();
+				graphics.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
+				graphics.addline("");
+				graphics.addline("You have found a shiny trinket!");
+				graphics.textboxcenterx();
 
 				std::string usethisnum;
 				if (map.custommode)
@@ -1903,8 +1902,8 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				{
 					usethisnum = "Twenty";
 				}
-				dwgfx.createtextbox(" " + help.number(game.trinkets) + " out of " + usethisnum + " ", 50, 135, 174, 174, 174);
-				dwgfx.textboxcenterx();
+				graphics.createtextbox(" " + help.number(game.trinkets) + " out of " + usethisnum + " ", 50, 135, 174, 174, 174);
+				graphics.textboxcenterx();
 
 				if (!game.backgroundtext)
 				{
@@ -1920,13 +1919,13 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			{
 				music.playef(3,10);
 
-				dwgfx.textboxremovefast();
+				graphics.textboxremovefast();
 
-				dwgfx.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
-				dwgfx.addline("");
-				dwgfx.addline("You have found the secret lab!");
-				dwgfx.textboxcenterx();
-				dwgfx.textboxcentery();
+				graphics.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
+				graphics.addline("");
+				graphics.addline("You have found the secret lab!");
+				graphics.textboxcenterx();
+				graphics.textboxcentery();
 
 				if (!game.backgroundtext)
 				{
@@ -1940,15 +1939,15 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "foundlab2")
 			{
-				dwgfx.textboxremovefast();
+				graphics.textboxremovefast();
 
-				dwgfx.createtextbox("The secret lab is separate from", 50, 85, 174, 174, 174);
-				dwgfx.addline("the rest of the game. You can");
-				dwgfx.addline("now come back here at any time");
-				dwgfx.addline("by selecting the new SECRET LAB");
-				dwgfx.addline("option in the play menu.");
-				dwgfx.textboxcenterx();
-				dwgfx.textboxcentery();
+				graphics.createtextbox("The secret lab is separate from", 50, 85, 174, 174, 174);
+				graphics.addline("the rest of the game. You can");
+				graphics.addline("now come back here at any time");
+				graphics.addline("by selecting the new SECRET LAB");
+				graphics.addline("option in the play menu.");
+				graphics.textboxcenterx();
+				graphics.textboxcentery();
 
 				if (!game.backgroundtext)
 				{
@@ -1985,11 +1984,11 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				game.savepoint = 0;
 				game.gravitycontrol = 0;
 
-				map.gotoroom(46, 54, dwgfx, game, obj, music);
+				map.gotoroom(46, 54);
 			}
 			else if (words[0] == "telesave")
 			{
-				if (!game.intimetrial && !game.nodeathmode && !game.inintermission) game.savetele(map, obj, music);
+				if (!game.intimetrial && !game.nodeathmode && !game.inintermission) game.savetele();
 			}
 			else if (words[0] == "createlastrescued")
 			{
@@ -2014,7 +2013,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 					r = 19;
 				}
 
-				obj.createentity(game, 200, 153, 18, r, 0, 19, 30);
+				obj.createentity(200, 153, 18, r, 0, 19, 30);
 				i = obj.getcrewman(game.lastsaved);
 				obj.entities[i].dir = 1;
 			}
@@ -2534,88 +2533,88 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 	}
 }
 
-void scriptclass::resetgametomenu( Graphics& dwgfx, Game& game,mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void scriptclass::resetgametomenu()
 {
 	game.gamestate = TITLEMODE;
-	dwgfx.flipmode = false;
+	graphics.flipmode = false;
 	obj.nentity = 0;
-	dwgfx.fademode = 4;
+	graphics.fademode = 4;
 	game.createmenu("gameover");
 }
 
-void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void scriptclass::startgamemode(int t)
 {
 	switch(t)
 	{
 	case 0:  //Normal new game
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
-		game.start(obj, music);
+		hardreset();
+		game.start();
 		game.jumpheld = true;
-		dwgfx.showcutscenebars = true;
-		dwgfx.cutscenebarspos = 320;
+		graphics.showcutscenebars = true;
+		graphics.cutscenebarspos = 320;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intro");
 		break;
 	case 1:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
-		game.start(obj, music);
-		game.loadtele(map, obj, music);
+		hardreset();
+		game.start();
+		game.loadtele();
 		game.gravitycontrol = game.savegc;
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
-		dwgfx.fademode = 4;
+		map.gotoroom(game.saverx, game.savery);
+		graphics.fademode = 4;
 		break;
 	case 2: //Load Quicksave
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
-		game.start(obj, music);
-		game.loadquick(map, obj, music);
+		hardreset();
+		game.start();
+		game.loadquick();
 		game.gravitycontrol = game.savegc;
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 		//a very special case for here needs to ensure that the tower is set correctly
 		if (map.towermode)
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 
 			i = obj.getplayer();
 			map.ypos = obj.entities[i].yp - 120;
@@ -2623,11 +2622,11 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 			map.cameramode = 0;
 			map.colsuperstate = 0;
 		}
-		dwgfx.fademode = 4;
+		graphics.fademode = 4;
 		break;
 	case 3:
 		//Start Time Trial 1
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2638,24 +2637,24 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		music.fadeout();
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
-		dwgfx.fademode = 4;
+		map.gotoroom(game.saverx, game.savery);
+		graphics.fademode = 4;
 		break;
 	case 4:
 		//Start Time Trial 2
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2666,24 +2665,24 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		music.fadeout();
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
-		dwgfx.fademode = 4;
+		map.gotoroom(game.saverx, game.savery);
+		graphics.fademode = 4;
 		break;
 	case 5:
 		//Start Time Trial 3 tow
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2694,24 +2693,24 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		music.fadeout();
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
-		dwgfx.fademode = 4;
+		map.gotoroom(game.saverx, game.savery);
+		graphics.fademode = 4;
 		break;
 	case 6:
 		//Start Time Trial 4 station
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2722,24 +2721,24 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		music.fadeout();
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
-		dwgfx.fademode = 4;
+		map.gotoroom(game.saverx, game.savery);
+		graphics.fademode = 4;
 		break;
 	case 7:
 		//Start Time Trial 5 warp
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2750,24 +2749,24 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		music.fadeout();
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
-		dwgfx.fademode = 4;
+		map.gotoroom(game.saverx, game.savery);
+		graphics.fademode = 4;
 		break;
 	case 8:
 		//Start Time Trial 6// final level!
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2784,82 +2783,78 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
-		dwgfx.fademode = 4;
+		map.gotoroom(game.saverx, game.savery);
+		graphics.fademode = 4;
 		break;
 	case 9:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.nodeathmode = true;
-		game.start(obj, music);
+		game.start();
 		game.jumpheld = true;
-		dwgfx.showcutscenebars = true;
-		dwgfx.cutscenebarspos = 320;
-		//game.starttest(obj, music);
-		//music.play(4);
+		graphics.showcutscenebars = true;
+		graphics.cutscenebarspos = 320;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 
 		load("intro");
 		break;
 	case 10:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.nodeathmode = true;
 		game.nocutscenes = true;
 
-		game.start(obj, music);
+		game.start();
 		game.jumpheld = true;
-		dwgfx.showcutscenebars = true;
-		dwgfx.cutscenebarspos = 320;
-		//game.starttest(obj, music);
-		//music.play(4);
+		graphics.showcutscenebars = true;
+		graphics.cutscenebarspos = 320;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 
 		load("intro");
 		break;
 	case 11:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 
-		game.startspecial(0, obj, music);
+		game.startspecial(0);
 		game.jumpheld = true;
 
 		//Secret lab, so reveal the map, give them all 20 trinkets
@@ -2876,23 +2871,23 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.showteleporters = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 		music.play(11);
-		dwgfx.fademode = 4;
+		graphics.fademode = 4;
 		break;
 	case 12:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		music.fadeout();
 
 		game.lastsaved = 2;
@@ -2908,26 +2903,26 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intermission_1");
 		break;
 	case 13:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		music.fadeout();
 
 		game.lastsaved = 3;
@@ -2943,26 +2938,26 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intermission_1");
 		break;
 	case 14:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		music.fadeout();
 
 		game.lastsaved = 4;
@@ -2978,26 +2973,26 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intermission_1");
 		break;
 	case 15:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		music.fadeout();
 
 		game.lastsaved = 5;
@@ -3013,26 +3008,26 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intermission_1");
 		break;
 	case 16:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		music.fadeout();
 
 		game.lastsaved = 2;
@@ -3045,26 +3040,26 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intermission_2");
 		break;
 	case 17:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		music.fadeout();
 
 		game.lastsaved = 3;
@@ -3077,26 +3072,26 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intermission_2");
 		break;
 	case 18:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		music.fadeout();
 
 		game.lastsaved = 4;
@@ -3109,26 +3104,26 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intermission_2");
 		break;
 	case 19:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		music.fadeout();
 
 		game.lastsaved = 5;
@@ -3141,49 +3136,49 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intermission_2");
 		break;
 #if !defined(NO_CUSTOM_LEVELS)
 	case 20:
 		//Level editor
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		ed.reset();
 		music.fadeout();
 
 		game.gamestate = EDITORMODE;
 		game.jumpheld = true;
 
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
-		dwgfx.fademode = 4;
+		map.gotoroom(game.saverx, game.savery);
+		graphics.fademode = 4;
 		break;
 	case 21:  //play custom level (in editor)
 		game.gamestate = GAMEMODE;
 		music.fadeout();
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		//If warpdir() is used during playtesting, we need to set it back after!
 		for (int j = 0; j < ed.maxheight; j++)
 		{
@@ -3192,7 +3187,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 				ed.kludgewarpdir[i+(j*ed.maxwidth)]=ed.level[i+(j*ed.maxwidth)].warpdir;
 			}
 		}
-		game.customstart(obj, music);
+		game.customstart();
 		game.jumpheld = true;
 
 
@@ -3200,120 +3195,106 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.customx = 100;
 		map.customy = 100;
 
-		//dwgfx.showcutscenebars = true;
-		//dwgfx.cutscenebarspos = 320;
-
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 		if(ed.levmusic>0){
 		  music.play(ed.levmusic);
 		}else{
 		  music.currentsong=-1;
 		}
-		//load("intro");
 		break;
-  case 22:  //play custom level (in game)
-    //Initilise the level
-    //First up, find the start point
-    ed.weirdloadthing(ed.ListOfMetaData[game.playcustomlevel].filename);
-    ed.findstartpoint(game);
+	case 22:  //play custom level (in game)
+	{
+		//Initilise the level
+		//First up, find the start point
+		std::string filename = ed.ListOfMetaData[game.playcustomlevel].filename;
+		ed.load(filename);
+		ed.findstartpoint();
 
-    game.gamestate = GAMEMODE;
-    music.fadeout();
-    hardreset(key, dwgfx, game, map, obj, help, music);
-    game.customstart(obj, music);
-    game.jumpheld = true;
+		game.gamestate = GAMEMODE;
+		music.fadeout();
+		hardreset();
+		game.customstart();
+		game.jumpheld = true;
 
 		map.custommodeforreal = true;
-    map.custommode = true;
-    map.customx = 100;
-    map.customy = 100;
+		map.custommode = true;
+		map.customx = 100;
+		map.customy = 100;
 
-    //dwgfx.showcutscenebars = true;
-    //dwgfx.cutscenebarspos = 320;
+		//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;
 
-    //set flipmode
-    if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if(obj.nentity==0)
+		{
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+		}
+		else
+		{
+			map.resetplayer();
+		}
+		map.gotoroom(game.saverx, game.savery);
 
-    if(obj.nentity==0)
-    {
-      obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
-    }
-    else
-    {
-      map.resetplayer(dwgfx, game, obj, music);
-    }
-    map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
-
-		ed.generatecustomminimap(dwgfx, map);
+		ed.generatecustomminimap();
 		map.customshowmm=true;
-    if(ed.levmusic>0){
-      music.play(ed.levmusic);
-    }else{
-      music.currentsong=-1;
+		if(ed.levmusic>0){
+			music.play(ed.levmusic);
+		}else{
+			music.currentsong=-1;
 		}
-		dwgfx.fademode = 4;
-    //load("intro");
-  break;
-  case 23: //Continue in custom level
-      //Initilise the level
-    //First up, find the start point
-    ed.weirdloadthing(ed.ListOfMetaData[game.playcustomlevel].filename);
-    ed.findstartpoint(game);
+		graphics.fademode = 4;
+		break;
+	}
+	case 23: //Continue in custom level
+	{
+		//Initilise the level
+		//First up, find the start point
+		std::string filename = ed.ListOfMetaData[game.playcustomlevel].filename;
+		ed.load(filename);
+		ed.findstartpoint();
 
-    game.gamestate = GAMEMODE;
-    music.fadeout();
-    hardreset(key, dwgfx, game, map, obj, help, music);
+		game.gamestate = GAMEMODE;
+		music.fadeout();
+		hardreset();
 		map.custommodeforreal = true;
-    map.custommode = true;
-    map.customx = 100;
-    map.customy = 100;
+		map.custommode = true;
+		map.customx = 100;
+		map.customy = 100;
 
-    game.customstart(obj, music);
-		game.customloadquick(ed.ListOfMetaData[game.playcustomlevel].filename, map, obj, music);
-    game.jumpheld = true;
-    game.gravitycontrol = game.savegc;
+		game.customstart();
+		game.customloadquick(ed.ListOfMetaData[game.playcustomlevel].filename);
+		game.jumpheld = true;
+		game.gravitycontrol = game.savegc;
 
+		//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;
 
-    //dwgfx.showcutscenebars = true;
-    //dwgfx.cutscenebarspos = 320;
-
-    //set flipmode
-    if (dwgfx.setflipmode) dwgfx.flipmode = true;
-
-    if(obj.nentity==0)
-    {
-      obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
-    }
-    else
-    {
-      map.resetplayer(dwgfx, game, obj, music);
-    }
-    map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
-    /* Handled by load
-    if(ed.levmusic>0){
-      music.play(ed.levmusic);
-    }else{
-      music.currentsong=-1;
+		if(obj.nentity==0)
+		{
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
-		*/
-		ed.generatecustomminimap(dwgfx, map);
-		dwgfx.fademode = 4;
-    //load("intro");
-  break;
+		else
+		{
+			map.resetplayer();
+		}
+		map.gotoroom(game.saverx, game.savery);
+		ed.generatecustomminimap();
+		graphics.fademode = 4;
+		break;
+	}
 #endif
 	case 100:
-		game.savestats(map, dwgfx);
+		game.savestats();
 
 		SDL_Quit();
 		exit(0);
@@ -3321,7 +3302,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 	}
 }
 
-void scriptclass::teleport( Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void scriptclass::teleport()
 {
 	//er, ok! Teleport to a new area, so!
 	//A general rule of thumb: if you teleport with a companion, get rid of them!
@@ -3344,7 +3325,7 @@ void scriptclass::teleport( Graphics& dwgfx, Game& game, mapclass& map, entitycl
 	}
 
 	game.gravitycontrol = 0;
-	map.gotoroom(100+game.teleport_to_x, 100+game.teleport_to_y, dwgfx, game, obj, music);
+	map.gotoroom(100+game.teleport_to_x, 100+game.teleport_to_y);
 	j = obj.getteleporter();
 	obj.entities[j].state = 2;
 	game.teleport_to_new_area = false;
@@ -3404,7 +3385,7 @@ void scriptclass::teleport( Graphics& dwgfx, Game& game, mapclass& map, entitycl
 	else
 	{
 		//change music based on location
-		if (dwgfx.setflipmode && game.teleport_to_x == 11 && game.teleport_to_y == 4)
+		if (graphics.setflipmode && game.teleport_to_x == 11 && game.teleport_to_y == 4)
 		{
 			music.niceplay(9);
 		}
@@ -3414,22 +3395,22 @@ void scriptclass::teleport( Graphics& dwgfx, Game& game, mapclass& map, entitycl
 		}
 		if (!game.intimetrial && !game.nodeathmode && !game.inintermission)
 		{
-			if (dwgfx.flipmode)
+			if (graphics.flipmode)
 			{
-				dwgfx.createtextbox("    Game Saved    ", -1, 202, 174, 174, 174);
-				dwgfx.textboxtimer(25);
+				graphics.createtextbox("    Game Saved    ", -1, 202, 174, 174, 174);
+				graphics.textboxtimer(25);
 			}
 			else
 			{
-				dwgfx.createtextbox("    Game Saved    ", -1, 12, 174, 174, 174);
-				dwgfx.textboxtimer(25);
+				graphics.createtextbox("    Game Saved    ", -1, 12, 174, 174, 174);
+				graphics.textboxtimer(25);
 			}
-			game.savetele(map, obj, music);
+			game.savetele();
 		}
 	}
 }
 
-void scriptclass::hardreset( KeyPoll& key, Graphics& dwgfx, Game& game,mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void scriptclass::hardreset()
 {
 	//Game:
 	game.hascontrol = true;
@@ -3526,13 +3507,13 @@ void scriptclass::hardreset( KeyPoll& key, Graphics& dwgfx, Game& game,mapclass&
 	game.pausescript = false;
 
 	//dwgraphicsclass
-	dwgfx.backgrounddrawn = false;
-	dwgfx.textboxremovefast();
-	dwgfx.flipmode = false; //This will be reset if needs be elsewhere
-	dwgfx.showcutscenebars = false;
-	dwgfx.cutscenebarspos = 0;
+	graphics.backgrounddrawn = false;
+	graphics.textboxremovefast();
+	graphics.flipmode = false; //This will be reset if needs be elsewhere
+	graphics.showcutscenebars = false;
+	graphics.cutscenebarspos = 0;
 
-  //mapclass
+	//mapclass
 	map.warpx = false;
 	map.warpy = false;
 	map.showteleporters = false;

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -17,8 +17,8 @@ public:
 
     scriptclass();
 
-	void load(std::string t);
-	void loadother(std::string t);
+    void load(std::string t);
+    void loadother(std::string t);
 
 
     void inline add(std::string t)
@@ -31,20 +31,15 @@ public:
 
     void tokenize(std::string t);
 
-    void run(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-             entityclass& obj, UtilityClass& help, musicclass& music);
+    void run();
 
-    void resetgametomenu(Graphics& dwgfx, Game& game,mapclass& map,
-                         entityclass& obj, UtilityClass& help, musicclass& music);
+    void resetgametomenu();
 
-    void startgamemode(int t, KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                       entityclass& obj, UtilityClass& help, musicclass& music);
+    void startgamemode(int t);
 
-    void teleport(Graphics& dwgfx, Game& game, mapclass& map,
-                  entityclass& obj, UtilityClass& help, musicclass& music);
+    void teleport();
 
-    void hardreset(KeyPoll& key, Graphics& dwgfx, Game& game,mapclass& map,
-                   entityclass& obj, UtilityClass& help, musicclass& music);
+    void hardreset();
 
     //Script contents
     std::vector<std::string> commands;

--- a/desktop_version/src/Spacestation2.cpp
+++ b/desktop_version/src/Spacestation2.cpp
@@ -2,7 +2,7 @@
 
 #include "MakeAndPlay.h"
 
-std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& game, entityclass& obj)
+std::vector<std::string> spacestation2class::loadlevel(int rx, int ry)
 {
 	int t;
 	rx -= 100;
@@ -14,7 +14,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 	t = rx + (ry * 100);
 
 	std::vector<std::string> tmap;
-	roomname = "Untitled room ["+UtilityClass::String(rx) + "," + UtilityClass::String(ry)+"]";
+	roomname = "Untitled room ["+help.String(rx) + "," + help.String(ry)+"]";
 
 	switch(t)
 	{
@@ -51,10 +51,10 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,276,277,277,277,277,277,278,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 96, 40, 10, 0, 450500);  // (savepoint)
+		obj.createentity(96, 40, 10, 0, 450500);  // (savepoint)
 		if(game.intimetrial)
 		{
-			obj.createentity(game, 136, 92, 11, 48);  // (horizontal gravity line)
+			obj.createentity(136, 92, 11, 48);  // (horizontal gravity line)
 		}
 
 		roomname = "Outer Hull"; //If not yet in level, use "The Space Station";
@@ -128,14 +128,14 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("107,107,107,107,107,107,229,689,689,689,689,227,107,107,107,107,107,107,107,148,188,188,188,188,188,188,188,188,188,188,188,188,188,188,188,188,149,107,107,107");
 		tmap.push_back("107,107,107,107,107,107,229,689,689,689,689,227,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107");
 
-		obj.createentity(game, 128, 176, 10, 1, 449490);  // (savepoint)
-		obj.createentity(game, 160, 192, 3);  //Disappearing Platform
-		obj.createentity(game, 192, 192, 3);  //Disappearing Platform
-		obj.createentity(game, 224, 192, 3);  //Disappearing Platform
-		obj.createentity(game, 256, 192, 3);  //Disappearing Platform
-		obj.createentity(game, 216-4, 168, 1, 0, 4, 160, 88, 256, 192);  // Enemy, bounded
-		obj.createentity(game, 184-24, 96, 1, 1, 4, 160, 88, 256, 192);  // Enemy, bounded
-		obj.createentity(game, 256, 8, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 176, 10, 1, 449490);  // (savepoint)
+		obj.createentity(160, 192, 3);  //Disappearing Platform
+		obj.createentity(192, 192, 3);  //Disappearing Platform
+		obj.createentity(224, 192, 3);  //Disappearing Platform
+		obj.createentity(256, 192, 3);  //Disappearing Platform
+		obj.createentity(216-4, 168, 1, 0, 4, 160, 88, 256, 192);  // Enemy, bounded
+		obj.createentity(184-24, 96, 1, 1, 4, 160, 88, 256, 192);  // Enemy, bounded
+		obj.createentity(256, 8, 2, 10, 4);  //Big Threadmill, >>>>>>
 		roomname = "Boldly To Go";
 		break;
 
@@ -172,7 +172,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("289,289,289,289,289,289,411,680,680,680,680,409,289,289,411,680,680,680,680,680,409,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289");
 		tmap.push_back("289,289,289,289,289,289,411,680,680,680,680,409,289,289,411,680,680,680,680,680,409,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289");
 
-		obj.createentity(game, 192, 96, 9, 2);  // (shiny trinket)
+		obj.createentity(192, 96, 9, 2);  // (shiny trinket)
 		roomname = "One Way Room";
 		break;
 
@@ -209,23 +209,23 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("92,92,92,92,92,92,214,0,0,803,683,212,92,92,214,683,683,683,683,683,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,212,92,92,92");
 		tmap.push_back("92,92,92,92,92,92,214,0,0,803,683,212,92,92,214,683,683,683,683,683,172,173,173,173,173,173,173,173,173,173,173,174,0,0,0,0,212,92,92,92");
 
-		obj.createentity(game, 56, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 120, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 184, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 88, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 216, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 280, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 32, 10, 0, 447490);  // (savepoint)
-		obj.createentity(game, 288, 160, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 280, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 160, 216, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 224, 216, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 248, 24, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 120, 168, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 184, 168, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 216, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 152, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 224, 120, 10, 0, 447491);  // (savepoint)
+		obj.createentity(56, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(120, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(184, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(88, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(216, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(280, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 32, 10, 0, 447490);  // (savepoint)
+		obj.createentity(288, 160, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(280, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(160, 216, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(224, 216, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(248, 24, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(120, 168, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(184, 168, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(216, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(152, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(224, 120, 10, 0, 447491);  // (savepoint)
 
 		roomname = "Conveying a New Idea";
 		break;
@@ -263,23 +263,23 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("98,98,98,220,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,218,98,98,220,0,0,0,0,218,98,98,98");
 		tmap.push_back("98,98,98,220,0,0,0,0,178,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,140,98,98,220,0,0,0,0,218,98,98,98");
 
-		obj.createentity(game, 0, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 96, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 160, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 168, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 168, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 160, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 160, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 0, 160, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 0, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 216, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 216, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 216, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 0, 168, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 112, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(0, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(96, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(160, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 168, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 168, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 160, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 160, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(0, 160, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(0, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 216, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 216, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 216, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(0, 168, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 112, 2, 8, 4);  //Threadmill, >>>
 		roomname = "Upstream Downstream";
 		break;
 
@@ -316,13 +316,13 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 
 		obj.platformtile = 119;
-		obj.createentity(game, 64, 72, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
-		obj.createentity(game, 96, 80, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
-		obj.createentity(game, 128, 88, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
-		obj.createentity(game, 160, 96, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
-		obj.createentity(game, 192, 104, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
-		obj.createentity(game, 224, 112, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
-		obj.createentity(game, 264, 96, 10, 1, 448500);  // (savepoint)
+		obj.createentity(64, 72, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
+		obj.createentity(96, 80, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
+		obj.createentity(128, 88, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
+		obj.createentity(160, 96, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
+		obj.createentity(192, 104, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
+		obj.createentity(224, 112, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
+		obj.createentity(264, 96, 10, 1, 448500);  // (savepoint)
 		roomname = "The High Road is Low";
 		break;
 
@@ -358,13 +358,13 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,235,8,8,8,8,233,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113");
 		tmap.push_back("113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,154,194,194,194,194,155,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113");
 
-		obj.createentity(game, 144, 200, 3, 51);  //Disappearing Platform
-		obj.createentity(game, 24, 16, 10, 0, 449500);  // (savepoint)
-		obj.createentity(game, 280, 16, 10, 0, 449501);  // (savepoint)
-		obj.createentity(game, 0, 8, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 8, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 224, 8, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 288, 8, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(144, 200, 3, 51);  //Disappearing Platform
+		obj.createentity(24, 16, 10, 0, 449500);  // (savepoint)
+		obj.createentity(280, 16, 10, 0, 449501);  // (savepoint)
+		obj.createentity(0, 8, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 8, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(224, 8, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(288, 8, 2, 9, 4);  //Threadmill, <<<
 		roomname = "Give Me A V";
 		break;
 
@@ -400,20 +400,20 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("83,83,83,124,164,164,164,164,164,164,164,164,164,164,164,164,164,164,164,164,164,164,164,164,125,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83");
 		tmap.push_back("83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83");
 
-		obj.createentity(game, 0, 8, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 64, 8, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 8, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 192, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 256, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 152, 88, 10, 1, 449510);  // (savepoint)
-		obj.createentity(game, 152, 120, 10, 0, 449511);  // (savepoint)
-		obj.createentity(game, 128, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 256, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 32, 208, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 64, 208, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 208, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(0, 8, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(64, 8, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 8, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(192, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(256, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(152, 88, 10, 1, 449510);  // (savepoint)
+		obj.createentity(152, 120, 10, 0, 449511);  // (savepoint)
+		obj.createentity(128, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(256, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(32, 208, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(64, 208, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 208, 2, 10, 4);  //Big Threadmill, >>>>>>
 		roomname = "Select Track";
 		break;
 
@@ -449,21 +449,21 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 
-		obj.createentity(game, 0, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 256, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 152, 128, 1, 0, 5, 72, 120, 256, 200);  // Enemy, bounded
-		obj.createentity(game, 240, 168, 1, 1, 5, 72, 120, 256, 200);  // Enemy, bounded
-		obj.createentity(game, 72, 168, 1, 1, 5, 72, 120, 256, 200);  // Enemy, bounded
-		obj.createentity(game, 0, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 256, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 32, 3,10);  //Disappearing Platform
-		obj.createentity(game, 96, 32, 3,10);  //Disappearing Platform
-		obj.createentity(game, 192, 32, 3,10);  //Disappearing Platform
-		obj.createentity(game, 224, 32, 3,10);  //Disappearing Platform
+		obj.createentity(0, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(256, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(152, 128, 1, 0, 5, 72, 120, 256, 200);  // Enemy, bounded
+		obj.createentity(240, 168, 1, 1, 5, 72, 120, 256, 200);  // Enemy, bounded
+		obj.createentity(72, 168, 1, 1, 5, 72, 120, 256, 200);  // Enemy, bounded
+		obj.createentity(0, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(256, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 32, 3,10);  //Disappearing Platform
+		obj.createentity(96, 32, 3,10);  //Disappearing Platform
+		obj.createentity(192, 32, 3,10);  //Disappearing Platform
+		obj.createentity(224, 32, 3,10);  //Disappearing Platform
 		roomname = "You Chose... Poorly";
 		break;
 
@@ -499,16 +499,16 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107");
 		tmap.push_back("107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107");
 
-		obj.createentity(game, 0, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 64, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 192, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 256, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 152, 120, 10, 0, 449530);  // (savepoint)
-		obj.createentity(game, 0, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 256, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(0, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(64, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(192, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(256, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(152, 120, 10, 0, 449530);  // (savepoint)
+		obj.createentity(0, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(256, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
 		roomname = "Hyperspace Bypass 5";
 		break;
 
@@ -545,14 +545,14 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92");
 
 		obj.platformtile = 319;
-		obj.createentity(game, 0, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 64, 104, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 0, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 112, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 136, 104, 2, 0, 5, 136, 88, 200, 152);  // Platform, bounded
-		obj.createentity(game, 168, 104, 2, 0, 5, 136, 88, 200, 152);  // Platform, bounded
-		obj.createentity(game, 80, 112, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 80, 104, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(0, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(64, 104, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(0, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 112, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(136, 104, 2, 0, 5, 136, 88, 200, 152);  // Platform, bounded
+		obj.createentity(168, 104, 2, 0, 5, 136, 88, 200, 152);  // Platform, bounded
+		obj.createentity(80, 112, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(80, 104, 2, 9, 4);  //Threadmill, <<<
 		roomname = "Plain Sailing from Here On";
 		break;
 
@@ -590,14 +590,14 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,605,0,0,0,0,0,0,0,0,603,483,483,483");
 
 		obj.platformtile = 10;
-		obj.createentity(game, 264, 128, 10, 0, 448540);  // (savepoint)
-		obj.createentity(game, 192, 32, 3, 10);  //Disappearing Platform
-		obj.createentity(game, 32, 176, 2, 3, 4);  // Platform
-		obj.createentity(game, 256, 120, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 224, 184, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 0, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 16, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 104, 24, 10, 0, 448541);  // (savepoint)
+		obj.createentity(264, 128, 10, 0, 448540);  // (savepoint)
+		obj.createentity(192, 32, 3, 10);  //Disappearing Platform
+		obj.createentity(32, 176, 2, 3, 4);  // Platform
+		obj.createentity(256, 120, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(224, 184, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(0, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 16, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(104, 24, 10, 0, 448541);  // (savepoint)
 		roomname = "Ha Ha Ha Not Really";
 		break;
 
@@ -635,18 +635,18 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("510,510,510,510,510,510,510,510,632,0,0,0,0,818,698,698,630,510,510,510,510,510,510,632,698,698,820,0,0,0,0,630,510,510,510,510,510,510,510,510");
 
 		obj.platformtile = 279;
-		obj.createentity(game, 32, 168, 9, 3);  // (shiny trinket)
-		obj.createentity(game, 16, 112, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 0, 112, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 0, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 256, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 96, 32, 2, 3, 4);  // Platform
-		obj.createentity(game, 240, 88, 2, 2, 4);  // Platform
-		obj.createentity(game, 128, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 152, 168, 10, 1, 448530);  // (savepoint)
-		obj.createentity(game, 72, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 184, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 48, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(32, 168, 9, 3);  // (shiny trinket)
+		obj.createentity(16, 112, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(0, 112, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(0, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(256, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(96, 32, 2, 3, 4);  // Platform
+		obj.createentity(240, 88, 2, 2, 4);  // Platform
+		obj.createentity(128, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(152, 168, 10, 1, 448530);  // (savepoint)
+		obj.createentity(72, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(184, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(48, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
 
 		roomname="You Just Keep Coming Back";
 		break;
@@ -684,16 +684,16 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289");
 
 		obj.platformtile = 359;
-		obj.createentity(game, 256, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 256, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 0, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 0, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 120, 104, 2, 0, 4, 96, 64, 224, 160);  // Platform, bounded
-		obj.createentity(game, 168, 80, 2, 0, 4, 96, 64, 224, 160);  // Platform, bounded
-		obj.createentity(game, 72, 64, 10, 1, 448520);  // (savepoint)
-		obj.createentity(game, 232, 64, 10, 1, 448521);  // (savepoint)
-		obj.createentity(game, 232, 144, 10, 0, 448522);  // (savepoint)
-		obj.createentity(game, 72, 144, 10, 0, 448523);  // (savepoint)
+		obj.createentity(256, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(256, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(0, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(0, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(120, 104, 2, 0, 4, 96, 64, 224, 160);  // Platform, bounded
+		obj.createentity(168, 80, 2, 0, 4, 96, 64, 224, 160);  // Platform, bounded
+		obj.createentity(72, 64, 10, 1, 448520);  // (savepoint)
+		obj.createentity(232, 64, 10, 1, 448521);  // (savepoint)
+		obj.createentity(232, 144, 10, 0, 448522);  // (savepoint)
+		obj.createentity(72, 144, 10, 0, 448523);  // (savepoint)
 		roomname = "Gordian Knot";
 		break;
 
@@ -730,20 +730,20 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313");
 		tmap.push_back("313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313");
 
-		obj.createentity(game, 256, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 192, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 64, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 256, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 96, 40, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 160, 40, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 32, 40, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 72, 80, 10, 1, 448510);  // (savepoint)
-		obj.createentity(game, 104, 128, 1, 0, 5, 104, 120, 288, 200);  // Enemy, bounded
-		obj.createentity(game, 160+8, 168, 1, 1, 5, 104, 120, 288, 200);  // Enemy, bounded
-		obj.createentity(game, 216+16, 128, 1, 0, 5, 104, 120, 288, 200);  // Enemy, bounded
+		obj.createentity(256, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(192, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(64, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(256, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(96, 40, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(160, 40, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(32, 40, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(72, 80, 10, 1, 448510);  // (savepoint)
+		obj.createentity(104, 128, 1, 0, 5, 104, 120, 288, 200);  // Enemy, bounded
+		obj.createentity(160+8, 168, 1, 1, 5, 104, 120, 288, 200);  // Enemy, bounded
+		obj.createentity(216+16, 128, 1, 0, 5, 104, 120, 288, 200);  // Enemy, bounded
 
 		roomname = "Backsliders";
 		break;
@@ -780,16 +780,16 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("283,283,283,283,283,283,283,405,0,0,0,0,363,364,364,364,325,283,283,283,283,283,283,283,283,283,283,283,283,324,364,364,364,364,364,364,364,364,364,364");
 		tmap.push_back("283,283,283,283,283,283,283,405,0,0,0,0,403,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 
-		obj.createentity(game, 72, 184, 10, 0, 447510);  // (savepoint)
-		obj.createentity(game, 80, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 144, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 208, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(72, 184, 10, 0, 447510);  // (savepoint)
+		obj.createentity(80, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(144, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(208, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
 
-		obj.createentity(game, 24 - 8, 144 - 8, 1, 10, 0);  // Enemy
+		obj.createentity(24 - 8, 144 - 8, 1, 10, 0);  // Enemy
 
-		obj.createentity(game, 24 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 8 + (117 * 3), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 8 + (117 * 3), 144 - 8, 1, 10, 1);  // Enemy
 
 		//LIES emitter starts here
 		roomname = "The Cuckoo";
@@ -827,15 +827,15 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("391,391,391,391,391,391,391,391,391,391,352,351,391,391,391,391,391,391,391,391,352,310,310,351,391,391,391,391,391,391,391,391,391,391,391,391,391,391,391,391");
 		tmap.push_back("310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310");
 
-		obj.createentity(game, 8, 200, 10, 1, 447520);  // (savepoint)
-		obj.createentity(game, 200, 192, 9, 4);  // (shiny trinket)
-		obj.createentity(game, 232, 96, 10, 1, 447521);  // (savepoint)
+		obj.createentity(8, 200, 10, 1, 447520);  // (savepoint)
+		obj.createentity(200, 192, 9, 4);  // (shiny trinket)
+		obj.createentity(232, 96, 10, 1, 447521);  // (savepoint)
 
-		obj.createentity(game, 24 - 60 - 8, 144 - 8, 1, 10, 0);  // Enemy
+		obj.createentity(24 - 60 - 8, 144 - 8, 1, 10, 0);  // Enemy
 
-		obj.createentity(game, 24 - 60 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 60 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 60 - 8 + (117 * 3), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + (117 * 3), 144 - 8, 1, 10, 1);  // Enemy
 		//LIES Emitter, manually positioned
 		roomname = "Clarion Call";
 		break;
@@ -872,11 +872,11 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,232,0,0,0,0,230,110,110,110,110,110,110,110,110,110,110,110,110,110,110");
 		tmap.push_back("110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,232,0,0,0,0,230,110,110,110,110,110,110,110,110,110,110,110,110,110,110");
 
-		obj.createentity(game, 176, 104, 10, 0, 446510);  // (savepoint)
+		obj.createentity(176, 104, 10, 0, 446510);  // (savepoint)
 
-		obj.createentity(game, 7 * 8, 17 * 8, 1, 12, 0);  // Enemy
+		obj.createentity(7 * 8, 17 * 8, 1, 12, 0);  // Enemy
 
-		obj.createentity(game, 7*8, 2*8, 1, 12, 1);  // Enemy
+		obj.createentity(7*8, 2*8, 1, 12, 1);  // Enemy
 		//FACTORY emitter starts here
 		roomname = "The Solution is Dilution";
 		break;
@@ -913,12 +913,12 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("92,92,92,92,92,92,214,683,683,683,683,683,172,173,134,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92");
 		tmap.push_back("92,92,92,92,92,92,214,683,683,683,683,683,212,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92");
 
-		obj.createentity(game, 96, 168, 10, 0, 445510);  // (savepoint)
+		obj.createentity(96, 168, 10, 0, 445510);  // (savepoint)
 
-		obj.createentity(game, 7 * 8, 36 * 8, 1, 12, 0);  // Enemy
+		obj.createentity(7 * 8, 36 * 8, 1, 12, 0);  // Enemy
 
-		obj.createentity(game, 7 * 8, (36 * 8)-108, 1, 12, 1);  // Enemy
-		obj.createentity(game, 7 * 8, (36 * 8)-216, 1, 12, 1);  // Enemy
+		obj.createentity(7 * 8, (36 * 8)-108, 1, 12, 1);  // Enemy
+		obj.createentity(7 * 8, (36 * 8)-216, 1, 12, 1);  // Enemy
 		//FACTORY emitter starts here (manually placed)
 
 		roomname = "Lighter Than Air";
@@ -957,19 +957,19 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("292,292,292,292,333,373,374,701,701,701,701,701,412,292,292,292,292,292,292,292,414,0,0,0,0,372,373,373,373,373,373,373,373,373,373,373,373,334,292,292");
 		tmap.push_back("292,292,292,292,292,292,414,701,701,701,701,701,412,292,292,292,292,292,292,292,414,0,0,0,0,412,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 
-		obj.createentity(game, 224, 200, 10, 1, 444510);  // (savepoint)
+		obj.createentity(224, 200, 10, 1, 444510);  // (savepoint)
 
-		obj.createentity(game, 56, 40, 1, 0, 2);  // Enemy //collector
+		obj.createentity(56, 40, 1, 0, 2);  // Enemy //collector
 
-		obj.createentity(game, 7 * 8, 36 * 8, 1, 12, 0);  // Enemy
+		obj.createentity(7 * 8, 36 * 8, 1, 12, 0);  // Enemy
 
-		obj.createentity(game, 7 * 8, (36 * 8)-108, 1, 12, 1);  // Enemy
-		obj.createentity(game, 7 * 8, (36 * 8)-216, 1, 12, 1);  // Enemy
+		obj.createentity(7 * 8, (36 * 8)-108, 1, 12, 1);  // Enemy
+		obj.createentity(7 * 8, (36 * 8)-216, 1, 12, 1);  // Enemy
 		//FACTORY emitter starts here (manually placed)
 
 		if(!game.intimetrial)
 		{
-			obj.createentity(game, 18 * 8, (5 * 8) + 4, 14); //Teleporter!
+			obj.createentity(18 * 8, (5 * 8) + 4, 14); //Teleporter!
 		}
 		roomname = "Level Complete!";
 		break;
@@ -1041,11 +1041,11 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("98,98,98,98,220,0,0,0,0,0,800,680,680,680,680,680,680,680,680,680,802,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("98,98,98,98,220,0,0,0,0,0,800,680,680,680,680,680,680,680,680,680,802,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 248 - 4, 160 - 48, 1, 1, 0);  // Enemy
-		obj.createentity(game, 124, 120, 20, 1);  // (terminal)
+		obj.createentity(248 - 4, 160 - 48, 1, 1, 0);  // Enemy
+		obj.createentity(124, 120, 20, 1);  // (terminal)
 		obj.createblock(5, 124-4, 120, 20, 16, 14);
 
-		obj.createentity(game, 156, 40, 20, 1);  // (terminal)
+		obj.createentity(156, 40, 20, 1);  // (terminal)
 		obj.createblock(5, 156-4, 40, 20, 16, 15);
 
 		roomname = "The Hanged Man, Reversed";
@@ -1083,7 +1083,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,330,370,371,0,0,0,0,369,370,331,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289");
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,411,0,0,0,0,409,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289");
 
-		obj.createentity(game, 152, 120, 10, 0, 445530);  // (savepoint)
+		obj.createentity(152, 120, 10, 0, 445530);  // (savepoint)
 		roomname = "doomS";
 		break;
 
@@ -1119,12 +1119,12 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("170,170,170,170,170,170,131,89,89,130,170,170,170,170,170,170,170,170,131,89,89,130,170,170,170,170,170,170,170,170,131,89,89,130,170,170,170,170,170,170");
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 
-		obj.createentity(game, 24-60-8, 144-8, 1, 10, 0);  // Enemy
+		obj.createentity(24-60-8, 144-8, 1, 10, 0);  // Enemy
 		//LIES Emitter, manually positioned
 
-		obj.createentity(game, 24 - 60 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 60 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 60 - 8 + (117 * 3), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + (117 * 3), 144 - 8, 1, 10, 1);  // Enemy
 
 		roomname = "Chinese Rooms";
 		break;
@@ -1161,7 +1161,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 152, 96, 10, 1, 446530);  // (savepoint)
+		obj.createentity(152, 96, 10, 1, 446530);  // (savepoint)
 		roomname = "Swoop";
 		break;
 
@@ -1197,11 +1197,11 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,229,0,0,0,0,227,229,0,0,0,0,0,0");
 		tmap.push_back("107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,229,0,0,0,0,227,229,0,0,0,0,0,0");
 
-		obj.createentity(game, 64, 40, 10, 1, 446520);  // (savepoint)
-		obj.createentity(game, 208, 88, 3, 827);  //Disappearing Platform
-		obj.createentity(game, 152, 160, 3, 827);  //Disappearing Platform
-		obj.createentity(game, 96, 88, 3, 827);  //Disappearing Platform
-		obj.createentity(game, 40, 160, 3, 827);  //Disappearing Platform
+		obj.createentity(64, 40, 10, 1, 446520);  // (savepoint)
+		obj.createentity(208, 88, 3, 827);  //Disappearing Platform
+		obj.createentity(152, 160, 3, 827);  //Disappearing Platform
+		obj.createentity(96, 88, 3, 827);  //Disappearing Platform
+		obj.createentity(40, 160, 3, 827);  //Disappearing Platform
 		roomname = "Manic Mine";
 		break;
 
@@ -1273,26 +1273,26 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,435,0,0,0,0,0,0,0,0,0,0,433,313,313,313,313,313,313,313,313,313,313,313,313");
 		tmap.push_back("313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,354,394,394,394,394,394,394,394,394,394,394,355,313,313,313,313,313,313,313,313,313,313,313,313");
 
-		obj.createentity(game, 144-4, 208, 1, 1, 6);  // Enemy
-		obj.createentity(game, 128+4, 8, 1, 0, 6);  // Enemy
-		obj.createentity(game, 64, 200, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 216, 200, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 96, 160, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 160, 160, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 208, 160, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 248, 184, 10, 1, 445540);  // (savepoint)
-		obj.createentity(game, 184, 24, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 64, 64, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 152, 64, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 152, 88, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 64, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 96, 136, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 160, 136, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 184, 136, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 152, 24, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 104, 200, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 104, 136, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 104, 160, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(144-4, 208, 1, 1, 6);  // Enemy
+		obj.createentity(128+4, 8, 1, 0, 6);  // Enemy
+		obj.createentity(64, 200, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(216, 200, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(96, 160, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(160, 160, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(208, 160, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(248, 184, 10, 1, 445540);  // (savepoint)
+		obj.createentity(184, 24, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(64, 64, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(152, 64, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(152, 88, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(64, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(96, 136, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(160, 136, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(184, 136, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(152, 24, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(104, 200, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(104, 136, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(104, 160, 2, 9, 4);  //Threadmill, <<<
 
 		roomname = "$eeing Dollar $ign$";
 		break;
@@ -1329,19 +1329,19 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("0,0,0,0,0,206,86,208,0,0,818,698,206,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,208,698,698,820,0,0,206,86,86,86,86");
 		tmap.push_back("0,0,0,0,0,206,86,208,0,0,818,698,206,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,208,698,698,820,0,0,206,86,86,86,86");
 
-		obj.createentity(game, 184, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 248, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 312, 56, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 152, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 216, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 280, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 280, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 272, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 64, 152, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 120, 152, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 96, 192, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 152, 192, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 240, 88, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(184, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(248, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(312, 56, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(152, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(216, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(280, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(280, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(272, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(64, 152, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(120, 152, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(96, 192, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(152, 192, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(240, 88, 2, 9, 4);  //Threadmill, <<<
 		roomname = "Parabolica";
 		break;
 
@@ -1377,23 +1377,23 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("167,167,167,167,128,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86");
 		tmap.push_back("86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86");
 
-		obj.createentity(game, 96, 80, 10, 1, 447540);  // (savepoint)
-		obj.createentity(game, 64, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 112, 184, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 176, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 224, 184, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 232, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 288, 128, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 288, 184, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 120, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 168, 112, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 208, 168, 10, 1, 447541);  // (savepoint)
+		obj.createentity(96, 80, 10, 1, 447540);  // (savepoint)
+		obj.createentity(64, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(112, 184, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(176, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(224, 184, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(232, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(288, 128, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(288, 184, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(120, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(168, 112, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(208, 168, 10, 1, 447541);  // (savepoint)
 
-		obj.createentity(game, 24 - 60 - 8, 144 - 8, 1, 10, 0);  // Enemy
+		obj.createentity(24 - 60 - 8, 144 - 8, 1, 10, 0);  // Enemy
 
-		obj.createentity(game, 24 - 60 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 60 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 60 - 8 + (117 * 3), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + (117 * 3), 144 - 8, 1, 10, 1);  // Enemy
 
 		//LIES Emitter, manually positioned
 		roomname = "Spikes Do!";
@@ -1431,10 +1431,10 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 64, 152, 10, 1, 446540);  // (savepoint)
-		obj.createentity(game, 120, 72, 3, 707);  //Disappearing Platform
-		obj.createentity(game, 248, 72, 3, 707);  //Disappearing Platform
-		obj.createentity(game, 184, 200, 3, 707);  //Disappearing Platform
+		obj.createentity(64, 152, 10, 1, 446540);  // (savepoint)
+		obj.createentity(120, 72, 3, 707);  //Disappearing Platform
+		obj.createentity(248, 72, 3, 707);  //Disappearing Platform
+		obj.createentity(184, 200, 3, 707);  //Disappearing Platform
 		roomname = "What Lies Beneath?";
 		break;
 
@@ -1470,18 +1470,18 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 
-		obj.createentity(game, 0, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 112, 128, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 0, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 184, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 152, 168, 10, 1, 447550);  // (savepoint)
+		obj.createentity(0, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(112, 128, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(0, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(184, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(152, 168, 10, 1, 447550);  // (savepoint)
 
-		obj.createentity(game, 264, 136, 1, 0, 2);  // Enemy //Collector
-		obj.createentity(game, 24 - 60 - 8, 144 - 8, 1, 10, 0);  // Enemy
-		obj.createentity(game, 24 - 60 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 60 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(264, 136, 1, 0, 2);  // Enemy //Collector
+		obj.createentity(24 - 60 - 8, 144 - 8, 1, 10, 0);  // Enemy
+		obj.createentity(24 - 60 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
 		//LIES Emitter, manually positioned, collector!
 		roomname = "Chipper Cipher";
 		break;
@@ -1518,7 +1518,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("0,0,0,0,0,0,0,803,683,683,683,683,683,683,683,624,504,626,683,683,683,683,683,683,683,805,0,0,0,0,0,624,504,504,504,504,504,504,504,504");
 		tmap.push_back("0,0,0,0,0,0,0,803,683,683,683,683,683,683,683,624,504,626,683,683,683,683,683,683,683,805,0,0,0,0,0,624,504,504,504,504,504,504,504,504");
 
-		obj.createentity(game, 40, 72, 3, 787);  //Disappearing Platform
+		obj.createentity(40, 72, 3, 787);  //Disappearing Platform
 		roomname = "If You Fall Up";
 		break;
 
@@ -1555,9 +1555,9 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,620,695,695,695,695,618,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498");
 
 		obj.platformtile = 159;
-		obj.createentity(game, 24, 80, 2, 3, 6);  // Platform
-		obj.createentity(game, 64, 176, 10, 0, 445550);  // (savepoint)
-		obj.createentity(game, 216 - 4, 192, 10, 1, 445551);  // (savepoint)
+		obj.createentity(24, 80, 2, 3, 6);  // Platform
+		obj.createentity(64, 176, 10, 0, 445550);  // (savepoint)
+		obj.createentity(216 - 4, 192, 10, 1, 445551);  // (savepoint)
 		roomname = "Just Pick Yourself Down";
 		break;
 
@@ -1594,37 +1594,37 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,408,0,0,0,0,406,286");
 		tmap.push_back("286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,408,0,0,0,0,406,286");
 
-		obj.createentity(game, 32, 40, 10, 1, 444560);  // (savepoint)
-		obj.createentity(game, 56, 24, 10, 0, 444551);  // (savepoint)
-		obj.createentity(game, 80, 40, 10, 1, 444552);  // (savepoint)
-		obj.createentity(game, 104, 24, 10, 0, 444553);  // (savepoint)
-		obj.createentity(game, 128, 40, 10, 1, 444554);  // (savepoint)
-		obj.createentity(game, 152, 24, 10, 0, 444555);  // (savepoint)
-		obj.createentity(game, 176, 40, 10, 1, 444556);  // (savepoint)
-		obj.createentity(game, 200, 24, 10, 0, 444557);  // (savepoint)
-		obj.createentity(game, 224, 40, 10, 1, 444558);  // (savepoint)
-		obj.createentity(game, 248, 24, 10, 0, 444559);  // (savepoint)
-		obj.createentity(game, 272, 40, 10, 1, 444550);  // (savepoint)
-		obj.createentity(game, 0, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 256, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 0, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 256, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 0, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 64, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 192, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 240, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 0, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 64, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 192, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 240, 128, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(32, 40, 10, 1, 444560);  // (savepoint)
+		obj.createentity(56, 24, 10, 0, 444551);  // (savepoint)
+		obj.createentity(80, 40, 10, 1, 444552);  // (savepoint)
+		obj.createentity(104, 24, 10, 0, 444553);  // (savepoint)
+		obj.createentity(128, 40, 10, 1, 444554);  // (savepoint)
+		obj.createentity(152, 24, 10, 0, 444555);  // (savepoint)
+		obj.createentity(176, 40, 10, 1, 444556);  // (savepoint)
+		obj.createentity(200, 24, 10, 0, 444557);  // (savepoint)
+		obj.createentity(224, 40, 10, 1, 444558);  // (savepoint)
+		obj.createentity(248, 24, 10, 0, 444559);  // (savepoint)
+		obj.createentity(272, 40, 10, 1, 444550);  // (savepoint)
+		obj.createentity(0, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(256, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(0, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(256, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(0, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(64, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(192, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(240, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(0, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(64, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(192, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(240, 128, 2, 9, 4);  //Threadmill, <<<
 		roomname = "The Warning";
 		break;
 
@@ -1661,13 +1661,13 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("420,49,0,0,0,0,50,418,298,420,0,0,0,0,0,0,0,0,0,0,50,418,298,298,298,298,420,49,0,0,0,0,0,0,0,0,0,0,418,298");
 		tmap.push_back("420,49,0,0,0,0,50,418,298,420,0,0,0,0,0,0,0,0,0,0,50,418,298,298,298,298,420,49,0,0,0,0,0,0,0,0,0,0,418,298");
 
-		obj.createentity(game, 176, 80, 3, 55);  //Disappearing Platform
-		obj.createentity(game, 0, 56, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 16, 56, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 72, 72, 10, 1, 444561);  // (savepoint)
-		obj.createentity(game, 8, 144, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 48, 144, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 0, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(176, 80, 3, 55);  //Disappearing Platform
+		obj.createentity(0, 56, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(16, 56, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(72, 72, 10, 1, 444561);  // (savepoint)
+		obj.createentity(8, 144, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(48, 144, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(0, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
 
 
 		roomname = "Getting Here is Half the Fun";
@@ -1880,10 +1880,10 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("89,89,89,89,89,89,211,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,169,170,170,170,170,170,170,170,131,89,89");
 		tmap.push_back("89,89,89,89,89,89,130,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,131,89,89,89,89,89,89,89,89,89,89");
 
-		obj.createentity(game, 224, 144, 9, 5);  // (shiny trinket)
-		obj.createentity(game, 96, 152, 10, 1, 450560);  // (savepoint)
+		obj.createentity(224, 144, 9, 5);  // (shiny trinket)
+		obj.createentity(96, 152, 10, 1, 450560);  // (savepoint)
 
-		obj.createentity(game, 24, 152, 20, 1);  // (terminal)
+		obj.createentity(24, 152, 20, 1);  // (terminal)
 		obj.createblock(5, 24-4, 152, 20, 16, 16);
 		roomname = "Doing Things The Hard Way";
 		break;
@@ -1923,8 +1923,8 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,617,0,0,0,0,0,0,0,0,0,0,615,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 
 		obj.platformtile = 707;
-		obj.createentity(game, 272, 40, 2, 14, 2);  // Platform
-		obj.createentity(game, 240, 40, 3, 707);  //Disappearing Platform
+		obj.createentity(272, 40, 2, 14, 2);  // Platform
+		obj.createentity(240, 40, 3, 707);  //Disappearing Platform
 
 		if(game.intimetrial && game.timetriallevel > 0)
 		{
@@ -1965,11 +1965,11 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("301,301,301,301,301,301,301,423,0,0,0,0,421,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301");
 		tmap.push_back("301,301,301,301,301,301,301,423,0,0,0,0,421,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301");
 
-		obj.createentity(game, 0, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 64, 168, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 72, 128, 10, 1, 443560);  // (savepoint)
+		obj.createentity(0, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(64, 168, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(72, 128, 10, 1, 443560);  // (savepoint)
 
-		obj.createentity(game, (21 * 8), (9 * 8), 14); //Teleporter!
+		obj.createentity((21 * 8), (9 * 8), 14); //Teleporter!
 
 		if(game.intimetrial)
 		{
@@ -2026,16 +2026,16 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86");
 		tmap.push_back("86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86");
 
-		obj.createentity(game, 0, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 63, 64-16, 1, 3, 4, 64, 0, 256, 204);  // Enemy, bounded
-		obj.createentity(game, 256-28, 80, 1, 2, 4, 64, 0, 256, 204);  // Enemy, bounded
-		obj.createentity(game, 48, 168, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 104, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 152, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 240, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 288, 168, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 160 - 48, 184 - 8, 1, 3, 5);// , 160, 0, 320, 240);  // Enemy, bounded
-		obj.createentity(game, 160 - 28 + 48, 184 - 8, 1, 2, 5);// , 0, 0, 160, 240);  // Enemy, bounded
+		obj.createentity(0, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(63, 64-16, 1, 3, 4, 64, 0, 256, 204);  // Enemy, bounded
+		obj.createentity(256-28, 80, 1, 2, 4, 64, 0, 256, 204);  // Enemy, bounded
+		obj.createentity(48, 168, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(104, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(152, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(240, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(288, 168, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(160 - 48, 184 - 8, 1, 3, 5);// , 160, 0, 320, 240);  // Enemy, bounded
+		obj.createentity(160 - 28 + 48, 184 - 8, 1, 2, 5);// , 0, 0, 160, 240);  // Enemy, bounded
 		roomname = "Brass Sent Us Under The Top";
 		break;
 
@@ -2071,13 +2071,13 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507");
 		tmap.push_back("507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507");
 
-		obj.createentity(game, 64, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 192, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 256, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 32+4, 48, 10, 0, 443540);  // (savepoint)
-		obj.createentity(game, 208-4, 48, 1, 0, 3, 104, 40, 324, 136);  // Enemy, bounded
-		obj.createentity(game, 136 + 4, 96, 10, 1, 443541);  // (savepoint)
+		obj.createentity(64, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(192, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(256, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(32+4, 48, 10, 0, 443540);  // (savepoint)
+		obj.createentity(208-4, 48, 1, 0, 3, 104, 40, 324, 136);  // Enemy, bounded
+		obj.createentity(136 + 4, 96, 10, 1, 443541);  // (savepoint)
 
 		roomname = "The Tomb of Mad Carew";
 		break;
@@ -2114,8 +2114,8 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("310,310,310,310,432,0,0,0,0,0,812,692,430,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,432,0,0,0,0,0,0,430,310,310,310,310");
 		tmap.push_back("310,310,310,310,432,0,0,0,0,0,812,692,430,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,432,0,0,0,0,0,0,430,310,310,310,310");
 
-		obj.createentity(game, 56, 144, 10, 0, 443520);  // (savepoint)
-		obj.createentity(game, 152, 80, 10, 1, 443521);  // (savepoint)
+		obj.createentity(56, 144, 10, 0, 443520);  // (savepoint)
+		obj.createentity(152, 80, 10, 1, 443521);  // (savepoint)
 		roomname = "The Sensible Room";
 		break;
 
@@ -2151,7 +2151,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 
-		obj.createentity(game, 0, -200, 1, 16, 6, -64, -500, 320 + 64, 340);
+		obj.createentity(0, -200, 1, 16, 6, -64, -500, 320 + 64, 340);
 		roomname = "B-B-B-Busted";
 		break;
 
@@ -2188,8 +2188,8 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("286,286,286,327,367,367,367,367,328,286,286,327,367,367,367,367,328,286,286,327,367,367,367,367,328,286,286,327,367,367,367,367,328,286,286,286,286,286,286,286");
 		tmap.push_back("286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 
-		obj.createentity(game, 280, 192, 10, 1, 443500);  // (savepoint)
-		obj.createentity(game, 64, 80, 10, 1, 443501);  // (savepoint)
+		obj.createentity(280, 192, 10, 1, 443500);  // (savepoint)
+		obj.createentity(64, 80, 10, 1, 443501);  // (savepoint)
 
 		if(!game.nocutscenes)
 		{
@@ -2239,12 +2239,12 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 
 		obj.platformtile = 747;
-		obj.createentity(game, 120, 72, 3, 747);  //Disappearing Platform
-		obj.createentity(game, 120, 112, 3, 747);  //Disappearing Platform
-		obj.createentity(game, 120, 128, 3, 747);  //Disappearing Platform
-		obj.createentity(game, 88, 72, 2, 15, 4);  // Platform
-		obj.createentity(game, 192, 128, 9, 6);  // (shiny trinket)
-		obj.createentity(game, 240, 136, 10, 0, 443490);  // (savepoint)
+		obj.createentity(120, 72, 3, 747);  //Disappearing Platform
+		obj.createentity(120, 112, 3, 747);  //Disappearing Platform
+		obj.createentity(120, 128, 3, 747);  //Disappearing Platform
+		obj.createentity(88, 72, 2, 15, 4);  // Platform
+		obj.createentity(192, 128, 9, 6);  // (shiny trinket)
+		obj.createentity(240, 136, 10, 0, 443490);  // (savepoint)
 		roomname = "Prize for the Reckless";
 		if(game.nodeathmode)
 		{
@@ -2288,16 +2288,16 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 
-		obj.createentity(game, 152, 32, 10, 1, 443480);  // (savepoint)
-		obj.createentity(game, 152, 184, 10, 0, 443481);  // (savepoint)
-		obj.createentity(game, 272, 120, 1, 2, 8);  // Enemy
-		obj.createentity(game, 32, 96, 1, 3, 8);  // Enemy
-		obj.createentity(game, 104, 80, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 168, 80, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 232, 80, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 56, 144, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 120, 144, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 184, 144, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(152, 32, 10, 1, 443480);  // (savepoint)
+		obj.createentity(152, 184, 10, 0, 443481);  // (savepoint)
+		obj.createentity(272, 120, 1, 2, 8);  // Enemy
+		obj.createentity(32, 96, 1, 3, 8);  // Enemy
+		obj.createentity(104, 80, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(168, 80, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(232, 80, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(56, 144, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(120, 144, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(184, 144, 2, 8, 4);  //Threadmill, >>>
 		roomname = "A Deception";
 		break;
 
@@ -2334,12 +2334,12 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("310,310,432,692,692,692,692,430,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310");
 
 		obj.platformtile = 239;
-		obj.createentity(game, 88, 112, 2, 0, 4, 88, 64, 264, 168);  // Platform, bounded
-		obj.createentity(game, 136, 112, 2, 1, 4, 88, 64, 264, 168);  // Platform, bounded
-		obj.createentity(game, 184, 112, 2, 0, 4, 88, 64, 264, 168);  // Platform, bounded
-		obj.createentity(game, 232, 112, 2, 1, 4, 88, 64, 264, 168);  // Platform, bounded
-		obj.createentity(game, 56, 64, 10, 0, 442480);  // (savepoint)
-		obj.createentity(game, 280, 152, 10, 1, 442481);  // (savepoint)
+		obj.createentity(88, 112, 2, 0, 4, 88, 64, 264, 168);  // Platform, bounded
+		obj.createentity(136, 112, 2, 1, 4, 88, 64, 264, 168);  // Platform, bounded
+		obj.createentity(184, 112, 2, 0, 4, 88, 64, 264, 168);  // Platform, bounded
+		obj.createentity(232, 112, 2, 1, 4, 88, 64, 264, 168);  // Platform, bounded
+		obj.createentity(56, 64, 10, 0, 442480);  // (savepoint)
+		obj.createentity(280, 152, 10, 1, 442481);  // (savepoint)
 
 		roomname = "Down Under";
 		break;
@@ -2376,10 +2376,10 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("295,417,779,779,779,779,415,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,417,698,698,698,820,0,0,415,295,295,295,295,295");
 		tmap.push_back("295,417,698,698,698,698,415,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,417,698,698,698,820,0,0,415,295,295,295,295,295");
 
-		obj.createentity(game, 16, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 104, 184, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 144, 168, 10, 1, 442490);  // (savepoint)
-		obj.createentity(game, 24, 112, 10, 0, 442491);  // (savepoint)
+		obj.createentity(16, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(104, 184, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(144, 168, 10, 1, 442490);  // (savepoint)
+		obj.createentity(24, 112, 10, 0, 442491);  // (savepoint)
 		roomname = "Shenanigan";
 		break;
 
@@ -2415,13 +2415,13 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,611,0,0,0,809,689,689,609,489,489,489,489,489");
 		tmap.push_back("489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,611,0,0,0,809,689,689,609,489,489,489,489,489");
 
-		obj.createentity(game, 192, 88, 10, 0, 441490);  // (savepoint)
+		obj.createentity(192, 88, 10, 0, 441490);  // (savepoint)
 
 		if(!game.intimetrial)
 		{
 			if(game.companion==0 && obj.flags[10]==0 &&  !game.crewstats[2])   //also need to check if he's rescued in a previous game
 			{
-				obj.createentity(game, 42, 86, 16, 0);
+				obj.createentity(42, 86, 16, 0);
 				obj.createblock(1, 0, 0, 140, 240, 34);
 			}
 		}
@@ -2460,7 +2460,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298");
 		tmap.push_back("298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298");
 
-		obj.createentity(game, (5 * 8) - 4, (8 * 8) + 4, 14); //Teleporter!
+		obj.createentity((5 * 8) - 4, (8 * 8) + 4, 14); //Teleporter!
 
 		if(game.intimetrial)
 		{
@@ -2501,8 +2501,8 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,414,0,0,0,0,412,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,414,0,0,0,0,412,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 
-		obj.createentity(game, 40, 24, 10, 0, 442530);  // (savepoint)
-		obj.createentity(game, 264, 24, 10, 0, 442531);  // (savepoint)
+		obj.createentity(40, 24, 10, 0, 442530);  // (savepoint)
+		obj.createentity(264, 24, 10, 0, 442531);  // (savepoint)
 
 		roomname = "Driller";
 		break;
@@ -2539,24 +2539,24 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,214,0,0,0,0,0,0,172,173,134,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92");
 		tmap.push_back("92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,214,0,0,0,0,0,0,212,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92");
 
-		obj.createentity(game, 128, 80, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 160, 80, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 192, 80, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 128, 88, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 160, 88, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 192, 88, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 128, 96, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 128, 104, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 128, 112, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 128, 120, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 160, 96, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 160, 104, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 160, 112, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 160, 120, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 192, 96, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 192, 104, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 192, 112, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 192, 120, 3, 867);  //Disappearing Platform
+		obj.createentity(128, 80, 3, 867);  //Disappearing Platform
+		obj.createentity(160, 80, 3, 867);  //Disappearing Platform
+		obj.createentity(192, 80, 3, 867);  //Disappearing Platform
+		obj.createentity(128, 88, 3, 867);  //Disappearing Platform
+		obj.createentity(160, 88, 3, 867);  //Disappearing Platform
+		obj.createentity(192, 88, 3, 867);  //Disappearing Platform
+		obj.createentity(128, 96, 3, 867);  //Disappearing Platform
+		obj.createentity(128, 104, 3, 867);  //Disappearing Platform
+		obj.createentity(128, 112, 3, 867);  //Disappearing Platform
+		obj.createentity(128, 120, 3, 867);  //Disappearing Platform
+		obj.createentity(160, 96, 3, 867);  //Disappearing Platform
+		obj.createentity(160, 104, 3, 867);  //Disappearing Platform
+		obj.createentity(160, 112, 3, 867);  //Disappearing Platform
+		obj.createentity(160, 120, 3, 867);  //Disappearing Platform
+		obj.createentity(192, 96, 3, 867);  //Disappearing Platform
+		obj.createentity(192, 104, 3, 867);  //Disappearing Platform
+		obj.createentity(192, 112, 3, 867);  //Disappearing Platform
+		obj.createentity(192, 120, 3, 867);  //Disappearing Platform
 
 		if(!game.nocutscenes)
 		{
@@ -2601,8 +2601,8 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,217,0,0,809,689,689,689,689,689,215,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95");
 		tmap.push_back("95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,217,0,0,809,689,689,689,689,689,215,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95");
 
-		obj.createentity(game, 144, 40, 3);  //Disappearing Platform
-		obj.createentity(game, 200, 128, 3);  //Disappearing Platform
+		obj.createentity(144, 40, 3);  //Disappearing Platform
+		obj.createentity(200, 128, 3);  //Disappearing Platform
 		roomname = "Boo! Think Fast!";
 		break;
 
@@ -2638,12 +2638,12 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("495,495,495,495,495,617,0,0,0,0,0,0,615,495,617,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,615,495,495,495,495");
 		tmap.push_back("495,495,495,495,495,617,0,0,0,0,0,0,615,495,536,576,576,576,576,576,576,576,576,576,576,576,576,576,576,576,576,576,576,576,576,537,495,495,495,495");
 
-		obj.createentity(game, 288, 160, 10, 1, 442500);  // (savepoint)
+		obj.createentity(288, 160, 10, 1, 442500);  // (savepoint)
 
 
-		obj.createentity(game, 135, 75, 2, 0, 3, 100, 70, 320, 160);
-		obj.createentity(game, 185, 110, 2, 0, 3, 100, 70, 320, 160);
-		obj.createentity(game, 235, 145, 2, 0, 3, 100, 70, 320, 160);
+		obj.createentity(135, 75, 2, 0, 3, 100, 70, 320, 160);
+		obj.createentity(185, 110, 2, 0, 3, 100, 70, 320, 160);
+		obj.createentity(235, 145, 2, 0, 3, 100, 70, 320, 160);
 		roomname = "Stop and Reflect";
 		break;
 
@@ -2680,11 +2680,11 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86");
 
 		obj.platformtile = 207;
-		obj.createentity(game, 112-4, 200-4, 1, 1, 6, 104, 144, 264, 240);  // Enemy, bounded
-		obj.createentity(game, 176-4, 152, 1, 0, 6, 104, 144, 264, 240);  // Enemy, bounded
-		obj.createentity(game, 240-4, 200-4, 1, 1, 6, 104, 144, 264, 240);  // Enemy, bounded
-		obj.createentity(game, 64, 48, 2, 3, 4);  // Platform
-		obj.createentity(game, 272, 152, 9, 1);  // (shiny trinket)
+		obj.createentity(112-4, 200-4, 1, 1, 6, 104, 144, 264, 240);  // Enemy, bounded
+		obj.createentity(176-4, 152, 1, 0, 6, 104, 144, 264, 240);  // Enemy, bounded
+		obj.createentity(240-4, 200-4, 1, 1, 6, 104, 144, 264, 240);  // Enemy, bounded
+		obj.createentity(64, 48, 2, 3, 4);  // Platform
+		obj.createentity(272, 152, 9, 1);  // (shiny trinket)
 
 		if(!game.nocutscenes)
 		{
@@ -2726,14 +2726,14 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("92,92,92,92,92,214,683,683,683,683,683,683,212,92,214,683,683,683,212,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92");
 		tmap.push_back("92,92,92,92,92,214,683,683,683,683,683,683,212,92,133,173,173,173,134,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92");
 
-		obj.createentity(game, 120+2, 8, 1, 0, 3);  // Enemy
-		obj.createentity(game, 264+2, 8, 1, 0, 3);  // Enemy
-		obj.createentity(game, 120+2, 208-4, 1, 1, 3);  // Enemy
-		obj.createentity(game, 192+2, 176-4, 1, 1, 3);  // Enemy
-		obj.createentity(game, 192+2, 40, 1, 0, 3);  // Enemy
+		obj.createentity(120+2, 8, 1, 0, 3);  // Enemy
+		obj.createentity(264+2, 8, 1, 0, 3);  // Enemy
+		obj.createentity(120+2, 208-4, 1, 1, 3);  // Enemy
+		obj.createentity(192+2, 176-4, 1, 1, 3);  // Enemy
+		obj.createentity(192+2, 40, 1, 0, 3);  // Enemy
 
-		obj.createentity(game, 64, 80, 10, 1, 441501);  // (savepoint)
-		obj.createentity(game, 64, 136, 10, 0, 441502);  // (savepoint)
+		obj.createentity(64, 80, 10, 1, 441501);  // (savepoint)
+		obj.createentity(64, 136, 10, 0, 441502);  // (savepoint)
 
 		roomname = "The Yes Men";
 		break;
@@ -2771,12 +2771,12 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("283,283,283,283,283,405,0,0,0,0,0,0,403,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 
 		obj.platformtile = 10;
-		obj.createentity(game, 136-32, 64, 3, 10);  //Disappearing Platform
-		obj.createentity(game, 136, 64, 3, 10);  //Disappearing Platform
-		obj.createentity(game, 136+32, 64, 3, 10);  //Disappearing Platform
-		obj.createentity(game, 56, 104, 10, 1, 440500);  // (savepoint)
-		obj.createentity(game, 56, 152, 2, 3, 3);  // Platform
-		obj.createentity(game, 280, 192, 10, 1, 440501);  // (savepoint)
+		obj.createentity(136-32, 64, 3, 10);  //Disappearing Platform
+		obj.createentity(136, 64, 3, 10);  //Disappearing Platform
+		obj.createentity(136+32, 64, 3, 10);  //Disappearing Platform
+		obj.createentity(56, 104, 10, 1, 440500);  // (savepoint)
+		obj.createentity(56, 152, 2, 3, 3);  // Platform
+		obj.createentity(280, 192, 10, 1, 440501);  // (savepoint)
 
 		roomname = "Gantry and Dolly";
 		break;
@@ -2813,13 +2813,12 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("495,495,495,495,495,495,495,495,495,617,680,680,680,680,680,680,680,680,680,615,495,495,495,495,617,680,680,680,680,680,680,680,680,680,680,615,495,495,495,495");
 		tmap.push_back("495,495,495,495,495,495,495,495,495,536,576,576,576,576,576,576,576,576,576,537,495,495,495,495,536,576,576,576,576,576,576,576,576,576,576,537,495,495,495,495");
 
-		obj.createentity(game, 88, 104, 21, 1);  // (savepoint)
-		obj.createentity(game, 112, 104, 21, 1, 440511);  // (savepoint)
-		obj.createentity(game, 136, 88, 1, 0, 0);  // Enemy //the radar dish
-		//obj.createentity(game, 176, 104, 10, 1, 440512);  // (savepoint)
-		obj.createentity(game, 200, 104, 21, 1);  // (savepoint)
-		obj.createentity(game, 224, 104, 21, 1);  // (savepoint)
-		obj.createentity(game, 256, 32, 1, 0, 0);  // Enemy //in this case, the transmitter
+		obj.createentity(88, 104, 21, 1);  // (savepoint)
+		obj.createentity(112, 104, 21, 1, 440511);  // (savepoint)
+		obj.createentity(136, 88, 1, 0, 0);  // Enemy //the radar dish
+		obj.createentity(200, 104, 21, 1);  // (savepoint)
+		obj.createentity(224, 104, 21, 1);  // (savepoint)
+		obj.createentity(256, 32, 1, 0, 0);  // Enemy //in this case, the transmitter
 
 		if(!game.intimetrial)
 		{
@@ -2861,8 +2860,8 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("292,292,292,292,292,414,0,0,0,0,0,0,412,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 		tmap.push_back("292,292,292,292,292,414,0,0,0,0,0,0,412,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 
-		obj.createentity(game, 200, 32, 1, 0, 8);  // Enemy
-		obj.createentity(game, 168, 104, 10, 1, 439500);  // (savepoint)
+		obj.createentity(200, 32, 1, 0, 8);  // Enemy
+		obj.createentity(168, 104, 10, 1, 439500);  // (savepoint)
 
 		roomname = "Security Sweep";
 		break;
@@ -2899,12 +2898,12 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,136,176,176,176,176,176,176,176,176,176,137,95,95");
 		tmap.push_back("95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95");
 
-		obj.createentity(game, 24, 168, 10, 1, 439510);  // (savepoint)
-		obj.createentity(game, 280, 48, 10, 0, 439511);  // (savepoint)
-		obj.createentity(game, 80, 88, 1, 3, 3);  // Enemy
-		obj.createentity(game, 224 - 16, 128, 1, 2, 3);  // Enemy
+		obj.createentity(24, 168, 10, 1, 439510);  // (savepoint)
+		obj.createentity(280, 48, 10, 0, 439511);  // (savepoint)
+		obj.createentity(80, 88, 1, 3, 3);  // Enemy
+		obj.createentity(224 - 16, 128, 1, 2, 3);  // Enemy
 
-		obj.createentity(game, 256-4, 200, 20, 1);  // (terminal)
+		obj.createentity(256-4, 200, 20, 1);  // (terminal)
 		obj.createblock(5, 256-8, 200, 20, 16, 6);
 		roomname = "Linear Collider";
 		break;
@@ -2941,8 +2940,8 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,411,0,0,0,0,409,289,289,289,289,289,289,289,289,289");
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,411,0,0,0,0,409,289,289,289,289,289,289,289,289,289");
 
-		obj.createentity(game, 192, 48, 10, 0, 439520);  // (savepoint)
-		obj.createentity(game, 112, 160, 10, 1, 439521);  // (savepoint)
+		obj.createentity(192, 48, 10, 0, 439520);  // (savepoint)
+		obj.createentity(112, 160, 10, 1, 439521);  // (savepoint)
 		roomname = "Atmospheric Filtering Unit";
 		break;
 
@@ -2980,11 +2979,11 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 
 		roomname = "Traffic Jam";
 
-		obj.createentity(game, 45, 118, 1, 1, 4);
-		obj.createentity(game, 205, 118, 1, 1, 4);
-		obj.createentity(game, 125, 18, 1, 0, 4);
+		obj.createentity(45, 118, 1, 1, 4);
+		obj.createentity(205, 118, 1, 1, 4);
+		obj.createentity(125, 18, 1, 0, 4);
 
-		obj.createentity(game, 232, 184, 10, 0, 1);
+		obj.createentity(232, 184, 10, 0, 1);
 		break;
 
 	case rn(53,40):
@@ -3053,7 +3052,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 		tmap.push_back("286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 
-		obj.createentity(game, 152, 168, 10, 1, 441530);  // (savepoint)
+		obj.createentity(152, 168, 10, 1, 441530);  // (savepoint)
 
 		if(!game.nocutscenes)
 		{
@@ -3171,8 +3170,8 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 
-		obj.createentity(game, 216, 144, 10, 1, 440520);  // (savepoint)
-		obj.createentity(game, 16, 136, 9, 0);  // (shiny trinket)
+		obj.createentity(216, 144, 10, 1, 440520);  // (savepoint)
+		obj.createentity(16, 136, 9, 0);  // (shiny trinket)
 
 		roomname = "It's a Secret to Nobody";
 		break;

--- a/desktop_version/src/Spacestation2.h
+++ b/desktop_version/src/Spacestation2.h
@@ -10,7 +10,7 @@
 class spacestation2class
 {
 public:
-	std::vector<std::string> loadlevel(int rx, int ry, Game& game, entityclass& obj);
+	std::vector<std::string> loadlevel(int rx, int ry);
 	std::string roomname;
 };
 

--- a/desktop_version/src/WarpClass.cpp
+++ b/desktop_version/src/WarpClass.cpp
@@ -2,7 +2,7 @@
 
 #include "MakeAndPlay.h"
 
-std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entityclass& obj)
+std::vector<std::string> warpclass::loadlevel(int rx, int ry)
 {
 	int t;
 
@@ -18,7 +18,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 	warpx = false;
 	warpy = false;
 
-	roomname = "Untitled room ["+UtilityClass::String(rx) + "," + UtilityClass::String(ry)+"]";
+	roomname = "Untitled room ["+help.String(rx) + "," + help.String(ry)+"]";
 
 	switch(t)
 	{
@@ -55,7 +55,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("120,120,120,120,120,120,120,120,120,120,120,120,120,200,80,202,0,0,0,0,0,0,0,0,200,80,202,120,120,120,120,120,120,120,120,120,120,120,120,120");
 		tmap.push_back("120,120,120,120,120,120,120,120,120,120,120,120,120,200,80,202,0,0,0,0,0,0,0,0,200,80,202,120,120,120,120,120,120,120,120,120,120,120,120,120");
 
-		obj.createentity(game, 288, 168, 10, 1, 50500);  // (savepoint)
+		obj.createentity(288, 168, 10, 1, 50500);  // (savepoint)
 
 		if(game.intimetrial)
 		{
@@ -136,9 +136,9 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("83,83,83,83,83,205,0,0,0,0,203,83,83,83,83,83,83,205,0,0,0,0,203,83,83,83,83,83,83,205,0,0,0,0,203,83,83,83,83,83");
 		tmap.push_back("83,83,83,83,83,205,0,0,0,0,203,83,83,83,83,83,83,205,0,0,0,0,203,83,83,83,83,83,83,205,0,0,0,0,203,83,83,83,83,83");
 
-		obj.createentity(game, 248, 80, 10, 1, 51510);  // (savepoint)
-		obj.createentity(game, 136, 128, 1, 3, 3, 128, 120, 288, 152);  // Enemy, bounded
-		obj.createentity(game, 104, 192, 10, 1, 51511);  // (savepoint)
+		obj.createentity(248, 80, 10, 1, 51510);  // (savepoint)
+		obj.createentity(136, 128, 1, 3, 3, 128, 120, 288, 152);  // Enemy, bounded
+		obj.createentity(104, 192, 10, 1, 51511);  // (savepoint)
 		rcol = 1;
 		warpy = true;
 		roomname = "Take the Red Pill";
@@ -176,11 +176,11 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("135,135,135,135,135,135,135,135,135,135,215,95,217,215,95,95,95,95,95,95,95,95,95,217,215,95,217,135,135,135,135,135,135,135,135,135,135,135,135,135");
 		tmap.push_back("135,135,135,135,135,135,135,135,135,135,215,95,217,215,95,95,95,95,95,95,95,95,95,217,215,95,217,135,135,135,135,135,135,135,135,135,135,135,135,135");
 
-		obj.createentity(game, 32, 24, 1, 3, 4, -56, -40, 384, 312);  // Enemy, bounded
-		obj.createentity(game, 96, 24, 1, 3, 4, -56, -40, 384, 312);  // Enemy, bounded
-		obj.createentity(game, 160, 24, 1, 3, 4, -56, -40, 384, 312);  // Enemy, bounded
-		obj.createentity(game, 224, 24, 1, 3, 4, -56, -40, 384, 312);  // Enemy, bounded
-		obj.createentity(game, 232, 152, 10, 1, 51520);  // (savepoint)
+		obj.createentity(32, 24, 1, 3, 4, -56, -40, 384, 312);  // Enemy, bounded
+		obj.createentity(96, 24, 1, 3, 4, -56, -40, 384, 312);  // Enemy, bounded
+		obj.createentity(160, 24, 1, 3, 4, -56, -40, 384, 312);  // Enemy, bounded
+		obj.createentity(224, 24, 1, 3, 4, -56, -40, 384, 312);  // Enemy, bounded
+		obj.createentity(232, 152, 10, 1, 51520);  // (savepoint)
 		rcol = 5;
 		warpx = true;
 		roomname = "Short Circuit";
@@ -218,7 +218,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("213,212,92,214,172,174,0,0,0,0,0,0,212,214,0,0,0,0,0,0,212,214,0,0,0,0,0,0,212,214,0,0,0,0,0,0,212,92,92,92");
 		tmap.push_back("213,212,92,214,252,254,0,0,0,0,0,0,212,214,0,0,0,0,0,0,212,214,0,0,0,0,0,0,212,214,0,0,0,0,0,0,212,92,92,92");
 
-		obj.createentity(game, 32, 16, 10, 0, 50520);  // (savepoint)
+		obj.createentity(32, 16, 10, 0, 50520);  // (savepoint)
 		rcol = 4;
 		warpy = true;
 		roomname = "As you like it";
@@ -257,7 +257,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,209,211,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,209,211,0,0,0,0,0");
 		tmap.push_back("170,170,170,170,170,170,170,170,170,170,170,170,170,170,171,209,211,169,170,170,170,170,170,170,170,170,170,170,170,170,170,170,171,209,211,169,170,170,170,170");
 
-		obj.createentity(game, 16, 120, 10, 1, 50530);  // (savepoint)
+		obj.createentity(16, 120, 10, 1, 50530);  // (savepoint)
 		rcol = 3;
 		warpx = true;
 		roomname = "Maze With No Entrance";
@@ -295,7 +295,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("126,126,126,126,206,86,208,0,0,0,166,167,168,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,166,167");
 		tmap.push_back("126,126,126,126,206,86,208,0,0,0,206,86,208,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,206,86");
 
-		obj.createentity(game, 64, 152, 10, 0, 49530);  // (savepoint)
+		obj.createentity(64, 152, 10, 0, 49530);  // (savepoint)
 		rcol = 2;
 		warpy = true;
 		roomname = "As we go up, we go down";
@@ -333,10 +333,10 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("161,161,161,161,161,161,161,161,161,162,200,202,0,0,0,0,160,161,161,161,161,161,161,161,161,161,161,161,161,161,161,161,161,161,161,162,200,202,160,161");
 		tmap.push_back("80,80,80,80,80,80,80,80,80,202,200,202,0,0,0,0,200,80,80,80,80,80,80,80,80,80,80,80,80,80,80,80,80,80,80,202,200,202,200,80");
 
-		obj.createentity(game, 296, 64, 10, 1, 49540);  // (savepoint)
-		obj.createentity(game, 152-4-15+8, 32, 1, 0, 6, 128, 32, 288, 200);  // Enemy, bounded
-		obj.createentity(game, 240-4-15+8, 186, 1, 1, 6, 128, 32, 288, 200);  // Enemy, bounded
-		obj.createentity(game, 296, 152, 10, 0, 49541);  // (savepoint)
+		obj.createentity(296, 64, 10, 1, 49540);  // (savepoint)
+		obj.createentity(152-4-15+8, 32, 1, 0, 6, 128, 32, 288, 200);  // Enemy, bounded
+		obj.createentity(240-4-15+8, 186, 1, 1, 6, 128, 32, 288, 200);  // Enemy, bounded
+		obj.createentity(296, 152, 10, 0, 49541);  // (savepoint)
 		rcol = 0;
 		warpx = true;
 		roomname = "Time to get serious";
@@ -376,7 +376,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("86,86,208,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,206,86,86");
 		if(!game.intimetrial)
 		{
-			obj.createentity(game, (7 * 8) + 4, (6 * 8), 14); //Teleporter!
+			obj.createentity((7 * 8) + 4, (6 * 8), 14); //Teleporter!
 		}
 		rcol = 2;
 		warpy = true;
@@ -415,10 +415,10 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("212,92,92,214,212,92,92,214,172,173,173,174,0,0,0,0,0,0,0,0,212,92,92,214,212,92,92,214,212,92,92,214,212,92,92,214,212,92,92,214");
 		tmap.push_back("212,92,92,214,212,92,92,214,212,92,92,214,172,173,173,174,0,0,0,0,212,92,92,214,212,92,92,214,212,92,92,214,212,92,92,214,212,92,92,214");
 
-		obj.createentity(game, 96, 72, 1, 3, 8, 64, 56, 256, 152);  // Enemy, bounded
-		obj.createentity(game, 240, 120, 1, 2, 8, 64, 56, 256, 152);  // Enemy, bounded
-		obj.createentity(game, 72, 16, 10, 0, 50550);  // (savepoint)
-		obj.createentity(game, 264, 176, 10, 1, 50551);  // (savepoint)
+		obj.createentity(96, 72, 1, 3, 8, 64, 56, 256, 152);  // Enemy, bounded
+		obj.createentity(240, 120, 1, 2, 8, 64, 56, 256, 152);  // Enemy, bounded
+		obj.createentity(72, 16, 10, 0, 50550);  // (savepoint)
+		obj.createentity(264, 176, 10, 1, 50551);  // (savepoint)
 		rcol = 4;
 		warpx = true;
 		roomname = "Ascending and Descending";
@@ -456,12 +456,12 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("83,83,83,205,0,0,0,0,203,205,0,0,0,0,203,205,0,0,0,0,163,165,0,0,0,0,163,165,0,0,0,0,203,205,0,0,0,0,203,83");
 		tmap.push_back("83,83,83,205,0,0,0,0,203,205,0,0,0,0,203,205,0,0,0,0,203,205,0,0,0,0,203,205,0,0,0,0,203,205,0,0,0,0,203,83");
 
-		obj.createentity(game, 280, 24, 1, 2, 3, 128, 16, 304, 216);  // Enemy, bounded
-		obj.createentity(game, 136, 192, 1, 3, 3, 128, 16, 304, 216);  // Enemy, bounded
-		obj.createentity(game, 40, 8, 1, 0, 10, 24, -56, 120, 280);  // Enemy, bounded
-		obj.createentity(game, 88, 8, 1, 0, 10, 24, -40, 120, 272);  // Enemy, bounded
-		obj.createentity(game, 256, 128, 10, 1, 51550);  // (savepoint)
-		obj.createentity(game, 136, 32, 10, 1, 51551);  // (savepoint)
+		obj.createentity(280, 24, 1, 2, 3, 128, 16, 304, 216);  // Enemy, bounded
+		obj.createentity(136, 192, 1, 3, 3, 128, 16, 304, 216);  // Enemy, bounded
+		obj.createentity(40, 8, 1, 0, 10, 24, -56, 120, 280);  // Enemy, bounded
+		obj.createentity(88, 8, 1, 0, 10, 24, -40, 120, 272);  // Enemy, bounded
+		obj.createentity(256, 128, 10, 1, 51550);  // (savepoint)
+		obj.createentity(136, 32, 10, 1, 51551);  // (savepoint)
 		rcol = 1;
 		warpy = true;
 		roomname = "Shockwave Rider";
@@ -499,13 +499,13 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,171,169,170,170,171,169,170,170,170,170,170,170,170,170,171,0,0,0,0,169,170,170,170");
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,211,209,89,89,211,209,89,89,89,89,89,89,89,89,211,0,0,0,0,209,89,89,89");
 
-		obj.createentity(game, 296, 32, 10, 1, 51540);  // (savepoint)
-		obj.createentity(game, 184, 192, 1, 18, 48, -800, -24, 4000, 264);  // Enemy, bounded
-		obj.createentity(game, 88, 136, 1, 17, 48, -800, -32, 4000, 272);  // Enemy, bounded
-		obj.createentity(game, 184, 80, 1, 18, 48, -800, -32, 4000, 272);  // Enemy, bounded
+		obj.createentity(296, 32, 10, 1, 51540);  // (savepoint)
+		obj.createentity(184, 192, 1, 18, 48, -800, -24, 4000, 264);  // Enemy, bounded
+		obj.createentity(88, 136, 1, 17, 48, -800, -32, 4000, 272);  // Enemy, bounded
+		obj.createentity(184, 80, 1, 18, 48, -800, -32, 4000, 272);  // Enemy, bounded
 
 
-		obj.createentity(game, 8, 32, 20, 1);  // (terminal)
+		obj.createentity(8, 32, 20, 1);  // (terminal)
 		obj.createblock(5, 8-8, 32, 20, 16, 17);
 
 		rcol = 3;
@@ -545,18 +545,18 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("176,176,176,177,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,175,177,0,0,0,0,175,176,176,176");
 		tmap.push_back("95,95,95,217,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,255,257,0,0,0,0,215,95,95,95");
 
-		obj.createentity(game, 288, 200, 10, 1, 52540);  // (savepoint)
-		obj.createentity(game, 48, 16, 1, 1, 10, 0, -40, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 64, 16+8+4+2, 1, 1, 10, 0, -48, 320, 280);  // Enemy, bounded
-		obj.createentity(game, 80, 16+16+8+4, 1, 1, 10, 0, -40, 320, 280);  // Enemy, bounded
-		obj.createentity(game, 96, 16+24+12+6, 1, 1, 10, 0, -40, 320, 304);  // Enemy, bounded
-		obj.createentity(game, 112, 16+32+16+8, 1, 1, 10, 0, -48, 320, 288);  // Enemy, bounded
-		obj.createentity(game, 128, 16+40+20+10, 1, 1, 10, 0, -40, 320, 280);  // Enemy, bounded
-		obj.createentity(game, 144, 16+48+24+12, 1, 1, 10, 0, -56, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 160, 16+56+28+14, 1, 1, 10, 0, -48, 320, 288);  // Enemy, bounded
-		obj.createentity(game, 176, 16+64+32+16, 1, 1, 10, 0, -48, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 192, 16+72+36+18, 1, 1, 10, 0, -40, 320, 280);  // Enemy, bounded
-		obj.createentity(game, 208, 16+80+40+20, 1, 1, 10, 0, -48, 320, 280);  // Enemy, bounded
+		obj.createentity(288, 200, 10, 1, 52540);  // (savepoint)
+		obj.createentity(48, 16, 1, 1, 10, 0, -40, 320, 296);  // Enemy, bounded
+		obj.createentity(64, 16+8+4+2, 1, 1, 10, 0, -48, 320, 280);  // Enemy, bounded
+		obj.createentity(80, 16+16+8+4, 1, 1, 10, 0, -40, 320, 280);  // Enemy, bounded
+		obj.createentity(96, 16+24+12+6, 1, 1, 10, 0, -40, 320, 304);  // Enemy, bounded
+		obj.createentity(112, 16+32+16+8, 1, 1, 10, 0, -48, 320, 288);  // Enemy, bounded
+		obj.createentity(128, 16+40+20+10, 1, 1, 10, 0, -40, 320, 280);  // Enemy, bounded
+		obj.createentity(144, 16+48+24+12, 1, 1, 10, 0, -56, 320, 296);  // Enemy, bounded
+		obj.createentity(160, 16+56+28+14, 1, 1, 10, 0, -48, 320, 288);  // Enemy, bounded
+		obj.createentity(176, 16+64+32+16, 1, 1, 10, 0, -48, 320, 296);  // Enemy, bounded
+		obj.createentity(192, 16+72+36+18, 1, 1, 10, 0, -40, 320, 280);  // Enemy, bounded
+		obj.createentity(208, 16+80+40+20, 1, 1, 10, 0, -48, 320, 280);  // Enemy, bounded
 		rcol = 5;
 		warpy = true;
 		roomname = "Mind The Gap";
@@ -594,17 +594,17 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167");
 		tmap.push_back("86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86");
 
-		obj.createentity(game, 152, 200, 10, 1, 52530);  // (savepoint)
-		obj.createentity(game, 248, 48, 1, 3, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 152, 48, 1, 3, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 152, 96, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 56, 96, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 104, 144, 1, 3, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 200, 144, 1, 3, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 280, 16, 9, 12); //Shiny Trinket
+		obj.createentity(152, 200, 10, 1, 52530);  // (savepoint)
+		obj.createentity(248, 48, 1, 3, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(152, 48, 1, 3, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(152, 96, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(56, 96, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(104, 144, 1, 3, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(200, 144, 1, 3, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(280, 16, 9, 12); //Shiny Trinket
 
 
-		obj.createentity(game, 24, 200, 20, 1);  // (terminal)
+		obj.createentity(24, 200, 20, 1);  // (terminal)
 		obj.createblock(5, 24-8, 200, 20, 16, 18);
 		rcol = 2;
 		warpx = true;
@@ -643,7 +643,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("83,83,205,0,0,0,0,203,205,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,203,205,0,0,0,0,203,205,0,0,0,0,203,83,83");
 		tmap.push_back("83,83,205,0,0,0,0,203,205,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,203,205,0,0,0,0,203,205,0,0,0,0,203,83,83");
 
-		obj.createentity(game, 152, 112, 13);
+		obj.createentity(152, 112, 13);
 		rcol = 1;
 		warpx = true;
 		warpy = true;
@@ -682,8 +682,8 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("0,0,212,92,214,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,212,92,214,0,0");
 		tmap.push_back("0,0,212,92,214,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,212,92,214,0,0");
 
-		obj.createentity(game, 152, 112, 13);
-		obj.createentity(game, 152, 152, 10, 0, 49550);  // (savepoint)
+		obj.createentity(152, 112, 13);
+		obj.createentity(152, 152, 10, 0, 49550);  // (savepoint)
 		rcol = 4;
 		warpx = true;
 		warpy = true;
@@ -722,8 +722,8 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 152, 112, 13);
-		obj.createentity(game, 136, 40, 10, 1, 52550);  // (savepoint)
+		obj.createentity(152, 112, 13);
+		obj.createentity(136, 40, 10, 1, 52550);  // (savepoint)
 		rcol = 3;
 		warpx = true;
 		warpy = true;
@@ -762,8 +762,8 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,215,95,217,216,216,216,216,215,95,217,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,215,95,217,216,216,216,216,215,95,217,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 152, 112, 13);
-		obj.createentity(game, 288, 120, 10, 1, 52520);  // (savepoint)
+		obj.createentity(152, 112, 13);
+		obj.createentity(288, 120, 10, 1, 52520);  // (savepoint)
 		rcol = 5;
 		warpx = true;
 		warpy = true;
@@ -802,12 +802,12 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("83,83,83,83,83,83,83,83,83,83,83,83,83,205,163,164,164,164,164,164,164,164,164,164,164,165,0,0,0,0,203,83,83,83,83,83,83,83,83,83");
 		tmap.push_back("83,83,83,83,83,83,83,83,83,83,83,83,83,205,203,83,83,83,83,83,83,83,83,83,83,205,0,0,0,0,203,83,83,83,83,83,83,83,83,83");
 
-		obj.createentity(game, 152, 112, 13);
-		obj.createentity(game, 24, 128, 10, 1, 52510);  // (savepoint)
-		obj.createentity(game, 56, 48, 1, 0, 10, -16, -16, 336, 256);  // Enemy, bounded
-		obj.createentity(game, 264, 48, 1, 0, 10, -16, -16, 336, 256);  // Enemy, bounded
-		obj.createentity(game, 152, 48, 1, 2, 8, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 152, 176, 1, 2, 8, -24, -16, 344, 256);  // Enemy, bounded
+		obj.createentity(152, 112, 13);
+		obj.createentity(24, 128, 10, 1, 52510);  // (savepoint)
+		obj.createentity(56, 48, 1, 0, 10, -16, -16, 336, 256);  // Enemy, bounded
+		obj.createentity(264, 48, 1, 0, 10, -16, -16, 336, 256);  // Enemy, bounded
+		obj.createentity(152, 48, 1, 2, 8, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(152, 176, 1, 2, 8, -24, -16, 344, 256);  // Enemy, bounded
 		rcol = 1;
 		warpx = true;
 		warpy = true;
@@ -846,13 +846,13 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("86,86,86,86,86,208,0,0,0,0,206,208,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,206,208,0,0,0,0,206,86,86,86,86,86");
 		tmap.push_back("86,86,86,86,86,208,0,0,0,0,206,208,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,206,208,0,0,0,0,206,86,86,86,86,86");
 
-		obj.createentity(game, 152, 112, 13);
-		obj.createentity(game, 248, 16, 1, 0, 10, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 64, 16, 1, 0, 10, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 200, 56, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 152, 56, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 104, 56, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 152, 152, 10, 0, 49520);  // (savepoint)
+		obj.createentity(152, 112, 13);
+		obj.createentity(248, 16, 1, 0, 10, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(64, 16, 1, 0, 10, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(200, 56, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(152, 56, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(104, 56, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(152, 152, 10, 0, 49520);  // (savepoint)
 		rcol = 2;
 		warpx = true;
 		warpy = true;
@@ -933,7 +933,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 
 		obj.entities[obj.nentity].active = true;
 		obj.nentity++;
-		obj.createentity(game, 14 * 8, (8 * 8) + 4, 14); //Teleporter!
+		obj.createentity(14 * 8, (8 * 8) + 4, 14); //Teleporter!
 		obj.entities[obj.nentity - 2].active = false;
 
 		if(game.intimetrial)
@@ -982,7 +982,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		{
 			if(game.companion==0 && obj.flags[11]==0 && !game.crewstats[4])   //also need to check if he's rescued in a previous game
 			{
-				obj.createentity(game, 255, 121, 15, 0);
+				obj.createentity(255, 121, 15, 0);
 				obj.createblock(1, 215, 0, 160, 240, 35);
 			}
 		}

--- a/desktop_version/src/WarpClass.h
+++ b/desktop_version/src/WarpClass.h
@@ -10,7 +10,7 @@
 class warpclass
 {
 public:
-	std::vector<std::string> loadlevel(int rx, int ry , Game& game, entityclass& obj);
+	std::vector<std::string> loadlevel(int rx, int ry);
 	std::string roomname;
 	int coin, rcol;
 	bool warpx, warpy;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -359,14 +359,6 @@ void editorclass::reset()
     returneditoralpha = 0;
 }
 
-void editorclass::weirdloadthing(std::string t)
-{
-    //Stupid pointless function because I hate C++ and everything to do with it
-    //It's even stupider now that I don't need to append .vvvvvv anymore! bah, whatever
-    //t=t+".vvvvvv";
-    load(t);
-}
-
 void editorclass::gethooks()
 {
     //Scan through the script and create a hooks list based on it
@@ -1577,7 +1569,7 @@ int editorclass::spikedir( int x, int y )
     return 8;
 }
 
-void editorclass::findstartpoint(Game& game)
+void editorclass::findstartpoint()
 {
     //Ok! Scan the room for the closest checkpoint
     int testeditor=-1;
@@ -1985,7 +1977,7 @@ void editorclass::save(std::string& _path)
     msg->LinkEndChild( meta );
 
     meta = new TiXmlElement( "Created" );
-    meta->LinkEndChild( new TiXmlText( UtilityClass::String(version).c_str() ));
+    meta->LinkEndChild( new TiXmlText( help.String(version).c_str() ));
     msg->LinkEndChild( meta );
 
     meta = new TiXmlElement( "Modified" );
@@ -1993,7 +1985,7 @@ void editorclass::save(std::string& _path)
     msg->LinkEndChild( meta );
 
     meta = new TiXmlElement( "Modifiers" );
-    meta->LinkEndChild( new TiXmlText( UtilityClass::String(version).c_str() ));
+    meta->LinkEndChild( new TiXmlText( help.String(version).c_str() ));
     msg->LinkEndChild( meta );
 
     meta = new TiXmlElement( "Desc1" );
@@ -2015,15 +2007,15 @@ void editorclass::save(std::string& _path)
     data->LinkEndChild( msg );
 
     msg = new TiXmlElement( "mapwidth" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(mapwidth).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(mapwidth).c_str() ));
     data->LinkEndChild( msg );
 
     msg = new TiXmlElement( "mapheight" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(mapheight).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(mapheight).c_str() ));
     data->LinkEndChild( msg );
 
     msg = new TiXmlElement( "levmusic" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(levmusic).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(levmusic).c_str() ));
     data->LinkEndChild( msg );
 
     //New save format
@@ -2032,25 +2024,13 @@ void editorclass::save(std::string& _path)
     {
         for(int x = 0; x < mapwidth*40; x++ )
         {
-            contentsString += UtilityClass::String(contents[x + (maxwidth*40*y)]) + ",";
+            contentsString += help.String(contents[x + (maxwidth*40*y)]) + ",";
         }
     }
     msg = new TiXmlElement( "contents" );
     msg->LinkEndChild( new TiXmlText( contentsString.c_str() ));
     data->LinkEndChild( msg );
 
-
-    //Old save format
-    /*
-    std::string contentsString;
-    for(int i = 0; i < contents.size(); i++ )
-    {
-    	contentsString += UtilityClass::String(contents[i]) + ",";
-    }
-    msg = new TiXmlElement( "contents" );
-    msg->LinkEndChild( new TiXmlText( contentsString.c_str() ));
-    data->LinkEndChild( msg );
-    */
 
     msg = new TiXmlElement( "edEntities" );
     for(size_t i = 0; i < edentity.size(); i++)
@@ -2149,20 +2129,20 @@ bool edentclear( int xp, int yp )
     return true;
 }
 
-void fillbox( Graphics& dwgfx, int x, int y, int x2, int y2, int c )
+void fillbox(int x, int y, int x2, int y2, int c)
 {
-    FillRect(dwgfx.backBuffer, x, y, x2-x, 1, c);
-    FillRect(dwgfx.backBuffer, x, y2-1, x2-x, 1, c);
-    FillRect(dwgfx.backBuffer, x, y, 1, y2-y, c);
-    FillRect(dwgfx.backBuffer, x2-1, y, 1, y2-y, c);
+    FillRect(graphics.backBuffer, x, y, x2-x, 1, c);
+    FillRect(graphics.backBuffer, x, y2-1, x2-x, 1, c);
+    FillRect(graphics.backBuffer, x, y, 1, y2-y, c);
+    FillRect(graphics.backBuffer, x2-1, y, 1, y2-y, c);
 }
 
-void fillboxabs( Graphics& dwgfx, int x, int y, int x2, int y2, int c )
+void fillboxabs(int x, int y, int x2, int y2, int c)
 {
-    FillRect(dwgfx.backBuffer, x, y, x2, 1, c);
-    FillRect(dwgfx.backBuffer, x, y+y2-1, x2, 1, c);
-    FillRect(dwgfx.backBuffer, x, y, 1, y2, c);
-    FillRect(dwgfx.backBuffer, x+x2-1, y, 1, y2, c);
+    FillRect(graphics.backBuffer, x, y, x2, 1, c);
+    FillRect(graphics.backBuffer, x, y+y2-1, x2, 1, c);
+    FillRect(graphics.backBuffer, x, y, 1, y2, c);
+    FillRect(graphics.backBuffer, x+x2-1, y, 1, y2, c);
 }
 
 
@@ -2172,7 +2152,7 @@ extern int temp;
 
 extern scriptclass script;
 
-void editorclass::generatecustomminimap(Graphics& dwgfx, mapclass& map)
+void editorclass::generatecustomminimap()
 {
     map.customwidth=mapwidth;
     map.customheight=mapheight;
@@ -2207,7 +2187,7 @@ void editorclass::generatecustomminimap(Graphics& dwgfx, mapclass& map)
         map.custommmysize=180-(map.custommmyoff*2);
     }
 
-    FillRect(dwgfx.images[12], dwgfx.getRGB(0,0,0));
+    FillRect(graphics.images[12], graphics.getRGB(0,0,0));
 
     int tm=0;
     int temp=0;
@@ -2231,7 +2211,7 @@ void editorclass::generatecustomminimap(Graphics& dwgfx, mapclass& map)
                         if(temp>=1)
                         {
                             //Fill in this pixel
-                            FillRect(dwgfx.images[12], (i2*48)+i, (j2*36)+j, 1, 1, dwgfx.getRGB(tm, tm, tm));
+                            FillRect(graphics.images[12], (i2*48)+i, (j2*36)+j, 1, 1, graphics.getRGB(tm, tm, tm));
                         }
                     }
                 }
@@ -2257,7 +2237,7 @@ void editorclass::generatecustomminimap(Graphics& dwgfx, mapclass& map)
                         if(temp>=1)
                         {
                             //Fill in this pixel
-                            FillRect(dwgfx.images[12], (i2*24)+i, (j2*18)+j, 1, 1, dwgfx.getRGB(tm, tm, tm));
+                            FillRect(graphics.images[12], (i2*24)+i, (j2*18)+j, 1, 1, graphics.getRGB(tm, tm, tm));
                         }
                     }
                 }
@@ -2282,7 +2262,7 @@ void editorclass::generatecustomminimap(Graphics& dwgfx, mapclass& map)
                         if(temp>=1)
                         {
                             //Fill in this pixel
-                            FillRect(dwgfx.images[12], (i2*12)+i, (j2*9)+j, 1, 1, dwgfx.getRGB(tm, tm, tm));
+                            FillRect(graphics.images[12], (i2*12)+i, (j2*9)+j, 1, 1, graphics.getRGB(tm, tm, tm));
                         }
                     }
                 }
@@ -2291,51 +2271,47 @@ void editorclass::generatecustomminimap(Graphics& dwgfx, mapclass& map)
     }
 }
 
-void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help )
+void editorrender()
 {
-    //TODO
-    //dwgfx.backbuffer.lock();
-
     //Draw grid
 
-    FillRect(dwgfx.backBuffer, 0, 0, 320,240, dwgfx.getRGB(0,0,0));
+    FillRect(graphics.backBuffer, 0, 0, 320,240, graphics.getRGB(0,0,0));
     for(int j=0; j<30; j++)
     {
         for(int i=0; i<40; i++)
         {
-            fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(8,8,8)); //a simple grid
-            if(i%4==0) fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(16,16,16));
-            if(j%4==0) fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(16,16,16));
+            fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(8,8,8)); //a simple grid
+            if(i%4==0) fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(16,16,16));
+            if(j%4==0) fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(16,16,16));
 
             //Minor guides
-            if(i==9) fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(24,24,24));
-            if(i==30) fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(24,24,24));
-            if(j==6 || j==7) fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(24,24,24));
-            if(j==21 || j==22) fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(24,24,24));
+            if(i==9) fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(24,24,24));
+            if(i==30) fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(24,24,24));
+            if(j==6 || j==7) fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(24,24,24));
+            if(j==21 || j==22) fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(24,24,24));
 
             //Major guides
-            if(i==20 || i==19) fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(32,32,32));
-            if(j==14) fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(32,32,32));
+            if(i==20 || i==19) fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(32,32,32));
+            if(j==14) fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(32,32,32));
         }
     }
 
     //Or draw background
-    //dwgfx.drawbackground(1, map);
     if(!ed.settingsmod)
     {
         switch(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir)
         {
         case 1:
-            dwgfx.rcol=ed.getwarpbackground(ed.levx, ed.levy);
-            dwgfx.drawbackground(3, map);
+            graphics.rcol=ed.getwarpbackground(ed.levx, ed.levy);
+            graphics.drawbackground(3);
             break;
         case 2:
-            dwgfx.rcol=ed.getwarpbackground(ed.levx, ed.levy);
-            dwgfx.drawbackground(4, map);
+            graphics.rcol=ed.getwarpbackground(ed.levx, ed.levy);
+            graphics.drawbackground(4);
             break;
         case 3:
-            dwgfx.rcol=ed.getwarpbackground(ed.levx, ed.levy);
-            dwgfx.drawbackground(5, map);
+            graphics.rcol=ed.getwarpbackground(ed.levx, ed.levy);
+            graphics.drawbackground(5);
             break;
         default:
             break;
@@ -2351,7 +2327,7 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             for (int i = 0; i < 40; i++)
             {
                 temp=ed.contents[i + (ed.levx*40) + ed.vmult[j+(ed.levy*30)]];
-                if(temp>0) dwgfx.drawtile(i*8,j*8,temp,0,0,0);
+                if(temp>0) graphics.drawtile(i*8,j*8,temp);
             }
         }
     }
@@ -2362,7 +2338,7 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             for (int i = 0; i < 40; i++)
             {
                 temp=ed.contents[i + (ed.levx*40) + ed.vmult[j+(ed.levy*30)]];
-                if(temp>0) dwgfx.drawtile2(i*8,j*8,temp,0,0,0);
+                if(temp>0) graphics.drawtile2(i*8,j*8,temp);
             }
         }
     }
@@ -2375,12 +2351,12 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
         //left edge
         if(ed.freewrap((ed.levx*40)-1,j+(ed.levy*30))==1)
         {
-            FillRect(dwgfx.backBuffer, 0,j*8, 2,8, dwgfx.getRGB(255,255,255-help.glow));
+            FillRect(graphics.backBuffer, 0,j*8, 2,8, graphics.getRGB(255,255,255-help.glow));
         }
         //right edge
         if(ed.freewrap((ed.levx*40)+40,j+(ed.levy*30))==1)
         {
-            FillRect(dwgfx.backBuffer, 318,j*8, 2,8, dwgfx.getRGB(255,255,255-help.glow));
+            FillRect(graphics.backBuffer, 318,j*8, 2,8, graphics.getRGB(255,255,255-help.glow));
         }
     }
 
@@ -2388,12 +2364,12 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
     {
         if(ed.freewrap((ed.levx*40)+i,(ed.levy*30)-1)==1)
         {
-            FillRect(dwgfx.backBuffer, i*8,0, 8,2, dwgfx.getRGB(255,255,255-help.glow));
+            FillRect(graphics.backBuffer, i*8,0, 8,2, graphics.getRGB(255,255,255-help.glow));
         }
 
         if(ed.freewrap((ed.levx*40)+i,30+(ed.levy*30))==1)
         {
-            FillRect(dwgfx.backBuffer, i*8,238, 8,2, dwgfx.getRGB(255,255,255-help.glow));
+            FillRect(graphics.backBuffer, i*8,238, 8,2, graphics.getRGB(255,255,255-help.glow));
         }
     }
 
@@ -2419,111 +2395,106 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             switch(edentity[i].t)
             {
             case 1: //Entities
-                //FillRect(dwgfx.backBuffer, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), 16,16, dwgfx.getRGB(64,32,64));
-                //dwgfx.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),ed.getenemyframe(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype),164,48,48);
-                dwgfx.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),ed.getenemyframe(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype),ed.entcol,help);
-                if(edentity[i].p1==0) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "V", 255, 255, 255 - help.glow, false);
-                if(edentity[i].p1==1) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "^", 255, 255, 255 - help.glow, false);
-                if(edentity[i].p1==2) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "<", 255, 255, 255 - help.glow, false);
-                if(edentity[i].p1==3) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, ">", 255, 255, 255 - help.glow, false);
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,dwgfx.getBGR(255,164,255));
+                graphics.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),ed.getenemyframe(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype),ed.entcol);
+                if(edentity[i].p1==0) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "V", 255, 255, 255 - help.glow, false);
+                if(edentity[i].p1==1) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "^", 255, 255, 255 - help.glow, false);
+                if(edentity[i].p1==2) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "<", 255, 255, 255 - help.glow, false);
+                if(edentity[i].p1==3) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, ">", 255, 255, 255 - help.glow, false);
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,graphics.getBGR(255,164,255));
                 break;
             case 2: //Threadmills & platforms
                 tpoint.x = (edentity[i].x*8)- (ed.levx*40*8);
                 tpoint.y = (edentity[i].y*8)- (ed.levy*30*8);
-                drawRect = dwgfx.tiles_rect;
+                drawRect = graphics.tiles_rect;
                 drawRect.x += tpoint.x;
                 drawRect.y += tpoint.y;
-                BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                 drawRect.x += 8;
-                BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                 drawRect.x += 8;
-                BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                 drawRect.x += 8;
-                BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL,dwgfx.backBuffer, &drawRect);
+                BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL,graphics.backBuffer, &drawRect);
 
                 if(edentity[i].p1<=4)
                 {
-                    if(edentity[i].p1==0) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+12,(edentity[i].y*8)- (ed.levy*30*8), "V", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                    if(edentity[i].p1==1) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+12,(edentity[i].y*8)- (ed.levy*30*8), "^", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                    if(edentity[i].p1==2) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+12,(edentity[i].y*8)- (ed.levy*30*8), "<", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                    if(edentity[i].p1==3) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+12,(edentity[i].y*8)- (ed.levy*30*8), ">", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),32,8,dwgfx.getBGR(255,255,255));
+                    if(edentity[i].p1==0) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+12,(edentity[i].y*8)- (ed.levy*30*8), "V", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                    if(edentity[i].p1==1) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+12,(edentity[i].y*8)- (ed.levy*30*8), "^", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                    if(edentity[i].p1==2) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+12,(edentity[i].y*8)- (ed.levy*30*8), "<", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                    if(edentity[i].p1==3) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+12,(edentity[i].y*8)- (ed.levy*30*8), ">", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),32,8,graphics.getBGR(255,255,255));
                 }
 
                 if(edentity[i].p1==5)
                 {
-                    dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), ">>>>", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),32,8,dwgfx.getBGR(255,255,255));
+                    graphics.Print((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), ">>>>", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),32,8,graphics.getBGR(255,255,255));
                 }
                 else if(edentity[i].p1==6)
                 {
-                    dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), "<<<<", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),32,8,dwgfx.getBGR(255,255,255));
+                    graphics.Print((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), "<<<<", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),32,8,graphics.getBGR(255,255,255));
                 }
 
                 if(edentity[i].p1>=7)
                 {
-                    //FillRect(dwgfx.backBuffer, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), 32,8, dwgfx.getBGR(64,128,64));
                     tpoint.x = (edentity[i].x*8)- (ed.levx*40*8)+32;
                     tpoint.y = (edentity[i].y*8)- (ed.levy*30*8);
-                    drawRect = dwgfx.tiles_rect;
+                    drawRect = graphics.tiles_rect;
                     drawRect.x += tpoint.x;
                     drawRect.y += tpoint.y;
-                    BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                    BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                     drawRect.x += 8;
-                    BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                    BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                     drawRect.x += 8;
-                    BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                    BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                     drawRect.x += 8;
-                    BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL,dwgfx.backBuffer, &drawRect);
+                    BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL,graphics.backBuffer, &drawRect);
 
                 }
 
                 if(edentity[i].p1==7)
                 {
-                    dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8), "> > > > ", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),64,8,dwgfx.getBGR(255,255,255));
+                    graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8), "> > > > ", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),64,8,graphics.getBGR(255,255,255));
                 }
                 else if(edentity[i].p1==8)
                 {
-                    dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8), "< < < < ", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),64,8,dwgfx.getBGR(255,255,255));
+                    graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8), "< < < < ", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),64,8,graphics.getBGR(255,255,255));
                 }
                 break;
             case 3: //Disappearing Platform
-                //FillRect(dwgfx.backBuffer, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), 32,8, dwgfx.getBGR(64,64,128));
-
                 tpoint.x = (edentity[i].x*8)- (ed.levx*40*8);
                 tpoint.y = (edentity[i].y*8)- (ed.levy*30*8);
-                drawRect = dwgfx.tiles_rect;
+                drawRect = graphics.tiles_rect;
                 drawRect.x += tpoint.x;
                 drawRect.y += tpoint.y;
-                BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                 drawRect.x += 8;
-                BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                 drawRect.x += 8;
-                BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                 drawRect.x += 8;
-                BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL,dwgfx.backBuffer, &drawRect);
+                BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL,graphics.backBuffer, &drawRect);
 
-                dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), "////", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),32,8,dwgfx.getBGR(255,255,255));
+                graphics.Print((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), "////", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),32,8,graphics.getBGR(255,255,255));
                 break;
             case 9: //Shiny Trinket
-                dwgfx.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),22,196,196,196);
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,dwgfx.getRGB(164,164,255));
+                graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),22,196,196,196);
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,graphics.getRGB(164,164,255));
                 break;
             case 10: //Checkpoints
                 if(edentity[i].p1==0)  //From roof
                 {
-                    dwgfx.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),20,196,196,196);
+                    graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),20,196,196,196);
                 }
                 else if(edentity[i].p1==1)   //From floor
                 {
-                    dwgfx.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),21,196,196,196);
+                    graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),21,196,196,196);
                 }
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,dwgfx.getRGB(164,164,255));
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,graphics.getRGB(164,164,255));
                 break;
             case 11: //Gravity lines
                 if(edentity[i].p1==0)  //Horizontal
@@ -2534,8 +2505,8 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                     while(ed.spikefree(tx,ty)==0) tx--;
                     while(ed.spikefree(tx2,ty)==0) tx2++;
                     tx++;
-                    FillRect(dwgfx.backBuffer, (tx*8),(ty*8)+4, (tx2-tx)*8,1, dwgfx.getRGB(194,194,194));
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,dwgfx.getRGB(164,255,164));
+                    FillRect(graphics.backBuffer, (tx*8),(ty*8)+4, (tx2-tx)*8,1, graphics.getRGB(194,194,194));
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(164,255,164));
                     edentity[i].p2=tx;
                     edentity[i].p3=(tx2-tx)*8;
                 }
@@ -2547,74 +2518,74 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                     while(ed.spikefree(tx,ty)==0) ty--;
                     while(ed.spikefree(tx,ty2)==0) ty2++;
                     ty++;
-                    FillRect(dwgfx.backBuffer, (tx*8)+3,(ty*8), 1,(ty2-ty)*8, dwgfx.getRGB(194,194,194));
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,dwgfx.getRGB(164,255,164));
+                    FillRect(graphics.backBuffer, (tx*8)+3,(ty*8), 1,(ty2-ty)*8, graphics.getRGB(194,194,194));
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(164,255,164));
                     edentity[i].p2=ty;
                     edentity[i].p3=(ty2-ty)*8;
                 }
                 break;
             case 13://Warp tokens
-                dwgfx.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),18+(ed.entframe%2),196,196,196);
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,dwgfx.getRGB(164,164,255));
+                graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),18+(ed.entframe%2),196,196,196);
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,graphics.getRGB(164,164,255));
                 if(ed.temp==i)
                 {
-                    dwgfx.bprint((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)-8,
+                    graphics.bprint((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)-8,
                                 "("+help.String(((edentity[i].p1-int(edentity[i].p1%40))/40)+1)+","+help.String(((edentity[i].p2-int(edentity[i].p2%30))/30)+1)+")",210,210,255);
                 }
                 else
                 {
-                    dwgfx.bprint((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)-8,help.String(ed.findwarptoken(i)),210,210,255);
+                    graphics.bprint((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)-8,help.String(ed.findwarptoken(i)),210,210,255);
                 }
                 break;
             case 15: //Crewmates
-                dwgfx.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),144,obj.crewcolour(edentity[i].p1), help);
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,24,dwgfx.getRGB(164,164,164));
+                graphics.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),144,obj.crewcolour(edentity[i].p1));
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,24,graphics.getRGB(164,164,164));
                 break;
             case 16: //Start
                 if(edentity[i].p1==0)  //Left
                 {
-                    dwgfx.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),0,obj.crewcolour(0), help);
+                    graphics.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),0,obj.crewcolour(0));
                 }
                 else if(edentity[i].p1==1)
                 {
-                    dwgfx.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),3,obj.crewcolour(0), help);
+                    graphics.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),3,obj.crewcolour(0));
                 }
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,24,dwgfx.getRGB(164,255,255));
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,24,graphics.getRGB(164,255,255));
                 if(ed.entframe<2)
                 {
-                    dwgfx.bprint((edentity[i].x*8)- (ed.levx*40*8)-12,(edentity[i].y*8)- (ed.levy*30*8)-8,"START",255,255,255);
+                    graphics.bprint((edentity[i].x*8)- (ed.levx*40*8)-12,(edentity[i].y*8)- (ed.levy*30*8)-8,"START",255,255,255);
                 }
                 else
                 {
-                    dwgfx.bprint((edentity[i].x*8)- (ed.levx*40*8)-12,(edentity[i].y*8)- (ed.levy*30*8)-8,"START",196,196,196);
+                    graphics.bprint((edentity[i].x*8)- (ed.levx*40*8)-12,(edentity[i].y*8)- (ed.levy*30*8)-8,"START",196,196,196);
                 }
                 break;
             case 17: //Roomtext
                 if(edentity[i].scriptname.length()<1)
                 {
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,dwgfx.getRGB(96,96,96));
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(96,96,96));
                 }
                 else
                 {
                     int length = utf8::unchecked::distance(edentity[i].scriptname.begin(), edentity[i].scriptname.end());
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),length*8,8,dwgfx.getRGB(96,96,96));
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),length*8,8,graphics.getRGB(96,96,96));
                 }
-                dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), edentity[i].scriptname, 196, 196, 255 - help.glow);
+                graphics.Print((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), edentity[i].scriptname, 196, 196, 255 - help.glow);
                 break;
             case 18: //Terminals
-                dwgfx.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)+8,17,96,96,96);
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,24,dwgfx.getRGB(164,164,164));
+                graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)+8,17,96,96,96);
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,24,graphics.getRGB(164,164,164));
                 if(ed.temp==i)
                 {
-                    dwgfx.bprint((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)-8,edentity[i].scriptname,210,210,255);
+                    graphics.bprint((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)-8,edentity[i].scriptname,210,210,255);
                 }
                 break;
             case 19: //Script Triggers
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),edentity[i].p1*8,edentity[i].p2*8,dwgfx.getRGB(255,164,255));
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,dwgfx.getRGB(255,255,255));
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),edentity[i].p1*8,edentity[i].p2*8,graphics.getRGB(255,164,255));
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(255,255,255));
                 if(ed.temp==i)
                 {
-                    dwgfx.bprint((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)-8,edentity[i].scriptname,210,210,255);
+                    graphics.bprint((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)-8,edentity[i].scriptname,210,210,255);
                 }
                 break;
             case 50: //Warp lines
@@ -2626,8 +2597,8 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                     while(ed.free(tx,ty)==0) tx--;
                     while(ed.free(tx2,ty)==0) tx2++;
                     tx++;
-                    fillboxabs(dwgfx, (tx*8),(ty*8)+1, (tx2-tx)*8,6, dwgfx.getRGB(255,255,194));
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,dwgfx.getRGB(255,255,164));
+                    fillboxabs((tx*8),(ty*8)+1, (tx2-tx)*8,6, graphics.getRGB(255,255,194));
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(255,255,164));
                     edentity[i].p2=tx;
                     edentity[i].p3=(tx2-tx)*8;
                 }
@@ -2639,8 +2610,8 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                     while(ed.free(tx,ty)==0) ty--;
                     while(ed.free(tx,ty2)==0) ty2++;
                     ty++;
-                    fillboxabs(dwgfx, (tx*8)+1,(ty*8), 6,(ty2-ty)*8, dwgfx.getRGB(255,255,194));
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,dwgfx.getRGB(255,255,164));
+                    fillboxabs((tx*8)+1,(ty*8), 6,(ty2-ty)*8, graphics.getRGB(255,255,194));
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(255,255,164));
                     edentity[i].p2=ty;
                     edentity[i].p3=(ty2-ty)*8;
                 }
@@ -2655,16 +2626,16 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             ty=(edentity[i].p2-(edentity[i].p2%30))/30;
             if(tx==ed.levx && ty==ed.levy)
             {
-                dwgfx.drawsprite((edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8),18+(ed.entframe%2),64,64,64);
-                fillboxabs(dwgfx, (edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8),16,16,dwgfx.getRGB(64,64,96));
+                graphics.drawsprite((edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8),18+(ed.entframe%2),64,64,64);
+                fillboxabs((edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8),16,16,graphics.getRGB(64,64,96));
                 if(ed.tilex+(ed.levx*40)==edentity[i].p1 && ed.tiley+(ed.levy*30)==edentity[i].p2)
                 {
-                    dwgfx.bprint((edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8)-8,
+                    graphics.bprint((edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8)-8,
                                 "("+help.String(((edentity[i].x-int(edentity[i].x%40))/40)+1)+","+help.String(((edentity[i].y-int(edentity[i].y%30))/30)+1)+")",190,190,225);
                 }
                 else
                 {
-                    dwgfx.bprint((edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8)-8,help.String(ed.findwarptoken(i)),190,190,225);
+                    graphics.bprint((edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8)-8,help.String(ed.findwarptoken(i)),190,190,225);
                 }
             }
         }
@@ -2674,20 +2645,20 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
     {
         if(ed.boundarymod==1)
         {
-            fillboxabs(dwgfx, ed.tilex*8, ed.tiley*8, 8,8,dwgfx.getRGB(255-(help.glow/2),191+(help.glow),210+(help.glow/2)));
-            fillboxabs(dwgfx, (ed.tilex*8)+2, (ed.tiley*8)+2, 4,4,dwgfx.getRGB(128-(help.glow/4),100+(help.glow/2),105+(help.glow/4)));
+            fillboxabs(ed.tilex*8, ed.tiley*8, 8,8,graphics.getRGB(255-(help.glow/2),191+(help.glow),210+(help.glow/2)));
+            fillboxabs((ed.tilex*8)+2, (ed.tiley*8)+2, 4,4,graphics.getRGB(128-(help.glow/4),100+(help.glow/2),105+(help.glow/4)));
         }
         else if(ed.boundarymod==2)
         {
             if((ed.tilex*8)+8<=ed.boundx1 || (ed.tiley*8)+8<=ed.boundy1)
             {
-                fillboxabs(dwgfx, ed.boundx1, ed.boundy1, 8, 8,dwgfx.getRGB(255-(help.glow/2),191+(help.glow),210+(help.glow/2)));
-                fillboxabs(dwgfx, ed.boundx1+2, ed.boundy1+2, 4, 4,dwgfx.getRGB(128-(help.glow/4),100+(help.glow/2),105+(help.glow/4)));
+                fillboxabs(ed.boundx1, ed.boundy1, 8, 8,graphics.getRGB(255-(help.glow/2),191+(help.glow),210+(help.glow/2)));
+                fillboxabs(ed.boundx1+2, ed.boundy1+2, 4, 4,graphics.getRGB(128-(help.glow/4),100+(help.glow/2),105+(help.glow/4)));
             }
             else
             {
-                fillboxabs(dwgfx, ed.boundx1, ed.boundy1, (ed.tilex*8)+8-ed.boundx1,(ed.tiley*8)+8-ed.boundy1,dwgfx.getRGB(255-(help.glow/2),191+(help.glow),210+(help.glow/2)));
-                fillboxabs(dwgfx, ed.boundx1+2, ed.boundy1+2, (ed.tilex*8)+8-ed.boundx1-4,(ed.tiley*8)+8-ed.boundy1-4,dwgfx.getRGB(128-(help.glow/4),100+(help.glow/2),105+(help.glow/4)));
+                fillboxabs(ed.boundx1, ed.boundy1, (ed.tilex*8)+8-ed.boundx1,(ed.tiley*8)+8-ed.boundy1,graphics.getRGB(255-(help.glow/2),191+(help.glow),210+(help.glow/2)));
+                fillboxabs(ed.boundx1+2, ed.boundy1+2, (ed.tilex*8)+8-ed.boundx1-4,(ed.tiley*8)+8-ed.boundy1-4,graphics.getRGB(128-(help.glow/4),100+(help.glow/2),105+(help.glow/4)));
             }
         }
     }
@@ -2698,19 +2669,19 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
         if(ed.level[tmp].enemyx1!=0 && ed.level[tmp].enemyy1!=0
                 && ed.level[tmp].enemyx2!=320 && ed.level[tmp].enemyy2!=240)
         {
-            fillboxabs(dwgfx,  ed.level[tmp].enemyx1, ed.level[tmp].enemyy1,
+            fillboxabs(ed.level[tmp].enemyx1, ed.level[tmp].enemyy1,
                        ed.level[tmp].enemyx2-ed.level[tmp].enemyx1,
                        ed.level[tmp].enemyy2-ed.level[tmp].enemyy1,
-                       dwgfx.getBGR(255-(help.glow/2),64,64));
+                       graphics.getBGR(255-(help.glow/2),64,64));
         }
 
         if(ed.level[tmp].platx1!=0 && ed.level[tmp].platy1!=0
                 && ed.level[tmp].platx2!=320 && ed.level[tmp].platy2!=240)
         {
-            fillboxabs(dwgfx,  ed.level[tmp].platx1, ed.level[tmp].platy1,
+            fillboxabs(ed.level[tmp].platx1, ed.level[tmp].platy1,
                        ed.level[tmp].platx2-ed.level[tmp].platx1,
                        ed.level[tmp].platy2-ed.level[tmp].platy1,
-                       dwgfx.getBGR(64,64,255-(help.glow/2)));
+                       graphics.getBGR(64,64,255-(help.glow/2)));
         }
     }
 
@@ -2726,33 +2697,33 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
     case 9:
     case 10:
     case 12: //Single point
-        fillboxabs(dwgfx, (ed.tilex*8),(ed.tiley*8),8,8, dwgfx.getRGB(200,32,32));
+        fillboxabs((ed.tilex*8),(ed.tiley*8),8,8, graphics.getRGB(200,32,32));
         break;
     case 3:
     case 4:
     case 8:
     case 13://2x2
-        fillboxabs(dwgfx, (ed.tilex*8),(ed.tiley*8),16,16, dwgfx.getRGB(200,32,32));
+        fillboxabs((ed.tilex*8),(ed.tiley*8),16,16, graphics.getRGB(200,32,32));
         break;
     case 5:
     case 6:
     case 7://Platform
-        fillboxabs(dwgfx, (ed.tilex*8),(ed.tiley*8),32,8, dwgfx.getRGB(200,32,32));
+        fillboxabs((ed.tilex*8),(ed.tiley*8),32,8, graphics.getRGB(200,32,32));
         break;
     case 14: //X if not on edge
         if(ed.tilex==0 || ed.tilex==39 || ed.tiley==0 || ed.tiley==29)
         {
-            fillboxabs(dwgfx, (ed.tilex*8),(ed.tiley*8),8,8, dwgfx.getRGB(200,32,32));
+            fillboxabs((ed.tilex*8),(ed.tiley*8),8,8, graphics.getRGB(200,32,32));
         }
         else
         {
-            dwgfx.Print((ed.tilex*8),(ed.tiley*8),"X",255,0,0);
+            graphics.Print((ed.tilex*8),(ed.tiley*8),"X",255,0,0);
         }
         break;
     case 11:
     case 15:
     case 16: //2x3
-        fillboxabs(dwgfx, (ed.tilex*8),(ed.tiley*8),16,24, dwgfx.getRGB(200,32,32));
+        fillboxabs((ed.tilex*8),(ed.tiley*8),16,24, graphics.getRGB(200,32,32));
         break;
     }
 
@@ -2760,11 +2731,11 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
     {
         if(ed.zmod && ed.drawmode<2)
         {
-            fillboxabs(dwgfx, (ed.tilex*8)-8,(ed.tiley*8)-8,24,24, dwgfx.getRGB(200,32,32));
+            fillboxabs((ed.tilex*8)-8,(ed.tiley*8)-8,24,24, graphics.getRGB(200,32,32));
         }
         else if(ed.xmod && ed.drawmode<2)
         {
-            fillboxabs(dwgfx, (ed.tilex*8)-16,(ed.tiley*8)-16,24+16,24+16, dwgfx.getRGB(200,32,32));
+            fillboxabs((ed.tilex*8)-16,(ed.tiley*8)-16,24+16,24+16, graphics.getRGB(200,32,32));
         }
     }
 
@@ -2784,65 +2755,65 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             //Draw five lines of the editor
             temp=ed.dmtile-(ed.dmtile%40);
             temp-=80;
-            FillRect(dwgfx.backBuffer, 0,-t2,320,40, dwgfx.getRGB(0,0,0));
-            FillRect(dwgfx.backBuffer, 0,-t2+40,320,2, dwgfx.getRGB(255,255,255));
+            FillRect(graphics.backBuffer, 0,-t2,320,40, graphics.getRGB(0,0,0));
+            FillRect(graphics.backBuffer, 0,-t2+40,320,2, graphics.getRGB(255,255,255));
             if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
             {
                 for(int i=0; i<40; i++)
                 {
-                    dwgfx.drawtile(i*8,0-t2,(temp+1200+i)%1200,0,0,0);
-                    dwgfx.drawtile(i*8,8-t2,(temp+1200+40+i)%1200,0,0,0);
-                    dwgfx.drawtile(i*8,16-t2,(temp+1200+80+i)%1200,0,0,0);
-                    dwgfx.drawtile(i*8,24-t2,(temp+1200+120+i)%1200,0,0,0);
-                    dwgfx.drawtile(i*8,32-t2,(temp+1200+160+i)%1200,0,0,0);
+                    graphics.drawtile(i*8,0-t2,(temp+1200+i)%1200);
+                    graphics.drawtile(i*8,8-t2,(temp+1200+40+i)%1200);
+                    graphics.drawtile(i*8,16-t2,(temp+1200+80+i)%1200);
+                    graphics.drawtile(i*8,24-t2,(temp+1200+120+i)%1200);
+                    graphics.drawtile(i*8,32-t2,(temp+1200+160+i)%1200);
                 }
             }
             else
             {
                 for(int i=0; i<40; i++)
                 {
-                    dwgfx.drawtile2(i*8,0-t2,(temp+1200+i)%1200,0,0,0);
-                    dwgfx.drawtile2(i*8,8-t2,(temp+1200+40+i)%1200,0,0,0);
-                    dwgfx.drawtile2(i*8,16-t2,(temp+1200+80+i)%1200,0,0,0);
-                    dwgfx.drawtile2(i*8,24-t2,(temp+1200+120+i)%1200,0,0,0);
-                    dwgfx.drawtile2(i*8,32-t2,(temp+1200+160+i)%1200,0,0,0);
+                    graphics.drawtile2(i*8,0-t2,(temp+1200+i)%1200);
+                    graphics.drawtile2(i*8,8-t2,(temp+1200+40+i)%1200);
+                    graphics.drawtile2(i*8,16-t2,(temp+1200+80+i)%1200);
+                    graphics.drawtile2(i*8,24-t2,(temp+1200+120+i)%1200);
+                    graphics.drawtile2(i*8,32-t2,(temp+1200+160+i)%1200);
                 }
             }
             //Highlight our little block
-            fillboxabs(dwgfx,((ed.dmtile%40)*8)-2,16-2,12,12,dwgfx.getRGB(196, 196, 255 - help.glow));
-            fillboxabs(dwgfx,((ed.dmtile%40)*8)-1,16-1,10,10,dwgfx.getRGB(0,0,0));
+            fillboxabs(((ed.dmtile%40)*8)-2,16-2,12,12,graphics.getRGB(196, 196, 255 - help.glow));
+            fillboxabs(((ed.dmtile%40)*8)-1,16-1,10,10,graphics.getRGB(0,0,0));
         }
 
         if(ed.dmtileeditor>0 && t2<=30)
         {
-            dwgfx.bprint(2, 45-t2, "Tile:", 196, 196, 255 - help.glow, false);
-            dwgfx.bprint(58, 45-t2, help.String(ed.dmtile), 196, 196, 255 - help.glow, false);
-            FillRect(dwgfx.backBuffer, 44,44-t2,10,10, dwgfx.getRGB(196, 196, 255 - help.glow));
-            FillRect(dwgfx.backBuffer, 45,45-t2,8,8, dwgfx.getRGB(0,0,0));
+            graphics.bprint(2, 45-t2, "Tile:", 196, 196, 255 - help.glow, false);
+            graphics.bprint(58, 45-t2, help.String(ed.dmtile), 196, 196, 255 - help.glow, false);
+            FillRect(graphics.backBuffer, 44,44-t2,10,10, graphics.getRGB(196, 196, 255 - help.glow));
+            FillRect(graphics.backBuffer, 45,45-t2,8,8, graphics.getRGB(0,0,0));
 
             if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
             {
-                dwgfx.drawtile(45,45-t2,ed.dmtile,0,0,0);
+                graphics.drawtile(45,45-t2,ed.dmtile);
             }
             else
             {
-                dwgfx.drawtile2(45,45-t2,ed.dmtile,0,0,0);
+                graphics.drawtile2(45,45-t2,ed.dmtile);
             }
         }
         else
         {
-            dwgfx.bprint(2, 12, "Tile:", 196, 196, 255 - help.glow, false);
-            dwgfx.bprint(58, 12, help.String(ed.dmtile), 196, 196, 255 - help.glow, false);
-            FillRect(dwgfx.backBuffer, 44,11,10,10, dwgfx.getRGB(196, 196, 255 - help.glow));
-            FillRect(dwgfx.backBuffer, 45,12,8,8, dwgfx.getRGB(0,0,0));
+            graphics.bprint(2, 12, "Tile:", 196, 196, 255 - help.glow, false);
+            graphics.bprint(58, 12, help.String(ed.dmtile), 196, 196, 255 - help.glow, false);
+            FillRect(graphics.backBuffer, 44,11,10,10, graphics.getRGB(196, 196, 255 - help.glow));
+            FillRect(graphics.backBuffer, 45,12,8,8, graphics.getRGB(0,0,0));
 
             if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
             {
-                dwgfx.drawtile(45,12,ed.dmtile,0,0,0);
+                graphics.drawtile(45,12,ed.dmtile);
             }
             else
             {
-                dwgfx.drawtile2(45,12,ed.dmtile,0,0,0);
+                graphics.drawtile2(45,12,ed.dmtile);
             }
         }
     }
@@ -2855,47 +2826,47 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
     {
         if(ed.boundarymod==1)
         {
-            FillRect(dwgfx.backBuffer, 0,230,320,240, dwgfx.getRGB(32,32,32));
-            FillRect(dwgfx.backBuffer, 0,231,320,240, dwgfx.getRGB(0,0,0));
+            FillRect(graphics.backBuffer, 0,230,320,240, graphics.getRGB(32,32,32));
+            FillRect(graphics.backBuffer, 0,231,320,240, graphics.getRGB(0,0,0));
             switch(ed.boundarytype)
             {
             case 0:
-                dwgfx.Print(4, 232, "SCRIPT BOX: Click on top left", 255,255,255, false);
+                graphics.Print(4, 232, "SCRIPT BOX: Click on top left", 255,255,255, false);
                 break;
             case 1:
-                dwgfx.Print(4, 232, "ENEMY BOUNDS: Click on top left", 255,255,255, false);
+                graphics.Print(4, 232, "ENEMY BOUNDS: Click on top left", 255,255,255, false);
                 break;
             case 2:
-                dwgfx.Print(4, 232, "PLATFORM BOUNDS: Click on top left", 255,255,255, false);
+                graphics.Print(4, 232, "PLATFORM BOUNDS: Click on top left", 255,255,255, false);
                 break;
             case 3:
-                dwgfx.Print(4, 232, "COPY TILES: Click on top left", 255,255,255, false);
+                graphics.Print(4, 232, "COPY TILES: Click on top left", 255,255,255, false);
                 break;
             default:
-                dwgfx.Print(4, 232, "Click on top left", 255,255,255, false);
+                graphics.Print(4, 232, "Click on top left", 255,255,255, false);
                 break;
             }
         }
         else if(ed.boundarymod==2)
         {
-            FillRect(dwgfx.backBuffer, 0,230,320,240, dwgfx.getRGB(32,32,32));
-            FillRect(dwgfx.backBuffer, 0,231,320,240, dwgfx.getRGB(0,0,0));
+            FillRect(graphics.backBuffer, 0,230,320,240, graphics.getRGB(32,32,32));
+            FillRect(graphics.backBuffer, 0,231,320,240, graphics.getRGB(0,0,0));
             switch(ed.boundarytype)
             {
             case 0:
-                dwgfx.Print(4, 232, "SCRIPT BOX: Click on bottom right", 255,255,255, false);
+                graphics.Print(4, 232, "SCRIPT BOX: Click on bottom right", 255,255,255, false);
                 break;
             case 1:
-                dwgfx.Print(4, 232, "ENEMY BOUNDS: Click on bottom right", 255,255,255, false);
+                graphics.Print(4, 232, "ENEMY BOUNDS: Click on bottom right", 255,255,255, false);
                 break;
             case 2:
-                dwgfx.Print(4, 232, "PLATFORM BOUNDS: Click on bottom right", 255,255,255, false);
+                graphics.Print(4, 232, "PLATFORM BOUNDS: Click on bottom right", 255,255,255, false);
                 break;
             case 3:
-                dwgfx.Print(4, 232, "COPY TILES: Click on bottom right", 255,255,255, false);
+                graphics.Print(4, 232, "COPY TILES: Click on bottom right", 255,255,255, false);
                 break;
             default:
-                dwgfx.Print(4, 232, "Click on bottom right", 255,255,255, false);
+                graphics.Print(4, 232, "Click on bottom right", 255,255,255, false);
                 break;
             }
         }
@@ -2903,14 +2874,13 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
     else if(ed.scripteditmod)
     {
         //Elaborate C64 BASIC menu goes here!
-        FillRect(dwgfx.backBuffer, 0,0,320,240, dwgfx.getBGR(123, 111, 218));
-        FillRect(dwgfx.backBuffer, 14,16,292,208, dwgfx.getRGB(162,48,61));
+        FillRect(graphics.backBuffer, 0,0,320,240, graphics.getBGR(123, 111, 218));
+        FillRect(graphics.backBuffer, 14,16,292,208, graphics.getRGB(162,48,61));
         switch(ed.scripthelppage)
         {
         case 0:
-            dwgfx.Print(16,28,"**** VVVVVV SCRIPT EDITOR ****", 123, 111, 218, true);
-            dwgfx.Print(16,44,"PRESS ESC TO RETURN TO MENU", 123, 111, 218, true);
-            //dwgfx.Print(16,60,"READY.", 123, 111, 218, false);
+            graphics.Print(16,28,"**** VVVVVV SCRIPT EDITOR ****", 123, 111, 218, true);
+            graphics.Print(16,44,"PRESS ESC TO RETURN TO MENU", 123, 111, 218, true);
 
             if(ed.numhooks>0)
             {
@@ -2922,45 +2892,45 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                         {
                             std::string tstring="> " + ed.hooklist[(ed.numhooks-1)-(ed.hookmenupage+i)] + " <";
                             std::transform(tstring.begin(), tstring.end(),tstring.begin(), ::toupper);
-                            dwgfx.Print(16,68+(i*16),tstring,123, 111, 218, true);
+                            graphics.Print(16,68+(i*16),tstring,123, 111, 218, true);
                         }
                         else
                         {
-                            dwgfx.Print(16,68+(i*16),ed.hooklist[(ed.numhooks-1)-(ed.hookmenupage+i)],123, 111, 218, true);
+                            graphics.Print(16,68+(i*16),ed.hooklist[(ed.numhooks-1)-(ed.hookmenupage+i)],123, 111, 218, true);
                         }
                     }
                 }
             }
             else
             {
-                dwgfx.Print(16,110,"NO SCRIPT IDS FOUND", 123, 111, 218, true);
-                dwgfx.Print(16,130,"CREATE A SCRIPT WITH EITHER", 123, 111, 218, true);
-                dwgfx.Print(16,140,"THE TERMINAL OR SCRIPT BOX TOOLS", 123, 111, 218, true);
+                graphics.Print(16,110,"NO SCRIPT IDS FOUND", 123, 111, 218, true);
+                graphics.Print(16,130,"CREATE A SCRIPT WITH EITHER", 123, 111, 218, true);
+                graphics.Print(16,140,"THE TERMINAL OR SCRIPT BOX TOOLS", 123, 111, 218, true);
             }
             break;
         case 1:
             //Current scriptname
-            FillRect(dwgfx.backBuffer, 14,226,292,12, dwgfx.getRGB(162,48,61));
-            dwgfx.Print(16,228,"CURRENT SCRIPT: " + ed.sbscript, 123, 111, 218, true);
+            FillRect(graphics.backBuffer, 14,226,292,12, graphics.getRGB(162,48,61));
+            graphics.Print(16,228,"CURRENT SCRIPT: " + ed.sbscript, 123, 111, 218, true);
             //Draw text
             for(int i=0; i<25; i++)
             {
                 if(i+ed.pagey<500)
                 {
-                    dwgfx.Print(16,20+(i*8),ed.sb[i+ed.pagey], 123, 111, 218, false);
+                    graphics.Print(16,20+(i*8),ed.sb[i+ed.pagey], 123, 111, 218, false);
                 }
             }
             //Draw cursor
             if(ed.entframe<2)
             {
-                dwgfx.Print(16+(ed.sbx*8),20+(ed.sby*8),"_",123, 111, 218, false);
+                graphics.Print(16+(ed.sbx*8),20+(ed.sby*8),"_",123, 111, 218, false);
             }
             break;
         }
     }
     else if(ed.settingsmod)
     {
-        if(!game.colourblindmode) dwgfx.drawtowerbackgroundsolo(map);
+        if(!game.colourblindmode) graphics.drawtowerbackgroundsolo();
 
         int tr = map.r - (help.glow / 4) - int(fRandom() * 4);
         int tg = map.g - (help.glow / 4) - int(fRandom() * 4);
@@ -2973,7 +2943,7 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
         if(tb>255) tb=255;
         if (game.currentmenuname == "ed_settings")
         {
-            dwgfx.bigprint( -1, 75, "Map Settings", tr, tg, tb, true);
+            graphics.bigprint( -1, 75, "Map Settings", tr, tg, tb, true);
         }
         else if (game.currentmenuname=="ed_desc")
         {
@@ -2981,242 +2951,233 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             {
                 if(ed.entframe<2)
                 {
-                    dwgfx.bigprint( -1, 35, key.keybuffer+"_", tr, tg, tb, true);
+                    graphics.bigprint( -1, 35, key.keybuffer+"_", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.bigprint( -1, 35, key.keybuffer+" ", tr, tg, tb, true);
+                    graphics.bigprint( -1, 35, key.keybuffer+" ", tr, tg, tb, true);
                 }
             }
             else
             {
-                dwgfx.bigprint( -1, 35, EditorData::GetInstance().title, tr, tg, tb, true);
+                graphics.bigprint( -1, 35, EditorData::GetInstance().title, tr, tg, tb, true);
             }
             if(ed.creatormod)
             {
                 if(ed.entframe<2)
                 {
-                    dwgfx.Print( -1, 60, "by " + key.keybuffer+ "_", tr, tg, tb, true);
+                    graphics.Print( -1, 60, "by " + key.keybuffer+ "_", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 60, "by " + key.keybuffer+ " ", tr, tg, tb, true);
+                    graphics.Print( -1, 60, "by " + key.keybuffer+ " ", tr, tg, tb, true);
                 }
             }
             else
             {
-                dwgfx.Print( -1, 60, "by " + EditorData::GetInstance().creator, tr, tg, tb, true);
+                graphics.Print( -1, 60, "by " + EditorData::GetInstance().creator, tr, tg, tb, true);
             }
             if(ed.websitemod)
             {
                 if(ed.entframe<2)
                 {
-                    dwgfx.Print( -1, 70, key.keybuffer+"_", tr, tg, tb, true);
+                    graphics.Print( -1, 70, key.keybuffer+"_", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 70, key.keybuffer+" ", tr, tg, tb, true);
+                    graphics.Print( -1, 70, key.keybuffer+" ", tr, tg, tb, true);
                 }
             }
             else
             {
-                dwgfx.Print( -1, 70, ed.website, tr, tg, tb, true);
+                graphics.Print( -1, 70, ed.website, tr, tg, tb, true);
             }
             if(ed.desc1mod)
             {
                 if(ed.entframe<2)
                 {
-                    dwgfx.Print( -1, 90, key.keybuffer+"_", tr, tg, tb, true);
+                    graphics.Print( -1, 90, key.keybuffer+"_", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 90, key.keybuffer+" ", tr, tg, tb, true);
+                    graphics.Print( -1, 90, key.keybuffer+" ", tr, tg, tb, true);
                 }
             }
             else
             {
-                dwgfx.Print( -1, 90, ed.Desc1, tr, tg, tb, true);
+                graphics.Print( -1, 90, ed.Desc1, tr, tg, tb, true);
             }
             if(ed.desc2mod)
             {
                 if(ed.entframe<2)
                 {
-                    dwgfx.Print( -1, 100, key.keybuffer+"_", tr, tg, tb, true);
+                    graphics.Print( -1, 100, key.keybuffer+"_", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 100, key.keybuffer+" ", tr, tg, tb, true);
+                    graphics.Print( -1, 100, key.keybuffer+" ", tr, tg, tb, true);
                 }
             }
             else
             {
-                dwgfx.Print( -1, 100, ed.Desc2, tr, tg, tb, true);
+                graphics.Print( -1, 100, ed.Desc2, tr, tg, tb, true);
             }
             if(ed.desc3mod)
             {
                 if(ed.entframe<2)
                 {
-                    dwgfx.Print( -1, 110, key.keybuffer+"_", tr, tg, tb, true);
+                    graphics.Print( -1, 110, key.keybuffer+"_", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 110, key.keybuffer+" ", tr, tg, tb, true);
+                    graphics.Print( -1, 110, key.keybuffer+" ", tr, tg, tb, true);
                 }
             }
             else
             {
-                dwgfx.Print( -1, 110, ed.Desc3, tr, tg, tb, true);
+                graphics.Print( -1, 110, ed.Desc3, tr, tg, tb, true);
             }
         }
         else if (game.currentmenuname == "ed_music")
         {
-            dwgfx.bigprint( -1, 65, "Map Music", tr, tg, tb, true);
+            graphics.bigprint( -1, 65, "Map Music", tr, tg, tb, true);
 
-            dwgfx.Print( -1, 85, "Current map music:", tr, tg, tb, true);
+            graphics.Print( -1, 85, "Current map music:", tr, tg, tb, true);
             switch(ed.levmusic)
             {
             case 0:
-                dwgfx.Print( -1, 120, "No background music", tr, tg, tb, true);
+                graphics.Print( -1, 120, "No background music", tr, tg, tb, true);
                 break;
             case 1:
-                dwgfx.Print( -1, 120, "1: Pushing Onwards", tr, tg, tb, true);
+                graphics.Print( -1, 120, "1: Pushing Onwards", tr, tg, tb, true);
                 break;
             case 2:
-                dwgfx.Print( -1, 120, "2: Positive Force", tr, tg, tb, true);
+                graphics.Print( -1, 120, "2: Positive Force", tr, tg, tb, true);
                 break;
             case 3:
-                dwgfx.Print( -1, 120, "3: Potential for Anything", tr, tg, tb, true);
+                graphics.Print( -1, 120, "3: Potential for Anything", tr, tg, tb, true);
                 break;
             case 4:
-                dwgfx.Print( -1, 120, "4: Passion for Exploring", tr, tg, tb, true);
+                graphics.Print( -1, 120, "4: Passion for Exploring", tr, tg, tb, true);
                 break;
             case 6:
-                dwgfx.Print( -1, 120, "5: Presenting VVVVVV", tr, tg, tb, true);
+                graphics.Print( -1, 120, "5: Presenting VVVVVV", tr, tg, tb, true);
                 break;
             case 8:
-                dwgfx.Print( -1, 120, "6: Predestined Fate", tr, tg, tb, true);
+                graphics.Print( -1, 120, "6: Predestined Fate", tr, tg, tb, true);
                 break;
             case 10:
-                dwgfx.Print( -1, 120, "7: Popular Potpourri", tr, tg, tb, true);
+                graphics.Print( -1, 120, "7: Popular Potpourri", tr, tg, tb, true);
                 break;
             case 11:
-                dwgfx.Print( -1, 120, "8: Pipe Dream", tr, tg, tb, true);
+                graphics.Print( -1, 120, "8: Pipe Dream", tr, tg, tb, true);
                 break;
             case 12:
-                dwgfx.Print( -1, 120, "9: Pressure Cooker", tr, tg, tb, true);
+                graphics.Print( -1, 120, "9: Pressure Cooker", tr, tg, tb, true);
                 break;
             case 13:
-                dwgfx.Print( -1, 120, "10: Paced Energy", tr, tg, tb, true);
+                graphics.Print( -1, 120, "10: Paced Energy", tr, tg, tb, true);
                 break;
             case 14:
-                dwgfx.Print( -1, 120, "11: Piercing the Sky", tr, tg, tb, true);
+                graphics.Print( -1, 120, "11: Piercing the Sky", tr, tg, tb, true);
                 break;
             default:
-                dwgfx.Print( -1, 120, "?: something else", tr, tg, tb, true);
+                graphics.Print( -1, 120, "?: something else", tr, tg, tb, true);
                 break;
             }
         }
         else if (game.currentmenuname == "ed_quit")
         {
-            dwgfx.bigprint( -1, 90, "Save before", tr, tg, tb, true);
-            dwgfx.bigprint( -1, 110, "quitting?", tr, tg, tb, true);
+            graphics.bigprint( -1, 90, "Save before", tr, tg, tb, true);
+            graphics.bigprint( -1, 110, "quitting?", tr, tg, tb, true);
         }
 
-        dwgfx.drawmenu(game, tr, tg, tb, 15);
-
-        /*
-        dwgfx.Print(4, 224, "Enter name to save map as:", 255,255,255, false);
-        if(ed.entframe<2){
-          dwgfx.Print(4, 232, ed.filename+"_", 196, 196, 255 - help.glow, true);
-        }else{
-          dwgfx.Print(4, 232, ed.filename+" ", 196, 196, 255 - help.glow, true);
-        }
-        */
+        graphics.drawmenu(tr, tg, tb, 15);
     }
     else if(ed.scripttextmod)
     {
-        FillRect(dwgfx.backBuffer, 0,221,320,240, dwgfx.getRGB(32,32,32));
-        FillRect(dwgfx.backBuffer, 0,222,320,240, dwgfx.getRGB(0,0,0));
-        dwgfx.Print(4, 224, "Enter script id name:", 255,255,255, false);
+        FillRect(graphics.backBuffer, 0,221,320,240, graphics.getRGB(32,32,32));
+        FillRect(graphics.backBuffer, 0,222,320,240, graphics.getRGB(0,0,0));
+        graphics.Print(4, 224, "Enter script id name:", 255,255,255, false);
         if(ed.entframe<2)
         {
-            dwgfx.Print(4, 232, edentity[ed.textent].scriptname+"_", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, edentity[ed.textent].scriptname+"_", 196, 196, 255 - help.glow, true);
         }
         else
         {
-            dwgfx.Print(4, 232, edentity[ed.textent].scriptname+" ", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, edentity[ed.textent].scriptname+" ", 196, 196, 255 - help.glow, true);
         }
     }
     else if(ed.savemod)
     {
-        FillRect(dwgfx.backBuffer, 0,221,320,240, dwgfx.getRGB(32,32,32));
-        FillRect(dwgfx.backBuffer, 0,222,320,240, dwgfx.getRGB(0,0,0));
-        dwgfx.Print(4, 224, "Enter filename to save map as:", 255,255,255, false);
+        FillRect(graphics.backBuffer, 0,221,320,240, graphics.getRGB(32,32,32));
+        FillRect(graphics.backBuffer, 0,222,320,240, graphics.getRGB(0,0,0));
+        graphics.Print(4, 224, "Enter filename to save map as:", 255,255,255, false);
         if(ed.entframe<2)
         {
-            dwgfx.Print(4, 232, ed.filename+"_", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, ed.filename+"_", 196, 196, 255 - help.glow, true);
         }
         else
         {
-            dwgfx.Print(4, 232, ed.filename+" ", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, ed.filename+" ", 196, 196, 255 - help.glow, true);
         }
     }
     else if(ed.loadmod)
     {
-        FillRect(dwgfx.backBuffer, 0,221,320,240, dwgfx.getRGB(32,32,32));
-        FillRect(dwgfx.backBuffer, 0,222,320,240, dwgfx.getRGB(0,0,0));
-        dwgfx.Print(4, 224, "Enter map filename to load:", 255,255,255, false);
+        FillRect(graphics.backBuffer, 0,221,320,240, graphics.getRGB(32,32,32));
+        FillRect(graphics.backBuffer, 0,222,320,240, graphics.getRGB(0,0,0));
+        graphics.Print(4, 224, "Enter map filename to load:", 255,255,255, false);
         if(ed.entframe<2)
         {
-            dwgfx.Print(4, 232, ed.filename+"_", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, ed.filename+"_", 196, 196, 255 - help.glow, true);
         }
         else
         {
-            dwgfx.Print(4, 232, ed.filename+" ", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, ed.filename+" ", 196, 196, 255 - help.glow, true);
         }
     }
     else if(ed.roomnamemod)
     {
-        FillRect(dwgfx.backBuffer, 0,221,320,240, dwgfx.getRGB(32,32,32));
-        FillRect(dwgfx.backBuffer, 0,222,320,240, dwgfx.getRGB(0,0,0));
-        dwgfx.Print(4, 224, "Enter new room name:", 255,255,255, false);
+        FillRect(graphics.backBuffer, 0,221,320,240, graphics.getRGB(32,32,32));
+        FillRect(graphics.backBuffer, 0,222,320,240, graphics.getRGB(0,0,0));
+        graphics.Print(4, 224, "Enter new room name:", 255,255,255, false);
         if(ed.entframe<2)
         {
-            dwgfx.Print(4, 232, ed.level[ed.levx+(ed.levy*ed.maxwidth)].roomname+"_", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, ed.level[ed.levx+(ed.levy*ed.maxwidth)].roomname+"_", 196, 196, 255 - help.glow, true);
         }
         else
         {
-            dwgfx.Print(4, 232, ed.level[ed.levx+(ed.levy*ed.maxwidth)].roomname+" ", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, ed.level[ed.levx+(ed.levy*ed.maxwidth)].roomname+" ", 196, 196, 255 - help.glow, true);
         }
     }
     else if(ed.roomtextmod)
     {
-        FillRect(dwgfx.backBuffer, 0,221,320,240, dwgfx.getRGB(32,32,32));
-        FillRect(dwgfx.backBuffer, 0,222,320,240, dwgfx.getRGB(0,0,0));
-        dwgfx.Print(4, 224, "Enter text string:", 255,255,255, false);
+        FillRect(graphics.backBuffer, 0,221,320,240, graphics.getRGB(32,32,32));
+        FillRect(graphics.backBuffer, 0,222,320,240, graphics.getRGB(0,0,0));
+        graphics.Print(4, 224, "Enter text string:", 255,255,255, false);
         if(ed.entframe<2)
         {
-            dwgfx.Print(4, 232, edentity[ed.textent].scriptname+"_", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, edentity[ed.textent].scriptname+"_", 196, 196, 255 - help.glow, true);
         }
         else
         {
-            dwgfx.Print(4, 232, edentity[ed.textent].scriptname+" ", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, edentity[ed.textent].scriptname+" ", 196, 196, 255 - help.glow, true);
         }
     }
     else if(ed.warpmod)
     {
         //placing warp token
-        FillRect(dwgfx.backBuffer, 0,221,320,240, dwgfx.getRGB(32,32,32));
-        FillRect(dwgfx.backBuffer, 0,222,320,240, dwgfx.getRGB(0,0,0));
-        dwgfx.Print(4, 224, "Left click to place warp destination", 196, 196, 255 - help.glow, false);
-        dwgfx.Print(4, 232, "Right click to cancel", 196, 196, 255 - help.glow, false);
+        FillRect(graphics.backBuffer, 0,221,320,240, graphics.getRGB(32,32,32));
+        FillRect(graphics.backBuffer, 0,222,320,240, graphics.getRGB(0,0,0));
+        graphics.Print(4, 224, "Left click to place warp destination", 196, 196, 255 - help.glow, false);
+        graphics.Print(4, 232, "Right click to cancel", 196, 196, 255 - help.glow, false);
     }
     else
     {
         if(ed.spacemod)
         {
-            FillRect(dwgfx.backBuffer, 0,208,320,240, dwgfx.getRGB(32,32,32));
-            FillRect(dwgfx.backBuffer, 0,209,320,240, dwgfx.getRGB(0,0,0));
+            FillRect(graphics.backBuffer, 0,208,320,240, graphics.getRGB(32,32,32));
+            FillRect(graphics.backBuffer, 0,209,320,240, graphics.getRGB(0,0,0));
 
             //Draw little icons for each thingy
             int tx=6, ty=211, tg=32;
@@ -3225,192 +3186,190 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             {
                 for(int i=0; i<10; i++)
                 {
-                    FillRect(dwgfx.backBuffer, 4+(i*tg), 209,20,20,dwgfx.getRGB(32,32,32));
+                    FillRect(graphics.backBuffer, 4+(i*tg), 209,20,20,graphics.getRGB(32,32,32));
                 }
-                FillRect(dwgfx.backBuffer, 4+(ed.drawmode*tg), 209,20,20,dwgfx.getRGB(64,64,64));
+                FillRect(graphics.backBuffer, 4+(ed.drawmode*tg), 209,20,20,graphics.getRGB(64,64,64));
                 //0:
-                dwgfx.drawtile(tx,ty,83,0,0,0);
-                dwgfx.drawtile(tx+8,ty,83,0,0,0);
-                dwgfx.drawtile(tx,ty+8,83,0,0,0);
-                dwgfx.drawtile(tx+8,ty+8,83,0,0,0);
+                graphics.drawtile(tx,ty,83);
+                graphics.drawtile(tx+8,ty,83);
+                graphics.drawtile(tx,ty+8,83);
+                graphics.drawtile(tx+8,ty+8,83);
                 //1:
                 tx+=tg;
-                dwgfx.drawtile(tx,ty,680,0,0,0);
-                dwgfx.drawtile(tx+8,ty,680,0,0,0);
-                dwgfx.drawtile(tx,ty+8,680,0,0,0);
-                dwgfx.drawtile(tx+8,ty+8,680,0,0,0);
+                graphics.drawtile(tx,ty,680);
+                graphics.drawtile(tx+8,ty,680);
+                graphics.drawtile(tx,ty+8,680);
+                graphics.drawtile(tx+8,ty+8,680);
                 //2:
                 tx+=tg;
-                dwgfx.drawtile(tx+4,ty+4,8,0,0,0);
+                graphics.drawtile(tx+4,ty+4,8);
                 //3:
                 tx+=tg;
-                dwgfx.drawsprite(tx,ty,22,196,196,196);
+                graphics.drawsprite(tx,ty,22,196,196,196);
                 //4:
                 tx+=tg;
-                dwgfx.drawsprite(tx,ty,21,196,196,196);
+                graphics.drawsprite(tx,ty,21,196,196,196);
                 //5:
                 tx+=tg;
-                dwgfx.drawtile(tx,ty+4,3,0,0,0);
-                dwgfx.drawtile(tx+8,ty+4,4,0,0,0);
+                graphics.drawtile(tx,ty+4,3);
+                graphics.drawtile(tx+8,ty+4,4);
                 //6:
                 tx+=tg;
-                dwgfx.drawtile(tx,ty+4,24,0,0,0);
-                dwgfx.drawtile(tx+8,ty+4,24,0,0,0);
+                graphics.drawtile(tx,ty+4,24);
+                graphics.drawtile(tx+8,ty+4,24);
                 //7:
                 tx+=tg;
-                dwgfx.drawtile(tx,ty+4,1,0,0,0);
-                dwgfx.drawtile(tx+8,ty+4,1,0,0,0);
+                graphics.drawtile(tx,ty+4,1);
+                graphics.drawtile(tx+8,ty+4,1);
                 //8:
                 tx+=tg;
-                dwgfx.drawsprite(tx,ty,78+ed.entframe,196,196,196);
+                graphics.drawsprite(tx,ty,78+ed.entframe,196,196,196);
                 //9:
                 tx+=tg;
-                FillRect(dwgfx.backBuffer, tx+2,ty+8,12,1,dwgfx.getRGB(255,255,255));
+                FillRect(graphics.backBuffer, tx+2,ty+8,12,1,graphics.getRGB(255,255,255));
 
                 for(int i=0; i<9; i++)
                 {
-                    fillboxabs(dwgfx, 4+(i*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                    dwgfx.Print(22+(i*tg)-4, 225-4,help.String(i+1),164,164,164,false);
+                    fillboxabs(4+(i*tg), 209,20,20,graphics.getRGB(96,96,96));
+                    graphics.Print(22+(i*tg)-4, 225-4,help.String(i+1),164,164,164,false);
                 }
 
-                if(ed.drawmode==9)dwgfx.Print(22+(ed.drawmode*tg)-4, 225-4,"0",255,255,255,false);
+                if(ed.drawmode==9)graphics.Print(22+(ed.drawmode*tg)-4, 225-4,"0",255,255,255,false);
 
-                fillboxabs(dwgfx, 4+(9*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                dwgfx.Print(22+(9*tg)-4, 225-4, "0",164,164,164,false);
+                fillboxabs(4+(9*tg), 209,20,20,graphics.getRGB(96,96,96));
+                graphics.Print(22+(9*tg)-4, 225-4, "0",164,164,164,false);
 
-                fillboxabs(dwgfx, 4+(ed.drawmode*tg), 209,20,20,dwgfx.getRGB(200,200,200));
+                fillboxabs(4+(ed.drawmode*tg), 209,20,20,graphics.getRGB(200,200,200));
                 if(ed.drawmode<9)
                 {
-                    dwgfx.Print(22+(ed.drawmode*tg)-4, 225-4,help.String(ed.drawmode+1),255,255,255,false);
+                    graphics.Print(22+(ed.drawmode*tg)-4, 225-4,help.String(ed.drawmode+1),255,255,255,false);
                 }
 
-                dwgfx.Print(4, 232, "1/2", 196, 196, 255 - help.glow, false);
+                graphics.Print(4, 232, "1/2", 196, 196, 255 - help.glow, false);
             }
             else
             {
                 for(int i=0; i<7; i++)
                 {
-                    FillRect(dwgfx.backBuffer, 4+(i*tg), 209,20,20,dwgfx.getRGB(32,32,32));
+                    FillRect(graphics.backBuffer, 4+(i*tg), 209,20,20,graphics.getRGB(32,32,32));
                 }
-                FillRect(dwgfx.backBuffer, 4+((ed.drawmode-10)*tg), 209,20,20,dwgfx.getRGB(64,64,64));
+                FillRect(graphics.backBuffer, 4+((ed.drawmode-10)*tg), 209,20,20,graphics.getRGB(64,64,64));
                 //10:
-                dwgfx.Print(tx,ty,"A",196, 196, 255 - help.glow, false);
-                dwgfx.Print(tx+8,ty,"B",196, 196, 255 - help.glow, false);
-                dwgfx.Print(tx,ty+8,"C",196, 196, 255 - help.glow, false);
-                dwgfx.Print(tx+8,ty+8,"D",196, 196, 255 - help.glow, false);
+                graphics.Print(tx,ty,"A",196, 196, 255 - help.glow, false);
+                graphics.Print(tx+8,ty,"B",196, 196, 255 - help.glow, false);
+                graphics.Print(tx,ty+8,"C",196, 196, 255 - help.glow, false);
+                graphics.Print(tx+8,ty+8,"D",196, 196, 255 - help.glow, false);
                 //11:
                 tx+=tg;
-                dwgfx.drawsprite(tx,ty,17,196,196,196);
+                graphics.drawsprite(tx,ty,17,196,196,196);
                 //12:
                 tx+=tg;
-                fillboxabs(dwgfx, tx+4,ty+4,8,8,dwgfx.getRGB(96,96,96));
+                fillboxabs(tx+4,ty+4,8,8,graphics.getRGB(96,96,96));
                 //13:
                 tx+=tg;
-                dwgfx.drawsprite(tx,ty,18+(ed.entframe%2),196,196,196);
+                graphics.drawsprite(tx,ty,18+(ed.entframe%2),196,196,196);
                 //14:
                 tx+=tg;
-                FillRect(dwgfx.backBuffer, tx+6,ty+2,4,12,dwgfx.getRGB(255,255,255));
+                FillRect(graphics.backBuffer, tx+6,ty+2,4,12,graphics.getRGB(255,255,255));
                 //15:
                 tx+=tg;
-                dwgfx.drawsprite(tx,ty,186,75, 75, 255- help.glow/4 - (fRandom()*20));
+                graphics.drawsprite(tx,ty,186,75, 75, 255- help.glow/4 - (fRandom()*20));
                 //16:
                 tx+=tg;
-                dwgfx.drawsprite(tx,ty,184,160- help.glow/2 - (fRandom()*20), 200- help.glow/2, 220 - help.glow);
+                graphics.drawsprite(tx,ty,184,160- help.glow/2 - (fRandom()*20), 200- help.glow/2, 220 - help.glow);
 
-                if(ed.drawmode==10)dwgfx.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"R",255,255,255,false);
-                if(ed.drawmode==11)dwgfx.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"T",255,255,255,false);
-                if(ed.drawmode==12)dwgfx.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"Y",255,255,255,false);
-                if(ed.drawmode==13)dwgfx.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"U",255,255,255,false);
-                if(ed.drawmode==14)dwgfx.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"I",255,255,255,false);
-                if(ed.drawmode==15)dwgfx.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"O",255,255,255,false);
-                if(ed.drawmode==16)dwgfx.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"P",255,255,255,false);
+                if(ed.drawmode==10)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"R",255,255,255,false);
+                if(ed.drawmode==11)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"T",255,255,255,false);
+                if(ed.drawmode==12)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"Y",255,255,255,false);
+                if(ed.drawmode==13)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"U",255,255,255,false);
+                if(ed.drawmode==14)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"I",255,255,255,false);
+                if(ed.drawmode==15)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"O",255,255,255,false);
+                if(ed.drawmode==16)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"P",255,255,255,false);
 
-                fillboxabs(dwgfx, 4+(0*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                dwgfx.Print(22+(0*tg)-4, 225-4, "R",164,164,164,false);
-                fillboxabs(dwgfx, 4+(1*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                dwgfx.Print(22+(1*tg)-4, 225-4, "T",164,164,164,false);
-                fillboxabs(dwgfx, 4+(2*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                dwgfx.Print(22+(2*tg)-4, 225-4, "Y",164,164,164,false);
-                fillboxabs(dwgfx, 4+(3*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                dwgfx.Print(22+(3*tg)-4, 225-4, "U",164,164,164,false);
-                fillboxabs(dwgfx, 4+(4*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                dwgfx.Print(22+(4*tg)-4, 225-4, "I",164,164,164,false);
-                fillboxabs(dwgfx, 4+(5*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                dwgfx.Print(22+(5*tg)-4, 225-4, "O",164,164,164,false);
-                fillboxabs(dwgfx, 4+(6*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                dwgfx.Print(22+(6*tg)-4, 225-4, "P",164,164,164,false);
+                fillboxabs(4+(0*tg), 209,20,20,graphics.getRGB(96,96,96));
+                graphics.Print(22+(0*tg)-4, 225-4, "R",164,164,164,false);
+                fillboxabs(4+(1*tg), 209,20,20,graphics.getRGB(96,96,96));
+                graphics.Print(22+(1*tg)-4, 225-4, "T",164,164,164,false);
+                fillboxabs(4+(2*tg), 209,20,20,graphics.getRGB(96,96,96));
+                graphics.Print(22+(2*tg)-4, 225-4, "Y",164,164,164,false);
+                fillboxabs(4+(3*tg), 209,20,20,graphics.getRGB(96,96,96));
+                graphics.Print(22+(3*tg)-4, 225-4, "U",164,164,164,false);
+                fillboxabs(4+(4*tg), 209,20,20,graphics.getRGB(96,96,96));
+                graphics.Print(22+(4*tg)-4, 225-4, "I",164,164,164,false);
+                fillboxabs(4+(5*tg), 209,20,20,graphics.getRGB(96,96,96));
+                graphics.Print(22+(5*tg)-4, 225-4, "O",164,164,164,false);
+                fillboxabs(4+(6*tg), 209,20,20,graphics.getRGB(96,96,96));
+                graphics.Print(22+(6*tg)-4, 225-4, "P",164,164,164,false);
 
-                dwgfx.Print(4, 232, "2/2", 196, 196, 255 - help.glow, false);
+                graphics.Print(4, 232, "2/2", 196, 196, 255 - help.glow, false);
             }
 
-            dwgfx.Print(128, 232, "< and > keys change tool", 196, 196, 255 - help.glow, false);
+            graphics.Print(128, 232, "< and > keys change tool", 196, 196, 255 - help.glow, false);
 
-            FillRect(dwgfx.backBuffer, 0,198,120,10, dwgfx.getRGB(32,32,32));
-            FillRect(dwgfx.backBuffer, 0,199,119,9, dwgfx.getRGB(0,0,0));
+            FillRect(graphics.backBuffer, 0,198,120,10, graphics.getRGB(32,32,32));
+            FillRect(graphics.backBuffer, 0,199,119,9, graphics.getRGB(0,0,0));
             switch(ed.drawmode)
             {
             case 0:
-                dwgfx.bprint(2,199, "1: Walls",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "1: Walls",196, 196, 255 - help.glow);
                 break;
             case 1:
-                dwgfx.bprint(2,199, "2: Backing",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "2: Backing",196, 196, 255 - help.glow);
                 break;
             case 2:
-                dwgfx.bprint(2,199, "3: Spikes",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "3: Spikes",196, 196, 255 - help.glow);
                 break;
             case 3:
-                dwgfx.bprint(2,199, "4: Trinkets",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "4: Trinkets",196, 196, 255 - help.glow);
                 break;
             case 4:
-                dwgfx.bprint(2,199, "5: Checkpoint",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "5: Checkpoint",196, 196, 255 - help.glow);
                 break;
             case 5:
-                dwgfx.bprint(2,199, "6: Disappear",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "6: Disappear",196, 196, 255 - help.glow);
                 break;
             case 6:
-                dwgfx.bprint(2,199, "7: Conveyors",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "7: Conveyors",196, 196, 255 - help.glow);
                 break;
             case 7:
-                dwgfx.bprint(2,199, "8: Moving",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "8: Moving",196, 196, 255 - help.glow);
                 break;
             case 8:
-                dwgfx.bprint(2,199, "9: Enemies",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "9: Enemies",196, 196, 255 - help.glow);
                 break;
             case 9:
-                dwgfx.bprint(2,199, "0: Grav Line",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "0: Grav Line",196, 196, 255 - help.glow);
                 break;
             case 10:
-                dwgfx.bprint(2,199, "R: Roomtext",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "R: Roomtext",196, 196, 255 - help.glow);
                 break;
             case 11:
-                dwgfx.bprint(2,199, "T: Terminal",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "T: Terminal",196, 196, 255 - help.glow);
                 break;
             case 12:
-                dwgfx.bprint(2,199, "Y: Script Box",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "Y: Script Box",196, 196, 255 - help.glow);
                 break;
             case 13:
-                dwgfx.bprint(2,199, "U: Warp Token",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "U: Warp Token",196, 196, 255 - help.glow);
                 break;
             case 14:
-                dwgfx.bprint(2,199, "I: Warp Lines",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "I: Warp Lines",196, 196, 255 - help.glow);
                 break;
             case 15:
-                dwgfx.bprint(2,199, "O: Crewmate",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "O: Crewmate",196, 196, 255 - help.glow);
                 break;
             case 16:
-                dwgfx.bprint(2,199, "P: Start Point",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "P: Start Point",196, 196, 255 - help.glow);
                 break;
             }
 
-            FillRect(dwgfx.backBuffer, 260,198,80,10, dwgfx.getRGB(32,32,32));
-            FillRect(dwgfx.backBuffer, 261,199,80,9, dwgfx.getRGB(0,0,0));
-            dwgfx.bprint(268,199, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);
+            FillRect(graphics.backBuffer, 260,198,80,10, graphics.getRGB(32,32,32));
+            FillRect(graphics.backBuffer, 261,199,80,9, graphics.getRGB(0,0,0));
+            graphics.bprint(268,199, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);
 
         }
         else
         {
-            //FillRect(dwgfx.backBuffer, 0,230,72,240, dwgfx.RGB(32,32,32));
-            //FillRect(dwgfx.backBuffer, 0,231,71,240, dwgfx.RGB(0,0,0));
             if(ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname!="")
             {
                 if(ed.tiley<28)
@@ -3421,45 +3380,45 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                 {
                     if(ed.roomnamehide<12) ed.roomnamehide++;
                 }
-                if (dwgfx.translucentroomname)
+                if (graphics.translucentroomname)
                 {
-                    dwgfx.footerrect.y = 230+ed.roomnamehide;
-                    SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
+                    graphics.footerrect.y = 230+ed.roomnamehide;
+                    SDL_BlitSurface(graphics.footerbuffer, NULL, graphics.backBuffer, &graphics.footerrect);
                 }
                 else
                 {
-                    FillRect(dwgfx.backBuffer, 0,230+ed.roomnamehide,320,10, dwgfx.getRGB(0,0,0));
+                    FillRect(graphics.backBuffer, 0,230+ed.roomnamehide,320,10, graphics.getRGB(0,0,0));
                 }
-                dwgfx.bprint(5,231+ed.roomnamehide,ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname, 196, 196, 255 - help.glow, true);
-                dwgfx.bprint(4, 222, "SPACE ^  SHIFT ^", 196, 196, 255 - help.glow, false);
-                dwgfx.bprint(268,222, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);
+                graphics.bprint(5,231+ed.roomnamehide,ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname, 196, 196, 255 - help.glow, true);
+                graphics.bprint(4, 222, "SPACE ^  SHIFT ^", 196, 196, 255 - help.glow, false);
+                graphics.bprint(268,222, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);
             }
             else
             {
-                dwgfx.bprint(4, 232, "SPACE ^  SHIFT ^", 196, 196, 255 - help.glow, false);
-                dwgfx.bprint(268,232, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);
+                graphics.bprint(4, 232, "SPACE ^  SHIFT ^", 196, 196, 255 - help.glow, false);
+                graphics.bprint(268,232, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);
             }
         }
 
         if(ed.shiftmenu)
         {
-            fillboxabs(dwgfx, 0, 127,161+8,140,dwgfx.getRGB(64,64,64));
-            FillRect(dwgfx.backBuffer, 0,128,160+8,140, dwgfx.getRGB(0,0,0));
-            dwgfx.Print(4, 130, "F1: Change Tileset",164,164,164,false);
-            dwgfx.Print(4, 140, "F2: Change Colour",164,164,164,false);
-            dwgfx.Print(4, 150, "F3: Change Enemies",164,164,164,false);
-            dwgfx.Print(4, 160, "F4: Enemy Bounds",164,164,164,false);
-            dwgfx.Print(4, 170, "F5: Platform Bounds",164,164,164,false);
+            fillboxabs(0, 127,161+8,140,graphics.getRGB(64,64,64));
+            FillRect(graphics.backBuffer, 0,128,160+8,140, graphics.getRGB(0,0,0));
+            graphics.Print(4, 130, "F1: Change Tileset",164,164,164,false);
+            graphics.Print(4, 140, "F2: Change Colour",164,164,164,false);
+            graphics.Print(4, 150, "F3: Change Enemies",164,164,164,false);
+            graphics.Print(4, 160, "F4: Enemy Bounds",164,164,164,false);
+            graphics.Print(4, 170, "F5: Platform Bounds",164,164,164,false);
 
-            dwgfx.Print(4, 190, "F10: Direct Mode",164,164,164,false);
+            graphics.Print(4, 190, "F10: Direct Mode",164,164,164,false);
 
-            dwgfx.Print(4, 210, "W: Change Warp Dir",164,164,164,false);
-            dwgfx.Print(4, 220, "E: Change Roomname",164,164,164,false);
+            graphics.Print(4, 210, "W: Change Warp Dir",164,164,164,false);
+            graphics.Print(4, 220, "E: Change Roomname",164,164,164,false);
 
-            fillboxabs(dwgfx, 220, 207,100,60,dwgfx.getRGB(64,64,64));
-            FillRect(dwgfx.backBuffer, 221,208,160,60, dwgfx.getRGB(0,0,0));
-            dwgfx.Print(224, 210, "S: Save Map",164,164,164,false);
-            dwgfx.Print(224, 220, "L: Load Map",164,164,164,false);
+            fillboxabs(220, 207,100,60,graphics.getRGB(64,64,64));
+            FillRect(graphics.backBuffer, 221,208,160,60, graphics.getRGB(0,0,0));
+            graphics.Print(224, 210, "S: Save Map",164,164,164,false);
+            graphics.Print(224, 220, "L: Load Map",164,164,164,false);
         }
     }
 
@@ -3470,106 +3429,91 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
         switch(ed.drawmode)
         {
         case 0:
-            dwgfx.bprint(2,2, "1: Walls",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "1: Walls",196, 196, 255 - help.glow);
             break;
         case 1:
-            dwgfx.bprint(2,2, "2: Backing",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "2: Backing",196, 196, 255 - help.glow);
             break;
         case 2:
-            dwgfx.bprint(2,2, "3: Spikes",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "3: Spikes",196, 196, 255 - help.glow);
             break;
         case 3:
-            dwgfx.bprint(2,2, "4: Trinkets",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "4: Trinkets",196, 196, 255 - help.glow);
             break;
         case 4:
-            dwgfx.bprint(2,2, "5: Checkpoint",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "5: Checkpoint",196, 196, 255 - help.glow);
             break;
         case 5:
-            dwgfx.bprint(2,2, "6: Disappear",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "6: Disappear",196, 196, 255 - help.glow);
             break;
         case 6:
-            dwgfx.bprint(2,2, "7: Conveyors",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "7: Conveyors",196, 196, 255 - help.glow);
             break;
         case 7:
-            dwgfx.bprint(2,2, "8: Moving",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "8: Moving",196, 196, 255 - help.glow);
             break;
         case 8:
-            dwgfx.bprint(2,2, "9: Enemies",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "9: Enemies",196, 196, 255 - help.glow);
             break;
         case 9:
-            dwgfx.bprint(2,2, "0: Grav Line",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "0: Grav Line",196, 196, 255 - help.glow);
             break;
         case 10:
-            dwgfx.bprint(2,2, "R: Roomtext",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "R: Roomtext",196, 196, 255 - help.glow);
             break;
         case 11:
-            dwgfx.bprint(2,2, "T: Terminal",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "T: Terminal",196, 196, 255 - help.glow);
             break;
         case 12:
-            dwgfx.bprint(2,2, "Y: Script Box",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "Y: Script Box",196, 196, 255 - help.glow);
             break;
         case 13:
-            dwgfx.bprint(2,2, "U: Warp Token",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "U: Warp Token",196, 196, 255 - help.glow);
             break;
         case 14:
-            dwgfx.bprint(2,2, "I: Warp Lines",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "I: Warp Lines",196, 196, 255 - help.glow);
             break;
         case 15:
-            dwgfx.bprint(2,2, "O: Crewmate",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "O: Crewmate",196, 196, 255 - help.glow);
             break;
         case 16:
-            dwgfx.bprint(2,2, "P: Start Point",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "P: Start Point",196, 196, 255 - help.glow);
             break;
         }
-
-        //dwgfx.Print(254, 2, "F1: HELP", 196, 196, 255 - help.glow, false);
     }
-
-    /*
-    for(int i=0; i<script.customscript.size(); i++){
-      dwgfx.Print(0,i*8,script.customscript[i],255,255,255);
-    }
-    dwgfx.Print(0,8*script.customscript.size(),help.String(script.customscript.size()),255,255,255);
-
-    for(int i=0; i<ed.numhooks; i++){
-      dwgfx.Print(260,i*8,ed.hooklist[i],255,255,255);
-    }
-    dwgfx.Print(260,8*ed.numhooks,help.String(ed.numhooks),255,255,255);
-    */
 
     if(ed.notedelay>0)
     {
-        FillRect(dwgfx.backBuffer, 0,115,320,18, dwgfx.getRGB(92,92,92));
-        FillRect(dwgfx.backBuffer, 0,116,320,16, dwgfx.getRGB(0,0,0));
-        dwgfx.Print(0,121, ed.note,196-((45-ed.notedelay)*4), 196-((45-ed.notedelay)*4), 196-((45-ed.notedelay)*4), true);
+        FillRect(graphics.backBuffer, 0,115,320,18, graphics.getRGB(92,92,92));
+        FillRect(graphics.backBuffer, 0,116,320,16, graphics.getRGB(0,0,0));
+        graphics.Print(0,121, ed.note,196-((45-ed.notedelay)*4), 196-((45-ed.notedelay)*4), 196-((45-ed.notedelay)*4), true);
     }
 
     if (game.test)
     {
-        dwgfx.bprint(5, 5, game.teststring, 196, 196, 255 - help.glow, false);
+        graphics.bprint(5, 5, game.teststring, 196, 196, 255 - help.glow, false);
     }
 
-    dwgfx.drawfade();
+    graphics.drawfade();
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
-        dwgfx.flashlight();
+        graphics.flashlight();
     }
 
     if (game.screenshake > 0  && !game.noflashingmode)
     {
         game.screenshake--;
-        dwgfx.screenshake();
+        graphics.screenshake();
     }
     else
     {
-        dwgfx.render();
+        graphics.render();
     }
-    //dwgfx.backbuffer.unlock();
 }
 
-void editorlogic( KeyPoll& key, Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music, mapclass& map, UtilityClass& help )
+void editorlogic()
 {
     //Misc
     help.updateglow();
@@ -3589,26 +3533,25 @@ void editorlogic( KeyPoll& key, Graphics& dwgfx, Game& game, entityclass& obj, m
         ed.notedelay--;
     }
 
-    if (dwgfx.fademode == 1)
+    if (graphics.fademode == 1)
     {
         //Return to game
         map.nexttowercolour();
         map.colstate = 10;
         game.gamestate = 1;
-        dwgfx.fademode = 4;
+        graphics.fademode = 4;
         music.stopmusic();
         music.play(6);
         map.nexttowercolour();
         ed.settingsmod=false;
-        dwgfx.backgrounddrawn=false;
+        graphics.backgrounddrawn=false;
         game.createmenu("mainmenu");
     }
 }
 
 
-void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void editorinput()
 {
-    //TODO Mouse Input!
     game.mx = (float) key.mx;
     game.my = (float) key.my;
     ed.tilex=(game.mx - (game.mx%8))/8;
@@ -3616,7 +3559,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
     if (game.stretchMode == 1) {
         // In this mode specifically, we have to fix the mouse coordinates
         int winwidth, winheight;
-        dwgfx.screenbuffer->GetWindowSize(&winwidth, &winheight);
+        graphics.screenbuffer->GetWindowSize(&winwidth, &winheight);
         ed.tilex = ed.tilex * 320 / winwidth;
         ed.tiley = ed.tiley * 240 / winheight;
     }
@@ -3682,7 +3625,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
         {
 
             ed.settingsmod=!ed.settingsmod;
-            dwgfx.backgrounddrawn=false;
+            graphics.backgrounddrawn=false;
 
             game.createmenu("ed_settings");
             map.nexttowercolour();
@@ -3963,7 +3906,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                     if(ed.saveandquit)
                     {
                         //quit editor
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                 }
                 else if(ed.loadmod)
@@ -4150,7 +4093,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         {
                             //Load level
                             ed.settingsmod=false;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                             map.nexttowercolour();
 
                             ed.loadmod=true;
@@ -4159,13 +4102,13 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                             key.keybuffer=ed.filename;
                             ed.keydelay=6;
                             game.mapheld=true;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                         }
                         else if (game.currentmenuoption == 4)
                         {
                             //Save level
                             ed.settingsmod=false;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                             map.nexttowercolour();
 
                             ed.savemod=true;
@@ -4174,7 +4117,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                             key.keybuffer=ed.filename;
                             ed.keydelay=6;
                             game.mapheld=true;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                         }
                         else if (game.currentmenuoption == 5)
                         {
@@ -4218,7 +4161,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                             ed.saveandquit=true;
 
                             ed.settingsmod=false;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                             map.nexttowercolour();
 
                             ed.savemod=true;
@@ -4227,14 +4170,14 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                             key.keybuffer=ed.filename;
                             ed.keydelay=6;
                             game.mapheld=true;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                         }
                         else if (game.currentmenuoption == 1)
                         {
                             //Quit without saving
                             music.playef(11, 10);
                             music.fadeout();
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else if (game.currentmenuoption == 2)
                         {
@@ -4254,7 +4197,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
             if(key.keymap[SDLK_F1] && ed.keydelay==0)
             {
                 ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset++;
-                dwgfx.backgrounddrawn=false;
+                graphics.backgrounddrawn=false;
                 if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset>=5) ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset=0;
                 if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
                 {
@@ -4299,7 +4242,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
             if(key.keymap[SDLK_F2] && ed.keydelay==0)
             {
                 ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol++;
-                dwgfx.backgrounddrawn=false;
+                graphics.backgrounddrawn=false;
                 if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
                 {
                     if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol>=32) ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol=0;
@@ -4348,7 +4291,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                     ed.level[ed.levx+(ed.levy*ed.maxwidth)].directmode=1;
                     ed.note="Direct Mode Enabled";
                 }
-                dwgfx.backgrounddrawn=false;
+                graphics.backgrounddrawn=false;
 
                 ed.notedelay=45;
                 ed.updatetiles=true;
@@ -4399,25 +4342,25 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                     {
                         ed.note="Room warping disabled";
                         ed.notedelay=45;
-                        dwgfx.backgrounddrawn=false;
+                        graphics.backgrounddrawn=false;
                     }
                     else if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir==1)
                     {
                         ed.note="Room warps horizontally";
                         ed.notedelay=45;
-                        dwgfx.backgrounddrawn=false;
+                        graphics.backgrounddrawn=false;
                     }
                     else if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir==2)
                     {
                         ed.note="Room warps vertically";
                         ed.notedelay=45;
-                        dwgfx.backgrounddrawn=false;
+                        graphics.backgrounddrawn=false;
                     }
                     else if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir==3)
                     {
                         ed.note="Room warps in all directions";
                         ed.notedelay=45;
-                        dwgfx.backgrounddrawn=false;
+                        graphics.backgrounddrawn=false;
                     }
                 }
                 ed.keydelay=6;
@@ -4441,7 +4384,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                 key.keybuffer=ed.filename;
                 ed.keydelay=6;
                 game.mapheld=true;
-                dwgfx.backgrounddrawn=false;
+                graphics.backgrounddrawn=false;
             }
 
             if(key.keymap[SDLK_l] && ed.keydelay==0)
@@ -4452,7 +4395,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                 key.keybuffer=ed.filename;
                 ed.keydelay=6;
                 game.mapheld=true;
-                dwgfx.backgrounddrawn=false;
+                graphics.backgrounddrawn=false;
             }
 
             if(!game.press_map) game.mapheld=false;
@@ -4540,17 +4483,10 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         }
 
                         music.stopmusic();
-                        dwgfx.backgrounddrawn=false;
+                        graphics.backgrounddrawn=false;
                         ed.returneditoralpha = 1000; // Let's start it higher than 255 since it gets clamped
-                        script.startgamemode(21, key, dwgfx, game, map, obj, help, music);
+                        script.startgamemode(21);
                     }
-                    //Return to game
-                    //game.gamestate=GAMEMODE;
-                    /*if(dwgfx.fademode==0)
-                    {
-                    dwgfx.fademode = 2;
-                    music.fadeout();
-                    }*/
                 }
             }
 
@@ -4676,7 +4612,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         if(key.keymap[SDLK_UP])
                         {
                             ed.keydelay=6;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                             ed.levy--;
                             ed.updatetiles=true;
                             ed.changeroom=true;
@@ -4684,7 +4620,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         else if(key.keymap[SDLK_DOWN])
                         {
                             ed.keydelay=6;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                             ed.levy++;
                             ed.updatetiles=true;
                             ed.changeroom=true;
@@ -4692,7 +4628,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         else if(key.keymap[SDLK_LEFT])
                         {
                             ed.keydelay=6;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                             ed.levx--;
                             ed.updatetiles=true;
                             ed.changeroom=true;
@@ -4700,7 +4636,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         else if(key.keymap[SDLK_RIGHT])
                         {
                             ed.keydelay=6;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                             ed.levx++;
                             ed.updatetiles=true;
                             ed.changeroom=true;
@@ -4959,7 +4895,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                                 ed.textentry=true;
                                 key.enabletextentry();
                                 key.keybuffer="";
-                                dwgfx.backgrounddrawn=false;
+                                graphics.backgrounddrawn=false;
                                 addedentity(ed.tilex+ (ed.levx*40),ed.tiley+ (ed.levy*30),17);
                                 ed.lclickdelay=1;
                             }

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -129,7 +129,7 @@ class editorclass{
 
   void load(std::string& _path);
   void save(std::string& _path);
-  void generatecustomminimap(Graphics& dwgfx, mapclass& map);
+  void generatecustomminimap();
   int edgetile(int x, int y);
   int warpzoneedgetile(int x, int y);
   int outsideedgetile(int x, int y);
@@ -142,8 +142,7 @@ class editorclass{
   int findcrewmate(int t);
   int findwarptoken(int t);
   void countstuff();
-  void findstartpoint(Game& game);
-  void weirdloadthing(std::string t);
+  void findstartpoint();
   int getlevelcol(int t);
   int getenemycol(int t);
   int entcol;
@@ -247,16 +246,15 @@ int edentat(int xp, int yp);
 
 bool edentclear(int xp, int yp);
 
-void fillbox(Graphics& dwgfx, int x, int y, int x2, int y2, int c);
+void fillbox(int x, int y, int x2, int y2, int c);
 
-void fillboxabs(Graphics& dwgfx, int x, int y, int x2, int y2, int c);
+void fillboxabs(int x, int y, int x2, int y2, int c);
 
-void editorrender(KeyPoll& key, Graphics& dwgfx, Game& game,  mapclass& map, entityclass& obj, UtilityClass& help);
+void editorrender();
 
-void editorlogic(KeyPoll& key, Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help);
+void editorlogic();
 
-void editorinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                 entityclass& obj, UtilityClass& help, musicclass& music);
+void editorinput();
 
 #endif /* EDITOR_H */
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
     map.bypos = map.ypos / 2;
 
     //Moved screensetting init here from main menu V2.1
-    game.loadstats(map, graphics);
+    game.loadstats();
     if (game.skipfakeload)
         game.gamestate = TITLEMODE;
 		if(game.usingmmmmmm==0) music.usingmmmmmm=false;
@@ -274,8 +274,6 @@ int main(int argc, char *argv[])
 
     while(!key.quitProgram)
     {
-		//gameScreen.ClearScreen(0x00);
-
         time = SDL_GetTicks();
 
         // Update network per frame.
@@ -357,141 +355,78 @@ int main(int argc, char *argv[])
             {
             case PRELOADER:
                 //Render
-                preloaderrender(graphics, game, help);
+                preloaderrender();
                 break;
-        #if !defined(NO_CUSTOM_LEVELS)
+#if !defined(NO_CUSTOM_LEVELS)
             case EDITORMODE:
-				graphics.flipmode = false;
+                graphics.flipmode = false;
                 //Input
-                editorinput(key, graphics, game, map, obj, help, music);
+                editorinput();
                 //Render
-                editorrender(key, graphics, game, map, obj, help);
+                editorrender();
                 ////Logic
-                editorlogic(key, graphics, game, obj, music, map, help);
+                editorlogic();
                 break;
-        #endif
+#endif
             case TITLEMODE:
-                //Input
-                titleinput(key, graphics, map, game, obj, help, music);
-                //Render
-                titlerender(graphics, map, game, obj, help, music);
-                ////Logic
-                titlelogic(graphics, game, obj, help, music, map);
+                titleinput();
+                titlerender();
+                titlelogic();
                 break;
             case GAMEMODE:
                 if (map.towermode)
                 {
-					gameinput(key, graphics, game, map, obj, help, music);
-
-                    //if(game.recording==1)
-                    //{
-                    // ///recordinput(key, graphics, game, map, obj, help, music);
-                    //}
-                    //else
-                    //{
-                    //}
-                    towerrender(graphics, game, map, obj, help);
-                    towerlogic(graphics, game,  obj,  music, map, help);
-
+                    gameinput();
+                    towerrender();
+                    towerlogic();
                 }
                 else
                 {
-
-                    if (game.recording == 1)
+                    if (script.running)
                     {
-                        //recordinput(key, dwgfx, game, map, obj, help, music);
+                        script.run();
                     }
-                    else
-                    {
-                        if (script.running)
-                        {
-                            script.run(key, graphics, game, map, obj, help, music);
-                        }
 
-                        gameinput(key, graphics, game, map, obj, help, music);
-                        //}
-                        gamerender(graphics,map, game,  obj, help);
-                        gamelogic(graphics, game,obj, music, map,  help);
-
-
-                    }
-                    break;
-                case MAPMODE:
-                    maprender(graphics, game, map, obj, help);
-                    if (game.recording == 1)
-                    {
-                        //recordinput(key, dwgfx, game, map, obj, help, music); //will implement this later if it's actually needed
-                    }
-                    else
-                    {
-                        mapinput(key, graphics, game, map, obj, help, music);
-                    }
-                    maplogic(graphics, game, obj ,music , map, help );
-                    break;
-                case TELEPORTERMODE:
-                    teleporterrender(graphics, game, map, obj, help);
-                    if (game.recording == 1)
-                    {
-                        //recordinput(key, graphics, game, map, obj, help, music);
-                    }
-                    else
-                    {
-                        if(game.useteleporter)
-                        {
-                            teleporterinput(key, graphics, game, map, obj, help, music);
-                        }
-                        else
-                        {
-                            if (script.running)
-                            {
-                                script.run(key, graphics, game, map, obj, help, music);
-                            }
-                            gameinput(key, graphics, game, map, obj, help, music);
-                        }
-                    }
-                    maplogic(graphics, game,  obj, music, map, help);
-                    break;
-                case GAMECOMPLETE:
-                    gamecompleterender(graphics, game, obj, help, map);
-                    //Input
-                    gamecompleteinput(key, graphics, game, map, obj, help, music);
-                    //Logic
-                    gamecompletelogic(graphics, game,  obj, music, map, help);
-                    break;
-                case GAMECOMPLETE2:
-                    gamecompleterender2(graphics, game, obj, help);
-                    //Input
-                    gamecompleteinput2(key, graphics, game, map, obj, help, music);
-                    //Logic
-                    gamecompletelogic2(graphics, game,  obj, music, map, help);
-                    break;
-                case CLICKTOSTART:
-
-                    //dwgfx.bprint(5, 115, "[Click to start]", 196 - help.glow, 196 - help.glow, 255 - help.glow, true);
-                    //dwgfx.drawgui(help);
-                    //dwgfx.render();
-                    //dwgfx.backbuffer.unlock();
-
-                    help.updateglow();
-                    // if (key.click) {
-                    //  dwgfx.textboxremove();
-                    // }
-                    // if (dwgfx.ntextbox == 0) {
-                    //  //music.play(6);
-                    //  map.ypos = (700-29) * 8;
-                    //  map.bypos = map.ypos / 2;
-                    //  map.cameramode = 0;
-
-                    //  game.gamestate = TITLEMODE;
-                    // }
-                    break;
-                default:
-
-                break;
+                    gameinput();
+                    gamerender();
+                    gamelogic();
                 }
-
+                break;
+            case MAPMODE:
+                maprender();
+                mapinput();
+                maplogic();
+                break;
+            case TELEPORTERMODE:
+                teleporterrender();
+                if(game.useteleporter)
+                {
+                    teleporterinput();
+                }
+                else
+                {
+                    if (script.running)
+                    {
+                        script.run();
+                    }
+                    gameinput();
+                }
+                maplogic();
+                break;
+            case GAMECOMPLETE:
+                gamecompleterender();
+                gamecompleteinput();
+                gamecompletelogic();
+                break;
+            case GAMECOMPLETE2:
+                gamecompleterender2();
+                gamecompleteinput2();
+                gamecompletelogic2();
+                break;
+            case CLICKTOSTART:
+                help.updateglow();
+                break;
             }
-
         }
 
         //We did editorinput, now it's safe to turn this off
@@ -500,15 +435,15 @@ int main(int argc, char *argv[])
         if (game.savemystats)
         {
             game.savemystats = false;
-            game.savestats(map, graphics);
+            game.savestats();
         }
 
         //Mute button
-    #if !defined(NO_CUSTOM_LEVELS)
+#if !defined(NO_CUSTOM_LEVELS)
         bool inEditor = ed.textentry || ed.scripthelppage == 1;
-    #else
+#else
         bool inEditor = false;
-    #endif
+#endif
         if (key.isDown(KEYBOARD_m) && game.mutebutton<=0 && !inEditor)
         {
             game.mutebutton = 8;
@@ -565,7 +500,7 @@ int main(int argc, char *argv[])
     //SDL_FreeSurface( gameScreen );
 
     //Quit SDL
-    game.savestats(map, graphics);
+    game.savestats();
     NETWORK_shutdown();
     SDL_Quit();
     FILESYSTEM_deinit();

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -9,11 +9,8 @@ int pre_darkcol=0, pre_lightcol=0, pre_curcol=0, pre_coltimer=0, pre_offset=0;
 int pre_frontrectx=30, pre_frontrecty=20, pre_frontrectw=260, pre_frontrecth=200;
 int pre_temprectx=0, pre_temprecty=0, pre_temprectw=320, pre_temprecth=240;
 
-void preloaderrender(Graphics& dwgfx, Game& game, UtilityClass& help)
+void preloaderrender()
 {
-	//TODO
-	//dwgfx.backbuffer.lock();
-
 	//Draw grid
 
   //pre_transition = -10;	pre_fakepercent = 100;
@@ -34,32 +31,32 @@ void preloaderrender(Graphics& dwgfx, Game& game, UtilityClass& help)
     }
     switch(pre_curcol) {
 	case 0:
-		pre_lightcol = dwgfx.RGBflip(0xBF,0x59,0x6F);
-		pre_darkcol = dwgfx.RGBflip(0x88,0x3E,0x53);
+		pre_lightcol = graphics.RGBflip(0xBF,0x59,0x6F);
+		pre_darkcol = graphics.RGBflip(0x88,0x3E,0x53);
 		break;
 	case 1:
-		pre_lightcol = dwgfx.RGBflip(0x6C,0xBC,0x5C);
-		pre_darkcol = dwgfx.RGBflip(0x50,0x86,0x40);
+		pre_lightcol = graphics.RGBflip(0x6C,0xBC,0x5C);
+		pre_darkcol = graphics.RGBflip(0x50,0x86,0x40);
 		break;
 	case 2:
-		pre_lightcol = dwgfx.RGBflip(0x5D,0x57,0xAA);
-		pre_darkcol = dwgfx.RGBflip(0x2F,0x2F,0x6C);
+		pre_lightcol = graphics.RGBflip(0x5D,0x57,0xAA);
+		pre_darkcol = graphics.RGBflip(0x2F,0x2F,0x6C);
 		break;
 	case 3:
-		pre_lightcol = dwgfx.RGBflip(0xB7,0xBA,0x5E);
-		pre_darkcol = dwgfx.RGBflip(0x84,0x83,0x42);
+		pre_lightcol = graphics.RGBflip(0xB7,0xBA,0x5E);
+		pre_darkcol = graphics.RGBflip(0x84,0x83,0x42);
 		break;
 	case 4:
-		pre_lightcol = dwgfx.RGBflip(0x57,0x90,0xAA);
-		pre_darkcol = dwgfx.RGBflip(0x2F,0x5B,0x6C);
+		pre_lightcol = graphics.RGBflip(0x57,0x90,0xAA);
+		pre_darkcol = graphics.RGBflip(0x2F,0x5B,0x6C);
 		break;
 	case 5:
-		pre_lightcol = dwgfx.RGBflip(0x90,0x61,0xB1);
-		pre_darkcol = dwgfx.RGBflip(0x58,0x3D,0x71);
+		pre_lightcol = graphics.RGBflip(0x90,0x61,0xB1);
+		pre_darkcol = graphics.RGBflip(0x58,0x3D,0x71);
 		break;
 	default:
-		pre_lightcol = dwgfx.RGBflip(0x00,0x00,0x00);
-		pre_darkcol = dwgfx.RGBflip(0x08,0x00,0x00);
+		pre_lightcol = graphics.RGBflip(0x00,0x00,0x00);
+		pre_darkcol = graphics.RGBflip(0x08,0x00,0x00);
 		break;
     }
 
@@ -67,20 +64,20 @@ void preloaderrender(Graphics& dwgfx, Game& game, UtilityClass& help)
       pre_temprecty = (i * 16)- pre_offset;
       if (i % 2 == 0) 
 	  {
-        FillRect(dwgfx.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, pre_lightcol);
+        FillRect(graphics.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, pre_lightcol);
       }
 	  else
 	  {
-        FillRect(dwgfx.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, pre_darkcol);
+        FillRect(graphics.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, pre_darkcol);
       }
     }
 
-    FillRect(dwgfx.backBuffer, pre_frontrectx, pre_frontrecty, pre_frontrectw,pre_frontrecth, dwgfx.getBGR(0x3E,0x31,0xA2));
+    FillRect(graphics.backBuffer, pre_frontrectx, pre_frontrecty, pre_frontrectw,pre_frontrecth, graphics.getBGR(0x3E,0x31,0xA2));
 
     if(pre_fakepercent==100){
-      dwgfx.Print(282-(15*8), 204, "LOADING... " + help.String(int(pre_fakepercent))+"%", 124, 112, 218, false);
+      graphics.Print(282-(15*8), 204, "LOADING... " + help.String(int(pre_fakepercent))+"%", 124, 112, 218, false);
     }else{
-      dwgfx.Print(282-(14*8), 204, "LOADING... " + help.String(int(pre_fakepercent))+"%", 124, 112, 218, false);
+      graphics.Print(282-(14*8), 204, "LOADING... " + help.String(int(pre_fakepercent))+"%", 124, 112, 218, false);
     }
 
     //Render
@@ -90,37 +87,36 @@ void preloaderrender(Graphics& dwgfx, Game& game, UtilityClass& help)
   }else if (pre_transition <= -10) {
     game.gamestate=TITLEMODE;
   }else if (pre_transition < 5) {
-	  FillRect(dwgfx.backBuffer, 0, 0, 320,240, dwgfx.getBGR(0,0,0));
+	  FillRect(graphics.backBuffer, 0, 0, 320,240, graphics.getBGR(0,0,0));
   }else if (pre_transition < 20) {
     pre_temprecty = 0;
     pre_temprecth = 240;
-    FillRect(dwgfx.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, 0x000000);
-    FillRect(dwgfx.backBuffer, pre_frontrectx, pre_frontrecty, pre_frontrectw,pre_frontrecth, dwgfx.getBGR(0x3E,0x31,0xA2));
+    FillRect(graphics.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, 0x000000);
+    FillRect(graphics.backBuffer, pre_frontrectx, pre_frontrecty, pre_frontrectw,pre_frontrecth, graphics.getBGR(0x3E,0x31,0xA2));
 
-    dwgfx.Print(282-(15*8), 204, "LOADING... 100%", 124, 112, 218, false);
+    graphics.Print(282-(15*8), 204, "LOADING... 100%", 124, 112, 218, false);
   }
 
 	if (game.test)
 	{
-		dwgfx.Print(5, 5, game.teststring, 196, 196, 255 - help.glow, false);
+		graphics.Print(5, 5, game.teststring, 196, 196, 255 - help.glow, false);
 	}
 
-	dwgfx.drawfade();
+	graphics.drawfade();
 
 	if (game.flashlight > 0 && !game.noflashingmode)
 	{
 		game.flashlight--;
-		dwgfx.flashlight();
+		graphics.flashlight();
 	}
 
 	if (game.screenshake > 0  && !game.noflashingmode)
 	{
 		game.screenshake--;
-		dwgfx.screenshake();
+		graphics.screenshake();
 	}
 	else
 	{
-		dwgfx.render();
+		graphics.render();
 	}
-	//dwgfx.backbuffer.unlock();
 }

--- a/desktop_version/src/preloader.h
+++ b/desktop_version/src/preloader.h
@@ -5,6 +5,6 @@
 #include "Game.h"
 #include "UtilityClass.h"
 
-void preloaderrender(Graphics& dwgfx, Game& game, UtilityClass& help);
+void preloaderrender();
 
 #endif /* PRELOADER_H */

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -22,15 +22,10 @@ int tb;
 
 std::string tempstring;
 
-void updategraphicsmode(Game& game, Graphics& dwgfx)
-{
-    swfStage = stage;
-}
-
-void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, UtilityClass& help, musicclass& music)
+void titlerender()
 {
 
-    FillRect(dwgfx.backBuffer, 0,0,dwgfx.backBuffer->w, dwgfx.backBuffer->h, 0x00000000 );
+    FillRect(graphics.backBuffer, 0,0,graphics.backBuffer->w, graphics.backBuffer->h, 0x00000000 );
 
     if (!game.menustart)
     {
@@ -39,29 +34,22 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
         tb = 164 - (help.glow / 2) - int(fRandom() * 4);
 
         temp = 50;
-        dwgfx.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
-				#if defined(MAKEANDPLAY)
-					dwgfx.Print(-1,temp+35,"     MAKE AND PLAY EDITION",tr, tg, tb, true);
-				#endif
+        graphics.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
+#if defined(MAKEANDPLAY)
+        graphics.Print(-1,temp+35,"     MAKE AND PLAY EDITION",tr, tg, tb, true);
+#endif
 
-        dwgfx.Print(5, 175, "[ Press ACTION to Start ]", tr, tg, tb, true);
-        dwgfx.Print(5, 195, "ACTION = Space, Z, or V", int(tr*0.5f), int(tg*0.5f), int(tb*0.5f), true);
-
-        //dwgfx.Print(5, 215, "Press CTRL-F for Fullscreen", tr, tg, tb, true);
-
-        /*dwgfx.Print(5, 5, "IGF WIP Build, 29th Oct '09", tr, tg, tb, true);
-        dwgfx.Print(5, 200, "Game by Terry Cavanagh", tr, tg, tb, true);
-        dwgfx.Print(5, 210, "Music by Magnus P~lsson", tr, tg, tb, true);
-        dwgfx.Print(5, 220, "Roomnames by Bennett Foddy", tr, tg, tb, true);*/
+        graphics.Print(5, 175, "[ Press ACTION to Start ]", tr, tg, tb, true);
+        graphics.Print(5, 195, "ACTION = Space, Z, or V", int(tr*0.5f), int(tg*0.5f), int(tb*0.5f), true);
     }
     else
     {
-        if(!game.colourblindmode) dwgfx.drawtowerbackgroundsolo(map);
+        if(!game.colourblindmode) graphics.drawtowerbackgroundsolo();
 
         tr = map.r - (help.glow / 4) - int(fRandom() * 4);
         tg = map.g - (help.glow / 4) - int(fRandom() * 4);
@@ -77,26 +65,27 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
 
         if(game.currentmenuname=="mainmenu")
         {
-            dwgfx.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
-            dwgfx.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
-            dwgfx.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
-            dwgfx.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
-            dwgfx.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
-            dwgfx.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
-						#if defined(MAKEANDPLAY)
-							dwgfx.Print(-1,temp+35,"     MAKE AND PLAY EDITION",tr, tg, tb, true);
-						#endif
-            dwgfx.Print( 310 - (4*8), 230, "v2.2", tr/2, tg/2, tb/2);
+            graphics.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
+            graphics.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
+            graphics.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
+            graphics.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
+            graphics.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
+            graphics.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
+#if defined(MAKEANDPLAY)
+            graphics.Print(-1,temp+35,"     MAKE AND PLAY EDITION",tr, tg, tb, true);
+#endif
+            graphics.Print( 310 - (4*8), 230, "v2.2", tr/2, tg/2, tb/2);
 
-						if(music.mmmmmm){
-						  dwgfx.Print( 10, 230, "[MMMMMM Mod Installed]", tr/2, tg/2, tb/2);
-						}
+            if(music.mmmmmm)
+            {
+                graphics.Print(10, 230, "[MMMMMM Mod Installed]", tr/2, tg/2, tb/2);
+            }
         }
-    #if !defined(NO_CUSTOM_LEVELS)
+#if !defined(NO_CUSTOM_LEVELS)
         else if (game.currentmenuname == "levellist")
         {
           if(ed.ListOfMetaData.size()==0){
-          dwgfx.Print( -1, 100, "ERROR: No levels found.", tr, tg, tb, true);
+          graphics.Print( -1, 100, "ERROR: No levels found.", tr, tg, tb, true);
           }
           int tmp=game.currentmenuoption+(game.levelpage*8);
           if(tmp>=0 && tmp < (int) ed.ListOfMetaData.size()){ // FIXME: size_t/int! -flibit
@@ -104,183 +93,188 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
             if(game.nummenuoptions - game.currentmenuoption<=2){
 
             }else{
-              dwgfx.bigprint( -1, 15, ed.ListOfMetaData[tmp].title, tr, tg, tb, true);
-              dwgfx.Print( -1, 40, "by " + ed.ListOfMetaData[tmp].creator, tr, tg, tb, true);
-              dwgfx.Print( -1, 50, ed.ListOfMetaData[tmp].website, tr, tg, tb, true);
-              dwgfx.Print( -1, 70, ed.ListOfMetaData[tmp].Desc1, tr, tg, tb, true);
-              dwgfx.Print( -1, 80, ed.ListOfMetaData[tmp].Desc2, tr, tg, tb, true);
-              dwgfx.Print( -1, 90, ed.ListOfMetaData[tmp].Desc3, tr, tg, tb, true);
+              graphics.bigprint( -1, 15, ed.ListOfMetaData[tmp].title, tr, tg, tb, true);
+              graphics.Print( -1, 40, "by " + ed.ListOfMetaData[tmp].creator, tr, tg, tb, true);
+              graphics.Print( -1, 50, ed.ListOfMetaData[tmp].website, tr, tg, tb, true);
+              graphics.Print( -1, 70, ed.ListOfMetaData[tmp].Desc1, tr, tg, tb, true);
+              graphics.Print( -1, 80, ed.ListOfMetaData[tmp].Desc2, tr, tg, tb, true);
+              graphics.Print( -1, 90, ed.ListOfMetaData[tmp].Desc3, tr, tg, tb, true);
             }
           }
         }
-    #endif
+#endif
         else if (game.currentmenuname == "errornostart")
         {
-          dwgfx.Print( -1, 65, "ERROR: This level has", tr, tg, tb, true);
-          dwgfx.Print( -1, 75, "no start point!", tr, tg, tb, true);
+          graphics.Print( -1, 65, "ERROR: This level has", tr, tg, tb, true);
+          graphics.Print( -1, 75, "no start point!", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "options")
         {
-				
-						#if defined(MAKEANDPLAY)
-							if (game.currentmenuoption == 0)
-							{
-									dwgfx.bigprint( -1, 30, "Accessibility", tr, tg, tb, true);
-									dwgfx.Print( -1, 65, "Disable screen effects, enable", tr, tg, tb, true);
-									dwgfx.Print( -1, 75, "slowdown modes or invincibility", tr, tg, tb, true);
-							}
-							else if (game.currentmenuoption == 1)
-							{
-								dwgfx.bigprint( -1, 30, "Game Pad Options", tr, tg, tb, true);
-								dwgfx.Print( -1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
-								dwgfx.Print( -1, 75, "and adjust sensitivity", tr, tg, tb, true);
-							}
-							else if (game.currentmenuoption == 2)
-							{
-									dwgfx.bigprint( -1, 30, "Clear Data", tr, tg, tb, true);
-									dwgfx.Print( -1, 65, "Delete your save data", tr, tg, tb, true);
-									dwgfx.Print( -1, 75, "and unlocked play modes", tr, tg, tb, true);
-							}else if (game.currentmenuoption == 3){
-								if(music.mmmmmm){
-									dwgfx.bigprint( -1, 30, "Soundtrack", tr, tg, tb, true);
-									dwgfx.Print( -1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);
-									if(music.usingmmmmmm){
-										dwgfx.Print( -1, 85, "Current soundtrack: MMMMMM", tr, tg, tb, true);
-									}else{
-										dwgfx.Print( -1, 85, "Current soundtrack: PPPPPP", tr, tg, tb, true);
-									}
-								}
-							}
-						#elif !defined(MAKEANDPLAY)
-							if (game.currentmenuoption == 0)
-							{
-									dwgfx.bigprint( -1, 30, "Accessibility", tr, tg, tb, true);
-									dwgfx.Print( -1, 65, "Disable screen effects, enable", tr, tg, tb, true);
-									dwgfx.Print( -1, 75, "slowdown modes or invincibility", tr, tg, tb, true);
-							}
-							else if (game.currentmenuoption == 1)
-							{
-									dwgfx.bigprint( -1, 30, "Unlock Play Modes", tr, tg, tb, true);
-									dwgfx.Print( -1, 65, "Unlock parts of the game normally", tr, tg, tb, true);
-									dwgfx.Print( -1, 75, "unlocked as you progress", tr, tg, tb, true);
-							}
-							else if (game.currentmenuoption == 2)
-							{
-								dwgfx.bigprint( -1, 30, "Game Pad Options", tr, tg, tb, true);
-								dwgfx.Print( -1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
-								dwgfx.Print( -1, 75, "and adjust sensitivity", tr, tg, tb, true);
-							}
-							else if (game.currentmenuoption == 3)
-							{
-									dwgfx.bigprint( -1, 30, "Clear Data", tr, tg, tb, true);
-									dwgfx.Print( -1, 65, "Delete your save data", tr, tg, tb, true);
-									dwgfx.Print( -1, 75, "and unlocked play modes", tr, tg, tb, true);
-							}else if (game.currentmenuoption == 4)
-							{
-							if(music.mmmmmm){
-									dwgfx.bigprint( -1, 30, "Soundtrack", tr, tg, tb, true);
-									dwgfx.Print( -1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);
-									if(music.usingmmmmmm){
-										dwgfx.Print( -1, 85, "Current soundtrack: MMMMMM", tr, tg, tb, true);
-									}else{
-										dwgfx.Print( -1, 85, "Current soundtrack: PPPPPP", tr, tg, tb, true);
-									}
-							}
-							}
-						#endif
+#if defined(MAKEANDPLAY)
+        if (game.currentmenuoption == 0)
+        {
+            graphics.bigprint( -1, 30, "Accessibility", tr, tg, tb, true);
+            graphics.Print( -1, 65, "Disable screen effects, enable", tr, tg, tb, true);
+            graphics.Print( -1, 75, "slowdown modes or invincibility", tr, tg, tb, true);
+        }
+        else if (game.currentmenuoption == 1)
+        {
+            graphics.bigprint( -1, 30, "Game Pad Options", tr, tg, tb, true);
+            graphics.Print( -1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
+            graphics.Print( -1, 75, "and adjust sensitivity", tr, tg, tb, true);
+        }
+        else if (game.currentmenuoption == 2)
+        {
+            graphics.bigprint( -1, 30, "Clear Data", tr, tg, tb, true);
+            graphics.Print( -1, 65, "Delete your save data", tr, tg, tb, true);
+            graphics.Print( -1, 75, "and unlocked play modes", tr, tg, tb, true);
+        }else if (game.currentmenuoption == 3){
+            if(music.mmmmmm)
+            {
+                graphics.bigprint( -1, 30, "Soundtrack", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);
+                if(music.usingmmmmmm)
+                {
+                    graphics.Print( -1, 85, "Current soundtrack: MMMMMM", tr, tg, tb, true);
+                }
+                else
+                {
+                    graphics.Print( -1, 85, "Current soundtrack: PPPPPP", tr, tg, tb, true);
+                }
+            }
+        }
+#elif !defined(MAKEANDPLAY)
+        if (game.currentmenuoption == 0)
+        {
+            graphics.bigprint( -1, 30, "Accessibility", tr, tg, tb, true);
+            graphics.Print( -1, 65, "Disable screen effects, enable", tr, tg, tb, true);
+            graphics.Print( -1, 75, "slowdown modes or invincibility", tr, tg, tb, true);
+        }
+        else if (game.currentmenuoption == 1)
+        {
+            graphics.bigprint( -1, 30, "Unlock Play Modes", tr, tg, tb, true);
+            graphics.Print( -1, 65, "Unlock parts of the game normally", tr, tg, tb, true);
+            graphics.Print( -1, 75, "unlocked as you progress", tr, tg, tb, true);
+        }
+        else if (game.currentmenuoption == 2)
+        {
+            graphics.bigprint( -1, 30, "Game Pad Options", tr, tg, tb, true);
+            graphics.Print( -1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
+            graphics.Print( -1, 75, "and adjust sensitivity", tr, tg, tb, true);
+        }
+        else if (game.currentmenuoption == 3)
+        {
+            graphics.bigprint( -1, 30, "Clear Data", tr, tg, tb, true);
+            graphics.Print( -1, 65, "Delete your save data", tr, tg, tb, true);
+            graphics.Print( -1, 75, "and unlocked play modes", tr, tg, tb, true);
+        }else if (game.currentmenuoption == 4)
+        {
+            if(music.mmmmmm)
+            {
+                graphics.bigprint( -1, 30, "Soundtrack", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);
+                if(music.usingmmmmmm)
+                {
+                    graphics.Print( -1, 85, "Current soundtrack: MMMMMM", tr, tg, tb, true);
+                }
+                else
+                {
+                    graphics.Print( -1, 85, "Current soundtrack: PPPPPP", tr, tg, tb, true);
+                }
+            }
+        }
+#endif
         }
         else if (game.currentmenuname == "graphicoptions")
         {
           if (game.currentmenuoption == 0)
           {
-              dwgfx.bigprint( -1, 30, "Toggle Fullscreen", tr, tg, tb, true);
-              dwgfx.Print( -1, 65, "Change to fullscreen/windowed mode.", tr, tg, tb, true);
+              graphics.bigprint( -1, 30, "Toggle Fullscreen", tr, tg, tb, true);
+              graphics.Print( -1, 65, "Change to fullscreen/windowed mode.", tr, tg, tb, true);
 
               if(game.fullscreen){
-                dwgfx.Print( -1, 85, "Current mode: FULLSCREEN", tr, tg, tb, true);
+                graphics.Print( -1, 85, "Current mode: FULLSCREEN", tr, tg, tb, true);
               }else{
-                dwgfx.Print( -1, 85, "Current mode: WINDOWED", tr, tg, tb, true);
+                graphics.Print( -1, 85, "Current mode: WINDOWED", tr, tg, tb, true);
               }
 
-          }else if (game.currentmenuoption == 1)
-                {
-                    dwgfx.bigprint( -1, 30, "Toggle Letterbox", tr, tg, tb, true);
-                    dwgfx.Print( -1, 65, "Choose letterbox/stretch/integer mode.", tr, tg, tb, true);
+          }
+          else if (game.currentmenuoption == 1)
+          {
+              graphics.bigprint( -1, 30, "Toggle Letterbox", tr, tg, tb, true);
+              graphics.Print( -1, 65, "Choose letterbox/stretch/integer mode.", tr, tg, tb, true);
 
               if(game.stretchMode == 2){
-                dwgfx.Print( -1, 85, "Current mode: INTEGER", tr, tg, tb, true);
+                graphics.Print( -1, 85, "Current mode: INTEGER", tr, tg, tb, true);
               }else if (game.stretchMode == 1){
-                dwgfx.Print( -1, 85, "Current mode: STRETCH", tr, tg, tb, true);
+                graphics.Print( -1, 85, "Current mode: STRETCH", tr, tg, tb, true);
               }else{
-                dwgfx.Print( -1, 85, "Current mode: LETTERBOX", tr, tg, tb, true);
+                graphics.Print( -1, 85, "Current mode: LETTERBOX", tr, tg, tb, true);
               }
-          }else if (game.currentmenuoption == 2)
-                {
-                    dwgfx.bigprint( -1, 30, "Toggle Filter", tr, tg, tb, true);
-                    dwgfx.Print( -1, 65, "Change to nearest/linear filter.", tr, tg, tb, true);
+          }
+          else if (game.currentmenuoption == 2)
+          {
+              graphics.bigprint( -1, 30, "Toggle Filter", tr, tg, tb, true);
+              graphics.Print( -1, 65, "Change to nearest/linear filter.", tr, tg, tb, true);
 
               if(game.useLinearFilter){
-                dwgfx.Print( -1, 85, "Current mode: LINEAR", tr, tg, tb, true);
+                graphics.Print( -1, 85, "Current mode: LINEAR", tr, tg, tb, true);
               }else{
-                dwgfx.Print( -1, 85, "Current mode: NEAREST", tr, tg, tb, true);
+                graphics.Print( -1, 85, "Current mode: NEAREST", tr, tg, tb, true);
               }
-
-                } else if (game.currentmenuoption == 3)
-                {
-                    dwgfx.bigprint( -1, 30, "Analogue Mode", tr, tg, tb, true);
-                    dwgfx.Print( -1, 65, "There is nothing wrong with your", tr, tg, tb, true);
-                    dwgfx.Print( -1, 75, "television set. Do not attempt to", tr, tg, tb, true);
-                    dwgfx.Print( -1, 85, "adjust the picture.", tr, tg, tb, true);
-                }
+          }
+          else if (game.currentmenuoption == 3)
+          {
+              graphics.bigprint( -1, 30, "Analogue Mode", tr, tg, tb, true);
+              graphics.Print( -1, 65, "There is nothing wrong with your", tr, tg, tb, true);
+              graphics.Print( -1, 75, "television set. Do not attempt to", tr, tg, tb, true);
+              graphics.Print( -1, 85, "adjust the picture.", tr, tg, tb, true);
+          }
           else if (game.currentmenuoption == 4)
           {
-              dwgfx.bigprint(-1, 30, "Toggle Mouse Cursor", tr, tg, tb, true);
-              dwgfx.Print(-1, 65, "Show/hide the system mouse cursor.", tr, tg, tb, true);
+              graphics.bigprint(-1, 30, "Toggle Mouse Cursor", tr, tg, tb, true);
+              graphics.Print(-1, 65, "Show/hide the system mouse cursor.", tr, tg, tb, true);
 
-              if (dwgfx.showmousecursor) {
-                  dwgfx.Print(-1, 85, "Current mode: SHOW", tr, tg, tb, true);
+              if (graphics.showmousecursor) {
+                  graphics.Print(-1, 85, "Current mode: SHOW", tr, tg, tb, true);
               }
               else {
-                  dwgfx.Print(-1, 85, "Current mode: HIDE", tr/2, tg/2, tb/2, true);
+                  graphics.Print(-1, 85, "Current mode: HIDE", tr/2, tg/2, tb/2, true);
               }
           }
         }
         else if (game.currentmenuname == "credits")
         {
-            dwgfx.Print( -1, 50, "VVVVVV is a game by", tr, tg, tb, true);
-            dwgfx.bigprint( 40, 65, "Terry Cavanagh", tr, tg, tb, true, 2);
+            graphics.Print( -1, 50, "VVVVVV is a game by", tr, tg, tb, true);
+            graphics.bigprint( 40, 65, "Terry Cavanagh", tr, tg, tb, true, 2);
 
-            dwgfx.drawimagecol(7, -1, 86, tr *0.75, tg *0.75, tb *0.75, true);
-            //dwgfx.Print( 40, 85, "http://www.distractionware.com", tr, tg, tb, true);
+            graphics.drawimagecol(7, -1, 86, tr *0.75, tg *0.75, tb *0.75, true);
 
-            dwgfx.Print( -1, 120, "and features music by", tr, tg, tb, true);
-            dwgfx.bigprint( 40, 135, "Magnus P~lsson", tr, tg, tb, true, 2);
-            dwgfx.drawimagecol(8, -1, 156, tr *0.75, tg *0.75, tb *0.75, true);
-            //dwgfx.Print( 40, 155, "http://souleye.madtracker.net", tr, tg, tb, true);
+            graphics.Print( -1, 120, "and features music by", tr, tg, tb, true);
+            graphics.bigprint( 40, 135, "Magnus P~lsson", tr, tg, tb, true, 2);
+            graphics.drawimagecol(8, -1, 156, tr *0.75, tg *0.75, tb *0.75, true);
         }
         else if (game.currentmenuname == "credits2")
         {
-            dwgfx.Print( -1, 50, "Roomnames are by", tr, tg, tb, true);
-            dwgfx.bigprint( 40, 65, "Bennett Foddy", tr, tg, tb, true);
-            dwgfx.drawimagecol(9, -1, 86, tr*0.75, tg *0.75, tb *0.75, true);
-            //dwgfx.Print( 40, 80, "http://www.distractionware.com", tr, tg, tb);
-            dwgfx.Print( -1, 110, "C++ version by", tr, tg, tb, true);
-            dwgfx.bigprint( 40, 125, "Simon Roth", tr, tg, tb, true);
-						dwgfx.bigprint( 40, 145, "Ethan Lee", tr, tg, tb, true);
-           //dwgfx.drawimagecol(11, -1, 156, tr*0.75, tg *0.75, tb *0.75, true);
+            graphics.Print( -1, 50, "Roomnames are by", tr, tg, tb, true);
+            graphics.bigprint( 40, 65, "Bennett Foddy", tr, tg, tb, true);
+            graphics.drawimagecol(9, -1, 86, tr*0.75, tg *0.75, tb *0.75, true);
+            graphics.Print( -1, 110, "C++ version by", tr, tg, tb, true);
+            graphics.bigprint( 40, 125, "Simon Roth", tr, tg, tb, true);
+            graphics.bigprint( 40, 145, "Ethan Lee", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "credits25")
         {
-            dwgfx.Print( -1, 40, "Beta Testing by", tr, tg, tb, true);
-            dwgfx.bigprint( 40, 55, "Sam Kaplan", tr, tg, tb, true);
-            dwgfx.bigprint( 40, 75, "Pauli Kohberger", tr, tg, tb, true);
-            dwgfx.Print( -1, 130, "Ending Picture by", tr, tg, tb, true);
-            dwgfx.bigprint( 40, 145, "Pauli Kohberger", tr, tg, tb, true);
+            graphics.Print( -1, 40, "Beta Testing by", tr, tg, tb, true);
+            graphics.bigprint( 40, 55, "Sam Kaplan", tr, tg, tb, true);
+            graphics.bigprint( 40, 75, "Pauli Kohberger", tr, tg, tb, true);
+            graphics.Print( -1, 130, "Ending Picture by", tr, tg, tb, true);
+            graphics.bigprint( 40, 145, "Pauli Kohberger", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "credits3")
         {
-            dwgfx.Print( -1, 20, "VVVVVV is supported by", tr, tg, tb, true);
-            dwgfx.Print( 40, 30, "the following patrons", tr, tg, tb, true);
+            graphics.Print( -1, 20, "VVVVVV is supported by", tr, tg, tb, true);
+            graphics.Print( 40, 30, "the following patrons", tr, tg, tb, true);
 
             int startidx = game.current_credits_list_index;
             int endidx = std::min(startidx + 9, (int)game.superpatrons.size());
@@ -290,14 +284,14 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
 
             for (int i = startidx; i < endidx; ++i)
             {
-                dwgfx.Print(xofs, yofs, game.superpatrons[i], tr, tg, tb);
+                graphics.Print(xofs, yofs, game.superpatrons[i], tr, tg, tb);
                 xofs += 4;
                 yofs += 14;
             }
         }
         else if (game.currentmenuname == "credits4")
         {
-            dwgfx.Print( -1, 20, "and also by", tr, tg, tb, true);
+            graphics.Print( -1, 20, "and also by", tr, tg, tb, true);
 
             int startidx = game.current_credits_list_index;
             int endidx = std::min(startidx + 14, (int)game.patrons.size());
@@ -310,14 +304,14 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
 
             for (int i = startidx; i < endidx; ++i)
             {
-                dwgfx.Print(80, yofs, game.patrons[i], tr, tg, tb);
+                graphics.Print(80, yofs, game.patrons[i], tr, tg, tb);
                 yofs += 10;
             }
         }
         else if (game.currentmenuname == "credits5")
         {
-            dwgfx.Print( -1, 20, "With contributions on", tr, tg, tb, true);
-            dwgfx.Print( 40, 30, "GitHub from", tr, tg, tb, true);
+            graphics.Print( -1, 20, "With contributions on", tr, tg, tb, true);
+            graphics.Print( 40, 30, "GitHub from", tr, tg, tb, true);
 
             int startidx = game.current_credits_list_index;
             int endidx = std::min(startidx + 9, (int)game.githubfriends.size());
@@ -331,351 +325,349 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
 
             for (int i = startidx; i < endidx; ++i)
             {
-                dwgfx.Print(xofs, yofs, game.githubfriends[i], tr, tg, tb);
+                graphics.Print(xofs, yofs, game.githubfriends[i], tr, tg, tb);
                 xofs += 4;
                 yofs += 14;
             }
         }
         else if (game.currentmenuname == "credits6")
         {
-            dwgfx.Print( -1, 20, "and thanks also to:", tr, tg, tb, true);
+            graphics.Print( -1, 20, "and thanks also to:", tr, tg, tb, true);
 
-            dwgfx.bigprint(80, 60, "You!", tr, tg, tb, true);
+            graphics.bigprint(80, 60, "You!", tr, tg, tb, true);
 
-            dwgfx.Print( 80, 100, "Your support makes it possible", tr, tg, tb,true);
-            dwgfx.Print( 80, 110,"for me to continue making the", tr, tg, tb,true);
-            dwgfx.Print( 80, 120,"games I want to make, now", tr, tg, tb,true);
-            dwgfx.Print( 80, 130, "and into the future.", tr, tg, tb, true);
+            graphics.Print( 80, 100, "Your support makes it possible", tr, tg, tb,true);
+            graphics.Print( 80, 110,"for me to continue making the", tr, tg, tb,true);
+            graphics.Print( 80, 120,"games I want to make, now", tr, tg, tb,true);
+            graphics.Print( 80, 130, "and into the future.", tr, tg, tb, true);
 
-            dwgfx.Print( 80, 150,"Thank you!", tr, tg, tb,true);
+            graphics.Print( 80, 150,"Thank you!", tr, tg, tb,true);
         }
         else if (game.currentmenuname == "setinvincibility")
         {
-            dwgfx.Print( -1, 100, "Are you sure you want to ", tr, tg, tb, true);
-            dwgfx.Print( -1, 110, "enable invincibility?", tr, tg, tb, true);
+            graphics.Print( -1, 100, "Are you sure you want to ", tr, tg, tb, true);
+            graphics.Print( -1, 110, "enable invincibility?", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "setslowdown1")
         {
-            dwgfx.Print( -1, 90, "Warning! Changing the game speed", tr, tg, tb, true);
-            dwgfx.Print( -1, 100, "requires a game restart, and will", tr, tg, tb, true);
-            dwgfx.Print( -1, 110, "delete your current saves.", tr, tg, tb, true);
-            dwgfx.Print( -1, 120, "Is this ok?", tr, tg, tb, true);
+            graphics.Print( -1, 90, "Warning! Changing the game speed", tr, tg, tb, true);
+            graphics.Print( -1, 100, "requires a game restart, and will", tr, tg, tb, true);
+            graphics.Print( -1, 110, "delete your current saves.", tr, tg, tb, true);
+            graphics.Print( -1, 120, "Is this ok?", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "setslowdown2")
         {
-            dwgfx.bigprint( -1, 40, "Game Speed", tr, tg, tb, true);
-            dwgfx.Print( -1, 75, "Select a new game speed below.", tr, tg, tb, true);
+            graphics.bigprint( -1, 40, "Game Speed", tr, tg, tb, true);
+            graphics.Print( -1, 75, "Select a new game speed below.", tr, tg, tb, true);
             if (game.gameframerate==34)
             {
-                dwgfx.Print( -1, 105, "Game speed is normal.", tr/2, tg/2, tb/2, true);
+                graphics.Print( -1, 105, "Game speed is normal.", tr/2, tg/2, tb/2, true);
             }
             else if (game.gameframerate==41)
             {
-                dwgfx.Print( -1, 105, "Game speed is at 80%", tr, tg, tb, true);
+                graphics.Print( -1, 105, "Game speed is at 80%", tr, tg, tb, true);
             }
             else if (game.gameframerate==55)
             {
-                dwgfx.Print( -1, 105, "Game speed is at 60%", tr, tg, tb, true);
+                graphics.Print( -1, 105, "Game speed is at 60%", tr, tg, tb, true);
             }
             else if (game.gameframerate==83)
             {
-                dwgfx.Print( -1, 105, "Game speed is at 40%", tr, tg, tb, true);
+                graphics.Print( -1, 105, "Game speed is at 40%", tr, tg, tb, true);
             }
         }
         else if (game.currentmenuname == "newgamewarning")
         {
-            dwgfx.Print( -1, 100, "Are you sure? This will", tr, tg, tb, true);
-            dwgfx.Print( -1, 110, "delete your current saves...", tr, tg, tb, true);
+            graphics.Print( -1, 100, "Are you sure? This will", tr, tg, tb, true);
+            graphics.Print( -1, 110, "delete your current saves...", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "cleardatamenu")
         {
-            dwgfx.Print( -1, 100, "Are you sure you want to", tr, tg, tb, true);
-            dwgfx.Print( -1, 110, "delete all your saved data?", tr, tg, tb, true);
+            graphics.Print( -1, 100, "Are you sure you want to", tr, tg, tb, true);
+            graphics.Print( -1, 110, "delete all your saved data?", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "startnodeathmode")
         {
-            dwgfx.Print( -1, 45, "Good luck!", tr, tg, tb, true);
-            dwgfx.Print( -1, 80, "You cannot save in this mode.", tr, tg, tb, true);
-            dwgfx.Print( -1, 100, "Would you like to disable the", tr, tg, tb, true);
-            dwgfx.Print( -1, 112, "cutscenes during the game?", tr, tg, tb, true);
+            graphics.Print( -1, 45, "Good luck!", tr, tg, tb, true);
+            graphics.Print( -1, 80, "You cannot save in this mode.", tr, tg, tb, true);
+            graphics.Print( -1, 100, "Would you like to disable the", tr, tg, tb, true);
+            graphics.Print( -1, 112, "cutscenes during the game?", tr, tg, tb, true);
         }
-		else if (game.currentmenuname == "controller")
-		{
-			dwgfx.bigprint( -1, 30, "Game Pad", tr, tg, tb, true);
-			dwgfx.Print( -1, 55, "Change controller options.", tr, tg, tb, true);
-			if (game.currentmenuoption == 0)
-			{
-				switch(game.controllerSensitivity)
-				{
-				case 0:
-					dwgfx.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
-					dwgfx.Print( -1, 95, "[]..................", tr, tg, tb, true);
-					break;
-				case 1:
-					dwgfx.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
-					dwgfx.Print( -1, 95, ".....[].............", tr, tg, tb, true);
-					break;
-				case 2:
-					dwgfx.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
-					dwgfx.Print( -1, 95, ".........[].........", tr, tg, tb, true);
-					break;
-				case 3:
-					dwgfx.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
-					dwgfx.Print( -1, 95, ".............[].....", tr, tg, tb, true);
-					break;
-				case 4:
-					dwgfx.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
-					dwgfx.Print( -1, 95, "..................[]", tr, tg, tb, true);
-					break;
-				}
-			}
-			if (    game.currentmenuoption == 1 ||
-                                game.currentmenuoption == 2 ||
-                                game.currentmenuoption == 3     )
-			{
-				dwgfx.Print( -1, 85, "Flip is bound to: " + std::string(UtilityClass::GCString(game.controllerButton_flip)) , tr, tg, tb, true);
-				dwgfx.Print( -1, 95, "Enter is bound to: "  + std::string(UtilityClass::GCString(game.controllerButton_map)), tr, tg, tb, true);
-				dwgfx.Print( -1, 105, "Menu is bound to: " + std::string(UtilityClass::GCString(game.controllerButton_esc)) , tr, tg, tb, true);
-			}
-
-
-		}
+        else if (game.currentmenuname == "controller")
+        {
+            graphics.bigprint( -1, 30, "Game Pad", tr, tg, tb, true);
+            graphics.Print( -1, 55, "Change controller options.", tr, tg, tb, true);
+            if (game.currentmenuoption == 0)
+            {
+                switch(game.controllerSensitivity)
+                {
+                case 0:
+                    graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
+                    graphics.Print( -1, 95, "[]..................", tr, tg, tb, true);
+                    break;
+                case 1:
+                    graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
+                    graphics.Print( -1, 95, ".....[].............", tr, tg, tb, true);
+                    break;
+                case 2:
+                    graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
+                    graphics.Print( -1, 95, ".........[].........", tr, tg, tb, true);
+                    break;
+                case 3:
+                    graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
+                    graphics.Print( -1, 95, ".............[].....", tr, tg, tb, true);
+                    break;
+                case 4:
+                    graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
+                    graphics.Print( -1, 95, "..................[]", tr, tg, tb, true);
+                    break;
+                }
+            }
+            if (game.currentmenuoption == 1 ||
+            game.currentmenuoption == 2 ||
+            game.currentmenuoption == 3)
+            {
+                graphics.Print( -1, 85, "Flip is bound to: " + std::string(UtilityClass::GCString(game.controllerButton_flip)) , tr, tg, tb, true);
+                graphics.Print( -1, 95, "Enter is bound to: "  + std::string(UtilityClass::GCString(game.controllerButton_map)), tr, tg, tb, true);
+                graphics.Print( -1, 105, "Menu is bound to: " + std::string(UtilityClass::GCString(game.controllerButton_esc)) , tr, tg, tb, true);
+            }
+        }
         else if (game.currentmenuname == "accessibility")
         {
             if (game.currentmenuoption == 0)
             {
-                dwgfx.bigprint( -1, 40, "Backgrounds", tr, tg, tb, true);
+                graphics.bigprint( -1, 40, "Backgrounds", tr, tg, tb, true);
                 if (!game.colourblindmode)
                 {
-                    dwgfx.Print( -1, 75, "Backgrounds are ON.", tr, tg, tb, true);
+                    graphics.Print( -1, 75, "Backgrounds are ON.", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 75, "Backgrounds are OFF.", tr/2, tg/2, tb/2, true);
+                    graphics.Print( -1, 75, "Backgrounds are OFF.", tr/2, tg/2, tb/2, true);
                 }
             }
             else if (game.currentmenuoption == 1)
             {
-                dwgfx.bigprint( -1, 40, "Screen Effects", tr, tg, tb, true);
-                dwgfx.Print( -1, 75, "Disables screen shakes and flashes.", tr, tg, tb, true);
+                graphics.bigprint( -1, 40, "Screen Effects", tr, tg, tb, true);
+                graphics.Print( -1, 75, "Disables screen shakes and flashes.", tr, tg, tb, true);
                 if (!game.noflashingmode)
                 {
-                    dwgfx.Print( -1, 85, "Screen Effects are ON.", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "Screen Effects are ON.", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 85, "Screen Effects are OFF.", tr/2, tg/2, tb/2, true);
+                    graphics.Print( -1, 85, "Screen Effects are OFF.", tr/2, tg/2, tb/2, true);
                 }
             }
             else if (game.currentmenuoption == 2)
             {
-                dwgfx.bigprint( -1, 40, "Text Outline", tr, tg, tb, true);
-                dwgfx.Print( -1, 75, "Disables outline on game text", tr, tg, tb, true);
+                graphics.bigprint( -1, 40, "Text Outline", tr, tg, tb, true);
+                graphics.Print( -1, 75, "Disables outline on game text", tr, tg, tb, true);
                 // FIXME: Maybe do an outlined print instead? -flibit
-                if (!dwgfx.notextoutline)
+                if (!graphics.notextoutline)
                 {
-                    dwgfx.Print( -1, 85, "Text outlines are ON.", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "Text outlines are ON.", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 85, "Text outlines are OFF.", tr/2, tg/2, tb/2, true);
+                    graphics.Print( -1, 85, "Text outlines are OFF.", tr/2, tg/2, tb/2, true);
                 }
             }
             else if (game.currentmenuoption == 3)
             {
-                dwgfx.bigprint( -1, 40, "Invincibility", tr, tg, tb, true);
-                dwgfx.Print( -1, 75, "Provided to help disabled gamers", tr, tg, tb, true);
-                dwgfx.Print( -1, 85, "explore the game. Can cause glitches.", tr, tg, tb, true);
+                graphics.bigprint( -1, 40, "Invincibility", tr, tg, tb, true);
+                graphics.Print( -1, 75, "Provided to help disabled gamers", tr, tg, tb, true);
+                graphics.Print( -1, 85, "explore the game. Can cause glitches.", tr, tg, tb, true);
                 if (map.invincibility)
                 {
-                    dwgfx.Print( -1, 105, "Invincibility is ON.", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "Invincibility is ON.", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 105, "Invincibility is off.", tr/2, tg/2, tb/2, true);
+                    graphics.Print( -1, 105, "Invincibility is off.", tr/2, tg/2, tb/2, true);
                 }
             }
             else if (game.currentmenuoption == 4)
             {
-                dwgfx.bigprint( -1, 40, "Game Speed", tr, tg, tb, true);
-                dwgfx.Print( -1, 75, "May be useful for disabled gamers", tr, tg, tb, true);
-                dwgfx.Print( -1, 85, "using one switch devices.", tr, tg, tb, true);
+                graphics.bigprint( -1, 40, "Game Speed", tr, tg, tb, true);
+                graphics.Print( -1, 75, "May be useful for disabled gamers", tr, tg, tb, true);
+                graphics.Print( -1, 85, "using one switch devices.", tr, tg, tb, true);
                 if (game.gameframerate==34)
                 {
-                    dwgfx.Print( -1, 105, "Game speed is normal.", tr/2, tg/2, tb/2, true);
+                    graphics.Print( -1, 105, "Game speed is normal.", tr/2, tg/2, tb/2, true);
                 }
                 else if (game.gameframerate==41)
                 {
-                    dwgfx.Print( -1, 105, "Game speed is at 80%", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "Game speed is at 80%", tr, tg, tb, true);
                 }
                 else if (game.gameframerate==55)
                 {
-                    dwgfx.Print( -1, 105, "Game speed is at 60%", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "Game speed is at 60%", tr, tg, tb, true);
                 }
                 else if (game.gameframerate==83)
                 {
-                    dwgfx.Print( -1, 105, "Game speed is at 40%", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "Game speed is at 40%", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 5)
             {
-                dwgfx.bigprint(-1, 30, "Fake Load Screen", tr, tg, tb, true);
+                graphics.bigprint(-1, 30, "Fake Load Screen", tr, tg, tb, true);
                 if (game.skipfakeload)
-                    dwgfx.Print(-1, 75, "Fake loading screen is OFF", tr/2, tg/2, tb/2, true);
+                    graphics.Print(-1, 75, "Fake loading screen is OFF", tr/2, tg/2, tb/2, true);
                 else
-                    dwgfx.Print(-1, 75, "Fake loading screen is ON", tr, tg, tb, true);
+                    graphics.Print(-1, 75, "Fake loading screen is ON", tr, tg, tb, true);
             }
             else if (game.currentmenuoption == 6)
             {
-                dwgfx.bigprint(-1, 30, "Room Name BG", tr, tg, tb, true);
-                dwgfx.Print( -1, 75, "Lets you see through what is behind", tr, tg, tb, true);
-                dwgfx.Print( -1, 85, "the name at the bottom of the screen.", tr, tg, tb, true);
-                if (dwgfx.translucentroomname)
-                    dwgfx.Print(-1, 105, "Room name background is TRANSLUCENT", tr/2, tg/2, tb/2, true);
+                graphics.bigprint(-1, 30, "Room Name BG", tr, tg, tb, true);
+                graphics.Print( -1, 75, "Lets you see through what is behind", tr, tg, tb, true);
+                graphics.Print( -1, 85, "the name at the bottom of the screen.", tr, tg, tb, true);
+                if (graphics.translucentroomname)
+                    graphics.Print(-1, 105, "Room name background is TRANSLUCENT", tr/2, tg/2, tb/2, true);
                 else
-                    dwgfx.Print(-1, 105, "Room name background is OPAQUE", tr, tg, tb, true);
+                    graphics.Print(-1, 105, "Room name background is OPAQUE", tr, tg, tb, true);
             }
         }
         else if (game.currentmenuname == "playint1" || game.currentmenuname == "playint2")
         {
-            dwgfx.Print( -1, 65, "Who do you want to play", tr, tg, tb, true);
-            dwgfx.Print( -1, 75, "the level with?", tr, tg, tb, true);
+            graphics.Print( -1, 65, "Who do you want to play", tr, tg, tb, true);
+            graphics.Print( -1, 75, "the level with?", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "playmodes")
         {
             if (game.currentmenuoption == 0)
             {
-                dwgfx.bigprint( -1, 30, "Time Trials", tr, tg, tb, true);
-                dwgfx.Print( -1, 65, "Replay any level in the game in", tr, tg, tb, true);
-                dwgfx.Print( -1, 75, "a competitive time trial mode.", tr, tg, tb, true);
+                graphics.bigprint( -1, 30, "Time Trials", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Replay any level in the game in", tr, tg, tb, true);
+                graphics.Print( -1, 75, "a competitive time trial mode.", tr, tg, tb, true);
 
                 if (game.gameframerate > 34 || map.invincibility)
                 {
-                    dwgfx.Print( -1, 105, "Time Trials are not available", tr, tg, tb, true);
-                    dwgfx.Print( -1, 115, "with slowdown or invincibility.", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "Time Trials are not available", tr, tg, tb, true);
+                    graphics.Print( -1, 115, "with slowdown or invincibility.", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 1)
             {
-                dwgfx.bigprint( -1, 30, "Intermissions", tr, tg, tb, true);
-                dwgfx.Print( -1, 65, "Replay the intermission levels.", tr, tg, tb, true);
+                graphics.bigprint( -1, 30, "Intermissions", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Replay the intermission levels.", tr, tg, tb, true);
 
                 if (!game.unlock[15] && !game.unlock[16])
                 {
-                    dwgfx.Print( -1, 95, "TO UNLOCK: Complete the", tr, tg, tb, true);
-                    dwgfx.Print( -1, 105, "intermission levels in-game.", tr, tg, tb, true);
+                    graphics.Print( -1, 95, "TO UNLOCK: Complete the", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "intermission levels in-game.", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 2)
             {
-                dwgfx.bigprint( -1, 30, "No Death Mode", tr, tg, tb, true);
-                dwgfx.Print( -1, 65, "Play the entire game", tr, tg, tb, true);
-                dwgfx.Print( -1, 75, "without dying once.", tr, tg, tb, true);
+                graphics.bigprint( -1, 30, "No Death Mode", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Play the entire game", tr, tg, tb, true);
+                graphics.Print( -1, 75, "without dying once.", tr, tg, tb, true);
 
                 if (game.gameframerate > 34 || map.invincibility)
                 {
-                    dwgfx.Print( -1, 105, "No death mode is not available", tr, tg, tb, true);
-                    dwgfx.Print( -1, 115, "with slowdown or invincibility.", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "No death mode is not available", tr, tg, tb, true);
+                    graphics.Print( -1, 115, "with slowdown or invincibility.", tr, tg, tb, true);
                 }
                 else if (!game.unlock[17])
                 {
-                    dwgfx.Print( -1, 105, "TO UNLOCK: Achieve an S-rank or", tr, tg, tb, true);
-                    dwgfx.Print( -1, 115, "above in at least 4 time trials.", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "TO UNLOCK: Achieve an S-rank or", tr, tg, tb, true);
+                    graphics.Print( -1, 115, "above in at least 4 time trials.", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 3)
             {
-                dwgfx.bigprint( -1, 30, "Flip Mode", tr, tg, tb, true);
-                dwgfx.Print( -1, 65, "Flip the entire game vertically.", tr, tg, tb, true);
-                dwgfx.Print( -1, 75, "Compatible with other game modes.", tr, tg, tb, true);
+                graphics.bigprint( -1, 30, "Flip Mode", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Flip the entire game vertically.", tr, tg, tb, true);
+                graphics.Print( -1, 75, "Compatible with other game modes.", tr, tg, tb, true);
 
                 if (game.unlock[18])
                 {
-                    if (dwgfx.setflipmode)
+                    if (graphics.setflipmode)
                     {
-                        dwgfx.Print( -1, 105, "Currently ENABLED!", tr, tg, tb, true);
+                        graphics.Print( -1, 105, "Currently ENABLED!", tr, tg, tb, true);
                     }
                     else
                     {
-                        dwgfx.Print( -1, 105, "Currently Disabled.", tr/2, tg/2, tb/2, true);
+                        graphics.Print( -1, 105, "Currently Disabled.", tr/2, tg/2, tb/2, true);
                     }
                 }
                 else
                 {
-                    dwgfx.Print( -1, 105, "TO UNLOCK: Complete the game.", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "TO UNLOCK: Complete the game.", tr, tg, tb, true);
                 }
             }
         }
         else if (game.currentmenuname == "youwannaquit")
         {
-            dwgfx.Print( -1, 75, "Are you sure you want to quit?", tr, tg, tb, true);
+            graphics.Print( -1, 75, "Are you sure you want to quit?", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "continue")
         {
-            dwgfx.crewframedelay--;
-            if (dwgfx.crewframedelay <= 0)
+            graphics.crewframedelay--;
+            if (graphics.crewframedelay <= 0)
             {
-                dwgfx.crewframedelay = 8;
-                dwgfx.crewframe = (dwgfx.crewframe + 1) % 2;
+                graphics.crewframedelay = 8;
+                graphics.crewframe = (graphics.crewframe + 1) % 2;
             }
             if (game.currentmenuoption == 0)
             {
                 //Show teleporter save info
-                dwgfx.drawpixeltextbox(25, 65-20, 270, 90, 34,12, 65, 185, 207,0,4);
+                graphics.drawpixeltextbox(25, 65-20, 270, 90, 34,12, 65, 185, 207,0,4);
 
-                dwgfx.bigprint(-1, 20, "Tele Save", tr, tg, tb, true);
-                dwgfx.Print(0, 80-20, game.tele_currentarea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
+                graphics.bigprint(-1, 20, "Tele Save", tr, tg, tb, true);
+                graphics.Print(0, 80-20, game.tele_currentarea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
                 for (int i = 0; i < 6; i++)
                 {
-                    dwgfx.drawcrewman(169-(3*42)+(i*42), 95-20, i, game.tele_crewstats[i], help, true);
+                    graphics.drawcrewman(169-(3*42)+(i*42), 95-20, i, game.tele_crewstats[i], true);
                 }
-                dwgfx.Print(160 - 84, 132-20, game.tele_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-                dwgfx.Print(160 + 40, 132-20, help.number(game.tele_trinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                graphics.Print(160 - 84, 132-20, game.tele_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                graphics.Print(160 + 40, 132-20, help.number(game.tele_trinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                dwgfx.drawspritesetcol(50, 126-20, 50, 18, help);
-                dwgfx.drawspritesetcol(175, 126-20, 22, 18, help);
+                graphics.drawspritesetcol(50, 126-20, 50, 18);
+                graphics.drawspritesetcol(175, 126-20, 22, 18);
             }
             else if (game.currentmenuoption == 1)
             {
                 //Show quick save info
-                dwgfx.drawpixeltextbox(25, 65-20, 270, 90, 34,12, 65, 185, 207,0,4);
+                graphics.drawpixeltextbox(25, 65-20, 270, 90, 34,12, 65, 185, 207,0,4);
 
-                dwgfx.bigprint(-1, 20, "Quick Save", tr, tg, tb, true);
-                dwgfx.Print(0, 80-20, game.quick_currentarea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
+                graphics.bigprint(-1, 20, "Quick Save", tr, tg, tb, true);
+                graphics.Print(0, 80-20, game.quick_currentarea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
                 for (int i = 0; i < 6; i++)
                 {
-                    dwgfx.drawcrewman(169-(3*42)+(i*42), 95-20, i, game.quick_crewstats[i], help, true);
+                    graphics.drawcrewman(169-(3*42)+(i*42), 95-20, i, game.quick_crewstats[i], true);
                 }
-                dwgfx.Print(160 - 84, 132-20, game.quick_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-                dwgfx.Print(160 + 40, 132-20, help.number(game.quick_trinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                graphics.Print(160 - 84, 132-20, game.quick_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                graphics.Print(160 + 40, 132-20, help.number(game.quick_trinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                dwgfx.drawspritesetcol(50, 126-20, 50, 18, help);
-                dwgfx.drawspritesetcol(175, 126-20, 22, 18, help);
+                graphics.drawspritesetcol(50, 126-20, 50, 18);
+                graphics.drawspritesetcol(175, 126-20, 22, 18);
             }
         }
         else if (game.currentmenuname == "gameover" || game.currentmenuname == "gameover2")
         {
-            dwgfx.bigprint( -1, 25, "GAME OVER", tr, tg, tb, true, 3);
+            graphics.bigprint( -1, 25, "GAME OVER", tr, tg, tb, true, 3);
 
-            dwgfx.crewframedelay--;
-            if (dwgfx.crewframedelay <= 0)
+            graphics.crewframedelay--;
+            if (graphics.crewframedelay <= 0)
             {
-                dwgfx.crewframedelay = 8;
-                dwgfx.crewframe = (dwgfx.crewframe + 1) % 2;
+                graphics.crewframedelay = 8;
+                graphics.crewframe = (graphics.crewframe + 1) % 2;
             }
             for (int i = 0; i < 6; i++)
             {
-                dwgfx.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], help, true);
+                graphics.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], true);
             }
             tempstring = "You rescued " + help.number(game.crewrescued()) + " crewmates";
-            dwgfx.Print(0, 100, tempstring, tr, tg, tb, true);
+            graphics.Print(0, 100, tempstring, tr, tg, tb, true);
 
             tempstring = "and found " + help.number(game.trinkets) + " trinkets.";
-            dwgfx.Print(0, 110, tempstring, tr, tg, tb, true);
+            graphics.Print(0, 110, tempstring, tr, tg, tb, true);
 
             tempstring = "You managed to reach:";
-            dwgfx.Print(0, 145, tempstring, tr, tg, tb, true);
-            dwgfx.Print(0, 155, game.hardestroom, tr, tg, tb, true);
+            graphics.Print(0, 145, tempstring, tr, tg, tb, true);
+            graphics.Print(0, 155, game.hardestroom, tr, tg, tb, true);
 
             if (game.crewrescued() == 1)
             {
@@ -702,68 +694,68 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 tempstring = "Er, how did you do that?";
             }
 
-            dwgfx.Print(0, 190, tempstring, tr, tg, tb, true);
+            graphics.Print(0, 190, tempstring, tr, tg, tb, true);
         }
         else if (game.currentmenuname == "nodeathmodecomplete" || game.currentmenuname == "nodeathmodecomplete2")
         {
-            dwgfx.bigprint( -1, 8, "WOW", tr, tg, tb, true, 4);
+            graphics.bigprint( -1, 8, "WOW", tr, tg, tb, true, 4);
 
-            dwgfx.crewframedelay--;
-            if (dwgfx.crewframedelay <= 0)
+            graphics.crewframedelay--;
+            if (graphics.crewframedelay <= 0)
             {
-                dwgfx.crewframedelay = 8;
-                dwgfx.crewframe = (dwgfx.crewframe + 1) % 2;
+                graphics.crewframedelay = 8;
+                graphics.crewframe = (graphics.crewframe + 1) % 2;
             }
             for (int i = 0; i < 6; i++)
             {
-                dwgfx.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], help, true);
+                graphics.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], true);
             }
             tempstring = "You rescued all the crewmates!";
-            dwgfx.Print(0, 100, tempstring, tr, tg, tb, true);
+            graphics.Print(0, 100, tempstring, tr, tg, tb, true);
 
             tempstring = "And you found " + help.number(game.trinkets) + " trinkets.";
-            dwgfx.Print(0, 110, tempstring, tr, tg, tb, true);
+            graphics.Print(0, 110, tempstring, tr, tg, tb, true);
 
-            dwgfx.Print(0, 160, "A new trophy has been awarded and", tr, tg, tb, true);
-            dwgfx.Print(0, 170, "placed in the secret lab to", tr, tg, tb, true);
-            dwgfx.Print(0, 180, "acknowledge your achievement!", tr, tg, tb, true);
+            graphics.Print(0, 160, "A new trophy has been awarded and", tr, tg, tb, true);
+            graphics.Print(0, 170, "placed in the secret lab to", tr, tg, tb, true);
+            graphics.Print(0, 180, "acknowledge your achievement!", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "timetrialcomplete" || game.currentmenuname == "timetrialcomplete2"
                  || game.currentmenuname == "timetrialcomplete3" || game.currentmenuname == "timetrialcomplete4")
         {
-            dwgfx.bigprint( -1, 20, "Results", tr, tg, tb, true, 3);
+            graphics.bigprint( -1, 20, "Results", tr, tg, tb, true, 3);
 
-            tempstring = game.resulttimestring(help) + " / " + game.partimestring(help);
+            tempstring = game.resulttimestring() + " / " + game.partimestring();
 
-            dwgfx.drawspritesetcol(30, 80-15, 50, 22, help);
-            dwgfx.Print(65, 80-15, "TIME TAKEN:", 255, 255, 255);
-            dwgfx.Print(65, 90-15, tempstring, tr, tg, tb);
+            graphics.drawspritesetcol(30, 80-15, 50, 22);
+            graphics.Print(65, 80-15, "TIME TAKEN:", 255, 255, 255);
+            graphics.Print(65, 90-15, tempstring, tr, tg, tb);
             if (game.timetrialresulttime <= game.timetrialpar)
             {
-                dwgfx.Print(220, 85-15, "+1 Rank!", 255, 255, 255);
+                graphics.Print(220, 85-15, "+1 Rank!", 255, 255, 255);
             }
 
             tempstring = help.String(game.deathcounts);
-            dwgfx.drawspritesetcol(30-4, 80+20-4, 12, 22, help);
-            dwgfx.Print(65, 80+20, "NUMBER OF DEATHS:", 255, 255, 255);
-            dwgfx.Print(65, 90+20, tempstring, tr, tg, tb);
+            graphics.drawspritesetcol(30-4, 80+20-4, 12, 22);
+            graphics.Print(65, 80+20, "NUMBER OF DEATHS:", 255, 255, 255);
+            graphics.Print(65, 90+20, tempstring, tr, tg, tb);
             if (game.deathcounts == 0)
             {
-                dwgfx.Print(220, 85+20, "+1 Rank!", 255, 255, 255);
+                graphics.Print(220, 85+20, "+1 Rank!", 255, 255, 255);
             }
 
             tempstring = help.String(game.trinkets) + " of " + help.String(game.timetrialshinytarget);
-            dwgfx.drawspritesetcol(30, 80+55, 22, 22, help);
-            dwgfx.Print(65, 80+55, "SHINY TRINKETS:", 255, 255, 255);
-            dwgfx.Print(65, 90+55, tempstring, tr, tg, tb);
+            graphics.drawspritesetcol(30, 80+55, 22, 22);
+            graphics.Print(65, 80+55, "SHINY TRINKETS:", 255, 255, 255);
+            graphics.Print(65, 90+55, tempstring, tr, tg, tb);
             if (game.trinkets >= game.timetrialshinytarget)
             {
-                dwgfx.Print(220, 85+55, "+1 Rank!", 255, 255, 255);
+                graphics.Print(220, 85+55, "+1 Rank!", 255, 255, 255);
             }
 
             if (game.currentmenuname == "timetrialcomplete2" || game.currentmenuname == "timetrialcomplete3")
             {
-                dwgfx.bigprint( 100, 175, "Rank:", tr, tg, tb, false, 2);
+                graphics.bigprint( 100, 175, "Rank:", tr, tg, tb, false, 2);
             }
 
             if (game.currentmenuname == "timetrialcomplete3")
@@ -771,25 +763,25 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 switch(game.timetrialrank)
                 {
                 case 0:
-                    dwgfx.bigprint( 195, 165, "B", 255, 255, 255, false, 4);
+                    graphics.bigprint( 195, 165, "B", 255, 255, 255, false, 4);
                     break;
                 case 1:
-                    dwgfx.bigprint( 195, 165, "A", 255, 255, 255, false, 4);
+                    graphics.bigprint( 195, 165, "A", 255, 255, 255, false, 4);
                     break;
                 case 2:
-                    dwgfx.bigprint( 195, 165, "S", 255, 255, 255, false, 4);
+                    graphics.bigprint( 195, 165, "S", 255, 255, 255, false, 4);
                     break;
                 case 3:
-                    dwgfx.bigprint( 195, 165, "V", 255, 255, 255, false, 4);
+                    graphics.bigprint( 195, 165, "V", 255, 255, 255, false, 4);
                     break;
                 }
             }
         }
         else if (game.currentmenuname == "unlockmenutrials")
         {
-            dwgfx.bigprint( -1, 30, "Unlock Time Trials", tr, tg, tb, true);
-            dwgfx.Print( -1, 65, "You can unlock each time", tr, tg, tb, true);
-            dwgfx.Print( -1, 75, "trial separately.", tr, tg, tb, true);
+            graphics.bigprint( -1, 30, "Unlock Time Trials", tr, tg, tb, true);
+            graphics.Print( -1, 65, "You can unlock each time", tr, tg, tb, true);
+            graphics.Print( -1, 75, "trial separately.", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "timetrials")
         {
@@ -797,36 +789,36 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
             {
                 if(game.unlock[9])
                 {
-                    dwgfx.bigprint( -1, 30, "Space Station 1", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "Space Station 1", tr, tg, tb, true);
                     if (game.besttimes[0] == -1)
                     {
-                        dwgfx.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
+                        graphics.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
                     }
                     else
                     {
-                        dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
-                        dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
-                        dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[0], help), tr, tg, tb);
-                        dwgfx.Print( 110, 75, help.String(game.besttrinkets[0])+"/2", tr, tg, tb);
-                        dwgfx.Print( 110, 85,help.String(game.bestlives[0]), tr, tg, tb);
+                        graphics.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
+                        graphics.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
+                        graphics.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
+                        graphics.Print( 110, 65, game.timetstring(game.besttimes[0]), tr, tg, tb);
+                        graphics.Print( 110, 75, help.String(game.besttrinkets[0])+"/2", tr, tg, tb);
+                        graphics.Print( 110, 85,help.String(game.bestlives[0]), tr, tg, tb);
 
 
-                        dwgfx.Print( 170, 65, "PAR TIME    1:15", tr, tg, tb);
-                        dwgfx.Print( 170, 85, "Best Rank", tr, tg, tb);
+                        graphics.Print( 170, 65, "PAR TIME    1:15", tr, tg, tb);
+                        graphics.Print( 170, 85, "Best Rank", tr, tg, tb);
                         switch(game.bestrank[0])
                         {
                         case 0:
-                            dwgfx.bigprint( 275, 82, "B", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "B", 225, 225, 225);
                             break;
                         case 1:
-                            dwgfx.bigprint( 275, 82, "A", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "A", 225, 225, 225);
                             break;
                         case 2:
-                            dwgfx.bigprint( 275, 82, "S", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "S", 225, 225, 225);
                             break;
                         case 3:
-                            dwgfx.bigprint( 275, 82, "V", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "V", 225, 225, 225);
                             break;
                         }
                     }
@@ -834,46 +826,46 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 }
                 else
                 {
-                    dwgfx.bigprint( -1, 30, "???", tr, tg, tb, true);
-                    dwgfx.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
-                    dwgfx.Print( -1, 75, "Rescue Violet", tr, tg, tb, true);
-                    dwgfx.Print( -1, 85, "Find three trinkets", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "???", tr, tg, tb, true);
+                    graphics.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
+                    graphics.Print( -1, 75, "Rescue Violet", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "Find three trinkets", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 1)
             {
                 if(game.unlock[10])
                 {
-                    dwgfx.bigprint( -1, 30, "The Laboratory", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "The Laboratory", tr, tg, tb, true);
                     if (game.besttimes[1] == -1)
                     {
-                        dwgfx.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
+                        graphics.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
                     }
                     else
                     {
-                        dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
-                        dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
-                        dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[1], help), tr, tg, tb);
-                        dwgfx.Print( 110, 75, help.String(game.besttrinkets[1])+"/4", tr, tg, tb);
-                        dwgfx.Print( 110, 85, help.String(game.bestlives[1]), tr, tg, tb);
+                        graphics.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
+                        graphics.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
+                        graphics.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
+                        graphics.Print( 110, 65, game.timetstring(game.besttimes[1]), tr, tg, tb);
+                        graphics.Print( 110, 75, help.String(game.besttrinkets[1])+"/4", tr, tg, tb);
+                        graphics.Print( 110, 85, help.String(game.bestlives[1]), tr, tg, tb);
 
 
-                        dwgfx.Print( 170, 65, "PAR TIME    2:45", tr, tg, tb);
-                        dwgfx.Print( 170, 85, "Best Rank", tr, tg, tb);
+                        graphics.Print( 170, 65, "PAR TIME    2:45", tr, tg, tb);
+                        graphics.Print( 170, 85, "Best Rank", tr, tg, tb);
                         switch(game.bestrank[1])
                         {
                         case 0:
-                            dwgfx.bigprint( 275, 82, "B", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "B", 225, 225, 225);
                             break;
                         case 1:
-                            dwgfx.bigprint( 275, 82, "A", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "A", 225, 225, 225);
                             break;
                         case 2:
-                            dwgfx.bigprint( 275, 82, "S", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "S", 225, 225, 225);
                             break;
                         case 3:
-                            dwgfx.bigprint( 275, 82, "V", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "V", 225, 225, 225);
                             break;
                         }
                     }
@@ -881,46 +873,46 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 }
                 else
                 {
-                    dwgfx.bigprint( -1, 30, "???", tr, tg, tb, true);
-                    dwgfx.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
-                    dwgfx.Print( -1, 75, "Rescue Victoria", tr, tg, tb, true);
-                    dwgfx.Print( -1, 85, "Find six trinkets", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "???", tr, tg, tb, true);
+                    graphics.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
+                    graphics.Print( -1, 75, "Rescue Victoria", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "Find six trinkets", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 2)
             {
                 if(game.unlock[11])
                 {
-                    dwgfx.bigprint( -1, 30, "The Tower", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "The Tower", tr, tg, tb, true);
                     if (game.besttimes[2] == -1)
                     {
-                        dwgfx.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
+                        graphics.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
                     }
                     else
                     {
-                        dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
-                        dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
-                        dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[2], help), tr, tg, tb);
-                        dwgfx.Print( 110, 75, help.String(game.besttrinkets[2])+"/2", tr, tg, tb);
-                        dwgfx.Print( 110, 85, help.String(game.bestlives[2]), tr, tg, tb);
+                        graphics.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
+                        graphics.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
+                        graphics.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
+                        graphics.Print( 110, 65, game.timetstring(game.besttimes[2]), tr, tg, tb);
+                        graphics.Print( 110, 75, help.String(game.besttrinkets[2])+"/2", tr, tg, tb);
+                        graphics.Print( 110, 85, help.String(game.bestlives[2]), tr, tg, tb);
 
 
-                        dwgfx.Print( 170, 65, "PAR TIME    1:45", tr, tg, tb);
-                        dwgfx.Print( 170, 85, "Best Rank", tr, tg, tb);
+                        graphics.Print( 170, 65, "PAR TIME    1:45", tr, tg, tb);
+                        graphics.Print( 170, 85, "Best Rank", tr, tg, tb);
                         switch(game.bestrank[2])
                         {
                         case 0:
-                            dwgfx.bigprint( 275, 82, "B", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "B", 225, 225, 225);
                             break;
                         case 1:
-                            dwgfx.bigprint( 275, 82, "A", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "A", 225, 225, 225);
                             break;
                         case 2:
-                            dwgfx.bigprint( 275, 82, "S", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "S", 225, 225, 225);
                             break;
                         case 3:
-                            dwgfx.bigprint( 275, 82, "V", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "V", 225, 225, 225);
                             break;
                         }
                     }
@@ -928,46 +920,46 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 }
                 else
                 {
-                    dwgfx.bigprint( -1, 30, "???", tr, tg, tb, true);
-                    dwgfx.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
-                    dwgfx.Print( -1, 75, "Rescue Vermilion", tr, tg, tb, true);
-                    dwgfx.Print( -1, 85, "Find nine trinkets", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "???", tr, tg, tb, true);
+                    graphics.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
+                    graphics.Print( -1, 75, "Rescue Vermilion", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "Find nine trinkets", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 3)
             {
                 if(game.unlock[12])
                 {
-                    dwgfx.bigprint( -1, 30, "Space Station 2", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "Space Station 2", tr, tg, tb, true);
                     if (game.besttimes[3] == -1)
                     {
-                        dwgfx.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
+                        graphics.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
                     }
                     else
                     {
-                        dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
-                        dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
-                        dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[3], help), tr, tg, tb);
-                        dwgfx.Print( 110, 75, help.String(game.besttrinkets[3])+"/5", tr, tg, tb);
-                        dwgfx.Print( 110, 85, help.String(game.bestlives[3]), tr, tg, tb);
+                        graphics.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
+                        graphics.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
+                        graphics.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
+                        graphics.Print( 110, 65, game.timetstring(game.besttimes[3]), tr, tg, tb);
+                        graphics.Print( 110, 75, help.String(game.besttrinkets[3])+"/5", tr, tg, tb);
+                        graphics.Print( 110, 85, help.String(game.bestlives[3]), tr, tg, tb);
 
 
-                        dwgfx.Print( 170, 65, "PAR TIME    3:20", tr, tg, tb);
-                        dwgfx.Print( 170, 85, "Best Rank", tr, tg, tb);
+                        graphics.Print( 170, 65, "PAR TIME    3:20", tr, tg, tb);
+                        graphics.Print( 170, 85, "Best Rank", tr, tg, tb);
                         switch(game.bestrank[3])
                         {
                         case 0:
-                            dwgfx.bigprint( 275, 82, "B", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "B", 225, 225, 225);
                             break;
                         case 1:
-                            dwgfx.bigprint( 275, 82, "A", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "A", 225, 225, 225);
                             break;
                         case 2:
-                            dwgfx.bigprint( 275, 82, "S", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "S", 225, 225, 225);
                             break;
                         case 3:
-                            dwgfx.bigprint( 275, 82, "V", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "V", 225, 225, 225);
                             break;
                         }
                     }
@@ -975,46 +967,46 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 }
                 else
                 {
-                    dwgfx.bigprint( -1, 30, "???", tr, tg, tb, true);
-                    dwgfx.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
-                    dwgfx.Print( -1, 75, "Rescue Vitellary", tr, tg, tb, true);
-                    dwgfx.Print( -1, 85, "Find twelve trinkets", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "???", tr, tg, tb, true);
+                    graphics.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
+                    graphics.Print( -1, 75, "Rescue Vitellary", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "Find twelve trinkets", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 4)
             {
                 if(game.unlock[13])
                 {
-                    dwgfx.bigprint( -1, 30, "The Warp Zone", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "The Warp Zone", tr, tg, tb, true);
                     if (game.besttimes[4] == -1)
                     {
-                        dwgfx.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
+                        graphics.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
                     }
                     else
                     {
-                        dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
-                        dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
-                        dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[4], help), tr, tg, tb);
-                        dwgfx.Print( 110, 75, help.String(game.besttrinkets[4])+"/1", tr, tg, tb);
-                        dwgfx.Print( 110, 85, help.String(game.bestlives[4]), tr, tg, tb);
+                        graphics.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
+                        graphics.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
+                        graphics.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
+                        graphics.Print( 110, 65, game.timetstring(game.besttimes[4]), tr, tg, tb);
+                        graphics.Print( 110, 75, help.String(game.besttrinkets[4])+"/1", tr, tg, tb);
+                        graphics.Print( 110, 85, help.String(game.bestlives[4]), tr, tg, tb);
 
 
-                        dwgfx.Print( 170, 65, "PAR TIME    2:00", tr, tg, tb);
-                        dwgfx.Print( 170, 85, "Best Rank", tr, tg, tb);
+                        graphics.Print( 170, 65, "PAR TIME    2:00", tr, tg, tb);
+                        graphics.Print( 170, 85, "Best Rank", tr, tg, tb);
                         switch(game.bestrank[4])
                         {
                         case 0:
-                            dwgfx.bigprint( 275, 82, "B", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "B", 225, 225, 225);
                             break;
                         case 1:
-                            dwgfx.bigprint( 275, 82, "A", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "A", 225, 225, 225);
                             break;
                         case 2:
-                            dwgfx.bigprint( 275, 82, "S", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "S", 225, 225, 225);
                             break;
                         case 3:
-                            dwgfx.bigprint( 275, 82, "V", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "V", 225, 225, 225);
                             break;
                         }
                     }
@@ -1022,46 +1014,46 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 }
                 else
                 {
-                    dwgfx.bigprint( -1, 30, "???", tr, tg, tb, true);
-                    dwgfx.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
-                    dwgfx.Print( -1, 75, "Rescue Verdigris", tr, tg, tb, true);
-                    dwgfx.Print( -1, 85, "Find fifteen trinkets", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "???", tr, tg, tb, true);
+                    graphics.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
+                    graphics.Print( -1, 75, "Rescue Verdigris", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "Find fifteen trinkets", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 5)
             {
                 if(game.unlock[14])
                 {
-                    dwgfx.bigprint( -1, 30, "The Final Level", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "The Final Level", tr, tg, tb, true);
                     if (game.besttimes[5] == -1)
                     {
-                        dwgfx.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
+                        graphics.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
                     }
                     else
                     {
-                        dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
-                        dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
-                        dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[5], help), tr, tg, tb);
-                        dwgfx.Print( 110, 75, help.String(game.besttrinkets[5])+"/1", tr, tg, tb);
-                        dwgfx.Print( 110, 85, help.String(game.bestlives[5]), tr, tg, tb);
+                        graphics.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
+                        graphics.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
+                        graphics.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
+                        graphics.Print( 110, 65, game.timetstring(game.besttimes[5]), tr, tg, tb);
+                        graphics.Print( 110, 75, help.String(game.besttrinkets[5])+"/1", tr, tg, tb);
+                        graphics.Print( 110, 85, help.String(game.bestlives[5]), tr, tg, tb);
 
 
-                        dwgfx.Print( 170, 65, "PAR TIME    2:15", tr, tg, tb);
-                        dwgfx.Print( 170, 85, "Best Rank", tr, tg, tb);
+                        graphics.Print( 170, 65, "PAR TIME    2:15", tr, tg, tb);
+                        graphics.Print( 170, 85, "Best Rank", tr, tg, tb);
                         switch(game.bestrank[5])
                         {
                         case 0:
-                            dwgfx.bigprint( 275, 82, "B", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "B", 225, 225, 225);
                             break;
                         case 1:
-                            dwgfx.bigprint( 275, 82, "A", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "A", 225, 225, 225);
                             break;
                         case 2:
-                            dwgfx.bigprint( 275, 82, "S", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "S", 225, 225, 225);
                             break;
                         case 3:
-                            dwgfx.bigprint( 275, 82, "V", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "V", 225, 225, 225);
                             break;
                         }
                     }
@@ -1069,109 +1061,85 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 }
                 else
                 {
-                    dwgfx.bigprint( -1, 30, "???", tr, tg, tb, true);
-                    dwgfx.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
-                    dwgfx.Print( -1, 75, "Complete the game", tr, tg, tb, true);
-                    dwgfx.Print( -1, 85, "Find eighteen trinkets", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "???", tr, tg, tb, true);
+                    graphics.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
+                    graphics.Print( -1, 75, "Complete the game", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "Find eighteen trinkets", tr, tg, tb, true);
                 }
             }
         }
         else if (game.currentmenuname == "gamecompletecontinue")
         {
-            dwgfx.bigprint( -1, 25, "Congratulations!", tr, tg, tb, true, 2);
+            graphics.bigprint( -1, 25, "Congratulations!", tr, tg, tb, true, 2);
 
-            dwgfx.Print( -1, 45, "Your save files have been updated.", tr, tg, tb, true);
+            graphics.Print( -1, 45, "Your save files have been updated.", tr, tg, tb, true);
 
-            dwgfx.Print( -1, 110, "If you want to keep exploring", tr, tg, tb, true);
-            dwgfx.Print( -1, 120, "the game, select CONTINUE", tr, tg, tb, true);
-            dwgfx.Print( -1, 130, "from the play menu.", tr, tg, tb, true);
+            graphics.Print( -1, 110, "If you want to keep exploring", tr, tg, tb, true);
+            graphics.Print( -1, 120, "the game, select CONTINUE", tr, tg, tb, true);
+            graphics.Print( -1, 130, "from the play menu.", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "unlockmenu")
         {
-            dwgfx.bigprint( -1, 25, "Unlock Play Modes", tr, tg, tb, true, 2);
+            graphics.bigprint( -1, 25, "Unlock Play Modes", tr, tg, tb, true, 2);
 
-            dwgfx.Print( -1, 55, "From here, you may unlock parts", tr, tg, tb, true);
-            dwgfx.Print( -1, 65, "of the game that are normally", tr, tg, tb, true);
-            dwgfx.Print( -1, 75, "unlocked as you play.", tr, tg, tb, true);
+            graphics.Print( -1, 55, "From here, you may unlock parts", tr, tg, tb, true);
+            graphics.Print( -1, 65, "of the game that are normally", tr, tg, tb, true);
+            graphics.Print( -1, 75, "unlocked as you play.", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "unlocktimetrial")
         {
-            dwgfx.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
+            graphics.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
 
-            dwgfx.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
-            dwgfx.Print( -1, 135, "a new Time Trial.", tr, tg, tb, true);
+            graphics.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
+            graphics.Print( -1, 135, "a new Time Trial.", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "unlocktimetrials")
         {
-            dwgfx.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
+            graphics.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
 
-            dwgfx.Print( -1, 125, "Your have unlocked some", tr, tg, tb, true);
-            dwgfx.Print( -1, 135, "new Time Trials.", tr, tg, tb, true);
+            graphics.Print( -1, 125, "Your have unlocked some", tr, tg, tb, true);
+            graphics.Print( -1, 135, "new Time Trials.", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "unlocknodeathmode")
         {
-            dwgfx.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
+            graphics.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
 
-            dwgfx.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
-            dwgfx.Print( -1, 135, "No Death Mode.", tr, tg, tb, true);
+            graphics.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
+            graphics.Print( -1, 135, "No Death Mode.", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "unlockflipmode")
         {
-            dwgfx.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
+            graphics.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
 
-            dwgfx.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
-            dwgfx.Print( -1, 135, "Flip Mode.", tr, tg, tb, true);
+            graphics.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
+            graphics.Print( -1, 135, "Flip Mode.", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "unlockintermission")
         {
-            dwgfx.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
+            graphics.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
 
-            dwgfx.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
-            dwgfx.Print( -1, 135, "the intermission levels.", tr, tg, tb, true);
+            graphics.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
+            graphics.Print( -1, 135, "the intermission levels.", tr, tg, tb, true);
         }else if (game.currentmenuname == "playerworlds")
         {   
-						dwgfx.tempstring = FILESYSTEM_getUserLevelDirectory();
-						if(dwgfx.tempstring.length()>80){
-							dwgfx.Print( -1, 160, "To install new player levels, copy", tr, tg, tb, true);
-							dwgfx.Print( -1, 170, "the .vvvvvv files to this folder:", tr, tg, tb, true);
-							dwgfx.Print( 320-((dwgfx.tempstring.length()-80)*8), 190, dwgfx.tempstring.substr(0,dwgfx.tempstring.length()-80), tr, tg, tb);
-							dwgfx.Print( 0, 200, dwgfx.tempstring.substr(dwgfx.tempstring.length()-80,40), tr, tg, tb);
-							dwgfx.Print( 0, 210, dwgfx.tempstring.substr(dwgfx.tempstring.length()-40,40), tr, tg, tb);
-						}else if(dwgfx.tempstring.length()>40){
-							dwgfx.Print( -1, 170, "To install new player levels, copy", tr, tg, tb, true);
-							dwgfx.Print( -1, 180, "the .vvvvvv files to this folder:", tr, tg, tb, true);
-							dwgfx.Print( 320-((dwgfx.tempstring.length()-40)*8), 200, dwgfx.tempstring.substr(0,dwgfx.tempstring.length()-40), tr, tg, tb);
-							dwgfx.Print( 0, 210, dwgfx.tempstring.substr(dwgfx.tempstring.length()-40,40), tr, tg, tb);
+						graphics.tempstring = FILESYSTEM_getUserLevelDirectory();
+						if(graphics.tempstring.length()>80){
+							graphics.Print( -1, 160, "To install new player levels, copy", tr, tg, tb, true);
+							graphics.Print( -1, 170, "the .vvvvvv files to this folder:", tr, tg, tb, true);
+							graphics.Print( 320-((graphics.tempstring.length()-80)*8), 190, graphics.tempstring.substr(0,graphics.tempstring.length()-80), tr, tg, tb);
+							graphics.Print( 0, 200, graphics.tempstring.substr(graphics.tempstring.length()-80,40), tr, tg, tb);
+							graphics.Print( 0, 210, graphics.tempstring.substr(graphics.tempstring.length()-40,40), tr, tg, tb);
+						}else if(graphics.tempstring.length()>40){
+							graphics.Print( -1, 170, "To install new player levels, copy", tr, tg, tb, true);
+							graphics.Print( -1, 180, "the .vvvvvv files to this folder:", tr, tg, tb, true);
+							graphics.Print( 320-((graphics.tempstring.length()-40)*8), 200, graphics.tempstring.substr(0,graphics.tempstring.length()-40), tr, tg, tb);
+							graphics.Print( 0, 210, graphics.tempstring.substr(graphics.tempstring.length()-40,40), tr, tg, tb);
 						}else{
-							dwgfx.Print( -1, 180, "To install new player levels, copy", tr, tg, tb, true);
-							dwgfx.Print( -1, 190, "the .vvvvvv files to this folder:", tr, tg, tb, true);
-							dwgfx.Print( 320-(dwgfx.tempstring.length()*8), 210, dwgfx.tempstring, tr, tg, tb);
+							graphics.Print( -1, 180, "To install new player levels, copy", tr, tg, tb, true);
+							graphics.Print( -1, 190, "the .vvvvvv files to this folder:", tr, tg, tb, true);
+							graphics.Print( 320-(graphics.tempstring.length()*8), 210, graphics.tempstring, tr, tg, tb);
 						}
         }
-
-        /*
-        switch(game.mainmenu) {
-        	case 0:
-        		dwgfx.Print(5, 115, "[ NEW GAME ]", tr, tg, tb, true);
-        	break;
-        	case 1:
-        		if (game.telesummary == "") {
-        			dwgfx.Print(5, 115, "[ no teleporter save ]", tr/3, tg/3, tb/3, true);
-        		}else {
-        			dwgfx.Print(5, 115, "[ RESTORE FROM LAST TELEPORTER ]", tr, tg, tb, true);
-        			dwgfx.Print(5, 125, game.telesummary, tr, tg, tb, true);
-        		}
-        	break;
-        	case 2:
-        		if (game.quicksummary == "") {
-        			dwgfx.Print(5, 115, "[ no quicksave ]", tr/3, tg/3, tb/3, true);
-        		}else {
-        			dwgfx.Print(5, 115, "[ RESTORE FROM LAST QUICKSAVE ]", tr, tg, tb, true);
-        			dwgfx.Print(5, 125, game.quicksummary, tr, tg, tb, true);
-        		}
-        	break;
-        }
-        */
 
         tr = int(tr * .8f);
         tg = int(tg * .8f);
@@ -1184,73 +1152,63 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
         if(tb>255) tb=255;
         if (game.currentmenuname == "timetrials" || game.currentmenuname == "unlockmenutrials")
         {
-            dwgfx.drawmenu(game, tr, tg, tb, 15);
+            graphics.drawmenu(tr, tg, tb, 15);
         }
         else if (game.currentmenuname == "unlockmenu")
         {
-            dwgfx.drawmenu(game, tr, tg, tb, 15);
+            graphics.drawmenu(tr, tg, tb, 15);
         }
         else if (game.currentmenuname == "playmodes")
         {
-            dwgfx.drawmenu(game, tr, tg, tb, 20);
+            graphics.drawmenu(tr, tg, tb, 20);
         }
         else if (game.currentmenuname == "mainmenu")
         {
-            dwgfx.drawmenu(game, tr, tg, tb, 15);
+            graphics.drawmenu(tr, tg, tb, 15);
         }
         else if (game.currentmenuname == "playerworlds")
         {
-            dwgfx.drawmenu(game, tr, tg, tb, 15);
+            graphics.drawmenu(tr, tg, tb, 15);
         }
         else if (game.currentmenuname == "levellist")
         {
-            dwgfx.drawlevelmenu(game, tr, tg, tb, 5);
+            graphics.drawlevelmenu(tr, tg, tb, 5);
         }
         else
         {
-            dwgfx.drawmenu(game, tr, tg, tb);
+            graphics.drawmenu(tr, tg, tb);
         }
-
-        //dwgfx.Print(5, 228, "Left/Right to Choose, V to Select", tr, tg, tb, true);
     }
 
     if (game.test)
     {
-        dwgfx.Print(5, 5, game.teststring, 196, 196, 255, false);
+        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
     }
 
-    dwgfx.drawfade();
+    graphics.drawfade();
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
-        dwgfx.flashlight();
+        graphics.flashlight();
     }
 
     if (game.screenshake > 0  && !game.noflashingmode)
     {
         game.screenshake--;
-        dwgfx.screenshake();
+        graphics.screenshake();
     }
     else
     {
-        dwgfx.render();
+        graphics.render();
     }
-    //dwgfx.backbuffer.unlock();
 }
 
-void gamecompleterender(Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help, mapclass& map)
+void gamecompleterender()
 {
-    //dwgfx.backbuffer.lock();
-    FillRect(dwgfx.backBuffer, 0x000000);
+    FillRect(graphics.backBuffer, 0x000000);
 
-    if(!game.colourblindmode) dwgfx.drawtowerbackgroundsolo(map);
-    //dwgfx.drawtowermap(map);
-
-    for (int i = 0; i < 6; i++)
-    {
-        //dwgfx.drawsprite((160-96)+ i * 32, 10, 23, 96+(i*10)+(random()*16), 196-(help.glow)-(random()*16), 255 - (help.glow*2));
-    }
+    if(!game.colourblindmode) graphics.drawtowerbackgroundsolo();
 
     tr = map.r - (help.glow / 4) - fRandom() * 4;
     tg = map.g - (help.glow / 4) - fRandom() * 4;
@@ -1265,164 +1223,162 @@ void gamecompleterender(Graphics& dwgfx, Game& game, entityclass& obj, UtilityCl
 
     //rendering starts... here!
 
-    if (dwgfx.onscreen(220 + game.creditposition))
+    if (graphics.onscreen(220 + game.creditposition))
     {
         temp = 220 + game.creditposition;
-        dwgfx.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
     }
 
-    if (dwgfx.onscreen(290 + game.creditposition)) dwgfx.bigprint( -1, 290 + game.creditposition, "Starring", tr, tg, tb, true, 2);
+    if (graphics.onscreen(290 + game.creditposition)) graphics.bigprint( -1, 290 + game.creditposition, "Starring", tr, tg, tb, true, 2);
 
-    if (dwgfx.onscreen(320 + game.creditposition))
+    if (graphics.onscreen(320 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 320 + game.creditposition, 0, true, help);
-        dwgfx.Print(100, 330 + game.creditposition, "Captain Viridian", tr, tg, tb);
+        graphics.drawcrewman(70, 320 + game.creditposition, 0, true);
+        graphics.Print(100, 330 + game.creditposition, "Captain Viridian", tr, tg, tb);
     }
-    if (dwgfx.onscreen(350 + game.creditposition))
+    if (graphics.onscreen(350 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 350 + game.creditposition, 1, true, help);
-        dwgfx.Print(100, 360 + game.creditposition, "Doctor Violet", tr, tg, tb);
+        graphics.drawcrewman(70, 350 + game.creditposition, 1, true);
+        graphics.Print(100, 360 + game.creditposition, "Doctor Violet", tr, tg, tb);
     }
-    if (dwgfx.onscreen(380 + game.creditposition))
+    if (graphics.onscreen(380 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 380 + game.creditposition, 2, true, help);
-        dwgfx.Print(100, 390 + game.creditposition, "Professor Vitellary", tr, tg, tb);
+        graphics.drawcrewman(70, 380 + game.creditposition, 2, true);
+        graphics.Print(100, 390 + game.creditposition, "Professor Vitellary", tr, tg, tb);
     }
-    if (dwgfx.onscreen(410 + game.creditposition))
+    if (graphics.onscreen(410 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 410 + game.creditposition, 3, true, help);
-        dwgfx.Print(100, 420 + game.creditposition, "Officer Vermilion", tr, tg, tb);
+        graphics.drawcrewman(70, 410 + game.creditposition, 3, true);
+        graphics.Print(100, 420 + game.creditposition, "Officer Vermilion", tr, tg, tb);
     }
-    if (dwgfx.onscreen(440 + game.creditposition))
+    if (graphics.onscreen(440 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 440 + game.creditposition, 4, true, help);
-        dwgfx.Print(100, 450 + game.creditposition, "Chief Verdigris", tr, tg, tb);
+        graphics.drawcrewman(70, 440 + game.creditposition, 4, true);
+        graphics.Print(100, 450 + game.creditposition, "Chief Verdigris", tr, tg, tb);
     }
-    if (dwgfx.onscreen(470 + game.creditposition))
+    if (graphics.onscreen(470 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 470 + game.creditposition, 5, true, help);
-        dwgfx.Print(100, 480 + game.creditposition, "Doctor Victoria", tr, tg, tb);
-    }
-
-    if (dwgfx.onscreen(520 + game.creditposition)) dwgfx.bigprint( -1, 520 + game.creditposition, "Credits", tr, tg, tb, true, 3);
-
-    if (dwgfx.onscreen(560 + game.creditposition))
-    {
-        dwgfx.Print(40, 560 + game.creditposition, "Created by", tr, tg, tb);
-        dwgfx.bigprint(60, 570 + game.creditposition, "Terry Cavanagh", tr, tg, tb);
+        graphics.drawcrewman(70, 470 + game.creditposition, 5, true);
+        graphics.Print(100, 480 + game.creditposition, "Doctor Victoria", tr, tg, tb);
     }
 
-    if (dwgfx.onscreen(600 + game.creditposition))
+    if (graphics.onscreen(520 + game.creditposition)) graphics.bigprint( -1, 520 + game.creditposition, "Credits", tr, tg, tb, true, 3);
+
+    if (graphics.onscreen(560 + game.creditposition))
     {
-        dwgfx.Print(40, 600 + game.creditposition, "With Music by", tr, tg, tb);
-        dwgfx.bigprint(60, 610 + game.creditposition, "Magnus P~lsson", tr, tg, tb);
+        graphics.Print(40, 560 + game.creditposition, "Created by", tr, tg, tb);
+        graphics.bigprint(60, 570 + game.creditposition, "Terry Cavanagh", tr, tg, tb);
     }
 
-    if (dwgfx.onscreen(640 + game.creditposition))
+    if (graphics.onscreen(600 + game.creditposition))
     {
-        dwgfx.Print(40, 640 + game.creditposition, "Rooms Named by", tr, tg, tb);
-        dwgfx.bigprint(60, 650 + game.creditposition, "Bennett Foddy", tr, tg, tb);
+        graphics.Print(40, 600 + game.creditposition, "With Music by", tr, tg, tb);
+        graphics.bigprint(60, 610 + game.creditposition, "Magnus P~lsson", tr, tg, tb);
     }
 
-    if (dwgfx.onscreen(680 + game.creditposition))
+    if (graphics.onscreen(640 + game.creditposition))
     {
-        dwgfx.Print(40, 680 + game.creditposition, "C++ Port by", tr, tg, tb);
-        dwgfx.bigprint(60, 690 + game.creditposition, "Simon Roth", tr, tg, tb);
-        dwgfx.bigprint(60, 710 + game.creditposition, "Ethan Lee", tr, tg, tb);
+        graphics.Print(40, 640 + game.creditposition, "Rooms Named by", tr, tg, tb);
+        graphics.bigprint(60, 650 + game.creditposition, "Bennett Foddy", tr, tg, tb);
+    }
+
+    if (graphics.onscreen(680 + game.creditposition))
+    {
+        graphics.Print(40, 680 + game.creditposition, "C++ Port by", tr, tg, tb);
+        graphics.bigprint(60, 690 + game.creditposition, "Simon Roth", tr, tg, tb);
+        graphics.bigprint(60, 710 + game.creditposition, "Ethan Lee", tr, tg, tb);
     }
 
 
-    if (dwgfx.onscreen(740 + game.creditposition))
+    if (graphics.onscreen(740 + game.creditposition))
     {
-        dwgfx.Print(40, 740 + game.creditposition, "Beta Testing by", tr, tg, tb);
-        dwgfx.bigprint(60, 750 + game.creditposition, "Sam Kaplan", tr, tg, tb);
-        dwgfx.bigprint(60, 770 + game.creditposition, "Pauli Kohberger", tr, tg, tb);
+        graphics.Print(40, 740 + game.creditposition, "Beta Testing by", tr, tg, tb);
+        graphics.bigprint(60, 750 + game.creditposition, "Sam Kaplan", tr, tg, tb);
+        graphics.bigprint(60, 770 + game.creditposition, "Pauli Kohberger", tr, tg, tb);
     }
 
-    if (dwgfx.onscreen(800 + game.creditposition))
+    if (graphics.onscreen(800 + game.creditposition))
     {
-        dwgfx.Print(40, 800 + game.creditposition, "Ending Picture by", tr, tg, tb);
-        dwgfx.bigprint(60, 810 + game.creditposition, "Pauli Kohberger", tr, tg, tb);
+        graphics.Print(40, 800 + game.creditposition, "Ending Picture by", tr, tg, tb);
+        graphics.bigprint(60, 810 + game.creditposition, "Pauli Kohberger", tr, tg, tb);
     }
 
-    if (dwgfx.onscreen(890 + game.creditposition)) dwgfx.bigprint( -1, 870 + game.creditposition, "Patrons", tr, tg, tb, true, 3);
+    if (graphics.onscreen(890 + game.creditposition)) graphics.bigprint( -1, 870 + game.creditposition, "Patrons", tr, tg, tb, true, 3);
 
     int creditOffset = 930;
 
     for (size_t i = 0; i < game.superpatrons.size(); i += 1)
     {
-        if (dwgfx.onscreen(creditOffset + game.creditposition))
+        if (graphics.onscreen(creditOffset + game.creditposition))
         {
-            dwgfx.Print(-1, creditOffset + game.creditposition, game.superpatrons[i], tr, tg, tb, true);
+            graphics.Print(-1, creditOffset + game.creditposition, game.superpatrons[i], tr, tg, tb, true);
         }
         creditOffset += 10;
     }
 
     creditOffset += 10;
-    if (dwgfx.onscreen(creditOffset + game.creditposition)) dwgfx.Print( -1, creditOffset + game.creditposition, "and", tr, tg, tb, true);
+    if (graphics.onscreen(creditOffset + game.creditposition)) graphics.Print( -1, creditOffset + game.creditposition, "and", tr, tg, tb, true);
     creditOffset += 20;
 
     for (size_t i = 0; i < game.patrons.size(); i += 1)
     {
-        if (dwgfx.onscreen(creditOffset + game.creditposition))
+        if (graphics.onscreen(creditOffset + game.creditposition))
         {
-            dwgfx.Print(-1, creditOffset + game.creditposition, game.patrons[i], tr, tg, tb, true);
+            graphics.Print(-1, creditOffset + game.creditposition, game.patrons[i], tr, tg, tb, true);
         }
         creditOffset += 10;
     }
 
     creditOffset += 20;
-    if (dwgfx.onscreen(creditOffset + game.creditposition)) dwgfx.bigprint(40, creditOffset + game.creditposition, "GitHub Contributors", tr, tg, tb, true);
+    if (graphics.onscreen(creditOffset + game.creditposition)) graphics.bigprint(40, creditOffset + game.creditposition, "GitHub Contributors", tr, tg, tb, true);
     creditOffset += 30;
 
     for (size_t i = 0; i < game.githubfriends.size(); i += 1)
     {
-        if (dwgfx.onscreen(creditOffset + game.creditposition))
+        if (graphics.onscreen(creditOffset + game.creditposition))
         {
-            dwgfx.Print(-1, creditOffset + game.creditposition, game.githubfriends[i], tr, tg, tb, true);
+            graphics.Print(-1, creditOffset + game.creditposition, game.githubfriends[i], tr, tg, tb, true);
         }
         creditOffset += 10;
     }
 
     creditOffset += 140;
-    if (dwgfx.onscreen(creditOffset + game.creditposition)) dwgfx.bigprint( -1, creditOffset + game.creditposition, "Thanks for playing!", tr, tg, tb, true, 2);
+    if (graphics.onscreen(creditOffset + game.creditposition)) graphics.bigprint( -1, creditOffset + game.creditposition, "Thanks for playing!", tr, tg, tb, true, 2);
 
     if (game.test)
     {
-        dwgfx.Print(5, 5, game.teststring, 196, 196, 255, false);
+        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
     }
 
-    dwgfx.drawfade();
+    graphics.drawfade();
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
-        dwgfx.flashlight();
+        graphics.flashlight();
     }
 
     if (game.screenshake > 0 && !game.noflashingmode)
     {
         game.screenshake--;
-        dwgfx.screenshake();
+        graphics.screenshake();
     }
     else
     {
-        dwgfx.render();
+        graphics.render();
     }
-    //dwgfx.backbuffer.unlock();
 }
 
-void gamecompleterender2(Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help)
+void gamecompleterender2()
 {
-    //dwgfx.backbuffer.lock();
-    FillRect(dwgfx.backBuffer, 0x000000);
+    FillRect(graphics.backBuffer, 0x000000);
 
-    dwgfx.drawimage(10, 0, 0);
+    graphics.drawimage(10, 0, 0);
 
     for (int j = 0; j < 30; j++)
     {
@@ -1432,65 +1388,61 @@ void gamecompleterender2(Graphics& dwgfx, Game& game, entityclass& obj, UtilityC
             {
                 if (i > game.creditposx)
                 {
-                    FillRect(dwgfx.backBuffer, i * 8, j * 8, 8, 8, 0, 0, 0);
+                    FillRect(graphics.backBuffer, i * 8, j * 8, 8, 8, 0, 0, 0);
                 }
             }
 
             if (j > game.creditposy)
             {
-                FillRect(dwgfx.backBuffer, i * 8, j * 8, 8, 8, 0, 0, 0);
+                FillRect(graphics.backBuffer, i * 8, j * 8, 8, 8, 0, 0, 0);
             }
         }
     }
 
     if (game.test)
     {
-        dwgfx.Print(5, 5, game.teststring, 196, 196, 255, false);
+        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
     }
 
-    dwgfx.drawfade();
+    graphics.drawfade();
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
-        dwgfx.flashlight();
+        graphics.flashlight();
     }
 
     if (game.screenshake > 0 && !game.noflashingmode)
     {
         game.screenshake--;
-        dwgfx.screenshake();
+        graphics.screenshake();
     }
     else
     {
-        dwgfx.render();
+        graphics.render();
     }
-    //dwgfx.backbuffer.unlock();
 }
 
-void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, UtilityClass& help)
+void gamerender()
 {
-
-
-
     if(!game.blackout)
     {
 
         if(!game.colourblindmode)
-		{
-        dwgfx.drawbackground(map.background, map);
-		}
-		else
-		{
-			FillRect(dwgfx.backBuffer,0x00000);
-		}
-        if (map.final_colormode)
-		{
-        	dwgfx.drawfinalmap(map);
+        {
+            graphics.drawbackground(map.background);
         }
         else
-		{
-        dwgfx.drawmap(map);
+        {
+            FillRect(graphics.backBuffer,0x00000);
+        }
+        if (map.final_colormode)
+        {
+            graphics.drawfinalmap();
+        }
+        else
+        {
+            graphics.drawmap();
         }
 
 
@@ -1499,7 +1451,7 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
             for (int i = 0; i < obj.nentity; i++)
             {
                 //Is this entity on the ground? (needed for jumping)
-                if (obj.entitycollidefloor(map, i))
+                if (obj.entitycollidefloor(i))
                 {
                     obj.entities[i].onground = 2;
                 }
@@ -1508,7 +1460,7 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
                     obj.entities[i].onground--;
                 }
 
-                if (obj.entitycollideroof(map, i))
+                if (obj.entitycollideroof(i))
                 {
                     obj.entities[i].onroof = 2;
                 }
@@ -1518,38 +1470,31 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
                 }
 
                 //Animate the entities
-                obj.animateentities(i, game, help);
+                obj.animateentities(i);
             }
         }
 
-        dwgfx.drawentities(map, obj, help);
+        graphics.drawentities();
     }
-
-    /*for(int i=0; i<obj.nblocks; i++){
-    if (obj.blocks[i].active) {
-    		dwgfx.backbuffer.fillRect(obj.blocks[i].rect, 0xDDDDDD);
-    }
-      }*/
-    //dwgfx.drawminimap(game, map);
 
     if(map.extrarow==0 || (map.custommode && map.roomname!=""))
     {
-        dwgfx.footerrect.y = 230;
-        if (dwgfx.translucentroomname)
+        graphics.footerrect.y = 230;
+        if (graphics.translucentroomname)
         {
-            SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
+            SDL_BlitSurface(graphics.footerbuffer, NULL, graphics.backBuffer, &graphics.footerrect);
         }
         else
         {
-            FillRect(dwgfx.backBuffer, dwgfx.footerrect, 0);
+            FillRect(graphics.backBuffer, graphics.footerrect, 0);
         }
 
         if (map.finalmode)
         {
-        	map.glitchname = map.getglitchname(game.roomx, game.roomy);
-          dwgfx.bprint(5, 231, map.glitchname, 196, 196, 255 - help.glow, true);
+            map.glitchname = map.getglitchname(game.roomx, game.roomy);
+            graphics.bprint(5, 231, map.glitchname, 196, 196, 255 - help.glow, true);
         }else{
-          dwgfx.bprint(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
+            graphics.bprint(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
         }
     }
 
@@ -1558,14 +1503,14 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
         //Draw room text!
         for (size_t i = 0; i < map.roomtext.size(); i++)
         {
-            dwgfx.Print(map.roomtext[i].x*8, (map.roomtext[i].y*8), map.roomtext[i].text, 196, 196, 255 - help.glow);
+            graphics.Print(map.roomtext[i].x*8, (map.roomtext[i].y*8), map.roomtext[i].text, 196, 196, 255 - help.glow);
         }
     }
 
 #if !defined(NO_CUSTOM_LEVELS)
      if(map.custommode && !map.custommodeforreal && !game.advancetext){
         //Return to level editor
-        dwgfx.bprintalpha(5, 5, "[Press ENTER to return to editor]", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), ed.returneditoralpha, false);
+        graphics.bprintalpha(5, 5, "[Press ENTER to return to editor]", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), ed.returneditoralpha, false);
         if (ed.returneditoralpha > 0) {
             ed.returneditoralpha -= 15;
         }
@@ -1573,29 +1518,29 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
 #endif
 
 
-    dwgfx.cutscenebars();
-    dwgfx.drawfade();
-	BlitSurfaceStandard(dwgfx.backBuffer, NULL, dwgfx.tempBuffer, NULL);
+    graphics.cutscenebars();
+    graphics.drawfade();
+    BlitSurfaceStandard(graphics.backBuffer, NULL, graphics.tempBuffer, NULL);
 
-    dwgfx.drawgui(help);
-    if (dwgfx.flipmode)
+    graphics.drawgui();
+    if (graphics.flipmode)
     {
-        if (game.advancetext) dwgfx.bprint(5, 228, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+        if (game.advancetext) graphics.bprint(5, 228, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
     else
     {
-        if (game.advancetext) dwgfx.bprint(5, 5, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+        if (game.advancetext) graphics.bprint(5, 5, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
 
     if (game.readytotele > 100 && !game.advancetext && game.hascontrol && !script.running && !game.intimetrial)
     {
-        if(dwgfx.flipmode)
+        if(graphics.flipmode)
         {
-            dwgfx.bprint(5, 20, "- Press ENTER to Teleport -", game.readytotele - 20 - (help.glow / 2), game.readytotele - 20 - (help.glow / 2), game.readytotele, true);
+            graphics.bprint(5, 20, "- Press ENTER to Teleport -", game.readytotele - 20 - (help.glow / 2), game.readytotele - 20 - (help.glow / 2), game.readytotele, true);
         }
         else
         {
-            dwgfx.bprint(5, 210, "- Press ENTER to Teleport -", game.readytotele - 20 - (help.glow / 2), game.readytotele - 20 - (help.glow / 2), game.readytotele, true);
+            graphics.bprint(5, 210, "- Press ENTER to Teleport -", game.readytotele - 20 - (help.glow / 2), game.readytotele - 20 - (help.glow / 2), game.readytotele, true);
         }
     }
 
@@ -1604,56 +1549,56 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
         if (game.swngame == 0)
         {
             tempstring = help.timestring(game.swntimer);
-            dwgfx.bigprint( -1, 20, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
+            graphics.bigprint( -1, 20, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
         }
         else if (game.swngame == 1)
         {
             if (game.swnmessage == 0)
             {
                 tempstring = help.timestring(game.swntimer);
-                dwgfx.Print( 10, 10, "Current Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
-                dwgfx.bigprint( 25, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
+                graphics.Print( 10, 10, "Current Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
+                graphics.bigprint( 25, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
                 tempstring = help.timestring(game.swnrecord);
-                dwgfx.Print( 240, 10, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
-                dwgfx.bigrprint( 300, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
+                graphics.Print( 240, 10, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
+                graphics.bigrprint( 300, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
 
                 switch(game.swnbestrank)
                 {
                 case 0:
-                    dwgfx.Print( -1, 204, "Next Trophy at 5 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+                    graphics.Print( -1, 204, "Next Trophy at 5 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
                     break;
                 case 1:
-                    dwgfx.Print( -1, 204, "Next Trophy at 10 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+                    graphics.Print( -1, 204, "Next Trophy at 10 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
                     break;
                 case 2:
-                    dwgfx.Print( -1, 204, "Next Trophy at 15 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+                    graphics.Print( -1, 204, "Next Trophy at 15 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
                     break;
                 case 3:
-                    dwgfx.Print( -1, 204, "Next Trophy at 20 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+                    graphics.Print( -1, 204, "Next Trophy at 20 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
                     break;
                 case 4:
-                    dwgfx.Print( -1, 204, "Next Trophy at 30 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+                    graphics.Print( -1, 204, "Next Trophy at 30 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
                     break;
                 case 5:
-                    dwgfx.Print( -1, 204, "Next Trophy at 1 minute", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+                    graphics.Print( -1, 204, "Next Trophy at 1 minute", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
                     break;
                 case 6:
-                    dwgfx.Print( -1, 204, "All Trophies collected!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+                    graphics.Print( -1, 204, "All Trophies collected!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
                     break;
                 }
             }
             else if (game.swnmessage == 1)
             {
                 tempstring = help.timestring(game.swntimer);
-                dwgfx.Print( 10, 10, "Current Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
-                dwgfx.bigprint( 25, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
+                graphics.Print( 10, 10, "Current Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
+                graphics.bigprint( 25, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
                 tempstring = help.timestring(game.swnrecord);
                 if (int(game.deathseq / 5) % 2 == 1)
                 {
-                    dwgfx.Print( 240, 10, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
-                    dwgfx.bigrprint( 300, 24, tempstring, 128 - (help.glow), 220 - (help.glow), 128 - (help.glow / 2), false, 2);
+                    graphics.Print( 240, 10, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
+                    graphics.bigrprint( 300, 24, tempstring, 128 - (help.glow), 220 - (help.glow), 128 - (help.glow / 2), false, 2);
 
-                    dwgfx.bigprint( -1, 200, "New Record!", 128 - (help.glow), 220 - (help.glow), 128 - (help.glow / 2), true, 2);
+                    graphics.bigprint( -1, 200, "New Record!", 128 - (help.glow), 220 - (help.glow), 128 - (help.glow / 2), true, 2);
                 }
             }
             else if (game.swnmessage >= 2)
@@ -1661,33 +1606,33 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
                 game.swnmessage--;
                 if (game.swnmessage == 2) game.swnmessage = 0;
                 tempstring = help.timestring(game.swntimer);
-                dwgfx.Print( 10, 10, "Current Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
-                dwgfx.bigprint( 25, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
+                graphics.Print( 10, 10, "Current Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
+                graphics.bigprint( 25, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
                 tempstring = help.timestring(game.swnrecord);
-                dwgfx.Print( 240, 10, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
-                dwgfx.bigrprint( 300, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
+                graphics.Print( 240, 10, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
+                graphics.bigrprint( 300, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
 
                 if (int(game.swnmessage / 5) % 2 == 1)
                 {
-                    dwgfx.bigprint( -1, 200, "New Trophy!", 220 - (help.glow), 128 - (help.glow), 128 - (help.glow / 2), true, 2);
+                    graphics.bigprint( -1, 200, "New Trophy!", 220 - (help.glow), 128 - (help.glow), 128 - (help.glow / 2), true, 2);
                 }
             }
 
-            dwgfx.Print( 20, 228, "[Press ENTER to stop]", 160 - (help.glow/2), 160 - (help.glow/2), 160 - (help.glow/2), true);
+            graphics.Print( 20, 228, "[Press ENTER to stop]", 160 - (help.glow/2), 160 - (help.glow/2), 160 - (help.glow/2), true);
         }
         else if(game.swngame==2)
         {
             if (int(game.swndelay / 15) % 2 == 1 || game.swndelay >= 120)
             {
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.bigprint( -1, 30, "Survive for", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
-                    dwgfx.bigprint( -1, 10, "60 seconds!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
+                    graphics.bigprint( -1, 30, "Survive for", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
+                    graphics.bigprint( -1, 10, "60 seconds!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
                 }
                 else
                 {
-                    dwgfx.bigprint( -1, 10, "Survive for", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
-                    dwgfx.bigprint( -1, 30, "60 seconds!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
+                    graphics.bigprint( -1, 10, "Survive for", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
+                    graphics.bigprint( -1, 30, "60 seconds!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
                 }
             }
         }
@@ -1695,21 +1640,21 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
         {
             if (game.swndelay >= 60)
             {
-                dwgfx.bigprint( -1, 20, "SUPER GRAVITRON", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
+                graphics.bigprint( -1, 20, "SUPER GRAVITRON", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
 
                 tempstring = help.timestring(game.swnrecord);
-                dwgfx.Print( 240, 190, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
-                dwgfx.bigrprint( 300, 205, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
+                graphics.Print( 240, 190, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+                graphics.bigrprint( 300, 205, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
             }
-            else	if (int(game.swndelay / 10) % 2 == 1)
+            else if (int(game.swndelay / 10) % 2 == 1)
             {
-                dwgfx.bigprint( -1, 20, "SUPER GRAVITRON", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
-                dwgfx.bigprint( -1, 200, "GO!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 3);
+                graphics.bigprint( -1, 20, "SUPER GRAVITRON", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
+                graphics.bigprint( -1, 200, "GO!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 3);
             }
         }
     }
 
-    if (game.intimetrial && dwgfx.fademode==0)
+    if (game.intimetrial && graphics.fademode==0)
     {
         //Draw countdown!
         if (game.timetrialcountdown > 0)
@@ -1717,69 +1662,68 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
             if (game.timetrialcountdown < 30)
             {
                 game.resetgameclock();
-                if (int(game.timetrialcountdown / 4) % 2 == 0) dwgfx.bigprint( -1, 100, "Go!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
+                if (int(game.timetrialcountdown / 4) % 2 == 0) graphics.bigprint( -1, 100, "Go!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
             else if (game.timetrialcountdown < 60)
             {
-                dwgfx.bigprint( -1, 100, "1", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
+                graphics.bigprint( -1, 100, "1", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
             else if (game.timetrialcountdown < 90)
             {
-                dwgfx.bigprint( -1, 100, "2", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
+                graphics.bigprint( -1, 100, "2", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
             else if (game.timetrialcountdown < 120)
             {
-                dwgfx.bigprint( -1, 100, "3", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
+                graphics.bigprint( -1, 100, "3", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
         }
         else
         {
             //Draw OSD stuff
-            dwgfx.bprint(6, 18, "TIME :",  255,255,255);
-            dwgfx.bprint(6, 30, "DEATH:",  255, 255, 255);
-            dwgfx.bprint(6, 42, "SHINY:",  255,255,255);
+            graphics.bprint(6, 18, "TIME :",  255,255,255);
+            graphics.bprint(6, 30, "DEATH:",  255, 255, 255);
+            graphics.bprint(6, 42, "SHINY:",  255,255,255);
 
             if(game.timetrialparlost)
             {
-                dwgfx.bprint(56, 18, game.timestring(help),  196, 80, 80);
+                graphics.bprint(56, 18, game.timestring(),  196, 80, 80);
             }
             else
             {
-                dwgfx.bprint(56, 18, game.timestring(help),  196, 196, 196);
+                graphics.bprint(56, 18, game.timestring(),  196, 196, 196);
             }
             if(game.deathcounts>0)
             {
-                dwgfx.bprint(56, 30,help.String(game.deathcounts),  196, 80, 80);
+                graphics.bprint(56, 30,help.String(game.deathcounts),  196, 80, 80);
             }
             else
             {
-                dwgfx.bprint(56, 30,help.String(game.deathcounts),  196, 196, 196);
+                graphics.bprint(56, 30,help.String(game.deathcounts),  196, 196, 196);
             }
             if(game.trinkets<game.timetrialshinytarget)
             {
-                dwgfx.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 80, 80);
+                graphics.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 80, 80);
             }
             else
             {
-                dwgfx.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 196, 196);
+                graphics.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 196, 196);
             }
 
             if(game.timetrialparlost)
             {
-                dwgfx.bprint(195, 214, "PAR TIME:",  80, 80, 80);
-                dwgfx.bprint(275, 214, game.partimestring(help),  80, 80, 80);
+                graphics.bprint(195, 214, "PAR TIME:",  80, 80, 80);
+                graphics.bprint(275, 214, game.partimestring(),  80, 80, 80);
             }
             else
             {
-                dwgfx.bprint(195, 214, "PAR TIME:",  255, 255, 255);
-                dwgfx.bprint(275, 214, game.partimestring(help),  196, 196, 196);
+                graphics.bprint(195, 214, "PAR TIME:",  255, 255, 255);
+                graphics.bprint(275, 214, game.partimestring(),  196, 196, 196);
             }
         }
     }
 
     if (game.activeactivity > -1)
     {
-        //dwgfx.backbuffer.fillRect(new Rectangle(0, 0, 320, 18), 0x000000);
         game.activity_lastprompt = obj.blocks[game.activeactivity].prompt;
         game.activity_r = obj.blocks[game.activeactivity].r;
         game.activity_g = obj.blocks[game.activeactivity].g;
@@ -1789,178 +1733,127 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
         {
             game.act_fade++;
         }
-        dwgfx.drawtextbox(16, 4, 36, 3, game.activity_r*(game.act_fade/10.0f), game.activity_g*(game.act_fade/10.0f), game.activity_b*(game.act_fade/10.0f));
-        dwgfx.Print(5, 12, game.activity_lastprompt, game.activity_r*(game.act_fade/10.0f), game.activity_g*(game.act_fade/10.0f), game.activity_b*(game.act_fade/10.0f), true);
+        graphics.drawtextbox(16, 4, 36, 3, game.activity_r*(game.act_fade/10.0f), game.activity_g*(game.act_fade/10.0f), game.activity_b*(game.act_fade/10.0f));
+        graphics.Print(5, 12, game.activity_lastprompt, game.activity_r*(game.act_fade/10.0f), game.activity_g*(game.act_fade/10.0f), game.activity_b*(game.act_fade/10.0f), true);
     }
     else
     {
         if(game.act_fade>5)
         {
-            dwgfx.drawtextbox(16, 4, 36, 3, game.activity_r*(game.act_fade/10.0f), game.activity_g*(game.act_fade/10.0f), game.activity_b*(game.act_fade/10.0f));
-            dwgfx.Print(5, 12, game.activity_lastprompt, game.activity_r*(game.act_fade/10.0f), game.activity_g*(game.act_fade/10.0f), game.activity_b*(game.act_fade/10.0f), true);
+            graphics.drawtextbox(16, 4, 36, 3, game.activity_r*(game.act_fade/10.0f), game.activity_g*(game.act_fade/10.0f), game.activity_b*(game.act_fade/10.0f));
+            graphics.Print(5, 12, game.activity_lastprompt, game.activity_r*(game.act_fade/10.0f), game.activity_g*(game.act_fade/10.0f), game.activity_b*(game.act_fade/10.0f), true);
             game.act_fade--;
         }
     }
 
     if (obj.trophytext > 0)
     {
-        dwgfx.drawtrophytext(obj, help);
+        graphics.drawtrophytext();
         obj.trophytext--;
     }
 
-    //dwgfx.rprint(5, 231,help.String(game.coins), 255 - help.glow/2, 255 - help.glow/2, 196, true);
-    //dwgfx.drawhuetile(311, 230, 48, 1);
-
-    //Level complete image
-    //if (game.state >= 3007) {
-    //	dwgfx.drawimage(0, 0, 12, true);
-    //}
-
-    //state changes
-
-    /*
-    game.test = true;
-    if (game.teststring !=help.String(game.state)) trace(game.state);
-    game.teststring =help.String(game.state);
-    */
-
-    //Detail entity info for debuging
-    /*
-    for (int i = 0; i < obj.nentity; i++) {
-    	game.tempstring =help.String(obj.entities[i].type) +", (" +help.String(obj.entities[i].xp) + "," +help.String(obj.entities[i].yp) + ")";
-    	game.tempstring += " state:" +obj.entities[i].state + ", delay:" + obj.entities[i].statedelay;
-    	dwgfx.Print(5, 5 + i * 8, game.tempstring, 255, 255, 255);
-    }
-    */
-
-    /*
-    game.test = true;
-    game.teststring =help.String(int(obj.entities[obj.getplayer()].xp)) + "," +help.String(int(obj.entities[obj.getplayer()].yp));
-    game.teststring += "   [" +help.String(game.roomx) + "," +help.String(game.roomy) + "]";
-    */
-
-    //game.test = true;
-    //game.teststring = "Current room deaths: " +help.String(game.currentroomdeaths);
-
-    //Special thing for loading:
-    /*
-    if(dwgfx.fademode==1){
-      if(game.mainmenu==22){
-        dwgfx.Print(5, 225, "Loading...", 196, 196, 255 - help.glow, false);
-      }
-    }
-    */
-
-
     if (game.test)
     {
-        dwgfx.Print(5, 5, game.teststring, 196, 196, 255, false);
+        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
     }
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
-        dwgfx.flashlight();
+        graphics.flashlight();
     }
 
     if (game.screenshake > 0 && !game.noflashingmode)
     {
         game.screenshake--;
-        dwgfx.screenshake();
+        graphics.screenshake();
     }
     else
     {
-        dwgfx.render();
+        graphics.render();
     }
 
-    //dwgfx.backbuffer.unlock();
 }
 
-void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help)
+void maprender()
 {
-    //dwgfx.backbuffer.lock();
-
-
-    dwgfx.drawgui(help);
+    graphics.drawgui();
 
     //draw screen alliteration
     //Roomname:
-	//CRASH
     temp = map.area(game.roomx, game.roomy);
-    if (temp < 2 && !map.custommode && dwgfx.fademode==0)
+    if (temp < 2 && !map.custommode && graphics.fademode==0)
     {
         if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111)
         {
-            dwgfx.Print(5, 2, "The Ship", 196, 196, 255 - help.glow, true);
+            graphics.Print(5, 2, "The Ship", 196, 196, 255 - help.glow, true);
         }
         else
         {
-            dwgfx.Print(5, 2, "Dimension VVVVVV", 196, 196, 255 - help.glow, true);
+            graphics.Print(5, 2, "Dimension VVVVVV", 196, 196, 255 - help.glow, true);
         }
     }
     else
     {
       if (map.finalmode){
         map.glitchname = map.getglitchname(game.roomx, game.roomy);
-        dwgfx.Print(5, 2, map.glitchname, 196, 196, 255 - help.glow, true);
+        graphics.Print(5, 2, map.glitchname, 196, 196, 255 - help.glow, true);
       }else{
-        dwgfx.Print(5, 2, map.roomname, 196, 196, 255 - help.glow, true);
+        graphics.Print(5, 2, map.roomname, 196, 196, 255 - help.glow, true);
       }
     }
 
-    //Background color
-    //dwgfx.drawfillrect(0, 12, 320, 240, 10, 24, 26);
-    FillRect(dwgfx.backBuffer,0, 12, 320, 240, 10, 24, 26 );
+    FillRect(graphics.backBuffer,0, 12, 320, 240, 10, 24, 26 );
 
-    dwgfx.crewframedelay--;
-    if (dwgfx.crewframedelay <= 0)
+    graphics.crewframedelay--;
+    if (graphics.crewframedelay <= 0)
     {
-        dwgfx.crewframedelay = 8;
-        dwgfx.crewframe = (dwgfx.crewframe + 1) % 2;
+        graphics.crewframedelay = 8;
+        graphics.crewframe = (graphics.crewframe + 1) % 2;
     }
 
 
 
     //Menubar:
-    dwgfx.drawtextbox( -10, 212, 42, 3, 65, 185, 207);
+    graphics.drawtextbox( -10, 212, 42, 3, 65, 185, 207);
     switch(game.menupage)
     {
     case 0:
-        dwgfx.Print(30 - 8, 220, "[MAP]", 196, 196, 255 - help.glow);
+        graphics.Print(30 - 8, 220, "[MAP]", 196, 196, 255 - help.glow);
         if (game.insecretlab)
         {
-            dwgfx.Print(103, 220, "GRAV", 64, 64, 64);
+            graphics.Print(103, 220, "GRAV", 64, 64, 64);
         }
         else if (obj.flags[67] == 1 && !map.custommode)
         {
-            dwgfx.Print(103, 220, "SHIP", 64,64,64);
+            graphics.Print(103, 220, "SHIP", 64,64,64);
         }
         else
         {
-            dwgfx.Print(103, 220, "CREW", 64,64,64);
+            graphics.Print(103, 220, "CREW", 64,64,64);
         }
-        dwgfx.Print(185-4, 220, "STATS", 64,64,64);
-        dwgfx.Print(258, 220, "SAVE", 64,64,64);
+        graphics.Print(185-4, 220, "STATS", 64,64,64);
+        graphics.Print(258, 220, "SAVE", 64,64,64);
 
         if (map.finalmode || (map.custommode&&!map.customshowmm))
         {
             //draw the map image
-            dwgfx.drawpixeltextbox(35, 16, 250, 190, 32,24, 65, 185, 207,4,0);
-            dwgfx.drawimage(1, 40, 21, false);
+            graphics.drawpixeltextbox(35, 16, 250, 190, 32,24, 65, 185, 207,4,0);
+            graphics.drawimage(1, 40, 21, false);
             for (int j = 0; j < 20; j++)
             {
                 for (int i = 0; i < 20; i++)
                 {
-                    dwgfx.drawimage(2, 40 + (i * 12), 21 + (j * 9), false);
+                    graphics.drawimage(2, 40 + (i * 12), 21 + (j * 9), false);
                 }
             }
-            dwgfx.Print(-1, 105, "NO SIGNAL", 245, 245, 245, true);
+            graphics.Print(-1, 105, "NO SIGNAL", 245, 245, 245, true);
         }
         else if(map.custommode)
         {
           //draw the map image
-          dwgfx.drawcustompixeltextbox(35+map.custommmxoff, 16+map.custommmyoff, map.custommmxsize+10, map.custommmysize+10, (map.custommmxsize+10)/8, (map.custommmysize+10)/8, 65, 185, 207,4,0);
-          dwgfx.drawpartimage(12, 40+map.custommmxoff, 21+map.custommmyoff, map.custommmxsize,map.custommmysize);
+          graphics.drawcustompixeltextbox(35+map.custommmxoff, 16+map.custommmyoff, map.custommmxsize+10, map.custommmysize+10, (map.custommmxsize+10)/8, (map.custommmysize+10)/8, 65, 185, 207,4,0);
+          graphics.drawpartimage(12, 40+map.custommmxoff, 21+map.custommmyoff, map.custommmxsize,map.custommmysize);
 
           //Black out here
           if(map.customzoom==4){
@@ -1968,25 +1861,25 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
               for (int i = 0; i < map.customwidth; i++){
                 if(map.explored[i+(j*20)]==0){
                   //Draw the fog of war on the map
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + (j * 36), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + (j * 36), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + 9 + (j * 36), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + 9+ (j * 36), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + (j * 36), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + (j * 36), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + 9 + (j * 36), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + 9+ (j * 36), false);
 
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 48) + 24, map.custommmyoff+21 + (j * 36), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 48) + 24, map.custommmyoff+21 + (j * 36), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 48) + 24, map.custommmyoff+ 21 + 9 + (j * 36), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 48) + 24, map.custommmyoff+21 + 9+ (j * 36), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 48) + 24, map.custommmyoff+21 + (j * 36), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48) + 24, map.custommmyoff+21 + (j * 36), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 48) + 24, map.custommmyoff+ 21 + 9 + (j * 36), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48) + 24, map.custommmyoff+21 + 9+ (j * 36), false);
 
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + (j * 36)+18, false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + (j * 36)+18, false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + 9 + (j * 36)+18, false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + 9+ (j * 36)+18, false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + (j * 36)+18, false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + (j * 36)+18, false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + 9 + (j * 36)+18, false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + 9+ (j * 36)+18, false);
 
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 48) + 24, map.custommmyoff+21 + (j * 36)+18, false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 48) + 24, map.custommmyoff+21 + (j * 36)+18, false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 48) + 24, map.custommmyoff+21 + 9 + (j * 36)+18, false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 48) + 24, map.custommmyoff+21 + 9+ (j * 36)+18, false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 48) + 24, map.custommmyoff+21 + (j * 36)+18, false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48) + 24, map.custommmyoff+21 + (j * 36)+18, false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 48) + 24, map.custommmyoff+21 + 9 + (j * 36)+18, false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48) + 24, map.custommmyoff+21 + 9+ (j * 36)+18, false);
                 }
               }
             }
@@ -1995,10 +1888,10 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
               for (int i = 0; i < map.customwidth; i++){
                 if(map.explored[i+(j*20)]==0){
                   //Draw the fog of war on the map
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 24), map.custommmyoff+21 + (j * 18), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 24), map.custommmyoff+21 + (j * 18), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 24), map.custommmyoff+21 + 9 + (j * 18), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 24), map.custommmyoff+21 + 9+ (j * 18), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 24), map.custommmyoff+21 + (j * 18), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 24), map.custommmyoff+21 + (j * 18), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 24), map.custommmyoff+21 + 9 + (j * 18), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 24), map.custommmyoff+21 + 9+ (j * 18), false);
                 }
               }
             }
@@ -2007,7 +1900,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
               for (int i = 0; i < map.customwidth; i++){
                 if(map.explored[i+(j*20)]==0){
                   //Draw the fog of war on the map
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 12), map.custommmyoff+21 + (j * 9), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 12), map.custommmyoff+21 + (j * 9), false);
                 }
               }
             }
@@ -2030,34 +1923,34 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
           if(map.customzoom==4){
             if(map.cursorstate==1){
               if (int(map.cursordelay / 4) % 2 == 0){
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 48) +map.custommmxoff, 21 + ((game.roomy - 100) * 36)+map.custommmyoff , 48 , 36 , 255,255,255);
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 48) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 36) + 2+map.custommmyoff, 48 - 4, 36 - 4, 255,255,255);
+                graphics.drawrect(40 + ((game.roomx - 100) * 48) +map.custommmxoff, 21 + ((game.roomy - 100) * 36)+map.custommmyoff , 48 , 36 , 255,255,255);
+                graphics.drawrect(40 + ((game.roomx - 100) * 48) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 36) + 2+map.custommmyoff, 48 - 4, 36 - 4, 255,255,255);
               }
             }else if (map.cursorstate == 2){
               if (int(map.cursordelay / 15) % 2 == 0){
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 48) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 36) + 2+map.custommmyoff, 48 - 4, 36 - 4, 16, 245 - (help.glow), 245 - (help.glow));
+                graphics.drawrect(40 + ((game.roomx - 100) * 48) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 36) + 2+map.custommmyoff, 48 - 4, 36 - 4, 16, 245 - (help.glow), 245 - (help.glow));
               }
             }
           }else if(map.customzoom==2){
             if(map.cursorstate==1){
               if (int(map.cursordelay / 4) % 2 == 0){
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 24)+map.custommmxoff , 21 + ((game.roomy - 100) * 18)+map.custommmyoff , 24 , 18 , 255,255,255);
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 24) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 18) + 2+map.custommmyoff, 24 - 4, 18 - 4, 255,255,255);
+                graphics.drawrect(40 + ((game.roomx - 100) * 24)+map.custommmxoff , 21 + ((game.roomy - 100) * 18)+map.custommmyoff , 24 , 18 , 255,255,255);
+                graphics.drawrect(40 + ((game.roomx - 100) * 24) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 18) + 2+map.custommmyoff, 24 - 4, 18 - 4, 255,255,255);
               }
             }else if (map.cursorstate == 2){
               if (int(map.cursordelay / 15) % 2 == 0){
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 24) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 18) + 2+map.custommmyoff, 24 - 4, 18 - 4, 16, 245 - (help.glow), 245 - (help.glow));
+                graphics.drawrect(40 + ((game.roomx - 100) * 24) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 18) + 2+map.custommmyoff, 24 - 4, 18 - 4, 16, 245 - (help.glow), 245 - (help.glow));
               }
             }
           }else{
             if(map.cursorstate==1){
               if (int(map.cursordelay / 4) % 2 == 0){
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 12)+map.custommmxoff , 21 + ((game.roomy - 100) * 9)+map.custommmyoff , 12 , 9 , 255,255,255);
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 9) + 2+map.custommmyoff, 12 - 4, 9 - 4, 255,255,255);
+                graphics.drawrect(40 + ((game.roomx - 100) * 12)+map.custommmxoff , 21 + ((game.roomy - 100) * 9)+map.custommmyoff , 12 , 9 , 255,255,255);
+                graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 9) + 2+map.custommmyoff, 12 - 4, 9 - 4, 255,255,255);
               }
             }else if (map.cursorstate == 2){
               if (int(map.cursordelay / 15) % 2 == 0){
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 9) + 2+map.custommmyoff, 12 - 4, 9 - 4, 16, 245 - (help.glow), 245 - (help.glow));
+                graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 9) + 2+map.custommmyoff, 12 - 4, 9 - 4, 16, 245 - (help.glow), 245 - (help.glow));
               }
             }
           }
@@ -2065,8 +1958,8 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
         else
         {
             //draw the map image
-            dwgfx.drawpixeltextbox(35, 16, 250, 190, 32,24, 65, 185, 207,4,0);
-            dwgfx.drawimage(1, 40, 21, false);
+            graphics.drawpixeltextbox(35, 16, 250, 190, 32,24, 65, 185, 207,4,0);
+            graphics.drawimage(1, 40, 21, false);
 
             //black out areas we can't see yet
             for (int j = 0; j < 20; j++)
@@ -2076,7 +1969,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                     if(map.explored[i+(j*20)]==0)
                     {
                         //Draw the fog of war on the map
-                        dwgfx.drawimage(2, 40 + (i * 12), 21 + (j * 9), false);
+                        graphics.drawimage(2, 40 + (i * 12), 21 + (j * 9), false);
                     }
                 }
             }
@@ -2084,11 +1977,6 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
             if (game.roomx == 109)
             {
                 //tower!instead of room y, scale map.ypos
-                /*if (map.ypos > (0.57 * (680 * 8))) {
-                	i = int(map.ypos - (0.57 * (680 * 8)));
-                	i = int((i / (0.43 * (680 * 8)))*9);
-                	dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + i + 2, 12 - 4, 9 - 4, 16, 245 - (help.glow * 2), 245 - (help.glow * 2));
-                }*/
                 if (map.cursorstate == 0)
                 {
                     map.cursordelay++;
@@ -2103,8 +1991,8 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                     map.cursordelay++;
                     if (int(map.cursordelay / 4) % 2 == 0)
                     {
-                        dwgfx.drawrect(40 + ((game.roomx - 100) * 12) , 21 , 12, 180, 255,255,255);
-                        dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2 , 21  + 2, 12 - 4, 180 - 4, 255,255,255);
+                        graphics.drawrect(40 + ((game.roomx - 100) * 12) , 21 , 12, 180, 255,255,255);
+                        graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2 , 21  + 2, 12 - 4, 180 - 4, 255,255,255);
                     }
                     if (map.cursordelay > 30) map.cursorstate = 2;
                 }
@@ -2113,7 +2001,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                     map.cursordelay++;
                     if (int(map.cursordelay / 15) % 2 == 0)
                     {
-                        dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2 , 21  + 2, 12 - 4, 180 - 4,16, 245 - (help.glow), 245 - (help.glow));
+                        graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2 , 21  + 2, 12 - 4, 180 - 4,16, 245 - (help.glow), 245 - (help.glow));
                     }
                 }
             }
@@ -2133,8 +2021,8 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                     map.cursordelay++;
                     if (int(map.cursordelay / 4) % 2 == 0)
                     {
-                        dwgfx.drawrect(40 + ((game.roomx - 100) * 12) , 21 + ((game.roomy - 100) * 9) , 12 , 9 , 255,255,255);
-                        dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + ((game.roomy - 100) * 9) + 2, 12 - 4, 9 - 4, 255,255,255);
+                        graphics.drawrect(40 + ((game.roomx - 100) * 12) , 21 + ((game.roomy - 100) * 9) , 12 , 9 , 255,255,255);
+                        graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + ((game.roomy - 100) * 9) + 2, 12 - 4, 9 - 4, 255,255,255);
                     }
                     if (map.cursordelay > 30) map.cursorstate = 2;
                 }
@@ -2143,7 +2031,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                     map.cursordelay++;
                     if (int(map.cursordelay / 15) % 2 == 0)
                     {
-                        dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + ((game.roomy - 100) * 9) + 2, 12 - 4, 9 - 4, 16, 245 - (help.glow), 245 - (help.glow));
+                        graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + ((game.roomy - 100) * 9) + 2, 12 - 4, 9 - 4, 16, 245 - (help.glow), 245 - (help.glow));
                     }
                 }
             }
@@ -2154,16 +2042,15 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                 if (map.showteleporters && map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)] > 0)
                 {
                     temp = 1126 + map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)];
-                    if (dwgfx.flipmode) temp += 3;
-                    dwgfx.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
+                    if (graphics.flipmode) temp += 3;
+                    graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
                 }
                 else if(map.showtargets && map.explored[map.teleporters[i].x+(20*map.teleporters[i].y)]==0)
                 {
                     temp = 1126 + map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)];
-                    if (dwgfx.flipmode) temp += 3;
-                    dwgfx.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
+                    if (graphics.flipmode) temp += 3;
+                    graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
                 }
-                //dwgfx.drawtile(40+3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), 1086); //for shiny trinkets, do later
             }
 
             if (map.showtrinkets)
@@ -2173,8 +2060,8 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                     if (obj.collect[i] == 0)
                     {
                         temp = 1086;
-                        if (dwgfx.flipmode) temp += 3;
-                        dwgfx.drawtile(40 + 3 + (map.shinytrinkets[i].x * 12), 22 + (map.shinytrinkets[i].y * 9),	temp);
+                        if (graphics.flipmode) temp += 3;
+                        graphics.drawtile(40 + 3 + (map.shinytrinkets[i].x * 12), 22 + (map.shinytrinkets[i].y * 9),	temp);
                     }
                 }
             }
@@ -2183,159 +2070,159 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
     case 1:
         if (game.insecretlab)
         {
-            dwgfx.Print(30, 220, "MAP", 64,64,64);
-            dwgfx.Print(103-8, 220, "[GRAV]", 196, 196, 255 - help.glow);
-            dwgfx.Print(185-4, 220, "STATS", 64,64,64);
-            dwgfx.Print(258, 220, "SAVE", 64, 64, 64);
+            graphics.Print(30, 220, "MAP", 64,64,64);
+            graphics.Print(103-8, 220, "[GRAV]", 196, 196, 255 - help.glow);
+            graphics.Print(185-4, 220, "STATS", 64,64,64);
+            graphics.Print(258, 220, "SAVE", 64, 64, 64);
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.Print(0, 174, "SUPER GRAVITRON HIGHSCORE", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 174, "SUPER GRAVITRON HIGHSCORE", 196, 196, 255 - help.glow, true);
 
                 tempstring = help.timestring(game.swnrecord);
-                dwgfx.Print( 240, 124, "Best Time", 196, 196, 255 - help.glow, true);
-                dwgfx.bigrprint( 300, 94, tempstring, 196, 196, 255 - help.glow, true, 2);
+                graphics.Print( 240, 124, "Best Time", 196, 196, 255 - help.glow, true);
+                graphics.bigrprint( 300, 94, tempstring, 196, 196, 255 - help.glow, true, 2);
 
                 switch(game.swnbestrank)
                 {
                 case 0:
-                    dwgfx.Print( -1, 40, "Next Trophy at 5 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 40, "Next Trophy at 5 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 1:
-                    dwgfx.Print( -1, 40, "Next Trophy at 10 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 40, "Next Trophy at 10 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 2:
-                    dwgfx.Print( -1, 40, "Next Trophy at 15 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 40, "Next Trophy at 15 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 3:
-                    dwgfx.Print( -1, 40, "Next Trophy at 20 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 40, "Next Trophy at 20 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 4:
-                    dwgfx.Print( -1, 40, "Next Trophy at 30 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 40, "Next Trophy at 30 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 5:
-                    dwgfx.Print( -1, 40, "Next Trophy at 1 minute", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 40, "Next Trophy at 1 minute", 196, 196, 255 - help.glow, true);
                     break;
                 case 6:
-                    dwgfx.Print( -1, 40, "All Trophies collected!", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 40, "All Trophies collected!", 196, 196, 255 - help.glow, true);
                     break;
                 }
             }
             else
             {
-                dwgfx.Print(0, 40, "SUPER GRAVITRON HIGHSCORE", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 40, "SUPER GRAVITRON HIGHSCORE", 196, 196, 255 - help.glow, true);
 
                 tempstring = help.timestring(game.swnrecord);
-                dwgfx.Print( 240, 90, "Best Time", 196, 196, 255 - help.glow, true);
-                dwgfx.bigrprint( 300, 104, tempstring, 196, 196, 255 - help.glow, true, 2);
+                graphics.Print( 240, 90, "Best Time", 196, 196, 255 - help.glow, true);
+                graphics.bigrprint( 300, 104, tempstring, 196, 196, 255 - help.glow, true, 2);
 
                 switch(game.swnbestrank)
                 {
                 case 0:
-                    dwgfx.Print( -1, 174, "Next Trophy at 5 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 174, "Next Trophy at 5 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 1:
-                    dwgfx.Print( -1, 174, "Next Trophy at 10 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 174, "Next Trophy at 10 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 2:
-                    dwgfx.Print( -1, 174, "Next Trophy at 15 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 174, "Next Trophy at 15 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 3:
-                    dwgfx.Print( -1, 174, "Next Trophy at 20 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 174, "Next Trophy at 20 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 4:
-                    dwgfx.Print( -1, 174, "Next Trophy at 30 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 174, "Next Trophy at 30 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 5:
-                    dwgfx.Print( -1, 174, "Next Trophy at 1 minute", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 174, "Next Trophy at 1 minute", 196, 196, 255 - help.glow, true);
                     break;
                 case 6:
-                    dwgfx.Print( -1, 174, "All Trophies collected!", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 174, "All Trophies collected!", 196, 196, 255 - help.glow, true);
                     break;
                 }
             }
         }
         else if (obj.flags[67] == 1 && !map.custommode)
         {
-            dwgfx.Print(30, 220, "MAP", 64,64,64);
-            dwgfx.Print(103-8, 220, "[SHIP]", 196, 196, 255 - help.glow);
-            dwgfx.Print(185-4, 220, "STATS", 64,64,64);
-            dwgfx.Print(258, 220, "SAVE", 64, 64, 64);
+            graphics.Print(30, 220, "MAP", 64,64,64);
+            graphics.Print(103-8, 220, "[SHIP]", 196, 196, 255 - help.glow);
+            graphics.Print(185-4, 220, "STATS", 64,64,64);
+            graphics.Print(258, 220, "SAVE", 64, 64, 64);
 
-            dwgfx.Print(0, 105, "Press ACTION to warp to the ship.", 196, 196, 255 - help.glow, true);
+            graphics.Print(0, 105, "Press ACTION to warp to the ship.", 196, 196, 255 - help.glow, true);
         }
-    #if !defined(NO_CUSTOM_LEVELS)
+#if !defined(NO_CUSTOM_LEVELS)
         else if(map.custommode){
-          dwgfx.Print(30, 220, "MAP", 64,64,64);
-            dwgfx.Print(103-8, 220, "[CREW]", 196, 196, 255 - help.glow);
-            dwgfx.Print(185-4, 220, "STATS", 64,64,64);
-            dwgfx.Print(258, 220, "SAVE", 64, 64, 64);
+          graphics.Print(30, 220, "MAP", 64,64,64);
+            graphics.Print(103-8, 220, "[CREW]", 196, 196, 255 - help.glow);
+            graphics.Print(185-4, 220, "STATS", 64,64,64);
+            graphics.Print(258, 220, "SAVE", 64, 64, 64);
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-              dwgfx.bigprint( -1, 220-45, ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 220-70, "by " + ed.ListOfMetaData[game.playcustomlevel].creator, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 220-80, ed.ListOfMetaData[game.playcustomlevel].website, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 220-100, ed.ListOfMetaData[game.playcustomlevel].Desc1, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 220-110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 220-120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
+              graphics.bigprint( -1, 220-45, ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 220-70, "by " + ed.ListOfMetaData[game.playcustomlevel].creator, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 220-80, ed.ListOfMetaData[game.playcustomlevel].website, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 220-100, ed.ListOfMetaData[game.playcustomlevel].Desc1, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 220-110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 220-120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
 
               if(map.customcrewmates-game.crewmates==1){
-                dwgfx.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmate remains", 196, 196, 255 - help.glow, true);
+                graphics.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmate remains", 196, 196, 255 - help.glow, true);
               }else if(map.customcrewmates-game.crewmates>0){
-                dwgfx.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmates remain", 196, 196, 255 - help.glow, true);
+                graphics.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmates remain", 196, 196, 255 - help.glow, true);
               }
             }
             else
             {
-              dwgfx.bigprint( -1, 45, ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 70, "by " + ed.ListOfMetaData[game.playcustomlevel].creator, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 80, ed.ListOfMetaData[game.playcustomlevel].website, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 100, ed.ListOfMetaData[game.playcustomlevel].Desc1, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
+              graphics.bigprint( -1, 45, ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 70, "by " + ed.ListOfMetaData[game.playcustomlevel].creator, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 80, ed.ListOfMetaData[game.playcustomlevel].website, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 100, ed.ListOfMetaData[game.playcustomlevel].Desc1, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
 
               if(map.customcrewmates-game.crewmates==1){
-                dwgfx.Print(1,165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmate remains", 196, 196, 255 - help.glow, true);
+                graphics.Print(1,165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmate remains", 196, 196, 255 - help.glow, true);
               }else if(map.customcrewmates-game.crewmates>0){
-                dwgfx.Print(1,165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmates remain", 196, 196, 255 - help.glow, true);
+                graphics.Print(1,165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmates remain", 196, 196, 255 - help.glow, true);
               }
             }
         }
-    #endif
+#endif
         else
         {
-            dwgfx.Print(30, 220, "MAP", 64,64,64);
-            dwgfx.Print(103-8, 220, "[CREW]", 196, 196, 255 - help.glow);
-            dwgfx.Print(185-4, 220, "STATS", 64,64,64);
-            dwgfx.Print(258, 220, "SAVE", 64, 64, 64);
+            graphics.Print(30, 220, "MAP", 64,64,64);
+            graphics.Print(103-8, 220, "[CREW]", 196, 196, 255 - help.glow);
+            graphics.Print(185-4, 220, "STATS", 64,64,64);
+            graphics.Print(258, 220, "SAVE", 64, 64, 64);
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
                 for (int i = 0; i < 3; i++)
                 {
-                    dwgfx.drawcrewman(16, 32 + (i * 64), 2-i, game.crewstats[2-i], help);
+                    graphics.drawcrewman(16, 32 + (i * 64), 2-i, game.crewstats[2-i]);
                     if (game.crewstats[(2-i)])
                     {
-                        dwgfx.printcrewname(44, 32 + (i * 64)+4+10, 2-i);
-                        dwgfx.printcrewnamestatus(44, 32 + (i * 64)+4, 2-i);
+                        graphics.printcrewname(44, 32 + (i * 64)+4+10, 2-i);
+                        graphics.printcrewnamestatus(44, 32 + (i * 64)+4, 2-i);
                     }
                     else
                     {
-                        dwgfx.printcrewnamedark(44, 32 + (i * 64)+4+10, 2-i);
-                        dwgfx.Print(44, 32 + (i * 64) + 4, "Missing...", 64,64,64);
+                        graphics.printcrewnamedark(44, 32 + (i * 64)+4+10, 2-i);
+                        graphics.Print(44, 32 + (i * 64) + 4, "Missing...", 64,64,64);
                     }
 
-                    dwgfx.drawcrewman(16+160, 32 + (i * 64), (2-i)+3, game.crewstats[(2-i)+3], help);
+                    graphics.drawcrewman(16+160, 32 + (i * 64), (2-i)+3, game.crewstats[(2-i)+3]);
                     if (game.crewstats[(2-i)+3])
                     {
-                        dwgfx.printcrewname(44+160, 32 + (i * 64)+4+10, (2-i)+3);
-                        dwgfx.printcrewnamestatus(44+160, 32 + (i * 64)+4, (2-i)+3);
+                        graphics.printcrewname(44+160, 32 + (i * 64)+4+10, (2-i)+3);
+                        graphics.printcrewnamestatus(44+160, 32 + (i * 64)+4, (2-i)+3);
                     }
                     else
                     {
-                        dwgfx.printcrewnamedark(44+160, 32 + (i * 64)+4+10, (2-i)+3);
-                        dwgfx.Print(44+160, 32 + (i * 64) + 4, "Missing...", 64,64,64);
+                        graphics.printcrewnamedark(44+160, 32 + (i * 64)+4+10, (2-i)+3);
+                        graphics.Print(44+160, 32 + (i * 64) + 4, "Missing...", 64,64,64);
                     }
                 }
             }
@@ -2343,334 +2230,334 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
             {
                 for (int i = 0; i < 3; i++)
                 {
-                    dwgfx.drawcrewman(16, 32 + (i * 64), i, game.crewstats[i], help);
+                    graphics.drawcrewman(16, 32 + (i * 64), i, game.crewstats[i]);
                     if (game.crewstats[i])
                     {
-                        dwgfx.printcrewname(44, 32 + (i * 64)+4, i);
-                        dwgfx.printcrewnamestatus(44, 32 + (i * 64)+4+10, i);
+                        graphics.printcrewname(44, 32 + (i * 64)+4, i);
+                        graphics.printcrewnamestatus(44, 32 + (i * 64)+4+10, i);
                     }
                     else
                     {
-                        dwgfx.printcrewnamedark(44, 32 + (i * 64)+4, i);
-                        dwgfx.Print(44, 32 + (i * 64) + 4 + 10, "Missing...", 64,64,64);
+                        graphics.printcrewnamedark(44, 32 + (i * 64)+4, i);
+                        graphics.Print(44, 32 + (i * 64) + 4 + 10, "Missing...", 64,64,64);
                     }
 
-                    dwgfx.drawcrewman(16+160, 32 + (i * 64), i+3, game.crewstats[i+3], help);
+                    graphics.drawcrewman(16+160, 32 + (i * 64), i+3, game.crewstats[i+3]);
                     if (game.crewstats[i+3])
                     {
-                        dwgfx.printcrewname(44+160, 32 + (i * 64)+4, i+3);
-                        dwgfx.printcrewnamestatus(44+160, 32 + (i * 64)+4+10, i+3);
+                        graphics.printcrewname(44+160, 32 + (i * 64)+4, i+3);
+                        graphics.printcrewnamestatus(44+160, 32 + (i * 64)+4+10, i+3);
                     }
                     else
                     {
-                        dwgfx.printcrewnamedark(44+160, 32 + (i * 64)+4, i+3);
-                        dwgfx.Print(44+160, 32 + (i * 64) + 4 + 10, "Missing...", 64,64,64);
+                        graphics.printcrewnamedark(44+160, 32 + (i * 64)+4, i+3);
+                        graphics.Print(44+160, 32 + (i * 64) + 4 + 10, "Missing...", 64,64,64);
                     }
                 }
             }
         }
         break;
     case 2:
-        dwgfx.Print(30, 220, "MAP", 64,64,64);
+        graphics.Print(30, 220, "MAP", 64,64,64);
         if (game.insecretlab)
         {
-            dwgfx.Print(103, 220, "GRAV", 64, 64, 64);
+            graphics.Print(103, 220, "GRAV", 64, 64, 64);
         }
         else if (obj.flags[67] == 1 && !map.custommode)
         {
-            dwgfx.Print(103, 220, "SHIP", 64,64,64);
+            graphics.Print(103, 220, "SHIP", 64,64,64);
         }
         else
         {
-            dwgfx.Print(103, 220, "CREW", 64,64,64);
+            graphics.Print(103, 220, "CREW", 64,64,64);
         }
-        dwgfx.Print(185-12, 220, "[STATS]", 196, 196, 255 - help.glow);
-        dwgfx.Print(258, 220, "SAVE", 64, 64, 64);
+        graphics.Print(185-12, 220, "[STATS]", 196, 196, 255 - help.glow);
+        graphics.Print(258, 220, "SAVE", 64, 64, 64);
 
         if(map.custommode){
-          if (dwgfx.flipmode)
+          if (graphics.flipmode)
           {
-              dwgfx.Print(0, 164, "[Trinkets found]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 152, help.number(game.trinkets) + " out of " + help.number(map.customtrinkets), 96,96,96, true);
+              graphics.Print(0, 164, "[Trinkets found]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 152, help.number(game.trinkets) + " out of " + help.number(map.customtrinkets), 96,96,96, true);
 
-              dwgfx.Print(0, 114, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 102,help.String(game.deathcounts),  96,96,96, true);
+              graphics.Print(0, 114, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 102,help.String(game.deathcounts),  96,96,96, true);
 
-              dwgfx.Print(0, 64, "[Time Taken]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 52, game.timestring(help),  96, 96, 96, true);
+              graphics.Print(0, 64, "[Time Taken]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 52, game.timestring(),  96, 96, 96, true);
           }
           else
           {
-              dwgfx.Print(0, 52, "[Trinkets found]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 64, help.number(game.trinkets) + " out of "+help.number(map.customtrinkets), 96,96,96, true);
+              graphics.Print(0, 52, "[Trinkets found]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 64, help.number(game.trinkets) + " out of "+help.number(map.customtrinkets), 96,96,96, true);
 
-              dwgfx.Print(0, 102, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 114,help.String(game.deathcounts),  96,96,96, true);
+              graphics.Print(0, 102, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 114,help.String(game.deathcounts),  96,96,96, true);
 
-              dwgfx.Print(0, 152, "[Time Taken]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 164, game.timestring(help),  96, 96, 96, true);
+              graphics.Print(0, 152, "[Time Taken]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 164, game.timestring(),  96, 96, 96, true);
           }
         }else{
-          if (dwgfx.flipmode)
+          if (graphics.flipmode)
           {
-              dwgfx.Print(0, 164, "[Trinkets found]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 152, help.number(game.trinkets) + " out of Twenty", 96,96,96, true);
+              graphics.Print(0, 164, "[Trinkets found]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 152, help.number(game.trinkets) + " out of Twenty", 96,96,96, true);
 
-              dwgfx.Print(0, 114, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 102,help.String(game.deathcounts),  96,96,96, true);
+              graphics.Print(0, 114, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 102,help.String(game.deathcounts),  96,96,96, true);
 
-              dwgfx.Print(0, 64, "[Time Taken]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 52, game.timestring(help),  96, 96, 96, true);
+              graphics.Print(0, 64, "[Time Taken]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 52, game.timestring(),  96, 96, 96, true);
           }
           else
           {
-              dwgfx.Print(0, 52, "[Trinkets found]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 64, help.number(game.trinkets) + " out of Twenty", 96,96,96, true);
+              graphics.Print(0, 52, "[Trinkets found]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 64, help.number(game.trinkets) + " out of Twenty", 96,96,96, true);
 
-              dwgfx.Print(0, 102, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 114,help.String(game.deathcounts),  96,96,96, true);
+              graphics.Print(0, 102, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 114,help.String(game.deathcounts),  96,96,96, true);
 
-              dwgfx.Print(0, 152, "[Time Taken]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 164, game.timestring(help),  96, 96, 96, true);
+              graphics.Print(0, 152, "[Time Taken]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 164, game.timestring(),  96, 96, 96, true);
           }
         }
         break;
     case 3:
-        dwgfx.Print(30, 220, "MAP", 64,64,64);
+        graphics.Print(30, 220, "MAP", 64,64,64);
         if (game.insecretlab)
         {
-            dwgfx.Print(103, 220, "GRAV", 64, 64, 64);
+            graphics.Print(103, 220, "GRAV", 64, 64, 64);
         }
         else if (obj.flags[67] == 1 && !map.custommode)
         {
-            dwgfx.Print(103, 220, "SHIP", 64,64,64);
+            graphics.Print(103, 220, "SHIP", 64,64,64);
         }
         else
         {
-            dwgfx.Print(103, 220, "CREW", 64,64,64);
+            graphics.Print(103, 220, "CREW", 64,64,64);
         }
-        dwgfx.Print(185-4, 220, "STATS", 64,64,64);
-        dwgfx.Print(258 - 8, 220, "[SAVE]", 196, 196, 255 - help.glow);
+        graphics.Print(185-4, 220, "STATS", 64,64,64);
+        graphics.Print(258 - 8, 220, "[SAVE]", 196, 196, 255 - help.glow);
 
         if (game.inintermission)
         {
-            dwgfx.Print(0, 115, "Cannot Save in Level Replay", 146, 146, 180, true);
+            graphics.Print(0, 115, "Cannot Save in Level Replay", 146, 146, 180, true);
         }
         else if (game.nodeathmode)
         {
-            dwgfx.Print(0, 115, "Cannot Save in No Death Mode", 146, 146, 180, true);
+            graphics.Print(0, 115, "Cannot Save in No Death Mode", 146, 146, 180, true);
         }
         else if (game.intimetrial)
         {
-            dwgfx.Print(0, 115, "Cannot Save in Time Trial", 146, 146, 180, true);
+            graphics.Print(0, 115, "Cannot Save in Time Trial", 146, 146, 180, true);
         }
         else if (game.insecretlab)
         {
-            dwgfx.Print(0, 115, "Cannot Save in Secret Lab", 146, 146, 180, true);
+            graphics.Print(0, 115, "Cannot Save in Secret Lab", 146, 146, 180, true);
         }
         else if (map.custommode)
         {
           if (game.gamesaved)
             {
-                dwgfx.Print(0, 36, "Game saved ok!", 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2), true);
+                graphics.Print(0, 36, "Game saved ok!", 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2), true);
 
-                dwgfx.drawpixeltextbox(25, 65, 270, 90, 34,12, 65, 185, 207,0,4);
+                graphics.drawpixeltextbox(25, 65, 270, 90, 34,12, 65, 185, 207,0,4);
 
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.Print(0, 122, game.customleveltitle, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
-                    dwgfx.Print(160 - 84, 78, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-                    dwgfx.Print(160 + 40, 78, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(0, 122, game.customleveltitle, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
+                    graphics.Print(160 - 84, 78, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(160 + 40, 78, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    dwgfx.drawspritesetcol(50, 74, 50, 18, help);
-                    dwgfx.drawspritesetcol(175, 74, 22, 18, help);
+                    graphics.drawspritesetcol(50, 74, 50, 18);
+                    graphics.drawspritesetcol(175, 74, 22, 18);
                 }
                 else
                 {
-                    dwgfx.Print(0, 90, game.customleveltitle, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
-                    dwgfx.Print(160 - 84, 132, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-                    dwgfx.Print(160 + 40, 132, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(0, 90, game.customleveltitle, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
+                    graphics.Print(160 - 84, 132, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(160 + 40, 132, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    dwgfx.drawspritesetcol(50, 126, 50, 18, help);
-                    dwgfx.drawspritesetcol(175, 126, 22, 18, help);
+                    graphics.drawspritesetcol(50, 126, 50, 18);
+                    graphics.drawspritesetcol(175, 126, 22, 18);
                 }
             }
             else
             {
-                dwgfx.Print(0, 80, "[Press ACTION to save your game]", 255 - (help.glow * 2), 255 - (help.glow * 2), 255 - help.glow, true);
+                graphics.Print(0, 80, "[Press ACTION to save your game]", 255 - (help.glow * 2), 255 - (help.glow * 2), 255 - help.glow, true);
             }
         }
         else
         {
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.Print(0, 186, "(Note: The game is autosaved", 146, 146, 180, true);
-                dwgfx.Print(0, 174, "at every teleporter.)", 146, 146, 180, true);
+                graphics.Print(0, 186, "(Note: The game is autosaved", 146, 146, 180, true);
+                graphics.Print(0, 174, "at every teleporter.)", 146, 146, 180, true);
             }
             else
             {
-                dwgfx.Print(0, 174, "(Note: The game is autosaved", 146, 146, 180, true);
-                dwgfx.Print(0, 186, "at every teleporter.)", 146, 146, 180, true);
+                graphics.Print(0, 174, "(Note: The game is autosaved", 146, 146, 180, true);
+                graphics.Print(0, 186, "at every teleporter.)", 146, 146, 180, true);
             }
 
             if (game.gamesaved)
             {
-                dwgfx.Print(0, 36, "Game saved ok!", 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2), true);
+                graphics.Print(0, 36, "Game saved ok!", 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2), true);
 
-                dwgfx.drawpixeltextbox(25, 65, 270, 90, 34,12, 65, 185, 207,0,4);
+                graphics.drawpixeltextbox(25, 65, 270, 90, 34,12, 65, 185, 207,0,4);
 
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.Print(0, 132, game.savearea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
+                    graphics.Print(0, 132, game.savearea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
                     for (int i = 0; i < 6; i++)
                     {
-                        dwgfx.drawcrewman(169-(3*42)+(i*42), 98, i, game.crewstats[i], help, true);
+                        graphics.drawcrewman(169-(3*42)+(i*42), 98, i, game.crewstats[i], true);
                     }
-                    dwgfx.Print(160 - 84, 78, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-                    dwgfx.Print(160 + 40, 78, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(160 - 84, 78, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(160 + 40, 78, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    dwgfx.drawspritesetcol(50, 74, 50, 18, help);
-                    dwgfx.drawspritesetcol(175, 74, 22, 18, help);
+                    graphics.drawspritesetcol(50, 74, 50, 18);
+                    graphics.drawspritesetcol(175, 74, 22, 18);
                 }
                 else
                 {
-                    dwgfx.Print(0, 80, game.savearea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
+                    graphics.Print(0, 80, game.savearea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
                     for (int i = 0; i < 6; i++)
                     {
-                        dwgfx.drawcrewman(169-(3*42)+(i*42), 95, i, game.crewstats[i], help, true);
+                        graphics.drawcrewman(169-(3*42)+(i*42), 95, i, game.crewstats[i], true);
                     }
-                    dwgfx.Print(160 - 84, 132, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-                    dwgfx.Print(160 + 40, 132, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(160 - 84, 132, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(160 + 40, 132, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    dwgfx.drawspritesetcol(50, 126, 50, 18, help);
-                    dwgfx.drawspritesetcol(175, 126, 22, 18, help);
+                    graphics.drawspritesetcol(50, 126, 50, 18);
+                    graphics.drawspritesetcol(175, 126, 22, 18);
                 }
             }
             else
             {
-                dwgfx.Print(0, 80, "[Press ACTION to save your game]", 255 - (help.glow * 2), 255 - (help.glow * 2), 255 - help.glow, true);
+                graphics.Print(0, 80, "[Press ACTION to save your game]", 255 - (help.glow * 2), 255 - (help.glow * 2), 255 - help.glow, true);
 
                 if (game.quicksummary != "")
                 {
-                    if (dwgfx.flipmode)
+                    if (graphics.flipmode)
                     {
-                        dwgfx.Print(0, 110, "Last Save:", 164 - (help.glow / 4), 164 - (help.glow / 4), 164, true);
-                        dwgfx.Print(0, 100, game.quicksummary, 164  - (help.glow / 4), 164 - (help.glow / 4), 164, true);
+                        graphics.Print(0, 110, "Last Save:", 164 - (help.glow / 4), 164 - (help.glow / 4), 164, true);
+                        graphics.Print(0, 100, game.quicksummary, 164  - (help.glow / 4), 164 - (help.glow / 4), 164, true);
                     }
                     else
                     {
-                        dwgfx.Print(0, 100, "Last Save:", 164 - (help.glow / 4), 164 - (help.glow / 4), 164, true);
-                        dwgfx.Print(0, 110, game.quicksummary, 164  - (help.glow / 4), 164 - (help.glow / 4), 164, true);
+                        graphics.Print(0, 100, "Last Save:", 164 - (help.glow / 4), 164 - (help.glow / 4), 164, true);
+                        graphics.Print(0, 110, game.quicksummary, 164  - (help.glow / 4), 164 - (help.glow / 4), 164, true);
                     }
                 }
             }
         }
         break;
     case 10:
-        dwgfx.Print(128, 220, "[ QUIT ]", 196, 196, 255 - help.glow);
+        graphics.Print(128, 220, "[ QUIT ]", 196, 196, 255 - help.glow);
 
-        if (dwgfx.flipmode)
+        if (graphics.flipmode)
         {
             if (game.intimetrial || game.insecretlab || game.nodeathmode || game.menukludge)
             {
-                dwgfx.Print(0, 135, "Return to main menu?", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 135, "Return to main menu?", 196, 196, 255 - help.glow, true);
             }
             else
             {
-                dwgfx.Print(0, 142, "Do you want to quit? You will", 196, 196, 255 - help.glow, true);
-                dwgfx.Print(0, 130, "lose any unsaved progress.", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 142, "Do you want to quit? You will", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 130, "lose any unsaved progress.", 196, 196, 255 - help.glow, true);
             }
 
-            dwgfx.Print(80-16, 88, "[ NO, KEEP PLAYING ]", 196, 196, 255 - help.glow);
-            dwgfx.Print(80 + 32, 76, "yes, quit to menu",  96, 96, 96);
+            graphics.Print(80-16, 88, "[ NO, KEEP PLAYING ]", 196, 196, 255 - help.glow);
+            graphics.Print(80 + 32, 76, "yes, quit to menu",  96, 96, 96);
         }
         else
         {
 
             if (game.intimetrial || game.insecretlab || game.nodeathmode || game.menukludge)
             {
-                dwgfx.Print(0, 80, "Return to main menu?", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 80, "Return to main menu?", 196, 196, 255 - help.glow, true);
             }
             else
             {
-                dwgfx.Print(0, 76, "Do you want to quit? You will", 196, 196, 255 - help.glow, true);
-                dwgfx.Print(0, 88, "lose any unsaved progress.", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 76, "Do you want to quit? You will", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 88, "lose any unsaved progress.", 196, 196, 255 - help.glow, true);
             }
 
-            dwgfx.Print(80-16, 130, "[ NO, KEEP PLAYING ]", 196, 196, 255 - help.glow);
-            dwgfx.Print(80 + 32, 142, "yes, quit to menu",  96, 96, 96);
+            graphics.Print(80-16, 130, "[ NO, KEEP PLAYING ]", 196, 196, 255 - help.glow);
+            graphics.Print(80 + 32, 142, "yes, quit to menu",  96, 96, 96);
 
         }
         break;
     case 11:
-        dwgfx.Print(128, 220, "[ QUIT ]", 196, 196, 255 - help.glow);
+        graphics.Print(128, 220, "[ QUIT ]", 196, 196, 255 - help.glow);
 
-        if (dwgfx.flipmode)
+        if (graphics.flipmode)
         {
             if (game.intimetrial || game.insecretlab || game.nodeathmode || game.menukludge)
             {
-                dwgfx.Print(0, 135, "Return to main menu?", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 135, "Return to main menu?", 196, 196, 255 - help.glow, true);
             }
             else
             {
-                dwgfx.Print(0, 142, "Do you want to quit? You will", 196, 196, 255 - help.glow, true);
-                dwgfx.Print(0, 130, "lose any unsaved progress.", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 142, "Do you want to quit? You will", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 130, "lose any unsaved progress.", 196, 196, 255 - help.glow, true);
             }
 
-            dwgfx.Print(80, 88, "no, keep playing", 96,96,96);
-            dwgfx.Print(80+32-16, 76, "[ YES, QUIT TO MENU ]",  196, 196, 255 - help.glow);
+            graphics.Print(80, 88, "no, keep playing", 96,96,96);
+            graphics.Print(80+32-16, 76, "[ YES, QUIT TO MENU ]",  196, 196, 255 - help.glow);
         }
         else
         {
             if (game.intimetrial || game.insecretlab || game.nodeathmode || game.menukludge)
             {
-                dwgfx.Print(0, 80, "Return to main menu?", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 80, "Return to main menu?", 196, 196, 255 - help.glow, true);
             }
             else
             {
-                dwgfx.Print(0, 76, "Do you want to quit? You will", 196, 196, 255 - help.glow, true);
-                dwgfx.Print(0, 88, "lose any unsaved progress.", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 76, "Do you want to quit? You will", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 88, "lose any unsaved progress.", 196, 196, 255 - help.glow, true);
             }
 
-            dwgfx.Print(80, 130, "no, keep playing", 96,96,96);
-            dwgfx.Print(80+32-16, 142, "[ YES, QUIT TO MENU ]", 196, 196, 255 - help.glow);
+            graphics.Print(80, 130, "no, keep playing", 96,96,96);
+            graphics.Print(80+32-16, 142, "[ YES, QUIT TO MENU ]", 196, 196, 255 - help.glow);
         }
         break;
     case 20:
-        dwgfx.Print(128, 220, "[ GRAVITRON ]", 196, 196, 255 - help.glow, true);
+        graphics.Print(128, 220, "[ GRAVITRON ]", 196, 196, 255 - help.glow, true);
 
-        if (dwgfx.flipmode)
+        if (graphics.flipmode)
         {
-            dwgfx.Print(0, 76, "the secret laboratory?", 196, 196, 255 - help.glow, true);
-            dwgfx.Print(0, 88, "Do you want to return to", 196, 196, 255 - help.glow, true);
-            dwgfx.Print(80-16, 142, "[ NO, KEEP PLAYING ]", 196, 196, 255 - help.glow);
-            dwgfx.Print(80 + 32, 130, "yes, return",  96, 96, 96);
+            graphics.Print(0, 76, "the secret laboratory?", 196, 196, 255 - help.glow, true);
+            graphics.Print(0, 88, "Do you want to return to", 196, 196, 255 - help.glow, true);
+            graphics.Print(80-16, 142, "[ NO, KEEP PLAYING ]", 196, 196, 255 - help.glow);
+            graphics.Print(80 + 32, 130, "yes, return",  96, 96, 96);
         }
         else
         {
-            dwgfx.Print(0, 76, "Do you want to return to", 196, 196, 255 - help.glow, true);
-            dwgfx.Print(0, 88, "the secret laboratory?", 196, 196, 255 - help.glow, true);
-            dwgfx.Print(80-16, 130, "[ NO, KEEP PLAYING ]", 196, 196, 255 - help.glow);
-            dwgfx.Print(80 + 32, 142, "yes, return",  96, 96, 96);
+            graphics.Print(0, 76, "Do you want to return to", 196, 196, 255 - help.glow, true);
+            graphics.Print(0, 88, "the secret laboratory?", 196, 196, 255 - help.glow, true);
+            graphics.Print(80-16, 130, "[ NO, KEEP PLAYING ]", 196, 196, 255 - help.glow);
+            graphics.Print(80 + 32, 142, "yes, return",  96, 96, 96);
         }
 
         break;
     case 21:
-        dwgfx.Print(128, 220, "[ GRAVITRON ]", 196, 196, 255 - help.glow, true);
+        graphics.Print(128, 220, "[ GRAVITRON ]", 196, 196, 255 - help.glow, true);
 
-        if (dwgfx.flipmode)
+        if (graphics.flipmode)
         {
-            dwgfx.Print(0, 76, "the secret laboratory?", 196, 196, 255 - help.glow, true);
-            dwgfx.Print(0, 88, "Do you want to return to", 196, 196, 255 - help.glow, true);
-            dwgfx.Print(80, 142, "no, keep playing", 96, 96, 96);
-            dwgfx.Print(80 + 32-16, 130, "[ YES, RETURN ]",  196, 196, 255 - help.glow);
+            graphics.Print(0, 76, "the secret laboratory?", 196, 196, 255 - help.glow, true);
+            graphics.Print(0, 88, "Do you want to return to", 196, 196, 255 - help.glow, true);
+            graphics.Print(80, 142, "no, keep playing", 96, 96, 96);
+            graphics.Print(80 + 32-16, 130, "[ YES, RETURN ]",  196, 196, 255 - help.glow);
         }
         else
         {
-            dwgfx.Print(0, 76, "Do you want to return to", 196, 196, 255 - help.glow, true);
-            dwgfx.Print(0, 88, "the secret laboratory?", 196, 196, 255 - help.glow, true);
-            dwgfx.Print(80, 130, "no, keep playing", 96, 96, 96);
-            dwgfx.Print(80 + 32-16, 142, "[ YES, RETURN ]",  196, 196, 255 - help.glow);
+            graphics.Print(0, 76, "Do you want to return to", 196, 196, 255 - help.glow, true);
+            graphics.Print(0, 88, "the secret laboratory?", 196, 196, 255 - help.glow, true);
+            graphics.Print(80, 130, "no, keep playing", 96, 96, 96);
+            graphics.Print(80 + 32-16, 142, "[ YES, RETURN ]",  196, 196, 255 - help.glow);
         }
 
     }
@@ -2678,27 +2565,27 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
 
 
 
-    dwgfx.drawfade();
+    graphics.drawfade();
 
     if (game.test)
     {
-        dwgfx.Print(5, 5, game.teststring, 196, 196, 255, false);
+        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
     }
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
-        dwgfx.flashlight();
+        graphics.flashlight();
     }
 
-    if (dwgfx.resumegamemode)
+    if (graphics.resumegamemode)
     {
-        dwgfx.menuoffset += 25;
+        graphics.menuoffset += 25;
         if (map.extrarow)
         {
-            if (dwgfx.menuoffset >= 230)
+            if (graphics.menuoffset >= 230)
             {
-                dwgfx.menuoffset = 230;
+                graphics.menuoffset = 230;
                 //go back to gamemode!
                 game.mapheld = true;
                 game.gamestate = GAMEMODE;
@@ -2706,51 +2593,48 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
         }
         else
         {
-            if (dwgfx.menuoffset >= 240)
+            if (graphics.menuoffset >= 240)
             {
-                dwgfx.menuoffset = 240;
+                graphics.menuoffset = 240;
                 //go back to gamemode!
                 game.mapheld = true;
                 game.gamestate = GAMEMODE;
             }
         }
-        dwgfx.menuoffrender();
+        graphics.menuoffrender();
     }
-    else if (dwgfx.menuoffset > 0)
+    else if (graphics.menuoffset > 0)
     {
-        dwgfx.menuoffset -= 25;
-        if (dwgfx.menuoffset < 0) dwgfx.menuoffset = 0;
-        dwgfx.menuoffrender();
+        graphics.menuoffset -= 25;
+        if (graphics.menuoffset < 0) graphics.menuoffset = 0;
+        graphics.menuoffrender();
     }
     else
     {
         if (game.screenshake > 0 && !game.noflashingmode)
         {
             game.screenshake--;
-            dwgfx.screenshake();
+            graphics.screenshake();
         }
         else
         {
-            dwgfx.render();
+            graphics.render();
         }
     }
-
-    //dwgfx.backbuffer.unlock();
 }
 
-void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help)
+void towerrender()
 {
-
-    FillRect(dwgfx.backBuffer, 0x000000);
+    FillRect(graphics.backBuffer, 0x000000);
 
     if (!game.colourblindmode)
     {
-        dwgfx.drawtowerbackground(map);
-        dwgfx.drawtowermap(map);
+        graphics.drawtowerbackground();
+        graphics.drawtowermap();
     }
     else
     {
-        dwgfx.drawtowermap_nobackground(map);
+        graphics.drawtowermap_nobackground();
     }
 
     if(!game.completestop)
@@ -2758,7 +2642,7 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
         for (int i = 0; i < obj.nentity; i++)
         {
             //Is this entity on the ground? (needed for jumping)
-            if (obj.entitycollidefloor(map, i))
+            if (obj.entitycollidefloor(i))
             {
                 obj.entities[i].onground = 2;
             }
@@ -2767,7 +2651,7 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
                 obj.entities[i].onground--;
             }
 
-            if (obj.entitycollideroof(map, i))
+            if (obj.entitycollideroof(i))
             {
                 obj.entities[i].onroof = 2;
             }
@@ -2777,49 +2661,41 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
             }
 
             //Animate the entities
-            obj.animateentities(i, game, help);
+            obj.animateentities(i);
         }
     }
 
-    dwgfx.drawtowerentities(map, obj, help);
+    graphics.drawtowerentities();
 
-    dwgfx.drawtowerspikes(map);
+    graphics.drawtowerspikes();
 
 
-    /*for(int i=0; i<obj.nblocks; i++){
-    if (obj.blocks[i].active) {
-    		dwgfx.backbuffer.fillRect(obj.blocks[i].rect, 0xDDDDDD);
-    }
-      }*/
-    dwgfx.cutscenebars();
-    BlitSurfaceStandard(dwgfx.backBuffer, NULL, dwgfx.tempBuffer, NULL);
+    graphics.cutscenebars();
+    BlitSurfaceStandard(graphics.backBuffer, NULL, graphics.tempBuffer, NULL);
 
-    dwgfx.drawgui(help);
-    if (dwgfx.flipmode)
+    graphics.drawgui();
+    if (graphics.flipmode)
     {
-        if (game.advancetext) dwgfx.bprint(5, 228, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+        if (game.advancetext) graphics.bprint(5, 228, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
     else
     {
-        if (game.advancetext) dwgfx.bprint(5, 5, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+        if (game.advancetext) graphics.bprint(5, 5, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
 
 
-    dwgfx.footerrect.y = 230;
-    if (dwgfx.translucentroomname)
+    graphics.footerrect.y = 230;
+    if (graphics.translucentroomname)
     {
-        SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
+        SDL_BlitSurface(graphics.footerbuffer, NULL, graphics.backBuffer, &graphics.footerrect);
     }
     else
     {
-        FillRect(dwgfx.backBuffer, dwgfx.footerrect, 0);
+        FillRect(graphics.backBuffer, graphics.footerrect, 0);
     }
-    dwgfx.bprint(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
+    graphics.bprint(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
 
-    //dwgfx.rprint(5, 231,help.String(game.coins), 255 - help.glow/2, 255 - help.glow/2, 196, true);
-    //dwgfx.drawhuetile(311, 230, 48, 1);
-
-    if (game.intimetrial && dwgfx.fademode==0)
+    if (game.intimetrial && graphics.fademode==0)
     {
         //Draw countdown!
         if (game.timetrialcountdown > 0)
@@ -2827,120 +2703,119 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
             if (game.timetrialcountdown < 30)
             {
                 game.resetgameclock();
-                if (int(game.timetrialcountdown / 4) % 2 == 0) dwgfx.bigprint( -1, 100, "Go!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
+                if (int(game.timetrialcountdown / 4) % 2 == 0) graphics.bigprint( -1, 100, "Go!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
             else if (game.timetrialcountdown < 60)
             {
-                dwgfx.bigprint( -1, 100, "1", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
+                graphics.bigprint( -1, 100, "1", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
             else if (game.timetrialcountdown < 90)
             {
-                dwgfx.bigprint( -1, 100, "2", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
+                graphics.bigprint( -1, 100, "2", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
             else if (game.timetrialcountdown < 120)
             {
-                dwgfx.bigprint( -1, 100, "3", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
+                graphics.bigprint( -1, 100, "3", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
         }
         else
         {
             //Draw OSD stuff
-            dwgfx.bprint(6, 18, "TIME :",  255,255,255);
-            dwgfx.bprint(6, 30, "DEATH:",  255, 255, 255);
-            dwgfx.bprint(6, 42, "SHINY:",  255,255,255);
+            graphics.bprint(6, 18, "TIME :",  255,255,255);
+            graphics.bprint(6, 30, "DEATH:",  255, 255, 255);
+            graphics.bprint(6, 42, "SHINY:",  255,255,255);
 
             if(game.timetrialparlost)
             {
-                dwgfx.bprint(56, 18, game.timestring(help),  196, 80, 80);
+                graphics.bprint(56, 18, game.timestring(),  196, 80, 80);
             }
             else
             {
-                dwgfx.bprint(56, 18, game.timestring(help),  196, 196, 196);
+                graphics.bprint(56, 18, game.timestring(),  196, 196, 196);
             }
             if(game.deathcounts>0)
             {
-                dwgfx.bprint(56, 30,help.String(game.deathcounts),  196, 80, 80);
+                graphics.bprint(56, 30,help.String(game.deathcounts),  196, 80, 80);
             }
             else
             {
-                dwgfx.bprint(56, 30,help.String(game.deathcounts),  196, 196, 196);
+                graphics.bprint(56, 30,help.String(game.deathcounts),  196, 196, 196);
             }
             if(game.trinkets<game.timetrialshinytarget)
             {
-                dwgfx.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 80, 80);
+                graphics.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 80, 80);
             }
             else
             {
-                dwgfx.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 196, 196);
+                graphics.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 196, 196);
             }
 
             if(game.timetrialparlost)
             {
-                dwgfx.bprint(195, 214, "PAR TIME:",  80, 80, 80);
-                dwgfx.bprint(275, 214, game.partimestring(help),  80, 80, 80);
+                graphics.bprint(195, 214, "PAR TIME:",  80, 80, 80);
+                graphics.bprint(275, 214, game.partimestring(),  80, 80, 80);
             }
             else
             {
-                dwgfx.bprint(195, 214, "PAR TIME:",  255, 255, 255);
-                dwgfx.bprint(275, 214, game.partimestring(help),  196, 196, 196);
+                graphics.bprint(195, 214, "PAR TIME:",  255, 255, 255);
+                graphics.bprint(275, 214, game.partimestring(),  196, 196, 196);
             }
         }
     }
 
-    dwgfx.drawfade();
+    graphics.drawfade();
 
     if (game.test)
     {
-        dwgfx.Print(5, 5, game.teststring, 196, 196, 255, false);
+        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
     }
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
-        dwgfx.flashlight();
+        graphics.flashlight();
     }
 
     if (game.screenshake > 0 && !game.noflashingmode)
     {
         game.screenshake--;
-        dwgfx.screenshake();
+        graphics.screenshake();
     }
     else
     {
-        dwgfx.render();
+        graphics.render();
     }
 }
 
-void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help)
+void teleporterrender()
 {
-    //dwgfx.backbuffer.lock();
     int tempx;
     int tempy;
     //draw screen alliteration
     //Roomname:
     temp = map.area(game.roomx, game.roomy);
-    if (temp < 2 && !map.custommode && dwgfx.fademode==0)
+    if (temp < 2 && !map.custommode && graphics.fademode==0)
     {
         if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111)
         {
-            dwgfx.Print(5, 2, "The Ship", 196, 196, 255 - help.glow, true);
+            graphics.Print(5, 2, "The Ship", 196, 196, 255 - help.glow, true);
         }
         else
         {
-            dwgfx.Print(5, 2, "Dimension VVVVVV", 196, 196, 255 - help.glow, true);
+            graphics.Print(5, 2, "Dimension VVVVVV", 196, 196, 255 - help.glow, true);
         }
     }
     else
     {
-        dwgfx.Print(5, 2, map.roomname, 196, 196, 255 - help.glow, true);
+        graphics.Print(5, 2, map.roomname, 196, 196, 255 - help.glow, true);
     }
 
     //Background color
-    FillRect(dwgfx.backBuffer, 0, 12, 320, 240, 10, 24, 26);
+    FillRect(graphics.backBuffer, 0, 12, 320, 240, 10, 24, 26);
 
     //draw the map image
-    dwgfx.drawpixeltextbox(35, 16, 250, 190, 32,24, 65, 185, 207,4,0);
-    dwgfx.drawimage(1, 40, 21, false);
+    graphics.drawpixeltextbox(35, 16, 250, 190, 32,24, 65, 185, 207,4,0);
+    graphics.drawimage(1, 40, 21, false);
     //black out areas we can't see yet
     for (int j = 0; j < 20; j++)
     {
@@ -2948,8 +2823,7 @@ void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& o
         {
             if(map.explored[i+(j*20)]==0)
             {
-                //dwgfx.drawfillrect(10 + (i * 12), 21 + (j * 9), 12, 9, 16, 16, 16);
-                dwgfx.drawimage(2, 40 + (i * 12), 21 + (j * 9), false);
+                graphics.drawimage(2, 40 + (i * 12), 21 + (j * 9), false);
             }
         }
     }
@@ -2958,22 +2832,22 @@ void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& o
     if (game.roomx == 109)
     {
         //tower!instead of room y, scale map.ypos
-        dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21  + 2, 12 - 4, 180 - 4, 16, 245 - (help.glow * 2), 245 - (help.glow * 2));
+        graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21  + 2, 12 - 4, 180 - 4, 16, 245 - (help.glow * 2), 245 - (help.glow * 2));
     }
     else
     {
-        dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + ((game.roomy - 100) * 9) + 2, 12 - 4, 9 - 4, 16, 245 - (help.glow * 2), 245 - (help.glow * 2));
+        graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + ((game.roomy - 100) * 9) + 2, 12 - 4, 9 - 4, 16, 245 - (help.glow * 2), 245 - (help.glow * 2));
     }
 
     if (game.useteleporter)
     {
         //Draw the chosen destination coordinate!
-		//TODO
+        //TODO
         //draw the coordinates //destination
         int tempx = map.teleporters[game.teleport_to_teleporter].x;
         int tempy = map.teleporters[game.teleport_to_teleporter].y;
-        dwgfx.drawrect(40 + (tempx * 12) + 1, 21 + (tempy * 9) + 1, 12 - 2, 9 - 2, 245 - (help.glow * 2), 16, 16);
-        dwgfx.drawrect(40 + (tempx * 12) + 3, 21 + (tempy * 9) + 3, 12 - 6, 9 - 6, 245 - (help.glow * 2), 16, 16);
+        graphics.drawrect(40 + (tempx * 12) + 1, 21 + (tempy * 9) + 1, 12 - 2, 9 - 2, 245 - (help.glow * 2), 16, 16);
+        graphics.drawrect(40 + (tempx * 12) + 3, 21 + (tempy * 9) + 3, 12 - 6, 9 - 6, 245 - (help.glow * 2), 16, 16);
     }
 
     //draw legend details
@@ -2982,16 +2856,15 @@ void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& o
         if (map.showteleporters && map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)] > 0)
         {
             temp = 1126 + map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)];
-            if (dwgfx.flipmode) temp += 3;
-            dwgfx.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
+            if (graphics.flipmode) temp += 3;
+            graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
         }
         else if(map.showtargets && map.explored[map.teleporters[i].x+(20*map.teleporters[i].y)]==0)
         {
             temp = 1126 + map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)];
-            if (dwgfx.flipmode) temp += 3;
-            dwgfx.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
+            if (graphics.flipmode) temp += 3;
+            graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
         }
-        //dwgfx.drawtile(40+3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), 1086); //for shiny trinkets, do later
     }
 
     if (map.showtrinkets)
@@ -3001,63 +2874,63 @@ void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& o
             if (obj.collect[i] == 0)
             {
                 temp = 1086;
-                if (dwgfx.flipmode) temp += 3;
-                dwgfx.drawtile(40 + 3 + (map.shinytrinkets[i].x * 12), 22 + (map.shinytrinkets[i].y * 9),	temp);
+                if (graphics.flipmode) temp += 3;
+                graphics.drawtile(40 + 3 + (map.shinytrinkets[i].x * 12), 22 + (map.shinytrinkets[i].y * 9),	temp);
             }
         }
     }
 
-	tempx = map.teleporters[game.teleport_to_teleporter].x;
-	tempy = map.teleporters[game.teleport_to_teleporter].y;
+    tempx = map.teleporters[game.teleport_to_teleporter].x;
+    tempy = map.teleporters[game.teleport_to_teleporter].y;
     if (game.useteleporter && ((help.slowsine%16)>8))
     {
         //colour in the legend
         temp = 1128;
-        if (dwgfx.flipmode) temp += 3;
-        dwgfx.drawtile(40 + 3 + (tempx * 12), 22 + (tempy * 9), temp);
+        if (graphics.flipmode) temp += 3;
+        graphics.drawtile(40 + 3 + (tempx * 12), 22 + (tempy * 9), temp);
     }
 
-    dwgfx.cutscenebars();
+    graphics.cutscenebars();
 
 
     if (game.useteleporter)
     {
         //Instructions!
-        dwgfx.Print(5, 210, "Press Left/Right to choose a Teleporter", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
-        dwgfx.Print(5, 225, "Press ENTER to Teleport", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+        graphics.Print(5, 210, "Press Left/Right to choose a Teleporter", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+        graphics.Print(5, 225, "Press ENTER to Teleport", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
 
-    dwgfx.drawgui(help);
+    graphics.drawgui();
 
-    if (dwgfx.flipmode)
+    if (graphics.flipmode)
     {
-        if (game.advancetext) dwgfx.bprint(5, 228, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+        if (game.advancetext) graphics.bprint(5, 228, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
     else
     {
-        if (game.advancetext) dwgfx.bprint(5, 5, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+        if (game.advancetext) graphics.bprint(5, 5, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
 
 
     if (game.test)
     {
-        dwgfx.Print(5, 5, game.teststring, 196, 196, 255, false);
+        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
     }
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
-        dwgfx.flashlight();
+        graphics.flashlight();
     }
 
-    if (dwgfx.resumegamemode)
+    if (graphics.resumegamemode)
     {
-        dwgfx.menuoffset += 25;
+        graphics.menuoffset += 25;
         if (map.extrarow)
         {
-            if (dwgfx.menuoffset >= 230)
+            if (graphics.menuoffset >= 230)
             {
-                dwgfx.menuoffset = 230;
+                graphics.menuoffset = 230;
                 //go back to gamemode!
                 game.mapheld = true;
                 game.gamestate = GAMEMODE;
@@ -3065,34 +2938,32 @@ void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& o
         }
         else
         {
-            if (dwgfx.menuoffset >= 240)
+            if (graphics.menuoffset >= 240)
             {
-                dwgfx.menuoffset = 240;
+                graphics.menuoffset = 240;
                 //go back to gamemode!
                 game.mapheld = true;
                 game.gamestate = GAMEMODE;
             }
         }
-        dwgfx.menuoffrender();
+        graphics.menuoffrender();
     }
-    else if (dwgfx.menuoffset > 0)
+    else if (graphics.menuoffset > 0)
     {
-        dwgfx.menuoffset -= 25;
-        if (dwgfx.menuoffset < 0) dwgfx.menuoffset = 0;
-        dwgfx.menuoffrender();
+        graphics.menuoffset -= 25;
+        if (graphics.menuoffset < 0) graphics.menuoffset = 0;
+        graphics.menuoffrender();
     }
     else
     {
         if (game.screenshake > 0 && !game.noflashingmode)
         {
             game.screenshake--;
-            dwgfx.screenshake();
+            graphics.screenshake();
         }
         else
         {
-            dwgfx.render();
+            graphics.render();
         }
     }
-
-    //dwgfx.backbuffer.unlock();
 }

--- a/desktop_version/src/titlerender.h
+++ b/desktop_version/src/titlerender.h
@@ -18,18 +18,18 @@ extern Stage stage;
 extern Stage swfStage;
 extern int temp;
 
-void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, UtilityClass& help, musicclass& music);
+void titlerender();
 
-void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help);
+void towerrender();
 
-void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, UtilityClass& help);
+void gamerender();
 
-void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help);
+void maprender();
 
-void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help);
+void teleporterrender();
 
-void gamecompleterender(Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help, mapclass& map);
+void gamecompleterender();
 
-void gamecompleterender2(Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help);
+void gamecompleterender2();
 
 #endif /* TITLERENDERER_H */


### PR DESCRIPTION
## Changes:

### Summary

This patch removes `graphics`, `map`, `obj`, `music`, `key`, and `help` from every single function signature. In other words, it strips out the argument passing stuff that is prevalent in this game.

As a bonus, I took the opportunity to do some cleanup of function arguments in general. I removed unused parameters from functions, and I removed some unused functions or variables, as well as ones that were essentially useless and did nothing (see below).

Furthermore, all expressions of the form `UtilityClass::`*`something`* have been
changed to `help.`*`something`*. It's shorter this way.

The following functions had unused parameters:
 - `entityclass::checkdirectional()`
 - `entityclass::getcompanion()`
 - `Graphics::drawtile()`
 - `Graphics::drawtile2()`
 - `Graphics::Hitest()`

The following unused or useless functions and variables have been removed:
 - `Game::telegotoship()`
 - `Game::sfpsmode`
 - `Game::telecookieexists`
 - `Game::quickcookieexists`
 - `updategraphicsmode()`
 - `editorclass::weirdloadthing()` (instead, make a copy of the string and use
   `editorclass::load()`)
 - `Screen::ClearScreen()`

I also cleaned up some formatting, such as removing mixed indentation, fixing spacing, and removing some commented-out code from earlier versions of the game.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
