### PR TITLE
Do proper error handling inside Screen::ResizeScreen()

### DIFF
--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -89,10 +89,8 @@ Screen::Screen()
     glScreen = true;
 }
 
-int Screen::ResizeScreen(int x, int y)
+void Screen::ResizeScreen(int x, int y)
 {
-	int result = 0; // 0 is success, nonzero is failure
-
 	static int resX = 320;
 	static int resY = 240;
 	if (x != -1 && y != -1)
@@ -104,11 +102,21 @@ int Screen::ResizeScreen(int x, int y)
 
 	if(!isWindowed)
 	{
-		result = SDL_SetWindowFullscreen(m_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+		int result = SDL_SetWindowFullscreen(m_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+		if (result != 0)
+		{
+			printf("Error: could not set the game to fullscreen mode: %s\n", SDL_GetError());
+			return;
+		}
 	}
 	else
 	{
-		result = SDL_SetWindowFullscreen(m_window, 0);
+		int result = SDL_SetWindowFullscreen(m_window, 0);
+		if (result != 0)
+		{
+			printf("Error: could not set the game to windowed mode: %s\n", SDL_GetError());
+			return;
+		}
 		if (x != -1 && y != -1)
 		{
 			SDL_SetWindowSize(m_window, resX, resY);
@@ -119,17 +127,30 @@ int Screen::ResizeScreen(int x, int y)
 	{
 		int winX, winY;
 		SDL_GetWindowSize(m_window, &winX, &winY);
-		SDL_RenderSetLogicalSize(m_renderer, winX, winY);
+		int result = SDL_RenderSetLogicalSize(m_renderer, winX, winY);
+		if (result != 0)
+		{
+			printf("Error: could not set logical size: %s\n", SDL_GetError());
+			return;
+		}
 		result = SDL_RenderSetIntegerScale(m_renderer, SDL_FALSE);
+		if (result != 0)
+		{
+			printf("Error: could not set scale: %s\n", SDL_GetError());
+			return;
+		}
 	}
 	else
 	{
 		SDL_RenderSetLogicalSize(m_renderer, 320, 240);
-		result = SDL_RenderSetIntegerScale(m_renderer, (SDL_bool) (stretchMode == 2));
+		int result = SDL_RenderSetIntegerScale(m_renderer, (SDL_bool) (stretchMode == 2));
+		if (result != 0)
+		{
+			printf("Error: could not set scale: %s\n", SDL_GetError());
+			return;
+		}
 	}
 	SDL_ShowWindow(m_window);
-
-	return result;
 }
 
 void Screen::GetWindowSize(int* x, int* y)
@@ -184,11 +205,10 @@ void Screen::FlipScreen()
 	SDL_FillRect(m_screen, NULL, 0x00000000);
 }
 
-int Screen::toggleFullScreen()
+void Screen::toggleFullScreen()
 {
 	isWindowed = !isWindowed;
-	int result = ResizeScreen(-1, -1);
-	return result;
+	ResizeScreen(-1, -1);
 }
 
 void Screen::toggleStretchMode()

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -8,7 +8,7 @@ class Screen
 public:
 	Screen();
 
-	int ResizeScreen(int x, int y);
+	void ResizeScreen(int x, int y);
 	void GetWindowSize(int* x, int* y);
 
 	void UpdateScreen(SDL_Surface* buffer, SDL_Rect* rect);
@@ -17,7 +17,7 @@ public:
 
 	const SDL_PixelFormat* GetFormat();
 
-	int toggleFullScreen();
+	void toggleFullScreen();
 	void toggleStretchMode();
 	void toggleLinearFilter();
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -325,7 +325,7 @@ int main(int argc, char *argv[])
                 SDL_ShowCursor(SDL_ENABLE);
             }
 
-            int result = gameScreen.toggleFullScreen();
+            gameScreen.toggleFullScreen();
             game.fullscreen = !game.fullscreen;
             key.toggleFullscreen = false;
 
@@ -334,11 +334,6 @@ int main(int argc, char *argv[])
             game.press_right = false;
             game.press_action = true;
             game.press_map = false;
-
-            if(result != 0)
-            {
-                printf("Error: toggling fullscreen failed: %s\n", SDL_GetError());
-            }
         }
 
         game.infocus = key.isActive;


### PR DESCRIPTION
## Changes:

* **Properly handle errors inside `Screen::ResizeScreen()`**

  Instead of passing the error codes out of the function, just handle the errors directly as they happen, and fail gracefully if something goes wrong instead of continuing.

  This should be done for every instance an SDL function is called, but this is a good start.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
