### PR TITLE
Don't print useless false error message when toggling fullscreen

### DIFF
--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -89,8 +89,10 @@ Screen::Screen()
     glScreen = true;
 }
 
-void Screen::ResizeScreen(int x , int y)
+int Screen::ResizeScreen(int x, int y)
 {
+	int result = 0; // 0 is success, nonzero is failure
+
 	static int resX = 320;
 	static int resY = 240;
 	if (x != -1 && y != -1)
@@ -102,11 +104,11 @@ void Screen::ResizeScreen(int x , int y)
 
 	if(!isWindowed)
 	{
-		SDL_SetWindowFullscreen(m_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+		result = SDL_SetWindowFullscreen(m_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
 	}
 	else
 	{
-		SDL_SetWindowFullscreen(m_window, 0);
+		result = SDL_SetWindowFullscreen(m_window, 0);
 		if (x != -1 && y != -1)
 		{
 			SDL_SetWindowSize(m_window, resX, resY);
@@ -118,14 +120,16 @@ void Screen::ResizeScreen(int x , int y)
 		int winX, winY;
 		SDL_GetWindowSize(m_window, &winX, &winY);
 		SDL_RenderSetLogicalSize(m_renderer, winX, winY);
-		SDL_RenderSetIntegerScale(m_renderer, SDL_FALSE);
+		result = SDL_RenderSetIntegerScale(m_renderer, SDL_FALSE);
 	}
 	else
 	{
 		SDL_RenderSetLogicalSize(m_renderer, 320, 240);
-		SDL_RenderSetIntegerScale(m_renderer, (SDL_bool) (stretchMode == 2));
+		result = SDL_RenderSetIntegerScale(m_renderer, (SDL_bool) (stretchMode == 2));
 	}
 	SDL_ShowWindow(m_window);
+
+	return result;
 }
 
 void Screen::GetWindowSize(int* x, int* y)
@@ -180,10 +184,11 @@ void Screen::FlipScreen()
 	SDL_FillRect(m_screen, NULL, 0x00000000);
 }
 
-void Screen::toggleFullScreen()
+int Screen::toggleFullScreen()
 {
 	isWindowed = !isWindowed;
-	ResizeScreen(-1, -1);
+	int result = ResizeScreen(-1, -1);
+	return result;
 }
 
 void Screen::toggleStretchMode()

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -8,7 +8,7 @@ class Screen
 public:
 	Screen();
 
-	void ResizeScreen(int x, int y);
+	int ResizeScreen(int x, int y);
 	void GetWindowSize(int* x, int* y);
 
 	void UpdateScreen(SDL_Surface* buffer, SDL_Rect* rect);
@@ -17,7 +17,7 @@ public:
 
 	const SDL_PixelFormat* GetFormat();
 
-	void toggleFullScreen();
+	int toggleFullScreen();
 	void toggleStretchMode();
 	void toggleLinearFilter();
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -307,44 +307,39 @@ int main(int argc, char *argv[])
 
 
         key.Poll();
-		if(key.toggleFullscreen)
-		{
-			if(!gameScreen.isWindowed)
-			{
-				//SDL_WM_GrabInput(SDL_GRAB_ON);
-				SDL_ShowCursor(SDL_DISABLE);
-				SDL_ShowCursor(SDL_ENABLE);
-			}
-			else
-			{
-				SDL_ShowCursor(SDL_ENABLE);
-			}
+        if(key.toggleFullscreen)
+        {
+            if(!gameScreen.isWindowed)
+            {
+                SDL_ShowCursor(SDL_DISABLE);
+                SDL_ShowCursor(SDL_ENABLE);
+            }
+            else
+            {
+                SDL_ShowCursor(SDL_ENABLE);
+            }
 
 
-			if(game.gamestate == EDITORMODE)
-			{
-				SDL_ShowCursor(SDL_ENABLE);
-			}
+            if(game.gamestate == EDITORMODE)
+            {
+                SDL_ShowCursor(SDL_ENABLE);
+            }
 
-			gameScreen.toggleFullScreen();
-			game.fullscreen = !game.fullscreen;
-			key.toggleFullscreen = false;
+            int result = gameScreen.toggleFullScreen();
+            game.fullscreen = !game.fullscreen;
+            key.toggleFullscreen = false;
 
-				key.keymap.clear(); //we lost the input due to a new window.
-				game.press_left = false;
-				game.press_right = false;
-				game.press_action = true;
-				game.press_map = false;
-			printf("Error: failed: %s\n", SDL_GetError());
+            key.keymap.clear(); //we lost the input due to a new window.
+            game.press_left = false;
+            game.press_right = false;
+            game.press_action = true;
+            game.press_map = false;
 
-
-
-
-		}
-		/*if(key.quitProgram)
-		{
-			music.playef(2);
-		}*/
+            if(result != 0)
+            {
+                printf("Error: toggling fullscreen failed: %s\n", SDL_GetError());
+            }
+        }
 
         game.infocus = key.isActive;
         if(!game.infocus)


### PR DESCRIPTION
## Changes:

* **Fix console message when using a shortcut that toggles fullscreen**

  Whenever you would press Alt+Enter, or Alt+F, or on macOS Command+Enter, or on macOS Command+F, or F11, the game would print this useless error message to console, every single time: "Error: failed: " and it would concatenate `SDL_GetError()` after it, but most of the time `SDL_GetError()` is blank, so it would print just that.

  Instead, what the fullscreen shortcut will now do is check the result of the relevant SDL functions, BEFORE it decides to print an error message. And when it DOES print an error message, it will be less vague and will say instead "Error: toggling fullscreen failed: `<output of SDL_GetError()>`".

  This means `Screen::ResizeScreen()` and `Screen::toggleFullScreen()` are now int-returning functions. Ideally, every function interfacing with SDL would return an error code, but that's too much for this simple patch.

  Additionally, I took the opportunity to clean up the surrounding formatting of the code a bit, most notably dedenting the keypress-clearing stuff by one tab level, converting the shortcut-handling code to spaces, and removing commented-out code.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
