### PR TITLE
Allow returning results from the earlier two SDL functions in Screen::ResizeScreen()

### DIFF
--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -92,6 +92,8 @@ Screen::Screen()
 int Screen::ResizeScreen(int x, int y)
 {
 	int result = 0; // 0 is success, nonzero is failure
+	int result2 = 0;
+	int result3 = 0;
 
 	static int resX = 320;
 	static int resY = 240;
@@ -119,16 +121,24 @@ int Screen::ResizeScreen(int x, int y)
 	{
 		int winX, winY;
 		SDL_GetWindowSize(m_window, &winX, &winY);
-		SDL_RenderSetLogicalSize(m_renderer, winX, winY);
-		result = SDL_RenderSetIntegerScale(m_renderer, SDL_FALSE);
+		result2 = SDL_RenderSetLogicalSize(m_renderer, winX, winY);
+		result3 = SDL_RenderSetIntegerScale(m_renderer, SDL_FALSE);
 	}
 	else
 	{
-		SDL_RenderSetLogicalSize(m_renderer, 320, 240);
-		result = SDL_RenderSetIntegerScale(m_renderer, (SDL_bool) (stretchMode == 2));
+		result2 = SDL_RenderSetLogicalSize(m_renderer, 320, 240);
+		result3 = SDL_RenderSetIntegerScale(m_renderer, (SDL_bool) (stretchMode == 2));
 	}
 	SDL_ShowWindow(m_window);
 
+	if (result3 != 0)
+	{
+		return result3;
+	}
+	if (result2 != 0)
+	{
+		return result2;
+	}
 	return result;
 }
 


### PR DESCRIPTION
## Changes:

* **Allow returning results from the earlier two SDL functions in `Screen::ResizeScreen()`**

  Any particular invocation of `Screen::ResizeScreen()` will end up calling three SDL functions, but there can only be one error code returned. My previous patch (#182) prioritized the last SDL function at all times, even if the earlier functions failed.

  So if the third fails, return the result of the third. Otherwise, if the second fails, return the result of the second. Else just return the result of the first.

  This is in sync with the fact that `SDL_GetError()` will prioritize the last failed function called, so the error code given is the one corresponding with `SDL_GetError()` in the end.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
