### PR TITLE
Don't let custom levels tamper with main game save data

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4208,6 +4208,12 @@ void Game::deletestats( mapclass& map, Graphics& dwgfx )
 
 void Game::unlocknum( int t, mapclass& map, Graphics& dwgfx )
 {
+    if (map.custommode)
+    {
+        //Don't let custom levels unlock things!
+        return;
+    }
+
     unlock[t] = true;
     savestats(map, dwgfx);
 }
@@ -5661,6 +5667,12 @@ void Game::savetele( mapclass& map, entityclass& obj, musicclass& music )
     //Save to the telesave cookie
     telecookieexists = true;
 
+    if (map.custommode)
+    {
+        //Don't trash save data!
+        return;
+    }
+
     TiXmlDocument doc;
     TiXmlElement* msg;
     TiXmlDeclaration* decl = new TiXmlDeclaration( "1.0", "", "" );
@@ -5903,6 +5915,12 @@ void Game::savetele( mapclass& map, entityclass& obj, musicclass& music )
 void Game::savequick( mapclass& map, entityclass& obj, musicclass& music )
 {
     quickcookieexists = true;
+
+    if (map.custommode)
+    {
+        //Don't trash save data!
+        return;
+    }
 
     TiXmlDocument doc;
     TiXmlElement* msg;


### PR DESCRIPTION
## Changes:

* **Prevent custom levels from tampering with main game save data**

  Someone being mean could've overwritten the telesaves of unsuspecting players, or unlocked a bunch of stuff which they shouldn't have for those players, using things like the `telesave()` command and gamestates. To prevent this, return early in `Game::savequick()`, `Game::savetele()`, and `Game::unlocknum()` if we are in custommode.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
