### PR TITLE
Correct Warp Zone's area name on the mobile version

### DIFF
--- a/mobile_version/src/mapclass.as
+++ b/mobile_version/src/mapclass.as
@@ -790,7 +790,7 @@
 				case 1: return "Dimension VVVVVV"; break;
 				case 2: return "Laboratory"; break;
 				case 3: return "The Tower"; break;
-				case 4: return "Warpzone"; break;
+				case 4: return "Warp Zone"; break;
 				case 5: return "Space Station"; break;
 				case 6: return "Outside Dimension VVVVVV"; break;
 				case 7: return "Outside Dimension VVVVVV"; break;


### PR DESCRIPTION
## Changes:

* **Correct Warp Zone's area name on the mobile version**

  This changes the name from "Warpzone" to "Warp Zone", like it properly should be.

  This is the name that gets displayed in your save file.

  This PR is the same as #84, but for the mobile version.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
