### PR TITLE
Allow using F11 and (on macOS) RCommand+Enter/F to toggle fullscreen

### DIFF
--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -81,14 +81,13 @@ void KeyPoll::Poll()
 			{
 				pressedbackspace = true;
 			}
-			else if (	(	evt.key.keysym.sym == SDLK_RETURN ||
-						evt.key.keysym.sym == SDLK_f	) &&
-#ifdef __APPLE__ /* OSX prefers the command key over the alt keys. -flibit */
-					keymap[SDLK_LGUI]	)
+			else if (((evt.key.keysym.sym == SDLK_RETURN || evt.key.keysym.sym == SDLK_f) &&
+#ifdef __APPLE__ /* OSX prefers the command keys over the alt keys. -flibit */
+			(keymap[SDLK_LGUI] || keymap[SDLK_RGUI])
 #else
-					(	keymap[SDLK_LALT] ||
-						keymap[SDLK_RALT]	)	)
+			(keymap[SDLK_LALT] || keymap[SDLK_RALT])
 #endif
+			) || evt.key.keysym.sym == SDLK_F11)
 			{
 				toggleFullscreen = true;
 			}

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -77,17 +77,21 @@ void KeyPoll::Poll()
 		if (evt.type == SDL_KEYDOWN)
 		{
 			keymap[evt.key.keysym.sym] = true;
+
 			if (evt.key.keysym.sym == SDLK_BACKSPACE)
 			{
 				pressedbackspace = true;
 			}
-			else if (((evt.key.keysym.sym == SDLK_RETURN || evt.key.keysym.sym == SDLK_f) &&
+
 #ifdef __APPLE__ /* OSX prefers the command keys over the alt keys. -flibit */
-			(keymap[SDLK_LGUI] || keymap[SDLK_RGUI])
+			bool altpressed = keymap[SDLK_LGUI] || keymap[SDLK_RGUI];
 #else
-			(keymap[SDLK_LALT] || keymap[SDLK_RALT])
+			bool altpressed = keymap[SDLK_LALT] || keymap[SDLK_RALT];
 #endif
-			) || evt.key.keysym.sym == SDLK_F11)
+			bool returnpressed = evt.key.keysym.sym == SDLK_RETURN;
+			bool fpressed = evt.key.keysym.sym == SDLK_f;
+			bool f11pressed = evt.key.keysym.sym == SDLK_F11;
+			if ((altpressed && (returnpressed || fpressed)) || f11pressed)
 			{
 				toggleFullscreen = true;
 			}


### PR DESCRIPTION
## Changes:

* **Allow using F11 and, on macOS, RCommand+Enter/F to toggle fullscreen**

  This patch allows the use of pressing F11 to toggle fullscreen, as well as allowing the use of Right Command when using the Command+Enter/F shortcut on macOS. Apparently Alt+Enter isn't the only shortcut to toggle fullscreen, Alt+F also works, which I didn't know before.

  I'm adding F11 as a shortcut because it's a far more natural shortcut to toggle fullscreen than this Alt+Enter or Alt+F business, which seems to be a relic mimicking some other games and some Microsoft stuff?

  I'm also adding RCommand+Enter/F because I see no reason not to. If you can use RAlt on non-macOS, why can't you use RCommand on macOS, too?

  I also cleaned up the formatting relating to the shortcut code, and took the ifdef for macOS outside of the if-statement to make it more readable.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
