### PR TITLE
Remove the passing around of 'dwgfx', 'map', 'obj', 'music', 'key', and 'help'

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4465,34 +4465,6 @@ bool entityclass::entitycollide( int a, int b )
     return false;
 }
 
-bool entityclass::checkdirectional( int t )
-{
-    //Returns true if player entity (rule 0) moving in dir t through directional block
-    for(int i=0; i < nentity; i++)
-    {
-        if(entities[i].rule==0)
-        {
-            tempx = entities[i].xp + entities[i].cx;
-            tempy = entities[i].yp + entities[i].cy;
-            tempw = entities[i].w;
-            temph = entities[i].h;
-            rectset(tempx, tempy, tempw, temph);
-
-            for (int j=0; j<nblocks; j++)
-            {
-                if (blocks[j].type == DIRECTIONAL && blocks[j].active)
-                {
-                    if(UtilityClass::intersects(blocks[j].rect,temprect))
-                    {
-                        return true;
-                    }
-                }
-            }
-        }
-    }
-    return false;
-}
-
 bool entityclass::checkdamage()
 {
     //Returns true if player entity (rule 0) collides with a damagepoint

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4309,7 +4309,7 @@ bool entityclass::gettype( int t )
     return false;
 }
 
-int entityclass::getcompanion( int t )
+int entityclass::getcompanion()
 {
     //Returns the index of the companion with rule t
     for (int i = 0; i < nentity; i++)

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -5274,7 +5274,7 @@ void entityclass::entitycollisioncheck()
                                 if (graphics.flipmode)
                                 {
                                     if (graphics.Hitest(graphics.flipsprites[entities[i].drawframe],
-                                                     colpoint1, 1, graphics.flipsprites[entities[j].drawframe], colpoint2, 1))
+                                                     colpoint1, graphics.flipsprites[entities[j].drawframe], colpoint2))
                                     {
                                         //Do the collision stuff
                                         game.deathseq = 30;
@@ -5283,7 +5283,7 @@ void entityclass::entitycollisioncheck()
                                 else
                                 {
                                     if (graphics.Hitest(graphics.sprites[entities[i].drawframe],
-                                                     colpoint1, 1, graphics.sprites[entities[j].drawframe], colpoint2, 1) )
+                                                     colpoint1, graphics.sprites[entities[j].drawframe], colpoint2) )
                                     {
                                         //Do the collision stuff
                                         game.deathseq = 30;
@@ -5402,7 +5402,7 @@ void entityclass::entitycollisioncheck()
                                         if (graphics.flipmode)
                                         {
                                             if (graphics.Hitest(graphics.flipsprites[entities[i].drawframe],
-                                                             colpoint1, 1, graphics.flipsprites[entities[j].drawframe], colpoint2, 1))
+                                                             colpoint1, graphics.flipsprites[entities[j].drawframe], colpoint2))
                                             {
                                                 //Do the collision stuff
                                                 game.deathseq = 30;
@@ -5412,7 +5412,7 @@ void entityclass::entitycollisioncheck()
                                         else
                                         {
                                             if (graphics.Hitest(graphics.sprites[entities[i].drawframe],
-                                                             colpoint1, 1, graphics.sprites[entities[j].drawframe], colpoint2, 1))
+                                                             colpoint1, graphics.sprites[entities[j].drawframe], colpoint2))
                                             {
                                                 //Do the collision stuff
                                                 game.deathseq = 30;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4805,7 +4805,7 @@ bool entityclass::entitywarphlinecollide(int t, int l) {
 					if (entities[t].oldyp < entities[l].yp + 10) linetemp++;
 					if (entities[t].oldyp + entities[t].h < entities[l].yp + 10) linetemp++;
 				}
-							
+
 				if (linetemp > 0) return true;
 				return false;
 			}else {
@@ -4816,7 +4816,7 @@ bool entityclass::entitywarphlinecollide(int t, int l) {
 					if (entities[t].oldyp > entities[l].yp - 10) linetemp++;
 					if (entities[t].oldyp + entities[t].h > entities[l].yp - 10) linetemp++;
 				}
-						
+
 				if (linetemp > 0) return true;
 				return false;
 			}
@@ -4824,7 +4824,7 @@ bool entityclass::entitywarphlinecollide(int t, int l) {
 	}
 	return false;
 }
-		
+
 bool entityclass::entitywarpvlinecollide(int t, int l) {
 	//Returns true is entity t collided with the vertical warp line l.
 	if(entities[t].yp + entities[t].cy+entities[t].h>=entities[l].yp){
@@ -4836,7 +4836,7 @@ bool entityclass::entitywarpvlinecollide(int t, int l) {
 				if (entities[t].xp + entities[t].cx+1 + entities[t].w < entities[l].xp + 10) linetemp++;
 				if (entities[t].oldxp + entities[t].cx + 1 < entities[l].xp + 10) linetemp++;
 				if (entities[t].oldxp + entities[t].cx + 1 + entities[t].w < entities[l].xp + 10) linetemp++;
-						
+
 				if (linetemp > 0) return true;
 				return false;
 			}else {
@@ -4845,7 +4845,7 @@ bool entityclass::entitywarpvlinecollide(int t, int l) {
 				if (entities[t].xp + entities[t].cx+1 + entities[t].w > entities[l].xp - 10) linetemp++;
 				if (entities[t].oldxp + entities[t].cx + 1 > entities[l].xp - 10) linetemp++;
 				if (entities[t].oldxp + entities[t].cx + 1 + entities[t].w > entities[l].xp - 10) linetemp++;
-						
+
 				if (linetemp > 0) return true;
 				return false;
 			}
@@ -5195,21 +5195,21 @@ void entityclass::hormovingplatformfix( int t )
 void entityclass::customwarplinecheck(int i) {
 		//Turns on obj.customwarpmodevon and obj.customwarpmodehon if player collides
 		//with warp lines
-			
+
 	if (entities[i].active) {
 		//We test entity to entity
 		for (int j = 0; j < nentity; j++) {
 			if (entities[j].active && i != j) {//Active
 				if (entities[i].rule == 0 && entities[j].rule == 5) { //Player vs vertical line!
-					if (entities[j].type == 51 || entities[j].type == 52) {								
-						if (entitywarpvlinecollide(i, j)) {	
+					if (entities[j].type == 51 || entities[j].type == 52) {
+						if (entitywarpvlinecollide(i, j)) {
 							customwarpmodevon = true;
 						}
 					}
 				}
-						
+
 				if (entities[i].rule == 0 && entities[j].rule == 7){   //Player vs horizontal WARP line
-					if (entities[j].type == 53 || entities[j].type == 54) {								
+					if (entities[j].type == 53 || entities[j].type == 54) {
 						if (entitywarphlinecollide(i, j)) {
 							customwarpmodehon = true;
 						}

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4461,7 +4461,7 @@ bool entityclass::entitycollide( int a, int b )
     temph = entities[b].h;
     rect2set(tempx, tempy, tempw, temph);
 
-    if (UtilityClass::intersects(temprect, temprect2)) return true;
+    if (help.intersects(temprect, temprect2)) return true;
     return false;
 }
 
@@ -4482,7 +4482,7 @@ bool entityclass::checkdamage()
             {
                 if (blocks[j].type == DAMAGE && blocks[j].active)
                 {
-                    if(UtilityClass::intersects(blocks[j].rect, temprect))
+                    if(help.intersects(blocks[j].rect, temprect))
                     {
                         return true;
                     }
@@ -4510,7 +4510,7 @@ bool entityclass::scmcheckdamage()
             {
                 if (blocks[j].type == DAMAGE && blocks[j].active)
                 {
-                    if(UtilityClass::intersects(blocks[j].rect, temprect))
+                    if(help.intersects(blocks[j].rect, temprect))
                     {
                         return true;
                     }
@@ -4548,7 +4548,7 @@ int entityclass::checktrigger()
             {
                 if (blocks[j].type == TRIGGER && blocks[j].active)
                 {
-                    if (UtilityClass::intersects(blocks[j].rect, temprect))
+                    if (help.intersects(blocks[j].rect, temprect))
                     {
                         activetrigger = blocks[j].trigger;
                         return blocks[j].trigger;
@@ -4577,7 +4577,7 @@ int entityclass::checkactivity()
             {
                 if (blocks[j].type == ACTIVITY && blocks[j].active)
                 {
-                    if (UtilityClass::intersects(blocks[j].rect, temprect))
+                    if (help.intersects(blocks[j].rect, temprect))
                     {
                         return j;
                     }
@@ -4614,7 +4614,7 @@ bool entityclass::checkplatform()
         {
             if (blocks[i].type == BLOCK)
             {
-                if (UtilityClass::intersects(blocks[i].rect, temprect))
+                if (help.intersects(blocks[i].rect, temprect))
                 {
                     px = blocks[i].xp;
                     py = blocks[i].yp;
@@ -4636,15 +4636,15 @@ bool entityclass::checkblocks()
             {
                 if (blocks[i].type == DIRECTIONAL)
                 {
-                    if (dy > 0 && blocks[i].trigger == 0) if (UtilityClass::intersects(blocks[i].rect, temprect)) return true;
-                    if (dy <= 0 && blocks[i].trigger == 1) if (UtilityClass::intersects(blocks[i].rect, temprect)) return true;
-                    if (dx > 0 && blocks[i].trigger == 2) if (UtilityClass::intersects(blocks[i].rect, temprect)) return true;
-                    if (dx <= 0 && blocks[i].trigger == 3) if (UtilityClass::intersects(blocks[i].rect, temprect)) return true;
+                    if (dy > 0 && blocks[i].trigger == 0) if (help.intersects(blocks[i].rect, temprect)) return true;
+                    if (dy <= 0 && blocks[i].trigger == 1) if (help.intersects(blocks[i].rect, temprect)) return true;
+                    if (dx > 0 && blocks[i].trigger == 2) if (help.intersects(blocks[i].rect, temprect)) return true;
+                    if (dx <= 0 && blocks[i].trigger == 3) if (help.intersects(blocks[i].rect, temprect)) return true;
                 }
             }
             if (blocks[i].type == BLOCK)
             {
-                if (UtilityClass::intersects(blocks[i].rect, temprect))
+                if (help.intersects(blocks[i].rect, temprect))
                 {
                     return true;
                 }
@@ -4653,7 +4653,7 @@ bool entityclass::checkblocks()
             {
                 if( (dr)==1)
                 {
-                    if (UtilityClass::intersects(blocks[i].rect, temprect))
+                    if (help.intersects(blocks[i].rect, temprect))
                     {
                         return true;
                     }

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1916,7 +1916,7 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         if (customplatformtile > 0){
             entities[k].tile = customplatformtile;
         }else if (platformtile > 0) {
-						entities[k].tile = platformtile;
+            entities[k].tile = platformtile;
         }else{
           //appearance again depends on location
           if (gridmatch(p1, p2, p3, p4, 100, 70, 320, 160)) entities[k].tile = 616;
@@ -1932,10 +1932,10 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         entities[k].w = 32;
         entities[k].h = 8;
 
-		if (int(vx) <= 1) vertplatforms = true;
-		if (int(vx) >= 2  && int(vx) <= 5) horplatforms = true;
-		if (int(vx) == 14 || int(vx) == 15) horplatforms = true; //special case for last part of Space Station
-		if (int(vx) >= 6  && int(vx) <= 7) vertplatforms = true;
+        if (int(vx) <= 1) vertplatforms = true;
+        if (int(vx) >= 2  && int(vx) <= 5) horplatforms = true;
+        if (int(vx) == 14 || int(vx) == 15) horplatforms = true; //special case for last part of Space Station
+        if (int(vx) >= 6  && int(vx) <= 7) vertplatforms = true;
 
         if (int(vx) >= 10  && int(vx) <= 11)
         {
@@ -4793,65 +4793,65 @@ bool entityclass::entityvlinecollide( int t, int l )
 }
 
 bool entityclass::entitywarphlinecollide(int t, int l) {
-	//Returns true is entity t collided with the horizontal line l.
-	if(entities[t].xp + entities[t].cx+entities[t].w>=entities[l].xp){
-		if(entities[t].xp + entities[t].cx<=entities[l].xp+entities[l].w){
-			linetemp = 0;
-			if (entities[l].yp < 120) {
-				//Top line
-				if (entities[t].vy < 0) {
-					if (entities[t].yp < entities[l].yp + 10) linetemp++;
-					if (entities[t].yp + entities[t].h < entities[l].yp + 10) linetemp++;
-					if (entities[t].oldyp < entities[l].yp + 10) linetemp++;
-					if (entities[t].oldyp + entities[t].h < entities[l].yp + 10) linetemp++;
-				}
+    //Returns true is entity t collided with the horizontal line l.
+    if(entities[t].xp + entities[t].cx+entities[t].w>=entities[l].xp){
+        if(entities[t].xp + entities[t].cx<=entities[l].xp+entities[l].w){
+            linetemp = 0;
+            if (entities[l].yp < 120) {
+                //Top line
+                if (entities[t].vy < 0) {
+                    if (entities[t].yp < entities[l].yp + 10) linetemp++;
+                    if (entities[t].yp + entities[t].h < entities[l].yp + 10) linetemp++;
+                    if (entities[t].oldyp < entities[l].yp + 10) linetemp++;
+                    if (entities[t].oldyp + entities[t].h < entities[l].yp + 10) linetemp++;
+                }
 
-				if (linetemp > 0) return true;
-				return false;
-			}else {
-				//Bottom line
-				if (entities[t].vy > 0) {
-					if (entities[t].yp > entities[l].yp - 10) linetemp++;
-					if (entities[t].yp + entities[t].h > entities[l].yp - 10) linetemp++;
-					if (entities[t].oldyp > entities[l].yp - 10) linetemp++;
-					if (entities[t].oldyp + entities[t].h > entities[l].yp - 10) linetemp++;
-				}
+                if (linetemp > 0) return true;
+                return false;
+            }else {
+                //Bottom line
+                if (entities[t].vy > 0) {
+                    if (entities[t].yp > entities[l].yp - 10) linetemp++;
+                    if (entities[t].yp + entities[t].h > entities[l].yp - 10) linetemp++;
+                    if (entities[t].oldyp > entities[l].yp - 10) linetemp++;
+                    if (entities[t].oldyp + entities[t].h > entities[l].yp - 10) linetemp++;
+                }
 
-				if (linetemp > 0) return true;
-				return false;
-			}
-		}
-	}
-	return false;
+                if (linetemp > 0) return true;
+                return false;
+            }
+        }
+    }
+    return false;
 }
 
 bool entityclass::entitywarpvlinecollide(int t, int l) {
-	//Returns true is entity t collided with the vertical warp line l.
-	if(entities[t].yp + entities[t].cy+entities[t].h>=entities[l].yp){
-		if (entities[t].yp + entities[t].cy <= entities[l].yp + entities[l].h) {
-			linetemp = 0;
-			if (entities[l].xp < 160) {
-				//Left hand line
-				if (entities[t].xp + entities[t].cx + 1 < entities[l].xp + 10) linetemp++;
-				if (entities[t].xp + entities[t].cx+1 + entities[t].w < entities[l].xp + 10) linetemp++;
-				if (entities[t].oldxp + entities[t].cx + 1 < entities[l].xp + 10) linetemp++;
-				if (entities[t].oldxp + entities[t].cx + 1 + entities[t].w < entities[l].xp + 10) linetemp++;
+    //Returns true is entity t collided with the vertical warp line l.
+    if(entities[t].yp + entities[t].cy+entities[t].h>=entities[l].yp){
+        if (entities[t].yp + entities[t].cy <= entities[l].yp + entities[l].h) {
+            linetemp = 0;
+            if (entities[l].xp < 160) {
+                //Left hand line
+                if (entities[t].xp + entities[t].cx + 1 < entities[l].xp + 10) linetemp++;
+                if (entities[t].xp + entities[t].cx+1 + entities[t].w < entities[l].xp + 10) linetemp++;
+                if (entities[t].oldxp + entities[t].cx + 1 < entities[l].xp + 10) linetemp++;
+                if (entities[t].oldxp + entities[t].cx + 1 + entities[t].w < entities[l].xp + 10) linetemp++;
 
-				if (linetemp > 0) return true;
-				return false;
-			}else {
-				//Right hand line
-				if (entities[t].xp + entities[t].cx + 1 > entities[l].xp - 10) linetemp++;
-				if (entities[t].xp + entities[t].cx+1 + entities[t].w > entities[l].xp - 10) linetemp++;
-				if (entities[t].oldxp + entities[t].cx + 1 > entities[l].xp - 10) linetemp++;
-				if (entities[t].oldxp + entities[t].cx + 1 + entities[t].w > entities[l].xp - 10) linetemp++;
+                if (linetemp > 0) return true;
+                return false;
+            }else {
+                //Right hand line
+                if (entities[t].xp + entities[t].cx + 1 > entities[l].xp - 10) linetemp++;
+                if (entities[t].xp + entities[t].cx+1 + entities[t].w > entities[l].xp - 10) linetemp++;
+                if (entities[t].oldxp + entities[t].cx + 1 > entities[l].xp - 10) linetemp++;
+                if (entities[t].oldxp + entities[t].cx + 1 + entities[t].w > entities[l].xp - 10) linetemp++;
 
-				if (linetemp > 0) return true;
-				return false;
-			}
-		}
-	}
-	return false;
+                if (linetemp > 0) return true;
+                return false;
+            }
+        }
+    }
+    return false;
 }
 
 float entityclass::entitycollideplatformroof( int t )
@@ -5193,31 +5193,31 @@ void entityclass::hormovingplatformfix( int t )
 }
 
 void entityclass::customwarplinecheck(int i) {
-		//Turns on obj.customwarpmodevon and obj.customwarpmodehon if player collides
-		//with warp lines
+    //Turns on obj.customwarpmodevon and obj.customwarpmodehon if player collides
+    //with warp lines
 
-	if (entities[i].active) {
-		//We test entity to entity
-		for (int j = 0; j < nentity; j++) {
-			if (entities[j].active && i != j) {//Active
-				if (entities[i].rule == 0 && entities[j].rule == 5) { //Player vs vertical line!
-					if (entities[j].type == 51 || entities[j].type == 52) {
-						if (entitywarpvlinecollide(i, j)) {
-							customwarpmodevon = true;
-						}
-					}
-				}
+    if (entities[i].active) {
+        //We test entity to entity
+        for (int j = 0; j < nentity; j++) {
+            if (entities[j].active && i != j) {//Active
+                if (entities[i].rule == 0 && entities[j].rule == 5) { //Player vs vertical line!
+                    if (entities[j].type == 51 || entities[j].type == 52) {
+                        if (entitywarpvlinecollide(i, j)) {
+                            customwarpmodevon = true;
+                        }
+                    }
+                }
 
-				if (entities[i].rule == 0 && entities[j].rule == 7){   //Player vs horizontal WARP line
-					if (entities[j].type == 53 || entities[j].type == 54) {
-						if (entitywarphlinecollide(i, j)) {
-							customwarpmodehon = true;
-						}
-					}
-				}
-			}
-		}
-	}
+                if (entities[i].rule == 0 && entities[j].rule == 7){   //Player vs horizontal WARP line
+                    if (entities[j].type == 53 || entities[j].type == 54) {
+                        if (entitywarphlinecollide(i, j)) {
+                            customwarpmodehon = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 void entityclass::entitycollisioncheck()
@@ -5338,7 +5338,7 @@ void entityclass::entitycollisioncheck()
                             }
                         }
                     }
-										/*
+                    /*
                     if (entities[i].rule == 0 && entities[j].rule == 7)   //Player vs horizontal WARP line
                     {
                         if(game.deathseq==-1)
@@ -5353,7 +5353,7 @@ void entityclass::entitycollisioncheck()
                             }
                         }
                     }
-										*/
+                    */
                     if (game.supercrewmate)
                     {
                         //some extra collisions

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -3,7 +3,7 @@
 #include "Map.h"
 #include "UtilityClass.h"
 
-bool entityclass::checktowerspikes(int t, mapclass& map)
+bool entityclass::checktowerspikes(int t)
 {
     tempx = entities[t].xp + entities[t].cx;
     tempy = entities[t].yp + entities[t].cy;
@@ -210,19 +210,19 @@ void entityclass::swnenemiescol( int t )
     }
 }
 
-void entityclass::gravcreate( Game& game, int ypos, int dir, int xoff /*= 0*/, int yoff /*= 0*/ )
+void entityclass::gravcreate( int ypos, int dir, int xoff /*= 0*/, int yoff /*= 0*/ )
 {
     if (dir == 0)
     {
-        createentity(game, -150 - xoff, 58 + (ypos * 20)+yoff, 23, 0, 0);
+        createentity(-150 - xoff, 58 + (ypos * 20)+yoff, 23, 0, 0);
     }
     else
     {
-        createentity(game, 320+150 + xoff, 58 + (ypos * 20)+yoff, 23, 1, 0);
+        createentity(320+150 + xoff, 58 + (ypos * 20)+yoff, 23, 1, 0);
     }
 }
 
-void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
+void entityclass::generateswnwave( int t )
 {
     //generate a wave for the SWN game
     if(game.swndelay<=0)
@@ -308,7 +308,7 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                 if (game.deathcounts - game.swndeaths > 25) game.swndelay += 4;
                 break;
             case 1:
-                createentity(game, -150, 58 + (int(fRandom() * 6) * 20), 23, 0, 0);
+                createentity(-150, 58 + (int(fRandom() * 6) * 20), 23, 0, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 break;
@@ -331,52 +331,52 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                         game.swnstate2++;
                     }
                 }
-                createentity(game, -150, 58 + (int(game.swnstate2) * 20), 23, 0, 0);
+                createentity(-150, 58 + (int(game.swnstate2) * 20), 23, 0, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 break;
             case 3:
-                createentity(game, 320+150, 58 + (int(fRandom() * 6) * 20), 23, 1, 0);
+                createentity(320+150, 58 + (int(fRandom() * 6) * 20), 23, 1, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 break;
             case 4:
                 //left and right compliments
                 game.swnstate2 = int(fRandom() * 6);
-                createentity(game, -150, 58 + (game.swnstate2  * 20), 23, 0, 0);
-                createentity(game, 320+150, 58 + ((5-game.swnstate2) * 20), 23, 1, 0);
+                createentity(-150, 58 + (game.swnstate2  * 20), 23, 0, 0);
+                createentity(320+150, 58 + ((5-game.swnstate2) * 20), 23, 1, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 game.swnstate2 = 0;
                 break;
             case 5:
                 //Top and bottom
-                createentity(game, -150, 58, 23, 0, 0);
-                createentity(game, -150, 58 + (5 * 20), 23, 0, 0);
+                createentity(-150, 58, 23, 0, 0);
+                createentity(-150, 58 + (5 * 20), 23, 0, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 game.swnstate2 = 1;
                 break;
             case 6:
                 //Middle
-                createentity(game, -150, 58 + (2 * 20), 23, 0, 0);
-                createentity(game, -150, 58 + (3 * 20), 23, 0, 0);
+                createentity(-150, 58 + (2 * 20), 23, 0, 0);
+                createentity(-150, 58 + (3 * 20), 23, 0, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 game.swnstate2 = 0;
                 break;
             case 7:
                 //Top and bottom
-                createentity(game, 320+150, 58, 23, 1, 0);
-                createentity(game, 320+150, 58 + (5 * 20), 23, 1, 0);
+                createentity(320+150, 58, 23, 1, 0);
+                createentity(320+150, 58 + (5 * 20), 23, 1, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 game.swnstate2 = 1;
                 break;
             case 8:
                 //Middle
-                createentity(game, 320+150, 58 + (2 * 20), 23, 1, 0);
-                createentity(game, 320+150, 58 + (3 * 20), 23, 1, 0);
+                createentity(320+150, 58 + (2 * 20), 23, 1, 0);
+                createentity(320+150, 58 + (3 * 20), 23, 1, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 game.swnstate2 = 0;
@@ -400,7 +400,7 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                         game.swnstate2++;
                     }
                 }
-                createentity(game, 320 + 150, 58 + (int(game.swnstate2) * 20), 23, 1, 0);
+                createentity(320 + 150, 58 + (int(game.swnstate2) * 20), 23, 1, 0);
                 game.swnstate = 0;
                 game.swndelay = 0; //return to decision state
                 break;
@@ -567,16 +567,16 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                 game.swnstate2 = 0;
                 break;
             case 10:
-                gravcreate(game, 0, 0);
-                gravcreate(game, 1, 0);
-                gravcreate(game, 2, 0);
+                gravcreate(0, 0);
+                gravcreate(1, 0);
+                gravcreate(2, 0);
                 game.swnstate++;
                 game.swndelay = 10; //return to decision state
                 break;
             case 11:
-                gravcreate(game, 3, 0);
-                gravcreate(game, 4, 0);
-                gravcreate(game, 5, 0);
+                gravcreate(3, 0);
+                gravcreate(4, 0);
+                gravcreate(5, 0);
                 game.swnstate2++;
                 if(game.swnstate2==3)
                 {
@@ -590,16 +590,16 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                 }
                 break;
             case 12:
-                gravcreate(game, 0, 1);
-                gravcreate(game, 1, 1);
-                gravcreate(game, 2, 1);
+                gravcreate(0, 1);
+                gravcreate(1, 1);
+                gravcreate(2, 1);
                 game.swnstate++;
                 game.swndelay = 10; //return to decision state
                 break;
             case 13:
-                gravcreate(game, 3, 1);
-                gravcreate(game, 4, 1);
-                gravcreate(game, 5, 1);
+                gravcreate(3, 1);
+                gravcreate(4, 1);
+                gravcreate(5, 1);
                 game.swnstate2++;
                 if(game.swnstate2==3)
                 {
@@ -613,43 +613,43 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                 }
                 break;
             case 14:
-                gravcreate(game, 0, 0, 0);
-                gravcreate(game, 5, 1, 0);
+                gravcreate(0, 0, 0);
+                gravcreate(5, 1, 0);
 
                 game.swnstate++;
                 game.swndelay = 20; //return to decision state
                 break;
             case 15:
-                gravcreate(game, 1, 0);
-                gravcreate(game, 4, 1);
+                gravcreate(1, 0);
+                gravcreate(4, 1);
 
                 game.swnstate++;
                 game.swndelay = 20; //return to decision state
                 break;
             case 16:
-                gravcreate(game, 2, 0);
-                gravcreate(game, 3, 1);
+                gravcreate(2, 0);
+                gravcreate(3, 1);
 
                 game.swnstate++;
                 game.swndelay = 20; //return to decision state
                 break;
             case 17:
-                gravcreate(game, 3, 0);
-                gravcreate(game, 2, 1);
+                gravcreate(3, 0);
+                gravcreate(2, 1);
 
                 game.swnstate++;
                 game.swndelay = 20; //return to decision state
                 break;
             case 18:
-                gravcreate(game, 4, 0);
-                gravcreate(game, 1, 1);
+                gravcreate(4, 0);
+                gravcreate(1, 1);
 
                 game.swnstate++;
                 game.swndelay = 20; //return to decision state
                 break;
             case 19:
-                gravcreate(game, 5, 0);
-                gravcreate(game, 0, 1);
+                gravcreate(5, 0);
+                gravcreate(0, 1);
 
                 game.swnstate=0;
                 game.swndelay = 20; //return to decision state
@@ -674,7 +674,7 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                         game.swnstate2++;
                     }
                 }
-                createentity(game, -150, 58 + (int(game.swnstate2) * 20), 23, 0, 0);
+                createentity(-150, 58 + (int(game.swnstate2) * 20), 23, 0, 0);
                 if(game.swnstate4<=6)
                 {
                     game.swnstate = 20;
@@ -706,7 +706,7 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                         game.swnstate2++;
                     }
                 }
-                createentity(game, 320+150, 58 + (int(game.swnstate2) * 20), 23, 1, 0);
+                createentity(320+150, 58 + (int(game.swnstate2) * 20), 23, 1, 0);
                 if(game.swnstate4<=6)
                 {
                     game.swnstate = 21;
@@ -722,8 +722,8 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                 game.swnstate4++;
                 //left and right compliments
                 game.swnstate2 = int(fRandom() * 6);
-                createentity(game, -150, 58 + (game.swnstate2  * 20), 23, 0, 0);
-                createentity(game, 320 + 150, 58 + ((5 - game.swnstate2) * 20), 23, 1, 0);
+                createentity(-150, 58 + (game.swnstate2  * 20), 23, 0, 0);
+                createentity(320 + 150, 58 + ((5 - game.swnstate2) * 20), 23, 1, 0);
                 if(game.swnstate4<=12)
                 {
                     game.swnstate = 22;
@@ -737,53 +737,53 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
                 game.swnstate2 = 0;
                 break;
             case 23:
-                gravcreate(game, 1, 0);
-                gravcreate(game, 2, 0, 15);
-                gravcreate(game, 2, 0, -15);
-                gravcreate(game, 3, 0, 15);
-                gravcreate(game, 3, 0, -15);
-                gravcreate(game, 4, 0);
+                gravcreate(1, 0);
+                gravcreate(2, 0, 15);
+                gravcreate(2, 0, -15);
+                gravcreate(3, 0, 15);
+                gravcreate(3, 0, -15);
+                gravcreate(4, 0);
                 game.swnstate = 0;
                 game.swndelay = 15; //return to decision state
                 break;
             case 24:
-                gravcreate(game, 1, 1);
-                gravcreate(game, 2, 1, 15);
-                gravcreate(game, 2, 1, -15);
-                gravcreate(game, 3, 1, 15);
-                gravcreate(game, 3, 1, -15);
-                gravcreate(game, 4, 1);
+                gravcreate(1, 1);
+                gravcreate(2, 1, 15);
+                gravcreate(2, 1, -15);
+                gravcreate(3, 1, 15);
+                gravcreate(3, 1, -15);
+                gravcreate(4, 1);
                 game.swnstate = 0;
                 game.swndelay = 15; //return to decision state
                 break;
             case 25:
-                gravcreate(game, 0, 0);
-                gravcreate(game, 1, 1,0,10);
-                gravcreate(game, 4, 1,0,-10);
-                gravcreate(game, 5, 0);
+                gravcreate(0, 0);
+                gravcreate(1, 1,0,10);
+                gravcreate(4, 1,0,-10);
+                gravcreate(5, 0);
                 game.swnstate = 0;
                 game.swndelay = 20; //return to decision state
                 break;
             case 26:
-                gravcreate(game, 0, 1, 0);
-                gravcreate(game, 1, 1, 10);
-                gravcreate(game, 4, 1, 40);
-                gravcreate(game, 5, 1, 50);
+                gravcreate(0, 1, 0);
+                gravcreate(1, 1, 10);
+                gravcreate(4, 1, 40);
+                gravcreate(5, 1, 50);
                 game.swnstate = 0;
                 game.swndelay = 20; //return to decision state
                 break;
             case 27:
-                gravcreate(game, 0, 0, 0);
-                gravcreate(game, 1, 0, 10);
-                gravcreate(game, 4, 0, 40);
-                gravcreate(game, 5, 0, 50);
+                gravcreate(0, 0, 0);
+                gravcreate(1, 0, 10);
+                gravcreate(4, 0, 40);
+                gravcreate(5, 0, 50);
                 game.swnstate = 0;
                 game.swndelay = 20; //return to decision state
                 break;
             case 28:
                 game.swnstate4++;
                 game.swnstate2 = int(fRandom() * 6);
-                createentity(game, -150, 58 + (game.swnstate2  * 20), 23, 0, 0);
+                createentity(-150, 58 + (game.swnstate2  * 20), 23, 0, 0);
                 if(game.swnstate4<=6)
                 {
                     game.swnstate = 28;
@@ -799,7 +799,7 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
             case 29:
                 game.swnstate4++;
                 game.swnstate2 = int(fRandom() * 6);
-                gravcreate(game, game.swnstate2, 1);
+                gravcreate(game.swnstate2, 1);
                 if(game.swnstate4<=6)
                 {
                     game.swnstate = 29;
@@ -815,8 +815,8 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
             case 30:
                 game.swnstate4++;
                 game.swnstate2 = int(fRandom() * 3);
-                gravcreate(game, game.swnstate2, 0);
-                gravcreate(game, 5-game.swnstate2, 0);
+                gravcreate(game.swnstate2, 0);
+                gravcreate(5-game.swnstate2, 0);
                 if(game.swnstate4<=2)
                 {
                     game.swnstate = 30;
@@ -832,8 +832,8 @@ void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
             case 31:
                 game.swnstate4++;
                 game.swnstate2 = int(fRandom() * 3);
-                gravcreate(game, game.swnstate2, 1);
-                gravcreate(game, 5-game.swnstate2, 1);
+                gravcreate(game.swnstate2, 1);
+                gravcreate(5-game.swnstate2, 1);
                 if(game.swnstate4<=2)
                 {
                     game.swnstate = 31;
@@ -1769,7 +1769,7 @@ void entityclass::settreadmillcolour( int t, int rx, int ry )
     }
 }
 
-void entityclass::createentity( Game& game, float xp, float yp, int t, float vx /*= 0*/, float vy /*= 0*/, int p1 /*= 0*/, int p2 /*= 0*/, int p3 /*= 320*/, int p4 /*= 240 */ )
+void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, float vy /*= 0*/, int p1 /*= 0*/, int p2 /*= 0*/, int p3 /*= 320*/, int p4 /*= 240 */ )
 {
     //Find the first inactive case z that we can use to index the new entity
     if (nentity == 0)
@@ -2764,7 +2764,7 @@ void entityclass::createentity( Game& game, float xp, float yp, int t, float vx 
     }
 }
 
-bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musicclass& music )
+bool entityclass::updateentities( int i )
 {
     if(entities[i].active)
     {
@@ -2785,7 +2785,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     if (entities[i].state == 0)   //Init
                     {
                         entities[i].state = 3;
-                        updateentities(i, help, game, music);
+                        updateentities(i);
                     }
                     else if (entities[i].state == 1)
                     {
@@ -2808,7 +2808,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     if (entities[i].state == 0)   //Init
                     {
                         entities[i].state = 2;
-                        updateentities(i, help, game, music);
+                        updateentities(i);
                     }
                     else if (entities[i].state == 1)
                     {
@@ -2831,7 +2831,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     if (entities[i].state == 0)   //Init
                     {
                         entities[i].state = 3;
-                        updateentities(i, help, game, music);
+                        updateentities(i);
                     }
                     else if (entities[i].state == 1)
                     {
@@ -2854,7 +2854,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     if (entities[i].state == 0)   //Init
                     {
                         entities[i].state = 3;
-                        updateentities(i, help, game, music);
+                        updateentities(i);
                     }
                     else if (entities[i].state == 1)
                     {
@@ -2932,7 +2932,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     //Emitter: shoot an enemy every so often
                     if (entities[i].state == 0)
                     {
-                        createentity(game, entities[i].xp+28, entities[i].yp, 1, 10, 1);
+                        createentity(entities[i].xp+28, entities[i].yp, 1, 10, 1);
                         entities[i].state = 1;
                         entities[i].statedelay = 12;
                     }
@@ -2961,7 +2961,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     //Emitter: shoot an enemy every so often (up)
                     if (entities[i].state == 0)
                     {
-                        createentity(game, entities[i].xp, entities[i].yp, 1, 12, 1);
+                        createentity(entities[i].xp, entities[i].yp, 1, 12, 1);
                         entities[i].state = 1;
                         entities[i].statedelay = 16;
                     }
@@ -2994,7 +2994,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                             if (entities[j].type == 2 && entities[j].state== 3 && entities[j].xp == (entities[i].xp-32) )
                             {
                                 entities[i].state = 3;
-                                updateentities(i, help, game, music);
+                                updateentities(i);
                             }
                         }
                     }
@@ -3023,7 +3023,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                             if (entities[j].type == 2 && entities[j].state==3 && entities[j].xp==entities[i].xp+32)
                             {
                                 entities[i].state = 3;
-                                updateentities(i, help, game, music);
+                                updateentities(i);
                             }
                         }
                     }
@@ -3064,14 +3064,14 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                             //approach from the left
                             entities[i].xp = -64;
                             entities[i].state = 2;
-                            updateentities(i, help, game, music); //right
+                            updateentities(i); //right
                         }
                         else
                         {
                             //approach from the left
                             entities[i].xp = 320;
                             entities[i].state = 3;
-                            updateentities(i, help, game, music); //left
+                            updateentities(i); //left
                         }
 
                     }
@@ -3931,7 +3931,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
     return true;
 }
 
-void entityclass::animateentities( int _i, Game& game, UtilityClass& help )
+void entityclass::animateentities( int _i )
 {
     if(entities[_i].active)
     {
@@ -4692,7 +4692,7 @@ bool entityclass::checkblocks()
     return false;
 }
 
-bool entityclass::checkwall( mapclass& map )
+bool entityclass::checkwall()
 {
     //Returns true if entity setup in temprect collides with a wall
     //used for proper collision functions; you can't just, like, call it
@@ -4882,7 +4882,7 @@ bool entityclass::entitywarpvlinecollide(int t, int l) {
 	return false;
 }
 
-float entityclass::entitycollideplatformroof( mapclass& map, int t )
+float entityclass::entitycollideplatformroof( int t )
 {
     tempx = entities[t].xp + entities[t].cx;
     tempy = entities[t].yp + entities[t].cy -1;
@@ -4898,7 +4898,7 @@ float entityclass::entitycollideplatformroof( mapclass& map, int t )
     return -1000;
 }
 
-float entityclass::entitycollideplatformfloor( mapclass& map, int t )
+float entityclass::entitycollideplatformfloor( int t )
 {
     tempx = entities[t].xp + entities[t].cx;
     tempy = entities[t].yp + entities[t].cy + 1;
@@ -4914,7 +4914,7 @@ float entityclass::entitycollideplatformfloor( mapclass& map, int t )
     return -1000;
 }
 
-bool entityclass::entitycollidefloor( mapclass& map, int t )
+bool entityclass::entitycollidefloor( int t )
 {
     //see? like here, for example!
     tempx = entities[t].xp + entities[t].cx;
@@ -4923,11 +4923,11 @@ bool entityclass::entitycollidefloor( mapclass& map, int t )
     temph = entities[t].h;
     rectset(tempx, tempy, tempw, temph);
 
-    if (checkwall(map)) return true;
+    if (checkwall()) return true;
     return false;
 }
 
-bool entityclass::entitycollideroof( mapclass& map, int t )
+bool entityclass::entitycollideroof( int t )
 {
     //and here!
     tempx = entities[t].xp + entities[t].cx;
@@ -4936,11 +4936,11 @@ bool entityclass::entitycollideroof( mapclass& map, int t )
     temph = entities[t].h;
     rectset(tempx, tempy, tempw, temph);
 
-    if (checkwall(map)) return true;
+    if (checkwall()) return true;
     return false;
 }
 
-bool entityclass::testwallsx( int t, mapclass& map, int tx, int ty )
+bool entityclass::testwallsx( int t, int tx, int ty )
 {
     tempx = tx + entities[t].cx;
     tempy = ty + entities[t].cy;
@@ -4963,19 +4963,19 @@ bool entityclass::testwallsx( int t, mapclass& map, int tx, int ty )
     dr = entities[t].rule;
 
     //Ok, now we check walls
-    if (checkwall(map))
+    if (checkwall())
     {
         if (entities[t].vx > 1.0f)
         {
             entities[t].vx--;
             entities[t].newxp = entities[t].xp + entities[t].vx;
-            return testwallsx(t, map, entities[t].newxp, entities[t].yp);
+            return testwallsx(t, entities[t].newxp, entities[t].yp);
         }
         else if (entities[t].vx < -1.0f)
         {
             entities[t].vx++;
             entities[t].newxp = entities[t].xp + entities[t].vx;
-            return testwallsx(t, map, entities[t].newxp, entities[t].yp);
+            return testwallsx(t, entities[t].newxp, entities[t].yp);
         }
         else
         {
@@ -4986,7 +4986,7 @@ bool entityclass::testwallsx( int t, mapclass& map, int tx, int ty )
     return true;
 }
 
-bool entityclass::testwallsy( int t, mapclass& map, float tx, float ty )
+bool entityclass::testwallsy( int t, float tx, float ty )
 {
     tempx = static_cast<int>(tx) + entities[t].cx;
     tempy = static_cast<int>(ty) + entities[t].cy;
@@ -5010,19 +5010,19 @@ bool entityclass::testwallsy( int t, mapclass& map, float tx, float ty )
     dr = entities[t].rule;
 
     //Ok, now we check walls
-    if (checkwall(map))
+    if (checkwall())
     {
         if (entities[t].vy > 1)
         {
             entities[t].vy--;
             entities[t].newyp = int(entities[t].yp + entities[t].vy);
-            return testwallsy(t, map, entities[t].xp, entities[t].newyp);
+            return testwallsy(t, entities[t].xp, entities[t].newyp);
         }
         else if (entities[t].vy < -1)
         {
             entities[t].vy++;
             entities[t].newyp = int(entities[t].yp + entities[t].vy);
-            return testwallsy(t, map, entities[t].xp, entities[t].newyp);
+            return testwallsy(t, entities[t].xp, entities[t].newyp);
         }
         else
         {
@@ -5073,7 +5073,7 @@ void entityclass::cleanup()
     }
 }
 
-void entityclass::updateentitylogic( int t, Game& game )
+void entityclass::updateentitylogic( int t )
 {
     entities[t].oldxp = entities[t].xp;
     entities[t].oldyp = entities[t].yp;
@@ -5110,9 +5110,9 @@ void entityclass::updateentitylogic( int t, Game& game )
     entities[t].newyp = entities[t].yp + entities[t].vy;
 }
 
-void entityclass::entitymapcollision( int t, mapclass& map )
+void entityclass::entitymapcollision( int t )
 {
-    if (testwallsx(t, map, entities[t].newxp, entities[t].yp))
+    if (testwallsx(t, entities[t].newxp, entities[t].yp))
     {
         entities[t].xp = entities[t].newxp;
     }
@@ -5121,7 +5121,7 @@ void entityclass::entitymapcollision( int t, mapclass& map )
         if (entities[t].onwall > 0) entities[t].state = entities[t].onwall;
         if (entities[t].onxwall > 0) entities[t].state = entities[t].onxwall;
     }
-    if (testwallsy(t, map, entities[t].xp, entities[t].newyp))
+    if (testwallsy(t, entities[t].xp, entities[t].newyp))
     {
         entities[t].yp = entities[t].newyp;
     }
@@ -5133,7 +5133,7 @@ void entityclass::entitymapcollision( int t, mapclass& map )
     }
 }
 
-void entityclass::movingplatformfix( int t, mapclass& map )
+void entityclass::movingplatformfix( int t )
 {
     //If this intersects the player, then we move the player along it
     int j = getplayer();
@@ -5146,7 +5146,7 @@ void entityclass::movingplatformfix( int t, mapclass& map )
             entities[j].yp = entities[j].yp - int(entities[j].vy);
             entities[j].vy = entities[t].vy;
             entities[j].newyp = entities[j].yp + int(entities[j].vy);
-            if (testwallsy(j, map, entities[j].xp, entities[j].newyp))
+            if (testwallsy(j, entities[j].xp, entities[j].newyp))
             {
                  if (entities[t].vy > 0)
                 {
@@ -5169,7 +5169,7 @@ void entityclass::movingplatformfix( int t, mapclass& map )
     }
 }
 
-void entityclass::scmmovingplatformfix( int t, mapclass& map )
+void entityclass::scmmovingplatformfix( int t )
 {
     //If this intersects the SuperCrewMate, then we move them along it
     int j = getscm();
@@ -5182,7 +5182,7 @@ void entityclass::scmmovingplatformfix( int t, mapclass& map )
             entities[j].yp = entities[j].yp -  (entities[j].vy);
             entities[j].vy = entities[t].vy;
             entities[j].newyp = static_cast<float>(entities[j].yp) + entities[j].vy;
-            if (testwallsy(j, map, entities[j].xp, entities[j].newyp))
+            if (testwallsy(j, entities[j].xp, entities[j].newyp))
             {
                 if (entities[t].vy > 0)
                 {
@@ -5205,7 +5205,7 @@ void entityclass::scmmovingplatformfix( int t, mapclass& map )
     }
 }
 
-void entityclass::hormovingplatformfix( int t, mapclass& map )
+void entityclass::hormovingplatformfix( int t )
 {
     //If this intersects the player, then we move the player along it
     //for horizontal platforms, this is simplier
@@ -5248,7 +5248,7 @@ void entityclass::customwarplinecheck(int i) {
 	}
 }
 
-void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& map, musicclass& music )
+void entityclass::entitycollisioncheck()
 {
     for (int i = 0; i < nentity; i++)
     {
@@ -5271,10 +5271,10 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
                                 colpoint1.y = entities[i].yp;
                                 colpoint2.x = entities[j].xp;
                                 colpoint2.y = entities[j].yp;
-                                if (dwgfx.flipmode)
+                                if (graphics.flipmode)
                                 {
-                                    if (dwgfx.Hitest(dwgfx.flipsprites[entities[i].drawframe],
-                                                     colpoint1, 1, dwgfx.flipsprites[entities[j].drawframe], colpoint2, 1))
+                                    if (graphics.Hitest(graphics.flipsprites[entities[i].drawframe],
+                                                     colpoint1, 1, graphics.flipsprites[entities[j].drawframe], colpoint2, 1))
                                     {
                                         //Do the collision stuff
                                         game.deathseq = 30;
@@ -5282,8 +5282,8 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
                                 }
                                 else
                                 {
-                                    if (dwgfx.Hitest(dwgfx.sprites[entities[i].drawframe],
-                                                     colpoint1, 1, dwgfx.sprites[entities[j].drawframe], colpoint2, 1) )
+                                    if (graphics.Hitest(graphics.sprites[entities[i].drawframe],
+                                                     colpoint1, 1, graphics.sprites[entities[j].drawframe], colpoint2, 1) )
                                     {
                                         //Do the collision stuff
                                         game.deathseq = 30;
@@ -5399,10 +5399,10 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
                                         colpoint1.y = entities[i].yp;
                                         colpoint2.x = entities[j].xp;
                                         colpoint2.y = entities[j].yp;
-                                        if (dwgfx.flipmode)
+                                        if (graphics.flipmode)
                                         {
-                                            if (dwgfx.Hitest(dwgfx.flipsprites[entities[i].drawframe],
-                                                             colpoint1, 1, dwgfx.flipsprites[entities[j].drawframe], colpoint2, 1))
+                                            if (graphics.Hitest(graphics.flipsprites[entities[i].drawframe],
+                                                             colpoint1, 1, graphics.flipsprites[entities[j].drawframe], colpoint2, 1))
                                             {
                                                 //Do the collision stuff
                                                 game.deathseq = 30;
@@ -5411,8 +5411,8 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
                                         }
                                         else
                                         {
-                                            if (dwgfx.Hitest(dwgfx.sprites[entities[i].drawframe],
-                                                             colpoint1, 1, dwgfx.sprites[entities[j].drawframe], colpoint2, 1))
+                                            if (graphics.Hitest(graphics.sprites[entities[i].drawframe],
+                                                             colpoint1, 1, graphics.sprites[entities[j].drawframe], colpoint2, 1))
                                             {
                                                 //Do the collision stuff
                                                 game.deathseq = 30;
@@ -5449,7 +5449,7 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
     //can't have the player being stuck...
     int j = getplayer();
     skipdirblocks = true;
-    if (!testwallsx(j, map, entities[j].xp, entities[j].yp))
+    if (!testwallsx(j, entities[j].xp, entities[j].yp))
     {
         //Let's try to get out...
         if (entities[j].rule == 0)
@@ -5471,7 +5471,7 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
     {
         j = getscm();
         skipdirblocks = true;
-        if (!testwallsx(j, map, entities[j].xp, entities[j].yp))
+        if (!testwallsx(j, entities[j].xp, entities[j].yp))
         {
             //Let's try to get out...
             if(game.gravitycontrol==0)

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -3116,7 +3116,7 @@ bool entityclass::updateentities( int i )
                     entities[i].state = 2;
                     entities[i].onentity = 0;
 
-                    music.playef(7,10);
+                    music.playef(7);
                 }
                 else if (entities[i].state == 2)
                 {
@@ -3164,7 +3164,7 @@ bool entityclass::updateentities( int i )
                     entities[i].life = 4;
                     entities[i].state = 2;
                     entities[i].onentity = 0;
-                    music.playef(6,10);
+                    music.playef(6);
                     /*}else if (entities[j].vy <= -0.5  && (entities[j].yp>=entities[i].yp+2)) {
                     entities[i].life = 4;
                     entities[i].state = 2; entities[i].onentity = 0;
@@ -3204,7 +3204,7 @@ bool entityclass::updateentities( int i )
                 if (entities[i].state == 1)
                 {
                     game.coins++;
-                    music.playef(4,10);
+                    music.playef(4);
                     collect[entities[i].para] = 1;
 
                     entities[i].active = false;
@@ -3218,14 +3218,14 @@ bool entityclass::updateentities( int i )
                     if (game.intimetrial)
                     {
                         collect[entities[i].para] = 1;
-                        music.playef(25,10);
+                        music.playef(25);
                     }
                     else
                     {
                         game.state = 1000;
                         //music.haltdasmusik();
                         if(music.currentsong!=-1) music.silencedasmusik();
-                        music.playef(3,10);
+                        music.playef(3);
                         collect[entities[i].para] = 1;
                         if (game.trinkets > game.stat_trinkets)
                         {
@@ -3252,7 +3252,7 @@ bool entityclass::updateentities( int i )
                     entities[i].colour = 5;
                     entities[i].onentity = 0;
                     game.savepoint = entities[i].para;
-                    music.playef(5,10);
+                    music.playef(5);
 
                     game.savex = entities[i].xp - 4;
 
@@ -3293,7 +3293,7 @@ bool entityclass::updateentities( int i )
                     entities[i].state = 2;
 
 
-                    music.playef(8,10);
+                    music.playef(8);
                     game.gravitycontrol = (game.gravitycontrol + 1) % 2;
                     game.totalflips++;
                     temp = getplayer();
@@ -3672,7 +3672,7 @@ bool entityclass::updateentities( int i )
                 {
                     entities[i].colour = 5;
                     entities[i].onentity = 0;
-                    music.playef(17,10);
+                    music.playef(17);
 
                     entities[i].state = 0;
                 }
@@ -3840,14 +3840,14 @@ bool entityclass::updateentities( int i )
                     if (game.intimetrial)
                     {
                         customcollect[entities[i].para] = 1;
-                        music.playef(27,10);
+                        music.playef(27);
                     }
                     else
                     {
                         game.state = 1010;
                         //music.haltdasmusik();
                         if(music.currentsong!=-1) music.silencedasmusik();
-                        music.playef(27,10);
+                        music.playef(27);
                         customcollect[entities[i].para] = 1;
                     }
 
@@ -3860,7 +3860,7 @@ bool entityclass::updateentities( int i )
                     //if inactive, activate!
                     if (entities[i].tile == 1)
                     {
-                        music.playef(18, 10);
+                        music.playef(18);
                         entities[i].onentity = 0;
                         entities[i].tile = 2;
                         entities[i].colour = 101;
@@ -5290,7 +5290,7 @@ void entityclass::entitycollisioncheck()
                             {
                                 if (entityhlinecollide(i, j))
                                 {
-                                    music.playef(8,10);
+                                    music.playef(8);
                                     game.gravitycontrol = (game.gravitycontrol + 1) % 2;
                                     game.totalflips++;
                                     if (game.gravitycontrol == 0)

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -146,10 +146,10 @@ public:
 
     bool entityvlinecollide(int t, int l);
 
-		bool entitywarphlinecollide(int t, int l);
-		bool entitywarpvlinecollide(int t, int l);
+    bool entitywarphlinecollide(int t, int l);
+    bool entitywarpvlinecollide(int t, int l);
 
-		void customwarplinecheck(int i);
+    void customwarplinecheck(int i);
 
     float entitycollideplatformroof(int t);
 
@@ -161,7 +161,7 @@ public:
 
     bool testwallsx(int t, int tx, int ty);
 
-	bool testwallsy(int t, float tx, float ty);
+    bool testwallsy(int t, float tx, float ty);
 
     void fixfriction(int t, float xfix, float xrate, float yrate);
 

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -97,7 +97,7 @@ public:
 
     bool gettype(int t);
 
-    int getcompanion(int t);
+    int getcompanion();
 
     int getplayer();
 

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -116,8 +116,6 @@ public:
 
     bool entitycollide(int a, int b);
 
-    bool checkdirectional(int t);
-
     bool checkdamage();
 
     bool scmcheckdamage();

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -145,7 +145,7 @@ public:
     bool entityhlinecollide(int t, int l);
 
     bool entityvlinecollide(int t, int l);
-		
+
 		bool entitywarphlinecollide(int t, int l);
 		bool entitywarpvlinecollide(int t, int l);
 

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -20,12 +20,6 @@ enum
     ACTIVITY = 5
 };
 
-class mapclass;
-class musicclass;
-class Graphics;
-class Game;
-class UtilityClass;
-
 class entityclass
 {
 public:
@@ -66,9 +60,9 @@ public:
 
     void swnenemiescol(int t);
 
-    void gravcreate(Game& game, int ypos, int dir, int xoff = 0, int yoff = 0);
+    void gravcreate(int ypos, int dir, int xoff = 0, int yoff = 0);
 
-    void generateswnwave(Game& game, UtilityClass& help, int t);
+    void generateswnwave(int t);
 
     void createblock(int t, int xp, int yp, int w, int h, int trig = 0);
 
@@ -94,12 +88,12 @@ public:
 
     void settreadmillcolour(int t, int rx, int ry);
 
-    void createentity(Game& game, float xp, float yp, int t, float vx = 0, float vy = 0,
+    void createentity(float xp, float yp, int t, float vx = 0, float vy = 0,
                       int p1 = 0, int p2 = 0, int p3 = 320, int p4 = 240 );
 
-    bool updateentities(int i, UtilityClass& help, Game& game, musicclass& music);
+    bool updateentities(int i);
 
-    void animateentities(int i, Game& game, UtilityClass& help);
+    void animateentities(int i);
 
     bool gettype(int t);
 
@@ -142,9 +136,9 @@ public:
 
     bool checkblocks();
 
-    bool checktowerspikes(int t, mapclass& map);
+    bool checktowerspikes(int t);
 
-    bool checkwall(mapclass& map);
+    bool checkwall();
 
     float hplatformat();
 
@@ -159,17 +153,17 @@ public:
 
 		void customwarplinecheck(int i);
 
-    float entitycollideplatformroof(mapclass& map, int t);
+    float entitycollideplatformroof(int t);
 
-    float entitycollideplatformfloor(mapclass& map, int t);
+    float entitycollideplatformfloor(int t);
 
-    bool entitycollidefloor(mapclass& map, int t);
+    bool entitycollidefloor(int t);
 
-    bool entitycollideroof(mapclass& map, int t);
+    bool entitycollideroof(int t);
 
-    bool testwallsx(int t, mapclass& map, int tx, int ty);
+    bool testwallsx(int t, int tx, int ty);
 
-	bool testwallsy(int t, mapclass& map, float tx, float ty);
+	bool testwallsy(int t, float tx, float ty);
 
     void fixfriction(int t, float xfix, float xrate, float yrate);
 
@@ -177,18 +171,18 @@ public:
 
     void cleanup();
 
-    void updateentitylogic(int t, Game& game);
+    void updateentitylogic(int t);
 
 
-    void entitymapcollision(int t, mapclass& map);
+    void entitymapcollision(int t);
 
-    void movingplatformfix(int t, mapclass& map);
+    void movingplatformfix(int t);
 
-    void scmmovingplatformfix(int t, mapclass& map);
+    void scmmovingplatformfix(int t);
 
-    void hormovingplatformfix(int t, mapclass& map);
+    void hormovingplatformfix(int t);
 
-    void entitycollisioncheck(Graphics& dwgfx, Game& game, mapclass& map, musicclass& music);
+    void entitycollisioncheck();
 
 
     std::vector<entclass> entities;

--- a/desktop_version/src/Finalclass.cpp
+++ b/desktop_version/src/Finalclass.cpp
@@ -13,7 +13,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry)
 	warpx = false;
 	warpy = false;
 
-	roomname = "Untitled room ["+UtilityClass::String(rx) + "," + UtilityClass::String(ry)+"]";
+	roomname = "Untitled room ["+help.String(rx) + "," + help.String(ry)+"]";
 
 	switch(t)
 	{

--- a/desktop_version/src/Finalclass.cpp
+++ b/desktop_version/src/Finalclass.cpp
@@ -2,7 +2,7 @@
 
 #include "MakeAndPlay.h"
 
-std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entityclass& obj)
+std::vector<std::string> finalclass::loadlevel(int rx, int ry)
 {
 	int t;
 

--- a/desktop_version/src/Finalclass.cpp
+++ b/desktop_version/src/Finalclass.cpp
@@ -50,11 +50,11 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,220,0,0,0,0,0,0,0,218,98,98,98,98,98,98,98,98,98,98,98");
 		tmap.push_back("98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,220,0,0,0,0,0,0,0,218,98,98,98,98,98,98,98,98,98,98,98");
 
-		obj.createentity(game, 163, 32, 12, 168);  // (vertical gravity line)
-		obj.createentity(game, 99, 32, 12, 168);  // (vertical gravity line)
-		obj.createentity(game, 227, 32, 12, 168);  // (vertical gravity line)
-		obj.createentity(game, 35, 32, 12, 168);  // (vertical gravity line)
-		obj.createentity(game, 291, 32, 12, 168);  // (vertical gravity line)
+		obj.createentity(163, 32, 12, 168);  // (vertical gravity line)
+		obj.createentity(99, 32, 12, 168);  // (vertical gravity line)
+		obj.createentity(227, 32, 12, 168);  // (vertical gravity line)
+		obj.createentity(35, 32, 12, 168);  // (vertical gravity line)
+		obj.createentity(291, 32, 12, 168);  // (vertical gravity line)
 
 		warpx = true;
 		roomname = "1954 World Cup Vinyl";
@@ -92,12 +92,12 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,178,179,179,180,0,0,0,0,0,0,0,178,179,179,180,0,0,0,0,0,0,0,178,179,179,180,0,0,0,0,0,0,0,218,98,220,740");
 		tmap.push_back("0,0,0,218,98,98,220,0,0,0,0,0,0,0,218,98,98,220,0,0,0,0,0,0,0,218,98,98,220,0,0,0,0,0,0,0,218,98,220,740");
 
-		obj.createentity(game, -8, 116, 11, 40);  // (horizontal gravity line)
-		obj.createentity(game, 48, 116, 11, 184);  // (horizontal gravity line)
-		obj.createentity(game, 32, 88, 10, 1, 51500);  // (savepoint)
-		obj.createentity(game, 32, 128, 10, 0, 51501);  // (savepoint)
-		obj.createentity(game, 256, 88, 10, 1, 51502);  // (savepoint)
-		obj.createentity(game, 256, 128, 10, 0, 51503);  // (savepoint)
+		obj.createentity(-8, 116, 11, 40);  // (horizontal gravity line)
+		obj.createentity(48, 116, 11, 184);  // (horizontal gravity line)
+		obj.createentity(32, 88, 10, 1, 51500);  // (savepoint)
+		obj.createentity(32, 128, 10, 0, 51501);  // (savepoint)
+		obj.createentity(256, 88, 10, 1, 51502);  // (savepoint)
+		obj.createentity(256, 128, 10, 0, 51503);  // (savepoint)
 		warpy = true;
 		roomname = "The V Stooges";
 		break;
@@ -135,10 +135,10 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,50,178,179,179,180,49,0,0,0,0,0,0,0,0,50,178,179,179,180,49,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,50,218,98,98,220,49,0,0,0,0,0,0,0,0,50,218,98,98,220,49,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 116, 11, 40);  // (horizontal gravity line)
-		obj.createentity(game, 288, 116, 11, 32);  // (horizontal gravity line)
-		obj.createentity(game, 64, 116, 11, 64);  // (horizontal gravity line)
-		obj.createentity(game, 192, 116, 11, 64);  // (horizontal gravity line)
+		obj.createentity(-8, 116, 11, 40);  // (horizontal gravity line)
+		obj.createentity(288, 116, 11, 32);  // (horizontal gravity line)
+		obj.createentity(64, 116, 11, 64);  // (horizontal gravity line)
+		obj.createentity(192, 116, 11, 64);  // (horizontal gravity line)
 
 		warpy = true;
 		roomname = "glitch";
@@ -176,13 +176,13 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 116, 11, 40);  // (horizontal gravity line)
-		obj.createentity(game, 48, 116, 11, 224);  // (horizontal gravity line)
-		obj.createentity(game, 288, 116, 11, 32);  // (horizontal gravity line)
-		obj.createentity(game, 56, 88, 1, 3, 10);  // Enemy
-		obj.createentity(game, 248-16, 128, 1, 2, 10);  // Enemy
-		obj.createentity(game, 272, 168, 10, 0, 51480);  // (savepoint)
-		obj.createentity(game, 32, 48, 10, 1, 51481);  // (savepoint)
+		obj.createentity(-8, 116, 11, 40);  // (horizontal gravity line)
+		obj.createentity(48, 116, 11, 224);  // (horizontal gravity line)
+		obj.createentity(288, 116, 11, 32);  // (horizontal gravity line)
+		obj.createentity(56, 88, 1, 3, 10);  // Enemy
+		obj.createentity(248-16, 128, 1, 2, 10);  // Enemy
+		obj.createentity(272, 168, 10, 0, 51480);  // (savepoint)
+		obj.createentity(32, 48, 10, 1, 51481);  // (savepoint)
 
 		warpy = true;
 		roomname = "glitch";
@@ -220,11 +220,11 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,218,220,0,0,0,0,0,0,218,220,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,218,220,0,0,0,0,0,0,218,220,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 148, 11, 104);  // (horizontal gravity line)
-		obj.createentity(game, -8, 84, 11, 80);  // (horizontal gravity line)
-		obj.createentity(game, 176, 116, 11, 144);  // (horizontal gravity line)
-		obj.createentity(game, 128, 96, 10, 0, 51470);  // (savepoint)
-		obj.createentity(game, 128, 56, 10, 1, 51471);  // (savepoint)
+		obj.createentity(-8, 148, 11, 104);  // (horizontal gravity line)
+		obj.createentity(-8, 84, 11, 80);  // (horizontal gravity line)
+		obj.createentity(176, 116, 11, 144);  // (horizontal gravity line)
+		obj.createentity(128, 96, 10, 0, 51470);  // (savepoint)
+		obj.createentity(128, 56, 10, 1, 51471);  // (savepoint)
 
 		warpy = true;
 		roomname = "change";
@@ -262,13 +262,13 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 84, 11, 328);  // (horizontal gravity line)
-		obj.createentity(game, -8, 148, 11, 328);  // (horizontal gravity line)
-		obj.createentity(game, 96, 120, 1, 2, 4);  // Enemy
-		obj.createentity(game, 144, 96, 1, 2, 4);  // Enemy
-		obj.createentity(game, 192, 120, 1, 2, 4);  // Enemy
-		obj.createentity(game, 240, 96, 1, 2, 4);  // Enemy
-		obj.createentity(game, 288, 120, 1, 2, 4);  // Enemy
+		obj.createentity(-8, 84, 11, 328);  // (horizontal gravity line)
+		obj.createentity(-8, 148, 11, 328);  // (horizontal gravity line)
+		obj.createentity(96, 120, 1, 2, 4);  // Enemy
+		obj.createentity(144, 96, 1, 2, 4);  // Enemy
+		obj.createentity(192, 120, 1, 2, 4);  // Enemy
+		obj.createentity(240, 96, 1, 2, 4);  // Enemy
+		obj.createentity(288, 120, 1, 2, 4);  // Enemy
 
 		warpy = true;
 		roomname = "change";
@@ -306,10 +306,10 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,218,220,0,0,0,0,0,0,218,220,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,218,220,0,0,0,0,0,0,218,220,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 248, 84, 11, 72);  // (horizontal gravity line)
-		obj.createentity(game, 224, 148, 11, 96);  // (horizontal gravity line)
-		obj.createentity(game, 176, 56, 10, 1, 51450);  // (savepoint)
-		obj.createentity(game, 176, 96, 10, 0, 51451);  // (savepoint)
+		obj.createentity(248, 84, 11, 72);  // (horizontal gravity line)
+		obj.createentity(224, 148, 11, 96);  // (horizontal gravity line)
+		obj.createentity(176, 56, 10, 1, 51450);  // (savepoint)
+		obj.createentity(176, 96, 10, 0, 51451);  // (savepoint)
 
 		warpy = true;
 		roomname = "change";
@@ -348,19 +348,19 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 64+32-8, 32-16, 1, 0, 7, 0, -48, 320, 312);  // Enemy, bounded
-		obj.createentity(game, 96+32-8, 32-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 128+32-8, 32-16, 1, 0, 7, 0, -40, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 160+32-8, 32-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 192+32-8, 32-16, 1, 0, 7, 0, -64, 320, 336);  // Enemy, bounded
-		obj.createentity(game, 64+32-8, 64-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 64+32-8, 96-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 64+32-8, 128-16, 1, 0, 7, 0, -64, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 64+32-8, 160-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 192+32-8, 128-16+8, 1, 0, 7, 0, -64, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 192+32-8, 160-16+8, 1, 0, 7, 0, -80, 320, 320);  // Enemy, bounded
-		obj.createentity(game, 192+32-8, 192-16+8, 1, 0, 7, 0, -80, 320, 304);  // Enemy, bounded
-		obj.createentity(game, 192+32-8, 192+24, 1, 0, 7, 0, -80, 320, 304);  // Enemy, bounded
+		obj.createentity(64+32-8, 32-16, 1, 0, 7, 0, -48, 320, 312);  // Enemy, bounded
+		obj.createentity(96+32-8, 32-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
+		obj.createentity(128+32-8, 32-16, 1, 0, 7, 0, -40, 320, 320);  // Enemy, bounded
+		obj.createentity(160+32-8, 32-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
+		obj.createentity(192+32-8, 32-16, 1, 0, 7, 0, -64, 320, 336);  // Enemy, bounded
+		obj.createentity(64+32-8, 64-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
+		obj.createentity(64+32-8, 96-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
+		obj.createentity(64+32-8, 128-16, 1, 0, 7, 0, -64, 320, 320);  // Enemy, bounded
+		obj.createentity(64+32-8, 160-16, 1, 0, 7, 0, -56, 320, 320);  // Enemy, bounded
+		obj.createentity(192+32-8, 128-16+8, 1, 0, 7, 0, -64, 320, 320);  // Enemy, bounded
+		obj.createentity(192+32-8, 160-16+8, 1, 0, 7, 0, -80, 320, 320);  // Enemy, bounded
+		obj.createentity(192+32-8, 192-16+8, 1, 0, 7, 0, -80, 320, 304);  // Enemy, bounded
+		obj.createentity(192+32-8, 192+24, 1, 0, 7, 0, -80, 320, 304);  // Enemy, bounded
 
 		warpy = true;
 		roomname = "Vertigo";
@@ -398,17 +398,17 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,178,179,180,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,218,98,220,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 155, 24, 12, 184);  // (vertical gravity line)
-		obj.createentity(game, 120, 152, 1, 1, 8, 0, -56, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 104, 136, 1, 1, 8, 0, -64, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 88, 120, 1, 1, 8, 0, -56, 320, 312);  // Enemy, bounded
-		obj.createentity(game, 72, 104, 1, 1, 8, 0, -56, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 56, 88, 1, 1, 8, 0, -48, 320, 328);  // Enemy, bounded
-		obj.createentity(game, 176, 56, 1, 0, 8, 0, -64, 320, 288);  // Enemy, bounded
-		obj.createentity(game, 192, 72, 1, 0, 8, 0, -48, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 208, 88, 1, 0, 8, 0, -72, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 224, 104, 1, 0, 8, 0, -56, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 240, 120, 1, 0, 8, 0, -48, 320, 296);  // Enemy, bounded
+		obj.createentity(155, 24, 12, 184);  // (vertical gravity line)
+		obj.createentity(120, 152, 1, 1, 8, 0, -56, 320, 296);  // Enemy, bounded
+		obj.createentity(104, 136, 1, 1, 8, 0, -64, 320, 296);  // Enemy, bounded
+		obj.createentity(88, 120, 1, 1, 8, 0, -56, 320, 312);  // Enemy, bounded
+		obj.createentity(72, 104, 1, 1, 8, 0, -56, 320, 296);  // Enemy, bounded
+		obj.createentity(56, 88, 1, 1, 8, 0, -48, 320, 328);  // Enemy, bounded
+		obj.createentity(176, 56, 1, 0, 8, 0, -64, 320, 288);  // Enemy, bounded
+		obj.createentity(192, 72, 1, 0, 8, 0, -48, 320, 296);  // Enemy, bounded
+		obj.createentity(208, 88, 1, 0, 8, 0, -72, 320, 296);  // Enemy, bounded
+		obj.createentity(224, 104, 1, 0, 8, 0, -56, 320, 296);  // Enemy, bounded
+		obj.createentity(240, 120, 1, 0, 8, 0, -48, 320, 296);  // Enemy, bounded
 
 		warpy = true;
 		roomname = "The Voon Show";
@@ -446,9 +446,9 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,218,98,220,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,218,98,220,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 168, 72, 10, 0, 51420);  // (savepoint)
-		obj.createentity(game, 24, 60, 11, 120);  // (horizontal gravity line)
-		obj.createentity(game, 24, 148, 11, 120);  // (horizontal gravity line)
+		obj.createentity(168, 72, 10, 0, 51420);  // (savepoint)
+		obj.createentity(24, 60, 11, 120);  // (horizontal gravity line)
+		obj.createentity(24, 148, 11, 120);  // (horizontal gravity line)
 
 		warpy = true;
 		roomname = "glitch";
@@ -487,11 +487,11 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,740,218,98,220,0,0,0,0,0,218,220,0,0,0,0,0,0,0,0,0,0,0,218,98,220,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 		tmap.push_back("740,740,218,98,220,0,0,0,0,0,218,220,178,179,179,179,179,179,179,179,179,179,180,218,98,220,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 
-		obj.createentity(game, 280, 120, 10, 1, 51410);  // (savepoint)
-		obj.createentity(game, 40, 28, 11, 192);  // (horizontal gravity line)
-		obj.createentity(game, 96, 204, 11, 88);  // (horizontal gravity line)
-		obj.createentity(game, 144, 156, 11, 88);  // (horizontal gravity line)
-		obj.createentity(game, 96, 92, 11, 88);  // (horizontal gravity line)
+		obj.createentity(280, 120, 10, 1, 51410);  // (savepoint)
+		obj.createentity(40, 28, 11, 192);  // (horizontal gravity line)
+		obj.createentity(96, 204, 11, 88);  // (horizontal gravity line)
+		obj.createentity(144, 156, 11, 88);  // (horizontal gravity line)
+		obj.createentity(96, 92, 11, 88);  // (horizontal gravity line)
 
 		warpx = true;
 		roomname = "1950 Silverstone Grand V";
@@ -530,8 +530,8 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,740,218,98,220,0,0,0,0,0,218,98,220,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 		tmap.push_back("740,740,218,98,220,0,0,0,0,0,218,98,220,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 
-		obj.createentity(game, 264, 168, 10, 1, 52410);  // (savepoint)
-		obj.createentity(game, 152, 112, 20, 1);  // (terminal)
+		obj.createentity(264, 168, 10, 1, 52410);  // (savepoint)
+		obj.createentity(152, 112, 20, 1);  // (terminal)
 
 		if(obj.flags[72] == 0)
 		{
@@ -617,12 +617,12 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220,178,179,179,180,218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220");
 		tmap.push_back("218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220,218,98,98,220");
 
-		obj.createentity(game, 264, 176, 10, 1, 52430);  // (savepoint)
-		obj.createentity(game, 96, 180, 11, 96);  // (horizontal gravity line)
-		obj.createentity(game, 160, 52, 11, 96);  // (horizontal gravity line)
-		obj.createentity(game, 240, 136, 1, 2, 8);  // Enemy
-		obj.createentity(game, 96, 88, 1, 3, 8);  // Enemy
-		obj.createentity(game, 72, 32, 10, 0, 52431);  // (savepoint)
+		obj.createentity(264, 176, 10, 1, 52430);  // (savepoint)
+		obj.createentity(96, 180, 11, 96);  // (horizontal gravity line)
+		obj.createentity(160, 52, 11, 96);  // (horizontal gravity line)
+		obj.createentity(240, 136, 1, 2, 8);  // Enemy
+		obj.createentity(96, 88, 1, 3, 8);  // Enemy
+		obj.createentity(72, 32, 10, 0, 52431);  // (savepoint)
 		roomname = "Upstairs, Downstairs";
 		break;
 
@@ -659,21 +659,21 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("98,98,98,98,98,98,220,218,220,218,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,220,218,98,98");
 		tmap.push_back("98,98,98,98,98,98,220,218,220,218,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,220,218,98,98");
 
-		obj.createentity(game, 64, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 192, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 32, 112, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(64, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(192, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(32, 112, 2, 9, 4);  //Threadmill, <<<
 
-		obj.createentity(game, 0, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 104, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(0, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 104, 2, 8, 4);  //Threadmill, >>>
 
-		obj.createentity(game, 80+8, 128, 1, 0, 5, 0, 120, 320, 200);  // Enemy, bounded
-		obj.createentity(game, 128+16, 168, 1, 1, 5, 0, 120, 320, 200);  // Enemy, bounded
-		obj.createentity(game, 176+24, 128, 1, 0, 5, 0, 120, 320, 200);  // Enemy, bounded
-		//obj.createentity(game, 224, 168, 1, 1, 5, 0, 120, 320, 200);  // Enemy, bounded
-		obj.createentity(game, 24, 184, 10, 1, 52440);  // (savepoint)
+		obj.createentity(80+8, 128, 1, 0, 5, 0, 120, 320, 200);  // Enemy, bounded
+		obj.createentity(128+16, 168, 1, 1, 5, 0, 120, 320, 200);  // Enemy, bounded
+		obj.createentity(176+24, 128, 1, 0, 5, 0, 120, 320, 200);  // Enemy, bounded
+		//obj.createentity(224, 168, 1, 1, 5, 0, 120, 320, 200);  // Enemy, bounded
+		obj.createentity(24, 184, 10, 1, 52440);  // (savepoint)
 		roomname = "Timeslip";
 		break;
 
@@ -709,10 +709,10 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,218,98,220,218,98,220,740,740,218,98,220,218,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,220,218,98,220,740,740,740,740,740,740,740");
 		tmap.push_back("740,218,98,220,218,98,220,740,740,218,98,220,218,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,220,218,98,220,740,740,740,740,740,740,740");
 
-		obj.createentity(game, 40, 176, 10, 1, 52450);  // (savepoint)
-		obj.createentity(game, 80, 156, 11, 176);  // (horizontal gravity line)
-		obj.createentity(game, 128, 88, 10, 1, 52451);  // (savepoint)
-		obj.createentity(game, 160, 76, 11, 96);  // (horizontal gravity line)
+		obj.createentity(40, 176, 10, 1, 52450);  // (savepoint)
+		obj.createentity(80, 156, 11, 176);  // (horizontal gravity line)
+		obj.createentity(128, 88, 10, 1, 52451);  // (savepoint)
+		obj.createentity(160, 76, 11, 96);  // (horizontal gravity line)
 		roomname = "Three's Company";
 		break;
 
@@ -748,12 +748,12 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,218,98,220,178,179,179,179,179,179,179,179,180,218,220,178,179,179,179,179,179,179,179,179,179,179,179,180,218,98,220,740,740,740,740,740,740,740,740,740");
 		tmap.push_back("740,218,98,220,218,98,98,98,98,98,98,98,220,218,220,218,98,98,98,98,98,98,98,98,98,98,98,220,218,98,220,740,740,740,740,740,740,740,740,740");
 
-		obj.createentity(game, 68-4, 56,  2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 132-4, 56,  2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 44, 192, 3);  //Disappearing Platform
-		obj.createentity(game, 92, 104, 3);  //Disappearing Platform
-		obj.createentity(game, 120, 192, 2, 3, 6);  // Platform
-		obj.createentity(game, 264, 48, 2, 2, 6);  // Platform
+		obj.createentity(68-4, 56,  2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(132-4, 56,  2, 9, 4);  //Threadmill, <<<
+		obj.createentity(44, 192, 3);  //Disappearing Platform
+		obj.createentity(92, 104, 3);  //Disappearing Platform
+		obj.createentity(120, 192, 2, 3, 6);  // Platform
+		obj.createentity(264, 48, 2, 2, 6);  // Platform
 		roomname = "Cosmic Creepers";
 		break;
 
@@ -789,12 +789,12 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("179,179,179,179,179,179,179,179,179,180,6,6,6,6,6,6,6,6,6,6,6,6,178,179,180,6,6,6,6,6,6,6,6,6,6,6,6,178,179,179");
 		tmap.push_back("98,98,98,98,98,98,98,98,98,220,178,179,179,179,179,179,179,179,179,179,179,180,218,98,220,178,179,179,179,179,179,179,179,179,179,179,180,218,98,98");
 
-		obj.createentity(game, 16, 112, 10, 1, 52480);  // (savepoint)
-		obj.createentity(game, 67, 24, 12, 96);  // (vertical gravity line)
-		obj.createentity(game, 243, 112, 12, 104);  // (vertical gravity line)
-		obj.createentity(game, 288, 104, 10, 0, 52481);  // (savepoint)
-		obj.createentity(game, 187, 24, 12, 80);  // (vertical gravity line)
-		obj.createentity(game, 123, 128, 12, 88);  // (vertical gravity line)
+		obj.createentity(16, 112, 10, 1, 52480);  // (savepoint)
+		obj.createentity(67, 24, 12, 96);  // (vertical gravity line)
+		obj.createentity(243, 112, 12, 104);  // (vertical gravity line)
+		obj.createentity(288, 104, 10, 0, 52481);  // (savepoint)
+		obj.createentity(187, 24, 12, 80);  // (vertical gravity line)
+		obj.createentity(123, 128, 12, 88);  // (vertical gravity line)
 
 		roomname = "The Villi People";
 		break;
@@ -831,16 +831,16 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("98,220,0,0,0,218,98,98,98,98,220,218,98,98,98,98,98,220,218,98,220,740,740,740,740,740,740,740,740,740,218,98,220,218,98,98,98,98,98,98");
 		tmap.push_back("98,220,0,0,0,218,98,98,98,98,220,218,98,98,98,98,98,220,218,98,220,740,740,740,740,740,740,740,740,740,218,98,220,218,98,98,98,98,98,98");
 
-		obj.createentity(game, 192, 56, 10, 1, 53500);  // (savepoint)
-		obj.createentity(game, 288, 104, 10, 0, 53501);  // (savepoint)
+		obj.createentity(192, 56, 10, 1, 53500);  // (savepoint)
+		obj.createentity(288, 104, 10, 0, 53501);  // (savepoint)
 
-		obj.createentity(game, 168, 96, 1, 0, 5);  // Enemy
-		obj.createentity(game, 184+2, 104, 1, 0, 5);  // Enemy
-		obj.createentity(game, 200+4, 112, 1, 0, 5);  // Enemy
+		obj.createentity(168, 96, 1, 0, 5);  // Enemy
+		obj.createentity(184+2, 104, 1, 0, 5);  // Enemy
+		obj.createentity(200+4, 112, 1, 0, 5);  // Enemy
 
-		obj.createentity(game, 88, 176-4, 1, 1, 5);  // Enemy
-		obj.createentity(game, 104+2, 168-4, 1, 1, 5);  // Enemy
-		obj.createentity(game, 120 + 4, 160 - 4, 1, 1, 5);  // Enemy
+		obj.createentity(88, 176-4, 1, 1, 5);  // Enemy
+		obj.createentity(104+2, 168-4, 1, 1, 5);  // Enemy
+		obj.createentity(120 + 4, 160 - 4, 1, 1, 5);  // Enemy
 
 		warpx = true;
 		roomname = "change";
@@ -878,13 +878,13 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259");
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 
-		obj.createentity(game, 24, 88, 10, 1, 54500);  // (savepoint)
-		obj.createentity(game, 280, 184, 10, 1, 54501);  // (savepoint)
-		obj.createentity(game, 56, 44, 11, 56);  // (horizontal gravity line)
-		obj.createentity(game, 131, 72, 12, 64);  // (vertical gravity line)
-		obj.createentity(game, 144, 36, 11, 48);  // (horizontal gravity line)
-		obj.createentity(game, 211, 80, 12, 56);  // (vertical gravity line)
-		obj.createentity(game, 224, 52, 11, 80);  // (horizontal gravity line)
+		obj.createentity(24, 88, 10, 1, 54500);  // (savepoint)
+		obj.createentity(280, 184, 10, 1, 54501);  // (savepoint)
+		obj.createentity(56, 44, 11, 56);  // (horizontal gravity line)
+		obj.createentity(131, 72, 12, 64);  // (vertical gravity line)
+		obj.createentity(144, 36, 11, 48);  // (horizontal gravity line)
+		obj.createentity(211, 80, 12, 56);  // (vertical gravity line)
+		obj.createentity(224, 52, 11, 80);  // (horizontal gravity line)
 
 		warpx = true;
 		roomname = "change";
@@ -923,14 +923,14 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 
-		obj.createentity(game, 16, 48, 10, 1, 53520);  // (savepoint)
-		obj.createentity(game, 96, 144, 3);  //Disappearing Platform
-		obj.createentity(game, 128, 144, 3);  //Disappearing Platform
-		obj.createentity(game, 160, 144, 3);  //Disappearing Platform
-		obj.createentity(game, 208, 80, 3);  //Disappearing Platform
-		obj.createentity(game, 240, 80, 3);  //Disappearing Platform
-		obj.createentity(game, 272, 80, 3);  //Disappearing Platform
-		obj.createentity(game, 304, 80, 3);  //Disappearing Platform
+		obj.createentity(16, 48, 10, 1, 53520);  // (savepoint)
+		obj.createentity(96, 144, 3);  //Disappearing Platform
+		obj.createentity(128, 144, 3);  //Disappearing Platform
+		obj.createentity(160, 144, 3);  //Disappearing Platform
+		obj.createentity(208, 80, 3);  //Disappearing Platform
+		obj.createentity(240, 80, 3);  //Disappearing Platform
+		obj.createentity(272, 80, 3);  //Disappearing Platform
+		obj.createentity(304, 80, 3);  //Disappearing Platform
 		roomname = "The Last Straw";
 		break;
 
@@ -966,16 +966,16 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,6,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 
-		obj.createentity(game, 0, 80, 3);  //Disappearing Platform
-		obj.createentity(game, 288, 88, 3);  //Disappearing Platform
-		obj.createentity(game, 32, 80, 3);  //Disappearing Platform
-		obj.createentity(game, 64, 136, 3);  //Disappearing Platform
-		obj.createentity(game, 96, 136, 3);  //Disappearing Platform
-		obj.createentity(game, 224, 144, 3);  //Disappearing Platform
-		obj.createentity(game, 192, 144, 3);  //Disappearing Platform
-		obj.createentity(game, 256, 88, 3);  //Disappearing Platform
-		obj.createentity(game, 128, 88, 3);  //Disappearing Platform
-		obj.createentity(game, 160, 88, 3);  //Disappearing Platform
+		obj.createentity(0, 80, 3);  //Disappearing Platform
+		obj.createentity(288, 88, 3);  //Disappearing Platform
+		obj.createentity(32, 80, 3);  //Disappearing Platform
+		obj.createentity(64, 136, 3);  //Disappearing Platform
+		obj.createentity(96, 136, 3);  //Disappearing Platform
+		obj.createentity(224, 144, 3);  //Disappearing Platform
+		obj.createentity(192, 144, 3);  //Disappearing Platform
+		obj.createentity(256, 88, 3);  //Disappearing Platform
+		obj.createentity(128, 88, 3);  //Disappearing Platform
+		obj.createentity(160, 88, 3);  //Disappearing Platform
 		roomname = "W";
 		break;
 
@@ -1011,10 +1011,10 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 		tmap.push_back("740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740,740");
 
-		obj.createentity(game, 0, 88, 3);  //Disappearing Platform
-		obj.createentity(game, 32, 88, 3);  //Disappearing Platform
-		obj.createentity(game, 64, 88, 3);  //Disappearing Platform
-		obj.createentity(game, 120, 128, 9, 19);  // (shiny trinket)
+		obj.createentity(0, 88, 3);  //Disappearing Platform
+		obj.createentity(32, 88, 3);  //Disappearing Platform
+		obj.createentity(64, 88, 3);  //Disappearing Platform
+		obj.createentity(120, 128, 9, 19);  // (shiny trinket)
 
 		roomname="V";
 		break;
@@ -1311,7 +1311,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,178,179,180,218,98,220,218,98,220,218,98,220,218,98,220,218,98,220,740,740,740,740,740,740");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,218,98,220,218,98,220,218,98,220,218,98,220,218,98,220,218,98,220,740,740,740,740,740,740");
 
-		obj.createentity(game, 264, 32, 10, 0, 54480);  // (savepoint)
+		obj.createentity(264, 32, 10, 0, 54480);  // (savepoint)
 
 		/*if(!game.nocutscenes && obj.flags[71]==0){
 		obj.createblock(1, 72, 0, 320, 240, 49);
@@ -1353,7 +1353,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("740,740,740,218,98,220,0,0,218,220,0,0,218,98,220,0,0,0,0,218,220,0,0,0,0,218,98,220,0,0,218,220,0,0,218,98,98,98,98,98");
 		tmap.push_back("740,740,740,218,98,220,0,0,218,220,0,0,218,98,220,0,0,0,0,218,220,0,0,0,0,218,98,220,0,0,218,220,0,0,218,98,98,98,98,98");
 
-		obj.createentity(game, 120, 116, 11, 80);  // (horizontal gravity line)
+		obj.createentity(120, 116, 11, 80);  // (horizontal gravity line)
 		warpy = true;
 		roomname = "Origami Room";
 		break;
@@ -1392,7 +1392,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("12,12,12,12,12,12,12,15,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,16,12");
 		tmap.push_back("12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12");
 
-		obj.createentity(game, 40, 80, 10, 1, 50500);  // (savepoint)
+		obj.createentity(40, 80, 10, 1, 50500);  // (savepoint)
 
 		roomname = "Teleporter Divot";
 		break;
@@ -1429,14 +1429,14 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12");
 		tmap.push_back("12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12");
 
-		obj.createentity(game, 16, 112, 10, 1, 50520);  // (savepoint)
+		obj.createentity(16, 112, 10, 1, 50520);  // (savepoint)
 		roomname = "Seeing Red";
 
 		if(!game.intimetrial)
 		{
 			if(game.companion==0 && obj.flags[8]==0 && !game.crewstats[3])   //also need to check if he's rescued in a previous game
 			{
-				obj.createentity(game, 264, 185, 18, 15, 1, 17, 0);
+				obj.createentity(264, 185, 18, 15, 1, 17, 0);
 				obj.createblock(1, 26*8, 0, 32, 240, 36);
 			}
 		}
@@ -1474,7 +1474,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12");
 		tmap.push_back("12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12");
 
-		obj.createentity(game, 128-16, 80-32, 14); //Teleporter!
+		obj.createentity(128-16, 80-32, 14); //Teleporter!
 		roomname = "Building Apport";
 
 		if(game.intimetrial)
@@ -1589,8 +1589,8 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
 
-		//obj.createentity(game, -8, 84-32, 11, 328);  // (horizontal gravity line)
-		obj.createentity(game, -8, 148 + 32, 11, 328);  // (horizontal gravity line)
+		//obj.createentity(-8, 84-32, 11, 328);  // (horizontal gravity line)
+		obj.createentity(-8, 148 + 32, 11, 328);  // (horizontal gravity line)
 
 		obj.createblock(1, -10, 84 - 16, 340, 32, 10); //create the second line!
 
@@ -1630,28 +1630,28 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("219,218,98,220,0,0,0,0,218,98,220,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 		tmap.push_back("219,218,98,220,0,0,0,0,218,98,220,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 
-		obj.createentity(game, 264, 176, 10, 1, 51530);  // (savepoint)
+		obj.createentity(264, 176, 10, 1, 51530);  // (savepoint)
 
 		if(game.companion==0)   //also need to check if he's rescued in a previous game
 		{
 			if (game.lastsaved == 2)
 			{
-				obj.createentity(game, 112, 169, 18, 14, 0, 17, 1);
+				obj.createentity(112, 169, 18, 14, 0, 17, 1);
 				obj.createblock(1, 22 * 8, 16*8, 32, 240, 37);
 			}
 			else if (game.lastsaved ==3)
 			{
-				obj.createentity(game, 112, 169, 18, 15, 0, 17, 1);
+				obj.createentity(112, 169, 18, 15, 0, 17, 1);
 				obj.createblock(1, 22 * 8, 16*8, 32, 240, 38);
 			}
 			else if (game.lastsaved == 4)
 			{
-				obj.createentity(game, 112, 169, 18, 13, 0, 17, 1);
+				obj.createentity(112, 169, 18, 13, 0, 17, 1);
 				obj.createblock(1, 22 * 8, 16*8, 32, 240, 39);
 			}
 			else
 			{
-				obj.createentity(game, 112, 169, 18, 16, 1, 17, 1);
+				obj.createentity(112, 169, 18, 16, 1, 17, 1);
 				obj.createblock(1, 22 * 8, 16*8, 32, 240, 40);
 			}
 		}
@@ -1695,7 +1695,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("219,219,219,219,219,219,219,219,218,98,220,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 		tmap.push_back("219,219,219,219,219,219,219,219,218,98,220,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 
-		obj.createentity(game, (22 * 8)+4, (9 * 8) + 4, 14); //Teleporter!
+		obj.createentity((22 * 8)+4, (9 * 8) + 4, 14); //Teleporter!
 
 		roomname = "House of Mirrors";
 		warpx = true;
@@ -1735,7 +1735,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,218,98,220,0,218,98,98,220,0,218,98,98,98,220,0,218,98,98,98,98,220,0,218,98,220,219,219,219,219,219");
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,218,98,220,0,218,98,98,220,0,218,98,98,98,220,0,218,98,98,98,98,220,0,218,98,220,219,219,219,219,219");
 
-		//obj.createentity(game, 164, 96, 10, 1, 56410);  // (savepoint)
+		//obj.createentity(164, 96, 10, 1, 56410);  // (savepoint)
 
 		warpy = true;
 		roomname = "Now Take My Lead";
@@ -1820,9 +1820,9 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		{
 			obj.createblock(1, 20, 0, 32, 240, 13); //scene 2
 		}
-		obj.createentity(game, 104, 120, 1, 0, 3);  // Enemy
-		obj.createentity(game, 168, 176, 1, 1, 3);  // Enemy
-		obj.createentity(game, 232, 120, 1, 0, 3);  // Enemy
+		obj.createentity(104, 120, 1, 0, 3);  // Enemy
+		obj.createentity(168, 176, 1, 1, 3);  // Enemy
+		obj.createentity(232, 120, 1, 0, 3);  // Enemy
 
 		warpy = true;
 		roomname = "Don't Get Ahead of Yourself!";
@@ -1860,7 +1860,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("259,259,259,259,259,259,259,259,259,259,259,259,259,100,98,220,218,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98");
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,219,219,219,218,98,220,218,98,99,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259");
 
-		obj.createentity(game, 144, 40, 10, 1, 56440);  // (savepoint)
+		obj.createentity(144, 40, 10, 1, 56440);  // (savepoint)
 
 		if(!game.nodeathmode)
 		{
@@ -1904,8 +1904,8 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98");
 		tmap.push_back("259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259");
 
-		obj.createentity(game, 104, 152, 1, 0, 3);  // Enemy
-		obj.createentity(game, 200, 152, 1, 0, 3);  // Enemy
+		obj.createentity(104, 152, 1, 0, 3);  // Enemy
+		obj.createentity(200, 152, 1, 0, 3);  // Enemy
 
 		roomname = "Must I Do Everything For You?";
 		warpy = true;
@@ -1944,7 +1944,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98");
 		tmap.push_back("259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259");
 
-		obj.createentity(game, 56, 192, 10, 1, 56460);  // (savepoint)
+		obj.createentity(56, 192, 10, 1, 56460);  // (savepoint)
 
 		if(!game.nodeathmode)
 		{
@@ -1987,7 +1987,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,98,220,6,6,6,6,218,98,98,220,218,98,220,219,219,219,219,219,219,219,219,219,219,219");
 		tmap.push_back("259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,100,98,220,178,179,179,180,218,98,98,220,218,98,220,219,219,219,219,219,219,219,219,219,219,219");
 
-		obj.createentity(game, 144, 64, 2, 0, 2, 144, 64, 176, 216);  // Platform, bounded
+		obj.createentity(144, 64, 2, 0, 2, 144, 64, 176, 216);  // Platform, bounded
 
 		roomname = "...But Not Too Close";
 		warpy = true;
@@ -2061,7 +2061,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 
-		obj.createentity(game, 152, 176, 10, 1, 56490);  // (savepoint)
+		obj.createentity(152, 176, 10, 1, 56490);  // (savepoint)
 		if(!game.nodeathmode)
 		{
 			obj.createblock(1, 200, 0, 32, 240, 44); //scene 3
@@ -2102,9 +2102,9 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("219,219,219,219,219,219,218,98,220,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,218,98,98,220,218,98");
 		tmap.push_back("219,219,219,219,219,219,218,98,220,178,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,180,218,98,98,220,218,98");
 
-		obj.createentity(game, 88, 200, 2, 1, 4, 88, 128, 216, 208);  // Platform, bounded
-		obj.createentity(game, 136, 136, 2, 0, 4, 88, 128, 216, 208);  // Platform, bounded
-		obj.createentity(game, 184, 200, 2, 1, 4, 88, 128, 216, 208);  // Platform, bounded
+		obj.createentity(88, 200, 2, 1, 4, 88, 128, 216, 208);  // Platform, bounded
+		obj.createentity(136, 136, 2, 0, 4, 88, 128, 216, 208);  // Platform, bounded
+		obj.createentity(184, 200, 2, 1, 4, 88, 128, 216, 208);  // Platform, bounded
 
 		roomname = "...Not as I Do";
 		warpy = true;
@@ -2142,7 +2142,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 
-		obj.createentity(game, 192, 136, 10, 1, 56510);  // (savepoint)
+		obj.createentity(192, 136, 10, 1, 56510);  // (savepoint)
 		if(!game.nodeathmode)
 		{
 			obj.createblock(1, 80, 0, 32, 240, 45); //scene 3
@@ -2183,13 +2183,13 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("219,218,98,220,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,218,98,220,219");
 		tmap.push_back("219,218,98,220,178,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,180,218,98,220,219");
 
-		obj.createentity(game, 48, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
-		obj.createentity(game, 80, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
-		obj.createentity(game, 112, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
-		obj.createentity(game, 144, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
-		obj.createentity(game, 176, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
-		obj.createentity(game, 208, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
-		obj.createentity(game, 240, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
+		obj.createentity(48, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
+		obj.createentity(80, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
+		obj.createentity(112, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
+		obj.createentity(144, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
+		obj.createentity(176, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
+		obj.createentity(208, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
+		obj.createentity(240, 200, 2, 1, 6, 48, 48, 272, 208);  // Platform, bounded
 
 		roomname = "Do Try To Keep Up";
 		warpy = true;
@@ -2227,7 +2227,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("219,219,219,219,219,218,98,220,218,98,99,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259");
 		tmap.push_back("219,219,219,219,219,218,98,220,218,98,220,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 
-		obj.createentity(game, 72, 72, 10, 1, 56530);  // (savepoint)
+		obj.createentity(72, 72, 10, 1, 56530);  // (savepoint)
 
 		roomname = "You're Falling Behind";
 		warpy = true;
@@ -2265,7 +2265,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry, Game& game, entit
 		tmap.push_back("259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259,259");
 		tmap.push_back("219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219,219");
 
-		obj.createentity(game, (18 * 8) + 4, (10 * 8) + 4, 14); //Teleporter!
+		obj.createentity((18 * 8) + 4, (10 * 8) + 4, 14); //Teleporter!
 
 		if(!game.nodeathmode)
 		{

--- a/desktop_version/src/Finalclass.h
+++ b/desktop_version/src/Finalclass.h
@@ -10,7 +10,7 @@
 class finalclass
 {
 public:
-    std::vector<std::string> loadlevel(int rx, int ry, Game& game, entityclass& obj);
+    std::vector<std::string> loadlevel(int rx, int ry);
 
     std::string roomname;
     int coin, rcol;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -659,13 +659,13 @@ void Game::savecustomlevelstats()
 
     if(numcustomlevelstats>=200)numcustomlevelstats=199;
     msg = new TiXmlElement( "numcustomlevelstats" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(numcustomlevelstats).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(numcustomlevelstats).c_str() ));
     msgs->LinkEndChild( msg );
 
     std::string customlevelscorestr;
     for(int i = 0; i < numcustomlevelstats; i++ )
     {
-        customlevelscorestr += UtilityClass::String(customlevelscore[i]) + ",";
+        customlevelscorestr += help.String(customlevelscore[i]) + ",";
     }
     msg = new TiXmlElement( "customlevelscore" );
     msg->LinkEndChild( new TiXmlText( customlevelscorestr.c_str() ));
@@ -4557,7 +4557,7 @@ void Game::savestats()
     std::string s_unlock;
     for(size_t i = 0; i < unlock.size(); i++ )
     {
-        s_unlock += UtilityClass::String(unlock[i]) + ",";
+        s_unlock += help.String(unlock[i]) + ",";
     }
     msg = new TiXmlElement( "unlock" );
     msg->LinkEndChild( new TiXmlText( s_unlock.c_str() ));
@@ -4566,7 +4566,7 @@ void Game::savestats()
     std::string s_unlocknotify;
     for(size_t i = 0; i < unlocknotify.size(); i++ )
     {
-        s_unlocknotify += UtilityClass::String(unlocknotify[i]) + ",";
+        s_unlocknotify += help.String(unlocknotify[i]) + ",";
     }
     msg = new TiXmlElement( "unlocknotify" );
     msg->LinkEndChild( new TiXmlText( s_unlocknotify.c_str() ));
@@ -4575,7 +4575,7 @@ void Game::savestats()
     std::string s_besttimes;
     for(size_t i = 0; i < besttrinkets.size(); i++ )
     {
-        s_besttimes += UtilityClass::String(besttimes[i]) + ",";
+        s_besttimes += help.String(besttimes[i]) + ",";
     }
     msg = new TiXmlElement( "besttimes" );
     msg->LinkEndChild( new TiXmlText( s_besttimes.c_str() ));
@@ -4584,7 +4584,7 @@ void Game::savestats()
     std::string s_besttrinkets;
     for(size_t i = 0; i < besttrinkets.size(); i++ )
     {
-        s_besttrinkets += UtilityClass::String(besttrinkets[i]) + ",";
+        s_besttrinkets += help.String(besttrinkets[i]) + ",";
     }
     msg = new TiXmlElement( "besttrinkets" );
     msg->LinkEndChild( new TiXmlText( s_besttrinkets.c_str() ));
@@ -4593,7 +4593,7 @@ void Game::savestats()
     std::string s_bestlives;
     for(size_t i = 0; i < bestlives.size(); i++ )
     {
-        s_bestlives += UtilityClass::String(bestlives[i]) + ",";
+        s_bestlives += help.String(bestlives[i]) + ",";
     }
     msg = new TiXmlElement( "bestlives" );
     msg->LinkEndChild( new TiXmlText( s_bestlives.c_str() ));
@@ -4602,7 +4602,7 @@ void Game::savestats()
     std::string s_bestrank;
     for(size_t i = 0; i < bestrank.size(); i++ )
     {
-        s_bestrank += UtilityClass::String(bestrank[i]) + ",";
+        s_bestrank += help.String(bestrank[i]) + ",";
     }
     msg = new TiXmlElement( "bestrank" );
     msg->LinkEndChild( new TiXmlText( s_bestrank.c_str() ));
@@ -5696,7 +5696,7 @@ void Game::savetele()
     std::string mapExplored;
     for(size_t i = 0; i < map.explored.size(); i++ )
     {
-        mapExplored += UtilityClass::String(map.explored[i]) + ",";
+        mapExplored += help.String(map.explored[i]) + ",";
     }
     msg = new TiXmlElement( "worldmap" );
     msg->LinkEndChild( new TiXmlText( mapExplored.c_str() ));
@@ -5705,7 +5705,7 @@ void Game::savetele()
     std::string flags;
     for(size_t i = 0; i < obj.flags.size(); i++ )
     {
-        flags += UtilityClass::String(obj.flags[i]) + ",";
+        flags += help.String(obj.flags[i]) + ",";
     }
     msg = new TiXmlElement( "flags" );
     msg->LinkEndChild( new TiXmlText( flags.c_str() ));
@@ -5714,7 +5714,7 @@ void Game::savetele()
     std::string crewstatsString;
     for(size_t i = 0; i < crewstats.size(); i++ )
     {
-        crewstatsString += UtilityClass::String(crewstats[i]) + ",";
+        crewstatsString += help.String(crewstats[i]) + ",";
     }
     msg = new TiXmlElement( "crewstats" );
     msg->LinkEndChild( new TiXmlText( crewstatsString.c_str() ));
@@ -5723,7 +5723,7 @@ void Game::savetele()
     std::string collect;
     for(size_t i = 0; i < obj.collect.size(); i++ )
     {
-        collect += UtilityClass::String(obj.collect[i]) + ",";
+        collect += help.String(obj.collect[i]) + ",";
     }
     msg = new TiXmlElement( "collect" );
     msg->LinkEndChild( new TiXmlText( collect.c_str() ));
@@ -5736,27 +5736,27 @@ void Game::savetele()
     //telecookie.data.savey = savey;
 
     msg = new TiXmlElement( "finalx" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(map.finalx).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(map.finalx).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "finaly" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(map.finaly).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(map.finaly).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savex" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savex).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savex).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savey" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savey).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savey).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "saverx" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(saverx).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(saverx).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savery" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savery).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savery).c_str() ));
     msgs->LinkEndChild( msg );
 
     //telecookie.data.saverx = saverx;
@@ -5767,19 +5767,19 @@ void Game::savetele()
     //telecookie.data.trinkets = trinkets;
 
     msg = new TiXmlElement( "savegc" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savegc).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savegc).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savedir" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savedir).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savedir).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savepoint" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savepoint).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savepoint).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "trinkets" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(trinkets).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(trinkets).c_str() ));
     msgs->LinkEndChild( msg );
 
 
@@ -5800,13 +5800,13 @@ void Game::savetele()
     if(music.nicefade==1)
     {
         msg = new TiXmlElement( "currentsong" );
-        msg->LinkEndChild( new TiXmlText( UtilityClass::String(music.nicechange).c_str() ));
+        msg->LinkEndChild( new TiXmlText( help.String(music.nicechange).c_str() ));
         msgs->LinkEndChild( msg );
     }
     else
     {
         msg = new TiXmlElement( "currentsong" );
-        msg->LinkEndChild( new TiXmlText( UtilityClass::String(music.currentsong).c_str() ));
+        msg->LinkEndChild( new TiXmlText( help.String(music.currentsong).c_str() ));
         msgs->LinkEndChild( msg );
     }
 
@@ -5814,18 +5814,18 @@ void Game::savetele()
     msg->LinkEndChild( new TiXmlText( teleportscript.c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "companion" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(companion).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(companion).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "lastsaved" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(lastsaved).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(lastsaved).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "supercrewmate" );
     msg->LinkEndChild( new TiXmlText( BoolToString(supercrewmate) ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "scmprogress" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(scmprogress).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(scmprogress).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "scmmoveme" );
     msg->LinkEndChild( new TiXmlText( BoolToString(scmmoveme) ));
@@ -5845,31 +5845,31 @@ void Game::savetele()
 
 
     msg = new TiXmlElement( "frames" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(frames).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(frames).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "seconds" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(seconds).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(seconds).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "minutes" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(minutes).c_str()) );
+    msg->LinkEndChild( new TiXmlText( help.String(minutes).c_str()) );
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "hours" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(hours).c_str()) );
+    msg->LinkEndChild( new TiXmlText( help.String(hours).c_str()) );
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "deathcounts" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(deathcounts).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(deathcounts).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "totalflips" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(totalflips).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(totalflips).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "hardestroom" );
     msg->LinkEndChild( new TiXmlText( hardestroom.c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "hardestroomdeaths" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(hardestroomdeaths).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(hardestroomdeaths).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "finalmode" );
@@ -5942,7 +5942,7 @@ void Game::savequick()
     std::string mapExplored;
     for(size_t i = 0; i < map.explored.size(); i++ )
     {
-        mapExplored += UtilityClass::String(map.explored[i]) + ",";
+        mapExplored += help.String(map.explored[i]) + ",";
     }
     msg = new TiXmlElement( "worldmap" );
     msg->LinkEndChild( new TiXmlText( mapExplored.c_str() ));
@@ -5951,7 +5951,7 @@ void Game::savequick()
     std::string flags;
     for(size_t i = 0; i < obj.flags.size(); i++ )
     {
-        flags += UtilityClass::String(obj.flags[i]) + ",";
+        flags += help.String(obj.flags[i]) + ",";
     }
     msg = new TiXmlElement( "flags" );
     msg->LinkEndChild( new TiXmlText( flags.c_str() ));
@@ -5960,7 +5960,7 @@ void Game::savequick()
     std::string crewstatsString;
     for(size_t i = 0; i < crewstats.size(); i++ )
     {
-        crewstatsString += UtilityClass::String(crewstats[i]) + ",";
+        crewstatsString += help.String(crewstats[i]) + ",";
     }
     msg = new TiXmlElement( "crewstats" );
     msg->LinkEndChild( new TiXmlText( crewstatsString.c_str() ));
@@ -5969,7 +5969,7 @@ void Game::savequick()
     std::string collect;
     for(size_t i = 0; i < obj.collect.size(); i++ )
     {
-        collect += UtilityClass::String(obj.collect[i]) + ",";
+        collect += help.String(obj.collect[i]) + ",";
     }
     msg = new TiXmlElement( "collect" );
     msg->LinkEndChild( new TiXmlText( collect.c_str() ));
@@ -5982,27 +5982,27 @@ void Game::savequick()
     //telecookie.data.savey = savey;
 
     msg = new TiXmlElement( "finalx" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(map.finalx).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(map.finalx).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "finaly" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(map.finaly).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(map.finaly).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savex" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savex).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savex).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savey" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savey).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savey).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "saverx" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(saverx).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(saverx).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savery" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savery).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savery).c_str() ));
     msgs->LinkEndChild( msg );
 
     //telecookie.data.saverx = saverx;
@@ -6013,19 +6013,19 @@ void Game::savequick()
     //telecookie.data.trinkets = trinkets;
 
     msg = new TiXmlElement( "savegc" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savegc).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savegc).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savedir" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savedir).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savedir).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savepoint" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savepoint).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savepoint).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "trinkets" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(trinkets).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(trinkets).c_str() ));
     msgs->LinkEndChild( msg );
 
 
@@ -6045,13 +6045,13 @@ void Game::savequick()
     if(music.nicefade==1)
     {
         msg = new TiXmlElement( "currentsong" );
-        msg->LinkEndChild( new TiXmlText( UtilityClass::String(music.nicechange).c_str() ));
+        msg->LinkEndChild( new TiXmlText( help.String(music.nicechange).c_str() ));
         msgs->LinkEndChild( msg );
     }
     else
     {
         msg = new TiXmlElement( "currentsong" );
-        msg->LinkEndChild( new TiXmlText( UtilityClass::String(music.currentsong).c_str() ));
+        msg->LinkEndChild( new TiXmlText( help.String(music.currentsong).c_str() ));
         msgs->LinkEndChild( msg );
     }
 
@@ -6059,18 +6059,18 @@ void Game::savequick()
     msg->LinkEndChild( new TiXmlText( teleportscript.c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "companion" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(companion).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(companion).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "lastsaved" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(lastsaved).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(lastsaved).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "supercrewmate" );
     msg->LinkEndChild( new TiXmlText( BoolToString(supercrewmate) ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "scmprogress" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(scmprogress).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(scmprogress).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "scmmoveme" );
     msg->LinkEndChild( new TiXmlText( BoolToString(scmmoveme) ));
@@ -6100,31 +6100,31 @@ void Game::savequick()
 
 
     msg = new TiXmlElement( "frames" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(frames).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(frames).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "seconds" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(seconds).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(seconds).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "minutes" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(minutes).c_str()) );
+    msg->LinkEndChild( new TiXmlText( help.String(minutes).c_str()) );
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "hours" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(hours).c_str()) );
+    msg->LinkEndChild( new TiXmlText( help.String(hours).c_str()) );
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "deathcounts" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(deathcounts).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(deathcounts).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "totalflips" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(totalflips).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(totalflips).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "hardestroom" );
     msg->LinkEndChild( new TiXmlText( hardestroom.c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "hardestroomdeaths" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(hardestroomdeaths).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(hardestroomdeaths).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "summary" );
@@ -6183,7 +6183,7 @@ void Game::customsavequick(std::string savfile)
     std::string mapExplored;
     for(size_t i = 0; i < map.explored.size(); i++ )
     {
-        mapExplored += UtilityClass::String(map.explored[i]) + ",";
+        mapExplored += help.String(map.explored[i]) + ",";
     }
     msg = new TiXmlElement( "worldmap" );
     msg->LinkEndChild( new TiXmlText( mapExplored.c_str() ));
@@ -6192,7 +6192,7 @@ void Game::customsavequick(std::string savfile)
     std::string flags;
     for(size_t i = 0; i < obj.flags.size(); i++ )
     {
-        flags += UtilityClass::String(obj.flags[i]) + ",";
+        flags += help.String(obj.flags[i]) + ",";
     }
     msg = new TiXmlElement( "flags" );
     msg->LinkEndChild( new TiXmlText( flags.c_str() ));
@@ -6201,7 +6201,7 @@ void Game::customsavequick(std::string savfile)
     std::string moods;
     for(int i = 0; i < 6; i++ )
     {
-        moods += UtilityClass::String(obj.customcrewmoods[i]) + ",";
+        moods += help.String(obj.customcrewmoods[i]) + ",";
     }
     msg = new TiXmlElement( "moods" );
     msg->LinkEndChild( new TiXmlText( moods.c_str() ));
@@ -6210,7 +6210,7 @@ void Game::customsavequick(std::string savfile)
     std::string crewstatsString;
     for(size_t i = 0; i < crewstats.size(); i++ )
     {
-        crewstatsString += UtilityClass::String(crewstats[i]) + ",";
+        crewstatsString += help.String(crewstats[i]) + ",";
     }
     msg = new TiXmlElement( "crewstats" );
     msg->LinkEndChild( new TiXmlText( crewstatsString.c_str() ));
@@ -6219,7 +6219,7 @@ void Game::customsavequick(std::string savfile)
     std::string collect;
     for(size_t i = 0; i < obj.collect.size(); i++ )
     {
-        collect += UtilityClass::String(obj.collect[i]) + ",";
+        collect += help.String(obj.collect[i]) + ",";
     }
     msg = new TiXmlElement( "collect" );
     msg->LinkEndChild( new TiXmlText( collect.c_str() ));
@@ -6228,7 +6228,7 @@ void Game::customsavequick(std::string savfile)
     std::string customcollect;
     for(size_t i = 0; i < obj.customcollect.size(); i++ )
     {
-        customcollect += UtilityClass::String(obj.customcollect[i]) + ",";
+        customcollect += help.String(obj.customcollect[i]) + ",";
     }
     msg = new TiXmlElement( "customcollect" );
     msg->LinkEndChild( new TiXmlText( customcollect.c_str() ));
@@ -6241,27 +6241,27 @@ void Game::customsavequick(std::string savfile)
     //telecookie.data.savey = savey;
 
     msg = new TiXmlElement( "finalx" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(map.finalx).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(map.finalx).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "finaly" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(map.finaly).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(map.finaly).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savex" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savex).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savex).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savey" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savey).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savey).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "saverx" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(saverx).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(saverx).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savery" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savery).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savery).c_str() ));
     msgs->LinkEndChild( msg );
 
     //telecookie.data.saverx = saverx;
@@ -6272,23 +6272,23 @@ void Game::customsavequick(std::string savfile)
     //telecookie.data.trinkets = trinkets;
 
     msg = new TiXmlElement( "savegc" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savegc).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savegc).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savedir" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savedir).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savedir).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "savepoint" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(savepoint).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(savepoint).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "trinkets" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(trinkets).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(trinkets).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "crewmates" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(crewmates).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(crewmates).c_str() ));
     msgs->LinkEndChild( msg );
 
 
@@ -6308,13 +6308,13 @@ void Game::customsavequick(std::string savfile)
     if(music.nicefade==1)
     {
         msg = new TiXmlElement( "currentsong" );
-        msg->LinkEndChild( new TiXmlText( UtilityClass::String(music.nicechange).c_str() ));
+        msg->LinkEndChild( new TiXmlText( help.String(music.nicechange).c_str() ));
         msgs->LinkEndChild( msg );
     }
     else
     {
         msg = new TiXmlElement( "currentsong" );
-        msg->LinkEndChild( new TiXmlText( UtilityClass::String(music.currentsong).c_str() ));
+        msg->LinkEndChild( new TiXmlText( help.String(music.currentsong).c_str() ));
         msgs->LinkEndChild( msg );
     }
 
@@ -6322,18 +6322,18 @@ void Game::customsavequick(std::string savfile)
     msg->LinkEndChild( new TiXmlText( teleportscript.c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "companion" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(companion).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(companion).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "lastsaved" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(lastsaved).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(lastsaved).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "supercrewmate" );
     msg->LinkEndChild( new TiXmlText( BoolToString(supercrewmate) ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "scmprogress" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(scmprogress).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(scmprogress).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "scmmoveme" );
     msg->LinkEndChild( new TiXmlText( BoolToString(scmmoveme) ));
@@ -6353,31 +6353,31 @@ void Game::customsavequick(std::string savfile)
 
 
     msg = new TiXmlElement( "frames" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(frames).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(frames).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "seconds" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(seconds).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(seconds).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "minutes" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(minutes).c_str()) );
+    msg->LinkEndChild( new TiXmlText( help.String(minutes).c_str()) );
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "hours" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(hours).c_str()) );
+    msg->LinkEndChild( new TiXmlText( help.String(hours).c_str()) );
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "deathcounts" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(deathcounts).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(deathcounts).c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "totalflips" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(totalflips).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(totalflips).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "hardestroom" );
     msg->LinkEndChild( new TiXmlText( hardestroom.c_str() ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "hardestroomdeaths" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(hardestroomdeaths).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(hardestroomdeaths).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "showminimap" );

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -915,7 +915,7 @@ void Game::updatestate()
             if(obj.entities[obj.getplayer()].tile == 0)
             {
                 obj.entities[obj.getplayer()].tile = 144;
-                music.playef(2, 10);
+                music.playef(2);
             }
             state = 0;
             break;
@@ -1293,7 +1293,7 @@ void Game::updatestate()
             break;
 
         case 50:
-            music.playef(15, 10);
+            music.playef(15);
             graphics.createtextbox("Help! Can anyone hear", 35, 15, 255, 134, 255);
             graphics.addline("this message?");
             graphics.textboxtimer(60);
@@ -1301,7 +1301,7 @@ void Game::updatestate()
             statedelay = 100;
             break;
         case 51:
-            music.playef(15, 10);
+            music.playef(15);
             graphics.createtextbox("Verdigris? Are you out", 30, 12, 255, 134, 255);
             graphics.addline("there? Are you ok?");
             graphics.textboxtimer(60);
@@ -1309,7 +1309,7 @@ void Game::updatestate()
             statedelay = 100;
             break;
         case 52:
-            music.playef(15, 10);
+            music.playef(15);
             graphics.createtextbox("Please help us! We've crashed", 5, 22, 255, 134, 255);
             graphics.addline("and need assistance!");
             graphics.textboxtimer(60);
@@ -1317,14 +1317,14 @@ void Game::updatestate()
             statedelay = 100;
             break;
         case 53:
-            music.playef(15, 10);
+            music.playef(15);
             graphics.createtextbox("Hello? Anyone out there?", 40, 15, 255, 134, 255);
             graphics.textboxtimer(60);
             state++;
             statedelay = 100;
             break;
         case 54:
-            music.playef(15, 10);
+            music.playef(15);
             graphics.createtextbox("This is Doctor Violet from the", 5, 8, 255, 134, 255);
             graphics.addline("D.S.S. Souleye! Please respond!");
             graphics.textboxtimer(60);
@@ -1332,14 +1332,14 @@ void Game::updatestate()
             statedelay = 100;
             break;
         case 55:
-            music.playef(15, 10);
+            music.playef(15);
             graphics.createtextbox("Please... Anyone...", 45, 14, 255, 134, 255);
             graphics.textboxtimer(60);
             state++;
             statedelay = 100;
             break;
         case 56:
-            music.playef(15, 10);
+            music.playef(15);
             graphics.createtextbox("Please be alright, everyone...", 25, 18, 255, 134, 255);
             graphics.textboxtimer(60);
             state=50;
@@ -1423,7 +1423,7 @@ void Game::updatestate()
             obj.removetrigger(85);
             //Init final stretch
             state++;
-            music.playef(9, 10);
+            music.playef(9);
             music.play(2);
             obj.flags[72] = 1;
 
@@ -1516,7 +1516,7 @@ void Game::updatestate()
             if (obj.entities[i].onroof > 0 && gravitycontrol == 1)
             {
                 gravitycontrol = 0;
-                music.playef(1, 10);
+                music.playef(1);
             }
             if (obj.entities[i].onground > 0)
             {
@@ -1538,13 +1538,13 @@ void Game::updatestate()
 
             graphics.createtextbox("Captain! I've been so worried!", 60, 90, 164, 255, 164);
             state++;
-            music.playef(12, 10);
+            music.playef(12);
         }
         break;
         case 104:
             graphics.createtextbox("I'm glad you're ok!", 135, 152, 164, 164, 255);
             state++;
-            music.playef(11, 10);
+            music.playef(11);
             graphics.textboxactive();
             break;
         case 106:
@@ -1553,7 +1553,7 @@ void Game::updatestate()
             graphics.addline("way out, but I keep going");
             graphics.addline("around in circles...");
             state++;
-            music.playef(2, 10);
+            music.playef(2);
             graphics.textboxactive();
             i = obj.getcompanion();
             obj.entities[i].tile = 54;
@@ -1564,7 +1564,7 @@ void Game::updatestate()
             graphics.createtextbox("Don't worry! I have a", 125, 152, 164, 164, 255);
             graphics.addline("teleporter key!");
             state++;
-            music.playef(11, 10);
+            music.playef(11);
             graphics.textboxactive();
             break;
         case 110:
@@ -1575,7 +1575,7 @@ void Game::updatestate()
             obj.entities[i].state = 1;
             graphics.createtextbox("Follow me!", 185, 154, 164, 164, 255);
             state++;
-            music.playef(11, 10);
+            music.playef(11);
             graphics.textboxactive();
 
         }
@@ -1634,7 +1634,7 @@ void Game::updatestate()
             if (obj.entities[i].onground > 0 && gravitycontrol == 0)
             {
                 gravitycontrol = 1;
-                music.playef(1, 10);
+                music.playef(1);
             }
             if (obj.entities[i].onroof > 0)
             {
@@ -1654,34 +1654,34 @@ void Game::updatestate()
 
             graphics.createtextbox("Captain! You're ok!", 60-10, 90-40, 255, 255, 134);
             state++;
-            music.playef(14, 10);
+            music.playef(14);
             break;
         case 124:
             graphics.createtextbox("I've found a teleporter, but", 60-20, 90 - 40, 255, 255, 134);
             graphics.addline("I can't get it to go anywhere...");
             state++;
-            music.playef(2, 10);
+            music.playef(2);
             graphics.textboxactive();
             i = obj.getcompanion();	//obj.entities[i].tile = 66;	obj.entities[i].state = 0;
             break;
         case 126:
             graphics.createtextbox("I can help with that!", 125, 152-40, 164, 164, 255);
             state++;
-            music.playef(11, 10);
+            music.playef(11);
             graphics.textboxactive();
             break;
         case 128:
             graphics.createtextbox("I have the teleporter", 130, 152-35, 164, 164, 255);
             graphics.addline("codex for our ship!");
             state++;
-            music.playef(11, 10);
+            music.playef(11);
             graphics.textboxactive();
             break;
 
         case 130:
             graphics.createtextbox("Yey! Let's go home!", 60-30, 90-35, 255, 255, 134);
             state++;
-            music.playef(14, 10);
+            music.playef(14);
             graphics.textboxactive();
             i = obj.getcompanion();
             obj.entities[i].tile = 6;
@@ -1698,7 +1698,7 @@ void Game::updatestate()
         case 200:
             //Init final stretch
             state++;
-            music.playef(9, 10);
+            music.playef(9);
             //music.play(2);
             obj.flags[72] = 1;
 
@@ -2148,7 +2148,7 @@ void Game::updatestate()
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 2501:
             //Activating a teleporter 2
@@ -2157,7 +2157,7 @@ void Game::updatestate()
             flashlight = 5;
             screenshake = 0;
             //we're done here!
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 2502:
             //Activating a teleporter 2
@@ -2220,7 +2220,7 @@ void Game::updatestate()
             hascontrol = false;
             graphics.createtextbox("Hello?", 125+24, 152-20, 164, 164, 255);
             state++;
-            music.playef(11, 10);
+            music.playef(11);
             graphics.textboxactive();
             break;
         case 2512:
@@ -2228,7 +2228,7 @@ void Game::updatestate()
             hascontrol = false;
             graphics.createtextbox("Is anyone there?", 125+8, 152-24, 164, 164, 255);
             state++;
-            music.playef(11, 10);
+            music.playef(11);
             graphics.textboxactive();
             break;
         case 2514:
@@ -2247,28 +2247,28 @@ void Game::updatestate()
             statedelay = 30;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 3001:
             //Activating a teleporter 2
             state++;
             statedelay = 15;
             flashlight = 5;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 3002:
             //Activating a teleporter 2
             state++;
             statedelay = 15;
             flashlight = 5;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 3003:
             //Activating a teleporter 2
             state++;
             statedelay = 15;
             flashlight = 5;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 3004:
             //Activating a teleporter 2
@@ -2277,7 +2277,7 @@ void Game::updatestate()
             flashlight = 5;
             screenshake = 0;
             //we're done here!
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 3005:
             //Activating a teleporter 2
@@ -3291,28 +3291,28 @@ void Game::updatestate()
             statedelay = 30;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 3512:
             //Activating a teleporter 2
             state++;
             statedelay = 15;
             flashlight = 5;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 3513:
             //Activating a teleporter 2
             state++;
             statedelay = 15;
             flashlight = 5;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 3514:
             //Activating a teleporter 2
             state++;
             statedelay = 15;
             flashlight = 5;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 3515:
             //Activating a teleporter 2
@@ -3326,7 +3326,7 @@ void Game::updatestate()
             obj.entities[i].invis = true;
 
             //we're done here!
-            music.playef(10, 10);
+            music.playef(10);
             statedelay = 60;
             break;
         case 3516:
@@ -3388,7 +3388,7 @@ void Game::updatestate()
             statedelay = 10;
             flashlight = 5;
             screenshake = 10;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4001:
             //Activating a teleporter 2
@@ -3397,7 +3397,7 @@ void Game::updatestate()
             flashlight = 5;
             screenshake = 0;
             //we're done here!
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4002:
             //Activating a teleporter 2
@@ -3431,7 +3431,7 @@ void Game::updatestate()
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4011:
             //Activating a teleporter 2
@@ -3439,7 +3439,7 @@ void Game::updatestate()
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4012:
             //Activating a teleporter 2
@@ -3520,7 +3520,7 @@ void Game::updatestate()
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4021:
             //Activating a teleporter 2
@@ -3528,7 +3528,7 @@ void Game::updatestate()
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4022:
             //Activating a teleporter 2
@@ -3596,7 +3596,7 @@ void Game::updatestate()
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4031:
             //Activating a teleporter 2
@@ -3604,7 +3604,7 @@ void Game::updatestate()
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4032:
             //Activating a teleporter 2
@@ -3672,7 +3672,7 @@ void Game::updatestate()
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4041:
             //Activating a teleporter 2
@@ -3680,7 +3680,7 @@ void Game::updatestate()
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4042:
             //Activating a teleporter 2
@@ -3753,7 +3753,7 @@ void Game::updatestate()
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4051:
             //Activating a teleporter 2
@@ -3761,7 +3761,7 @@ void Game::updatestate()
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4052:
             //Activating a teleporter 2
@@ -3834,7 +3834,7 @@ void Game::updatestate()
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4061:
             //Activating a teleporter 2
@@ -3842,7 +3842,7 @@ void Game::updatestate()
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4062:
             //Activating a teleporter 2
@@ -3913,7 +3913,7 @@ void Game::updatestate()
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4071:
             //Activating a teleporter 2
@@ -3921,7 +3921,7 @@ void Game::updatestate()
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4072:
             //Activating a teleporter 2
@@ -3989,7 +3989,7 @@ void Game::updatestate()
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4081:
             //Activating a teleporter 2
@@ -3997,7 +3997,7 @@ void Game::updatestate()
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4082:
             //Activating a teleporter 2
@@ -4065,7 +4065,7 @@ void Game::updatestate()
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4091:
             //Activating a teleporter 2
@@ -4073,7 +4073,7 @@ void Game::updatestate()
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4092:
             //Activating a teleporter 2
@@ -4799,7 +4799,7 @@ void Game::deathsequence()
             gameoverdelay = 60;
         }
         deathcounts++;
-        music.playef(2,10);
+        music.playef(2);
         obj.entities[i].invis = true;
         if (map.finalmode)
         {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -268,7 +268,6 @@ void Game::init(void)
     hardestroomdeaths = 0;
     currentroomdeaths=0;
 
-    sfpsmode = false; //by default, play at 30 fps
     inertia = 1.1f;
     swnmode = false;
     swntimer = 0;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1534,7 +1534,7 @@ void Game::updatestate()
 
 
             companion = 6;
-            i = obj.getcompanion(6);
+            i = obj.getcompanion();
             obj.entities[i].tile = 0;
             obj.entities[i].state = 1;
 
@@ -1560,7 +1560,7 @@ void Game::updatestate()
             state++;
             music.playef(2, 10);
             graphics.textboxactive();
-            i = obj.getcompanion(6);
+            i = obj.getcompanion();
             obj.entities[i].tile = 54;
             obj.entities[i].state = 0;
         }
@@ -1575,7 +1575,7 @@ void Game::updatestate()
         case 110:
         {
 
-            i = obj.getcompanion(6);
+            i = obj.getcompanion();
             obj.entities[i].tile = 0;
             obj.entities[i].state = 1;
             graphics.createtextbox("Follow me!", 185, 154, 164, 164, 255);
@@ -1650,7 +1650,7 @@ void Game::updatestate()
         break;
         case 122:
             companion = 7;
-            i = obj.getcompanion(7);
+            i = obj.getcompanion();
             obj.entities[i].tile = 6;
             obj.entities[i].state = 1;
 
@@ -1667,7 +1667,7 @@ void Game::updatestate()
             state++;
             music.playef(2, 10);
             graphics.textboxactive();
-            i = obj.getcompanion(7);	//obj.entities[i].tile = 66;	obj.entities[i].state = 0;
+            i = obj.getcompanion();	//obj.entities[i].tile = 66;	obj.entities[i].state = 0;
             break;
         case 126:
             graphics.createtextbox("I can help with that!", 125, 152-40, 164, 164, 255);
@@ -1688,7 +1688,7 @@ void Game::updatestate()
             state++;
             music.playef(14, 10);
             graphics.textboxactive();
-            i = obj.getcompanion(7);
+            i = obj.getcompanion();
             obj.entities[i].tile = 6;
             obj.entities[i].state = 1;
             break;
@@ -2317,7 +2317,7 @@ void Game::updatestate()
             obj.entities[i].colour = 0;
             obj.entities[i].invis = true;
 
-            i = obj.getcompanion(companion);
+            i = obj.getcompanion();
             if(i>-1)
             {
                 obj.entities[i].active = false;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -393,7 +393,7 @@ void Game::init(void)
     teststring = "TEST = True";
     state = 1;
     statedelay = 0;
-    //updatestate(dwgfx, map, obj, help, music);
+    //updatestate();
 
     skipfakeload = false;
 
@@ -503,7 +503,7 @@ Game::~Game(void)
 {
 }
 
-void Game::lifesequence( entityclass& obj )
+void Game::lifesequence()
 {
     if (lifeseq > 0)
     {
@@ -696,7 +696,7 @@ void Game::savecustomlevelstats()
     }
 }
 
-void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void Game::updatestate()
 {
     int i;
     statedelay--;
@@ -720,23 +720,23 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             advancetext = true;
             hascontrol = false;
             state = 3;
-            dwgfx.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            dwgfx.addline("intro to story!");
+            graphics.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
+            graphics.addline("intro to story!");
             //Oh no! what happen to rest of crew etc crash into dimension
             break;
         case 4:
             //End of opening cutscene for now
-            dwgfx.createtextbox("  Press arrow keys or WASD to move  ", -1, 195, 174, 174, 174);
-            dwgfx.textboxtimer(60);
+            graphics.createtextbox("  Press arrow keys or WASD to move  ", -1, 195, 174, 174, 174);
+            graphics.textboxtimer(60);
             state = 0;
             break;
         case 5:
             //Demo over
             advancetext = true;
             hascontrol = false;
-            /*dwgfx.createtextbox("   Prototype Complete    ", 50, 80, 164, 164, 255);
-            dwgfx.addline("Congrats! More Info Soon!");
-            dwgfx.textboxcenter();
+            /*graphics.createtextbox("   Prototype Complete    ", 50, 80, 164, 164, 255);
+            graphics.addline("Congrats! More Info Soon!");
+            graphics.textboxcenter();
             */
 
             startscript = true;
@@ -746,7 +746,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             break;
         case 7:
             //End of opening cutscene for now
-            dwgfx.textboxremove();
+            graphics.textboxremove();
             hascontrol = true;
             advancetext = false;
             state = 0;
@@ -757,9 +757,9 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (obj.flags[13] == 0)
             {
                 obj.changeflag(13, 1);
-                dwgfx.createtextbox("  Press ENTER to view map  ", -1, 155, 174, 174, 174);
-                dwgfx.addline("      and quicksave");
-                dwgfx.textboxtimer(60);
+                graphics.createtextbox("  Press ENTER to view map  ", -1, 155, 174, 174, 174);
+                graphics.addline("      and quicksave");
+                graphics.textboxtimer(60);
             }
             state = 0;
             break;
@@ -808,49 +808,49 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 11:
             //Intermission 1 instructional textbox, depends on last saved
-            dwgfx.textboxremovefast();
-            dwgfx.createtextbox("   When you're NOT standing on   ", -1, 3, 174, 174, 174);
-            if (dwgfx.flipmode)
+            graphics.textboxremovefast();
+            graphics.createtextbox("   When you're NOT standing on   ", -1, 3, 174, 174, 174);
+            if (graphics.flipmode)
             {
                 if (lastsaved == 2)
                 {
-                    dwgfx.addline("   the ceiling, Vitellary will");
+                    graphics.addline("   the ceiling, Vitellary will");
                 }
                 else if (lastsaved == 3)
                 {
-                    dwgfx.addline("   the ceiling, Vermilion will");
+                    graphics.addline("   the ceiling, Vermilion will");
                 }
                 else if (lastsaved == 4)
                 {
-                    dwgfx.addline("   the ceiling, Verdigris will");
+                    graphics.addline("   the ceiling, Verdigris will");
                 }
                 else if (lastsaved == 5)
                 {
-                    dwgfx.addline("   the ceiling, Victoria will");
+                    graphics.addline("   the ceiling, Victoria will");
                 }
             }
             else
             {
                 if (lastsaved == 2)
                 {
-                    dwgfx.addline("    the floor, Vitellary will");
+                    graphics.addline("    the floor, Vitellary will");
                 }
                 else if (lastsaved == 3)
                 {
-                    dwgfx.addline("    the floor, Vermilion will");
+                    graphics.addline("    the floor, Vermilion will");
                 }
                 else if (lastsaved == 4)
                 {
-                    dwgfx.addline("    the floor, Verdigris will");
+                    graphics.addline("    the floor, Verdigris will");
                 }
                 else if (lastsaved == 5)
                 {
-                    dwgfx.addline("    the floor, Victoria will");
+                    graphics.addline("    the floor, Victoria will");
                 }
             }
 
-            dwgfx.addline("     stop and wait for you.");
-            dwgfx.textboxtimer(180);
+            graphics.addline("     stop and wait for you.");
+            graphics.textboxtimer(180);
             state = 0;
             break;
         case 12:
@@ -859,53 +859,53 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (obj.flags[61] == 0)
             {
                 obj.changeflag(61, 1);
-                dwgfx.textboxremovefast();
-                dwgfx.createtextbox("  You can't continue to the next   ", -1, 8, 174, 174, 174);
+                graphics.textboxremovefast();
+                graphics.createtextbox("  You can't continue to the next   ", -1, 8, 174, 174, 174);
                 if (lastsaved == 5)
                 {
-                    dwgfx.addline("  room until she is safely across. ");
+                    graphics.addline("  room until she is safely across. ");
                 }
                 else
                 {
-                    dwgfx.addline("  room until he is safely across.  ");
+                    graphics.addline("  room until he is safely across.  ");
                 }
-                dwgfx.textboxtimer(120);
+                graphics.textboxtimer(120);
             }
             state = 0;
             break;
         case 13:
             //textbox removal
             obj.removetrigger(13);
-            dwgfx.textboxremovefast();
+            graphics.textboxremovefast();
             state = 0;
             break;
         case 14:
             //Intermission 1 instructional textbox, depends on last saved
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox(" When you're standing on the ceiling, ", -1, 3, 174, 174, 174);
+                graphics.createtextbox(" When you're standing on the ceiling, ", -1, 3, 174, 174, 174);
             }
             else
             {
-                dwgfx.createtextbox(" When you're standing on the floor, ", -1, 3, 174, 174, 174);
+                graphics.createtextbox(" When you're standing on the floor, ", -1, 3, 174, 174, 174);
             }
             if (lastsaved == 2)
             {
-                dwgfx.addline(" Vitellary will try to walk to you. ");
+                graphics.addline(" Vitellary will try to walk to you. ");
             }
             else if (lastsaved == 3)
             {
-                dwgfx.addline(" Vermilion will try to walk to you. ");
+                graphics.addline(" Vermilion will try to walk to you. ");
             }
             else if (lastsaved == 4)
             {
-                dwgfx.addline(" Verdigris will try to walk to you. ");
+                graphics.addline(" Verdigris will try to walk to you. ");
             }
             else if (lastsaved == 5)
             {
-                dwgfx.addline(" Victoria will try to walk to you. ");
+                graphics.addline(" Victoria will try to walk to you. ");
             }
-            dwgfx.textboxtimer(280);
+            graphics.textboxtimer(280);
 
             state = 0;
             break;
@@ -928,9 +928,9 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
         case 17:
             //Arrow key tutorial
             obj.removetrigger(17);
-            dwgfx.createtextbox(" If you prefer, you can press UP or ", -1, 195, 174, 174, 174);
-            dwgfx.addline("   DOWN instead of ACTION to flip.");
-            dwgfx.textboxtimer(100);
+            graphics.createtextbox(" If you prefer, you can press UP or ", -1, 195, 174, 174, 174);
+            graphics.addline("   DOWN instead of ACTION to flip.");
+            graphics.textboxtimer(100);
             state = 0;
             break;
 
@@ -939,7 +939,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             {
                 obj.changeflag(1, 1);
                 state = 0;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
             }
             obj.removetrigger(20);
             break;
@@ -948,18 +948,18 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             {
                 obj.changeflag(2, 1);
                 state = 0;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
             }
             obj.removetrigger(21);
             break;
         case 22:
             if (obj.flags[3] == 0)
             {
-                dwgfx.textboxremovefast();
+                graphics.textboxremovefast();
                 obj.changeflag(3, 1);
                 state = 0;
-                dwgfx.createtextbox("  Press ACTION to flip  ", -1, 25, 174, 174, 174);
-                dwgfx.textboxtimer(60);
+                graphics.createtextbox("  Press ACTION to flip  ", -1, 25, 174, 174, 174);
+                graphics.textboxtimer(60);
             }
             obj.removetrigger(22);
             break;
@@ -1299,54 +1299,54 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 50:
             music.playef(15, 10);
-            dwgfx.createtextbox("Help! Can anyone hear", 35, 15, 255, 134, 255);
-            dwgfx.addline("this message?");
-            dwgfx.textboxtimer(60);
+            graphics.createtextbox("Help! Can anyone hear", 35, 15, 255, 134, 255);
+            graphics.addline("this message?");
+            graphics.textboxtimer(60);
             state++;
             statedelay = 100;
             break;
         case 51:
             music.playef(15, 10);
-            dwgfx.createtextbox("Verdigris? Are you out", 30, 12, 255, 134, 255);
-            dwgfx.addline("there? Are you ok?");
-            dwgfx.textboxtimer(60);
+            graphics.createtextbox("Verdigris? Are you out", 30, 12, 255, 134, 255);
+            graphics.addline("there? Are you ok?");
+            graphics.textboxtimer(60);
             state++;
             statedelay = 100;
             break;
         case 52:
             music.playef(15, 10);
-            dwgfx.createtextbox("Please help us! We've crashed", 5, 22, 255, 134, 255);
-            dwgfx.addline("and need assistance!");
-            dwgfx.textboxtimer(60);
+            graphics.createtextbox("Please help us! We've crashed", 5, 22, 255, 134, 255);
+            graphics.addline("and need assistance!");
+            graphics.textboxtimer(60);
             state++;
             statedelay = 100;
             break;
         case 53:
             music.playef(15, 10);
-            dwgfx.createtextbox("Hello? Anyone out there?", 40, 15, 255, 134, 255);
-            dwgfx.textboxtimer(60);
+            graphics.createtextbox("Hello? Anyone out there?", 40, 15, 255, 134, 255);
+            graphics.textboxtimer(60);
             state++;
             statedelay = 100;
             break;
         case 54:
             music.playef(15, 10);
-            dwgfx.createtextbox("This is Doctor Violet from the", 5, 8, 255, 134, 255);
-            dwgfx.addline("D.S.S. Souleye! Please respond!");
-            dwgfx.textboxtimer(60);
+            graphics.createtextbox("This is Doctor Violet from the", 5, 8, 255, 134, 255);
+            graphics.addline("D.S.S. Souleye! Please respond!");
+            graphics.textboxtimer(60);
             state++;
             statedelay = 100;
             break;
         case 55:
             music.playef(15, 10);
-            dwgfx.createtextbox("Please... Anyone...", 45, 14, 255, 134, 255);
-            dwgfx.textboxtimer(60);
+            graphics.createtextbox("Please... Anyone...", 45, 14, 255, 134, 255);
+            graphics.textboxtimer(60);
             state++;
             statedelay = 100;
             break;
         case 56:
             music.playef(15, 10);
-            dwgfx.createtextbox("Please be alright, everyone...", 25, 18, 255, 134, 255);
-            dwgfx.textboxtimer(60);
+            graphics.createtextbox("Please be alright, everyone...", 25, 18, 255, 134, 255);
+            graphics.textboxtimer(60);
             state=50;
             statedelay = 100;
             break;
@@ -1354,15 +1354,15 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 80:
             //Used to return to menu from the game
-            if(dwgfx.fademode == 1)	state++;
+            if(graphics.fademode == 1)	state++;
             break;
         case 81:
             gamestate = 1;
-            dwgfx.fademode = 4;
+            graphics.fademode = 4;
             music.play(6);
-            dwgfx.backgrounddrawn = false;
+            graphics.backgrounddrawn = false;
             map.tdrawback = true;
-            dwgfx.flipmode = false;
+            graphics.flipmode = false;
             createmenu("mainmenu");
             state = 0;
             break;
@@ -1402,21 +1402,21 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 								}
             }
 
-            savestats(map, dwgfx);
+            savestats();
 
-            dwgfx.fademode = 2;
+            graphics.fademode = 2;
             music.fadeout();
             state++;
             break;
         case 83:
             frames--;
-            if(dwgfx.fademode == 1)	state++;
+            if(graphics.fademode == 1)	state++;
             break;
         case 84:
-            dwgfx.flipmode = false;
+            graphics.flipmode = false;
             gamestate = 1;
-            dwgfx.fademode = 4;
-            dwgfx.backgrounddrawn = true;
+            graphics.fademode = 4;
+            graphics.backgrounddrawn = true;
             map.tdrawback = true;
             createmenu("timetrialcomplete");
             state = 0;
@@ -1491,11 +1491,11 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 96:
             //Used to return to gravitron to game
-            if(dwgfx.fademode == 1)	state++;
+            if(graphics.fademode == 1)	state++;
             break;
         case 97:
             gamestate = 0;
-            dwgfx.fademode = 4;
+            graphics.fademode = 4;
             startscript = true;
             newscript="returntolab";
             state = 0;
@@ -1541,36 +1541,36 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             advancetext = true;
             hascontrol = false;
 
-            dwgfx.createtextbox("Captain! I've been so worried!", 60, 90, 164, 255, 164);
+            graphics.createtextbox("Captain! I've been so worried!", 60, 90, 164, 255, 164);
             state++;
             music.playef(12, 10);
         }
         break;
         case 104:
-            dwgfx.createtextbox("I'm glad you're ok!", 135, 152, 164, 164, 255);
+            graphics.createtextbox("I'm glad you're ok!", 135, 152, 164, 164, 255);
             state++;
             music.playef(11, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
             break;
         case 106:
         {
-            dwgfx.createtextbox("I've been trying to find a", 74, 70, 164, 255, 164);
-            dwgfx.addline("way out, but I keep going");
-            dwgfx.addline("around in circles...");
+            graphics.createtextbox("I've been trying to find a", 74, 70, 164, 255, 164);
+            graphics.addline("way out, but I keep going");
+            graphics.addline("around in circles...");
             state++;
             music.playef(2, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
             i = obj.getcompanion(6);
             obj.entities[i].tile = 54;
             obj.entities[i].state = 0;
         }
         break;
         case 108:
-            dwgfx.createtextbox("Don't worry! I have a", 125, 152, 164, 164, 255);
-            dwgfx.addline("teleporter key!");
+            graphics.createtextbox("Don't worry! I have a", 125, 152, 164, 164, 255);
+            graphics.addline("teleporter key!");
             state++;
             music.playef(11, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
             break;
         case 110:
         {
@@ -1578,15 +1578,15 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             i = obj.getcompanion(6);
             obj.entities[i].tile = 0;
             obj.entities[i].state = 1;
-            dwgfx.createtextbox("Follow me!", 185, 154, 164, 164, 255);
+            graphics.createtextbox("Follow me!", 185, 154, 164, 164, 255);
             state++;
             music.playef(11, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
 
         }
         break;
         case 112:
-            dwgfx.textboxremove();
+            graphics.textboxremove();
             hascontrol = true;
             advancetext = false;
 
@@ -1607,13 +1607,13 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             advancetext = true;
             hascontrol = false;
 
-            dwgfx.createtextbox("Sorry Eurogamers! Teleporting around", 60 - 20, 200, 255, 64, 64);
-            dwgfx.addline("the map doesn't work in this version!");
-            dwgfx.textboxcenterx();
+            graphics.createtextbox("Sorry Eurogamers! Teleporting around", 60 - 20, 200, 255, 64, 64);
+            graphics.addline("the map doesn't work in this version!");
+            graphics.textboxcenterx();
             state++;
             break;
         case 118:
-            dwgfx.textboxremove();
+            graphics.textboxremove();
             hascontrol = true;
             advancetext = false;
 
@@ -1657,43 +1657,43 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             advancetext = true;
             hascontrol = false;
 
-            dwgfx.createtextbox("Captain! You're ok!", 60-10, 90-40, 255, 255, 134);
+            graphics.createtextbox("Captain! You're ok!", 60-10, 90-40, 255, 255, 134);
             state++;
             music.playef(14, 10);
             break;
         case 124:
-            dwgfx.createtextbox("I've found a teleporter, but", 60-20, 90 - 40, 255, 255, 134);
-            dwgfx.addline("I can't get it to go anywhere...");
+            graphics.createtextbox("I've found a teleporter, but", 60-20, 90 - 40, 255, 255, 134);
+            graphics.addline("I can't get it to go anywhere...");
             state++;
             music.playef(2, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
             i = obj.getcompanion(7);	//obj.entities[i].tile = 66;	obj.entities[i].state = 0;
             break;
         case 126:
-            dwgfx.createtextbox("I can help with that!", 125, 152-40, 164, 164, 255);
+            graphics.createtextbox("I can help with that!", 125, 152-40, 164, 164, 255);
             state++;
             music.playef(11, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
             break;
         case 128:
-            dwgfx.createtextbox("I have the teleporter", 130, 152-35, 164, 164, 255);
-            dwgfx.addline("codex for our ship!");
+            graphics.createtextbox("I have the teleporter", 130, 152-35, 164, 164, 255);
+            graphics.addline("codex for our ship!");
             state++;
             music.playef(11, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
             break;
 
         case 130:
-            dwgfx.createtextbox("Yey! Let's go home!", 60-30, 90-35, 255, 255, 134);
+            graphics.createtextbox("Yey! Let's go home!", 60-30, 90-35, 255, 255, 134);
             state++;
             music.playef(14, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
             i = obj.getcompanion(7);
             obj.entities[i].tile = 6;
             obj.entities[i].state = 1;
             break;
         case 132:
-            dwgfx.textboxremove();
+            graphics.textboxremove();
             hascontrol = true;
             advancetext = false;
 
@@ -1947,7 +1947,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             break;
 
         case 1000:
-            dwgfx.showcutscenebars = true;
+            graphics.showcutscenebars = true;
             hascontrol = false;
             completestop = true;
             state++;
@@ -1957,56 +1957,56 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             //Found a trinket!
             advancetext = true;
             state++;
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("        Congratulations!       ", 50, 105, 174, 174, 174);
-                dwgfx.addline("");
-                dwgfx.addline("You have found a shiny trinket!");
-                dwgfx.textboxcenterx();
+                graphics.createtextbox("        Congratulations!       ", 50, 105, 174, 174, 174);
+                graphics.addline("");
+                graphics.addline("You have found a shiny trinket!");
+                graphics.textboxcenterx();
 
                 if(map.custommode)
                 {
-                    dwgfx.createtextbox(" " + help.number(trinkets) + " out of " + help.number(map.customtrinkets)+ " ", 50, 65, 174, 174, 174);
-                    dwgfx.textboxcenterx();
+                    graphics.createtextbox(" " + help.number(trinkets) + " out of " + help.number(map.customtrinkets)+ " ", 50, 65, 174, 174, 174);
+                    graphics.textboxcenterx();
                 }
                 else
                 {
-                    dwgfx.createtextbox(" " + help.number(trinkets) + " out of Twenty ", 50, 65, 174, 174, 174);
-                    dwgfx.textboxcenterx();
+                    graphics.createtextbox(" " + help.number(trinkets) + " out of Twenty ", 50, 65, 174, 174, 174);
+                    graphics.textboxcenterx();
                 }
             }
             else
             {
-                dwgfx.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
-                dwgfx.addline("");
-                dwgfx.addline("You have found a shiny trinket!");
-                dwgfx.textboxcenterx();
+                graphics.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
+                graphics.addline("");
+                graphics.addline("You have found a shiny trinket!");
+                graphics.textboxcenterx();
 
                 if(map.custommode)
                 {
-                    dwgfx.createtextbox(" " + help.number(trinkets) + " out of " + help.number(map.customtrinkets)+ " ", 50, 135, 174, 174, 174);
-                    dwgfx.textboxcenterx();
+                    graphics.createtextbox(" " + help.number(trinkets) + " out of " + help.number(map.customtrinkets)+ " ", 50, 135, 174, 174, 174);
+                    graphics.textboxcenterx();
                 }
                 else
                 {
-                    dwgfx.createtextbox(" " + help.number(trinkets) + " out of Twenty ", 50, 135, 174, 174, 174);
-                    dwgfx.textboxcenterx();
+                    graphics.createtextbox(" " + help.number(trinkets) + " out of Twenty ", 50, 135, 174, 174, 174);
+                    graphics.textboxcenterx();
                 }
             }
             break;
         case 1003:
-            dwgfx.textboxremove();
+            graphics.textboxremove();
             hascontrol = true;
             advancetext = false;
             completestop = false;
             state = 0;
             //music.play(music.resumesong);
             if(!muted && music.currentsong>-1) music.fadeMusicVolumeIn(3000);
-            dwgfx.showcutscenebars = false;
+            graphics.showcutscenebars = false;
             break;
 
         case 1010:
-            dwgfx.showcutscenebars = true;
+            graphics.showcutscenebars = true;
             hascontrol = false;
             completestop = true;
             state++;
@@ -2016,53 +2016,53 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             //Found a crewmate!
             advancetext = true;
             state++;
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("        Congratulations!       ", 50, 105, 174, 174, 174);
-                dwgfx.addline("");
-                dwgfx.addline("You have found a lost crewmate!");
-                dwgfx.textboxcenterx();
+                graphics.createtextbox("        Congratulations!       ", 50, 105, 174, 174, 174);
+                graphics.addline("");
+                graphics.addline("You have found a lost crewmate!");
+                graphics.textboxcenterx();
 
                 if(int(map.customcrewmates-crewmates)==0)
                 {
-                    dwgfx.createtextbox("     All crewmates rescued!    ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox("     All crewmates rescued!    ", 50, 65, 174, 174, 174);
                 }
                 else if(map.customcrewmates-crewmates==1)
                 {
-                    dwgfx.createtextbox("    " + help.number(int(map.customcrewmates-crewmates))+ " remains    ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox("    " + help.number(int(map.customcrewmates-crewmates))+ " remains    ", 50, 65, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox("     " + help.number(int(map.customcrewmates-crewmates))+ " remain    ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox("     " + help.number(int(map.customcrewmates-crewmates))+ " remain    ", 50, 65, 174, 174, 174);
                 }
-                dwgfx.textboxcenterx();
+                graphics.textboxcenterx();
 
             }
             else
             {
-                dwgfx.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
-                dwgfx.addline("");
-                dwgfx.addline("You have found a lost crewmate!");
-                dwgfx.textboxcenterx();
+                graphics.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
+                graphics.addline("");
+                graphics.addline("You have found a lost crewmate!");
+                graphics.textboxcenterx();
 
                 if(int(map.customcrewmates-crewmates)==0)
                 {
-                    dwgfx.createtextbox("     All crewmates rescued!    ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox("     All crewmates rescued!    ", 50, 135, 174, 174, 174);
                 }
                 else if(map.customcrewmates-crewmates==1)
                 {
-                    dwgfx.createtextbox("    " + help.number(int(map.customcrewmates-crewmates))+ " remains    ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox("    " + help.number(int(map.customcrewmates-crewmates))+ " remains    ", 50, 135, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox("     " + help.number(int(map.customcrewmates-crewmates))+ " remain    ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox("     " + help.number(int(map.customcrewmates-crewmates))+ " remain    ", 50, 135, 174, 174, 174);
                 }
-                dwgfx.textboxcenterx();
+                graphics.textboxcenterx();
             }
             break;
 #if !defined(NO_CUSTOM_LEVELS)
         case 1013:
-            dwgfx.textboxremove();
+            graphics.textboxremove();
             hascontrol = true;
             advancetext = false;
             completestop = false;
@@ -2072,7 +2072,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             {
                 if(map.custommodeforreal)
                 {
-                    dwgfx.fademode = 2;
+                    graphics.fademode = 2;
                     if(!muted && ed.levmusic>0) music.fadeMusicVolumeIn(3000);
                     if(ed.levmusic>0) music.fadeout();
                     state=1014;
@@ -2080,7 +2080,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
                 else
                 {
                     gamestate = EDITORMODE;
-                    dwgfx.backgrounddrawn=false;
+                    graphics.backgrounddrawn=false;
                     if(!muted && ed.levmusic>0) music.fadeMusicVolumeIn(3000);
                     if(ed.levmusic>0) music.fadeout();
                 }
@@ -2089,19 +2089,19 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             {
                 if(!muted && ed.levmusic>0) music.fadeMusicVolumeIn(3000);
             }
-            dwgfx.showcutscenebars = false;
+            graphics.showcutscenebars = false;
             break;
 #endif
         case 1014:
             frames--;
-            if(dwgfx.fademode == 1)	state++;
+            if(graphics.fademode == 1)	state++;
             break;
         case 1015:
-            dwgfx.flipmode = false;
+            graphics.flipmode = false;
             gamestate = TITLEMODE;
-            dwgfx.fademode = 4;
+            graphics.fademode = 4;
             music.play(6);
-            dwgfx.backgrounddrawn = true;
+            graphics.backgrounddrawn = true;
             map.tdrawback = true;
             //Update level stats
             if(map.customcrewmates-crewmates==0)
@@ -2130,16 +2130,16 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             }
             else
             {
-                savetele(map, obj, music);
-                if (dwgfx.flipmode)
+                savetele();
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox("    Game Saved    ", -1, 202, 174, 174, 174);
-                    dwgfx.textboxtimer(25);
+                    graphics.createtextbox("    Game Saved    ", -1, 202, 174, 174, 174);
+                    graphics.textboxtimer(25);
                 }
                 else
                 {
-                    dwgfx.createtextbox("    Game Saved    ", -1, 12, 174, 174, 174);
-                    dwgfx.textboxtimer(25);
+                    graphics.createtextbox("    Game Saved    ", -1, 12, 174, 174, 174);
+                    graphics.textboxtimer(25);
                 }
                 state = 0;
             }
@@ -2223,21 +2223,21 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
         case 2510:
             advancetext = true;
             hascontrol = false;
-            dwgfx.createtextbox("Hello?", 125+24, 152-20, 164, 164, 255);
+            graphics.createtextbox("Hello?", 125+24, 152-20, 164, 164, 255);
             state++;
             music.playef(11, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
             break;
         case 2512:
             advancetext = true;
             hascontrol = false;
-            dwgfx.createtextbox("Is anyone there?", 125+8, 152-24, 164, 164, 255);
+            graphics.createtextbox("Is anyone there?", 125+8, 152-24, 164, 164, 255);
             state++;
             music.playef(11, 10);
-            dwgfx.textboxactive();
+            graphics.textboxactive();
             break;
         case 2514:
-            dwgfx.textboxremove();
+            graphics.textboxremove();
             hascontrol = true;
             advancetext = false;
 
@@ -2330,48 +2330,48 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 3006:
             //Level complete! (warp zone)
-            unlocknum(4, map, dwgfx);
+            unlocknum(4);
             lastsaved = 4;
             music.play(0);
             state++;
             statedelay = 75;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 180, 165, 165, 255);
+                graphics.createtextbox("", -1, 180, 165, 165, 255);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 12, 165, 165, 255);
+                graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
-            //dwgfx.addline("      Level Complete!      ");
-            dwgfx.addline("                                   ");
-            dwgfx.addline("");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            //graphics.addline("      Level Complete!      ");
+            graphics.addline("                                   ");
+            graphics.addline("");
+            graphics.addline("");
+            graphics.textboxcenterx();
 
             /*												advancetext = true;
             hascontrol = false;
             state = 3;
-            dwgfx.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            dwgfx.addline("intro to story!");*/
+            graphics.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
+            graphics.addline("intro to story!");*/
             break;
         case 3007:
             state++;
             statedelay = 45;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 104, 175,174,174);
+                graphics.createtextbox("", -1, 104, 175,174,174);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 64+8+16, 175,174,174);
+                graphics.createtextbox("", -1, 64+8+16, 175,174,174);
             }
-            dwgfx.addline("     You have rescued  ");
-            dwgfx.addline("      a crew member!   ");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            graphics.addline("     You have rescued  ");
+            graphics.addline("      a crew member!   ");
+            graphics.addline("");
+            graphics.textboxcenterx();
             break;
         case 3008:
             state++;
@@ -2381,60 +2381,60 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (temp == 1)
             {
                 tempstring = "  One remains  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else if (temp > 0)
             {
                 tempstring = "  " + help.number(temp) + " remain  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else
             {
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
                 }
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3009:
             state++;
             statedelay = 0;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
             }
             else
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3010:
             if (jumppressed)
             {
                 state++;
                 statedelay = 30;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
             }
             break;
         case 3011:
@@ -2444,49 +2444,49 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 3020:
             //Level complete! (Space Station 2)
-            unlocknum(3, map, dwgfx);
+            unlocknum(3);
             lastsaved = 2;
             music.play(0);
             state++;
             statedelay = 75;
 
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 180, 165, 165, 255);
+                graphics.createtextbox("", -1, 180, 165, 165, 255);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 12, 165, 165, 255);
+                graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
-            //dwgfx.addline("      Level Complete!      ");
-            dwgfx.addline("                                   ");
-            dwgfx.addline("");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            //graphics.addline("      Level Complete!      ");
+            graphics.addline("                                   ");
+            graphics.addline("");
+            graphics.addline("");
+            graphics.textboxcenterx();
 
             /*												advancetext = true;
             hascontrol = false;
             state = 3;
-            dwgfx.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            dwgfx.addline("intro to story!");*/
+            graphics.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
+            graphics.addline("intro to story!");*/
             break;
         case 3021:
             state++;
             statedelay = 45;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 104, 174,175,174);
+                graphics.createtextbox("", -1, 104, 174,175,174);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 64+8+16, 174,175,174);
+                graphics.createtextbox("", -1, 64+8+16, 174,175,174);
             }
-            dwgfx.addline("     You have rescued  ");
-            dwgfx.addline("      a crew member!   ");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            graphics.addline("     You have rescued  ");
+            graphics.addline("      a crew member!   ");
+            graphics.addline("");
+            graphics.textboxcenterx();
             break;
         case 3022:
             state++;
@@ -2496,60 +2496,60 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (temp == 1)
             {
                 tempstring = "  One remains  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else if (temp > 0)
             {
                 tempstring = "  " + help.number(temp) + " remain  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else
             {
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
                 }
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3023:
             state++;
             statedelay = 0;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
             }
             else
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3024:
             if (jumppressed)
             {
                 state++;
                 statedelay = 30;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
             }
             break;
         case 3025:
@@ -2559,48 +2559,48 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 3040:
             //Level complete! (Lab)
-            unlocknum(1, map, dwgfx);
+            unlocknum(1);
             lastsaved = 5;
             music.play(0);
             state++;
             statedelay = 75;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 180, 165, 165, 255);
+                graphics.createtextbox("", -1, 180, 165, 165, 255);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 12, 165, 165, 255);
+                graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
-            //dwgfx.addline("      Level Complete!      ");
-            dwgfx.addline("                                   ");
-            dwgfx.addline("");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            //graphics.addline("      Level Complete!      ");
+            graphics.addline("                                   ");
+            graphics.addline("");
+            graphics.addline("");
+            graphics.textboxcenterx();
 
             /*												advancetext = true;
             hascontrol = false;
             state = 3;
-            dwgfx.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            dwgfx.addline("intro to story!");*/
+            graphics.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
+            graphics.addline("intro to story!");*/
             break;
         case 3041:
             state++;
             statedelay = 45;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 104, 174,174,175);
+                graphics.createtextbox("", -1, 104, 174,174,175);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 64+8+16, 174,174,175);
+                graphics.createtextbox("", -1, 64+8+16, 174,174,175);
             }
-            dwgfx.addline("     You have rescued  ");
-            dwgfx.addline("      a crew member!   ");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            graphics.addline("     You have rescued  ");
+            graphics.addline("      a crew member!   ");
+            graphics.addline("");
+            graphics.textboxcenterx();
             break;
         case 3042:
             state++;
@@ -2610,60 +2610,60 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (temp == 1)
             {
                 tempstring = "  One remains  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else if (temp > 0)
             {
                 tempstring = "  " + help.number(temp) + " remain  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else
             {
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
                 }
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3043:
             state++;
             statedelay = 0;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
             }
             else
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3044:
             if (jumppressed)
             {
                 state++;
                 statedelay = 30;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
             }
             break;
         case 3045:
@@ -2673,49 +2673,49 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 3050:
             //Level complete! (Space Station 1)
-            unlocknum(0, map, dwgfx);
+            unlocknum(0);
             lastsaved = 1;
             music.play(0);
             state++;
             statedelay = 75;
 
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 180, 165, 165, 255);
+                graphics.createtextbox("", -1, 180, 165, 165, 255);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 12, 165, 165, 255);
+                graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
-            //dwgfx.addline("      Level Complete!      ");
-            dwgfx.addline("                                   ");
-            dwgfx.addline("");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            //graphics.addline("      Level Complete!      ");
+            graphics.addline("                                   ");
+            graphics.addline("");
+            graphics.addline("");
+            graphics.textboxcenterx();
 
             /*												advancetext = true;
             hascontrol = false;
             state = 3;
-            dwgfx.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            dwgfx.addline("intro to story!");*/
+            graphics.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
+            graphics.addline("intro to story!");*/
             break;
         case 3051:
             state++;
             statedelay = 45;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 104, 175,175,174);
+                graphics.createtextbox("", -1, 104, 175,175,174);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 64+8+16, 175,175,174);
+                graphics.createtextbox("", -1, 64+8+16, 175,175,174);
             }
-            dwgfx.addline("     You have rescued  ");
-            dwgfx.addline("      a crew member!   ");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            graphics.addline("     You have rescued  ");
+            graphics.addline("      a crew member!   ");
+            graphics.addline("");
+            graphics.textboxcenterx();
             break;
         case 3052:
             state++;
@@ -2725,71 +2725,71 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (temp == 1)
             {
                 tempstring = "  One remains  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else if (temp > 0)
             {
                 tempstring = "  " + help.number(temp) + " remain  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else
             {
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
                 }
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3053:
             state++;
             statedelay = 0;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
             }
             else
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3054:
             if (jumppressed)
             {
                 state++;
                 statedelay = 30;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
                 crewstats[1] = 0; //Set violet's rescue script to 0 to make the next bit easier
                 teleportscript = "";
             }
             break;
         case 3055:
-            dwgfx.fademode = 2;
+            graphics.fademode = 2;
             state++;
             statedelay = 10;
             break;
         case 3056:
-            if(dwgfx.fademode==1)
+            if(graphics.fademode==1)
             {
                 startscript = true;
                 if (nocutscenes)
@@ -2807,48 +2807,48 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
         case 3060:
             //Level complete! (Tower)
-            unlocknum(2, map, dwgfx);
+            unlocknum(2);
             lastsaved = 3;
             music.play(0);
             state++;
             statedelay = 75;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 180, 165, 165, 255);
+                graphics.createtextbox("", -1, 180, 165, 165, 255);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 12, 165, 165, 255);
+                graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
-            //dwgfx.addline("      Level Complete!      ");
-            dwgfx.addline("                                   ");
-            dwgfx.addline("");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            //graphics.addline("      Level Complete!      ");
+            graphics.addline("                                   ");
+            graphics.addline("");
+            graphics.addline("");
+            graphics.textboxcenterx();
 
             /*												advancetext = true;
             hascontrol = false;
             state = 3;
-            dwgfx.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            dwgfx.addline("intro to story!");*/
+            graphics.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
+            graphics.addline("intro to story!");*/
             break;
         case 3061:
             state++;
             statedelay = 45;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 104, 175,174,175);
+                graphics.createtextbox("", -1, 104, 175,174,175);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 64+8+16, 175,174,175);
+                graphics.createtextbox("", -1, 64+8+16, 175,174,175);
             }
-            dwgfx.addline("     You have rescued  ");
-            dwgfx.addline("      a crew member!   ");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            graphics.addline("     You have rescued  ");
+            graphics.addline("      a crew member!   ");
+            graphics.addline("");
+            graphics.textboxcenterx();
             break;
         case 3062:
             state++;
@@ -2858,60 +2858,60 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (temp == 1)
             {
                 tempstring = "  One remains  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else if (temp > 0)
             {
                 tempstring = "  " + help.number(temp) + " remain  ";
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox(tempstring, -1, 72, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
                 }
             }
             else
             {
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
                 }
                 else
                 {
-                    dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
+                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
                 }
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3063:
             state++;
             statedelay = 0;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
             }
             else
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3064:
             if (jumppressed)
             {
                 state++;
                 statedelay = 30;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
             }
             break;
         case 3065:
@@ -2921,11 +2921,11 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
 
         case 3070:
-            dwgfx.fademode = 2;
+            graphics.fademode = 2;
             state++;
             break;
         case 3071:
-            if (dwgfx.fademode == 1) state++;
+            if (graphics.fademode == 1) state++;
             break;
         case 3072:
             //Ok, we need to adjust some flags based on who've we've rescued. Some of there conversation options
@@ -3000,20 +3000,20 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             //returning from an intermission, very like 3070
             if (inintermission)
             {
-                dwgfx.fademode = 2;
+                graphics.fademode = 2;
                 companion = 0;
                 state=3100;
             }
             else
             {
-                unlocknum(7, map, dwgfx);
-                dwgfx.fademode = 2;
+                unlocknum(7);
+                graphics.fademode = 2;
                 companion = 0;
                 state++;
             }
             break;
         case 3081:
-            if (dwgfx.fademode == 1) state++;
+            if (graphics.fademode == 1) state++;
             break;
         case 3082:
             map.finalmode = false;
@@ -3030,21 +3030,21 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
                 companion = 0;
                 supercrewmate = false;
                 state++;
-                dwgfx.fademode = 2;
+                graphics.fademode = 2;
                 music.fadeout();
                 state=3100;
             }
             else
             {
-                unlocknum(6, map, dwgfx);
-                dwgfx.fademode = 2;
+                unlocknum(6);
+                graphics.fademode = 2;
                 companion = 0;
                 supercrewmate = false;
                 state++;
             }
             break;
         case 3086:
-            if (dwgfx.fademode == 1) state++;
+            if (graphics.fademode == 1) state++;
             break;
         case 3087:
             map.finalmode = false;
@@ -3054,13 +3054,13 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             break;
 
         case 3100:
-            if(dwgfx.fademode == 1)	state++;
+            if(graphics.fademode == 1)	state++;
             break;
         case 3101:
-            dwgfx.flipmode = false;
+            graphics.flipmode = false;
             gamestate = 1;
-            dwgfx.fademode = 4;
-            dwgfx.backgrounddrawn = true;
+            graphics.fademode = 4;
+            graphics.backgrounddrawn = true;
             map.tdrawback = true;
             createmenu("play");
             music.play(6);
@@ -3077,17 +3077,17 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             help.toclipboard(recordstring);
             }
             test = true; teststring = recordstring;
-            dwgfx.createtextbox("   Congratulations!    ", 50, 80, 164, 164, 255);
-            dwgfx.addline("");
-            dwgfx.addline("Your play of this level has");
-            dwgfx.addline("been copied to the clipboard.");
-            dwgfx.addline("");
-            dwgfx.addline("Please consider pasting and");
-            dwgfx.addline("sending it to me! Even if you");
-            dwgfx.addline("made a lot of mistakes - knowing");
-            dwgfx.addline("exactly where people are having");
-            dwgfx.addline("trouble is extremely useful!");
-            dwgfx.textboxcenter();
+            graphics.createtextbox("   Congratulations!    ", 50, 80, 164, 164, 255);
+            graphics.addline("");
+            graphics.addline("Your play of this level has");
+            graphics.addline("been copied to the clipboard.");
+            graphics.addline("");
+            graphics.addline("Please consider pasting and");
+            graphics.addline("sending it to me! Even if you");
+            graphics.addline("made a lot of mistakes - knowing");
+            graphics.addline("exactly where people are having");
+            graphics.addline("trouble is extremely useful!");
+            graphics.textboxcenter();
             state = 0;
             break;*/
 
@@ -3100,53 +3100,53 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
         case 3501:
             //Game complete!
 						NETWORK_unlockAchievement("vvvvvvgamecomplete");
-            unlocknum(5, map, dwgfx);
+            unlocknum(5);
             crewstats[0] = true;
             state++;
             statedelay = 75;
             music.play(7);
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("", -1, 180, 164, 165, 255);
+                graphics.createtextbox("", -1, 180, 164, 165, 255);
             }
             else
             {
-                dwgfx.createtextbox("", -1, 12, 164, 165, 255);
+                graphics.createtextbox("", -1, 12, 164, 165, 255);
             }
-            dwgfx.addline("                                   ");
-            dwgfx.addline("");
-            dwgfx.addline("");
-            dwgfx.textboxcenterx();
+            graphics.addline("                                   ");
+            graphics.addline("");
+            graphics.addline("");
+            graphics.textboxcenterx();
             break;
         case 3502:
             state++;
             statedelay = 45+15;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 175-24, 0, 0, 0);
+                graphics.createtextbox("  All Crew Members Rescued!  ", -1, 175-24, 0, 0, 0);
             }
             else
             {
-                dwgfx.createtextbox("  All Crew Members Rescued!  ", -1, 64, 0, 0, 0);
+                graphics.createtextbox("  All Crew Members Rescued!  ", -1, 64, 0, 0, 0);
             }
-            savetime = timestring(help);
+            savetime = timestring();
             break;
         case 3503:
             state++;
             statedelay = 45;
 
             tempstring = help.number(trinkets);
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("Trinkets Found:", 48, 155-24, 0,0,0);
-                dwgfx.createtextbox(tempstring, 180, 155-24, 0, 0, 0);
+                graphics.createtextbox("Trinkets Found:", 48, 155-24, 0,0,0);
+                graphics.createtextbox(tempstring, 180, 155-24, 0, 0, 0);
             }
             else
             {
-                dwgfx.createtextbox("Trinkets Found:", 48, 84, 0,0,0);
-                dwgfx.createtextbox(tempstring, 180, 84, 0, 0, 0);
+                graphics.createtextbox("Trinkets Found:", 48, 84, 0,0,0);
+                graphics.createtextbox(tempstring, 180, 84, 0, 0, 0);
             }
             break;
         case 3504:
@@ -3154,84 +3154,84 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 45+15;
 
             tempstring = savetime;
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("   Game Time:", 64, 143-24, 0,0,0);
-                dwgfx.createtextbox(tempstring, 180, 143-24, 0, 0, 0);
+                graphics.createtextbox("   Game Time:", 64, 143-24, 0,0,0);
+                graphics.createtextbox(tempstring, 180, 143-24, 0, 0, 0);
             }
             else
             {
-                dwgfx.createtextbox("   Game Time:", 64, 96, 0,0,0);
-                dwgfx.createtextbox(tempstring, 180, 96, 0, 0, 0);
+                graphics.createtextbox("   Game Time:", 64, 96, 0,0,0);
+                graphics.createtextbox(tempstring, 180, 96, 0, 0, 0);
             }
             break;
         case 3505:
             state++;
             statedelay = 45;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox(" Total Flips:", 64, 116-24, 0,0,0);
-                dwgfx.createtextbox(help.String(totalflips), 180, 116-24, 0, 0, 0);
+                graphics.createtextbox(" Total Flips:", 64, 116-24, 0,0,0);
+                graphics.createtextbox(help.String(totalflips), 180, 116-24, 0, 0, 0);
             }
             else
             {
-                dwgfx.createtextbox(" Total Flips:", 64, 123, 0,0,0);
-                dwgfx.createtextbox(help.String(totalflips), 180, 123, 0, 0, 0);
+                graphics.createtextbox(" Total Flips:", 64, 123, 0,0,0);
+                graphics.createtextbox(help.String(totalflips), 180, 123, 0, 0, 0);
             }
             break;
         case 3506:
             state++;
             statedelay = 45+15;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox("Total Deaths:", 64, 104-24, 0,0,0);
-                dwgfx.createtextbox(help.String(deathcounts), 180, 104-24, 0, 0, 0);
+                graphics.createtextbox("Total Deaths:", 64, 104-24, 0,0,0);
+                graphics.createtextbox(help.String(deathcounts), 180, 104-24, 0, 0, 0);
             }
             else
             {
-                dwgfx.createtextbox("Total Deaths:", 64, 135, 0,0,0);
-                dwgfx.createtextbox(help.String(deathcounts), 180, 135, 0, 0, 0);
+                graphics.createtextbox("Total Deaths:", 64, 135, 0,0,0);
+                graphics.createtextbox(help.String(deathcounts), 180, 135, 0, 0, 0);
             }
             break;
         case 3507:
             state++;
             statedelay = 45+15;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
                 tempstring = "Hardest Room (with " + help.String(hardestroomdeaths) + " deaths)";
-                dwgfx.createtextbox(tempstring, -1, 81-24, 0,0,0);
-                dwgfx.createtextbox(hardestroom, -1, 69-24, 0, 0, 0);
+                graphics.createtextbox(tempstring, -1, 81-24, 0,0,0);
+                graphics.createtextbox(hardestroom, -1, 69-24, 0, 0, 0);
             }
             else
             {
                 tempstring = "Hardest Room (with " + help.String(hardestroomdeaths) + " deaths)";
-                dwgfx.createtextbox(tempstring, -1, 158, 0,0,0);
-                dwgfx.createtextbox(hardestroom, -1, 170, 0, 0, 0);
+                graphics.createtextbox(tempstring, -1, 158, 0,0,0);
+                graphics.createtextbox(hardestroom, -1, 170, 0, 0, 0);
             }
             break;
         case 3508:
             state++;
             statedelay = 0;
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
             }
             else
             {
-                dwgfx.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
+                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
             }
-            dwgfx.textboxcenterx();
+            graphics.textboxcenterx();
             break;
         case 3509:
             if (jumppressed)
             {
                 state++;
                 statedelay = 30;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
             }
             break;
         case 3510:
@@ -3271,7 +3271,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 						}
 						
 
-            savestats(map, dwgfx);
+            savestats();
             if (nodeathmode)
             {
 								NETWORK_unlockAchievement("vvvvvvmaster"); //bloody hell
@@ -3335,18 +3335,18 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 60;
             break;
         case 3516:
-            dwgfx.fademode = 2;
+            graphics.fademode = 2;
             state++;
             break;
         case 3517:
-            if (dwgfx.fademode == 1)
+            if (graphics.fademode == 1)
             {
                 state++;
                 statedelay = 30;
             }
             break;
         case 3518:
-            dwgfx.fademode = 4;
+            graphics.fademode = 4;
             state = 0;
             statedelay = 30;
             //music.play(5);
@@ -3360,7 +3360,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             map.finalx = 100;
             map.finaly = 100;
 
-            dwgfx.cutscenebarspos = 320;
+            graphics.cutscenebarspos = 320;
 
             teleport_to_new_area = true;
             teleportscript = "gamecomplete";
@@ -3371,17 +3371,17 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             hascontrol = false;
             crewstats[0] = true;
 
-            dwgfx.fademode = 2;
+            graphics.fademode = 2;
             state++;
             break;
         case 3521:
-            if(dwgfx.fademode == 1)	state++;
+            if(graphics.fademode == 1)	state++;
             break;
         case 3522:
-            dwgfx.flipmode = false;
+            graphics.flipmode = false;
             gamestate = 1;
-            dwgfx.fademode = 4;
-            dwgfx.backgrounddrawn = true;
+            graphics.fademode = 4;
+            graphics.backgrounddrawn = true;
             map.tdrawback = true;
             createmenu("nodeathmodecomplete");
             state = 0;
@@ -3506,7 +3506,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             }
             else
             {
-                savetele(map, obj, music);
+                savetele();
             }
             i = obj.getteleporter();
             activetele = true;
@@ -4151,7 +4151,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
     }
 }
 
-void Game::gethardestroom( mapclass& map )
+void Game::gethardestroom()
 {
     if (currentroomdeaths > hardestroomdeaths)
     {
@@ -4187,7 +4187,7 @@ void Game::gethardestroom( mapclass& map )
     }
 }
 
-void Game::deletestats( mapclass& map, Graphics& dwgfx )
+void Game::deletestats()
 {
     for (int i = 0; i < 25; i++)
     {
@@ -4201,12 +4201,12 @@ void Game::deletestats( mapclass& map, Graphics& dwgfx )
         bestlives[i] = -1;
         bestrank[i] = -1;
     }
-    dwgfx.setflipmode = false;
+    graphics.setflipmode = false;
     stat_trinkets = 0;
-    savestats(map, dwgfx);
+    savestats();
 }
 
-void Game::unlocknum( int t, mapclass& map, Graphics& dwgfx )
+void Game::unlocknum( int t )
 {
     if (map.custommode)
     {
@@ -4215,16 +4215,16 @@ void Game::unlocknum( int t, mapclass& map, Graphics& dwgfx )
     }
 
     unlock[t] = true;
-    savestats(map, dwgfx);
+    savestats();
 }
 
-void Game::loadstats( mapclass& map, Graphics& dwgfx )
+void Game::loadstats()
 {
     // TODO loadstats
     TiXmlDocument doc;
     if (!FILESYSTEM_loadTiXmlDocument("saves/unlock.vvv", &doc))
     {
-        savestats(map, dwgfx);
+        savestats();
         printf("No Stats found. Assuming a new player\n");
     }
 
@@ -4390,7 +4390,7 @@ void Game::loadstats( mapclass& map, Graphics& dwgfx )
 
         if (pKey == "setflipmode")
         {
-            dwgfx.setflipmode = atoi(pText);
+            graphics.setflipmode = atoi(pText);
         }
 
         if (pKey == "invincibility")
@@ -4440,7 +4440,7 @@ void Game::loadstats( mapclass& map, Graphics& dwgfx )
         if (pKey == "advanced_smoothing")
         {
             fullScreenEffect_badSignal = atoi(pText);
-            dwgfx.screenbuffer->badSignalEffect = fullScreenEffect_badSignal;
+            graphics.screenbuffer->badSignalEffect = fullScreenEffect_badSignal;
         }
 
 				if (pKey == "usingmmmmmm")
@@ -4459,17 +4459,17 @@ void Game::loadstats( mapclass& map, Graphics& dwgfx )
 
         if (pKey == "notextoutline")
         {
-            dwgfx.notextoutline = atoi(pText);
+            graphics.notextoutline = atoi(pText);
         }
 
         if (pKey == "translucentroomname")
         {
-            dwgfx.translucentroomname = atoi(pText);
+            graphics.translucentroomname = atoi(pText);
         }
 
         if (pKey == "showmousecursor")
         {
-            dwgfx.showmousecursor = atoi(pText);
+            graphics.showmousecursor = atoi(pText);
         }
 
 		if (pKey == "flipButton")
@@ -4508,19 +4508,19 @@ void Game::loadstats( mapclass& map, Graphics& dwgfx )
 
     if(fullscreen)
     {
-        dwgfx.screenbuffer->toggleFullScreen();
+        graphics.screenbuffer->toggleFullScreen();
     }
     for (int i = 0; i < stretchMode; i += 1)
     {
-        dwgfx.screenbuffer->toggleStretchMode();
+        graphics.screenbuffer->toggleStretchMode();
     }
     if (useLinearFilter)
     {
-        dwgfx.screenbuffer->toggleLinearFilter();
+        graphics.screenbuffer->toggleLinearFilter();
     }
-    dwgfx.screenbuffer->ResizeScreen(width, height);
+    graphics.screenbuffer->ResizeScreen(width, height);
 
-    if (dwgfx.showmousecursor == true)
+    if (graphics.showmousecursor == true)
     {
         SDL_ShowCursor(SDL_ENABLE);
     }
@@ -4542,7 +4542,7 @@ void Game::loadstats( mapclass& map, Graphics& dwgfx )
     }
 }
 
-void Game::savestats( mapclass& _map, Graphics& _dwgfx )
+void Game::savestats()
 {
     TiXmlDocument doc;
     TiXmlElement* msg;
@@ -4635,7 +4635,7 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
     dataNode->LinkEndChild( msg );
 
     int width, height;
-    _dwgfx.screenbuffer->GetWindowSize(&width, &height);
+    graphics.screenbuffer->GetWindowSize(&width, &height);
     msg = new TiXmlElement( "window_width" );
     msg->LinkEndChild( new TiXmlText( tu.String(width).c_str()));
     dataNode->LinkEndChild( msg );
@@ -4652,11 +4652,11 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "setflipmode" );
-    msg->LinkEndChild( new TiXmlText( tu.String(_dwgfx.setflipmode).c_str()));
+    msg->LinkEndChild( new TiXmlText( tu.String(graphics.setflipmode).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "invincibility" );
-    msg->LinkEndChild( new TiXmlText( tu.String(_map.invincibility).c_str()));
+    msg->LinkEndChild( new TiXmlText( tu.String(map.invincibility).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "slowdown" );
@@ -4690,15 +4690,15 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
     dataNode->LinkEndChild(msg);
 
     msg = new TiXmlElement("notextoutline");
-    msg->LinkEndChild(new TiXmlText(tu.String((int) _dwgfx.notextoutline).c_str()));
+    msg->LinkEndChild(new TiXmlText(tu.String((int) graphics.notextoutline).c_str()));
     dataNode->LinkEndChild(msg);
 
     msg = new TiXmlElement("translucentroomname");
-    msg->LinkEndChild(new TiXmlText(tu.String((int) _dwgfx.translucentroomname).c_str()));
+    msg->LinkEndChild(new TiXmlText(tu.String((int) graphics.translucentroomname).c_str()));
     dataNode->LinkEndChild(msg);
 
     msg = new TiXmlElement("showmousecursor");
-    msg->LinkEndChild(new TiXmlText(tu.String((int)_dwgfx.showmousecursor).c_str()));
+    msg->LinkEndChild(new TiXmlText(tu.String((int)graphics.showmousecursor).c_str()));
     dataNode->LinkEndChild(msg);
 
     for (size_t i = 0; i < controllerButton_flip.size(); i += 1)
@@ -4727,7 +4727,7 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
     FILESYSTEM_saveTiXmlDocument("saves/unlock.vvv", &doc);
 }
 
-void Game::customstart( entityclass& obj, musicclass& music )
+void Game::customstart()
 {
     jumpheld = true;
 
@@ -4755,7 +4755,7 @@ void Game::customstart( entityclass& obj, musicclass& music )
     //if (!nocutscenes) music.play(5);
 }
 
-void Game::start( entityclass& obj, musicclass& music )
+void Game::start()
 {
     jumpheld = true;
 
@@ -4782,7 +4782,7 @@ void Game::start( entityclass& obj, musicclass& music )
     if (!nocutscenes) music.play(5);
 }
 
-void Game::deathsequence( mapclass& map, entityclass& obj, musicclass& music )
+void Game::deathsequence()
 {
     int i;
     if (supercrewmate && scmhurt)
@@ -4833,7 +4833,7 @@ void Game::deathsequence( mapclass& map, entityclass& obj, musicclass& music )
     }
 }
 
-void Game::startspecial( int t, entityclass& obj, musicclass& music )
+void Game::startspecial( int t )
 {
     jumpheld = true;
 
@@ -4874,7 +4874,7 @@ void Game::startspecial( int t, entityclass& obj, musicclass& music )
     lifeseq = 0;
 }
 
-void Game::starttrial( int t, entityclass& obj, musicclass& music )
+void Game::starttrial( int t )
 {
     jumpheld = true;
 
@@ -4950,7 +4950,7 @@ void Game::starttrial( int t, entityclass& obj, musicclass& music )
     lifeseq = 0;
 }
 
-void Game::loadquick( mapclass& map, entityclass& obj, musicclass& music )
+void Game::loadquick()
 {
     TiXmlDocument doc;
     if (!FILESYSTEM_loadTiXmlDocument("saves/qsave.vvv", &doc)) return;
@@ -5171,7 +5171,7 @@ void Game::loadquick( mapclass& map, entityclass& obj, musicclass& music )
 
 }
 
-void Game::customloadquick(std::string savfile, mapclass& map, entityclass& obj, musicclass& music )
+void Game::customloadquick(std::string savfile)
 {
     std::string levelfile = savfile.substr(7);
     TiXmlDocument doc;
@@ -5429,7 +5429,7 @@ void Game::customloadquick(std::string savfile, mapclass& map, entityclass& obj,
 }
 
 //TODO load summary
-void Game::loadsummary( mapclass& map, UtilityClass& help )
+void Game::loadsummary()
 {
     //quickcookie = SharedObject.getLocal("dwvvvvvv_quick");
     //telecookie = SharedObject.getLocal("dwvvvvvv_tele");
@@ -5545,7 +5545,7 @@ void Game::loadsummary( mapclass& map, UtilityClass& help )
             }
 
         }
-        tele_gametime = giventimestring(l_hours,l_minute, l_second,help);
+        tele_gametime = giventimestring(l_hours,l_minute, l_second);
         tele_currentarea = map.currentarea(map.area(l_saveX, l_saveY));
     }
 
@@ -5637,7 +5637,7 @@ void Game::loadsummary( mapclass& map, UtilityClass& help )
 
         }
 
-        quick_gametime = giventimestring(l_hours,l_minute, l_second,help);
+        quick_gametime = giventimestring(l_hours,l_minute, l_second);
         quick_currentarea = map.currentarea(map.area(l_saveX, l_saveY));
     }
 
@@ -5645,7 +5645,7 @@ void Game::loadsummary( mapclass& map, UtilityClass& help )
 
 }
 
-void Game::initteleportermode( mapclass& map )
+void Game::initteleportermode()
 {
     //Set the teleporter variable to the right position!
     teleport_to_teleporter = 0;
@@ -5659,7 +5659,7 @@ void Game::initteleportermode( mapclass& map )
     }
 }
 
-void Game::savetele( mapclass& map, entityclass& obj, musicclass& music )
+void Game::savetele()
 {
     //TODO make this code a bit cleaner.
 
@@ -5891,8 +5891,7 @@ void Game::savetele( mapclass& map, entityclass& obj, musicclass& music )
 
 
     msg = new TiXmlElement( "summary" );
-    UtilityClass tempUtil;
-    std::string summary = savearea + ", " + timestring(tempUtil);
+    std::string summary = savearea + ", " + timestring();
     msg->LinkEndChild( new TiXmlText( summary.c_str() ));
     msgs->LinkEndChild( msg );
 
@@ -5912,7 +5911,7 @@ void Game::savetele( mapclass& map, entityclass& obj, musicclass& music )
 }
 
 
-void Game::savequick( mapclass& map, entityclass& obj, musicclass& music )
+void Game::savequick()
 {
     quickcookieexists = true;
 
@@ -6141,8 +6140,7 @@ void Game::savequick( mapclass& map, entityclass& obj, musicclass& music )
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "summary" );
-    UtilityClass tempUtil;
-    std::string summary = savearea + ", " + timestring(tempUtil);
+    std::string summary = savearea + ", " + timestring();
     msg->LinkEndChild( new TiXmlText( summary.c_str() ));
     msgs->LinkEndChild( msg );
 
@@ -6162,7 +6160,7 @@ void Game::savequick( mapclass& map, entityclass& obj, musicclass& music )
 
 }
 
-void Game::customsavequick(std::string savfile, mapclass& map, entityclass& obj, musicclass& music )
+void Game::customsavequick(std::string savfile)
 {
     quickcookieexists = true;
 
@@ -6401,8 +6399,7 @@ void Game::customsavequick(std::string savfile, mapclass& map, entityclass& obj,
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "summary" );
-    UtilityClass tempUtil;
-    std::string summary = savearea + ", " + timestring(tempUtil);
+    std::string summary = savearea + ", " + timestring();
     msg->LinkEndChild( new TiXmlText( summary.c_str() ));
     msgs->LinkEndChild( msg );
 
@@ -6423,7 +6420,7 @@ void Game::customsavequick(std::string savfile, mapclass& map, entityclass& obj,
 }
 
 
-void Game::loadtele( mapclass& map, entityclass& obj, musicclass& music )
+void Game::loadtele()
 {
     TiXmlDocument doc;
     if (!FILESYSTEM_loadTiXmlDocument("saves/tsave.vvv", &doc)) return;
@@ -6700,7 +6697,7 @@ teststring = os.str();
 	}
 }
 
-std::string Game::giventimestring( int hrs, int min, int sec, UtilityClass& help )
+std::string Game::giventimestring( int hrs, int min, int sec )
 {
     tempstring = "";
     if (hrs > 0)
@@ -6711,7 +6708,7 @@ std::string Game::giventimestring( int hrs, int min, int sec, UtilityClass& help
     return tempstring;
 }
 
-std::string Game::timestring( UtilityClass& help )
+std::string Game::timestring()
 {
     tempstring = "";
     if (hours > 0)
@@ -6722,7 +6719,7 @@ std::string Game::timestring( UtilityClass& help )
     return tempstring;
 }
 
-std::string Game::partimestring( UtilityClass& help )
+std::string Game::partimestring()
 {
     //given par time in seconds:
     tempstring = "";
@@ -6737,7 +6734,7 @@ std::string Game::partimestring( UtilityClass& help )
     return tempstring;
 }
 
-std::string Game::resulttimestring( UtilityClass& help )
+std::string Game::resulttimestring()
 {
     //given result time in seconds:
     tempstring = "";
@@ -6753,7 +6750,7 @@ std::string Game::resulttimestring( UtilityClass& help )
     return tempstring;
 }
 
-std::string Game::timetstring( int t, UtilityClass& help )
+std::string Game::timetstring( int t )
 {
     //given par time in seconds:
     tempstring = "";

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -39,77 +39,77 @@ const char* BoolToString(bool _b)
 
 bool GetButtonFromString(const char *pText, SDL_GameControllerButton *button)
 {
-	if (	*pText == '0' ||
-		*pText == 'a' ||
-		*pText == 'A'	)
-	{
-		*button = SDL_CONTROLLER_BUTTON_A;
-		return true;
-	}
-	if (	strcmp(pText, "1") == 0 ||
-		*pText == 'b' ||
-		*pText == 'B'	)
-	{
-		*button = SDL_CONTROLLER_BUTTON_B;
-		return true;
-	}
-	if (	*pText == '2' ||
-		*pText == 'x' ||
-		*pText == 'X'	)
-	{
-		*button = SDL_CONTROLLER_BUTTON_X;
-		return true;
-	}
-	if (	*pText == '3' ||
-		*pText == 'y' ||
-		*pText == 'Y'	)
-	{
-		*button = SDL_CONTROLLER_BUTTON_Y;
-		return true;
-	}
-	if (	*pText == '4' ||
-		strcasecmp(pText, "BACK") == 0	)
-	{
-		*button = SDL_CONTROLLER_BUTTON_BACK;
-		return true;
-	}
-	if (	*pText == '5' ||
-		strcasecmp(pText, "GUIDE") == 0	)
-	{
-		*button = SDL_CONTROLLER_BUTTON_GUIDE;
-		return true;
-	}
-	if (	*pText == '6' ||
-		strcasecmp(pText, "START") == 0	)
-	{
-		*button = SDL_CONTROLLER_BUTTON_START;
-		return true;
-	}
-	if (	*pText == '7' ||
-		strcasecmp(pText, "LS") == 0	)
-	{
-		*button = SDL_CONTROLLER_BUTTON_LEFTSTICK;
-		return true;
-	}
-	if (	*pText == '8' ||
-		strcasecmp(pText, "RS") == 0	)
-	{
-		*button = SDL_CONTROLLER_BUTTON_RIGHTSTICK;
-		return true;
-	}
-	if (	*pText == '9' ||
-		strcasecmp(pText, "LB") == 0	)
-	{
-		*button = SDL_CONTROLLER_BUTTON_LEFTSHOULDER;
-		return true;
-	}
-	if (	strcmp(pText, "10") == 0 ||
-		strcasecmp(pText, "RB") == 0	)
-	{
-		*button = SDL_CONTROLLER_BUTTON_RIGHTSHOULDER;
-		return true;
-	}
-	return false;
+    if (*pText == '0' ||
+        *pText == 'a' ||
+        *pText == 'A')
+    {
+        *button = SDL_CONTROLLER_BUTTON_A;
+        return true;
+    }
+    if (strcmp(pText, "1") == 0 ||
+        *pText == 'b' ||
+        *pText == 'B')
+    {
+        *button = SDL_CONTROLLER_BUTTON_B;
+        return true;
+    }
+    if (*pText == '2' ||
+        *pText == 'x' ||
+        *pText == 'X')
+    {
+        *button = SDL_CONTROLLER_BUTTON_X;
+        return true;
+    }
+    if (*pText == '3' ||
+        *pText == 'y' ||
+        *pText == 'Y')
+    {
+        *button = SDL_CONTROLLER_BUTTON_Y;
+        return true;
+    }
+    if (*pText == '4' ||
+        strcasecmp(pText, "BACK") == 0)
+    {
+        *button = SDL_CONTROLLER_BUTTON_BACK;
+        return true;
+    }
+    if (*pText == '5' ||
+        strcasecmp(pText, "GUIDE") == 0)
+    {
+        *button = SDL_CONTROLLER_BUTTON_GUIDE;
+        return true;
+    }
+    if (*pText == '6' ||
+        strcasecmp(pText, "START") == 0)
+    {
+        *button = SDL_CONTROLLER_BUTTON_START;
+        return true;
+    }
+    if (*pText == '7' ||
+        strcasecmp(pText, "LS") == 0)
+    {
+        *button = SDL_CONTROLLER_BUTTON_LEFTSTICK;
+        return true;
+    }
+    if (*pText == '8' ||
+        strcasecmp(pText, "RS") == 0)
+    {
+        *button = SDL_CONTROLLER_BUTTON_RIGHTSTICK;
+        return true;
+    }
+    if (*pText == '9' ||
+        strcasecmp(pText, "LB") == 0)
+    {
+        *button = SDL_CONTROLLER_BUTTON_LEFTSHOULDER;
+        return true;
+    }
+    if (strcmp(pText, "10") == 0 ||
+        strcasecmp(pText, "RB") == 0)
+    {
+        *button = SDL_CONTROLLER_BUTTON_RIGHTSHOULDER;
+        return true;
+    }
+    return false;
 }
 
 
@@ -124,7 +124,7 @@ void Game::init(void)
 
     timerStartTime= SDL_GetTicks();
 
-		glitchrunkludge = false;
+    glitchrunkludge = false;
     hascontrol = true;
     jumpheld = false;
     advancetext = false;
@@ -195,8 +195,8 @@ void Game::init(void)
     useLinearFilter = false;
     advanced_mode = false;
     fullScreenEffect_badSignal = false;
-	// 0..5
-	controllerSensitivity = 2;
+    // 0..5
+    controllerSensitivity = 2;
 
     nodeathmode = false;
     nocutscenes = false;
@@ -696,9 +696,9 @@ void Game::updatestate()
     int i;
     statedelay--;
     if(statedelay<=0){
-		  statedelay=0;
-			glitchrunkludge=false;
-		}
+        statedelay=0;
+        glitchrunkludge=false;
+    }
     if (statedelay <= 0)
     {
         switch(state)
@@ -1387,14 +1387,14 @@ void Game::updatestate()
             if (timetrialrank > bestrank[timetriallevel] || bestrank[timetriallevel]==-1)
             {
                 bestrank[timetriallevel] = timetrialrank;
-								if(timetrialrank>=3){
-									if(timetriallevel==0) NETWORK_unlockAchievement("vvvvvvtimetrial_station1_fixed");
-									if(timetriallevel==1) NETWORK_unlockAchievement("vvvvvvtimetrial_lab_fixed");
-									if(timetriallevel==2) NETWORK_unlockAchievement("vvvvvvtimetrial_tower_fixed");
-									if(timetriallevel==3) NETWORK_unlockAchievement("vvvvvvtimetrial_station2_fixed");
-									if(timetriallevel==4) NETWORK_unlockAchievement("vvvvvvtimetrial_warp_fixed");
-									if(timetriallevel==5) NETWORK_unlockAchievement("vvvvvvtimetrial_final_fixed");
-								}
+                if(timetrialrank>=3){
+                    if(timetriallevel==0) NETWORK_unlockAchievement("vvvvvvtimetrial_station1_fixed");
+                    if(timetriallevel==1) NETWORK_unlockAchievement("vvvvvvtimetrial_lab_fixed");
+                    if(timetriallevel==2) NETWORK_unlockAchievement("vvvvvvtimetrial_tower_fixed");
+                    if(timetriallevel==3) NETWORK_unlockAchievement("vvvvvvtimetrial_station2_fixed");
+                    if(timetriallevel==4) NETWORK_unlockAchievement("vvvvvvtimetrial_warp_fixed");
+                    if(timetriallevel==5) NETWORK_unlockAchievement("vvvvvvtimetrial_final_fixed");
+                }
             }
 
             savestats();
@@ -3094,7 +3094,7 @@ void Game::updatestate()
             break;
         case 3501:
             //Game complete!
-						NETWORK_unlockAchievement("vvvvvvgamecomplete");
+            NETWORK_unlockAchievement("vvvvvvgamecomplete");
             unlocknum(5);
             crewstats[0] = true;
             state++;
@@ -3234,7 +3234,7 @@ void Game::updatestate()
             if (obj.flags[73] == 0)
             {
                 //flip mode complete
-								NETWORK_unlockAchievement("vvvvvvgamecompleteflip");
+                NETWORK_unlockAchievement("vvvvvvgamecompleteflip");
                 unlock[19] = true;
             }
 
@@ -3250,26 +3250,26 @@ void Game::updatestate()
                 }
             }
 
-						if (bestgamedeaths > -1) {
-							if (bestgamedeaths <= 500) {
-							  NETWORK_unlockAchievement("vvvvvvcomplete500");
-							}
-							if (bestgamedeaths <= 250) {
-								NETWORK_unlockAchievement("vvvvvvcomplete250");
-							}
-							if (bestgamedeaths <= 100) {
-								NETWORK_unlockAchievement("vvvvvvcomplete100");
-							}
-							if (bestgamedeaths <= 50) {
-								NETWORK_unlockAchievement("vvvvvvcomplete50");
-							}
-						}
+            if (bestgamedeaths > -1) {
+                if (bestgamedeaths <= 500) {
+                    NETWORK_unlockAchievement("vvvvvvcomplete500");
+                }
+            if (bestgamedeaths <= 250) {
+                NETWORK_unlockAchievement("vvvvvvcomplete250");
+            }
+            if (bestgamedeaths <= 100) {
+                NETWORK_unlockAchievement("vvvvvvcomplete100");
+            }
+            if (bestgamedeaths <= 50) {
+                NETWORK_unlockAchievement("vvvvvvcomplete50");
+            }
+        }
 
 
             savestats();
             if (nodeathmode)
             {
-								NETWORK_unlockAchievement("vvvvvvmaster"); //bloody hell
+                NETWORK_unlockAchievement("vvvvvvmaster"); //bloody hell
                 unlock[20] = true;
                 state = 3520;
                 statedelay = 0;
@@ -4353,24 +4353,24 @@ void Game::loadstats()
             fullscreen = atoi(pText);
         }
 
-	if (pKey == "stretch")
-	{
-		stretchMode = atoi(pText);
-	}
+        if (pKey == "stretch")
+        {
+            stretchMode = atoi(pText);
+        }
 
-	if (pKey == "useLinearFilter")
-	{
-		useLinearFilter = atoi(pText);
-	}
+        if (pKey == "useLinearFilter")
+        {
+            useLinearFilter = atoi(pText);
+        }
 
-	if (pKey == "window_width")
-	{
-		width = atoi(pText);
-	}
-	if (pKey == "window_height")
-	{
-		height = atoi(pText);
-	}
+        if (pKey == "window_width")
+        {
+            width = atoi(pText);
+        }
+        if (pKey == "window_height")
+        {
+            height = atoi(pText);
+        }
 
 
         if (pKey == "noflashingmode")
@@ -4438,13 +4438,13 @@ void Game::loadstats()
             graphics.screenbuffer->badSignalEffect = fullScreenEffect_badSignal;
         }
 
-				if (pKey == "usingmmmmmm")
+        if (pKey == "usingmmmmmm")
         {
-					if(atoi(pText)>0){
-            usingmmmmmm = 1;
-					}else{
-					  usingmmmmmm = 0;
-					}
+            if(atoi(pText)>0){
+                usingmmmmmm = 1;
+            }else{
+                usingmmmmmm = 0;
+            }
         }
 
         if (pKey == "skipfakeload")
@@ -4467,37 +4467,37 @@ void Game::loadstats()
             graphics.showmousecursor = atoi(pText);
         }
 
-		if (pKey == "flipButton")
-		{
-			SDL_GameControllerButton newButton;
-			if (GetButtonFromString(pText, &newButton))
-			{
-				controllerButton_flip.push_back(newButton);
-			}
-		}
+        if (pKey == "flipButton")
+        {
+            SDL_GameControllerButton newButton;
+            if (GetButtonFromString(pText, &newButton))
+            {
+                controllerButton_flip.push_back(newButton);
+            }
+        }
 
-		if (pKey == "enterButton")
-		{
-			SDL_GameControllerButton newButton;
-			if (GetButtonFromString(pText, &newButton))
-			{
-				controllerButton_map.push_back(newButton);
-			}
-		}
+        if (pKey == "enterButton")
+        {
+            SDL_GameControllerButton newButton;
+            if (GetButtonFromString(pText, &newButton))
+            {
+                controllerButton_map.push_back(newButton);
+            }
+        }
 
-		if (pKey == "escButton")
-		{
-			SDL_GameControllerButton newButton;
-			if (GetButtonFromString(pText, &newButton))
-			{
-				controllerButton_esc.push_back(newButton);
-			}
-		}
+        if (pKey == "escButton")
+        {
+            SDL_GameControllerButton newButton;
+            if (GetButtonFromString(pText, &newButton))
+            {
+                controllerButton_esc.push_back(newButton);
+            }
+        }
 
-		if (pKey == "controllerSensitivity")
-		{
-			controllerSensitivity = atoi(pText);
-		}
+        if (pKey == "controllerSensitivity")
+        {
+            controllerSensitivity = atoi(pText);
+        }
 
     }
 
@@ -4715,9 +4715,9 @@ void Game::savestats()
         dataNode->LinkEndChild(msg);
     }
 
-	msg = new TiXmlElement( "controllerSensitivity" );
-	msg->LinkEndChild( new TiXmlText( tu.String(controllerSensitivity).c_str()));
-	dataNode->LinkEndChild( msg );
+    msg = new TiXmlElement( "controllerSensitivity" );
+    msg->LinkEndChild( new TiXmlText( tu.String(controllerSensitivity).c_str()));
+    dataNode->LinkEndChild( msg );
 
     FILESYSTEM_saveTiXmlDocument("saves/unlock.vvv", &doc);
 }
@@ -5108,7 +5108,7 @@ void Game::loadquick()
         else if (pKey == "frames")
         {
             frames = atoi(pText);
-						frames = 0;
+            frames = 0;
         }
         else if (pKey == "seconds")
         {
@@ -5376,7 +5376,7 @@ void Game::customloadquick(std::string savfile)
         else if (pKey == "frames")
         {
             frames = atoi(pText);
-						frames = 0;
+            frames = 0;
         }
         else if (pKey == "seconds")
         {
@@ -6585,7 +6585,7 @@ void Game::loadtele()
         else if (pKey == "frames")
         {
             frames = atoi(pText);
-						frames = 0;
+            frames = 0;
         }
         else if (pKey == "seconds")
         {
@@ -6662,25 +6662,25 @@ void Game::gameclock()
 /*
 test = true;
 std::ostringstream os;
-	os << hours << ":" << minutes << ":" << seconds << ", " << frames;
+    os << hours << ":" << minutes << ":" << seconds << ", " << frames;
 teststring = os.str();
 */
-  frames++;
-	if (frames >= 30)
-	{
-		frames -= 30;
-		seconds++;
-		if (seconds >= 60)
-		{
-			seconds -= 60;
-			minutes++;
-			if (minutes >= 60)
-			{
-				minutes -= 60;
-				hours++;
-			}
-		}
-	}
+    frames++;
+    if (frames >= 30)
+    {
+        frames -= 30;
+        seconds++;
+        if (seconds >= 60)
+        {
+            seconds -= 60;
+            minutes++;
+            if (minutes >= 60)
+            {
+                minutes -= 60;
+                hours++;
+            }
+        }
+    }
 }
 
 std::string Game::giventimestring( int hrs, int min, int sec )
@@ -6763,56 +6763,56 @@ void Game::createmenu( std::string t )
 
     if (t == "mainmenu")
     {
-			#if defined(MAKEANDPLAY)
-					menuoptions[0] = "player levels";
-					menuoptionsactive[0] = true;
-					menuoptions[1] = "graphic options";
-					menuoptionsactive[1] = true;
-					menuoptions[2] = "game options";
-					menuoptionsactive[2] = true;
-					menuoptions[3] = "quit game";
-					menuoptionsactive[3] = true;
-					nummenuoptions = 4;
-					menuxoff = -16;
-					menuyoff = -10;
-			#elif !defined(MAKEANDPLAY)
-				#if defined(NO_CUSTOM_LEVELS)
-					menuoptions[0] = "start game";
-					menuoptionsactive[0] = true;
-					menuoptions[1] = "graphic options";
-					menuoptionsactive[1] = true;
-					menuoptions[2] = "game options";
-					menuoptionsactive[2] = true;
-					menuoptions[3] = "view credits";
-					menuoptionsactive[3] = true;
-					menuoptions[4] = "quit game";
-					menuoptionsactive[4] = true;
-					nummenuoptions = 5;
-					menuxoff = -16;
-					menuyoff = -10;
-				#else
-					menuoptions[0] = "start game";
-					menuoptionsactive[0] = true;
-					menuoptions[1] = "player levels";
-					menuoptionsactive[1] = true;
-					menuoptions[2] = "graphic options";
-					menuoptionsactive[2] = true;
-					menuoptions[3] = "game options";
-					menuoptionsactive[3] = true;
-					menuoptions[4] = "view credits";
-					menuoptionsactive[4] = true;
-					menuoptions[5] = "quit game";
-					menuoptionsactive[5] = true;
-					nummenuoptions = 6;
-					menuxoff = -16;
-					menuyoff = -10;
-				#endif
-			#endif
+#if defined(MAKEANDPLAY)
+        menuoptions[0] = "player levels";
+        menuoptionsactive[0] = true;
+        menuoptions[1] = "graphic options";
+        menuoptionsactive[1] = true;
+        menuoptions[2] = "game options";
+        menuoptionsactive[2] = true;
+        menuoptions[3] = "quit game";
+        menuoptionsactive[3] = true;
+        nummenuoptions = 4;
+        menuxoff = -16;
+        menuyoff = -10;
+#elif !defined(MAKEANDPLAY)
+ #if defined(NO_CUSTOM_LEVELS)
+        menuoptions[0] = "start game";
+        menuoptionsactive[0] = true;
+        menuoptions[1] = "graphic options";
+        menuoptionsactive[1] = true;
+        menuoptions[2] = "game options";
+        menuoptionsactive[2] = true;
+        menuoptions[3] = "view credits";
+        menuoptionsactive[3] = true;
+        menuoptions[4] = "quit game";
+        menuoptionsactive[4] = true;
+        nummenuoptions = 5;
+        menuxoff = -16;
+        menuyoff = -10;
+ #else
+        menuoptions[0] = "start game";
+        menuoptionsactive[0] = true;
+        menuoptions[1] = "player levels";
+        menuoptionsactive[1] = true;
+        menuoptions[2] = "graphic options";
+        menuoptionsactive[2] = true;
+        menuoptions[3] = "game options";
+        menuoptionsactive[3] = true;
+        menuoptions[4] = "view credits";
+        menuoptionsactive[4] = true;
+        menuoptions[5] = "quit game";
+        menuoptionsactive[5] = true;
+        nummenuoptions = 6;
+        menuxoff = -16;
+        menuyoff = -10;
+ #endif
+#endif
     }
 #if !defined(NO_CUSTOM_LEVELS)
     else if (t == "playerworlds")
     {
-    #if !defined(NO_EDITOR)
+ #if !defined(NO_EDITOR)
         menuoptions[0] = "play a level";
         menuoptionsactive[0] = true;
         menuoptions[1] = "level editor";
@@ -6824,7 +6824,7 @@ void Game::createmenu( std::string t )
         nummenuoptions = 3;
         menuxoff = -30;
         menuyoff = -40;
-    #else
+ #else
         menuoptions[0] = "play a level";
         menuoptionsactive[0] = true;
         menuoptions[1] = "back to menu";
@@ -6832,7 +6832,7 @@ void Game::createmenu( std::string t )
         nummenuoptions = 2;
         menuxoff = -30;
         menuyoff = -40;
-    #endif
+ #endif
     }
     else if (t == "levellist")
     {
@@ -7069,34 +7069,34 @@ void Game::createmenu( std::string t )
     }
     else if (t == "options")
     {
-				#if defined(MAKEANDPLAY)
-					menuoptions[0] = "accessibility options";
-					menuoptionsactive[0] = true;
-					menuoptions[1] = "game pad options";
-					menuoptionsactive[1] = true;
-					menuoptions[2] = "clear data";
-					menuoptionsactive[2] = true;
-					menuoptions[3] = "return";
-					menuoptionsactive[3] = true;
-					nummenuoptions = 4;
-					menuxoff = -40;
-					menuyoff = 0;
-				#elif !defined(MAKEANDPLAY)
-					menuoptions[0] = "accessibility options";
-					menuoptionsactive[0] = true;
-					menuoptions[1] = "unlock play modes";
-					menuoptionsactive[1] = true;
-					menuoptions[2] = "game pad options";
-					menuoptionsactive[2] = true;
-					menuoptions[3] = "clear data";
-					menuoptionsactive[3] = true;
+#if defined(MAKEANDPLAY)
+        menuoptions[0] = "accessibility options";
+        menuoptionsactive[0] = true;
+        menuoptions[1] = "game pad options";
+        menuoptionsactive[1] = true;
+        menuoptions[2] = "clear data";
+        menuoptionsactive[2] = true;
+        menuoptions[3] = "return";
+        menuoptionsactive[3] = true;
+        nummenuoptions = 4;
+        menuxoff = -40;
+        menuyoff = 0;
+#elif !defined(MAKEANDPLAY)
+        menuoptions[0] = "accessibility options";
+        menuoptionsactive[0] = true;
+        menuoptions[1] = "unlock play modes";
+        menuoptionsactive[1] = true;
+        menuoptions[2] = "game pad options";
+        menuoptionsactive[2] = true;
+        menuoptions[3] = "clear data";
+        menuoptionsactive[3] = true;
 
-					menuoptions[4] = "return";
-					menuoptionsactive[4] = true;
-					nummenuoptions = 5;
-					menuxoff = -40;
-					menuyoff = 0;
-				#endif
+        menuoptions[4] = "return";
+        menuoptionsactive[4] = true;
+        nummenuoptions = 5;
+        menuxoff = -40;
+        menuyoff = 0;
+#endif
     }
     else if (t == "accessibility")
     {
@@ -7120,22 +7120,22 @@ void Game::createmenu( std::string t )
         menuxoff = -85;
         menuyoff = -10;
     }
-	else if(t == "controller")
-	{
-		menuoptions[0] = "analog stick sensitivity";
-		menuoptionsactive[0] = true;
-		menuoptions[1] = "bind flip";
-		menuoptionsactive[1] = true;
-		menuoptions[2] = "bind enter";
-		menuoptionsactive[2] = true;
-		menuoptions[3] = "bind menu";
-		menuoptionsactive[3] = true;
-		menuoptions[4] = "return";
-		menuoptionsactive[4] = true;
-		nummenuoptions = 5;
-		menuxoff = -40;
-		menuyoff = 10;
-	}
+    else if(t == "controller")
+    {
+        menuoptions[0] = "analog stick sensitivity";
+        menuoptionsactive[0] = true;
+        menuoptions[1] = "bind flip";
+        menuoptionsactive[1] = true;
+        menuoptions[2] = "bind enter";
+        menuoptionsactive[2] = true;
+        menuoptions[3] = "bind menu";
+        menuoptionsactive[3] = true;
+        menuoptions[4] = "return";
+        menuoptionsactive[4] = true;
+        nummenuoptions = 5;
+        menuxoff = -40;
+        menuyoff = 10;
+    }
     else if (t == "cleardatamenu")
     {
         menuoptions[0] = "no! don't delete";

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -2373,7 +2373,7 @@ void Game::updatestate()
             temp = 6 - crewrescued();
             if (temp == 1)
             {
-                tempstring = "  One remains  ";
+                std::string tempstring = "  One remains  ";
                 if (graphics.flipmode)
                 {
                     graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
@@ -2385,7 +2385,7 @@ void Game::updatestate()
             }
             else if (temp > 0)
             {
-                tempstring = "  " + help.number(temp) + " remain  ";
+                std::string tempstring = "  " + help.number(temp) + " remain  ";
                 if (graphics.flipmode)
                 {
                     graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
@@ -2488,7 +2488,7 @@ void Game::updatestate()
             temp = 6 - crewrescued();
             if (temp == 1)
             {
-                tempstring = "  One remains  ";
+                std::string tempstring = "  One remains  ";
                 if (graphics.flipmode)
                 {
                     graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
@@ -2500,7 +2500,7 @@ void Game::updatestate()
             }
             else if (temp > 0)
             {
-                tempstring = "  " + help.number(temp) + " remain  ";
+                std::string tempstring = "  " + help.number(temp) + " remain  ";
                 if (graphics.flipmode)
                 {
                     graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
@@ -2602,7 +2602,7 @@ void Game::updatestate()
             temp = 6 - crewrescued();
             if (temp == 1)
             {
-                tempstring = "  One remains  ";
+                std::string tempstring = "  One remains  ";
                 if (graphics.flipmode)
                 {
                     graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
@@ -2614,7 +2614,7 @@ void Game::updatestate()
             }
             else if (temp > 0)
             {
-                tempstring = "  " + help.number(temp) + " remain  ";
+                std::string tempstring = "  " + help.number(temp) + " remain  ";
                 if (graphics.flipmode)
                 {
                     graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
@@ -2717,7 +2717,7 @@ void Game::updatestate()
             temp = 6 - crewrescued();
             if (temp == 1)
             {
-                tempstring = "  One remains  ";
+                std::string tempstring = "  One remains  ";
                 if (graphics.flipmode)
                 {
                     graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
@@ -2729,7 +2729,7 @@ void Game::updatestate()
             }
             else if (temp > 0)
             {
-                tempstring = "  " + help.number(temp) + " remain  ";
+                std::string tempstring = "  " + help.number(temp) + " remain  ";
                 if (graphics.flipmode)
                 {
                     graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
@@ -2850,7 +2850,7 @@ void Game::updatestate()
             temp = 6 - crewrescued();
             if (temp == 1)
             {
-                tempstring = "  One remains  ";
+                std::string tempstring = "  One remains  ";
                 if (graphics.flipmode)
                 {
                     graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
@@ -2862,7 +2862,7 @@ void Game::updatestate()
             }
             else if (temp > 0)
             {
-                tempstring = "  " + help.number(temp) + " remain  ";
+                std::string tempstring = "  " + help.number(temp) + " remain  ";
                 if (graphics.flipmode)
                 {
                     graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
@@ -3127,10 +3127,11 @@ void Game::updatestate()
             savetime = timestring();
             break;
         case 3503:
+        {
             state++;
             statedelay = 45;
 
-            tempstring = help.number(trinkets);
+            std::string tempstring = help.number(trinkets);
             if (graphics.flipmode)
             {
                 graphics.createtextbox("Trinkets Found:", 48, 155-24, 0,0,0);
@@ -3142,11 +3143,13 @@ void Game::updatestate()
                 graphics.createtextbox(tempstring, 180, 84, 0, 0, 0);
             }
             break;
+        }
         case 3504:
+        {
             state++;
             statedelay = 45+15;
 
-            tempstring = savetime;
+            std::string tempstring = savetime;
             if (graphics.flipmode)
             {
                 graphics.createtextbox("   Game Time:", 64, 143-24, 0,0,0);
@@ -3158,6 +3161,7 @@ void Game::updatestate()
                 graphics.createtextbox(tempstring, 180, 96, 0, 0, 0);
             }
             break;
+        }
         case 3505:
             state++;
             statedelay = 45;
@@ -3189,22 +3193,24 @@ void Game::updatestate()
             }
             break;
         case 3507:
+        {
             state++;
             statedelay = 45+15;
 
             if (graphics.flipmode)
             {
-                tempstring = "Hardest Room (with " + help.String(hardestroomdeaths) + " deaths)";
+                std::string tempstring = "Hardest Room (with " + help.String(hardestroomdeaths) + " deaths)";
                 graphics.createtextbox(tempstring, -1, 81-24, 0,0,0);
                 graphics.createtextbox(hardestroom, -1, 69-24, 0, 0, 0);
             }
             else
             {
-                tempstring = "Hardest Room (with " + help.String(hardestroomdeaths) + " deaths)";
+                std::string tempstring = "Hardest Room (with " + help.String(hardestroomdeaths) + " deaths)";
                 graphics.createtextbox(tempstring, -1, 158, 0,0,0);
                 graphics.createtextbox(hardestroom, -1, 170, 0, 0, 0);
             }
             break;
+        }
         case 3508:
             state++;
             statedelay = 0;
@@ -6683,7 +6689,7 @@ teststring = os.str();
 
 std::string Game::giventimestring( int hrs, int min, int sec )
 {
-    tempstring = "";
+    std::string tempstring = "";
     if (hrs > 0)
     {
         tempstring += help.String(hrs) + ":";
@@ -6694,7 +6700,7 @@ std::string Game::giventimestring( int hrs, int min, int sec )
 
 std::string Game::timestring()
 {
-    tempstring = "";
+    std::string tempstring = "";
     if (hours > 0)
     {
         tempstring += help.String(hours) + ":";
@@ -6706,7 +6712,7 @@ std::string Game::timestring()
 std::string Game::partimestring()
 {
     //given par time in seconds:
-    tempstring = "";
+    std::string tempstring = "";
     if (timetrialpar >= 60)
     {
         tempstring = help.twodigits(int((timetrialpar - (timetrialpar % 60)) / 60)) + ":" + help.twodigits(timetrialpar % 60);
@@ -6721,7 +6727,7 @@ std::string Game::partimestring()
 std::string Game::resulttimestring()
 {
     //given result time in seconds:
-    tempstring = "";
+    std::string tempstring = "";
     if (timetrialresulttime > 60)
     {
         tempstring = help.twodigits(int((timetrialresulttime - (timetrialresulttime % 60)) / 60)) + ":"
@@ -6737,7 +6743,7 @@ std::string Game::resulttimestring()
 std::string Game::timetstring( int t )
 {
     //given par time in seconds:
-    tempstring = "";
+    std::string tempstring = "";
     if (t >= 60)
     {
         tempstring = help.twodigits(int((t - (t % 60)) / 60)) + ":" + help.twodigits(t % 60);

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -384,8 +384,6 @@ void Game::init(void)
 
     stat_trinkets = 0;
 
-    test = false;
-    teststring = "TEST = True";
     state = 1;
     statedelay = 0;
     //updatestate();

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -334,13 +334,11 @@ void Game::init(void)
     TiXmlDocument docTele;
     if (!FILESYSTEM_loadTiXmlDocument("saves/tsave.vvv", &docTele))
     {
-        telecookieexists = false;
         telesummary = "";
         printf("Teleporter Save Not Found\n");
     }
     else
     {
-        telecookieexists = true;
         TiXmlHandle hDoc(&docTele);
         TiXmlElement* pElem;
         TiXmlHandle hRoot(0);
@@ -5460,12 +5458,10 @@ void Game::loadsummary()
     TiXmlDocument docTele;
     if (!FILESYSTEM_loadTiXmlDocument("saves/tsave.vvv", &docTele))
     {
-        telecookieexists = false;
         telesummary = "";
     }
     else
     {
-        telecookieexists = true;
         TiXmlHandle hDoc(&docTele);
         TiXmlElement* pElem;
         TiXmlHandle hRoot(0);
@@ -5664,7 +5660,6 @@ void Game::savetele()
 
     //telecookie = SharedObject.getLocal("dwvvvvvv_tele");
     //Save to the telesave cookie
-    telecookieexists = true;
 
     if (map.custommode)
     {
@@ -7758,7 +7753,6 @@ void Game::deletetele()
         printf("Error deleting file\n");
 
     telesummary = "";
-    telecookieexists = false;
 }
 
 void Game::swnpenalty()

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -3264,7 +3264,7 @@ void Game::updatestate()
 								NETWORK_unlockAchievement("vvvvvvcomplete50");
 							}
 						}
-						
+
 
             savestats();
             if (nodeathmode)
@@ -4675,7 +4675,7 @@ void Game::savestats()
     msg->LinkEndChild( new TiXmlText( tu.String(fullScreenEffect_badSignal).c_str()));
     dataNode->LinkEndChild( msg );
 
-		
+
     msg = new TiXmlElement( "usingmmmmmm" );
     msg->LinkEndChild( new TiXmlText( tu.String(usingmmmmmm).c_str()));
     dataNode->LinkEndChild( msg );

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -368,18 +368,6 @@ void Game::init(void)
         }
     }
 
-    //if (telecookie.data.savex == undefined) {
-    // telecookieexists = false; telesummary = "";
-    //} else {
-    // telecookieexists = true; telesummary = telecookie.data.summary;
-    //}
-
-    //if (quickcookie.data.savex == undefined) {
-    // quickcookieexists = false; quicksummary = "";
-    //} else {
-    // quickcookieexists = true; quicksummary = quickcookie.data.summary;
-    //}
-
     screenshake = flashlight = 0 ;
 
     stat_trinkets = 0;
@@ -4219,7 +4207,6 @@ void Game::unlocknum( int t )
 
 void Game::loadstats()
 {
-    // TODO loadstats
     TiXmlDocument doc;
     if (!FILESYSTEM_loadTiXmlDocument("saves/unlock.vvv", &doc))
     {
@@ -5427,36 +5414,8 @@ void Game::customloadquick(std::string savfile)
 
 }
 
-//TODO load summary
 void Game::loadsummary()
 {
-    //quickcookie = SharedObject.getLocal("dwvvvvvv_quick");
-    //telecookie = SharedObject.getLocal("dwvvvvvv_tele");
-
-    //if (telecookie.data.savex == undefined) {
-    //	telecookieexists = false; telesummary = "";
-    //} else {
-    //	telecookieexists = true; telesummary = telecookie.data.summary;
-    //	tele_gametime = giventimestring(telecookie.data.hours, telecookie.data.minutes, telecookie.data.seconds, help);
-    //	tele_trinkets = telecookie.data.trinkets;
-    //	tele_currentarea = map.currentarea(map.area(telecookie.data.savex, telecookie.data.savey));
-
-    //	summary_crewstats = telecookie.data.crewstats.slice();
-    //	tele_crewstats = summary_crewstats.slice();
-    //}
-
-    //if (quickcookie.data.savex == undefined) {
-    //	quickcookieexists = false; quicksummary = "";
-    //} else {
-    //	quickcookieexists = true; quicksummary = quickcookie.data.summary;
-    //	quick_gametime = giventimestring(quickcookie.data.hours, quickcookie.data.minutes, quickcookie.data.seconds, help);
-    //	quick_trinkets = quickcookie.data.trinkets;
-    //	quick_currentarea = map.currentarea(map.area(quickcookie.data.savex, quickcookie.data.savey));
-
-    //	summary_crewstats = quickcookie.data.crewstats.slice();
-    //	quick_crewstats = summary_crewstats.slice();
-    //}
-
     TiXmlDocument docTele;
     if (!FILESYSTEM_loadTiXmlDocument("saves/tsave.vvv", &docTele))
     {
@@ -5658,9 +5617,6 @@ void Game::savetele()
 {
     //TODO make this code a bit cleaner.
 
-    //telecookie = SharedObject.getLocal("dwvvvvvv_tele");
-    //Save to the telesave cookie
-
     if (map.custommode)
     {
         //Don't trash save data!
@@ -5684,18 +5640,6 @@ void Game::savetele()
 
 
     //Flags, map and stats
-    //savestate[1].explored = map.explored.slice();
-    //savestate[1].flags = obj.flags.slice();
-    //savestate[1].crewstats = crewstats.slice();
-    //savestate[1].collect = obj.collect.slice();
-
-    //telecookie.data.worldmap = savestate[1].explored.slice();
-    //telecookie.data.flags = savestate[1].flags.slice();
-    //telecookie.data.crewstats = savestate[1].crewstats.slice();
-    //telecookie.data.collect = savestate[1].collect.slice();
-
-    //telecookie.data.finalmode = map.finalmode;
-    //telecookie.data.finalstretch = map.finalstretch;
 
     std::string mapExplored;
     for(size_t i = 0; i < map.explored.size(); i++ )
@@ -5733,11 +5677,7 @@ void Game::savetele()
     msg->LinkEndChild( new TiXmlText( collect.c_str() ));
     msgs->LinkEndChild( msg );
 
-    //telecookie.data.finalx = map.finalx;
-    //telecookie.data.finaly = map.finaly;
     //Position
-    //telecookie.data.savex = savex;
-    //telecookie.data.savey = savey;
 
     msg = new TiXmlElement( "finalx" );
     msg->LinkEndChild( new TiXmlText( help.String(map.finalx).c_str() ));
@@ -5763,13 +5703,6 @@ void Game::savetele()
     msg->LinkEndChild( new TiXmlText( help.String(savery).c_str() ));
     msgs->LinkEndChild( msg );
 
-    //telecookie.data.saverx = saverx;
-    //telecookie.data.savery = savery;
-    //telecookie.data.savegc = savegc;
-    //telecookie.data.savedir = savedir;
-    //telecookie.data.savepoint = savepoint;
-    //telecookie.data.trinkets = trinkets;
-
     msg = new TiXmlElement( "savegc" );
     msg->LinkEndChild( new TiXmlText( help.String(savegc).c_str() ));
     msgs->LinkEndChild( msg );
@@ -5787,19 +5720,7 @@ void Game::savetele()
     msgs->LinkEndChild( msg );
 
 
-    //if (music.nicechange != -1) {
-    //telecookie.data.currentsong = music.nicechange;
-    //}else{
-    //telecookie.data.currentsong = music.currentsong;
-    //}
-    //telecookie.data.teleportscript = teleportscript;
-
     //Special stats
-    //telecookie.data.companion = companion;
-    //telecookie.data.lastsaved = lastsaved;
-    //telecookie.data.supercrewmate = supercrewmate;
-    //telecookie.data.scmprogress = scmprogress;
-    //telecookie.data.scmmoveme = scmmoveme;
 
     if(music.nicefade==1)
     {
@@ -5834,18 +5755,6 @@ void Game::savetele()
     msg = new TiXmlElement( "scmmoveme" );
     msg->LinkEndChild( new TiXmlText( BoolToString(scmmoveme) ));
     msgs->LinkEndChild( msg );
-
-
-    //telecookie.data.frames = frames; telecookie.data.seconds = seconds;
-    //telecookie.data.minutes = minutes; telecookie.data.hours = hours;
-
-    //telecookie.data.deathcounts = deathcounts;
-    //telecookie.data.totalflips = totalflips;
-    //telecookie.data.hardestroom = hardestroom; telecookie.data.hardestroomdeaths = hardestroomdeaths;
-
-    //savearea = map.currentarea(map.area(roomx, roomy))
-    //telecookie.data.summary = savearea + ", " + timestring(help);
-    //telesummary = telecookie.data.summary;
 
 
     msg = new TiXmlElement( "frames" );
@@ -5890,8 +5799,6 @@ void Game::savetele()
     msgs->LinkEndChild( msg );
 
     telesummary = summary;
-    //telecookie.flush();
-    //telecookie.close();
 
     if(FILESYSTEM_saveTiXmlDocument("saves/tsave.vvv", &doc))
     {
@@ -5930,18 +5837,6 @@ void Game::savequick()
 
 
     //Flags, map and stats
-    //savestate[1].explored = map.explored.slice();
-    //savestate[1].flags = obj.flags.slice();
-    //savestate[1].crewstats = crewstats.slice();
-    //savestate[1].collect = obj.collect.slice();
-
-    //telecookie.data.worldmap = savestate[1].explored.slice();
-    //telecookie.data.flags = savestate[1].flags.slice();
-    //telecookie.data.crewstats = savestate[1].crewstats.slice();
-    //telecookie.data.collect = savestate[1].collect.slice();
-
-    //telecookie.data.finalmode = map.finalmode;
-    //telecookie.data.finalstretch = map.finalstretch;
 
     std::string mapExplored;
     for(size_t i = 0; i < map.explored.size(); i++ )
@@ -5979,11 +5874,7 @@ void Game::savequick()
     msg->LinkEndChild( new TiXmlText( collect.c_str() ));
     msgs->LinkEndChild( msg );
 
-    //telecookie.data.finalx = map.finalx;
-    //telecookie.data.finaly = map.finaly;
     //Position
-    //telecookie.data.savex = savex;
-    //telecookie.data.savey = savey;
 
     msg = new TiXmlElement( "finalx" );
     msg->LinkEndChild( new TiXmlText( help.String(map.finalx).c_str() ));
@@ -6009,13 +5900,6 @@ void Game::savequick()
     msg->LinkEndChild( new TiXmlText( help.String(savery).c_str() ));
     msgs->LinkEndChild( msg );
 
-    //telecookie.data.saverx = saverx;
-    //telecookie.data.savery = savery;
-    //telecookie.data.savegc = savegc;
-    //telecookie.data.savedir = savedir;
-    //telecookie.data.savepoint = savepoint;
-    //telecookie.data.trinkets = trinkets;
-
     msg = new TiXmlElement( "savegc" );
     msg->LinkEndChild( new TiXmlText( help.String(savegc).c_str() ));
     msgs->LinkEndChild( msg );
@@ -6033,19 +5917,8 @@ void Game::savequick()
     msgs->LinkEndChild( msg );
 
 
-    //if (music.nicechange != -1) {
-    //telecookie.data.currentsong = music.nicechange;
-    //}else{
-    //telecookie.data.currentsong = music.currentsong;
-    //}
-    //telecookie.data.teleportscript = teleportscript;
-
     //Special stats
-    //telecookie.data.companion = companion;
-    //telecookie.data.lastsaved = lastsaved;
-    //telecookie.data.supercrewmate = supercrewmate;
-    //telecookie.data.scmprogress = scmprogress;
-    //telecookie.data.scmmoveme = scmmoveme;
+
     if(music.nicefade==1)
     {
         msg = new TiXmlElement( "currentsong" );
@@ -6081,27 +5954,12 @@ void Game::savequick()
     msgs->LinkEndChild( msg );
 
 
-    //telecookie.data.finalmode = map.finalmode;
-    //telecookie.data.finalstretch = map.finalstretch;
-
     msg = new TiXmlElement( "finalmode" );
     msg->LinkEndChild( new TiXmlText( BoolToString(map.finalmode) ));
     msgs->LinkEndChild( msg );
     msg = new TiXmlElement( "finalstretch" );
     msg->LinkEndChild( new TiXmlText( BoolToString(map.finalstretch) ));
     msgs->LinkEndChild( msg );
-
-    //telecookie.data.frames = frames; telecookie.data.seconds = seconds;
-    //telecookie.data.minutes = minutes; telecookie.data.hours = hours;
-
-    //telecookie.data.deathcounts = deathcounts;
-    //telecookie.data.totalflips = totalflips;
-    //telecookie.data.hardestroom = hardestroom; telecookie.data.hardestroomdeaths = hardestroomdeaths;
-
-    //savearea = map.currentarea(map.area(roomx, roomy))
-    //telecookie.data.summary = savearea + ", " + timestring(help);
-    //telesummary = telecookie.data.summary;
-
 
     msg = new TiXmlElement( "frames" );
     msg->LinkEndChild( new TiXmlText( help.String(frames).c_str() ));
@@ -6137,8 +5995,6 @@ void Game::savequick()
     msgs->LinkEndChild( msg );
 
     quicksummary = summary;
-    //telecookie.flush();
-    //telecookie.close();
 
     if(FILESYSTEM_saveTiXmlDocument("saves/qsave.vvv", &doc))
     {
@@ -6171,18 +6027,6 @@ void Game::customsavequick(std::string savfile)
 
 
     //Flags, map and stats
-    //savestate[1].explored = map.explored.slice();
-    //savestate[1].flags = obj.flags.slice();
-    //savestate[1].crewstats = crewstats.slice();
-    //savestate[1].collect = obj.collect.slice();
-
-    //telecookie.data.worldmap = savestate[1].explored.slice();
-    //telecookie.data.flags = savestate[1].flags.slice();
-    //telecookie.data.crewstats = savestate[1].crewstats.slice();
-    //telecookie.data.collect = savestate[1].collect.slice();
-
-    //telecookie.data.finalmode = map.finalmode;
-    //telecookie.data.finalstretch = map.finalstretch;
 
     std::string mapExplored;
     for(size_t i = 0; i < map.explored.size(); i++ )
@@ -6238,11 +6082,7 @@ void Game::customsavequick(std::string savfile)
     msg->LinkEndChild( new TiXmlText( customcollect.c_str() ));
     msgs->LinkEndChild( msg );
 
-    //telecookie.data.finalx = map.finalx;
-    //telecookie.data.finaly = map.finaly;
     //Position
-    //telecookie.data.savex = savex;
-    //telecookie.data.savey = savey;
 
     msg = new TiXmlElement( "finalx" );
     msg->LinkEndChild( new TiXmlText( help.String(map.finalx).c_str() ));
@@ -6268,13 +6108,6 @@ void Game::customsavequick(std::string savfile)
     msg->LinkEndChild( new TiXmlText( help.String(savery).c_str() ));
     msgs->LinkEndChild( msg );
 
-    //telecookie.data.saverx = saverx;
-    //telecookie.data.savery = savery;
-    //telecookie.data.savegc = savegc;
-    //telecookie.data.savedir = savedir;
-    //telecookie.data.savepoint = savepoint;
-    //telecookie.data.trinkets = trinkets;
-
     msg = new TiXmlElement( "savegc" );
     msg->LinkEndChild( new TiXmlText( help.String(savegc).c_str() ));
     msgs->LinkEndChild( msg );
@@ -6296,19 +6129,8 @@ void Game::customsavequick(std::string savfile)
     msgs->LinkEndChild( msg );
 
 
-    //if (music.nicechange != -1) {
-    //telecookie.data.currentsong = music.nicechange;
-    //}else{
-    //telecookie.data.currentsong = music.currentsong;
-    //}
-    //telecookie.data.teleportscript = teleportscript;
-
     //Special stats
-    //telecookie.data.companion = companion;
-    //telecookie.data.lastsaved = lastsaved;
-    //telecookie.data.supercrewmate = supercrewmate;
-    //telecookie.data.scmprogress = scmprogress;
-    //telecookie.data.scmmoveme = scmmoveme;
+
     if(music.nicefade==1)
     {
         msg = new TiXmlElement( "currentsong" );
@@ -6342,18 +6164,6 @@ void Game::customsavequick(std::string savfile)
     msg = new TiXmlElement( "scmmoveme" );
     msg->LinkEndChild( new TiXmlText( BoolToString(scmmoveme) ));
     msgs->LinkEndChild( msg );
-
-
-    //telecookie.data.frames = frames; telecookie.data.seconds = seconds;
-    //telecookie.data.minutes = minutes; telecookie.data.hours = hours;
-
-    //telecookie.data.deathcounts = deathcounts;
-    //telecookie.data.totalflips = totalflips;
-    //telecookie.data.hardestroom = hardestroom; telecookie.data.hardestroomdeaths = hardestroomdeaths;
-
-    //savearea = map.currentarea(map.area(roomx, roomy))
-    //telecookie.data.summary = savearea + ", " + timestring(help);
-    //telesummary = telecookie.data.summary;
 
 
     msg = new TiXmlElement( "frames" );
@@ -6394,8 +6204,6 @@ void Game::customsavequick(std::string savfile)
     msgs->LinkEndChild( msg );
 
     customquicksummary = summary;
-    //telecookie.flush();
-    //telecookie.close();
 
     std::string levelfile = savfile.substr(7);
     if(FILESYSTEM_saveTiXmlDocument(("saves/"+levelfile+".vvv").c_str(), &doc))

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -296,13 +296,11 @@ void Game::init(void)
     TiXmlDocument doc;
     if (!FILESYSTEM_loadTiXmlDocument("saves/qsave.vvv", &doc))
     {
-        quickcookieexists = false;
         quicksummary = "";
         printf("Quick Save Not Found\n");
     }
     else
     {
-        quickcookieexists = true;
         TiXmlHandle hDoc(&doc);
         TiXmlElement* pElem;
         TiXmlHandle hRoot(0);
@@ -5547,12 +5545,10 @@ void Game::loadsummary()
     TiXmlDocument doc;
     if (!FILESYSTEM_loadTiXmlDocument("saves/qsave.vvv", &doc))
     {
-        quickcookieexists = false;
         quicksummary = "";
     }
     else
     {
-        quickcookieexists = true;
         TiXmlHandle hDoc(&doc);
         TiXmlElement* pElem;
         TiXmlHandle hRoot(0);
@@ -5907,8 +5903,6 @@ void Game::savetele()
 
 void Game::savequick()
 {
-    quickcookieexists = true;
-
     if (map.custommode)
     {
         //Don't trash save data!
@@ -6156,8 +6150,6 @@ void Game::savequick()
 
 void Game::customsavequick(std::string savfile)
 {
-    quickcookieexists = true;
-
     TiXmlDocument doc;
     TiXmlElement* msg;
     TiXmlDeclaration* decl = new TiXmlDeclaration( "1.0", "", "" );
@@ -7744,7 +7736,6 @@ void Game::deletequick()
         printf("Error deleting file\n");
 
     quicksummary = "";
-    quickcookieexists = false;
 }
 
 void Game::deletetele()

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -148,11 +148,6 @@ void Game::init(void)
     press_left = 0;
 
 
-    recording = 0;
-    recordinit = false;
-    playbackfinished = false;
-    recordstring = "";
-
     advancetext = false;
     pausescript = false;
     completestop = false;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -234,7 +234,6 @@ public:
     std::vector<int>bestlives;
     std::vector<int> bestrank;
 
-    bool telecookieexists;
     bool quickcookieexists;
 
     std::string tele_gametime;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -243,8 +243,7 @@ public:
 
     int mx, my;
     int screenshake, flashlight;
-    bool test;
-    std::string teststring, tempstring;
+    std::string tempstring;
     bool advancetext, pausescript;
 
     int deathseq, lifeseq;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -234,8 +234,6 @@ public:
     std::vector<int>bestlives;
     std::vector<int> bestrank;
 
-    bool quickcookieexists;
-
     std::string tele_gametime;
     int tele_trinkets;
     std::string tele_currentarea;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -284,22 +284,6 @@ public:
     int stretchMode;
     int controllerSensitivity;
 
-    //Screenrecording stuff, for beta/trailer
-    int recording;
-    std::string recordstring;
-    bool combomode;
-    int combolen;
-    std::string comboaction;
-    std::string currentaction;
-    bool recordinit;
-
-    std::vector<int> playback;
-    int playbackpos;
-    int playbacksize;
-    int playmove;
-    int playcombo;
-    bool playbackfinished;
-
     bool menukludge;
     bool quickrestartkludge;
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -243,7 +243,6 @@ public:
 
     int mx, my;
     int screenshake, flashlight;
-    std::string tempstring;
     bool advancetext, pausescript;
 
     int deathseq, lifeseq;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -9,11 +9,6 @@
 #include "GraphicsUtil.h"
 
 
-class entityclass;
-class mapclass;
-class Graphics;
-class musicclass;
-
 class Game
 {
 public:
@@ -37,52 +32,52 @@ public:
 
     void resetgameclock();
 
-    void customsavequick(std::string savfile, mapclass& map, entityclass& obj, musicclass& music);
-    void savequick(mapclass& map, entityclass& obj, musicclass& music);
+    void customsavequick(std::string savfile);
+    void savequick();
 
     void gameclock();
 
-    std::string giventimestring(int hrs, int min, int sec, UtilityClass& help );
+    std::string giventimestring(int hrs, int min, int sec);
 
-    std::string  timestring(UtilityClass& help);
+    std::string  timestring();
 
-    std::string partimestring(UtilityClass& help);
+    std::string partimestring();
 
-    std::string resulttimestring(UtilityClass& help);
+    std::string resulttimestring();
 
-    std::string timetstring(int t, UtilityClass& help);
+    std::string timetstring(int t);
 
     void  createmenu(std::string t);
 
-    void lifesequence(entityclass& obj);
+    void lifesequence();
 
-    void gethardestroom(mapclass& map);
+    void gethardestroom();
 
-    void updatestate(Graphics& dwgfx, mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music);
+    void updatestate();
 
-    void unlocknum(int t, mapclass& map, Graphics& dwgfx);
+    void unlocknum(int t);
 
-    void loadstats(mapclass& map, Graphics& dwgfx);
+    void loadstats();
 
-    void  savestats(mapclass& map, Graphics& dwgfx);
+    void  savestats();
 
-    void deletestats(mapclass& map, Graphics& dwgfx);
+    void deletestats();
 
     void deletequick();
 
-    void savetele(mapclass& map, entityclass& obj, musicclass& music);
+    void savetele();
 
-    void loadtele(mapclass& map, entityclass& obj, musicclass& music);
+    void loadtele();
 
     void deletetele();
 
-    void customstart(entityclass& obj, musicclass& music );
+    void customstart();
 
-    void start(entityclass& obj, musicclass& music );
+    void start();
 
-    void startspecial(int t, entityclass& obj, musicclass& music);
+    void startspecial(int t);
 
-    void starttrial(int t, entityclass& obj, musicclass& music);
+    void starttrial(int t);
 
     void telegotoship()
     {
@@ -104,14 +99,14 @@ public:
 
     void swnpenalty();
 
-    void deathsequence(mapclass& map, entityclass& obj, musicclass& music);
+    void deathsequence();
 
-    void customloadquick(std::string savfile, mapclass& map, entityclass& obj, musicclass& music);
-    void loadquick(mapclass& map, entityclass& obj, musicclass& music);
+    void customloadquick(std::string savfile);
+    void loadquick();
 
-    void loadsummary(mapclass& map, UtilityClass& help);
+    void loadsummary();
 
-    void initteleportermode(mapclass& map);
+    void initteleportermode();
 
 	std::string saveFilePath;
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -79,24 +79,6 @@ public:
 
     void starttrial(int t);
 
-    void telegotoship()
-    {
-        //Special function to move the telesave to the ship teleporter.
-        //telecookie.data.savex = 13*8;
-        //telecookie.data.savey = 129;
-        //telecookie.data.saverx = 102;
-        //telecookie.data.savery = 111;
-        //telecookie.data.savegc = 0;
-        //telecookie.data.savedir = 1;
-        //telecookie.data.savepoint = 0;
-
-        //telecookie.data.currentsong = 4;
-        //telecookie.data.companion = 0;
-
-        //telecookie.data.finalmode = false;
-        //telecookie.data.finalstretch = false;
-    }
-
     void swnpenalty();
 
     void deathsequence();

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -90,7 +90,7 @@ public:
 
     void initteleportermode();
 
-	std::string saveFilePath;
+    std::string saveFilePath;
 
 
     int door_left;
@@ -111,9 +111,9 @@ public:
     //State logic stuff
     int state, statedelay;
 
-		bool glitchrunkludge;
+    bool glitchrunkludge;
 
-		int usingmmmmmm;
+    int usingmmmmmm;
 
     int gamestate;
     bool hascontrol, jumpheld;
@@ -123,10 +123,10 @@ public:
     bool infocus;
     bool muted;
     int mutebutton;
-	private:
+private:
     float m_globalVol;
 
-	public:
+public:
 
     int tapleft, tapright;
 
@@ -136,7 +136,7 @@ public:
     //public var crewstats:Array = new Array();
     int lastsaved;
     int deathcounts;
-	int timerStartTime;
+    int timerStartTime;
 
     int frames, seconds, minutes, hours;
     bool gamesaved;
@@ -282,9 +282,9 @@ public:
 
     bool advanced_mode;
     bool fullScreenEffect_badSignal;
-	bool useLinearFilter;
-	int stretchMode;
-	int controllerSensitivity;
+    bool useLinearFilter;
+    int stretchMode;
+    int controllerSensitivity;
 
     //Screenrecording stuff, for beta/trailer
     int recording;
@@ -327,9 +327,9 @@ public:
     bool customlevelstatsloaded;
 
 
-	std::vector<SDL_GameControllerButton> controllerButton_map;
-	std::vector<SDL_GameControllerButton> controllerButton_flip;
-	std::vector<SDL_GameControllerButton> controllerButton_esc;
+    std::vector<SDL_GameControllerButton> controllerButton_map;
+    std::vector<SDL_GameControllerButton> controllerButton_flip;
+    std::vector<SDL_GameControllerButton> controllerButton_esc;
 
     bool skipfakeload;
 };

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -170,9 +170,6 @@ public:
     int creditposx, creditposy, creditposdelay;
 
 
-    //60 fps mode!
-    bool sfpsmode;
-
     //Sine Wave Ninja Minigame
     bool swnmode;
     int swngame, swnstate, swnstate2, swnstate3, swnstate4, swndelay, swndeaths;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1144,14 +1144,14 @@ void Graphics::drawmenu( int cr, int cg, int cb, int division /*= 30*/ )
             //Draw it highlighted
             if (game.menuoptionsactive[i])
             {
-                tempstring = game.menuoptions[i];
+                std::string tempstring = game.menuoptions[i];
                 std::transform(tempstring.begin(), tempstring.end(),tempstring.begin(), ::toupper);
                 tempstring = std::string("[ ") + tempstring + std::string(" ]");
                 Print(110 + (i * division) - 16 +game.menuxoff, 140 + (i * 12) +game.menuyoff, tempstring, cr, cg, cb);
             }
             else
             {
-                tempstring = game.menuoptions[i];
+                std::string tempstring = game.menuoptions[i];
                 tempstring = "[ " + tempstring + " ]";
                 //Draw it in gray
                 Print(110 + (i * division) - 16 +game.menuxoff, 140 + (i * 12)+game.menuyoff, tempstring, 128, 128, 128);
@@ -1183,14 +1183,14 @@ void Graphics::drawlevelmenu( int cr, int cg, int cb, int division /*= 30*/ )
             //Draw it highlighted
             if (game.menuoptionsactive[i])
             {
-                tempstring = game.menuoptions[i];
+                std::string tempstring = game.menuoptions[i];
                 std::transform(tempstring.begin(), tempstring.end(),tempstring.begin(), ::toupper);
                 tempstring = std::string("[ ") + tempstring + std::string(" ]");
                 Print(110 + (i * division) - 16 +game.menuxoff, 140+8 + (i * 12) +game.menuyoff, tempstring, cr, cg, cb);
             }
             else
             {
-                tempstring = game.menuoptions[i];
+                std::string tempstring = game.menuoptions[i];
                 tempstring = "[ " + tempstring + " ]";
                 //Draw it in gray
                 Print(110 + (i * division) - 16 +game.menuxoff, 140+8 + (i * 12)+game.menuyoff, tempstring, 128, 128, 128);
@@ -1199,14 +1199,14 @@ void Graphics::drawlevelmenu( int cr, int cg, int cb, int division /*= 30*/ )
             //Draw it highlighted
             if (game.menuoptionsactive[i])
             {
-                tempstring = game.menuoptions[i];
+                std::string tempstring = game.menuoptions[i];
                 std::transform(tempstring.begin(), tempstring.end(),tempstring.begin(), ::toupper);
                 tempstring = std::string("[ ") + tempstring + std::string(" ]");
                 Print(110 + (i * division) - 16 +game.menuxoff, 140 + (i * 12) +game.menuyoff, tempstring, cr, cg, cb);
             }
             else
             {
-                tempstring = game.menuoptions[i];
+                std::string tempstring = game.menuoptions[i];
                 tempstring = "[ " + tempstring + " ]";
                 //Draw it in gray
                 Print(110 + (i * division) - 16 +game.menuxoff, 140 + (i * 12)+game.menuyoff, tempstring, 128, 128, 128);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -556,7 +556,7 @@ void Graphics::drawsprite( int x, int y, int t, int r, int g,  int b )
     BlitSurfaceColoured(sprites[t], NULL, backBuffer, &rect, ct);
 }
 
-void Graphics::drawtile( int x, int y, int t, int r, int g,  int b )
+void Graphics::drawtile( int x, int y, int t )
 {
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
     BlitSurfaceStandard(tiles[t], NULL, backBuffer, &rect);
@@ -3196,13 +3196,6 @@ Uint32 Graphics::RGBf(int r, int g, int b)
 void Graphics::setcolreal(Uint32 t)
 {
 	ct.colour = t;
-}
-
-void Graphics::drawtile(int x, int y, int t)
-{
-	SDL_Rect drawRect;
-	setRect(drawRect,x,y, tiles_rect.w, tiles_rect.h  );
-	BlitSurfaceStandard(tiles[t] ,NULL, backBuffer,&drawRect);
 }
 
 void Graphics::drawforetile(int x, int y, int t)

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3031,7 +3031,6 @@ void Graphics::screenshake()
 		//	screenbuffer.draw(backbuffer, flipmatrix);
 		//	flipmatrix.translate(-tpoint.x, -tpoint.y);
 
-		screenbuffer->ClearScreen(0x000);
 		tpoint.x =  (fRandom() * 7) - 4;
 		tpoint.y =  (fRandom() * 7) - 4;
 		SDL_Rect shakeRect;
@@ -3046,7 +3045,6 @@ void Graphics::screenshake()
 		//SDL_Rect rect;
 		//setRect(rect, blackBars/2, 0, screenbuffer->w, screenbuffer->h);
 		//SDL_BlitSurface(backBuffer, NULL, screenbuffer, &rect);
-		screenbuffer->ClearScreen(0x000);
 		tpoint.x =  static_cast<Sint32>((fRandom() * 7) - 4);
 		tpoint.y =  static_cast<Sint32>((fRandom() * 7) - 4);
 		SDL_Rect shakeRect;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -563,7 +563,7 @@ void Graphics::drawtile( int x, int y, int t )
 }
 
 
-void Graphics::drawtile2( int x, int y, int t, int r, int g,  int b )
+void Graphics::drawtile2( int x, int y, int t )
 {
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
     BlitSurfaceStandard(tiles2[t], NULL, backBuffer, &rect);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -154,11 +154,11 @@ Graphics::~Graphics()
 
 }
 
-void Graphics::drawspritesetcol(int x, int y, int t, int c, UtilityClass& help)
+void Graphics::drawspritesetcol(int x, int y, int t, int c)
 {
     SDL_Rect rect;
     setRect(rect,x,y,sprites_rect.w,sprites_rect.h);
-    setcol(c, help);
+    setcol(c);
 
     BlitSurfaceColoured(sprites[t],NULL,backBuffer, &rect, ct);
     //.copyPixels(sprites[t], sprites_rect, backbuffer, tpoint);
@@ -596,7 +596,7 @@ void Graphics::drawtowertile3( int x, int y, int t, int off )
     BlitSurfaceStandard(tiles3[t+(off*30)], NULL, towerbuffer, &rect);
 }
 
-void Graphics::drawgui( UtilityClass& help )
+void Graphics::drawgui()
 {
     textboxcleanup();
     //Draw all the textboxes to the screen
@@ -843,7 +843,7 @@ void Graphics::cutscenebars()
     }
 }
 
-void Graphics::drawcrewman( int x, int y, int t, bool act, UtilityClass& help, bool noshift /*=false*/ )
+void Graphics::drawcrewman( int x, int y, int t, bool act, bool noshift /*=false*/ )
 {
     if (!act)
     {
@@ -851,22 +851,22 @@ void Graphics::drawcrewman( int x, int y, int t, bool act, UtilityClass& help, b
         {
             if (flipmode)
             {
-                drawspritesetcol(x, y, 14, 19, help);
+                drawspritesetcol(x, y, 14, 19);
             }
             else
             {
-                drawspritesetcol(x, y, 12, 19, help);
+                drawspritesetcol(x, y, 12, 19);
             }
         }
         else
         {
             if (flipmode)
             {
-                drawspritesetcol(x - 8, y, 14, 19, help);
+                drawspritesetcol(x - 8, y, 14, 19);
             }
             else
             {
-                drawspritesetcol(x - 8, y, 12, 19, help);
+                drawspritesetcol(x - 8, y, 12, 19);
             }
         }
     }
@@ -877,22 +877,22 @@ void Graphics::drawcrewman( int x, int y, int t, bool act, UtilityClass& help, b
         switch(t)
         {
         case 0:
-            drawspritesetcol(x, y, crewframe, 0 , help);
+            drawspritesetcol(x, y, crewframe, 0);
             break;
         case 1:
-            drawspritesetcol(x, y, crewframe, 20, help);
+            drawspritesetcol(x, y, crewframe, 20);
             break;
         case 2:
-            drawspritesetcol(x, y, crewframe, 14, help);
+            drawspritesetcol(x, y, crewframe, 14);
             break;
         case 3:
-            drawspritesetcol(x, y, crewframe, 15, help);
+            drawspritesetcol(x, y, crewframe, 15);
             break;
         case 4:
-            drawspritesetcol(x, y, crewframe, 13, help);
+            drawspritesetcol(x, y, crewframe, 13);
             break;
         case 5:
-            drawspritesetcol(x, y, crewframe, 16, help);
+            drawspritesetcol(x, y, crewframe, 16);
             break;
         }
 
@@ -1135,7 +1135,7 @@ void Graphics::processfade()
     }
 }
 
-void Graphics::drawmenu( Game& game, int cr, int cg, int cb, int division /*= 30*/ )
+void Graphics::drawmenu( int cr, int cg, int cb, int division /*= 30*/ )
 {
     for (int i = 0; i < game.nummenuoptions; i++)
     {
@@ -1173,7 +1173,7 @@ void Graphics::drawmenu( Game& game, int cr, int cg, int cb, int division /*= 30
     }
 }
 
-void Graphics::drawlevelmenu( Game& game, int cr, int cg, int cb, int division /*= 30*/ )
+void Graphics::drawlevelmenu( int cr, int cg, int cb, int division /*= 30*/ )
 {
     for (int i = 0; i < game.nummenuoptions; i++)
     {
@@ -1299,7 +1299,7 @@ bool Graphics::Hitest(SDL_Surface* surface1, point p1, int col, SDL_Surface* sur
 
 }
 
-void Graphics::drawgravityline( int t, entityclass& obj )
+void Graphics::drawgravityline( int t )
 {
     if (obj.entities[t].life == 0)
     {
@@ -1343,7 +1343,7 @@ void Graphics::drawgravityline( int t, entityclass& obj )
     }
 }
 
-void Graphics::drawtrophytext( entityclass& obj, UtilityClass& help )
+void Graphics::drawtrophytext()
 {
     int temp, temp2, temp3;
 
@@ -1430,7 +1430,7 @@ void Graphics::drawtrophytext( entityclass& obj, UtilityClass& help )
     }
 }
 
-void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help )
+void Graphics::drawentities()
 {
     //Update line colours!
     if (linedelay <= 0)
@@ -1462,7 +1462,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
                     //
-                    setcol(obj.entities[i].colour, help);
+                    setcol(obj.entities[i].colour);
                     //flipsprites[obj.entities[i].drawframe].colorTransform(sprites_rect, ct);
                     drawRect = sprites_rect;
                     drawRect.x += tpoint.x;
@@ -1514,7 +1514,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
                     //
-                    setcol(obj.entities[i].colour, help);
+                    setcol(obj.entities[i].colour);
                     //sprites[obj.entities[i].drawframe].colorTransform(sprites_rect, ct);
 
                     drawRect = sprites_rect;
@@ -1624,7 +1624,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                 line_rect.y = obj.entities[i].yp;
                 line_rect.w = obj.entities[i].w;
                 line_rect.h = 1;
-                drawgravityline(i, obj);
+                drawgravityline(i);
             }
             else if (obj.entities[i].size == 6)    //Vertical Line
             {
@@ -1632,11 +1632,11 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                 line_rect.y = obj.entities[i].yp;
                 line_rect.w = 1;
                 line_rect.h = obj.entities[i].h;
-                drawgravityline(i, obj);
+                drawgravityline(i);
             }
             else if (obj.entities[i].size == 7)    //Teleporter
             {
-                drawtele(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].drawframe, obj.entities[i].colour, help);
+                drawtele(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].drawframe, obj.entities[i].colour);
             }
             else if (obj.entities[i].size == 8)    // Special: Moving platform, 8 tiles
             {
@@ -1685,7 +1685,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
             {
                 if (flipmode)
                 {
-                    setcol(obj.entities[i].colour, help);
+                    setcol(obj.entities[i].colour);
 
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
@@ -1721,7 +1721,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                 }
                 else
                 {
-                    setcol(obj.entities[i].colour, help);
+                    setcol(obj.entities[i].colour);
 
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
@@ -1760,7 +1760,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
             {
                 if (flipmode)
                 {
-                    setcol(obj.entities[i].colour, help);
+                    setcol(obj.entities[i].colour);
 
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
@@ -1780,7 +1780,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                 }
                 else
                 {
-                    setcol(obj.entities[i].colour, help);
+                    setcol(obj.entities[i].colour);
 
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
@@ -1802,7 +1802,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
             else if (obj.entities[i].size == 11)    //The fucking elephant
             {
 				//TODO elephant bug
-                setcol(obj.entities[i].colour, help);
+                setcol(obj.entities[i].colour);
                 drawimagecol(3, obj.entities[i].xp, obj.entities[i].yp);
             }
             else if (obj.entities[i].size == 12)         // Regular sprites that don't wrap
@@ -1812,7 +1812,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                     //forget this for a minute;
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
-                    setcol(obj.entities[i].colour, help);
+                    setcol(obj.entities[i].colour);
                     //
 
                     drawRect = sprites_rect;
@@ -1833,7 +1833,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                         }
 
                         tpoint.y = tpoint.y+4;
-                        setcol(23, help);
+                        setcol(23);
 
                         drawRect = tiles_rect;
                         drawRect.x += tpoint.x;
@@ -1853,7 +1853,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                         }
 
                         tpoint.y = tpoint.y+4;
-                        setcol(23, help);
+                        setcol(23);
                         //
 
                         drawRect = tiles_rect;
@@ -1866,7 +1866,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                 {
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
-                    setcol(obj.entities[i].colour, help);
+                    setcol(obj.entities[i].colour);
                     //
                     drawRect = sprites_rect;
                     drawRect.x += tpoint.x;
@@ -1888,7 +1888,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                         }
 
                         tpoint.y = tpoint.y+4;
-                        setcol(23, help);
+                        setcol(23);
 
 
                         drawRect = tiles_rect;
@@ -1909,7 +1909,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
                         }
 
                         tpoint.y = tpoint.y+4;
-                        setcol(23, help);
+                        setcol(23);
                         //
 
                         drawRect = tiles_rect;
@@ -1932,7 +1932,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
 						FillRect(tempBuffer, 0x000000);
 
                 		tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
-                		setcol(obj.entities[i].colour, help);
+                		setcol(obj.entities[i].colour);
                 		//flipsprites[obj.entities[i].drawframe].colorTransform(sprites_rect, ct);
                 		//bigbuffer.copyPixels(flipsprites[obj.entities[i].drawframe], sprites_rect, new Point(0, 0));
 						SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), sprites_rect.x, sprites_rect.y   };
@@ -1945,7 +1945,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
 					{
 						//TODO checkthis
 						tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
-						setcol(obj.entities[i].colour, help);
+						setcol(obj.entities[i].colour);
 						//flipsprites[obj.entities[i].drawframe].colorTransform(sprites_rect, ct);
 						//bigbuffer.copyPixels(flipsprites[obj.entities[i].drawframe], sprites_rect, new Point(0, 0));
 						SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
@@ -1961,7 +1961,7 @@ void Graphics::drawentities( mapclass& map, entityclass& obj, UtilityClass& help
     }
 }
 
-void Graphics::drawbackground( int t, mapclass& map )
+void Graphics::drawbackground( int t )
 {
     int temp = 0;
 
@@ -2366,7 +2366,7 @@ void Graphics::drawbackground( int t, mapclass& map )
     }
 }
 
-void Graphics::drawmap( mapclass& map )
+void Graphics::drawmap()
 {
     ///TODO forground once;
     if (!foregrounddrawn)
@@ -2409,7 +2409,7 @@ void Graphics::drawmap( mapclass& map )
 
 }
 
-void Graphics::drawfinalmap(mapclass & map)
+void Graphics::drawfinalmap()
 {
 	//Update colour cycling for final level
 	if (map.final_colormode) {
@@ -2449,7 +2449,7 @@ void Graphics::drawfinalmap(mapclass & map)
 	OverlaySurfaceKeyed(foregroundBuffer, backBuffer, 0x00000000);
 }
 
-void Graphics::drawtowermap( mapclass& map )
+void Graphics::drawtowermap()
 {
     int temp;
     for (int j = 0; j < 30; j++)
@@ -2462,7 +2462,7 @@ void Graphics::drawtowermap( mapclass& map )
     }
 }
 
-void Graphics::drawtowermap_nobackground( mapclass& map )
+void Graphics::drawtowermap_nobackground()
 {
     int temp;
     for (j = 0; j < 30; j++)
@@ -2475,7 +2475,7 @@ void Graphics::drawtowermap_nobackground( mapclass& map )
     }
 }
 
-void Graphics::drawtowerentities( mapclass& map, entityclass& obj, UtilityClass& help )
+void Graphics::drawtowerentities()
 {
     //Update line colours!
     if (linedelay <= 0)
@@ -2500,7 +2500,7 @@ void Graphics::drawtowerentities( mapclass& map, entityclass& obj, UtilityClass&
 				trinketcolset = false;
                 tpoint.x = obj.entities[i].xp;
                 tpoint.y = obj.entities[i].yp-map.ypos;
-                setcol(obj.entities[i].colour, help);
+                setcol(obj.entities[i].colour);
                 setRect(trect, tpoint.x, tpoint.y, sprites_rect.w, sprites_rect.h);
                 BlitSurfaceColoured(sprites[obj.entities[i].drawframe], NULL, backBuffer, &trect, ct);
                 //screenwrapping!
@@ -2573,7 +2573,7 @@ void Graphics::drawtowerentities( mapclass& map, entityclass& obj, UtilityClass&
                 line_rect.y = obj.entities[i].yp-map.ypos;
                 line_rect.w = obj.entities[i].w;
                 line_rect.h = 1;
-                drawgravityline(i, obj);
+                drawgravityline(i);
             }
             else if (obj.entities[i].size == 6)    //Vertical Line
             {
@@ -2581,13 +2581,13 @@ void Graphics::drawtowerentities( mapclass& map, entityclass& obj, UtilityClass&
                 line_rect.y = obj.entities[i].yp-map.ypos;
                 line_rect.w = 1;
                 line_rect.h = obj.entities[i].h;
-                drawgravityline(i, obj);
+                drawgravityline(i);
             }
         }
     }
 }
 
-void Graphics::drawtowerspikes( mapclass& map )
+void Graphics::drawtowerspikes()
 {
     for (int i = 0; i < 40; i++)
     {
@@ -2596,7 +2596,7 @@ void Graphics::drawtowerspikes( mapclass& map )
     }
 }
 
-void Graphics::drawtowerbackgroundsolo( mapclass& map )
+void Graphics::drawtowerbackgroundsolo()
 {
     if (map.bypos < 0)
     {
@@ -2633,7 +2633,7 @@ void Graphics::drawtowerbackgroundsolo( mapclass& map )
     }
 }
 
-void Graphics::drawtowerbackground( mapclass& map )
+void Graphics::drawtowerbackground()
 {
     //TODO
     int temp;
@@ -2676,7 +2676,7 @@ void Graphics::drawtowerbackground( mapclass& map )
     }
 }
 
-void Graphics::setcol( int t, UtilityClass& help )
+void Graphics::setcol( int t )
 {
 	int temp;
 
@@ -3145,7 +3145,7 @@ void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool
 	}
 }
 
-void Graphics::drawtele(int x, int y, int t, int c, UtilityClass& help)
+void Graphics::drawtele(int x, int y, int t, int c)
 {
 	setcolreal(getRGB(16,16,16));
 
@@ -3153,7 +3153,7 @@ void Graphics::drawtele(int x, int y, int t, int c, UtilityClass& help)
 	setRect(telerect, x , y, tele_rect.w, tele_rect.h );
 	BlitSurfaceColoured(tele[0], NULL, backBuffer, &telerect, ct);
 
-	setcol(c, help);
+	setcol(c);
 	if (t > 9) t = 8;
 	if (t < 0) t = 0;
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -30,7 +30,7 @@ void Graphics::init()
 
     //ct = new ColorTransform(0, 0, 0, 1, 255, 255, 255, 1); //Set to white
 
-	linestate = 0;
+    linestate = 0;
 
 
     trinketcolset = false;
@@ -87,7 +87,7 @@ void Graphics::init()
 
     spcol = 0;
     spcoldel = 0;
-	rcol = 0;
+    rcol = 0;
 
     crewframe = 0;
     crewframedelay = 4;
@@ -313,10 +313,10 @@ void Graphics::bigprint(  int _x, int _y, std::string _s, int r, int g, int b, b
 
     ct.colour = getRGB(r, g, b);
 
-	if (cen)
-	{
-		_x = std::max(160 - (int((len(_s)/ 2.0)*sc)), 0 );
-	}
+    if (cen)
+    {
+        _x = std::max(160 - (int((len(_s)/ 2.0)*sc)), 0 );
+    }
 
     int bfontpos = 0;
     int curr;
@@ -336,17 +336,17 @@ void Graphics::bigprint(  int _x, int _y, std::string _s, int r, int g, int b, b
 
         if (flipmode)
         {
-			SDL_Surface* tempPrint = ScaleSurfaceSlow(flipbfont[font_idx(curr)], bfont[font_idx(curr)]->w *sc,bfont[font_idx(curr)]->h *sc);
-			SDL_Rect printrect = { Sint16((_x) + bfontpos), Sint16(_y) , Sint16(bfont_rect.w*sc), Sint16(bfont_rect.h * sc)};
-			BlitSurfaceColoured(tempPrint, NULL, backBuffer, &printrect, ct);
-			SDL_FreeSurface(tempPrint);
+            SDL_Surface* tempPrint = ScaleSurfaceSlow(flipbfont[font_idx(curr)], bfont[font_idx(curr)]->w *sc,bfont[font_idx(curr)]->h *sc);
+            SDL_Rect printrect = { Sint16((_x) + bfontpos), Sint16(_y) , Sint16(bfont_rect.w*sc), Sint16(bfont_rect.h * sc)};
+            BlitSurfaceColoured(tempPrint, NULL, backBuffer, &printrect, ct);
+            SDL_FreeSurface(tempPrint);
         }
         else
         {
-			SDL_Surface* tempPrint = ScaleSurfaceSlow(bfont[font_idx(curr)], bfont[font_idx(curr)]->w *sc,bfont[font_idx(curr)]->h *sc);
-			SDL_Rect printrect = { static_cast<Sint16>((_x) + bfontpos), static_cast<Sint16>(_y) , static_cast<Sint16>((bfont_rect.w*sc)+1), static_cast<Sint16>((bfont_rect.h * sc)+1)};
-			BlitSurfaceColoured(tempPrint, NULL, backBuffer, &printrect, ct);
-			SDL_FreeSurface(tempPrint);
+            SDL_Surface* tempPrint = ScaleSurfaceSlow(bfont[font_idx(curr)], bfont[font_idx(curr)]->w *sc,bfont[font_idx(curr)]->h *sc);
+            SDL_Rect printrect = { static_cast<Sint16>((_x) + bfontpos), static_cast<Sint16>(_y) , static_cast<Sint16>((bfont_rect.w*sc)+1), static_cast<Sint16>((bfont_rect.h * sc)+1)};
+            BlitSurfaceColoured(tempPrint, NULL, backBuffer, &printrect, ct);
+            SDL_FreeSurface(tempPrint);
         }
         bfontpos+=bfontlen(curr) *sc;
     }
@@ -744,10 +744,10 @@ void Graphics::drawgui()
 void Graphics::drawimagecol( int t, int xp, int yp, int r = 0, int g = 0, int b = 0, bool cent/*= false*/ )
 {
     SDL_Rect trect;
-	if(r+g+b != 0)
-	{
-		RGBf(r,g,b);
-	}
+    if(r+g+b != 0)
+    {
+        RGBf(r,g,b);
+    }
 
     point tpoint;
     if (cent)
@@ -832,8 +832,8 @@ void Graphics::cutscenebars()
         //disappearing
         if (cutscenebarspos > 0)
         {
-			cutscenebarspos -= 25;
-			cutscenebarspos = std::max(cutscenebarspos, 0);
+            cutscenebarspos -= 25;
+            cutscenebarspos = std::max(cutscenebarspos, 0);
             //draw
             FillRect(backBuffer, 0, 0, cutscenebarspos, 16, 0x000000);
             //backbuffer.fillRect(new Rectangle(0, 0, cutscenebarspos, 16), 0x000000);
@@ -1448,7 +1448,7 @@ void Graphics::drawentities()
 
     SDL_Rect drawRect;
 
-	trinketcolset = false;
+    trinketcolset = false;
 
     for (int i = obj.nentity - 1; i >= 0; i--)
     {
@@ -1640,7 +1640,7 @@ void Graphics::drawentities()
             }
             else if (obj.entities[i].size == 8)    // Special: Moving platform, 8 tiles
             {
-				//TODO check this is correct game breaking moving paltform
+                //TODO check this is correct game breaking moving paltform
                 tpoint.x = obj.entities[i].xp;
                 tpoint.y = obj.entities[i].yp;
                 drawRect = sprites_rect;
@@ -1801,7 +1801,7 @@ void Graphics::drawentities()
             }
             else if (obj.entities[i].size == 11)    //The fucking elephant
             {
-				//TODO elephant bug
+                //TODO elephant bug
                 setcol(obj.entities[i].colour);
                 drawimagecol(3, obj.entities[i].xp, obj.entities[i].yp);
             }
@@ -1923,36 +1923,36 @@ void Graphics::drawentities()
             {
                  //Special for epilogue: huge hero!
 
-                	if (flipmode) {
+                if (flipmode) {
 
 
 
-                		//scaleMatrix.scale(6, 6);
-                		//bigbuffer.fillRect(bigbuffer.rect, 0x000000);
-						FillRect(tempBuffer, 0x000000);
+                    //scaleMatrix.scale(6, 6);
+                    //bigbuffer.fillRect(bigbuffer.rect, 0x000000);
+                    FillRect(tempBuffer, 0x000000);
 
-                		tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
-                		setcol(obj.entities[i].colour);
-                		//flipsprites[obj.entities[i].drawframe].colorTransform(sprites_rect, ct);
-                		//bigbuffer.copyPixels(flipsprites[obj.entities[i].drawframe], sprites_rect, new Point(0, 0));
-						SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), sprites_rect.x, sprites_rect.y   };
-						SDL_Surface* TempSurface = ScaleSurface( flipsprites[obj.entities[i].drawframe], 6* sprites_rect.w,6* sprites_rect.w );
-						BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
-						SDL_FreeSurface(TempSurface);
-                		//scaleMatrix.translate(-obj.entities[i].xp, -obj.entities[i].yp);
-                	}
-					else
-					{
-						//TODO checkthis
-						tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
-						setcol(obj.entities[i].colour);
-						//flipsprites[obj.entities[i].drawframe].colorTransform(sprites_rect, ct);
-						//bigbuffer.copyPixels(flipsprites[obj.entities[i].drawframe], sprites_rect, new Point(0, 0));
-						SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
-						SDL_Surface* TempSurface = ScaleSurface( flipsprites[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
-						BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
-						SDL_FreeSurface(TempSurface);
-                	}
+                    tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
+                    setcol(obj.entities[i].colour);
+                    //flipsprites[obj.entities[i].drawframe].colorTransform(sprites_rect, ct);
+                    //bigbuffer.copyPixels(flipsprites[obj.entities[i].drawframe], sprites_rect, new Point(0, 0));
+                    SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), sprites_rect.x, sprites_rect.y   };
+                    SDL_Surface* TempSurface = ScaleSurface( flipsprites[obj.entities[i].drawframe], 6* sprites_rect.w,6* sprites_rect.w );
+                    BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
+                    SDL_FreeSurface(TempSurface);
+                    //scaleMatrix.translate(-obj.entities[i].xp, -obj.entities[i].yp);
+                }
+                else
+                {
+                    //TODO checkthis
+                    tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
+                    setcol(obj.entities[i].colour);
+                    //flipsprites[obj.entities[i].drawframe].colorTransform(sprites_rect, ct);
+                    //bigbuffer.copyPixels(flipsprites[obj.entities[i].drawframe], sprites_rect, new Point(0, 0));
+                    SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
+                    SDL_Surface* TempSurface = ScaleSurface( flipsprites[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
+                    BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
+                    SDL_FreeSurface(TempSurface);
+                }
 
 
 
@@ -2214,7 +2214,7 @@ void Graphics::drawbackground( int t )
         {
             //TODO scroll?!
             //towerbuffer.scroll(0, -3);
-			ScrollSurface(towerbuffer,0,-3);
+            ScrollSurface(towerbuffer,0,-3);
             for (int i = 0; i < 21; i++)
             {
                 temp = 760 + (rcol * 3);
@@ -2278,9 +2278,9 @@ void Graphics::drawbackground( int t )
             warpbcol = RGBflip(0x0A, 0x0A, 0x0A);
             warpfcol = RGBflip(0x12, 0x12, 0x12);
             break; //Gray
-		default:
-			warpbcol = RGBflip(0xFF, 0xFF, 0xFF);
-			warpfcol = RGBflip(0xFF, 0xFF, 0xFF);
+        default:
+            warpbcol = RGBflip(0xFF, 0xFF, 0xFF);
+            warpfcol = RGBflip(0xFF, 0xFF, 0xFF);
         }
 
         backoffset += 1;
@@ -2411,42 +2411,42 @@ void Graphics::drawmap()
 
 void Graphics::drawfinalmap()
 {
-	//Update colour cycling for final level
-	if (map.final_colormode) {
-		map.final_aniframedelay--;
-		if(map.final_aniframedelay==0)
-		{
-			foregrounddrawn=false;
-		}
-		if (map.final_aniframedelay <= 0) {
-			map.final_aniframedelay = 2;
-			map.final_aniframe++;
-			if (map.final_aniframe >= 4)
-				map.final_aniframe = 0;
-		}
-	}
+    //Update colour cycling for final level
+    if (map.final_colormode) {
+        map.final_aniframedelay--;
+        if(map.final_aniframedelay==0)
+        {
+            foregrounddrawn=false;
+        }
+        if (map.final_aniframedelay <= 0) {
+            map.final_aniframedelay = 2;
+            map.final_aniframe++;
+            if (map.final_aniframe >= 4)
+                map.final_aniframe = 0;
+        }
+    }
 
-	if (!foregrounddrawn) {
-		FillRect(foregroundBuffer, 0x00000000);
-		if(map.tileset==0){
-			for (int j = 0; j < 29+map.extrarow; j++) {
-				for (int i = 0; i < 40; i++) {
-					if((map.contents[i + map.vmult[j]])>0)
-						drawforetile(i * 8, j * 8, map.finalat(i,j));
-				}
-			}
-		}else if (map.tileset == 1) {
-			for (int j = 0; j < 29+map.extrarow; j++) {
-				for (int i = 0; i < 40; i++) {
-					if((map.contents[i + map.vmult[j]])>0)
-						drawforetile2(i * 8, j * 8, map.finalat(i,j));
-				}
-			}
-		}
-		foregrounddrawn=true;
-	}
+    if (!foregrounddrawn) {
+        FillRect(foregroundBuffer, 0x00000000);
+        if(map.tileset==0){
+            for (int j = 0; j < 29+map.extrarow; j++) {
+                for (int i = 0; i < 40; i++) {
+                    if((map.contents[i + map.vmult[j]])>0)
+                        drawforetile(i * 8, j * 8, map.finalat(i,j));
+                }
+            }
+        }else if (map.tileset == 1) {
+            for (int j = 0; j < 29+map.extrarow; j++) {
+                for (int i = 0; i < 40; i++) {
+                    if((map.contents[i + map.vmult[j]])>0)
+                        drawforetile2(i * 8, j * 8, map.finalat(i,j));
+                }
+            }
+        }
+        foregrounddrawn=true;
+    }
 
-	OverlaySurfaceKeyed(foregroundBuffer, backBuffer, 0x00000000);
+    OverlaySurfaceKeyed(foregroundBuffer, backBuffer, 0x00000000);
 }
 
 void Graphics::drawtowermap()
@@ -2497,7 +2497,7 @@ void Graphics::drawtowerentities()
         {
             if (obj.entities[i].size == 0)        // Sprites
             {
-				trinketcolset = false;
+                trinketcolset = false;
                 tpoint.x = obj.entities[i].xp;
                 tpoint.y = obj.entities[i].yp-map.ypos;
                 setcol(obj.entities[i].colour);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -25,10 +25,6 @@ void Graphics::init()
 
 
     //We initialise a few things
-    //updatebackground = true;
-
-
-    //ct = new ColorTransform(0, 0, 0, 1, 255, 255, 255, 1); //Set to white
 
     linestate = 0;
 
@@ -41,10 +37,6 @@ void Graphics::init()
 
     flipmode = false;
     setflipmode = false;
-    //flipmatrix.scale(1, -1);
-    //flipmatrix.translate(0, 240);
-    //flipfontmatrix.scale(1, -1);	flipfontmatrix.translate(0, 8);
-    //flipfontmatrix2.scale(1, -1);	flipfontmatrix2.translate(0, 9);
 
     //Background inits
     for (int i = 0; i < 50; i++)
@@ -77,7 +69,6 @@ void Graphics::init()
         backboxvy.push_back(bvy);
         backboxint.push_back(bint);
     }
-    //backboxrect = new Rectangle();
     backoffset = 0;
     backgrounddrawn = false;
 
@@ -161,7 +152,6 @@ void Graphics::drawspritesetcol(int x, int y, int t, int c)
     setcol(c);
 
     BlitSurfaceColoured(sprites[t],NULL,backBuffer, &rect, ct);
-    //.copyPixels(sprites[t], sprites_rect, backbuffer, tpoint);
 }
 
 void Graphics::Makebfont()
@@ -392,13 +382,10 @@ void Graphics::PrintOffAlpha( int _x, int _y, std::string _s, int r, int g, int 
 
         if (flipmode)
         {
-            //flipbfont[font_idx(cur)].colorTransform(bfont_rect, ct);
             BlitSurfaceColoured( flipbfont[font_idx(curr)], NULL, backBuffer, &fontRect , ct);
         }
         else
         {
-            //bfont[font_idx(cur)].colorTransform(bfont_rect, ct);
-            //backBuffer.copyPixels(bfont[font_idx(cur)], bfont_rect, tpoint);
             BlitSurfaceColoured( bfont[font_idx(curr)], NULL, backBuffer, &fontRect , ct);
         }
         bfontpos+=bfontlen(curr) ;
@@ -411,14 +398,11 @@ void Graphics::bprint( int x, int y, std::string t, int r, int g, int b, bool ce
 
 void Graphics::bprintalpha( int x, int y, std::string t, int r, int g, int b, int a, bool cen /*= false*/ )
 {
-
-    //printmask(x, y, t, cen);
     if (!notextoutline)
     {
         PrintAlpha(x, y - 1, t, 0, 0, 0, a, cen);
         if (cen)
         {
-            //TODO find different
             PrintOffAlpha(-1, y, t, 0, 0, 0, a, cen);
             PrintOffAlpha(1, y, t, 0, 0, 0, a, cen);
         }
@@ -457,13 +441,10 @@ void Graphics::RPrint( int _x, int _y, std::string _s, int r, int g, int b, bool
 
         if (flipmode)
         {
-            //flipbfont[font_idx(cur)].colorTransform(bfont_rect, ct);
             BlitSurfaceColoured( flipbfont[font_idx(curr)], NULL, backBuffer, &fontRect , ct);
         }
         else
         {
-            //bfont[font_idx(cur)].colorTransform(bfont_rect, ct);
-            //backBuffer.copyPixels(bfont[font_idx(cur)], bfont_rect, tpoint);
             BlitSurfaceColoured( bfont[font_idx(curr)], NULL, backBuffer, &fontRect , ct);
         }
         bfontpos+=bfontlen(curr) ;
@@ -552,7 +533,6 @@ void Graphics::drawsprite( int x, int y, int t, int r, int g,  int b )
 {
     SDL_Rect rect = { Sint16(x), Sint16(y), sprites_rect.w, sprites_rect.h };
     setcolreal(getRGB(r,g,b));
-    //sprites[t].colorTransform(sprites_rect, ct);
     BlitSurfaceColoured(sprites[t], NULL, backBuffer, &rect, ct);
 }
 
@@ -783,7 +763,6 @@ void Graphics::drawimage( int t, int xp, int yp, bool cent/*=false*/ )
         trect.w = images[t]->w;
         trect.h = images[t]->h;
         BlitSurfaceStandard(images[t], NULL, backBuffer, &trect);
-        //backbuffer.copyPixels(images[t], trect, tpoint);
     }
     else
     {
@@ -823,9 +802,7 @@ void Graphics::cutscenebars()
         cutscenebarspos += 25;
         cutscenebarspos = std::min(cutscenebarspos, 361);
         FillRect(backBuffer, 0, 0, cutscenebarspos, 16, 0x000000);
-        //backbuffer.fillRect(new Rectangle(0, 0, cutscenebarspos, 16), 0x000000);
         FillRect(backBuffer, 360-cutscenebarspos, 224, cutscenebarspos, 16, 0x000000);
-        //backbuffer.fillRect(new Rectangle(360-cutscenebarspos, 224, cutscenebarspos, 16), 0x000000);
     }
     else
     {
@@ -836,9 +813,7 @@ void Graphics::cutscenebars()
             cutscenebarspos = std::max(cutscenebarspos, 0);
             //draw
             FillRect(backBuffer, 0, 0, cutscenebarspos, 16, 0x000000);
-            //backbuffer.fillRect(new Rectangle(0, 0, cutscenebarspos, 16), 0x000000);
             FillRect(backBuffer, 360-cutscenebarspos, 224, cutscenebarspos, 16, 0x000000);
-            //backbuffer.fillRect(new Rectangle(360-cutscenebarspos, 224, cutscenebarspos, 16), 0x000000);
         }
     }
 }
@@ -905,7 +880,6 @@ void Graphics::drawpixeltextbox( int x, int y, int w, int h, int w2, int h2, int
     //given these parameters, draw a textbox with a pixel width
 
     //madrect.x = x; madrect.y = y; madrect.w = w; madrect.h = h;
-    //backbuffer.fillRect(madrect, RGB(r / 6, g / 6, b / 6));
     FillRect(backBuffer,x,y,w,h, r/6, g/6, b/6 );
 
     for (k = 0; k < w2-2; k++)
@@ -930,8 +904,6 @@ void Graphics::drawcustompixeltextbox( int x, int y, int w, int h, int w2, int h
 {
     //given these parameters, draw a textbox with a pixel width
 
-    //madrect.x = x; madrect.y = y; madrect.w = w; madrect.h = h;
-    //backbuffer.fillRect(madrect, RGB(r / 6, g / 6, b / 6));
     FillRect(backBuffer,x,y,w,h, r/6, g/6, b/6 );
 
     for (k = 0; k < w2-2; k++)
@@ -966,8 +938,6 @@ void Graphics::drawcustompixeltextbox( int x, int y, int w, int h, int w2, int h
 void Graphics::drawtextbox( int x, int y, int w, int h, int r, int g, int b )
 {
     //given these parameters, draw a textbox
-    //madrect.x = x; madrect.y = y; madrect.w = w*8; madrect.h = h*8;
-    //backbuffer.fillRect(madrect, RGB(r / 6, g / 6, b / 6));
     FillRect(backBuffer,x,y,w*8,h*8, r/6, g/6, b/6 );
 
     drawcoloredtile(x, y, 40, r, g, b);
@@ -1071,14 +1041,12 @@ void Graphics::drawfade()
     if ((fademode == 1)||(fademode == 4))
     {
         FillRect(backBuffer, 0, 0, backBuffer->w, backBuffer->h, 0x000000);
-        //backbuffer.fillRect(backbuffer.rect, 0x000000);
     }
     else if(fademode==3)
     {
         for (int i = 0; i < 15; i++)
         {
             FillRect(backBuffer, fadebars[i], i * 16, fadeamount, 16, 0x000000 );
-            //backbuffer.fillRect(new Rectangle(, , , 16), 0x000000);
         }
     }
     else if(fademode==5 )
@@ -1086,7 +1054,6 @@ void Graphics::drawfade()
         for (int i = 0; i < 15; i++)
         {
             FillRect(backBuffer, fadebars[i]-fadeamount, i * 16, 500, 16, 0x000000 );
-            //backbuffer.fillRect(new Rectangle(fadebars[i]-fadeamount, i * 16, 500, 16), 0x000000);
         }
     }
 
@@ -1461,14 +1428,11 @@ void Graphics::drawentities()
                 {
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
-                    //
                     setcol(obj.entities[i].colour);
-                    //flipsprites[obj.entities[i].drawframe].colorTransform(sprites_rect, ct);
                     drawRect = sprites_rect;
                     drawRect.x += tpoint.x;
                     drawRect.y += tpoint.y;
                     BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                    //backbuffer.copyPixels(flipsprites[obj.entities[i].drawframe], sprites_rect, tpoint);
                     if (map.warpx)
                     {
                         //screenwrapping!
@@ -1513,9 +1477,7 @@ void Graphics::drawentities()
                 {
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
-                    //
                     setcol(obj.entities[i].colour);
-                    //sprites[obj.entities[i].drawframe].colorTransform(sprites_rect, ct);
 
                     drawRect = sprites_rect;
                     drawRect.x += tpoint.x;
@@ -1605,12 +1567,10 @@ void Graphics::drawentities()
                 //A seperate index of colours, for simplicity
                 if(obj.entities[i].colour==1)
                 {
-                    //backbuffer.fillRect(prect, RGB(196 - (fRandom() * 64), 10, 10));
                     FillRect(backBuffer, prect, (fRandom() * 64), 10, 10);
                 }
                 else if (obj.entities[i].colour == 2)
                 {
-                    //backbuffer.fillRect(prect, RGB(160- help.glow/2 - (fRandom()*20), 200- help.glow/2, 220 - help.glow));
                     FillRect(backBuffer,prect, int(160- help.glow/2 - (fRandom()*20)),  200- help.glow/2, 220 - help.glow);
                 }
             }
@@ -1640,7 +1600,6 @@ void Graphics::drawentities()
             }
             else if (obj.entities[i].size == 8)    // Special: Moving platform, 8 tiles
             {
-                //TODO check this is correct game breaking moving paltform
                 tpoint.x = obj.entities[i].xp;
                 tpoint.y = obj.entities[i].yp;
                 drawRect = sprites_rect;
@@ -1801,7 +1760,6 @@ void Graphics::drawentities()
             }
             else if (obj.entities[i].size == 11)    //The fucking elephant
             {
-                //TODO elephant bug
                 setcol(obj.entities[i].colour);
                 drawimagecol(3, obj.entities[i].xp, obj.entities[i].yp);
             }
@@ -1813,7 +1771,6 @@ void Graphics::drawentities()
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
                     setcol(obj.entities[i].colour);
-                    //
 
                     drawRect = sprites_rect;
                     drawRect.x += tpoint.x;
@@ -1927,27 +1884,19 @@ void Graphics::drawentities()
 
 
 
-                    //scaleMatrix.scale(6, 6);
-                    //bigbuffer.fillRect(bigbuffer.rect, 0x000000);
                     FillRect(tempBuffer, 0x000000);
 
                     tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
                     setcol(obj.entities[i].colour);
-                    //flipsprites[obj.entities[i].drawframe].colorTransform(sprites_rect, ct);
-                    //bigbuffer.copyPixels(flipsprites[obj.entities[i].drawframe], sprites_rect, new Point(0, 0));
                     SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), sprites_rect.x, sprites_rect.y   };
                     SDL_Surface* TempSurface = ScaleSurface( flipsprites[obj.entities[i].drawframe], 6* sprites_rect.w,6* sprites_rect.w );
                     BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
                     SDL_FreeSurface(TempSurface);
-                    //scaleMatrix.translate(-obj.entities[i].xp, -obj.entities[i].yp);
                 }
                 else
                 {
-                    //TODO checkthis
                     tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
                     setcol(obj.entities[i].colour);
-                    //flipsprites[obj.entities[i].drawframe].colorTransform(sprites_rect, ct);
-                    //bigbuffer.copyPixels(flipsprites[obj.entities[i].drawframe], sprites_rect, new Point(0, 0));
                     SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
                     SDL_Surface* TempSurface = ScaleSurface( flipsprites[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
                     BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
@@ -1977,7 +1926,6 @@ void Graphics::drawbackground( int t )
             if (starsspeed[i] <= 6)
             {
                 FillRect(backBuffer,stars[i], getRGB(0x22,0x22,0x22));
-                //backbuffer.fillRect(stars[i], 0x222222);
             }
             else
             {
@@ -2171,8 +2119,6 @@ void Graphics::drawbackground( int t )
 
         if (backgrounddrawn)
         {
-            //TODO Scroll?
-            //towerbuffer.scroll( -3, 0);
             ScrollSurface(towerbuffer, -3, 0 );
             for (int j = 0; j < 15; j++)
             {
@@ -2201,9 +2147,6 @@ void Graphics::drawbackground( int t )
             }
             backgrounddrawn = true;
         }
-        //TODO this is why map breaks
-
-        //backbuffer.copyPixels(towerbuffer, towerbuffer.rect, tl);
         BlitSurfaceStandard(towerbuffer, NULL, backBuffer, NULL);
         break;
     case 4: //Warp zone (vertical)
@@ -2212,8 +2155,6 @@ void Graphics::drawbackground( int t )
 
         if (backgrounddrawn)
         {
-            //TODO scroll?!
-            //towerbuffer.scroll(0, -3);
             ScrollSurface(towerbuffer,0,-3);
             for (int i = 0; i < 21; i++)
             {
@@ -2358,8 +2299,6 @@ void Graphics::drawbackground( int t )
         break;
     default:
         FillRect(backBuffer, 0x000000 );
-        //TODO
-        //backbuffer.copyPixels(backgrounds[t], bg_rect, tl);
         BlitSurfaceStandard(backgrounds[t], NULL, backBuffer, &bg_rect);
 
         break;
@@ -2368,7 +2307,6 @@ void Graphics::drawbackground( int t )
 
 void Graphics::drawmap()
 {
-    ///TODO forground once;
     if (!foregrounddrawn)
     {
         FillRect(foregroundBuffer, 0x00000000);
@@ -2635,7 +2573,6 @@ void Graphics::drawtowerbackgroundsolo()
 
 void Graphics::drawtowerbackground()
 {
-    //TODO
     int temp;
 
     if (map.bypos < 0) map.bypos += 120 * 8;
@@ -2654,7 +2591,6 @@ void Graphics::drawtowerbackground()
             }
         }
 
-        //backbuffer.copyPixels(towerbuffer, towerbuffer.rect, tl, null, null, false);
         SDL_BlitSurface(towerbuffer,NULL, backBuffer,NULL);
 
         map.tdrawback = false;
@@ -2662,8 +2598,6 @@ void Graphics::drawtowerbackground()
     else
     {
         //just update the bottom
-        //TODO SCOLL
-        //towerbuffer.scroll(0, -map.bscroll);
         ScrollSurface(towerbuffer, 0, -map.bscroll);
         for (int i = 0; i < 40; i++)
         {
@@ -2671,7 +2605,6 @@ void Graphics::drawtowerbackground()
             drawtowertile3(i * 8, -(map.bypos % 8), temp, map.colstate);
         }
 
-        //backbuffer.copyPixels(towerbuffer, towerbuffer.rect, tl, null, null, false);
         SDL_BlitSurface(towerbuffer,NULL, backBuffer,NULL);
     }
 }
@@ -2875,15 +2808,10 @@ void Graphics::setcol( int t )
 		ct.colour = 0xFFFFFF;
 		break;
 	}
-	//ct.color = endian_swap(ct.color);
 }
 
 void Graphics::menuoffrender()
 {
-	//TODO
-	//screenbuffer.lock();
-	//screenbuffer.copyPixels(menubuffer, menubuffer.rect, tl, null, null, false);
-	//screenbuffer->UpdateScreen(menubuffer,NULL);
 	SDL_Rect offsetRect1;
 	setRect (offsetRect1, 0, 0, backBuffer->w ,backBuffer->h);
 
@@ -2913,20 +2841,15 @@ void Graphics::menuoffrender()
 		//put the stored backbuffer in the backbuffer.
 		BlitSurfaceStandard(tempBuffer, NULL, backBuffer, NULL);
 
-		//screenbuffer.copyPixels(backbuffer, backbuffer.rect, new Point(0, menuoffset), null, null, false);
 		SDL_Rect offsetRect;
 		setRect (offsetRect, 0, menuoffset, backBuffer->w ,backBuffer->h);
 		BlitSurfaceStandard(menubuffer,NULL,backBuffer,&offsetRect);
 	}
 
-	//screenbuffer.unlock();
 	SDL_Rect rect;
 	setRect(rect, 0, 0, backBuffer->w, backBuffer->h);
 	screenbuffer->UpdateScreen(backBuffer,&rect);
-	//backbuffer.lock();
-	//backbuffer.fillRect(backbuffer.rect, 0x000000);
 	FillRect(backBuffer, 0x000000);
-	//backbuffer.unlock();
 }
 
 void Graphics::drawhuetile( int x, int y, int t, int c )
@@ -3023,7 +2946,6 @@ void Graphics::flashlight()
 void Graphics::screenshake()
 {
 	point tpoint;
-	//screenbuffer.lock();
 	if(flipmode)
 	{
 		//	tpoint.x = int((Math.random() * 7) - 4); tpoint.y = int((Math.random() * 7) - 4);
@@ -3050,14 +2972,9 @@ void Graphics::screenshake()
 		SDL_Rect shakeRect;
 		setRect(shakeRect,tpoint.x, tpoint.y, backBuffer->w, backBuffer->h);
 		screenbuffer->UpdateScreen( backBuffer, &shakeRect);
-		// screenbuffer.copyPixels(backbuffer, backbuffer.rect, tpoint, null, null, false);
 	}
-	//screenbuffer.unlock();
 
-	//backbuffer.lock();
 	FillRect(backBuffer, 0x000000 );
-	//backbuffer.fillRect(backbuffer.rect, 0x000000);
-	//backbuffer.unlock();
 }
 
 void Graphics::render()
@@ -3198,7 +3115,6 @@ void Graphics::setcolreal(Uint32 t)
 
 void Graphics::drawforetile(int x, int y, int t)
 {
-	//frontbuffer.copyPixels(tiles[t], tiles_rect, tpoint);
 	SDL_Rect rect;
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
 	BlitSurfaceStandard(tiles[t],NULL, foregroundBuffer, &rect  );
@@ -3206,7 +3122,6 @@ void Graphics::drawforetile(int x, int y, int t)
 
 void Graphics::drawforetile2(int x, int y, int t)
 {
-	//frontbuffer.copyPixels(tiles2[t], tiles_rect, tpoint);
 	SDL_Rect rect;
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
 	BlitSurfaceStandard(tiles2[t],NULL, foregroundBuffer, &rect  );
@@ -3217,7 +3132,6 @@ void Graphics::drawforetile3(int x, int y, int t, int off)
 	SDL_Rect rect;
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
 	BlitSurfaceStandard(tiles3[t+(off*30)],NULL, foregroundBuffer, &rect  );
-	//frontbuffer.copyPixels(tiles3[t+(off*30)], tiles_rect, tpoint);
 }
 
 void Graphics::drawrect(int x, int y, int w, int h, int r, int g, int b)
@@ -3228,7 +3142,6 @@ void Graphics::drawrect(int x, int y, int w, int h, int r, int g, int b)
 	madrect.y = y;
 	madrect.w = w;
 	madrect.h = 1;
-	//backbuffer.fillRect(madrect, RGB(r,g,b));
 	FillRect(backBuffer, madrect, getRGB(b,g,r));
 
 	madrect.w = 1;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1253,7 +1253,7 @@ void Graphics::drawcoloredtile( int x, int y, int t, int r, int g, int b )
 }
 
 
-bool Graphics::Hitest(SDL_Surface* surface1, point p1, int col, SDL_Surface* surface2, point p2, int col2)
+bool Graphics::Hitest(SDL_Surface* surface1, point p1, SDL_Surface* surface2, point p2)
 {
 
     //find rectangle where they intersect:

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -162,11 +162,9 @@ public:
 	void drawtile3( int x, int y, int t, int off );
 	void drawentcolours( int x, int y, int t);
 	void drawtile2( int x, int y, int t, int r, int g, int b );
-	void drawtile( int x, int y, int t, int r, int g, int b );
+	void drawtile( int x, int y, int t );
 	void drawtowertile( int x, int y, int t );
 	void drawtowertile3( int x, int y, int t, int off );
-
-	void drawtile(int x, int y, int t);
 
 	void drawmap();
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -19,7 +19,8 @@
 #include "GraphicsUtil.h"
 #include "Screen.h"
 
-class map;
+class mapclass;
+class entityclass;
 
 class Graphics
 {

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -198,8 +198,6 @@ public:
 
 	colourTransform ct;
 
-	std::string tempstring;
-
 	int bcol, bcol2, rcol;
 
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -161,7 +161,7 @@ public:
 	void drawbackground(int t);
 	void drawtile3( int x, int y, int t, int off );
 	void drawentcolours( int x, int y, int t);
-	void drawtile2( int x, int y, int t, int r, int g, int b );
+	void drawtile2( int x, int y, int t );
 	void drawtile( int x, int y, int t );
 	void drawtowertile( int x, int y, int t );
 	void drawtowertile3( int x, int y, int t, int off );

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -132,7 +132,7 @@ public:
 
 	void render();
 
-	bool Hitest(SDL_Surface* surface1, point p1, int col, SDL_Surface* surface2, point p2, int col2);
+	bool Hitest(SDL_Surface* surface1, point p1, SDL_Surface* surface2, point p2);
 
 	void drawentities();
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -19,9 +19,6 @@
 #include "GraphicsUtil.h"
 #include "Screen.h"
 
-class mapclass;
-class entityclass;
-
 class Graphics
 {
 public:
@@ -37,7 +34,7 @@ public:
 
 	void drawhuetile(int x, int y, int t, int c);
 
-	void drawgravityline(int t, entityclass& obj);
+	void drawgravityline(int t);
 
 	void MakeTileArray();
 
@@ -47,8 +44,8 @@ public:
 
 	void drawcoloredtile(int x, int y, int t, int r, int g, int b);
 
-	void drawmenu(Game& game, int cr, int cg, int cb, int division = 30);
-	void drawlevelmenu(Game& game, int cr, int cg, int cb, int division = 30);
+	void drawmenu(int cr, int cg, int cb, int division = 30);
+	void drawlevelmenu(int cr, int cg, int cb, int division = 30);
 
 	void processfade();
 
@@ -89,7 +86,7 @@ public:
 	void drawpixeltextbox(int x, int y, int w, int h, int w2, int h2, int r, int g, int b, int xo, int yo);
 	void drawcustompixeltextbox(int x, int y, int w, int h, int w2, int h2, int r, int g, int b, int xo, int yo);
 
-	void drawcrewman(int x, int y, int t, bool act, UtilityClass& help, bool noshift =false);
+	void drawcrewman(int x, int y, int t, bool act, bool noshift =false);
 
 	int crewcolour(const int t);
 
@@ -101,7 +98,7 @@ public:
 
 	void drawimagecol(int t, int xp, int yp, int r, int g, int b, bool cent= false);
 
-	void drawgui(UtilityClass& help);
+	void drawgui();
 
 	void drawsprite(int x, int y, int t, int r, int g, int b);
 
@@ -127,7 +124,7 @@ public:
 
 	int len(std::string t);
 	void bigprint( int _x, int _y, std::string _s, int r, int g, int b, bool cen = false, int sc = 2 );
-	void drawspritesetcol(int x, int y, int t, int c, UtilityClass& help);
+	void drawspritesetcol(int x, int y, int t, int c);
 
 
 	void flashlight();
@@ -137,14 +134,14 @@ public:
 
 	bool Hitest(SDL_Surface* surface1, point p1, int col, SDL_Surface* surface2, point p2, int col2);
 
-	void drawentities(mapclass& map, entityclass& obj, UtilityClass& help);
+	void drawentities();
 
-	void drawtrophytext(entityclass&, UtilityClass& help);
+	void drawtrophytext();
 
 	void bigrprint(int x, int y, std::string& t, int r, int g, int b, bool cen = false, float sc = 2);
 
 
-	void drawtele(int x, int y, int t, int c, UtilityClass& help);
+	void drawtele(int x, int y, int t, int c);
 
 	Uint32 getRGBA(Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
@@ -161,7 +158,7 @@ public:
 
 	void setcolreal(Uint32 t);
 
-	void drawbackground(int t, mapclass& map);
+	void drawbackground(int t);
 	void drawtile3( int x, int y, int t, int off );
 	void drawentcolours( int x, int y, int t);
 	void drawtile2( int x, int y, int t, int r, int g, int b );
@@ -171,7 +168,7 @@ public:
 
 	void drawtile(int x, int y, int t);
 
-	void drawmap(mapclass& map);
+	void drawmap();
 
 	void drawforetile(int x, int y, int t);
 
@@ -181,25 +178,25 @@ public:
 
 	void drawrect(int x, int y, int w, int h, int r, int g, int b);
 
-	void drawtowermap(mapclass& map);
+	void drawtowermap();
 
-	void drawtowermap_nobackground(mapclass& map);
+	void drawtowermap_nobackground();
 
-	void drawtowerspikes(mapclass& map);
+	void drawtowerspikes();
 
-	void drawtowerentities(mapclass& map, entityclass& obj, UtilityClass& help);
+	void drawtowerentities();
 
 	bool onscreen(int t);
 
-	void drawtowerbackgroundsolo(mapclass& map);
+	void drawtowerbackgroundsolo();
 
 
 	void menuoffrender();
 
-	void drawtowerbackground(mapclass& map);
+	void drawtowerbackground();
 
-	void setcol(int t, UtilityClass& help);
-	void drawfinalmap(mapclass & map);
+	void setcol(int t);
+	void drawfinalmap();
 
 	colourTransform ct;
 

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -23,8 +23,8 @@ unsigned int endian_swap( unsigned int x )
 template <class T>
 void endian_swap(T *objp)
 {
-	unsigned char *memp = reinterpret_cast<unsigned char*>(objp);
-	std::reverse(memp, memp + sizeof(T));
+    unsigned char *memp = reinterpret_cast<unsigned char*>(objp);
+    std::reverse(memp, memp + sizeof(T));
 }
 
 
@@ -157,94 +157,94 @@ SDL_Surface * ScaleSurface( SDL_Surface *_surface, int Width, int Height, SDL_Su
     float  _stretch_factor_x = (static_cast<double>(Width)  / static_cast<double>(_surface->w)), _stretch_factor_y = (static_cast<double>(Height) / static_cast<double>(_surface->h));
 
 
-	SDL_Rect gigantoPixel;
+    SDL_Rect gigantoPixel;
     for(Sint32 y = 0; y < _surface->h; y++)
         for(Sint32 x = 0; x < _surface->w; x++)
-		{
-			setRect(gigantoPixel, static_cast<Sint32>((float(x)*_stretch_factor_x) -1), static_cast<Sint32>((float(y) *_stretch_factor_y)-1), static_cast<Sint32>(_stretch_factor_x +1.0),static_cast<Sint32>( _stretch_factor_y+1.0)) ;
-			SDL_FillRect(_ret, &gigantoPixel, ReadPixel(_surface, x, y));
-		}
+        {
+            setRect(gigantoPixel, static_cast<Sint32>((float(x)*_stretch_factor_x) -1), static_cast<Sint32>((float(y) *_stretch_factor_y)-1), static_cast<Sint32>(_stretch_factor_x +1.0),static_cast<Sint32>( _stretch_factor_y+1.0)) ;
+            SDL_FillRect(_ret, &gigantoPixel, ReadPixel(_surface, x, y));
+        }
 
-                   // DrawPixel(_ret, static_cast<Sint32>(_stretch_factor_x * x) + o_x,
-                              //static_cast<Sint32>(_stretch_factor_y * y) + o_y, ReadPixel(_surface, x, y));
+            // DrawPixel(_ret, static_cast<Sint32>(_stretch_factor_x * x) + o_x,
+                       //static_cast<Sint32>(_stretch_factor_y * y) + o_y, ReadPixel(_surface, x, y));
 
     return _ret;
 }
 
 SDL_Surface * ScaleSurfaceSlow( SDL_Surface *_surface, int Width, int Height)
 {
-	if(!_surface || !Width || !Height)
-		return 0;
+    if(!_surface || !Width || !Height)
+        return 0;
 
-	SDL_Surface *_ret;
+    SDL_Surface *_ret;
 
-		_ret = SDL_CreateRGBSurface(_surface->flags, Width, Height, _surface->format->BitsPerPixel,
-			_surface->format->Rmask, _surface->format->Gmask, _surface->format->Bmask, _surface->format->Amask);
-		if(_ret == NULL)
-		{
-			return NULL;
-		}
-
-
-
-	float  _stretch_factor_x = (static_cast<double>(Width)  / static_cast<double>(_surface->w)), _stretch_factor_y = (static_cast<double>(Height) / static_cast<double>(_surface->h));
+    _ret = SDL_CreateRGBSurface(_surface->flags, Width, Height, _surface->format->BitsPerPixel,
+        _surface->format->Rmask, _surface->format->Gmask, _surface->format->Bmask, _surface->format->Amask);
+    if(_ret == NULL)
+    {
+        return NULL;
+    }
 
 
-	for(Sint32 y = 0; y < _surface->h; y++)
-		for(Sint32 x = 0; x < _surface->w; x++)
-			for(Sint32 o_y = 0; o_y < _stretch_factor_y; ++o_y)
-				for(Sint32 o_x = 0; o_x < _stretch_factor_x; ++o_x)
-					DrawPixel(_ret, static_cast<Sint32>(_stretch_factor_x * x) + o_x,
-					static_cast<Sint32>(_stretch_factor_y * y) + o_y, ReadPixel(_surface, x, y));
 
-		// DrawPixel(_ret, static_cast<Sint32>(_stretch_factor_x * x) + o_x,
-		//static_cast<Sint32>(_stretch_factor_y * y) + o_y, ReadPixel(_surface, x, y));
+    float  _stretch_factor_x = (static_cast<double>(Width)  / static_cast<double>(_surface->w)), _stretch_factor_y = (static_cast<double>(Height) / static_cast<double>(_surface->h));
 
-	return _ret;
+
+    for(Sint32 y = 0; y < _surface->h; y++)
+        for(Sint32 x = 0; x < _surface->w; x++)
+            for(Sint32 o_y = 0; o_y < _stretch_factor_y; ++o_y)
+                for(Sint32 o_x = 0; o_x < _stretch_factor_x; ++o_x)
+                    DrawPixel(_ret, static_cast<Sint32>(_stretch_factor_x * x) + o_x,
+                    static_cast<Sint32>(_stretch_factor_y * y) + o_y, ReadPixel(_surface, x, y));
+
+                    // DrawPixel(_ret, static_cast<Sint32>(_stretch_factor_x * x) + o_x,
+                    //static_cast<Sint32>(_stretch_factor_y * y) + o_y, ReadPixel(_surface, x, y));
+
+    return _ret;
 }
 
 SDL_Surface *  FlipSurfaceHorizontal(SDL_Surface* _src)
 {
-	SDL_Surface * ret = SDL_CreateRGBSurface(_src->flags, _src->w, _src->h, _src->format->BitsPerPixel,
-		_src->format->Rmask, _src->format->Gmask, _src->format->Bmask, _src->format->Amask);
-	if(ret == NULL)
-	{
-		return NULL;
-	}
+    SDL_Surface * ret = SDL_CreateRGBSurface(_src->flags, _src->w, _src->h, _src->format->BitsPerPixel,
+        _src->format->Rmask, _src->format->Gmask, _src->format->Bmask, _src->format->Amask);
+    if(ret == NULL)
+    {
+        return NULL;
+    }
 
-	for(Sint32 y = 0; y < _src->h; y++)
-	{
-		for(Sint32 x = 0; x < _src->w; x++)
-		{
-			DrawPixel(ret,(_src->w -1) -x,y,ReadPixel(_src, x, y));
-		}
+    for(Sint32 y = 0; y < _src->h; y++)
+    {
+        for(Sint32 x = 0; x < _src->w; x++)
+        {
+            DrawPixel(ret,(_src->w -1) -x,y,ReadPixel(_src, x, y));
+        }
 
 
-	}
+    }
 
-	return ret;
+    return ret;
 }
 
 SDL_Surface *  FlipSurfaceVerticle(SDL_Surface* _src)
 {
-	SDL_Surface * ret = SDL_CreateRGBSurface(_src->flags, _src->w, _src->h, _src->format->BitsPerPixel,
-		_src->format->Rmask, _src->format->Gmask, _src->format->Bmask, _src->format->Amask);
-	if(ret == NULL)
-	{
-		return NULL;
-	}
+    SDL_Surface * ret = SDL_CreateRGBSurface(_src->flags, _src->w, _src->h, _src->format->BitsPerPixel,
+        _src->format->Rmask, _src->format->Gmask, _src->format->Bmask, _src->format->Amask);
+    if(ret == NULL)
+    {
+        return NULL;
+    }
 
-	for(Sint32 y = 0; y < _src->h; y++)
-	{
-		for(Sint32 x = 0; x < _src->w; x++)
-		{
-			DrawPixel(ret, x ,(_src->h-1) - y ,ReadPixel(_src, x, y));
-		}
+    for(Sint32 y = 0; y < _src->h; y++)
+    {
+        for(Sint32 x = 0; x < _src->w; x++)
+        {
+            DrawPixel(ret, x ,(_src->h-1) - y ,ReadPixel(_src, x, y));
+        }
 
 
-	}
+    }
 
-	return ret;
+    return ret;
 }
 
 void BlitSurfaceStandard( SDL_Surface* _src, SDL_Rect* _srcRect, SDL_Surface* _dest, SDL_Rect* _destRect )
@@ -317,74 +317,74 @@ int scrollamount = 0;
 bool isscrolling = 0;
 SDL_Surface* ApplyFilter( SDL_Surface* _src )
 {
-	SDL_Surface* _ret = SDL_CreateRGBSurface(_src->flags, _src->w, _src->h, 32,
-		_src->format->Rmask, _src->format->Gmask, _src->format->Bmask, _src->format->Amask);
+    SDL_Surface* _ret = SDL_CreateRGBSurface(_src->flags, _src->w, _src->h, 32,
+        _src->format->Rmask, _src->format->Gmask, _src->format->Bmask, _src->format->Amask);
 
-	if (rand() % 4000 < 8)
-	{
-		isscrolling = true;
-	}
+    if (rand() % 4000 < 8)
+    {
+        isscrolling = true;
+    }
 
-	if(isscrolling == true)
-	{
-		scrollamount += 20;
-		if(scrollamount > 240)
-		{
-			scrollamount = 0;
-			isscrolling = false;
-		}
-	}
+    if(isscrolling == true)
+    {
+        scrollamount += 20;
+        if(scrollamount > 240)
+        {
+            scrollamount = 0;
+            isscrolling = false;
+        }
+    }
 
-	int redOffset = rand() % 4;
+    int redOffset = rand() % 4;
 
-	for(int x = 0; x < _src->w; x++)
-	{
-		for(int y = 0; y < _src->h; y++)
-		{
-			int sampley = (y + scrollamount )% 240;
+    for(int x = 0; x < _src->w; x++)
+    {
+        for(int y = 0; y < _src->h; y++)
+        {
+            int sampley = (y + scrollamount )% 240;
 
-			Uint32 pixel = ReadPixel(_src, x,sampley);
+            Uint32 pixel = ReadPixel(_src, x,sampley);
 
-			Uint8 green = (pixel & _src->format->Gmask) >> 8;
-			Uint8 blue = (pixel & _src->format->Bmask) >> 0;
+            Uint8 green = (pixel & _src->format->Gmask) >> 8;
+            Uint8 blue = (pixel & _src->format->Bmask) >> 0;
 
-			Uint32 pixelOffset = ReadPixel(_src, std::min(x+redOffset, 319), sampley) ;
-			Uint8 red = (pixelOffset & _src->format->Rmask) >> 16 ;
+            Uint32 pixelOffset = ReadPixel(_src, std::min(x+redOffset, 319), sampley) ;
+            Uint8 red = (pixelOffset & _src->format->Rmask) >> 16 ;
 
-			if(isscrolling && sampley > 220 && ((rand() %10) < 4))
-			{
-				red = std::min(int(red+(fRandom() * 0.6)  * 254) , 255);
-				green = std::min(int(green+(fRandom() * 0.6)  * 254) , 255);
-				blue = std::min(int(blue+(fRandom() * 0.6)  * 254) , 255);
-			}
-			else
-			{
-				red = std::min(int(red+(fRandom() * 0.2)  * 254) , 255);
-				green = std::min(int(green+(fRandom() * 0.2)  * 254) , 255);
-				blue = std::min(int(blue+(fRandom() * 0.2)  * 254) , 255);
-			}
+            if(isscrolling && sampley > 220 && ((rand() %10) < 4))
+            {
+                red = std::min(int(red+(fRandom() * 0.6)  * 254) , 255);
+                green = std::min(int(green+(fRandom() * 0.6)  * 254) , 255);
+                blue = std::min(int(blue+(fRandom() * 0.6)  * 254) , 255);
+            }
+            else
+            {
+                red = std::min(int(red+(fRandom() * 0.2)  * 254) , 255);
+                green = std::min(int(green+(fRandom() * 0.2)  * 254) , 255);
+                blue = std::min(int(blue+(fRandom() * 0.2)  * 254) , 255);
+            }
 
 
-			if(y % 2 == 0)
-			{
-				red = static_cast<Uint8>(red / 1.2f);
-				green = static_cast<Uint8>(green / 1.2f);
-				blue =  static_cast<Uint8>(blue / 1.2f);
-			}
+            if(y % 2 == 0)
+            {
+                red = static_cast<Uint8>(red / 1.2f);
+                green = static_cast<Uint8>(green / 1.2f);
+                blue =  static_cast<Uint8>(blue / 1.2f);
+            }
 
-			int distX =  static_cast<int>((abs (160.0f -x ) / 160.0f) *16);
-			int distY =  static_cast<int>((abs (120.0f -y ) / 120.0f)*32);
+            int distX =  static_cast<int>((abs (160.0f -x ) / 160.0f) *16);
+            int distY =  static_cast<int>((abs (120.0f -y ) / 120.0f)*32);
 
-			red = std::max(red - ( distX +distY), 0);
-			green = std::max(green - ( distX +distY), 0);
-			blue = std::max(blue - ( distX +distY), 0);
+            red = std::max(red - ( distX +distY), 0);
+            green = std::max(green - ( distX +distY), 0);
+            blue = std::max(blue - ( distX +distY), 0);
 
-			Uint32 finalPixel = ((red<<16) + (green<<8) + (blue<<0)) | (pixel &_src->format->Amask);
-			DrawPixel(_ret,x,y,  finalPixel);
+            Uint32 finalPixel = ((red<<16) + (green<<8) + (blue<<0)) | (pixel &_src->format->Amask);
+            DrawPixel(_ret,x,y,  finalPixel);
 
-		}
-	}
-return _ret;
+        }
+    }
+    return _ret;
 }
 
 void FillRect( SDL_Surface* _surface, const int _x, const int _y, const int _w, const int _h, const int r, int g, int b )
@@ -454,7 +454,7 @@ void ScrollSurface( SDL_Surface* _src, int _pX, int _pY )
     SDL_Surface* part1 = NULL;
 
     SDL_Rect rect1;
-	 SDL_Rect rect2;
+    SDL_Rect rect2;
     //scrolling up;
     if(_pY < 0)
     {
@@ -488,39 +488,39 @@ void ScrollSurface( SDL_Surface* _src, int _pX, int _pY )
 
     }
 
-	//Right
-	else if(_pX <= 0)
-	{
-		setRect(rect2, 0, 0, _src->w - _pX,  _src->h );
+    //Right
+    else if(_pX <= 0)
+    {
+        setRect(rect2, 0, 0, _src->w - _pX,  _src->h );
 
-		part1 = GetSubSurface(_src, rect2.x, rect2.y, rect2.w, rect2.h);
+        part1 = GetSubSurface(_src, rect2.x, rect2.y, rect2.w, rect2.h);
 
-		SDL_Rect destrect1;
+        SDL_Rect destrect1;
 
-		SDL_SetSurfaceBlendMode(part1, SDL_BLENDMODE_NONE);
+        SDL_SetSurfaceBlendMode(part1, SDL_BLENDMODE_NONE);
 
-		setRect(destrect1, _pX,  0, _src->w - _pX, _src->h);
+        setRect(destrect1, _pX,  0, _src->w - _pX, _src->h);
 
-		SDL_BlitSurface (part1, NULL, _src, &destrect1);
-	}
+        SDL_BlitSurface (part1, NULL, _src, &destrect1);
+    }
 
-	else if(_pX > 0)
-	{
+    else if(_pX > 0)
+    {
 
-		setRect(rect1, _pX, 0, _src->w - _pX, _src->h );
+        setRect(rect1, _pX, 0, _src->w - _pX, _src->h );
 
-		part1 = GetSubSurface(_src, rect1.x, rect1.y, rect1.w, rect1.h);
+        part1 = GetSubSurface(_src, rect1.x, rect1.y, rect1.w, rect1.h);
 
-		SDL_Rect destrect1;
+        SDL_Rect destrect1;
 
-		SDL_SetSurfaceBlendMode(part1, SDL_BLENDMODE_NONE);
+        SDL_SetSurfaceBlendMode(part1, SDL_BLENDMODE_NONE);
 
-		setRect(destrect1, 0, 0, _src->w - _pX, _src->h);
+        setRect(destrect1, 0, 0, _src->w - _pX, _src->h);
 
-		SDL_BlitSurface (part1, NULL, _src, &destrect1);
+        SDL_BlitSurface (part1, NULL, _src, &destrect1);
 
-	}
-	//Cleanup temp surface
+    }
+    //Cleanup temp surface
     if (part1)
     {
         SDL_FreeSurface(part1);

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -511,7 +511,7 @@ SDL_assert(0 && "Remove open level dir");
                     dwgfx.screenbuffer->toggleFullScreen();
                     game.fullscreen = !game.fullscreen;
                     updategraphicsmode(game, dwgfx);
-                    game.savestats(map, dwgfx);
+                    game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 0;
                   }else if (game.currentmenuoption == 1){
@@ -519,7 +519,7 @@ SDL_assert(0 && "Remove open level dir");
                     dwgfx.screenbuffer->toggleStretchMode();
                     game.stretchMode = (game.stretchMode + 1) % 3;
                     updategraphicsmode(game, dwgfx);
-                    game.savestats(map, dwgfx);
+                    game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 1;
                   }else if (game.currentmenuoption == 2){
@@ -527,7 +527,7 @@ SDL_assert(0 && "Remove open level dir");
                     dwgfx.screenbuffer->toggleLinearFilter();
                     game.useLinearFilter = !game.useLinearFilter;
                     updategraphicsmode(game, dwgfx);
-                    game.savestats(map, dwgfx);
+                    game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 2;
                   }else if (game.currentmenuoption == 3){
@@ -537,7 +537,7 @@ SDL_assert(0 && "Remove open level dir");
                       //Hook the analogue thing in here: ABCDEFG
                       updategraphicsmode(game, dwgfx);
 					  dwgfx.screenbuffer->badSignalEffect= !dwgfx.screenbuffer->badSignalEffect;
-                      game.savestats(map, dwgfx);
+                      game.savestats();
                       game.createmenu("graphicoptions");
                       game.currentmenuoption = 3;
                   }else if (game.currentmenuoption == 4) {
@@ -577,7 +577,7 @@ SDL_assert(0 && "Remove open level dir");
                                 game.fullscreen = true;
                             }
                             updategraphicsmode(game, dwgfx);
-                            game.savestats(map, dwgfx);
+                            game.savestats();
                             game.createmenu("graphicoptions");
                         }
                         else if (game.currentmenuoption == 1)
@@ -593,7 +593,7 @@ SDL_assert(0 && "Remove open level dir");
                             }
                             updategraphicsmode(game, dwgfx);
 
-                            game.savestats(map, dwgfx);
+                            game.savestats();
                             game.createmenu("graphicoptions");
                             game.currentmenuoption = 1;
                         }
@@ -606,7 +606,7 @@ SDL_assert(0 && "Remove open level dir");
                             dwgfx.screenbuffer->SetScale(game.advanced_scaling);
                             updategraphicsmode(game, dwgfx);
 
-                            game.savestats(map, dwgfx);
+                            game.savestats();
                             game.createmenu("graphicoptions");
                             game.currentmenuoption = 2;
                         }
@@ -617,7 +617,7 @@ SDL_assert(0 && "Remove open level dir");
                             game.advanced_smoothing = !game.advanced_smoothing;
                             updategraphicsmode(game, dwgfx);
 
-                            game.savestats(map, dwgfx);
+                            game.savestats();
                             game.createmenu("graphicoptions");
                             game.currentmenuoption = 3;
                         }
@@ -646,7 +646,7 @@ SDL_assert(0 && "Remove open level dir");
                             }
                             updategraphicsmode(game, dwgfx);
 
-                            game.savestats(map, dwgfx);
+                            game.savestats();
                             game.createmenu("graphicoptions");
                         }
                         else if (game.currentmenuoption == 1)
@@ -662,7 +662,7 @@ SDL_assert(0 && "Remove open level dir");
                             }
                             updategraphicsmode(game, dwgfx);
 
-                            game.savestats(map, dwgfx);
+                            game.savestats();
                             game.createmenu("graphicoptions");
                             game.currentmenuoption = 1;
                         }
@@ -707,7 +707,7 @@ SDL_assert(0 && "Remove open level dir");
                         map.invincibility = !map.invincibility;
                         //game.deletequick();
                         //game.deletetele();
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         music.playef(11, 10);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 3;
@@ -741,7 +741,7 @@ SDL_assert(0 && "Remove open level dir");
                         //back
                         game.gameframerate=34;
                         game.slowdown = 30;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         music.playef(11, 10);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 4;
@@ -751,7 +751,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.gameframerate=41;
                         game.slowdown = 24;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         music.playef(11, 10);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 4;
@@ -761,7 +761,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.gameframerate=55;
                         game.slowdown = 18;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         music.playef(11, 10);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 4;
@@ -771,7 +771,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.gameframerate=83;
                         game.slowdown = 12;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         music.playef(11, 10);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 4;
@@ -784,7 +784,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         //disable animated backgrounds
                         game.colourblindmode = !game.colourblindmode;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         map.tdrawback = true;
                         music.playef(11, 10);
                     }
@@ -792,7 +792,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         //disable screeneffects
                         game.noflashingmode = !game.noflashingmode;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         if (!game.noflashingmode)
                         {
                             music.playef(18, 10);
@@ -806,7 +806,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         //disable text outline
                         dwgfx.notextoutline = !dwgfx.notextoutline;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         music.playef(11, 10);
                     }
                     else if (game.currentmenuoption == 3)
@@ -912,7 +912,7 @@ SDL_assert(0 && "Remove open level dir");
 													music.usingmmmmmm = !music.usingmmmmmm;
 													music.playef(11, 10);
 													music.play(6);
-													game.savestats(map, dwgfx);
+													game.savestats();
 													game.createmenu("mainmenu");
 													map.nexttowercolour();
 											}
@@ -975,7 +975,7 @@ SDL_assert(0 && "Remove open level dir");
 													music.usingmmmmmm = !music.usingmmmmmm;
 													music.playef(11, 10);
 													music.play(6);
-													game.savestats(map, dwgfx);
+													game.savestats();
 													game.createmenu("mainmenu");
 													map.nexttowercolour();
 											}
@@ -1004,7 +1004,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.unlock[9] = true;
                         game.unlocknotify[9] = true;
                         music.playef(11, 10);
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 0;
                     }
@@ -1013,7 +1013,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.unlock[10] = true;
                         game.unlocknotify[10] = true;
                         music.playef(11, 10);
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 1;
                     }
@@ -1022,7 +1022,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.unlock[11] = true;
                         game.unlocknotify[11] = true;
                         music.playef(11, 10);
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 2;
                     }
@@ -1031,7 +1031,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.unlock[12] = true;
                         game.unlocknotify[12] = true;
                         music.playef(11, 10);
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 3;
                     }
@@ -1040,7 +1040,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.unlock[13] = true;
                         game.unlocknotify[13] = true;
                         music.playef(11, 10);
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 4;
                     }
@@ -1049,7 +1049,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.unlock[14] = true;
                         game.unlocknotify[14] = true;
                         music.playef(11, 10);
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 5;
                     }
@@ -1078,7 +1078,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.unlocknotify[16] = true;
                         game.unlock[6] = true;
                         game.unlock[7] = true;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenu");
                         game.currentmenuoption = 1;
                     }
@@ -1088,7 +1088,7 @@ SDL_assert(0 && "Remove open level dir");
                         music.playef(11, 10);
                         game.unlock[17] = true;
                         game.unlocknotify[17] = true;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenu");
                         game.currentmenuoption = 2;
                     }
@@ -1098,7 +1098,7 @@ SDL_assert(0 && "Remove open level dir");
                         music.playef(11, 10);
                         game.unlock[18] = true;
                         game.unlocknotify[18] = true;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenu");
                         game.currentmenuoption = 3;
                     }
@@ -1107,7 +1107,7 @@ SDL_assert(0 && "Remove open level dir");
                         //unlock jukebox
                         music.playef(11, 10);
                         game.stat_trinkets = 20;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenu");
                         game.currentmenuoption = 4;
                     }
@@ -1117,7 +1117,7 @@ SDL_assert(0 && "Remove open level dir");
                         music.playef(11, 10);
                         game.unlock[8] = true;
                         game.unlocknotify[8] = true;
-                        game.savestats(map, dwgfx);
+                        game.savestats();
                         game.createmenu("unlockmenu");
                         game.currentmenuoption = 5;
                     }
@@ -1313,7 +1313,7 @@ SDL_assert(0 && "Remove open level dir");
                         {
                             //go to a menu!
                             music.playef(11, 10);
-                            game.loadsummary(map, help); //Prepare save slots to display
+                            game.loadsummary(); //Prepare save slots to display
                             game.createmenu("continue");
                             map.settowercolour(3);
                         }
@@ -1363,7 +1363,7 @@ SDL_assert(0 && "Remove open level dir");
                         {
                             //go to a menu!
                             music.playef(11, 10);
-                            game.loadsummary(map, help); //Prepare save slots to display
+                            game.loadsummary(); //Prepare save slots to display
                             game.createmenu("continue");
                             map.settowercolour(3);
                         }
@@ -1486,7 +1486,7 @@ SDL_assert(0 && "Remove open level dir");
                         music.playef(23, 10);
                         game.deletequick();
                         game.deletetele();
-                        game.deletestats(map, dwgfx);
+                        game.deletestats();
                         game.flashlight = 5;
                         game.screenshake = 15;
                         game.createmenu("mainmenu");
@@ -2071,7 +2071,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
                                 dwgfx.resumegamemode = false;
 
                                 game.useteleporter = true;
-                                game.initteleportermode(map);
+                                game.initteleportermode();
                             }
                             else
                             {
@@ -2403,7 +2403,7 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
             music.playef(18, 10);
             game.gamesaved = true;
 
-            game.savetime = game.timestring(help);
+            game.savetime = game.timestring();
             game.savearea = map.currentarea(map.area(game.roomx, game.roomy));
             game.savetrinkets = game.trinkets;
 
@@ -2412,12 +2412,12 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         #if !defined(NO_CUSTOM_LEVELS)
             if(map.custommodeforreal)
             {
-              game.customsavequick(ed.ListOfMetaData[game.playcustomlevel].filename, map, obj, music);
+              game.customsavequick(ed.ListOfMetaData[game.playcustomlevel].filename);
             }
             else
         #endif
             {
-              game.savequick(map, obj, music);
+              game.savequick();
             }
         }
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -125,7 +125,6 @@ void titleinput()
 
     if (graphics.flipmode)
     {
-        //GAMEPAD TODO
         if (key.isDown(KEYBOARD_LEFT) || key.isDown(KEYBOARD_DOWN) || key.isDown(KEYBOARD_a) ||  key.isDown(KEYBOARD_s) || key.controllerWantsRight(true)) game.press_left = true;
         if (key.isDown(KEYBOARD_RIGHT) || key.isDown(KEYBOARD_UP)  || key.isDown(KEYBOARD_d) ||  key.isDown(KEYBOARD_w) || key.controllerWantsLeft(true)) game.press_right = true;
     }
@@ -154,42 +153,6 @@ void titleinput()
         {
             game.jumpheld = true;
         }
-
-        /*
-        if (game.press_left) {
-        game.mainmenu--;
-        }else if (game.press_right) {
-        game.mainmenu++;
-        }
-
-        if (game.mainmenu < 0) game.mainmenu = 2;
-        if (game.mainmenu > 2 ) game.mainmenu = 0;
-        */
-
-
-        /*
-        if (game.press_action) {
-        if (!game.menustart) {
-        game.menustart = true;
-        music.play(6);
-        music.playef(18);
-        game.screenshake = 10;
-        game.flashlight = 5;
-        }else{
-        if(game.mainmenu==0){
-        graphics.fademode = 2;
-        }else if (game.mainmenu == 1) {
-        if (game.telesummary != "") {
-        graphics.fademode = 2;
-        }
-        }else if (game.mainmenu == 2) {
-        if (game.quicksummary != "") {
-        graphics.fademode = 2;
-        }
-        }
-        }
-        }
-        */
 
         if (key.isDown(27) && game.currentmenuname != "youwannaquit" && game.menustart)
         {
@@ -552,122 +515,6 @@ void titleinput()
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
-
-                    /* //Old stuff
-                    if (game.advanced_mode)
-                    {
-                        if (game.currentmenuoption == 0)
-                        {
-                            //toggle fullscreen
-                            graphics.screenbuffer->toggleFullScreen();
-                            music.playef(11);
-                            if (game.fullscreen)
-                            {
-                                game.fullscreen = false;
-                            }
-                            else
-                            {
-                                game.fullscreen = true;
-                            }
-                            updategraphicsmode();
-                            game.savestats();
-                            game.createmenu("graphicoptions");
-                        }
-                        else if (game.currentmenuoption == 1)
-                        {
-                            //enable acceleration: if in fullscreen, go back to window first
-                            music.playef(11);
-                            game.advanced_mode = false;
-                            if (game.fullscreen)
-                            {
-                                game.fullscreen = false;
-                                updategraphicsmode();
-                                game.fullscreen = true;
-                            }
-                            updategraphicsmode();
-
-                            game.savestats();
-                            game.createmenu("graphicoptions");
-                            game.currentmenuoption = 1;
-                        }
-                        else if (game.currentmenuoption == 2)
-                        {
-                            //change scaling mode
-                            music.playef(11);
-                            game.advanced_scaling = (game.advanced_scaling + 1) % 5;
-                            graphics.screenbuffer->ResizeScreen(320 *game.advanced_scaling,240*game.advanced_scaling );
-                            graphics.screenbuffer->SetScale(game.advanced_scaling);
-                            updategraphicsmode();
-
-                            game.savestats();
-                            game.createmenu("graphicoptions");
-                            game.currentmenuoption = 2;
-                        }
-                        else if (game.currentmenuoption == 3)
-                        {
-                            //change smoothing
-                            music.playef(11);
-                            game.advanced_smoothing = !game.advanced_smoothing;
-                            updategraphicsmode();
-
-                            game.savestats();
-                            game.createmenu("graphicoptions");
-                            game.currentmenuoption = 3;
-                        }
-                        else
-                        {
-                            //back
-                            music.playef(11);
-                            game.createmenu("mainmenu");
-                            map.nexttowercolour();
-                        }
-                    }
-                    else
-                    {
-                        if (game.currentmenuoption == 0)
-                        {
-                            graphics.screenbuffer->toggleFullScreen();
-                            //toggle fullscreen
-                            music.playef(11);
-                            if (game.fullscreen)
-                            {
-                                game.fullscreen = false;
-                            }
-                            else
-                            {
-                                game.fullscreen = true;
-                            }
-                            updategraphicsmode();
-
-                            game.savestats();
-                            game.createmenu("graphicoptions");
-                        }
-                        else if (game.currentmenuoption == 1)
-                        {
-                            //disable acceleration: if in fullscreen, go back to window first
-                            music.playef(11);
-                            game.advanced_mode = true;
-                            if (game.fullscreen)
-                            {
-                                game.fullscreen = false;
-                                updategraphicsmode();
-                                game.fullscreen = true;
-                            }
-                            updategraphicsmode();
-
-                            game.savestats();
-                            game.createmenu("graphicoptions");
-                            game.currentmenuoption = 1;
-                        }
-                        else
-                        {
-                            //back
-                            music.playef(11);
-                            game.createmenu("mainmenu");
-                            map.nexttowercolour();
-                        }
-                    }
-                    */
                 }
                 else if (game.currentmenuname == "youwannaquit")
                 {
@@ -698,8 +545,6 @@ void titleinput()
                     else
                     {
                         map.invincibility = !map.invincibility;
-                        //game.deletequick();
-                        //game.deletetele();
                         game.savestats();
                         music.playef(11);
                         game.createmenu("accessibility");
@@ -1803,87 +1648,25 @@ void gameinput()
         game.press_right = false;
         game.press_action = false;
         game.press_map = false;
-    }
-/*
-    if (game.recording == 2 && !game.playbackfinished)
-    {
-        //playback!
-        //record your input and add it to the record string
-        //Keys are:
-        //0 - nothing
-        //1 - left
-        //2 - right
-        //3 - left+right
-        //4 - flip
-        //5 - left+flip
-        //6 - right+flip
-        //7 - left+right+flip
-        //8 - Map/teleport
-        if (!game.recordinit)
-        {
-            //Init recording
-            game.recordinit = true;
-            game.combomode = false;
-            game.playmove = game.playback[game.playbackpos+1];
-            game.playcombo = game.playback[game.playbackpos];
-        }
 
-        if (game.playcombo <= 0)
+        if (key.isDown(KEYBOARD_LEFT) || key.isDown(KEYBOARD_a) || key.controllerWantsLeft(false))
         {
-            //move on to the next action
-            game.playbackpos += 2;
-            game.playmove = game.playback[game.playbackpos + 1];
-            game.playcombo = game.playback[game.playbackpos];
-            if (game.playcombo > 1) game.playcombo--;
+            game.press_left = true;
         }
-
-        if (game.playcombo >= 1)
+        if (key.isDown(KEYBOARD_RIGHT) || key.isDown(KEYBOARD_d) || key.controllerWantsRight(false))
         {
-            game.playcombo--;
-            if (game.playmove == 1 || game.playmove == 3 || game.playmove == 5 || game.playmove == 7)
-            {
-                game.press_left = true;
-            }
-            if (game.playmove == 2 || game.playmove == 3 || game.playmove == 6 || game.playmove == 7)
-            {
-                game.press_right = true;
-            }
-            if (game.playmove == 4 || game.playmove == 5 || game.playmove == 6 || game.playmove == 7)
-            {
-                game.press_action = true;
-            }
-            if (game.playmove == 8)
-            {
-                game.press_map = true;
-                //game.playbackfinished = true;
-                //TODO WTF is trace
-                //trace("finished!");
-            }
+            game.press_right = true;
+        }
+        if (key.isDown(KEYBOARD_z) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v)
+                || key.isDown(KEYBOARD_UP) || key.isDown(KEYBOARD_DOWN) || key.isDown(KEYBOARD_w) || key.isDown(KEYBOARD_s)|| key.isDown(game.controllerButton_flip))
+        {
+            game.press_action = true;
+        };
+        if (key.isDown(KEYBOARD_ENTER) || key.isDown(SDLK_KP_ENTER) || key.isDown(game.controllerButton_map)  )
+        {
+            game.press_map = true;
         }
     }
-    else
-    { */
-        if(!script.running)
-        {
-            if (key.isDown(KEYBOARD_LEFT) || key.isDown(KEYBOARD_a) || key.controllerWantsLeft(false))
-            {
-                game.press_left = true;
-            }
-            if (key.isDown(KEYBOARD_RIGHT) || key.isDown(KEYBOARD_d) || key.controllerWantsRight(false))
-            {
-                game.press_right = true;
-            }
-            if (key.isDown(KEYBOARD_z) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v)
-                    || key.isDown(KEYBOARD_UP) || key.isDown(KEYBOARD_DOWN) || key.isDown(KEYBOARD_w) || key.isDown(KEYBOARD_s)|| key.isDown(game.controllerButton_flip))
-            {
-                game.press_action = true;
-            };
-            if (key.isDown(KEYBOARD_ENTER) || key.isDown(SDLK_KP_ENTER) || key.isDown(game.controllerButton_map)  )
-            {
-                game.press_map = true;
-            }
-        }
-    //}
 
     if (game.advancetext)
     {
@@ -1913,36 +1696,6 @@ void gameinput()
     }
 
     if (!game.press_map) game.mapheld = false;
-
-    /*
-    if (key.isDown("1".charCodeAt(0))) {
-    graphics.screen.width = 640;
-    graphics.screen.height = 480;
-    setstage(640,480);
-    }
-    if (key.isDown("2".charCodeAt(0))) {
-    graphics.screen.width = 960;
-    graphics.screen.height = 720;
-    setstage(960,720);
-    }
-    if (key.isDown("3".charCodeAt(0))) {
-    graphics.screen.width = 1280;
-    graphics.screen.height = 960;
-    setstage(1280,960);
-    }
-    */
-    /*game.test = true;
-    game.teststring = String(game.inertia);
-    if (key.isDown("1".charCodeAt(0))) game.inertia = 0.5;
-    if (key.isDown("2".charCodeAt(0))) game.inertia = 0.6;
-    if (key.isDown("3".charCodeAt(0))) game.inertia = 0.7;
-    if (key.isDown("4".charCodeAt(0))) game.inertia = 0.8;
-    if (key.isDown("5".charCodeAt(0))) game.inertia = 0.9;
-    if (key.isDown("6".charCodeAt(0))) game.inertia = 1;
-    if (key.isDown("7".charCodeAt(0))) game.inertia = 1.1;
-    if (key.isDown("8".charCodeAt(0))) game.inertia = 1.2;
-    if (key.isDown("9".charCodeAt(0))) game.inertia = 1.3;
-    if (key.isDown("0".charCodeAt(0))) game.inertia = 1.4;*/
 
     if (game.intimetrial && graphics.fademode == 1 && game.quickrestartkludge)
     {
@@ -1995,27 +1748,8 @@ void gameinput()
     {
         if (obj.entities[ie].rule == 0)
         {
-            //game.test = true;
-            //game.teststring = "player(" + String(int(obj.entities[i])) + "," + String(int(obj.entities[i].yp)) + ")"
-            //  + ", mouse(" + String(int(game.mx)) + "," + String(int(game.my)) + ")";
             if (game.hascontrol && game.deathseq == -1 && game.lifeseq <= 5)
             {
-                /*
-                if (key.isDown(8)) {
-                script.load("returntohub");
-                }
-                */
-                /*
-                if (key.isDown(27)) {
-                game.state = 0;
-                graphics.textboxremove();
-
-                map.tdrawback = true;
-                music.haltdasmusik();
-                game.gamestate = TITLEMODE;
-                }
-                */
-
                 if (game.press_map && !game.mapheld)
                 {
                     game.mapheld = true;
@@ -2036,7 +1770,7 @@ void gameinput()
                                 //We're teleporting! Yey!
                                 game.activetele = false;
                                 game.hascontrol = false;
-                                music.fadeout(); //Uncomment this when it's working!
+                                music.fadeout();
 
                                 int player = obj.getplayer();
                                 obj.entities[player].colour = 102;
@@ -2054,10 +1788,7 @@ void gameinput()
                                 game.gamestate = 5;
                                 graphics.menuoffset = 240; //actually this should count the roomname
                                 if (map.extrarow) graphics.menuoffset -= 10;
-                                //graphics.menubuffer.copyPixels(graphics.screenbuffer, graphics.screenbuffer.rect, graphics.tl, null, null, false);
 
-                                //TODO TESTHIS
-                                //graphics.screenbuffer->UpdateScreen(graphics.menubuffer, NULL);
                                 BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
 
                                 graphics.resumegamemode = false;
@@ -2067,11 +1798,10 @@ void gameinput()
                             }
                             else
                             {
-                                //trace(game.recordstring);
                                 //We're teleporting! Yey!
                                 game.activetele = false;
                                 game.hascontrol = false;
-                                music.fadeout(); //Uncomment this when it's working!
+                                music.fadeout();
 
                                 int player = obj.getplayer();
                                 obj.entities[player].colour = 102;
@@ -2104,8 +1834,6 @@ void gameinput()
                         game.gamesaved = false;
                         graphics.resumegamemode = false;
                         game.menupage = 20; // The Map Page
-                        //graphics.menubuffer.copyPixels(graphics.screenbuffer, graphics.screenbuffer.rect, graphics.tl, null, null, false);
-                        //graphics.screenbuffer->UpdateScreen(graphics.menubuffer, NULL);
                         BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
                         graphics.menuoffset = 240; //actually this should count the roomname
                         if (map.extrarow) graphics.menuoffset -= 10;
@@ -2131,7 +1859,6 @@ void gameinput()
                         graphics.resumegamemode = false;
                         game.menupage = 0; // The Map Page
                         BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
-                        //graphics.screenbuffer->UpdateScreen(graphics.menubuffer, NULL);
                         graphics.menuoffset = 240; //actually this should count the roomname
                         if (map.extrarow) graphics.menuoffset -= 10;
                     }
@@ -2146,9 +1873,6 @@ void gameinput()
                     graphics.resumegamemode = false;
                     game.menupage = 10; // The Map Page
 
-                    //graphics.menubuffer.copyPixels(graphics.screenbuffer, graphics.screenbuffer.rect, graphics.tl, NULL, NULL, false);
-
-                    //graphics.screenbuffer->UpdateScreen(graphics.menubuffer, NULL);
                     BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
                     graphics.menuoffset = 240; //actually this should count the roomname
                     if (map.extrarow) graphics.menuoffset -= 10;
@@ -2193,13 +1917,11 @@ void gameinput()
 
                 if(game.press_left)
                 {
-                    //obj.entities[i].vx = -4;
                     obj.entities[ie].ax = -3;
                     obj.entities[ie].dir = 0;
                 }
                 else if (game.press_right)
                 {
-                    //obj.entities[i].vx = 4;
                     obj.entities[ie].ax = 3;
                     obj.entities[ie].dir = 1;
                 }
@@ -2566,9 +2288,6 @@ void teleporterinput()
 
 void gamecompleteinput()
 {
-    //game.mx = (mouseX / 2);
-    //game.my = (mouseY / 2);
-
     game.press_left = false;
     game.press_right = false;
     game.press_action = false;
@@ -2593,7 +2312,6 @@ void gamecompleteinput()
         game.press_action = true;
     }
     if (key.isDown(KEYBOARD_ENTER)|| key.isDown(game.controllerButton_map)) game.press_map = true;
-    //if (key.isDown(27)) { game.mapheld = true;  game.menupage = 10; }
 
     if (!game.mapheld)
     {
@@ -2610,11 +2328,6 @@ void gamecompleteinput()
 
 void gamecompleteinput2()
 {
-    //TODO Mouse Input!
-    //game.mx = (mouseX / 2);
-    //game.my = (mouseY / 2);
-
-
     game.press_left = false;
     game.press_right = false;
     game.press_action = false;
@@ -2635,7 +2348,6 @@ void gamecompleteinput2()
         game.press_action = true;
     }
     if (key.isDown(KEYBOARD_ENTER) || key.isDown(game.controllerButton_map)) game.press_map = true;
-    //if (key.isDown(27)) { game.mapheld = true;  game.menupage = 10; }
 
     if (!game.mapheld)
     {

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -10,7 +10,7 @@
 extern scriptclass script;
 
 // Found in titlerender.cpp
-void updategraphicsmode(Game& game, Graphics& graphics);
+void updategraphicsmode();
 
 void updatebuttonmappings(int bind)
 {
@@ -510,7 +510,7 @@ SDL_assert(0 && "Remove open level dir");
                     music.playef(11, 10);
                     graphics.screenbuffer->toggleFullScreen();
                     game.fullscreen = !game.fullscreen;
-                    updategraphicsmode(game, graphics);
+                    updategraphicsmode();
                     game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 0;
@@ -518,7 +518,7 @@ SDL_assert(0 && "Remove open level dir");
                     music.playef(11, 10);
                     graphics.screenbuffer->toggleStretchMode();
                     game.stretchMode = (game.stretchMode + 1) % 3;
-                    updategraphicsmode(game, graphics);
+                    updategraphicsmode();
                     game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 1;
@@ -526,7 +526,7 @@ SDL_assert(0 && "Remove open level dir");
                     music.playef(11, 10);
                     graphics.screenbuffer->toggleLinearFilter();
                     game.useLinearFilter = !game.useLinearFilter;
-                    updategraphicsmode(game, graphics);
+                    updategraphicsmode();
                     game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 2;
@@ -535,7 +535,7 @@ SDL_assert(0 && "Remove open level dir");
                       music.playef(11, 10);
                       game.fullScreenEffect_badSignal = !game.fullScreenEffect_badSignal;
                       //Hook the analogue thing in here: ABCDEFG
-                      updategraphicsmode(game, graphics);
+                      updategraphicsmode();
 					  graphics.screenbuffer->badSignalEffect= !graphics.screenbuffer->badSignalEffect;
                       game.savestats();
                       game.createmenu("graphicoptions");
@@ -576,7 +576,7 @@ SDL_assert(0 && "Remove open level dir");
                             {
                                 game.fullscreen = true;
                             }
-                            updategraphicsmode(game, graphics);
+                            updategraphicsmode();
                             game.savestats();
                             game.createmenu("graphicoptions");
                         }
@@ -588,10 +588,10 @@ SDL_assert(0 && "Remove open level dir");
                             if (game.fullscreen)
                             {
                                 game.fullscreen = false;
-                                updategraphicsmode(game, graphics);
+                                updategraphicsmode();
                                 game.fullscreen = true;
                             }
-                            updategraphicsmode(game, graphics);
+                            updategraphicsmode();
 
                             game.savestats();
                             game.createmenu("graphicoptions");
@@ -604,7 +604,7 @@ SDL_assert(0 && "Remove open level dir");
                             game.advanced_scaling = (game.advanced_scaling + 1) % 5;
                             graphics.screenbuffer->ResizeScreen(320 *game.advanced_scaling,240*game.advanced_scaling );
                             graphics.screenbuffer->SetScale(game.advanced_scaling);
-                            updategraphicsmode(game, graphics);
+                            updategraphicsmode();
 
                             game.savestats();
                             game.createmenu("graphicoptions");
@@ -615,7 +615,7 @@ SDL_assert(0 && "Remove open level dir");
                             //change smoothing
                             music.playef(11, 10);
                             game.advanced_smoothing = !game.advanced_smoothing;
-                            updategraphicsmode(game, graphics);
+                            updategraphicsmode();
 
                             game.savestats();
                             game.createmenu("graphicoptions");
@@ -644,7 +644,7 @@ SDL_assert(0 && "Remove open level dir");
                             {
                                 game.fullscreen = true;
                             }
-                            updategraphicsmode(game, graphics);
+                            updategraphicsmode();
 
                             game.savestats();
                             game.createmenu("graphicoptions");
@@ -657,10 +657,10 @@ SDL_assert(0 && "Remove open level dir");
                             if (game.fullscreen)
                             {
                                 game.fullscreen = false;
-                                updategraphicsmode(game, graphics);
+                                updategraphicsmode();
                                 game.fullscreen = true;
                             }
-                            updategraphicsmode(game, graphics);
+                            updategraphicsmode();
 
                             game.savestats();
                             game.createmenu("graphicoptions");

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -10,9 +10,9 @@
 extern scriptclass script;
 
 // Found in titlerender.cpp
-void updategraphicsmode(Game& game, Graphics& dwgfx);
+void updategraphicsmode(Game& game, Graphics& graphics);
 
-void updatebuttonmappings(Game& game, KeyPoll& key, musicclass& music, int bind)
+void updatebuttonmappings(int bind)
 {
 	for (
 		SDL_GameControllerButton i = SDL_CONTROLLER_BUTTON_A;
@@ -113,7 +113,7 @@ void updatebuttonmappings(Game& game, KeyPoll& key, musicclass& music, int bind)
 	}
 }
 
-void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, UtilityClass& help, musicclass& music)
+void titleinput()
 {
     //game.mx = (mouseX / 4);
     //game.my = (mouseY / 4);
@@ -126,7 +126,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
     game.press_action = false;
     game.press_map = false;
 
-    if (dwgfx.flipmode)
+    if (graphics.flipmode)
     {
 		//GAMEPAD TODO
         if (key.isDown(KEYBOARD_LEFT) || key.isDown(KEYBOARD_DOWN) || key.isDown(KEYBOARD_a) ||  key.isDown(KEYBOARD_s) || key.controllerWantsRight(true)) game.press_left = true;
@@ -151,7 +151,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
     if (!game.press_action && !game.press_left && !game.press_right) game.jumpheld = false;
     if (!game.press_map) game.mapheld = false;
 
-    if (!game.jumpheld && dwgfx.fademode==0)
+    if (!game.jumpheld && graphics.fademode==0)
     {
         if (game.press_action || game.press_left || game.press_right || game.press_map)
         {
@@ -180,14 +180,14 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
         game.flashlight = 5;
         }else{
         if(game.mainmenu==0){
-        dwgfx.fademode = 2;
+        graphics.fademode = 2;
         }else if (game.mainmenu == 1) {
         if (game.telesummary != "") {
-        dwgfx.fademode = 2;
+        graphics.fademode = 2;
         }
         }else if (game.mainmenu == 2) {
         if (game.quicksummary != "") {
-        dwgfx.fademode = 2;
+        graphics.fademode = 2;
         }
         }
         }
@@ -270,7 +270,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                         //bye!
                         music.playef(2, 10);
                         game.mainmenu = 100;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                 }
             #elif !defined(MAKEANDPLAY)
@@ -282,7 +282,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                         {
                             //No saves exist, just start a new game
                             game.mainmenu = 0;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else
                         {
@@ -327,7 +327,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                         //bye!
                         music.playef(2, 10);
                         game.mainmenu = 100;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                 #else
                     if (game.currentmenuoption == 0)
@@ -337,7 +337,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                         {
                             //No saves exist, just start a new game
                             game.mainmenu = 0;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else
                         {
@@ -389,7 +389,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                         //bye!
                         music.playef(2, 10);
                         game.mainmenu = 100;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
             #endif
                 }
@@ -425,7 +425,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                     TiXmlDocument doc;
 	                  if (!FILESYSTEM_loadTiXmlDocument(name.c_str(), &doc)){
 	                    game.mainmenu = 22;
-                      dwgfx.fademode = 2;
+                      graphics.fademode = 2;
 	                  }else{
                       game.createmenu("quickloadlevel");
                       map.nexttowercolour();
@@ -437,10 +437,10 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                 {
                   if(game.currentmenuoption==0){//continue save
                     game.mainmenu = 23;
-                    dwgfx.fademode = 2;
+                    graphics.fademode = 2;
                   }else if(game.currentmenuoption==1){
 	                  game.mainmenu = 22;
-                    dwgfx.fademode = 2;
+                    graphics.fademode = 2;
                   }else if(game.currentmenuoption==2){
                     music.playef(11, 10);
                     game.levelpage=0;
@@ -464,7 +464,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                     //LEVEL EDITOR HOOK
                     music.playef(11, 10);
                     game.mainmenu = 20;
-                    dwgfx.fademode = 2;
+                    graphics.fademode = 2;
                     ed.filename="";
                   }/*else if(game.currentmenuoption==2){
                     music.playef(11, 10);
@@ -508,25 +508,25 @@ SDL_assert(0 && "Remove open level dir");
                 {
                   if (game.currentmenuoption == 0){
                     music.playef(11, 10);
-                    dwgfx.screenbuffer->toggleFullScreen();
+                    graphics.screenbuffer->toggleFullScreen();
                     game.fullscreen = !game.fullscreen;
-                    updategraphicsmode(game, dwgfx);
+                    updategraphicsmode(game, graphics);
                     game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 0;
                   }else if (game.currentmenuoption == 1){
                     music.playef(11, 10);
-                    dwgfx.screenbuffer->toggleStretchMode();
+                    graphics.screenbuffer->toggleStretchMode();
                     game.stretchMode = (game.stretchMode + 1) % 3;
-                    updategraphicsmode(game, dwgfx);
+                    updategraphicsmode(game, graphics);
                     game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 1;
                   }else if (game.currentmenuoption == 2){
                     music.playef(11, 10);
-                    dwgfx.screenbuffer->toggleLinearFilter();
+                    graphics.screenbuffer->toggleLinearFilter();
                     game.useLinearFilter = !game.useLinearFilter;
-                    updategraphicsmode(game, dwgfx);
+                    updategraphicsmode(game, graphics);
                     game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 2;
@@ -535,21 +535,21 @@ SDL_assert(0 && "Remove open level dir");
                       music.playef(11, 10);
                       game.fullScreenEffect_badSignal = !game.fullScreenEffect_badSignal;
                       //Hook the analogue thing in here: ABCDEFG
-                      updategraphicsmode(game, dwgfx);
-					  dwgfx.screenbuffer->badSignalEffect= !dwgfx.screenbuffer->badSignalEffect;
+                      updategraphicsmode(game, graphics);
+					  graphics.screenbuffer->badSignalEffect= !graphics.screenbuffer->badSignalEffect;
                       game.savestats();
                       game.createmenu("graphicoptions");
                       game.currentmenuoption = 3;
                   }else if (game.currentmenuoption == 4) {
                       //toggle mouse cursor
                       music.playef(11, 10);
-                      if (dwgfx.showmousecursor == true) {
+                      if (graphics.showmousecursor == true) {
                           SDL_ShowCursor(SDL_DISABLE);
-                          dwgfx.showmousecursor = false;
+                          graphics.showmousecursor = false;
                       }
                       else {
                           SDL_ShowCursor(SDL_ENABLE);
-                          dwgfx.showmousecursor = true;
+                          graphics.showmousecursor = true;
                       }
                   }
                   else
@@ -566,7 +566,7 @@ SDL_assert(0 && "Remove open level dir");
                         if (game.currentmenuoption == 0)
                         {
                             //toggle fullscreen
-                            dwgfx.screenbuffer->toggleFullScreen();
+                            graphics.screenbuffer->toggleFullScreen();
                             music.playef(11, 10);
                             if (game.fullscreen)
                             {
@@ -576,7 +576,7 @@ SDL_assert(0 && "Remove open level dir");
                             {
                                 game.fullscreen = true;
                             }
-                            updategraphicsmode(game, dwgfx);
+                            updategraphicsmode(game, graphics);
                             game.savestats();
                             game.createmenu("graphicoptions");
                         }
@@ -588,10 +588,10 @@ SDL_assert(0 && "Remove open level dir");
                             if (game.fullscreen)
                             {
                                 game.fullscreen = false;
-                                updategraphicsmode(game, dwgfx);
+                                updategraphicsmode(game, graphics);
                                 game.fullscreen = true;
                             }
-                            updategraphicsmode(game, dwgfx);
+                            updategraphicsmode(game, graphics);
 
                             game.savestats();
                             game.createmenu("graphicoptions");
@@ -602,9 +602,9 @@ SDL_assert(0 && "Remove open level dir");
                             //change scaling mode
                             music.playef(11, 10);
                             game.advanced_scaling = (game.advanced_scaling + 1) % 5;
-                            dwgfx.screenbuffer->ResizeScreen(320 *game.advanced_scaling,240*game.advanced_scaling );
-                            dwgfx.screenbuffer->SetScale(game.advanced_scaling);
-                            updategraphicsmode(game, dwgfx);
+                            graphics.screenbuffer->ResizeScreen(320 *game.advanced_scaling,240*game.advanced_scaling );
+                            graphics.screenbuffer->SetScale(game.advanced_scaling);
+                            updategraphicsmode(game, graphics);
 
                             game.savestats();
                             game.createmenu("graphicoptions");
@@ -615,7 +615,7 @@ SDL_assert(0 && "Remove open level dir");
                             //change smoothing
                             music.playef(11, 10);
                             game.advanced_smoothing = !game.advanced_smoothing;
-                            updategraphicsmode(game, dwgfx);
+                            updategraphicsmode(game, graphics);
 
                             game.savestats();
                             game.createmenu("graphicoptions");
@@ -633,7 +633,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         if (game.currentmenuoption == 0)
                         {
-                            dwgfx.screenbuffer->toggleFullScreen();
+                            graphics.screenbuffer->toggleFullScreen();
                             //toggle fullscreen
                             music.playef(11, 10);
                             if (game.fullscreen)
@@ -644,7 +644,7 @@ SDL_assert(0 && "Remove open level dir");
                             {
                                 game.fullscreen = true;
                             }
-                            updategraphicsmode(game, dwgfx);
+                            updategraphicsmode(game, graphics);
 
                             game.savestats();
                             game.createmenu("graphicoptions");
@@ -657,10 +657,10 @@ SDL_assert(0 && "Remove open level dir");
                             if (game.fullscreen)
                             {
                                 game.fullscreen = false;
-                                updategraphicsmode(game, dwgfx);
+                                updategraphicsmode(game, graphics);
                                 game.fullscreen = true;
                             }
-                            updategraphicsmode(game, dwgfx);
+                            updategraphicsmode(game, graphics);
 
                             game.savestats();
                             game.createmenu("graphicoptions");
@@ -683,7 +683,7 @@ SDL_assert(0 && "Remove open level dir");
                         //bye!
                         music.playef(2, 10);
                         game.mainmenu = 100;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else
                     {
@@ -805,7 +805,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 2)
                     {
                         //disable text outline
-                        dwgfx.notextoutline = !dwgfx.notextoutline;
+                        graphics.notextoutline = !graphics.notextoutline;
                         game.savestats();
                         music.playef(11, 10);
                     }
@@ -839,7 +839,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 6)
                     {
                         // toggle translucent roomname BG
-                        dwgfx.translucentroomname = !dwgfx.translucentroomname;
+                        graphics.translucentroomname = !graphics.translucentroomname;
                         music.playef(11, 10);
                     }
                     else if (game.currentmenuoption == 7)
@@ -1301,13 +1301,13 @@ SDL_assert(0 && "Remove open level dir");
                         {
                             //You at least have a quicksave, or you couldn't have gotten here
                             game.mainmenu = 2;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else if (game.quicksummary == "")
                         {
                             //You at least have a telesave, or you couldn't have gotten here
                             game.mainmenu = 1;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else
                         {
@@ -1351,13 +1351,13 @@ SDL_assert(0 && "Remove open level dir");
                         {
                             //You at least have a quicksave, or you couldn't have gotten here
                             game.mainmenu = 2;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else if (game.quicksummary == "")
                         {
                             //You at least have a telesave, or you couldn't have gotten here
                             game.mainmenu = 1;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else
                         {
@@ -1372,7 +1372,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
 										  if(!map.invincibility){
                         game.mainmenu = 11;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
 											}else{
                         //Can't do yet! play sad sound
                         music.playef(2, 10);
@@ -1406,7 +1406,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         //yep
                         game.mainmenu = 0;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                         game.deletequick();
                         game.deletetele();
                     }
@@ -1519,7 +1519,7 @@ SDL_assert(0 && "Remove open level dir");
                         music.playef(18, 10);
                         game.screenshake = 10;
                         game.flashlight = 5;
-                        dwgfx.setflipmode = !dwgfx.setflipmode;
+                        graphics.setflipmode = !graphics.setflipmode;
                         game.savemystats = true;
                     }
                     else if (game.currentmenuoption == 4)
@@ -1540,12 +1540,12 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)   //start no death mode, disabling cutscenes
                     {
                         game.mainmenu = 10;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 1)
                     {
                         game.mainmenu = 9;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 2)
                     {
@@ -1560,12 +1560,12 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         game.mainmenu = 1;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 1)
                     {
                         game.mainmenu = 2;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 2)
                     {
@@ -1604,22 +1604,22 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         game.mainmenu = 12;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 1)
                     {
                         game.mainmenu = 13;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 2)
                     {
                         game.mainmenu = 14;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 3)
                     {
                         game.mainmenu = 15;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 4)
                     {
@@ -1634,22 +1634,22 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         game.mainmenu = 16;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 1)
                     {
                         game.mainmenu = 17;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 2)
                     {
                         game.mainmenu = 18;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 3)
                     {
                         game.mainmenu = 19;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 4)
                     {
@@ -1687,32 +1687,32 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0 && game.unlock[9])   //space station 1
                     {
                         game.mainmenu = 3;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 1 && game.unlock[10])    //lab
                     {
                         game.mainmenu = 4;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 2 && game.unlock[11])    //tower
                     {
                         game.mainmenu = 5;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 3 && game.unlock[12])    //station 2
                     {
                         game.mainmenu = 6;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 4 && game.unlock[13])    //warp
                     {
                         game.mainmenu = 7;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 5 && game.unlock[14])    //final
                     {
                         game.mainmenu = 8;
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                     else if (game.currentmenuoption == 6)    //go to the time trial menu
                     {
@@ -1743,32 +1743,32 @@ SDL_assert(0 && "Remove open level dir");
                         if (game.timetriallevel == 0)   //space station 1
                         {
                             game.mainmenu = 3;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else if (game.timetriallevel == 1)    //lab
                         {
                             game.mainmenu = 4;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else if (game.timetriallevel == 2)    //tower
                         {
                             game.mainmenu = 5;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else if (game.timetriallevel == 3)    //station 2
                         {
                             game.mainmenu = 6;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else if (game.timetriallevel == 4)    //warp
                         {
                             game.mainmenu = 7;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else if (game.timetriallevel == 5)    //final
                         {
                             game.mainmenu = 8;
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                     }
                 }
@@ -1789,17 +1789,16 @@ SDL_assert(0 && "Remove open level dir");
                 game.currentmenuoption < 4 &&
                 key.controllerButtonDown()      )
         {
-            updatebuttonmappings(game, key, music, game.currentmenuoption);
+            updatebuttonmappings(game.currentmenuoption);
         }
 
     }
 
-    if (dwgfx.fademode == 1)
+    if (graphics.fademode == 1)
         script.startgamemode(game.mainmenu);
 }
 
-void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-               entityclass& obj, UtilityClass& help, musicclass& music)
+void gameinput()
 {
     //TODO mouse input
     //game.mx = (mouseX / 2);
@@ -1924,18 +1923,18 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 
     /*
     if (key.isDown("1".charCodeAt(0))) {
-    dwgfx.screen.width = 640;
-    dwgfx.screen.height = 480;
+    graphics.screen.width = 640;
+    graphics.screen.height = 480;
     setstage(640,480);
     }
     if (key.isDown("2".charCodeAt(0))) {
-    dwgfx.screen.width = 960;
-    dwgfx.screen.height = 720;
+    graphics.screen.width = 960;
+    graphics.screen.height = 720;
     setstage(960,720);
     }
     if (key.isDown("3".charCodeAt(0))) {
-    dwgfx.screen.width = 1280;
-    dwgfx.screen.height = 960;
+    graphics.screen.width = 1280;
+    graphics.screen.height = 960;
     setstage(1280,960);
     }
     */
@@ -1952,7 +1951,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
     if (key.isDown("9".charCodeAt(0))) game.inertia = 1.3;
     if (key.isDown("0".charCodeAt(0))) game.inertia = 1.4;*/
 
-    if (game.intimetrial && dwgfx.fademode == 1 && game.quickrestartkludge)
+    if (game.intimetrial && graphics.fademode == 1 && game.quickrestartkludge)
     {
         //restart the time trial
         game.quickrestartkludge = false;
@@ -1976,14 +1975,14 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         }else{
           game.gamestate = EDITORMODE;
 
-          dwgfx.textboxremove();
+          graphics.textboxremove();
           game.hascontrol = true;
           game.advancetext = false;
           game.completestop = false;
           game.state = 0;
-			    dwgfx.showcutscenebars = false;
+			    graphics.showcutscenebars = false;
 
-          dwgfx.backgrounddrawn=false;
+          graphics.backgrounddrawn=false;
           music.fadeout();
           //If warpdir() is used during playtesting, we need to set it back after!
           for (int j = 0; j < ed.maxheight; j++)
@@ -2016,7 +2015,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
                 /*
                 if (key.isDown(27)) {
                 game.state = 0;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
 
                 map.tdrawback = true;
                 music.haltdasmusik();
@@ -2030,7 +2029,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 
                     if (game.activetele && game.readytotele > 20 && !game.intimetrial)
                     {
-                        if(!dwgfx.flipmode)
+                        if(!graphics.flipmode)
                         {
                             obj.flags[73] = 1; //Flip mode test
                         }
@@ -2060,15 +2059,15 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
                             {
                                 //Alright, normal teleporting
                                 game.gamestate = 5;
-                                dwgfx.menuoffset = 240; //actually this should count the roomname
-                                if (map.extrarow) dwgfx.menuoffset -= 10;
-                                //dwgfx.menubuffer.copyPixels(dwgfx.screenbuffer, dwgfx.screenbuffer.rect, dwgfx.tl, null, null, false);
+                                graphics.menuoffset = 240; //actually this should count the roomname
+                                if (map.extrarow) graphics.menuoffset -= 10;
+                                //graphics.menubuffer.copyPixels(graphics.screenbuffer, graphics.screenbuffer.rect, graphics.tl, null, null, false);
 
                                 //TODO TESTHIS
-                                //dwgfx.screenbuffer->UpdateScreen(dwgfx.menubuffer, NULL);
-								BlitSurfaceStandard(dwgfx.menubuffer,NULL,dwgfx.backBuffer, NULL);
+                                //graphics.screenbuffer->UpdateScreen(graphics.menubuffer, NULL);
+								BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
 
-                                dwgfx.resumegamemode = false;
+                                graphics.resumegamemode = false;
 
                                 game.useteleporter = true;
                                 game.initteleportermode();
@@ -2110,38 +2109,38 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
                         //Quit menu, same conditions as in game menu
                         game.gamestate = MAPMODE;
                         game.gamesaved = false;
-                        dwgfx.resumegamemode = false;
+                        graphics.resumegamemode = false;
                         game.menupage = 20; // The Map Page
-                        //dwgfx.menubuffer.copyPixels(dwgfx.screenbuffer, dwgfx.screenbuffer.rect, dwgfx.tl, null, null, false);
-                        //dwgfx.screenbuffer->UpdateScreen(dwgfx.menubuffer, NULL);
-														BlitSurfaceStandard(dwgfx.menubuffer,NULL,dwgfx.backBuffer, NULL);
-                        dwgfx.menuoffset = 240; //actually this should count the roomname
-                        if (map.extrarow) dwgfx.menuoffset -= 10;
+                        //graphics.menubuffer.copyPixels(graphics.screenbuffer, graphics.screenbuffer.rect, graphics.tl, null, null, false);
+                        //graphics.screenbuffer->UpdateScreen(graphics.menubuffer, NULL);
+														BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
+                        graphics.menuoffset = 240; //actually this should count the roomname
+                        if (map.extrarow) graphics.menuoffset -= 10;
                     }
-                    else if (game.intimetrial && dwgfx.fademode==0)
+                    else if (game.intimetrial && graphics.fademode==0)
                     {
                         //Quick restart of time trial
                         script.hardreset();
-                        if (dwgfx.setflipmode) dwgfx.flipmode = true;
-                        dwgfx.fademode = 2;
+                        if (graphics.setflipmode) graphics.flipmode = true;
+                        graphics.fademode = 2;
                         game.completestop = true;
                         music.fadeout();
                         game.intimetrial = true;
                         game.quickrestartkludge = true;
                     }
-                    else if (dwgfx.fademode==0)
+                    else if (graphics.fademode==0)
                     {
                         //Normal map screen, do transition later
                         game.gamestate = MAPMODE;
                         map.cursordelay = 0;
                         map.cursorstate = 0;
                         game.gamesaved = false;
-                        dwgfx.resumegamemode = false;
+                        graphics.resumegamemode = false;
                         game.menupage = 0; // The Map Page
-														BlitSurfaceStandard(dwgfx.menubuffer,NULL,dwgfx.backBuffer, NULL);
-                        //dwgfx.screenbuffer->UpdateScreen(dwgfx.menubuffer, NULL);
-                        dwgfx.menuoffset = 240; //actually this should count the roomname
-                        if (map.extrarow) dwgfx.menuoffset -= 10;
+														BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
+                        //graphics.screenbuffer->UpdateScreen(graphics.menubuffer, NULL);
+                        graphics.menuoffset = 240; //actually this should count the roomname
+                        if (map.extrarow) graphics.menuoffset -= 10;
                     }
                 }
 
@@ -2151,15 +2150,15 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
                     //Quit menu, same conditions as in game menu
                     game.gamestate = MAPMODE;
                     game.gamesaved = false;
-                    dwgfx.resumegamemode = false;
+                    graphics.resumegamemode = false;
                     game.menupage = 10; // The Map Page
 
-                    //dwgfx.menubuffer.copyPixels(dwgfx.screenbuffer, dwgfx.screenbuffer.rect, dwgfx.tl, NULL, NULL, false);
+                    //graphics.menubuffer.copyPixels(graphics.screenbuffer, graphics.screenbuffer.rect, graphics.tl, NULL, NULL, false);
 
-                    //dwgfx.screenbuffer->UpdateScreen(dwgfx.menubuffer, NULL);
-													BlitSurfaceStandard(dwgfx.menubuffer,NULL,dwgfx.backBuffer, NULL);
-                    dwgfx.menuoffset = 240; //actually this should count the roomname
-                    if (map.extrarow) dwgfx.menuoffset -= 10;
+                    //graphics.screenbuffer->UpdateScreen(graphics.menubuffer, NULL);
+													BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
+                    graphics.menuoffset = 240; //actually this should count the roomname
+                    if (map.extrarow) graphics.menuoffset -= 10;
                 }
 
                 if (key.keymap[SDLK_r] && game.deathseq<=0)// && map.custommode) //Have fun glitchrunners!
@@ -2267,8 +2266,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
     }
 }
 
-void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-              entityclass& obj, UtilityClass& help, musicclass& music)
+void mapinput()
 {
     //TODO Mouse Input!
     //game.mx = (mouseX / 2);
@@ -2279,9 +2277,9 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
     game.press_action = false;
     game.press_map = false;
 
-    if(dwgfx.menuoffset==0)
+    if(graphics.menuoffset==0)
     {
-        if (dwgfx.flipmode)
+        if (graphics.flipmode)
         {
             if (key.isDown(KEYBOARD_LEFT) || key.isDown(KEYBOARD_DOWN) || key.isDown(KEYBOARD_a) ||  key.isDown(KEYBOARD_s) || key.controllerWantsLeft(false) ) game.press_left = true;
             if (key.isDown(KEYBOARD_RIGHT) || key.isDown(KEYBOARD_UP) || key.isDown(KEYBOARD_d) ||  key.isDown(KEYBOARD_w) || key.controllerWantsRight(false)) game.press_right = true;
@@ -2336,14 +2334,14 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         if(game.press_map && game.menupage < 10)
         {
             //Normal map screen, do transition later
-            dwgfx.resumegamemode = true;
+            graphics.resumegamemode = true;
         }
     }
 
-    if (dwgfx.fademode == 1)
+    if (graphics.fademode == 1)
     {
-        FillRect(dwgfx.menubuffer, 0x000000);
-        dwgfx.resumegamemode = true;
+        FillRect(graphics.menubuffer, 0x000000);
+        graphics.resumegamemode = true;
         obj.removeallblocks();
         game.menukludge = false;
         if (game.menupage >= 20)
@@ -2377,7 +2375,7 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         if (game.menupage == 1 && obj.flags[67] == 1 && game.press_action && !game.insecretlab && !map.custommode)
         {
             //Warp back to the ship
-            dwgfx.resumegamemode = true;
+            graphics.resumegamemode = true;
 
             game.teleport_to_x = 2;
             game.teleport_to_y = 11;
@@ -2424,20 +2422,20 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         if (game.menupage == 10 && game.press_action)
         {
             //return to game
-            dwgfx.resumegamemode = true;
+            graphics.resumegamemode = true;
         }
         if (game.menupage == 11 && game.press_action)
         {
             //quit to menu
-            if (dwgfx.fademode == 0)
+            if (graphics.fademode == 0)
             {
 				//Kill contents of offset render buffer, since we do that for some reason.
 				//This fixes an apparent frame flicker.
-				FillRect(dwgfx.tempBuffer, 0x000000);
+				FillRect(graphics.tempBuffer, 0x000000);
                 if (game.intimetrial || game.insecretlab || game.nodeathmode) game.menukludge = true;
                 script.hardreset();
-                if(dwgfx.setflipmode) dwgfx.flipmode = true;
-                dwgfx.fademode = 2;
+                if(graphics.setflipmode) graphics.flipmode = true;
+                graphics.fademode = 2;
                 music.fadeout();
                 map.nexttowercolour();
             }
@@ -2446,15 +2444,15 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         if (game.menupage == 20 && game.press_action)
         {
             //return to game
-            dwgfx.resumegamemode = true;
+            graphics.resumegamemode = true;
         }
         if (game.menupage == 21 && game.press_action)
         {
             //quit to menu
-            if (dwgfx.fademode == 0)
+            if (graphics.fademode == 0)
             {
                 game.swnmode = false;
-                dwgfx.fademode = 2;
+                graphics.fademode = 2;
                 music.fadeout();
             }
         }
@@ -2471,8 +2469,7 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
     }
 }
 
-void teleporterinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                     entityclass& obj, UtilityClass& help, musicclass& music)
+void teleporterinput()
 {
     //Todo Mouseinput!
     //game.mx = (mouseX / 2);
@@ -2485,7 +2482,7 @@ void teleporterinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
     game.press_action = false;
     game.press_map = false;
 
-    if(dwgfx.menuoffset==0)
+    if(graphics.menuoffset==0)
     {
         if (key.isDown(KEYBOARD_LEFT)|| key.isDown(KEYBOARD_a) || key.controllerWantsLeft(false) ) game.press_left = true;
         if (key.isDown(KEYBOARD_RIGHT) || key.isDown(KEYBOARD_d)|| key.controllerWantsRight(false) ) game.press_right = true;
@@ -2546,12 +2543,12 @@ void teleporterinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
             if (game.roomx == tempx + 100 && game.roomy == tempy + 100)
             {
                 //cancel!
-                dwgfx.resumegamemode = true;
+                graphics.resumegamemode = true;
             }
             else
             {
                 //teleport
-                dwgfx.resumegamemode = true;
+                graphics.resumegamemode = true;
                 game.teleport_to_x = tempx;
                 game.teleport_to_y = tempy;
 
@@ -2574,8 +2571,7 @@ void teleporterinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
     }
 }
 
-void gamecompleteinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                       entityclass& obj, UtilityClass& help, musicclass& music)
+void gamecompleteinput()
 {
     //game.mx = (mouseX / 2);
     //game.my = (mouseY / 2);
@@ -2590,9 +2586,9 @@ void gamecompleteinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         game.creditposition -= 6;
         if (game.creditposition <= -game.creditmaxposition)
         {
-            if(dwgfx.fademode==0)
+            if(graphics.fademode==0)
             {
-                dwgfx.fademode = 2;
+                graphics.fademode = 2;
             }
             game.creditposition = -game.creditmaxposition;
         }
@@ -2611,16 +2607,15 @@ void gamecompleteinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         if(game.press_map)
         {
             //Return to game
-            if(dwgfx.fademode==0)
+            if(graphics.fademode==0)
             {
-                dwgfx.fademode = 2;
+                graphics.fademode = 2;
             }
         }
     }
 }
 
-void gamecompleteinput2(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                        entityclass& obj, UtilityClass& help, musicclass& music)
+void gamecompleteinput2()
 {
     //TODO Mouse Input!
     //game.mx = (mouseX / 2);
@@ -2638,9 +2633,9 @@ void gamecompleteinput2(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map
         game.creditposx++;
         if (game.creditposy >= 30)
         {
-            if(dwgfx.fademode==0)
+            if(graphics.fademode==0)
             {
-                dwgfx.fademode = 2;
+                graphics.fademode = 2;
                 music.fadeout();
             }
         }
@@ -2654,9 +2649,9 @@ void gamecompleteinput2(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map
         if(game.press_map)
         {
             //Return to game
-            if(dwgfx.fademode==0)
+            if(graphics.fademode==0)
             {
-                dwgfx.fademode = 2;
+                graphics.fademode = 2;
                 music.fadeout();
             }
         }

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1795,7 +1795,7 @@ SDL_assert(0 && "Remove open level dir");
     }
 
     if (dwgfx.fademode == 1)
-        script.startgamemode(game.mainmenu, key, dwgfx, game, map, obj, help, music);
+        script.startgamemode(game.mainmenu);
 }
 
 void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
@@ -1956,7 +1956,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
     {
         //restart the time trial
         game.quickrestartkludge = false;
-        script.startgamemode(game.timetriallevel + 3, key, dwgfx, game, map, obj, help, music);
+        script.startgamemode(game.timetriallevel + 3);
         game.deathseq = -1;
         game.completestop = false;
     }
@@ -2121,7 +2121,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
                     else if (game.intimetrial && dwgfx.fademode==0)
                     {
                         //Quick restart of time trial
-                        script.hardreset(key, dwgfx, game, map, obj, help, music);
+                        script.hardreset();
                         if (dwgfx.setflipmode) dwgfx.flipmode = true;
                         dwgfx.fademode = 2;
                         game.completestop = true;
@@ -2435,7 +2435,7 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				//This fixes an apparent frame flicker.
 				FillRect(dwgfx.tempBuffer, 0x000000);
                 if (game.intimetrial || game.insecretlab || game.nodeathmode) game.menukludge = true;
-                script.hardreset(key, dwgfx, game, map, obj, help, music);
+                script.hardreset();
                 if(dwgfx.setflipmode) dwgfx.flipmode = true;
                 dwgfx.fademode = 2;
                 music.fadeout();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -31,7 +31,7 @@ void updatebuttonmappings(int bind)
 				if (!dupe)
 				{
 					game.controllerButton_flip.push_back(i);
-					music.playef(11, 10);
+					music.playef(11);
 				}
 				for (size_t j = 0; j < game.controllerButton_map.size(); j += 1)
 				{
@@ -60,7 +60,7 @@ void updatebuttonmappings(int bind)
 				if (!dupe)
 				{
 					game.controllerButton_map.push_back(i);
-					music.playef(11, 10);
+					music.playef(11);
 				}
 				for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
 				{
@@ -89,7 +89,7 @@ void updatebuttonmappings(int bind)
 				if (!dupe)
 				{
 					game.controllerButton_esc.push_back(i);
-					music.playef(11, 10);
+					music.playef(11);
 				}
 				for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
 				{
@@ -172,7 +172,7 @@ void titleinput()
         if (!game.menustart) {
         game.menustart = true;
         music.play(6);
-        music.playef(18, 10);
+        music.playef(18);
         game.screenshake = 10;
         game.flashlight = 5;
         }else{
@@ -193,7 +193,7 @@ void titleinput()
 
         if (key.isDown(27) && game.currentmenuname != "youwannaquit" && game.menustart)
         {
-            music.playef(11, 10);
+            music.playef(11);
             game.previousmenuname = game.currentmenuname;
             game.createmenu("youwannaquit");
             map.nexttowercolour();
@@ -220,7 +220,7 @@ void titleinput()
             {
                 game.menustart = true;
                 music.play(6);
-                music.playef(18, 10);
+                music.playef(18);
                 game.screenshake = 10;
                 game.flashlight = 5;
                 map.colstate = 10;
@@ -235,21 +235,21 @@ void titleinput()
 				   if (game.currentmenuoption == 0)
                     {
                       //Bring you to the normal playmenu
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("playerworlds");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 1)
                     {
                         //Options
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("graphicoptions");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 2)
                     {
                         //Options
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("options");
 
 												//Add extra menu for mmmmmm mod
@@ -265,7 +265,7 @@ void titleinput()
                     else if (game.currentmenuoption == 3)
                     {
                         //bye!
-                        music.playef(2, 10);
+                        music.playef(2);
                         game.mainmenu = 100;
                         graphics.fademode = 2;
                     }
@@ -284,7 +284,7 @@ void titleinput()
                         else
                         {
                             //Bring you to the normal playmenu
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("play");
                             map.nexttowercolour();
                         }
@@ -292,14 +292,14 @@ void titleinput()
                     else if (game.currentmenuoption == 1)
                     {
                         //Options
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("graphicoptions");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 2)
                     {
                         //Options
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("options");
 
 												//Add extra menu for mmmmmm mod
@@ -315,14 +315,14 @@ void titleinput()
                     else if (game.currentmenuoption == 3)
                     {
                         //Credits
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 4)
                     {
                         //bye!
-                        music.playef(2, 10);
+                        music.playef(2);
                         game.mainmenu = 100;
                         graphics.fademode = 2;
                     }
@@ -339,7 +339,7 @@ void titleinput()
                         else
                         {
                             //Bring you to the normal playmenu
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("play");
                             map.nexttowercolour();
                         }
@@ -347,21 +347,21 @@ void titleinput()
                     else if (game.currentmenuoption == 1)
                     {
                         //Bring you to the normal playmenu
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("playerworlds");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 2)
                     {
                         //Options
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("graphicoptions");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 3)
                     {
                         //Options
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("options");
 
                         //Add extra menu for mmmmmm mod
@@ -377,14 +377,14 @@ void titleinput()
                     else if (game.currentmenuoption == 4)
                     {
                         //Credits
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 5)
                     {
                         //bye!
-                        music.playef(2, 10);
+                        music.playef(2);
                         game.mainmenu = 100;
                         graphics.fademode = 2;
                     }
@@ -396,12 +396,12 @@ void titleinput()
                 {
                   if(game.currentmenuoption==game.nummenuoptions-1){
                     //go back to menu
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.createmenu("mainmenu");
                     map.nexttowercolour();
                   }else if(game.currentmenuoption==game.nummenuoptions-2){
                     //next page
-                    music.playef(11, 10);
+                    music.playef(11);
                     if((size_t) ((game.levelpage*8)+8) >= ed.ListOfMetaData.size()){
                       game.levelpage=0;
                     }else{
@@ -413,7 +413,7 @@ void titleinput()
                   }else{
                     //Ok, launch the level!
                     //PLAY CUSTOM LEVEL HOOK
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.playcustomlevel=(game.levelpage*8)+game.currentmenuoption;
                     game.customleveltitle=ed.ListOfMetaData[game.playcustomlevel].title;
                     game.customlevelfilename=ed.ListOfMetaData[game.playcustomlevel].filename;
@@ -439,7 +439,7 @@ void titleinput()
 	                  game.mainmenu = 22;
                     graphics.fademode = 2;
                   }else if(game.currentmenuoption==2){
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.levelpage=0;
                     game.createmenu("levellist");
                     map.nexttowercolour();
@@ -451,7 +451,7 @@ void titleinput()
                 #if !defined(NO_EDITOR)
                   if(game.currentmenuoption==0){
 
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.levelpage=0;
                     ed.getDirectoryData();
                     game.loadcustomlevelstats(); //Should only load a file if it's needed
@@ -459,12 +459,12 @@ void titleinput()
                     map.nexttowercolour();
                   }else if(game.currentmenuoption==1){
                     //LEVEL EDITOR HOOK
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.mainmenu = 20;
                     graphics.fademode = 2;
                     ed.filename="";
                   }/*else if(game.currentmenuoption==2){
-                    music.playef(11, 10);
+                    music.playef(11);
                     //"OPENFOLDERHOOK"
                     //When the player selects the "open level folder" menu option,
                     //this is where it should run the appropriate code.
@@ -475,13 +475,13 @@ SDL_assert(0 && "Remove open level dir");
 
                   }*/else if(game.currentmenuoption==2){
                     //back
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.createmenu("mainmenu");
                     map.nexttowercolour();
                   }
                 #else
                   if(game.currentmenuoption==0){
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.levelpage=0;
                     ed.getDirectoryData();
                     game.loadcustomlevelstats(); //Should only load a file if it's needed
@@ -489,7 +489,7 @@ SDL_assert(0 && "Remove open level dir");
                     map.nexttowercolour();
                   }else if(game.currentmenuoption==1){
                     //back
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.createmenu("mainmenu");
                     map.nexttowercolour();
                   }
@@ -497,28 +497,28 @@ SDL_assert(0 && "Remove open level dir");
                 }
             #endif
                 else if(game.currentmenuname=="errornostart"){
-                  music.playef(11, 10);
+                  music.playef(11);
                   game.createmenu("mainmenu");
                   map.nexttowercolour();
                 }
                 else if (game.currentmenuname == "graphicoptions")
                 {
                   if (game.currentmenuoption == 0){
-                    music.playef(11, 10);
+                    music.playef(11);
                     graphics.screenbuffer->toggleFullScreen();
                     game.fullscreen = !game.fullscreen;
                     game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 0;
                   }else if (game.currentmenuoption == 1){
-                    music.playef(11, 10);
+                    music.playef(11);
                     graphics.screenbuffer->toggleStretchMode();
                     game.stretchMode = (game.stretchMode + 1) % 3;
                     game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 1;
                   }else if (game.currentmenuoption == 2){
-                    music.playef(11, 10);
+                    music.playef(11);
                     graphics.screenbuffer->toggleLinearFilter();
                     game.useLinearFilter = !game.useLinearFilter;
                     game.savestats();
@@ -526,7 +526,7 @@ SDL_assert(0 && "Remove open level dir");
                     game.currentmenuoption = 2;
                   }else if (game.currentmenuoption == 3){
                       //change smoothing
-                      music.playef(11, 10);
+                      music.playef(11);
                       game.fullScreenEffect_badSignal = !game.fullScreenEffect_badSignal;
                       //Hook the analogue thing in here: ABCDEFG
 					  graphics.screenbuffer->badSignalEffect= !graphics.screenbuffer->badSignalEffect;
@@ -535,7 +535,7 @@ SDL_assert(0 && "Remove open level dir");
                       game.currentmenuoption = 3;
                   }else if (game.currentmenuoption == 4) {
                       //toggle mouse cursor
-                      music.playef(11, 10);
+                      music.playef(11);
                       if (graphics.showmousecursor == true) {
                           SDL_ShowCursor(SDL_DISABLE);
                           graphics.showmousecursor = false;
@@ -548,7 +548,7 @@ SDL_assert(0 && "Remove open level dir");
                   else
                   {
                       //back
-                      music.playef(11, 10);
+                      music.playef(11);
                       game.createmenu("mainmenu");
                       map.nexttowercolour();
                   }
@@ -560,7 +560,7 @@ SDL_assert(0 && "Remove open level dir");
                         {
                             //toggle fullscreen
                             graphics.screenbuffer->toggleFullScreen();
-                            music.playef(11, 10);
+                            music.playef(11);
                             if (game.fullscreen)
                             {
                                 game.fullscreen = false;
@@ -576,7 +576,7 @@ SDL_assert(0 && "Remove open level dir");
                         else if (game.currentmenuoption == 1)
                         {
                             //enable acceleration: if in fullscreen, go back to window first
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.advanced_mode = false;
                             if (game.fullscreen)
                             {
@@ -593,7 +593,7 @@ SDL_assert(0 && "Remove open level dir");
                         else if (game.currentmenuoption == 2)
                         {
                             //change scaling mode
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.advanced_scaling = (game.advanced_scaling + 1) % 5;
                             graphics.screenbuffer->ResizeScreen(320 *game.advanced_scaling,240*game.advanced_scaling );
                             graphics.screenbuffer->SetScale(game.advanced_scaling);
@@ -606,7 +606,7 @@ SDL_assert(0 && "Remove open level dir");
                         else if (game.currentmenuoption == 3)
                         {
                             //change smoothing
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.advanced_smoothing = !game.advanced_smoothing;
                             updategraphicsmode();
 
@@ -617,7 +617,7 @@ SDL_assert(0 && "Remove open level dir");
                         else
                         {
                             //back
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("mainmenu");
                             map.nexttowercolour();
                         }
@@ -628,7 +628,7 @@ SDL_assert(0 && "Remove open level dir");
                         {
                             graphics.screenbuffer->toggleFullScreen();
                             //toggle fullscreen
-                            music.playef(11, 10);
+                            music.playef(11);
                             if (game.fullscreen)
                             {
                                 game.fullscreen = false;
@@ -645,7 +645,7 @@ SDL_assert(0 && "Remove open level dir");
                         else if (game.currentmenuoption == 1)
                         {
                             //disable acceleration: if in fullscreen, go back to window first
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.advanced_mode = true;
                             if (game.fullscreen)
                             {
@@ -662,7 +662,7 @@ SDL_assert(0 && "Remove open level dir");
                         else
                         {
                             //back
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("mainmenu");
                             map.nexttowercolour();
                         }
@@ -674,13 +674,13 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //bye!
-                        music.playef(2, 10);
+                        music.playef(2);
                         game.mainmenu = 100;
                         graphics.fademode = 2;
                     }
                     else
                     {
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu(game.previousmenuname);
                         map.nexttowercolour();
                     }
@@ -690,7 +690,7 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 3;
                         map.nexttowercolour();
@@ -701,7 +701,7 @@ SDL_assert(0 && "Remove open level dir");
                         //game.deletequick();
                         //game.deletetele();
                         game.savestats();
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 3;
                         map.nexttowercolour();
@@ -712,7 +712,7 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 4;
                         map.nexttowercolour();
@@ -724,7 +724,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.deletetele();
                         game.createmenu("setslowdown2");
                         map.nexttowercolour();
-                        music.playef(11, 10);
+                        music.playef(11);
                     }
                 }
                 else if (game.currentmenuname == "setslowdown2")
@@ -735,7 +735,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.gameframerate=34;
                         game.slowdown = 30;
                         game.savestats();
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 4;
                         map.nexttowercolour();
@@ -745,7 +745,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.gameframerate=41;
                         game.slowdown = 24;
                         game.savestats();
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 4;
                         map.nexttowercolour();
@@ -755,7 +755,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.gameframerate=55;
                         game.slowdown = 18;
                         game.savestats();
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 4;
                         map.nexttowercolour();
@@ -765,7 +765,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.gameframerate=83;
                         game.slowdown = 12;
                         game.savestats();
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 4;
                         map.nexttowercolour();
@@ -779,7 +779,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.colourblindmode = !game.colourblindmode;
                         game.savestats();
                         map.tdrawback = true;
-                        music.playef(11, 10);
+                        music.playef(11);
                     }
                     else if (game.currentmenuoption == 1)
                     {
@@ -788,11 +788,11 @@ SDL_assert(0 && "Remove open level dir");
                         game.savestats();
                         if (!game.noflashingmode)
                         {
-                            music.playef(18, 10);
+                            music.playef(18);
                             game.screenshake = 10;
                             game.flashlight = 5;
                         }else{
-                            music.playef(11, 10);
+                            music.playef(11);
                         }
                     }
                     else if (game.currentmenuoption == 2)
@@ -800,7 +800,7 @@ SDL_assert(0 && "Remove open level dir");
                         //disable text outline
                         graphics.notextoutline = !graphics.notextoutline;
                         game.savestats();
-                        music.playef(11, 10);
+                        music.playef(11);
                     }
                     else if (game.currentmenuoption == 3)
                     {
@@ -814,31 +814,31 @@ SDL_assert(0 && "Remove open level dir");
                         {
                             map.invincibility = !map.invincibility;
                         }
-                        music.playef(11, 10);
+                        music.playef(11);
                     }
                     else if (game.currentmenuoption == 4)
                     {
                         //change game speed
                         game.createmenu("setslowdown2");
                         map.nexttowercolour();
-                        music.playef(11, 10);
+                        music.playef(11);
                     }
                     else if (game.currentmenuoption == 5)
                     {
                         // toggle fake load screen
                         game.skipfakeload = !game.skipfakeload;
-                        music.playef(11, 10);
+                        music.playef(11);
                     }
                     else if (game.currentmenuoption == 6)
                     {
                         // toggle translucent roomname BG
                         graphics.translucentroomname = !graphics.translucentroomname;
-                        music.playef(11, 10);
+                        music.playef(11);
                     }
                     else if (game.currentmenuoption == 7)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("options");
 
 												//Add extra menu for mmmmmm mod
@@ -863,7 +863,7 @@ SDL_assert(0 && "Remove open level dir");
                     else
                     {
                         //Can't do yet! play sad sound
-                        music.playef(2, 10);
+                        music.playef(2);
                     }
                 }
                 else if (game.currentmenuname == "options")
@@ -873,7 +873,7 @@ SDL_assert(0 && "Remove open level dir");
 				if (game.currentmenuoption == 0)
                     {
                         //accessibility options
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         map.nexttowercolour();
                     }
@@ -881,14 +881,14 @@ SDL_assert(0 && "Remove open level dir");
 					else if (game.currentmenuoption == 1)
 					{
 						//clear data menu
-						music.playef(11, 10);
+						music.playef(11);
 						game.createmenu("controller");
 						map.nexttowercolour();
 					}
                     else if (game.currentmenuoption == 2)
                     {
                         //clear data menu
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("cleardatamenu");
                         map.nexttowercolour();
                     }
@@ -903,7 +903,7 @@ SDL_assert(0 && "Remove open level dir");
 														game.usingmmmmmm=1;
 													}
 													music.usingmmmmmm = !music.usingmmmmmm;
-													music.playef(11, 10);
+													music.playef(11);
 													music.play(6);
 													game.savestats();
 													game.createmenu("mainmenu");
@@ -912,7 +912,7 @@ SDL_assert(0 && "Remove open level dir");
 											if (game.currentmenuoption == 4)
 											{
 													//back
-													music.playef(11, 10);
+													music.playef(11);
 													game.createmenu("mainmenu");
 													map.nexttowercolour();
 											}
@@ -920,7 +920,7 @@ SDL_assert(0 && "Remove open level dir");
 											if (game.currentmenuoption == 3)
 											{
 													//back
-													music.playef(11, 10);
+													music.playef(11);
 													game.createmenu("mainmenu");
 													map.nexttowercolour();
 											}
@@ -930,28 +930,28 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //accessibility options
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 1)
                     {
                         //unlock play options
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("unlockmenu");
                         map.nexttowercolour();
                     }
 					else if (game.currentmenuoption == 2)
 					{
 						//clear data menu
-						music.playef(11, 10);
+						music.playef(11);
 						game.createmenu("controller");
 						map.nexttowercolour();
 					}
                     else if (game.currentmenuoption == 3)
                     {
                         //clear data menu
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("cleardatamenu");
                         map.nexttowercolour();
                     }
@@ -966,7 +966,7 @@ SDL_assert(0 && "Remove open level dir");
 														game.usingmmmmmm=1;
 													}
 													music.usingmmmmmm = !music.usingmmmmmm;
-													music.playef(11, 10);
+													music.playef(11);
 													music.play(6);
 													game.savestats();
 													game.createmenu("mainmenu");
@@ -975,7 +975,7 @@ SDL_assert(0 && "Remove open level dir");
 											if (game.currentmenuoption == 5)
 											{
 													//back
-													music.playef(11, 10);
+													music.playef(11);
 													game.createmenu("mainmenu");
 													map.nexttowercolour();
 											}
@@ -983,7 +983,7 @@ SDL_assert(0 && "Remove open level dir");
 											if (game.currentmenuoption == 4)
 											{
 													//back
-													music.playef(11, 10);
+													music.playef(11);
 													game.createmenu("mainmenu");
 													map.nexttowercolour();
 											}
@@ -996,7 +996,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.unlock[9] = true;
                         game.unlocknotify[9] = true;
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 0;
@@ -1005,7 +1005,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.unlock[10] = true;
                         game.unlocknotify[10] = true;
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 1;
@@ -1014,7 +1014,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.unlock[11] = true;
                         game.unlocknotify[11] = true;
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 2;
@@ -1023,7 +1023,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.unlock[12] = true;
                         game.unlocknotify[12] = true;
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 3;
@@ -1032,7 +1032,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.unlock[13] = true;
                         game.unlocknotify[13] = true;
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 4;
@@ -1041,7 +1041,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.unlock[14] = true;
                         game.unlocknotify[14] = true;
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.savestats();
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 5;
@@ -1049,7 +1049,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 6)   	//back
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("unlockmenu");
                         map.nexttowercolour();
                     }
@@ -1059,14 +1059,14 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //unlock time trials separately...
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("unlockmenutrials");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 1)
                     {
                         //unlock intermissions
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.unlock[16] = true;
                         game.unlocknotify[16] = true;
                         game.unlock[6] = true;
@@ -1078,7 +1078,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 2)
                     {
                         //unlock no death mode
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.unlock[17] = true;
                         game.unlocknotify[17] = true;
                         game.savestats();
@@ -1088,7 +1088,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 3)
                     {
                         //unlock flip mode
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.unlock[18] = true;
                         game.unlocknotify[18] = true;
                         game.savestats();
@@ -1098,7 +1098,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 4)
                     {
                         //unlock jukebox
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.stat_trinkets = 20;
                         game.savestats();
                         game.createmenu("unlockmenu");
@@ -1107,7 +1107,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 5)
                     {
                         //unlock secret lab
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.unlock[8] = true;
                         game.unlocknotify[8] = true;
                         game.savestats();
@@ -1117,7 +1117,7 @@ SDL_assert(0 && "Remove open level dir");
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("options");
                         map.nexttowercolour();
                     }
@@ -1127,14 +1127,14 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //next page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits2");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1144,14 +1144,14 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //next page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits25");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1161,14 +1161,14 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //next page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits3");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1178,7 +1178,7 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //next page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.current_credits_list_index += 9;
 
                         if (game.current_credits_list_index >= (int)game.superpatrons.size())
@@ -1198,7 +1198,7 @@ SDL_assert(0 && "Remove open level dir");
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.current_credits_list_index = 0;
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
@@ -1209,7 +1209,7 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //next page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.current_credits_list_index += 14;
 
                         if (game.current_credits_list_index >= (int)game.patrons.size())
@@ -1229,7 +1229,7 @@ SDL_assert(0 && "Remove open level dir");
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.current_credits_list_index = 0;
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
@@ -1240,7 +1240,7 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //next page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.current_credits_list_index += 9;
 
                         if (game.current_credits_list_index >= (int)game.githubfriends.size())
@@ -1260,7 +1260,7 @@ SDL_assert(0 && "Remove open level dir");
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.current_credits_list_index = 0;
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
@@ -1271,14 +1271,14 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //first page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                         music.niceplay(6);
@@ -1305,7 +1305,7 @@ SDL_assert(0 && "Remove open level dir");
                         else
                         {
                             //go to a menu!
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.loadsummary(); //Prepare save slots to display
                             game.createmenu("continue");
                             map.settowercolour(3);
@@ -1314,21 +1314,21 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 1)
                     {
                         //play modes
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("playmodes");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 2)
                     {
                         //newgame
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("newgamewarning");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 3)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1355,7 +1355,7 @@ SDL_assert(0 && "Remove open level dir");
                         else
                         {
                             //go to a menu!
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.loadsummary(); //Prepare save slots to display
                             game.createmenu("continue");
                             map.settowercolour(3);
@@ -1368,27 +1368,27 @@ SDL_assert(0 && "Remove open level dir");
                         graphics.fademode = 2;
 											}else{
                         //Can't do yet! play sad sound
-                        music.playef(2, 10);
+                        music.playef(2);
 											}
                     }
                     else if (game.currentmenuoption == 2)
                     {
                         //play modes
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("playmodes");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 3)
                     {
                         //newgame
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("newgamewarning");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 4)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1406,7 +1406,7 @@ SDL_assert(0 && "Remove open level dir");
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
@@ -1417,7 +1417,7 @@ SDL_assert(0 && "Remove open level dir");
 					if (game.currentmenuoption == 0)
 					{
 						game.controllerSensitivity++;
-						music.playef(11, 10);
+						music.playef(11);
 						if(game.controllerSensitivity > 4)
 						{
 							game.controllerSensitivity = 0;
@@ -1426,7 +1426,7 @@ SDL_assert(0 && "Remove open level dir");
 
 					if (game.currentmenuoption == 4)
 					{
-						music.playef(11, 10);
+						music.playef(11);
 						game.createmenu("options");
 
 						//Add extra menu for mmmmmm mod
@@ -1452,7 +1452,7 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("options");
 
 												//Add extra menu for mmmmmm mod
@@ -1476,7 +1476,7 @@ SDL_assert(0 && "Remove open level dir");
                     else
                     {
                         //yep
-                        music.playef(23, 10);
+                        music.playef(23);
                         game.deletequick();
                         game.deletetele();
                         game.deletestats();
@@ -1490,26 +1490,26 @@ SDL_assert(0 && "Remove open level dir");
                 {
                     if (game.currentmenuoption == 0  && game.slowdown == 30 && !map.invincibility)   //go to the time trial menu
                     {
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("timetrials");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 1 && game.unlock[16])
                     {
                         //intermission mode menu
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("intermissionmenu");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 2 && game.unlock[17] && game.slowdown == 30 && !map.invincibility)    //start a game in no death mode
                     {
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("startnodeathmode");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 3 && game.unlock[18])    //enable/disable flip mode
                     {
-                        music.playef(18, 10);
+                        music.playef(18);
                         game.screenshake = 10;
                         game.flashlight = 5;
                         graphics.setflipmode = !graphics.setflipmode;
@@ -1518,14 +1518,14 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 4)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //Can't do yet! play sad sound
-                        music.playef(2, 10);
+                        music.playef(2);
                     }
                 }
                 else if (game.currentmenuname == "startnodeathmode")
@@ -1543,7 +1543,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 2)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
@@ -1563,7 +1563,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 2)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
@@ -1572,14 +1572,14 @@ SDL_assert(0 && "Remove open level dir");
                 {
                     if (game.currentmenuoption == 0)
                     {
-                        music.playef(11, 10);
+                        music.playef(11);
                         music.play(6);
                         game.createmenu("playint1");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 1)
                     {
-                        music.playef(11, 10);
+                        music.playef(11);
                         music.play(6);
                         game.createmenu("playint2");
                         map.nexttowercolour();
@@ -1587,7 +1587,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 2)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
@@ -1617,7 +1617,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 4)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
@@ -1647,7 +1647,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 4)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
@@ -1655,7 +1655,7 @@ SDL_assert(0 && "Remove open level dir");
                 else if (game.currentmenuname == "gameover2")
                 {
                     //back
-                    music.playef(11, 10);
+                    music.playef(11);
                     music.play(6);
                     game.createmenu("mainmenu");
                     map.nexttowercolour();
@@ -1663,7 +1663,7 @@ SDL_assert(0 && "Remove open level dir");
                 else if (game.currentmenuname == "unlocktimetrials" || game.currentmenuname == "unlocktimetrial")
                 {
                     //back
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.createmenu("play");
                     map.nexttowercolour();
                 }
@@ -1671,7 +1671,7 @@ SDL_assert(0 && "Remove open level dir");
                          || game.currentmenuname == "unlockflipmode")
                 {
                     //back
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.createmenu("play");
                     map.nexttowercolour();
                 }
@@ -1710,14 +1710,14 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 6)    //go to the time trial menu
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //Can't do yet! play sad sound
-                        music.playef(2, 10);
+                        music.playef(2);
                     }
                 }
                 else if (game.currentmenuname == "timetrialcomplete3")
@@ -1725,7 +1725,7 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         music.play(6);
                         game.createmenu("play");
                         map.nexttowercolour();
@@ -1770,7 +1770,7 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         music.play(6);
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
@@ -2224,7 +2224,7 @@ void gameinput()
                         game.gravitycontrol = 1;
                         obj.entities[ie].vy = -4;
                         obj.entities[ie].ay = -3;
-                        music.playef(0, 10);
+                        music.playef(0);
                         game.jumppressed = 0;
                         game.totalflips++;
                     }
@@ -2233,7 +2233,7 @@ void gameinput()
                         game.gravitycontrol = 0;
                         obj.entities[ie].vy = 4;
                         obj.entities[ie].ay = 3;
-                        music.playef(1, 10);
+                        music.playef(1);
                         game.jumppressed = 0;
                         game.totalflips++;
                     }
@@ -2391,7 +2391,7 @@ void mapinput()
         {
             game.flashlight = 5;
             game.screenshake = 10;
-            music.playef(18, 10);
+            music.playef(18);
             game.gamesaved = true;
 
             game.savetime = game.timestring();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -11,103 +11,103 @@ extern scriptclass script;
 
 void updatebuttonmappings(int bind)
 {
-	for (
-		SDL_GameControllerButton i = SDL_CONTROLLER_BUTTON_A;
-		i < SDL_CONTROLLER_BUTTON_DPAD_UP;
-		i = (SDL_GameControllerButton) (i + 1)
-	) {
-		if (key.isDown(i))
-		{
-			bool dupe = false;
-			if (bind == 1)
-			{
-				for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
-				{
-					if (i == game.controllerButton_flip[j])
-					{
-						dupe = true;
-					}
-				}
-				if (!dupe)
-				{
-					game.controllerButton_flip.push_back(i);
-					music.playef(11);
-				}
-				for (size_t j = 0; j < game.controllerButton_map.size(); j += 1)
-				{
-					if (i == game.controllerButton_map[j])
-					{
-						game.controllerButton_map.erase(game.controllerButton_map.begin() + j);
-					}
-				}
-				for (size_t j = 0; j < game.controllerButton_esc.size(); j += 1)
-				{
-					if (i == game.controllerButton_esc[j])
-					{
-						game.controllerButton_esc.erase(game.controllerButton_esc.begin() + j);
-					}
-				}
-			}
-			if (bind == 2)
-			{
-				for (size_t j = 0; j < game.controllerButton_map.size(); j += 1)
-				{
-					if (i == game.controllerButton_map[j])
-					{
-						dupe = true;
-					}
-				}
-				if (!dupe)
-				{
-					game.controllerButton_map.push_back(i);
-					music.playef(11);
-				}
-				for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
-				{
-					if (i == game.controllerButton_flip[j])
-					{
-						game.controllerButton_flip.erase(game.controllerButton_flip.begin() + j);
-					}
-				}
-				for (size_t j = 0; j < game.controllerButton_esc.size(); j += 1)
-				{
-					if (i == game.controllerButton_esc[j])
-					{
-						game.controllerButton_esc.erase(game.controllerButton_esc.begin() + j);
-					}
-				}
-			}
-			if (bind == 3)
-			{
-				for (size_t j = 0; j < game.controllerButton_esc.size(); j += 1)
-				{
-					if (i == game.controllerButton_esc[j])
-					{
-						dupe = true;
-					}
-				}
-				if (!dupe)
-				{
-					game.controllerButton_esc.push_back(i);
-					music.playef(11);
-				}
-				for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
-				{
-					if (i == game.controllerButton_flip[j])
-					{
-						game.controllerButton_flip.erase(game.controllerButton_flip.begin() + j);
-					}
-				}
-				for (size_t j = 0; j < game.controllerButton_map.size(); j += 1)
-				{
-					if (i == game.controllerButton_map[j])
-					{
-						game.controllerButton_map.erase(game.controllerButton_map.begin() + j);
-					}
-				}
-			}
-		}
-	}
+    for (
+        SDL_GameControllerButton i = SDL_CONTROLLER_BUTTON_A;
+        i < SDL_CONTROLLER_BUTTON_DPAD_UP;
+        i = (SDL_GameControllerButton) (i + 1)
+    ) {
+        if (key.isDown(i))
+        {
+            bool dupe = false;
+            if (bind == 1)
+            {
+                for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
+                {
+                    if (i == game.controllerButton_flip[j])
+                    {
+                        dupe = true;
+                    }
+                }
+                if (!dupe)
+                {
+                    game.controllerButton_flip.push_back(i);
+                    music.playef(11);
+                }
+                for (size_t j = 0; j < game.controllerButton_map.size(); j += 1)
+                {
+                    if (i == game.controllerButton_map[j])
+                    {
+                        game.controllerButton_map.erase(game.controllerButton_map.begin() + j);
+                    }
+                }
+                for (size_t j = 0; j < game.controllerButton_esc.size(); j += 1)
+                {
+                    if (i == game.controllerButton_esc[j])
+                    {
+                        game.controllerButton_esc.erase(game.controllerButton_esc.begin() + j);
+                    }
+                }
+            }
+            if (bind == 2)
+            {
+                for (size_t j = 0; j < game.controllerButton_map.size(); j += 1)
+                {
+                    if (i == game.controllerButton_map[j])
+                    {
+                        dupe = true;
+                    }
+                }
+                if (!dupe)
+                {
+                    game.controllerButton_map.push_back(i);
+                    music.playef(11);
+                }
+                for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
+                {
+                    if (i == game.controllerButton_flip[j])
+                    {
+                        game.controllerButton_flip.erase(game.controllerButton_flip.begin() + j);
+                    }
+                }
+                for (size_t j = 0; j < game.controllerButton_esc.size(); j += 1)
+                {
+                    if (i == game.controllerButton_esc[j])
+                    {
+                        game.controllerButton_esc.erase(game.controllerButton_esc.begin() + j);
+                    }
+                }
+            }
+            if (bind == 3)
+            {
+                for (size_t j = 0; j < game.controllerButton_esc.size(); j += 1)
+                {
+                    if (i == game.controllerButton_esc[j])
+                    {
+                        dupe = true;
+                    }
+                }
+                if (!dupe)
+                {
+                    game.controllerButton_esc.push_back(i);
+                    music.playef(11);
+                }
+                for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
+                {
+                    if (i == game.controllerButton_flip[j])
+                    {
+                        game.controllerButton_flip.erase(game.controllerButton_flip.begin() + j);
+                    }
+                }
+                for (size_t j = 0; j < game.controllerButton_map.size(); j += 1)
+                {
+                    if (i == game.controllerButton_map[j])
+                    {
+                        game.controllerButton_map.erase(game.controllerButton_map.begin() + j);
+                    }
+                }
+            }
+        }
+    }
 }
 
 void titleinput()
@@ -115,8 +115,8 @@ void titleinput()
     //game.mx = (mouseX / 4);
     //game.my = (mouseY / 4);
 
-	//TODO bit wasteful doing this every poll
-	key.setSensitivity(game.controllerSensitivity);
+    //TODO bit wasteful doing this every poll
+    key.setSensitivity(game.controllerSensitivity);
 
     game.press_left = false;
     game.press_right = false;
@@ -125,7 +125,7 @@ void titleinput()
 
     if (graphics.flipmode)
     {
-		//GAMEPAD TODO
+        //GAMEPAD TODO
         if (key.isDown(KEYBOARD_LEFT) || key.isDown(KEYBOARD_DOWN) || key.isDown(KEYBOARD_a) ||  key.isDown(KEYBOARD_s) || key.controllerWantsRight(true)) game.press_left = true;
         if (key.isDown(KEYBOARD_RIGHT) || key.isDown(KEYBOARD_UP)  || key.isDown(KEYBOARD_d) ||  key.isDown(KEYBOARD_w) || key.controllerWantsLeft(true)) game.press_right = true;
     }
@@ -138,7 +138,7 @@ void titleinput()
         if (key.isDown(KEYBOARD_RIGHT) || key.isDown(KEYBOARD_DOWN)  || key.isDown(KEYBOARD_d) ||  key.isDown(KEYBOARD_s) || key.controllerWantsRight(true))
         {
             game.press_right = true;
-		}
+        }
     }
     if (key.isDown(KEYBOARD_z) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v) || key.isDown(game.controllerButton_flip)) game.press_action = true;
     //|| key.isDown(KEYBOARD_UP) || key.isDown(KEYBOARD_DOWN)) game.press_action = true; //on menus, up and down don't work as action
@@ -231,8 +231,8 @@ void titleinput()
                 if (game.currentmenuname == "mainmenu")
                 {
 
-            #if defined(MAKEANDPLAY)
-				   if (game.currentmenuoption == 0)
+#if defined(MAKEANDPLAY)
+                    if (game.currentmenuoption == 0)
                     {
                       //Bring you to the normal playmenu
                         music.playef(11);
@@ -252,14 +252,14 @@ void titleinput()
                         music.playef(11);
                         game.createmenu("options");
 
-												//Add extra menu for mmmmmm mod
-												if(music.mmmmmm){
-													game.menuoptions[3] = "soundtrack";
-													game.menuoptionsactive[3] = true;
-													game.menuoptions[4] = "return";
-													game.menuoptionsactive[4] = true;
-													game.nummenuoptions = 5;
-												}
+                        //Add extra menu for mmmmmm mod
+                        if(music.mmmmmm){
+                            game.menuoptions[3] = "soundtrack";
+                            game.menuoptionsactive[3] = true;
+                            game.menuoptions[4] = "return";
+                            game.menuoptionsactive[4] = true;
+                            game.nummenuoptions = 5;
+                        }
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 3)
@@ -270,8 +270,8 @@ void titleinput()
                         graphics.fademode = 2;
                     }
                 }
-            #elif !defined(MAKEANDPLAY)
-                #if defined(NO_CUSTOM_LEVELS)
+#elif !defined(MAKEANDPLAY)
+ #if defined(NO_CUSTOM_LEVELS)
                     if (game.currentmenuoption == 0)
                     {
                         //Play
@@ -302,14 +302,14 @@ void titleinput()
                         music.playef(11);
                         game.createmenu("options");
 
-												//Add extra menu for mmmmmm mod
-											  if(music.mmmmmm){
-													game.menuoptions[4] = "soundtrack";
-													game.menuoptionsactive[4] = true;
-													game.menuoptions[5] = "return";
-													game.menuoptionsactive[5] = true;
-													game.nummenuoptions = 6;
-												}
+                        //Add extra menu for mmmmmm mod
+                        if(music.mmmmmm){
+                            game.menuoptions[4] = "soundtrack";
+                            game.menuoptionsactive[4] = true;
+                            game.menuoptions[5] = "return";
+                            game.menuoptionsactive[5] = true;
+                            game.nummenuoptions = 6;
+                        }
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 3)
@@ -326,7 +326,7 @@ void titleinput()
                         game.mainmenu = 100;
                         graphics.fademode = 2;
                     }
-                #else
+ #else
                     if (game.currentmenuoption == 0)
                     {
                         //Play
@@ -388,172 +388,172 @@ void titleinput()
                         game.mainmenu = 100;
                         graphics.fademode = 2;
                     }
-            #endif
+ #endif
                 }
-								#endif
-            #if !defined(NO_CUSTOM_LEVELS)
+#endif
+#if !defined(NO_CUSTOM_LEVELS)
                 else if(game.currentmenuname=="levellist")
                 {
-                  if(game.currentmenuoption==game.nummenuoptions-1){
-                    //go back to menu
-                    music.playef(11);
-                    game.createmenu("mainmenu");
-                    map.nexttowercolour();
-                  }else if(game.currentmenuoption==game.nummenuoptions-2){
-                    //next page
-                    music.playef(11);
-                    if((size_t) ((game.levelpage*8)+8) >= ed.ListOfMetaData.size()){
-                      game.levelpage=0;
+                    if(game.currentmenuoption==game.nummenuoptions-1){
+                        //go back to menu
+                        music.playef(11);
+                        game.createmenu("mainmenu");
+                        map.nexttowercolour();
+                    }else if(game.currentmenuoption==game.nummenuoptions-2){
+                        //next page
+                        music.playef(11);
+                        if((size_t) ((game.levelpage*8)+8) >= ed.ListOfMetaData.size()){
+                            game.levelpage=0;
+                        }else{
+                            game.levelpage++;
+                        }
+                        game.createmenu("levellist");
+                        game.currentmenuoption=game.nummenuoptions-2;
+                        map.nexttowercolour();
                     }else{
-                      game.levelpage++;
-                    }
-                    game.createmenu("levellist");
-                    game.currentmenuoption=game.nummenuoptions-2;
-                    map.nexttowercolour();
-                  }else{
-                    //Ok, launch the level!
-                    //PLAY CUSTOM LEVEL HOOK
-                    music.playef(11);
-                    game.playcustomlevel=(game.levelpage*8)+game.currentmenuoption;
-                    game.customleveltitle=ed.ListOfMetaData[game.playcustomlevel].title;
-                    game.customlevelfilename=ed.ListOfMetaData[game.playcustomlevel].filename;
+                        //Ok, launch the level!
+                        //PLAY CUSTOM LEVEL HOOK
+                        music.playef(11);
+                        game.playcustomlevel=(game.levelpage*8)+game.currentmenuoption;
+                        game.customleveltitle=ed.ListOfMetaData[game.playcustomlevel].title;
+                        game.customlevelfilename=ed.ListOfMetaData[game.playcustomlevel].filename;
 
-                    std::string name = "saves/" + ed.ListOfMetaData[game.playcustomlevel].filename.substr(7) + ".vvv";
-                    TiXmlDocument doc;
-	                  if (!FILESYSTEM_loadTiXmlDocument(name.c_str(), &doc)){
-	                    game.mainmenu = 22;
-                      graphics.fademode = 2;
-	                  }else{
-                      game.createmenu("quickloadlevel");
-                      map.nexttowercolour();
-	                  }
-                  }
+                        std::string name = "saves/" + ed.ListOfMetaData[game.playcustomlevel].filename.substr(7) + ".vvv";
+                        TiXmlDocument doc;
+                        if (!FILESYSTEM_loadTiXmlDocument(name.c_str(), &doc)){
+                            game.mainmenu = 22;
+                            graphics.fademode = 2;
+                        }else{
+                            game.createmenu("quickloadlevel");
+                            map.nexttowercolour();
+                        }
+                    }
                 }
-            #endif
+#endif
                 else if(game.currentmenuname=="quickloadlevel")
                 {
-                  if(game.currentmenuoption==0){//continue save
-                    game.mainmenu = 23;
-                    graphics.fademode = 2;
-                  }else if(game.currentmenuoption==1){
-	                  game.mainmenu = 22;
-                    graphics.fademode = 2;
-                  }else if(game.currentmenuoption==2){
-                    music.playef(11);
-                    game.levelpage=0;
-                    game.createmenu("levellist");
-                    map.nexttowercolour();
-                  }
+                    if(game.currentmenuoption==0){//continue save
+                        game.mainmenu = 23;
+                        graphics.fademode = 2;
+                    }else if(game.currentmenuoption==1){
+                        game.mainmenu = 22;
+                        graphics.fademode = 2;
+                    }else if(game.currentmenuoption==2){
+                        music.playef(11);
+                        game.levelpage=0;
+                        game.createmenu("levellist");
+                        map.nexttowercolour();
+                    }
                 }
-            #if !defined(NO_CUSTOM_LEVELS)
+#if !defined(NO_CUSTOM_LEVELS)
                 else if(game.currentmenuname=="playerworlds")
                 {
-                #if !defined(NO_EDITOR)
-                  if(game.currentmenuoption==0){
+ #if !defined(NO_EDITOR)
+                    if(game.currentmenuoption==0){
 
-                    music.playef(11);
-                    game.levelpage=0;
-                    ed.getDirectoryData();
-                    game.loadcustomlevelstats(); //Should only load a file if it's needed
-                    game.createmenu("levellist");
-                    map.nexttowercolour();
-                  }else if(game.currentmenuoption==1){
-                    //LEVEL EDITOR HOOK
-                    music.playef(11);
-                    game.mainmenu = 20;
-                    graphics.fademode = 2;
-                    ed.filename="";
-                  }/*else if(game.currentmenuoption==2){
-                    music.playef(11);
-                    //"OPENFOLDERHOOK"
-                    //When the player selects the "open level folder" menu option,
-                    //this is where it should run the appropriate code.
-                    //This code should:
-                    // - Minimise the game
-                    // - Open the levels folder for whatever operating system we're on
-SDL_assert(0 && "Remove open level dir");
+                        music.playef(11);
+                        game.levelpage=0;
+                        ed.getDirectoryData();
+                        game.loadcustomlevelstats(); //Should only load a file if it's needed
+                        game.createmenu("levellist");
+                        map.nexttowercolour();
+                    }else if(game.currentmenuoption==1){
+                        //LEVEL EDITOR HOOK
+                        music.playef(11);
+                        game.mainmenu = 20;
+                        graphics.fademode = 2;
+                        ed.filename="";
+                    }/*else if(game.currentmenuoption==2){
+                        music.playef(11);
+                        //"OPENFOLDERHOOK"
+                        //When the player selects the "open level folder" menu option,
+                        //this is where it should run the appropriate code.
+                        //This code should:
+                        // - Minimise the game
+                        // - Open the levels folder for whatever operating system we're on
+                        SDL_assert(0 && "Remove open level dir");
 
-                  }*/else if(game.currentmenuoption==2){
-                    //back
-                    music.playef(11);
-                    game.createmenu("mainmenu");
-                    map.nexttowercolour();
-                  }
-                #else
-                  if(game.currentmenuoption==0){
-                    music.playef(11);
-                    game.levelpage=0;
-                    ed.getDirectoryData();
-                    game.loadcustomlevelstats(); //Should only load a file if it's needed
-                    game.createmenu("levellist");
-                    map.nexttowercolour();
-                  }else if(game.currentmenuoption==1){
-                    //back
-                    music.playef(11);
-                    game.createmenu("mainmenu");
-                    map.nexttowercolour();
-                  }
-                #endif
+                    }*/else if(game.currentmenuoption==2){
+                        //back
+                        music.playef(11);
+                        game.createmenu("mainmenu");
+                        map.nexttowercolour();
+                    }
+ #else
+                    if(game.currentmenuoption==0){
+                        music.playef(11);
+                        game.levelpage=0;
+                        ed.getDirectoryData();
+                        game.loadcustomlevelstats(); //Should only load a file if it's needed
+                        game.createmenu("levellist");
+                        map.nexttowercolour();
+                    }else if(game.currentmenuoption==1){
+                        //back
+                        music.playef(11);
+                        game.createmenu("mainmenu");
+                        map.nexttowercolour();
+                    }
+ #endif
                 }
-            #endif
+#endif
                 else if(game.currentmenuname=="errornostart"){
-                  music.playef(11);
-                  game.createmenu("mainmenu");
-                  map.nexttowercolour();
+                    music.playef(11);
+                    game.createmenu("mainmenu");
+                    map.nexttowercolour();
                 }
                 else if (game.currentmenuname == "graphicoptions")
                 {
-                  if (game.currentmenuoption == 0){
-                    music.playef(11);
-                    graphics.screenbuffer->toggleFullScreen();
-                    game.fullscreen = !game.fullscreen;
-                    game.savestats();
-                    game.createmenu("graphicoptions");
-                    game.currentmenuoption = 0;
-                  }else if (game.currentmenuoption == 1){
-                    music.playef(11);
-                    graphics.screenbuffer->toggleStretchMode();
-                    game.stretchMode = (game.stretchMode + 1) % 3;
-                    game.savestats();
-                    game.createmenu("graphicoptions");
-                    game.currentmenuoption = 1;
-                  }else if (game.currentmenuoption == 2){
-                    music.playef(11);
-                    graphics.screenbuffer->toggleLinearFilter();
-                    game.useLinearFilter = !game.useLinearFilter;
-                    game.savestats();
-                    game.createmenu("graphicoptions");
-                    game.currentmenuoption = 2;
-                  }else if (game.currentmenuoption == 3){
-                      //change smoothing
-                      music.playef(11);
-                      game.fullScreenEffect_badSignal = !game.fullScreenEffect_badSignal;
-                      //Hook the analogue thing in here: ABCDEFG
-					  graphics.screenbuffer->badSignalEffect= !graphics.screenbuffer->badSignalEffect;
-                      game.savestats();
-                      game.createmenu("graphicoptions");
-                      game.currentmenuoption = 3;
-                  }else if (game.currentmenuoption == 4) {
-                      //toggle mouse cursor
-                      music.playef(11);
-                      if (graphics.showmousecursor == true) {
-                          SDL_ShowCursor(SDL_DISABLE);
-                          graphics.showmousecursor = false;
-                      }
-                      else {
-                          SDL_ShowCursor(SDL_ENABLE);
-                          graphics.showmousecursor = true;
-                      }
-                  }
-                  else
-                  {
-                      //back
-                      music.playef(11);
-                      game.createmenu("mainmenu");
-                      map.nexttowercolour();
-                  }
+                    if (game.currentmenuoption == 0){
+                        music.playef(11);
+                        graphics.screenbuffer->toggleFullScreen();
+                        game.fullscreen = !game.fullscreen;
+                        game.savestats();
+                        game.createmenu("graphicoptions");
+                        game.currentmenuoption = 0;
+                    }else if (game.currentmenuoption == 1){
+                        music.playef(11);
+                        graphics.screenbuffer->toggleStretchMode();
+                        game.stretchMode = (game.stretchMode + 1) % 3;
+                        game.savestats();
+                        game.createmenu("graphicoptions");
+                        game.currentmenuoption = 1;
+                    }else if (game.currentmenuoption == 2){
+                        music.playef(11);
+                        graphics.screenbuffer->toggleLinearFilter();
+                        game.useLinearFilter = !game.useLinearFilter;
+                        game.savestats();
+                        game.createmenu("graphicoptions");
+                        game.currentmenuoption = 2;
+                    }else if (game.currentmenuoption == 3){
+                        //change smoothing
+                        music.playef(11);
+                        game.fullScreenEffect_badSignal = !game.fullScreenEffect_badSignal;
+                        //Hook the analogue thing in here: ABCDEFG
+                        graphics.screenbuffer->badSignalEffect= !graphics.screenbuffer->badSignalEffect;
+                        game.savestats();
+                        game.createmenu("graphicoptions");
+                        game.currentmenuoption = 3;
+                    }else if (game.currentmenuoption == 4) {
+                        //toggle mouse cursor
+                        music.playef(11);
+                        if (graphics.showmousecursor == true) {
+                            SDL_ShowCursor(SDL_DISABLE);
+                            graphics.showmousecursor = false;
+                        }
+                        else {
+                            SDL_ShowCursor(SDL_ENABLE);
+                            graphics.showmousecursor = true;
+                        }
+                    }
+                    else
+                    {
+                        //back
+                        music.playef(11);
+                        game.createmenu("mainmenu");
+                        map.nexttowercolour();
+                    }
 
-                  /* //Old stuff
+                    /* //Old stuff
                     if (game.advanced_mode)
                     {
                         if (game.currentmenuoption == 0)
@@ -841,22 +841,22 @@ SDL_assert(0 && "Remove open level dir");
                         music.playef(11);
                         game.createmenu("options");
 
-												//Add extra menu for mmmmmm mod
-												if(music.mmmmmm){
-													#if defined(MAKEANDPLAY)
-														game.menuoptions[3] = "soundtrack";
-														game.menuoptionsactive[3] = true;
-														game.menuoptions[4] = "return";
-														game.menuoptionsactive[4] = true;
-														game.nummenuoptions = 5;
-													#elif !defined(MAKEANDPLAY)
-														game.menuoptions[4] = "soundtrack";
-														game.menuoptionsactive[4] = true;
-														game.menuoptions[5] = "return";
-														game.menuoptionsactive[5] = true;
-														game.nummenuoptions = 6;
-													#endif
-												}
+                        //Add extra menu for mmmmmm mod
+                        if(music.mmmmmm){
+#if defined(MAKEANDPLAY)
+                            game.menuoptions[3] = "soundtrack";
+                            game.menuoptionsactive[3] = true;
+                            game.menuoptions[4] = "return";
+                            game.menuoptionsactive[4] = true;
+                            game.nummenuoptions = 5;
+#elif !defined(MAKEANDPLAY)
+                            game.menuoptions[4] = "soundtrack";
+                            game.menuoptionsactive[4] = true;
+                            game.menuoptions[5] = "return";
+                            game.menuoptionsactive[5] = true;
+                            game.nummenuoptions = 6;
+#endif
+                        }
 
                         map.nexttowercolour();
                     }
@@ -869,8 +869,8 @@ SDL_assert(0 && "Remove open level dir");
                 else if (game.currentmenuname == "options")
                 {
 
-				#if defined(MAKEANDPLAY)
-				if (game.currentmenuoption == 0)
+#if defined(MAKEANDPLAY)
+                    if (game.currentmenuoption == 0)
                     {
                         //accessibility options
                         music.playef(11);
@@ -878,13 +878,13 @@ SDL_assert(0 && "Remove open level dir");
                         map.nexttowercolour();
                     }
 
-					else if (game.currentmenuoption == 1)
-					{
-						//clear data menu
-						music.playef(11);
-						game.createmenu("controller");
-						map.nexttowercolour();
-					}
+                    else if (game.currentmenuoption == 1)
+                    {
+                        //clear data menu
+                        music.playef(11);
+                        game.createmenu("controller");
+                        map.nexttowercolour();
+                    }
                     else if (game.currentmenuoption == 2)
                     {
                         //clear data menu
@@ -893,40 +893,40 @@ SDL_assert(0 && "Remove open level dir");
                         map.nexttowercolour();
                     }
 
-										if(music.mmmmmm){
-											if (game.currentmenuoption == 3)
-											{
-													//**** TOGGLE MMMMMM
-													if(game.usingmmmmmm > 0){
-														game.usingmmmmmm=0;
-													}else{
-														game.usingmmmmmm=1;
-													}
-													music.usingmmmmmm = !music.usingmmmmmm;
-													music.playef(11);
-													music.play(6);
-													game.savestats();
-													game.createmenu("mainmenu");
-													map.nexttowercolour();
-											}
-											if (game.currentmenuoption == 4)
-											{
-													//back
-													music.playef(11);
-													game.createmenu("mainmenu");
-													map.nexttowercolour();
-											}
-										}else{
-											if (game.currentmenuoption == 3)
-											{
-													//back
-													music.playef(11);
-													game.createmenu("mainmenu");
-													map.nexttowercolour();
-											}
-										}
+                    if(music.mmmmmm){
+                        if (game.currentmenuoption == 3)
+                        {
+                            //**** TOGGLE MMMMMM
+                            if(game.usingmmmmmm > 0){
+                                game.usingmmmmmm=0;
+                            }else{
+                                game.usingmmmmmm=1;
+                            }
+                            music.usingmmmmmm = !music.usingmmmmmm;
+                            music.playef(11);
+                            music.play(6);
+                            game.savestats();
+                            game.createmenu("mainmenu");
+                            map.nexttowercolour();
+                        }
+                        if (game.currentmenuoption == 4)
+                        {
+                            //back
+                            music.playef(11);
+                            game.createmenu("mainmenu");
+                            map.nexttowercolour();
+                        }
+                    }else{
+                        if (game.currentmenuoption == 3)
+                        {
+                            //back
+                            music.playef(11);
+                            game.createmenu("mainmenu");
+                            map.nexttowercolour();
+                        }
+                    }
 
-				#elif !defined(MAKEANDPLAY)
+#elif !defined(MAKEANDPLAY)
                     if (game.currentmenuoption == 0)
                     {
                         //accessibility options
@@ -941,13 +941,13 @@ SDL_assert(0 && "Remove open level dir");
                         game.createmenu("unlockmenu");
                         map.nexttowercolour();
                     }
-					else if (game.currentmenuoption == 2)
-					{
-						//clear data menu
-						music.playef(11);
-						game.createmenu("controller");
-						map.nexttowercolour();
-					}
+                    else if (game.currentmenuoption == 2)
+                    {
+                        //clear data menu
+                        music.playef(11);
+                        game.createmenu("controller");
+                        map.nexttowercolour();
+                    }
                     else if (game.currentmenuoption == 3)
                     {
                         //clear data menu
@@ -956,39 +956,39 @@ SDL_assert(0 && "Remove open level dir");
                         map.nexttowercolour();
                     }
 
-										if(music.mmmmmm){
-											if (game.currentmenuoption == 4)
-											{
-													//**** TOGGLE MMMMMM
-													if(game.usingmmmmmm > 0){
-														game.usingmmmmmm=0;
-													}else{
-														game.usingmmmmmm=1;
-													}
-													music.usingmmmmmm = !music.usingmmmmmm;
-													music.playef(11);
-													music.play(6);
-													game.savestats();
-													game.createmenu("mainmenu");
-													map.nexttowercolour();
-											}
-											if (game.currentmenuoption == 5)
-											{
-													//back
-													music.playef(11);
-													game.createmenu("mainmenu");
-													map.nexttowercolour();
-											}
-										}else{
-											if (game.currentmenuoption == 4)
-											{
-													//back
-													music.playef(11);
-													game.createmenu("mainmenu");
-													map.nexttowercolour();
-											}
-										}
-										#endif
+                    if(music.mmmmmm){
+                        if (game.currentmenuoption == 4)
+                        {
+                            //**** TOGGLE MMMMMM
+                            if(game.usingmmmmmm > 0){
+                                game.usingmmmmmm=0;
+                            }else{
+                                game.usingmmmmmm=1;
+                            }
+                            music.usingmmmmmm = !music.usingmmmmmm;
+                            music.playef(11);
+                            music.play(6);
+                            game.savestats();
+                            game.createmenu("mainmenu");
+                            map.nexttowercolour();
+                        }
+                        if (game.currentmenuoption == 5)
+                        {
+                            //back
+                            music.playef(11);
+                            game.createmenu("mainmenu");
+                            map.nexttowercolour();
+                        }
+                    }else{
+                        if (game.currentmenuoption == 4)
+                        {
+                            //back
+                            music.playef(11);
+                            game.createmenu("mainmenu");
+                            map.nexttowercolour();
+                        }
+                    }
+#endif
                 }
                 else if (game.currentmenuname == "unlockmenutrials")
                 {
@@ -1363,13 +1363,13 @@ SDL_assert(0 && "Remove open level dir");
                     }
                     else if (game.currentmenuoption == 1)
                     {
-										  if(!map.invincibility){
-                        game.mainmenu = 11;
-                        graphics.fademode = 2;
-											}else{
-                        //Can't do yet! play sad sound
-                        music.playef(2);
-											}
+                        if(!map.invincibility){
+                            game.mainmenu = 11;
+                            graphics.fademode = 2;
+                        }else{
+                            //Can't do yet! play sad sound
+                            music.playef(2);
+                        }
                     }
                     else if (game.currentmenuoption == 2)
                     {
@@ -1412,41 +1412,41 @@ SDL_assert(0 && "Remove open level dir");
                     }
                 }
 
-				else if (game.currentmenuname == "controller")
-				{
-					if (game.currentmenuoption == 0)
-					{
-						game.controllerSensitivity++;
-						music.playef(11);
-						if(game.controllerSensitivity > 4)
-						{
-							game.controllerSensitivity = 0;
-						}
-					}
+                else if (game.currentmenuname == "controller")
+                {
+                    if (game.currentmenuoption == 0)
+                    {
+                        game.controllerSensitivity++;
+                        music.playef(11);
+                        if(game.controllerSensitivity > 4)
+                        {
+                            game.controllerSensitivity = 0;
+                        }
+                    }
 
-					if (game.currentmenuoption == 4)
-					{
-						music.playef(11);
-						game.createmenu("options");
+                    if (game.currentmenuoption == 4)
+                    {
+                        music.playef(11);
+                        game.createmenu("options");
 
-						//Add extra menu for mmmmmm mod
-						if(music.mmmmmm){
-							#if defined(MAKEANDPLAY)
-								game.menuoptions[3] = "soundtrack";
-								game.menuoptionsactive[3] = true;
-								game.menuoptions[4] = "return";
-								game.menuoptionsactive[4] = true;
-								game.nummenuoptions = 5;
-							#elif !defined(MAKEANDPLAY)
-								game.menuoptions[4] = "soundtrack";
-								game.menuoptionsactive[4] = true;
-								game.menuoptions[5] = "return";
-								game.menuoptionsactive[5] = true;
-								game.nummenuoptions = 6;
-							#endif
-						}
-					}
-				}
+                        //Add extra menu for mmmmmm mod
+                        if(music.mmmmmm){
+#if defined(MAKEANDPLAY)
+                            game.menuoptions[3] = "soundtrack";
+                            game.menuoptionsactive[3] = true;
+                            game.menuoptions[4] = "return";
+                            game.menuoptionsactive[4] = true;
+                            game.nummenuoptions = 5;
+#elif !defined(MAKEANDPLAY)
+                            game.menuoptions[4] = "soundtrack";
+                            game.menuoptionsactive[4] = true;
+                            game.menuoptions[5] = "return";
+                            game.menuoptionsactive[5] = true;
+                            game.nummenuoptions = 6;
+#endif
+                        }
+                    }
+                }
                 else if (game.currentmenuname == "cleardatamenu")
                 {
                     if (game.currentmenuoption == 0)
@@ -1455,22 +1455,22 @@ SDL_assert(0 && "Remove open level dir");
                         music.playef(11);
                         game.createmenu("options");
 
-												//Add extra menu for mmmmmm mod
-												if(music.mmmmmm){
-													#if defined(MAKEANDPLAY)
-														game.menuoptions[3] = "soundtrack";
-														game.menuoptionsactive[3] = true;
-														game.menuoptions[4] = "return";
-														game.menuoptionsactive[4] = true;
-														game.nummenuoptions = 5;
-													#elif !defined(MAKEANDPLAY)
-														game.menuoptions[4] = "soundtrack";
-														game.menuoptionsactive[4] = true;
-														game.menuoptions[5] = "return";
-														game.menuoptionsactive[5] = true;
-														game.nummenuoptions = 6;
-													#endif
-												}
+                        //Add extra menu for mmmmmm mod
+                        if(music.mmmmmm){
+#if defined(MAKEANDPLAY)
+                            game.menuoptions[3] = "soundtrack";
+                            game.menuoptionsactive[3] = true;
+                            game.menuoptions[4] = "return";
+                            game.menuoptionsactive[4] = true;
+                            game.nummenuoptions = 5;
+#elif !defined(MAKEANDPLAY)
+                            game.menuoptions[4] = "soundtrack";
+                            game.menuoptionsactive[4] = true;
+                            game.menuoptions[5] = "return";
+                            game.menuoptionsactive[5] = true;
+                            game.nummenuoptions = 6;
+#endif
+                        }
                         map.nexttowercolour();
                     }
                     else
@@ -1878,10 +1878,10 @@ void gameinput()
             {
                 game.press_action = true;
             };
-			if (key.isDown(KEYBOARD_ENTER) || key.isDown(SDLK_KP_ENTER) || key.isDown(game.controllerButton_map)  )
-			{
-				game.press_map = true;
-			}
+            if (key.isDown(KEYBOARD_ENTER) || key.isDown(SDLK_KP_ENTER) || key.isDown(game.controllerButton_map)  )
+            {
+                game.press_map = true;
+            }
         }
     //}
 
@@ -1904,10 +1904,10 @@ void gameinput()
             }
             else
             {
-						    if(!game.glitchrunkludge) game.state++;
-                game.jumpheld = true;
-								game.glitchrunkludge=true;
-								//Bug fix! You should only be able to do this ONCE.
+                if(!game.glitchrunkludge) game.state++;
+                    game.jumpheld = true;
+                    game.glitchrunkludge=true;
+                    //Bug fix! You should only be able to do this ONCE.
             }
         }
     }
@@ -1973,7 +1973,7 @@ void gameinput()
           game.advancetext = false;
           game.completestop = false;
           game.state = 0;
-			    graphics.showcutscenebars = false;
+          graphics.showcutscenebars = false;
 
           graphics.backgrounddrawn=false;
           music.fadeout();
@@ -2058,7 +2058,7 @@ void gameinput()
 
                                 //TODO TESTHIS
                                 //graphics.screenbuffer->UpdateScreen(graphics.menubuffer, NULL);
-								BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
+                                BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
 
                                 graphics.resumegamemode = false;
 
@@ -2106,7 +2106,7 @@ void gameinput()
                         game.menupage = 20; // The Map Page
                         //graphics.menubuffer.copyPixels(graphics.screenbuffer, graphics.screenbuffer.rect, graphics.tl, null, null, false);
                         //graphics.screenbuffer->UpdateScreen(graphics.menubuffer, NULL);
-														BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
+                        BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
                         graphics.menuoffset = 240; //actually this should count the roomname
                         if (map.extrarow) graphics.menuoffset -= 10;
                     }
@@ -2130,7 +2130,7 @@ void gameinput()
                         game.gamesaved = false;
                         graphics.resumegamemode = false;
                         game.menupage = 0; // The Map Page
-														BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
+                        BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
                         //graphics.screenbuffer->UpdateScreen(graphics.menubuffer, NULL);
                         graphics.menuoffset = 240; //actually this should count the roomname
                         if (map.extrarow) graphics.menuoffset -= 10;
@@ -2149,14 +2149,14 @@ void gameinput()
                     //graphics.menubuffer.copyPixels(graphics.screenbuffer, graphics.screenbuffer.rect, graphics.tl, NULL, NULL, false);
 
                     //graphics.screenbuffer->UpdateScreen(graphics.menubuffer, NULL);
-													BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
+                    BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
                     graphics.menuoffset = 240; //actually this should count the roomname
                     if (map.extrarow) graphics.menuoffset -= 10;
                 }
 
                 if (key.keymap[SDLK_r] && game.deathseq<=0)// && map.custommode) //Have fun glitchrunners!
                 {
-                	game.deathseq = 30;
+                    game.deathseq = 30;
                 }
 
                 if (game.press_left)
@@ -2400,15 +2400,15 @@ void mapinput()
 
             if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111) game.savearea = "The Ship";
 
-        #if !defined(NO_CUSTOM_LEVELS)
+#if !defined(NO_CUSTOM_LEVELS)
             if(map.custommodeforreal)
             {
-              game.customsavequick(ed.ListOfMetaData[game.playcustomlevel].filename);
+                game.customsavequick(ed.ListOfMetaData[game.playcustomlevel].filename);
             }
             else
-        #endif
+#endif
             {
-              game.savequick();
+                game.savequick();
             }
         }
 
@@ -2422,9 +2422,9 @@ void mapinput()
             //quit to menu
             if (graphics.fademode == 0)
             {
-				//Kill contents of offset render buffer, since we do that for some reason.
-				//This fixes an apparent frame flicker.
-				FillRect(graphics.tempBuffer, 0x000000);
+                //Kill contents of offset render buffer, since we do that for some reason.
+                //This fixes an apparent frame flicker.
+                FillRect(graphics.tempBuffer, 0x000000);
                 if (game.intimetrial || game.insecretlab || game.nodeathmode) game.menukludge = true;
                 script.hardreset();
                 if(graphics.setflipmode) graphics.flipmode = true;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -9,9 +9,6 @@
 
 extern scriptclass script;
 
-// Found in titlerender.cpp
-void updategraphicsmode();
-
 void updatebuttonmappings(int bind)
 {
 	for (
@@ -510,7 +507,6 @@ SDL_assert(0 && "Remove open level dir");
                     music.playef(11, 10);
                     graphics.screenbuffer->toggleFullScreen();
                     game.fullscreen = !game.fullscreen;
-                    updategraphicsmode();
                     game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 0;
@@ -518,7 +514,6 @@ SDL_assert(0 && "Remove open level dir");
                     music.playef(11, 10);
                     graphics.screenbuffer->toggleStretchMode();
                     game.stretchMode = (game.stretchMode + 1) % 3;
-                    updategraphicsmode();
                     game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 1;
@@ -526,7 +521,6 @@ SDL_assert(0 && "Remove open level dir");
                     music.playef(11, 10);
                     graphics.screenbuffer->toggleLinearFilter();
                     game.useLinearFilter = !game.useLinearFilter;
-                    updategraphicsmode();
                     game.savestats();
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 2;
@@ -535,7 +529,6 @@ SDL_assert(0 && "Remove open level dir");
                       music.playef(11, 10);
                       game.fullScreenEffect_badSignal = !game.fullScreenEffect_badSignal;
                       //Hook the analogue thing in here: ABCDEFG
-                      updategraphicsmode();
 					  graphics.screenbuffer->badSignalEffect= !graphics.screenbuffer->badSignalEffect;
                       game.savestats();
                       game.createmenu("graphicoptions");

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2082,7 +2082,7 @@ void gameinput()
 
                                 int player = obj.getplayer();
                                 obj.entities[player].colour = 102;
-                                int companion = obj.getcompanion(game.companion);
+                                int companion = obj.getcompanion();
                                 if(companion>-1) obj.entities[companion].colour = 102;
 
                                 int teleporter = obj.getteleporter();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -230,7 +230,7 @@ void titleinput()
             {
                 if (game.currentmenuname == "mainmenu")
                 {
-								
+
             #if defined(MAKEANDPLAY)
 				   if (game.currentmenuoption == 0)
                     {
@@ -868,7 +868,7 @@ SDL_assert(0 && "Remove open level dir");
                 }
                 else if (game.currentmenuname == "options")
                 {
-								
+
 				#if defined(MAKEANDPLAY)
 				if (game.currentmenuoption == 0)
                     {
@@ -877,7 +877,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.createmenu("accessibility");
                         map.nexttowercolour();
                     }
-                   
+
 					else if (game.currentmenuoption == 1)
 					{
 						//clear data menu
@@ -925,7 +925,7 @@ SDL_assert(0 && "Remove open level dir");
 													map.nexttowercolour();
 											}
 										}
-                    
+
 				#elif !defined(MAKEANDPLAY)
                     if (game.currentmenuoption == 0)
                     {
@@ -955,7 +955,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.createmenu("cleardatamenu");
                         map.nexttowercolour();
                     }
-                    
+
 										if(music.mmmmmm){
 											if (game.currentmenuoption == 4)
 											{

--- a/desktop_version/src/Input.h
+++ b/desktop_version/src/Input.h
@@ -9,22 +9,16 @@
 #include "Music.h"
 #include "Map.h"
 
-void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game,
-                entityclass& obj, UtilityClass& help, musicclass& music);
+void titleinput();
 
-void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-               entityclass& obj, UtilityClass& help, musicclass& music);
+void gameinput();
 
-void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-              entityclass& obj, UtilityClass& help, musicclass& music);
+void mapinput();
 
-void teleporterinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                     entityclass& obj, UtilityClass& help, musicclass& music);
+void teleporterinput();
 
-void gamecompleteinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                       entityclass& obj, UtilityClass& help, musicclass& music);
+void gamecompleteinput();
 
-void gamecompleteinput2(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                        entityclass& obj, UtilityClass& help, musicclass& music);
+void gamecompleteinput2();
 
 #endif /* INPUT_H */

--- a/desktop_version/src/Labclass.cpp
+++ b/desktop_version/src/Labclass.cpp
@@ -2,7 +2,7 @@
 
 #include "MakeAndPlay.h"
 
-std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entityclass& obj)
+std::vector<std::string> labclass::loadlevel(int rx, int ry)
 {
 	int t;
 

--- a/desktop_version/src/Labclass.cpp
+++ b/desktop_version/src/Labclass.cpp
@@ -1855,9 +1855,6 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry)
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		roomname = "Outer Space";
-
-		game.test = true;
-		game.teststring = "ERROR: Map not found in Lab Area";
 		break;
 #else
 	default:

--- a/desktop_version/src/Labclass.cpp
+++ b/desktop_version/src/Labclass.cpp
@@ -61,7 +61,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("283,283,324,364,364,364,364,364,364,364,364,364,364,364,364,364,364,364,364,364,364,364,364,364,325,283,405,0,0,0,0,0,0,403,283,283,283,283,283,283");
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,405,0,0,0,0,0,0,403,283,283,283,283,283,283");
 
-		obj.createentity(game, 232, 24, 10, 0, 250500);  // (savepoint)
+		obj.createentity(232, 24, 10, 0, 250500);  // (savepoint)
 
 		if(game.intimetrial)
 		{
@@ -104,7 +104,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("280,280,280,280,280,280,280,280,280,280,280,280,280,321,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,322,280");
 		tmap.push_back("280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280");
 
-		obj.createentity(game, 112, 180, 11, 192);  // (horizontal gravity line)
+		obj.createentity(112, 180, 11, 192);  // (horizontal gravity line)
 		rcol = 0;
 
 		roomname = "It's Perfectly Safe";
@@ -142,8 +142,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,414,0,0,0,0,0,0,0,412,292,292,292,292");
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,414,0,0,0,0,0,0,0,412,292,292,292,292");
 
-		obj.createentity(game, 96, 124, 11, 120);  // (horizontal gravity line)
-		obj.createentity(game, 248, 48, 10, 0, 251490);  // (savepoint)
+		obj.createentity(96, 124, 11, 120);  // (horizontal gravity line)
+		obj.createentity(248, 48, 10, 0, 251490);  // (savepoint)
 		rcol = 4;
 
 		roomname = "Rascasse";
@@ -181,11 +181,11 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("286,286,286,286,286,286,286,327,367,367,367,367,367,367,367,367,328,286,286,327,367,367,367,367,367,367,367,367,328,286,286,286,286,286,286,286,286,286,286,286");
 		tmap.push_back("286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 
-		obj.createentity(game, 248, 136, 10, 1, 252490);  // (savepoint)
-		obj.createentity(game, 16, 68, 11, 64);  // (horizontal gravity line)
-		obj.createentity(game, 112, 68, 11, 64);  // (horizontal gravity line)
-		obj.createentity(game, 64, 164, 11, 64);  // (horizontal gravity line)
-		obj.createentity(game, 160, 164, 11, 64);  // (horizontal gravity line)
+		obj.createentity(248, 136, 10, 1, 252490);  // (savepoint)
+		obj.createentity(16, 68, 11, 64);  // (horizontal gravity line)
+		obj.createentity(112, 68, 11, 64);  // (horizontal gravity line)
+		obj.createentity(64, 164, 11, 64);  // (horizontal gravity line)
+		obj.createentity(160, 164, 11, 64);  // (horizontal gravity line)
 		rcol = 2;
 
 		roomname = "Keep Going";
@@ -223,10 +223,10 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("289,411,0,0,0,0,0,0,0,0,0,409,289,289,289,289,289,289,330,370,370,370,370,370,331,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289");
 		tmap.push_back("289,411,0,0,0,0,0,0,0,0,0,409,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289");
 
-		obj.createentity(game, 280, 136, 10, 1, 252480);  // (savepoint)
-		obj.createentity(game, 48, 52, 11, 104);  // (horizontal gravity line)
-		obj.createentity(game, 192, 52, 11, 104);  // (horizontal gravity line)
-		obj.createentity(game, 152, 196, 11, 40);  // (horizontal gravity line)
+		obj.createentity(280, 136, 10, 1, 252480);  // (savepoint)
+		obj.createentity(48, 52, 11, 104);  // (horizontal gravity line)
+		obj.createentity(192, 52, 11, 104);  // (horizontal gravity line)
+		obj.createentity(152, 196, 11, 40);  // (horizontal gravity line)
 		rcol=3;
 
 		roomname = "Single-slit Experiment";
@@ -265,9 +265,9 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295");
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295");
 
-		obj.createentity(game, 32, 128, 10, 1, 253480);  // (savepoint)
-		obj.createentity(game, 187, 88, 12, 56);  // (vertical gravity line)
-		obj.createentity(game, 107, 88, 12, 56);  // (vertical gravity line)
+		obj.createentity(32, 128, 10, 1, 253480);  // (savepoint)
+		obj.createentity(187, 88, 12, 56);  // (vertical gravity line)
+		obj.createentity(107, 88, 12, 56);  // (vertical gravity line)
 		rcol = 5;
 
 		roomname = "Don't Flip Out";
@@ -305,12 +305,12 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 
-		obj.createentity(game, 43, 88, 12, 56);  // (vertical gravity line)
-		obj.createentity(game, 123, 88, 12, 56);  // (vertical gravity line)
-		obj.createentity(game, 203, 88, 12, 56);  // (vertical gravity line)
-		obj.createentity(game, 283, 88, 12, 56);  // (vertical gravity line)
+		obj.createentity(43, 88, 12, 56);  // (vertical gravity line)
+		obj.createentity(123, 88, 12, 56);  // (vertical gravity line)
+		obj.createentity(203, 88, 12, 56);  // (vertical gravity line)
+		obj.createentity(283, 88, 12, 56);  // (vertical gravity line)
 
-		obj.createentity(game, 156, 128, 20, 1);  // (terminal)
+		obj.createentity(156, 128, 20, 1);  // (terminal)
 		obj.createblock(5, 156-8, 128, 20, 16, 19);
 		rcol = 1;
 
@@ -349,8 +349,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,411,69,69,69,69,69,69,69,69");
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,330,370,370,370,370,370,370,370,370");
 
-		obj.createentity(game, 96, 192, 10, 1, 253500);  // (savepoint)
-		obj.createentity(game, 163, 32, 12, 168);  // (vertical gravity line)
+		obj.createentity(96, 192, 10, 1, 253500);  // (savepoint)
+		obj.createentity(163, 32, 12, 168);  // (vertical gravity line)
 		rcol = 3;
 
 		roomname = "Double-slit Experiment";
@@ -388,10 +388,10 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,67,406,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 		tmap.push_back("367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,328,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 
-		obj.createentity(game, 264, 104, 10, 1, 253510);  // (savepoint)
-		obj.createentity(game, 131, 120, 12, 96);  // (vertical gravity line)
-		obj.createentity(game, 187, 16, 12, 96);  // (vertical gravity line)
-		obj.createentity(game, 40, 112, 10, 0, 253511);  // (savepoint)
+		obj.createentity(264, 104, 10, 1, 253510);  // (savepoint)
+		obj.createentity(131, 120, 12, 96);  // (vertical gravity line)
+		obj.createentity(187, 16, 12, 96);  // (vertical gravity line)
+		obj.createentity(40, 112, 10, 0, 253511);  // (savepoint)
 		rcol = 2;
 		roomname = "They Call Him Flipper";
 		break;
@@ -428,8 +428,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,333,373,373,373,373,373,334,292,292,292,333,373,373,373,373,373,334,292,292,292,292,292,292,292,292,292,292");
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 
-		obj.createentity(game, 24, 184, 10, 1, 253520);  // (savepoint)
-		obj.createentity(game, 64, 164, 11, 200);  // (horizontal gravity line)
+		obj.createentity(24, 184, 10, 1, 253520);  // (savepoint)
+		obj.createentity(64, 164, 11, 200);  // (horizontal gravity line)
 		rcol = 4;
 		roomname = "Three's a Crowd";
 		break;
@@ -466,10 +466,10 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("286,286,286,286,286,286,286,408,0,0,0,0,0,0,366,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,367,328,286,286,286,286,286");
 		tmap.push_back("286,286,286,286,286,286,286,408,0,0,0,0,0,0,406,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 
-		obj.createentity(game, 195, 24, 12, 80);  // (vertical gravity line)
-		obj.createentity(game, 195, 128, 12, 80);  // (vertical gravity line)
-		obj.createentity(game, 80, 120, 10, 0, 252520);  // (savepoint)
-		obj.createentity(game, 80, 96, 10, 1, 252521);  // (savepoint)
+		obj.createentity(195, 24, 12, 80);  // (vertical gravity line)
+		obj.createentity(195, 128, 12, 80);  // (vertical gravity line)
+		obj.createentity(80, 120, 10, 0, 252520);  // (savepoint)
+		obj.createentity(80, 96, 10, 1, 252521);  // (savepoint)
 		rcol = 2;
 		roomname = "Hitting the Apex";
 		break;
@@ -506,10 +506,10 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("280,321,362,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,360,322,280,280,280,280,280,280,280");
 		tmap.push_back("280,280,321,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,361,322,280,280,280,280,280,280,280,280");
 
-		obj.createentity(game, 24, 188, 11, 224);  // (horizontal gravity line)
-		obj.createentity(game, 280, 96, 10, 1, 252510);  // (savepoint)
+		obj.createentity(24, 188, 11, 224);  // (horizontal gravity line)
+		obj.createentity(280, 96, 10, 1, 252510);  // (savepoint)
 
-		obj.createentity(game, 204, 32, 20, 0);  // (terminal)
+		obj.createentity(204, 32, 20, 0);  // (terminal)
 		obj.createblock(5, 204-8, 32, 20, 16, 20);
 		rcol=0;
 
@@ -549,8 +549,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("292,414,59,0,0,0,0,0,0,0,0,0,0,0,0,0,0,60,412,292,292,333,373,373,373,373,373,373,373,373,373,373,373,373,373,373,334,292,292,292");
 		tmap.push_back("292,414,59,0,0,0,0,0,0,0,0,0,0,0,0,0,0,60,412,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 
-		obj.createentity(game, 24, 44, 11, 112);  // (horizontal gravity line)
-		obj.createentity(game, 176, 180, 11, 112);  // (horizontal gravity line)
+		obj.createentity(24, 44, 11, 112);  // (horizontal gravity line)
+		obj.createentity(176, 180, 11, 112);  // (horizontal gravity line)
 		rcol = 4;
 		roomname = "Thorny Exchange";
 		break;
@@ -587,10 +587,10 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("283,283,324,365,65,65,65,65,65,65,65,65,65,65,65,65,65,65,363,325,405,53,0,0,0,0,0,0,0,0,0,0,0,0,0,0,54,403,283,283");
 		tmap.push_back("283,283,283,324,364,364,364,364,364,364,364,364,364,364,364,364,364,364,325,283,405,53,0,0,0,0,0,0,0,0,0,0,0,0,0,0,54,403,283,283");
 
-		obj.createentity(game, 32, 28, 11, 296);  // (horizontal gravity line)
-		obj.createentity(game, 32, 196, 11, 112);  // (horizontal gravity line)
-		obj.createentity(game, 128, 100, 11, 160);  // (horizontal gravity line)
-		obj.createentity(game, 88, 112, 10, 0, 250510);  // (savepoint)
+		obj.createentity(32, 28, 11, 296);  // (horizontal gravity line)
+		obj.createentity(32, 196, 11, 112);  // (horizontal gravity line)
+		obj.createentity(128, 100, 11, 160);  // (horizontal gravity line)
+		obj.createentity(88, 112, 10, 0, 250510);  // (savepoint)
 		roomname = "Brought to you by the letter G";
 		rcol = 1;
 		break;
@@ -627,8 +627,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("286,286,286,286,286,286,286,286,408,55,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("286,286,286,286,286,286,286,286,408,55,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 28, 11, 336);  // (horizontal gravity line)
-		obj.createentity(game, 32, 72, 10, 1, 250520);  // (savepoint)
+		obj.createentity(-8, 28, 11, 336);  // (horizontal gravity line)
+		obj.createentity(32, 72, 10, 1, 250520);  // (savepoint)
 		rcol=2;
 
 		roomname = "Free Your Mind";
@@ -666,7 +666,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280");
 		tmap.push_back("280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280");
 
-		obj.createentity(game, 80, 180, 11, 248);  // (horizontal gravity line)
+		obj.createentity(80, 180, 11, 248);  // (horizontal gravity line)
 		rcol=0;
 		roomname = "I Changed My Mind, Thelma...";
 		break;
@@ -703,8 +703,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 
-		obj.createentity(game, -8, 180, 11, 208);  // (horizontal gravity line)
-		obj.createentity(game, 240, 180, 11, 88);  // (horizontal gravity line)
+		obj.createentity(-8, 180, 11, 208);  // (horizontal gravity line)
+		obj.createentity(240, 180, 11, 88);  // (horizontal gravity line)
 		rcol=4;
 
 		roomname = "Indirect Jump Vector";
@@ -742,7 +742,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,62,415,295,417,61,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,62,415,295,417,61,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 28, 11, 336);  // (horizontal gravity line)
+		obj.createentity(-8, 28, 11, 336);  // (horizontal gravity line)
 		rcol=5;
 
 		roomname = "In a Single Bound";
@@ -780,9 +780,9 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("0,0,0,0,0,0,0,0,0,54,403,283,405,53,0,0,0,0,0,0,0,0,0,0,0,0,54,403,283,405,53,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,54,403,283,405,53,0,0,0,0,0,0,0,0,0,0,0,0,54,403,283,405,53,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 28, 11, 80);  // (horizontal gravity line)
-		obj.createentity(game, 112, 28, 11, 96);  // (horizontal gravity line)
-		obj.createentity(game, 248, 28, 11, 80);  // (horizontal gravity line)
+		obj.createentity(-8, 28, 11, 80);  // (horizontal gravity line)
+		obj.createentity(112, 28, 11, 96);  // (horizontal gravity line)
+		obj.createentity(248, 28, 11, 80);  // (horizontal gravity line)
 		rcol=1;
 
 		roomname = "Barani, Barani";
@@ -821,9 +821,9 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 		tmap.push_back("286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 
-		obj.createentity(game, -8, 180, 11, 80);  // (horizontal gravity line)
-		obj.createentity(game, 112, 180, 11, 96);  // (horizontal gravity line)
-		obj.createentity(game, 248, 180, 11, 80);  // (horizontal gravity line)
+		obj.createentity(-8, 180, 11, 80);  // (horizontal gravity line)
+		obj.createentity(112, 180, 11, 96);  // (horizontal gravity line)
+		obj.createentity(248, 180, 11, 80);  // (horizontal gravity line)
 		rcol=2;
 
 		roomname = "Safety Dance";
@@ -861,7 +861,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,58,409,411,0,0,0,0,0,0,409,289,289,289");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,58,409,411,0,0,0,0,0,0,409,289,289,289");
 
-		obj.createentity(game, -8, 28, 11, 40);  // (horizontal gravity line)
+		obj.createentity(-8, 28, 11, 40);  // (horizontal gravity line)
 
 		rcol=3;
 		roomname = "Heady Heights";
@@ -900,13 +900,13 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("295,295,295,295,295,295,417,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,62,415,295");
 
 
-		obj.createentity(game, 160, 176, 10, 0, 249550);  // (savepoint)
-		obj.createentity(game, 224, 68, 11, 72);  // (horizontal gravity line)
+		obj.createentity(160, 176, 10, 0, 249550);  // (savepoint)
+		obj.createentity(224, 68, 11, 72);  // (horizontal gravity line)
 
 
-		//obj.createentity(game, 224, 192, 10, 0, 249550);  // (savepoint)
+		//obj.createentity(224, 192, 10, 0, 249550);  // (savepoint)
 
-		if(!game.intimetrial) obj.createentity(game, (12 * 8)-4, (6 * 8) + 4, 14); //Teleporter!
+		if(!game.intimetrial) obj.createentity((12 * 8)-4, (6 * 8) + 4, 14); //Teleporter!
 		rcol = 5;
 
 		roomname = "Entanglement Generator";
@@ -945,7 +945,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,402,0,0,0,0,0,0,400,280,280,280");
 		tmap.push_back("280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,402,0,0,0,0,0,0,400,280,280,280");
 
-		obj.createentity(game, -8, 180, 11, 224);  // (horizontal gravity line)
+		obj.createentity(-8, 180, 11, 224);  // (horizontal gravity line)
 
 		rcol = 0;
 		roomname = "Exhausted?";
@@ -984,8 +984,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,414,59,0,0,0,0,0,0,0,60,412,292,414,0,0,0,0,0,0,412,292,292,292");
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,414,59,0,0,0,0,0,0,0,60,412,292,414,0,0,0,0,0,0,412,292,292,292");
 
-		obj.createentity(game, 32, 64, 9, 10);  // (shiny trinket)
-		obj.createentity(game, 120, 72, 10, 1, 252550);  // (savepoint)
+		obj.createentity(32, 64, 9, 10);  // (shiny trinket)
+		obj.createentity(120, 72, 10, 1, 252550);  // (savepoint)
 		rcol = 4;
 
 		roomname = "The Tantalizing Trinket";
@@ -1023,10 +1023,10 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("283,283,283,283,283,283,283,283,324,365,65,65,65,65,65,65,65,65,0,0,0,0,0,0,0,0,54,403,283,405,0,0,0,0,0,0,403,283,283,283");
 		tmap.push_back("283,283,283,283,283,283,283,283,283,324,364,364,364,364,364,364,364,365,53,0,0,0,0,0,0,0,54,403,283,405,0,0,0,0,0,0,403,283,283,283");
 
-		obj.createentity(game, 272, 144, 10, 1, 253550);  // (savepoint)
-		obj.createentity(game, 152, 116, 11, 56);  // (horizontal gravity line)
-		obj.createentity(game, 139, 16, 12, 72);  // (vertical gravity line)
-		obj.createentity(game, 139, 144, 12, 72);  // (vertical gravity line)
+		obj.createentity(272, 144, 10, 1, 253550);  // (savepoint)
+		obj.createentity(152, 116, 11, 56);  // (horizontal gravity line)
+		obj.createentity(139, 16, 12, 72);  // (vertical gravity line)
+		obj.createentity(139, 144, 12, 72);  // (vertical gravity line)
 		rcol=1;
 
 		roomname = "The Bernoulli Principle";
@@ -1064,9 +1064,9 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295");
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295");
 
-		obj.createentity(game, 216, 144, 10, 1, 254550);  // (savepoint)
-		obj.createentity(game, -8, 60, 11, 136);  // (horizontal gravity line)
-		obj.createentity(game, -8, 172, 11, 136);  // (horizontal gravity line)
+		obj.createentity(216, 144, 10, 1, 254550);  // (savepoint)
+		obj.createentity(-8, 60, 11, 136);  // (horizontal gravity line)
+		obj.createentity(-8, 172, 11, 136);  // (horizontal gravity line)
 		rcol = 5;
 
 		roomname = "Standing Wave";
@@ -1104,8 +1104,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,406,286,286,286,286,286,286,286,286,286,286,286");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,406,286,286,286,286,286,286,286,286,286,286,286");
 
-		obj.createentity(game, -8, 60, 11, 336);  // (horizontal gravity line)
-		obj.createentity(game, -8, 172, 11, 336);  // (horizontal gravity line)
+		obj.createentity(-8, 60, 11, 336);  // (horizontal gravity line)
+		obj.createentity(-8, 172, 11, 336);  // (horizontal gravity line)
 		rcol=2;
 
 		obj.fatal_top();
@@ -1144,14 +1144,14 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 60, 11, 120);  // (horizontal gravity line)
-		obj.createentity(game, -8, 172, 11, 40);  // (horizontal gravity line)
-		obj.createentity(game, 264, 72, 10, 0, 254530);  // (savepoint)
-		obj.createentity(game, 40, 144, 10, 1, 254531);  // (savepoint)
-		obj.createentity(game, 160, 60, 11, 48);  // (horizontal gravity line)
-		obj.createentity(game, 288, 60, 11, 40);  // (horizontal gravity line)
-		obj.createentity(game, 112, 172, 11, 48);  // (horizontal gravity line)
-		obj.createentity(game, 208, 172, 11, 120);  // (horizontal gravity line)
+		obj.createentity(-8, 60, 11, 120);  // (horizontal gravity line)
+		obj.createentity(-8, 172, 11, 40);  // (horizontal gravity line)
+		obj.createentity(264, 72, 10, 0, 254530);  // (savepoint)
+		obj.createentity(40, 144, 10, 1, 254531);  // (savepoint)
+		obj.createentity(160, 60, 11, 48);  // (horizontal gravity line)
+		obj.createentity(288, 60, 11, 40);  // (horizontal gravity line)
+		obj.createentity(112, 172, 11, 48);  // (horizontal gravity line)
+		obj.createentity(208, 172, 11, 120);  // (horizontal gravity line)
 		rcol=3;
 
 		obj.fatal_top();
@@ -1190,11 +1190,11 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 60, 11, 336);  // (horizontal gravity line)
-		obj.createentity(game, -8, 172, 11, 336);  // (horizontal gravity line)
-		obj.createentity(game, 72, 64, 1, 0, 8, 72, 64, 248, 168);  // Enemy, bounded
-		obj.createentity(game, 232, 64, 1, 0, 8, 72, 64, 248, 168);  // Enemy, bounded
-		obj.createentity(game, 152, 152, 1, 1, 8, 72, 64, 248, 168);  // Enemy, bounded
+		obj.createentity(-8, 60, 11, 336);  // (horizontal gravity line)
+		obj.createentity(-8, 172, 11, 336);  // (horizontal gravity line)
+		obj.createentity(72, 64, 1, 0, 8, 72, 64, 248, 168);  // Enemy, bounded
+		obj.createentity(232, 64, 1, 0, 8, 72, 64, 248, 168);  // Enemy, bounded
+		obj.createentity(152, 152, 1, 1, 8, 72, 64, 248, 168);  // Enemy, bounded
 
 		obj.fatal_top();
 		roomname = "Vibrating String Problem";
@@ -1233,11 +1233,11 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 176, 60, 11, 152);  // (horizontal gravity line)
-		obj.createentity(game, 176, 172, 11, 152);  // (horizontal gravity line)
-		obj.createentity(game, -8, 84, 11, 160);  // (horizontal gravity line)
-		obj.createentity(game, -8, 148, 11, 160);  // (horizontal gravity line)
-		obj.createentity(game, 160-4, 120, 10, 1, 254510);  // (savepoint)
+		obj.createentity(176, 60, 11, 152);  // (horizontal gravity line)
+		obj.createentity(176, 172, 11, 152);  // (horizontal gravity line)
+		obj.createentity(-8, 84, 11, 160);  // (horizontal gravity line)
+		obj.createentity(-8, 148, 11, 160);  // (horizontal gravity line)
+		obj.createentity(160-4, 120, 10, 1, 254510);  // (savepoint)
 		rcol=1;
 
 		obj.fatal_top();
@@ -1276,11 +1276,11 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, -8, 84, 11, 336);  // (horizontal gravity line)
-		obj.createentity(game, -8, 148, 11, 336);  // (horizontal gravity line)
-		obj.createentity(game, 88, 96, 1, 3, 3);  // Enemy
-		obj.createentity(game, 40, 120, 1, 3, 3);  // Enemy
-		obj.createentity(game, 136, 120, 1, 3, 3);  // Enemy
+		obj.createentity(-8, 84, 11, 336);  // (horizontal gravity line)
+		obj.createentity(-8, 148, 11, 336);  // (horizontal gravity line)
+		obj.createentity(88, 96, 1, 3, 3);  // Enemy
+		obj.createentity(40, 120, 1, 3, 3);  // Enemy
+		obj.createentity(136, 120, 1, 3, 3);  // Enemy
 		rcol = 0;
 
 		obj.fatal_top();
@@ -1320,10 +1320,10 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("286,286,286,286,408,55,0,0,0,0,0,0,56,430,55,0,0,0,0,0,0,56,430,55,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("286,286,286,286,408,55,0,0,0,0,0,0,56,430,55,0,0,0,0,0,0,56,430,55,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 264, 84, 11, 64);  // (horizontal gravity line)
-		obj.createentity(game, 240+4, 96, 10, 0, 254490);  // (savepoint)
-		obj.createentity(game, 48, 28, 11, 192);  // (horizontal gravity line)
-		obj.createentity(game, 120, 148, 11, 208);  // (horizontal gravity line)
+		obj.createentity(264, 84, 11, 64);  // (horizontal gravity line)
+		obj.createentity(240+4, 96, 10, 0, 254490);  // (savepoint)
+		obj.createentity(48, 28, 11, 192);  // (horizontal gravity line)
+		obj.createentity(120, 148, 11, 208);  // (horizontal gravity line)
 		rcol=2;
 
 		roomname = "I'm Sorry";
@@ -1362,8 +1362,8 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 
-		obj.createentity(game, 48, 156, 11, 200);  // (horizontal gravity line)
-		obj.createentity(game, 216, 56, 10, 0, 255490);  // (savepoint)
+		obj.createentity(48, 156, 11, 200);  // (horizontal gravity line)
+		obj.createentity(216, 56, 10, 0, 255490);  // (savepoint)
 		rcol=4;
 
 		roomname = "Please Forgive Me!";
@@ -1401,10 +1401,10 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 
-		obj.createentity(game, 131, 48, 12, 152);  // (vertical gravity line)
-		obj.createentity(game, 179, 48, 12, 152);  // (vertical gravity line)
-		obj.createentity(game, 227, 48, 12, 152);  // (vertical gravity line)
-		obj.createentity(game, 275, 48, 12, 152);  // (vertical gravity line)
+		obj.createentity(131, 48, 12, 152);  // (vertical gravity line)
+		obj.createentity(179, 48, 12, 152);  // (vertical gravity line)
+		obj.createentity(227, 48, 12, 152);  // (vertical gravity line)
+		obj.createentity(275, 48, 12, 152);  // (vertical gravity line)
 		rcol=1;
 
 		roomname = "Playing Foosball";
@@ -1442,17 +1442,17 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295");
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295");
 
-		obj.createentity(game, 91, 168, 12, 32);  // (vertical gravity line)
-		obj.createentity(game, 139, 80, 12, 120);  // (vertical gravity line)
-		obj.createentity(game, 235, 104, 12, 96);  // (vertical gravity line)
-		obj.createentity(game, 187, 144, 12, 56);  // (vertical gravity line)
-		obj.createentity(game, 43, 48, 12, 152);  // (vertical gravity line)
-		obj.createentity(game, 91, 48, 12, 112);  // (vertical gravity line)
-		obj.createentity(game, 139, 48, 12, 24);  // (vertical gravity line)
-		obj.createentity(game, 187, 48, 12, 88);  // (vertical gravity line)
-		obj.createentity(game, 235, 48, 12, 48);  // (vertical gravity line)
-		obj.createentity(game, 283, 48, 12, 152);  // (vertical gravity line)
-		obj.createentity(game, 8, 48, 10, 0, 255510);  // (savepoint)
+		obj.createentity(91, 168, 12, 32);  // (vertical gravity line)
+		obj.createentity(139, 80, 12, 120);  // (vertical gravity line)
+		obj.createentity(235, 104, 12, 96);  // (vertical gravity line)
+		obj.createentity(187, 144, 12, 56);  // (vertical gravity line)
+		obj.createentity(43, 48, 12, 152);  // (vertical gravity line)
+		obj.createentity(91, 48, 12, 112);  // (vertical gravity line)
+		obj.createentity(139, 48, 12, 24);  // (vertical gravity line)
+		obj.createentity(187, 48, 12, 88);  // (vertical gravity line)
+		obj.createentity(235, 48, 12, 48);  // (vertical gravity line)
+		obj.createentity(283, 48, 12, 152);  // (vertical gravity line)
+		obj.createentity(8, 48, 10, 0, 255510);  // (savepoint)
 		rcol=5;
 
 		roomname = "A Difficult Chord";
@@ -1490,11 +1490,11 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,402,51,0,0,0,0,0,52,400,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280");
 		tmap.push_back("280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,402,51,0,0,0,0,0,52,400,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280");
 
-		obj.createentity(game, 16, 184, 10, 1, 255520);  // (savepoint)
-		obj.createentity(game, 131, 88, 12, 96);  // (vertical gravity line)
-		obj.createentity(game, 208, 180, 11, 40);  // (horizontal gravity line)
-		obj.createentity(game, 67, 56, 12, 80);  // (vertical gravity line)
-		obj.createentity(game, 195, 56, 12, 80);  // (vertical gravity line)
+		obj.createentity(16, 184, 10, 1, 255520);  // (savepoint)
+		obj.createentity(131, 88, 12, 96);  // (vertical gravity line)
+		obj.createentity(208, 180, 11, 40);  // (horizontal gravity line)
+		obj.createentity(67, 56, 12, 80);  // (vertical gravity line)
+		obj.createentity(195, 56, 12, 80);  // (vertical gravity line)
 		rcol = 0;
 
 		roomname = "The Living Dead End";
@@ -1605,13 +1605,13 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("280,280,280,280,280,280,280,280,402,0,0,0,0,0,400,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280");
 		tmap.push_back("280,280,280,280,280,280,280,280,402,0,0,0,0,0,400,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280,280");
 
-		obj.createentity(game, 267, 24, 12, 184);  // (vertical gravity line)
-		obj.createentity(game, 16, 24, 9,  9);  // (shiny trinket)
-		obj.createentity(game, 187, 24, 12, 64);  // (vertical gravity line)
-		obj.createentity(game, 104, 124, 11, 80);  // (horizontal gravity line)
-		obj.createentity(game, 48, 72, 10, 1, 252500);  // (savepoint)
-		obj.createentity(game, 224, 72, 10, 1, 252501);  // (savepoint)
-		obj.createentity(game, 99, 24, 12, 80);  // (vertical gravity line)
+		obj.createentity(267, 24, 12, 184);  // (vertical gravity line)
+		obj.createentity(16, 24, 9,  9);  // (shiny trinket)
+		obj.createentity(187, 24, 12, 64);  // (vertical gravity line)
+		obj.createentity(104, 124, 11, 80);  // (horizontal gravity line)
+		obj.createentity(48, 72, 10, 1, 252500);  // (savepoint)
+		obj.createentity(224, 72, 10, 1, 252501);  // (savepoint)
+		obj.createentity(99, 24, 12, 80);  // (vertical gravity line)
 		rcol=0;
 
 		roomname = "Young Man, It's Worth the Challenge";
@@ -1686,7 +1686,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("289,289,289,289,289,330,371,446,447,288,286,327,367,367,367,367,328,286,287,447,448,369,331,289,289,289,289,289,289,289,289,289,289,289,289,289,289,330,370,370");
 		tmap.push_back("289,289,289,289,289,289,330,370,371,406,286,286,286,286,286,286,286,286,408,369,370,331,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289");
 
-		obj.createentity(game, 104, 128, 9, 11);  // (shiny trinket)
+		obj.createentity(104, 128, 9, 11);  // (shiny trinket)
 		rcol = 6;
 
 		roomname = "Purest Unobtainium";
@@ -1725,7 +1725,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		tmap.push_back("295,295,295,295,295,417,0,415,295,295,417,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,415,295,295,295,295");
 		tmap.push_back("295,295,295,295,295,417,0,415,295,295,336,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,376,337,295,295,295,295");
 
-		obj.createentity(game, 112, 184, 10, 1, 258520);  // (savepoint)
+		obj.createentity(112, 184, 10, 1, 258520);  // (savepoint)
 		rcol = 5;
 
 		roomname = "I Smell Ozone";
@@ -1768,7 +1768,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		{
 			if(game.companion==0 && obj.flags[9]==0 &&  !game.crewstats[5])   //also need to check if he's rescued in a previous game
 			{
-				obj.createentity(game, 32, 177, 18, 16, 1, 17, 1);
+				obj.createentity(32, 177, 18, 16, 1, 17, 1);
 				obj.createblock(1, 24*8, 0, 32, 240, 33);
 			}
 		}
@@ -1811,7 +1811,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry , Game& game, entity
 		rcol=3;
 
 
-		obj.createentity(game, (10 * 8)-4, (8 * 8) + 4, 14); //Teleporter!
+		obj.createentity((10 * 8)-4, (8 * 8) + 4, 14); //Teleporter!
 
 		if(game.intimetrial)
 		{

--- a/desktop_version/src/Labclass.cpp
+++ b/desktop_version/src/Labclass.cpp
@@ -23,7 +23,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry)
 	std::vector<std::string> tmap;
 	coin = 0;
 	rcol = 0;
-	roomname = "Untitled room ["+UtilityClass::String(rx) + "," + UtilityClass::String(ry)+"]";
+	roomname = "Untitled room ["+help.String(rx) + "," + help.String(ry)+"]";
 
 	switch(t)
 	{

--- a/desktop_version/src/Labclass.h
+++ b/desktop_version/src/Labclass.h
@@ -10,7 +10,7 @@
 class labclass
 {
 public:
-    std::vector<std::string>  loadlevel(int rx, int ry , Game& game, entityclass& obj);
+    std::vector<std::string>  loadlevel(int rx, int ry);
 
     std::string roomname;
     int coin, rcol;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -5,7 +5,7 @@
 extern int temp;
 extern scriptclass script;
 
-void titlelogic( Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help, musicclass& music, mapclass& map)
+void titlelogic()
 {
     //Misc
     //map.updatetowerglow();
@@ -38,19 +38,19 @@ void titlelogic( Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& he
     }
 }
 
-void maplogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help)
+void maplogic()
 {
     //Misc
     help.updateglow();
 }
 
 
-void gamecompletelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help)
+void gamecompletelogic()
 {
     //Misc
     map.updatetowerglow();
     help.updateglow();
-    dwgfx.crewframe = 0;
+    graphics.crewframe = 0;
 
     map.tdrawback = true;
 
@@ -66,18 +66,18 @@ void gamecompletelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclas
         map.bscroll = +1;
     }
 
-    if (dwgfx.fademode == 1)
+    if (graphics.fademode == 1)
     {
         //Fix some graphical things
-        dwgfx.showcutscenebars = false;
-        dwgfx.cutscenebarspos = 0;
+        graphics.showcutscenebars = false;
+        graphics.cutscenebarspos = 0;
         //Return to game
         game.gamestate = 7;
-        dwgfx.fademode = 4;
+        graphics.fademode = 4;
     }
 }
 
-void gamecompletelogic2(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help)
+void gamecompletelogic2()
 {
     //Misc
     map.updatetowerglow();
@@ -105,11 +105,11 @@ void gamecompletelogic2(Graphics& dwgfx, Game& game, entityclass& obj,  musiccla
     }
     */
 
-    if (dwgfx.fademode == 1)
+    if (graphics.fademode == 1)
     {
         //Fix some graphical things
-        dwgfx.showcutscenebars = false;
-        dwgfx.cutscenebarspos = 0;
+        graphics.showcutscenebars = false;
+        graphics.cutscenebarspos = 0;
         //Fix the save thingy
         game.deletequick();
         int tmp=music.currentsong;
@@ -120,7 +120,7 @@ void gamecompletelogic2(Graphics& dwgfx, Game& game, entityclass& obj,  musiccla
         //Return to game
         map.colstate = 10;
         game.gamestate = 1;
-        dwgfx.fademode = 4;
+        graphics.fademode = 4;
         music.playef(18, 10);
         game.createmenu("gamecompletecontinue");
         map.nexttowercolour();
@@ -128,7 +128,7 @@ void gamecompletelogic2(Graphics& dwgfx, Game& game, entityclass& obj,  musiccla
 }
 
 
-void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help)
+void towerlogic()
 {
     //Logic for the tower level
     map.updatetowerglow();
@@ -277,8 +277,8 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
                 game.deathseq = 1;
                 game.gethardestroom();
                 //start depressing sequence here...
-                if (game.gameoverdelay <= -10 && dwgfx.fademode==0) dwgfx.fademode = 2;
-                if (dwgfx.fademode == 1) script.resetgametomenu();
+                if (game.gameoverdelay <= -10 && graphics.fademode==0) graphics.fademode = 2;
+                if (graphics.fademode == 1) script.resetgametomenu();
             }
             else
             {
@@ -289,7 +289,7 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
                 }
 
                 game.gravitycontrol = game.savegc;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
                 map.resetplayer();
             }
         }
@@ -376,7 +376,7 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
             obj.entitycollisioncheck();         // Check ent v ent collisions, update states
             //special for tower: is the player touching any spike blocks?
             int player = obj.getplayer();
-            if(obj.checktowerspikes(player) && dwgfx.fademode==0)
+            if(obj.checktowerspikes(player) && graphics.fademode==0)
             {
                 game.deathseq = 30;
             }
@@ -526,7 +526,7 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
     if (game.teleport_to_new_area) script.teleport();
 }
 
-void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help)
+void gamelogic()
 {
     //Misc
     help.updateglow();
@@ -656,8 +656,8 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 game.deathseq = 1;
                 game.gethardestroom();
                 //start depressing sequence here...
-                if (game.gameoverdelay <= -10 && dwgfx.fademode==0) dwgfx.fademode = 2;
-                if (dwgfx.fademode == 1) script.resetgametomenu();
+                if (game.gameoverdelay <= -10 && graphics.fademode==0) graphics.fademode = 2;
+                if (graphics.fademode == 1) script.resetgametomenu();
             }
             else
             {
@@ -677,7 +677,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
 
 
                 game.gravitycontrol = game.savegc;
-                dwgfx.textboxremove();
+                graphics.textboxremove();
                 map.resetplayer();
             }
         }
@@ -832,7 +832,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 {
                     game.swncolstate = (game.swncolstate+1)%6;
                     game.swncoldelay = 30;
-                    dwgfx.rcol = game.swncolstate;
+                    graphics.rcol = game.swncolstate;
                     obj.swnenemiescol(game.swncolstate);
                 }
             }
@@ -1422,7 +1422,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 {
                     if (obj.flags[59] == 0)
                     {
-                        obj.createentity(225.0f, 169.0f, 18, dwgfx.crewcolour(game.lastsaved), 0, 10);
+                        obj.createentity(225.0f, 169.0f, 18, graphics.crewcolour(game.lastsaved), 0, 10);
                         j = obj.getcompanion(10);
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
@@ -1432,7 +1432,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 {
                     if (obj.flags[59] == 1)
                     {
-                        obj.createentity(160.0f, 177.0f, 18, dwgfx.crewcolour(game.lastsaved), 0, 18, 1);
+                        obj.createentity(160.0f, 177.0f, 18, graphics.crewcolour(game.lastsaved), 0, 18, 1);
                         j = obj.getcompanion(10);
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
@@ -1440,7 +1440,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     else
                     {
                         obj.flags[59] = 1;
-                        obj.createentity(obj.entities[i].xp, -20.0f, 18.0f, dwgfx.crewcolour(game.lastsaved), 0, 10, 0);
+                        obj.createentity(obj.entities[i].xp, -20.0f, 18.0f, graphics.crewcolour(game.lastsaved), 0, 10, 0);
                         j = obj.getcompanion(10);
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
@@ -1449,60 +1449,60 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 break;
             case 11:
                 //Intermission 1: We're using the SuperCrewMate instead!
-                //obj.createentity(obj.entities[i].xp, obj.entities[i].yp, 24, dwgfx.crewcolour(game.lastsaved));
+                //obj.createentity(obj.entities[i].xp, obj.entities[i].yp, 24, graphics.crewcolour(game.lastsaved));
                 if(game.roomx-41==game.scmprogress)
                 {
                     switch(game.scmprogress)
                     {
                     case 0:
-                        obj.createentity(76, 161, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(76, 161, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 1:
-                        obj.createentity(10, 169, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 169, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 2:
-                        obj.createentity(10, 177, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 177, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 3:
                         if (game.scmmoveme)
                         {
-                            obj.createentity(obj.entities[obj.getplayer()].xp, 185, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                            obj.createentity(obj.entities[obj.getplayer()].xp, 185, 24, graphics.crewcolour(game.lastsaved), 2);
                             game.scmmoveme = false;
                         }
                         else
                         {
-                            obj.createentity(10, 177, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                            obj.createentity(10, 177, 24, graphics.crewcolour(game.lastsaved), 2);
                         }
                         break;
                     case 4:
-                        obj.createentity(10, 185, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 185, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 5:
-                        obj.createentity(10, 185, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 185, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 6:
-                        obj.createentity(10, 185, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 185, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 7:
-                        obj.createentity(10, 41, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 41, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 8:
-                        obj.createentity(10, 169, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 169, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 9:
-                        obj.createentity(10, 169, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 169, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 10:
-                        obj.createentity(10, 129, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 129, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 11:
-                        obj.createentity(10, 129, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 129, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 12:
-                        obj.createentity(10, 65, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 65, 24, graphics.crewcolour(game.lastsaved), 2);
                         break;
                     case 13:
-                        obj.createentity(10, 177, 24, dwgfx.crewcolour(game.lastsaved));
+                        obj.createentity(10, 177, 24, graphics.crewcolour(game.lastsaved));
                         break;
                     }
                 }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -278,7 +278,7 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
                 game.gethardestroom();
                 //start depressing sequence here...
                 if (game.gameoverdelay <= -10 && dwgfx.fademode==0) dwgfx.fademode = 2;
-                if (dwgfx.fademode == 1) script.resetgametomenu(dwgfx, game, map, obj, help, music);
+                if (dwgfx.fademode == 1) script.resetgametomenu();
             }
             else
             {
@@ -523,7 +523,7 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
         //Looping around, room change conditions!
     }
 
-    if (game.teleport_to_new_area) script.teleport(dwgfx, game, map,	obj, help, music);
+    if (game.teleport_to_new_area) script.teleport();
 }
 
 void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help)
@@ -657,7 +657,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 game.gethardestroom();
                 //start depressing sequence here...
                 if (game.gameoverdelay <= -10 && dwgfx.fademode==0) dwgfx.fademode = 2;
-                if (dwgfx.fademode == 1) script.resetgametomenu(dwgfx, game, map, obj, help, music);
+                if (dwgfx.fademode == 1) script.resetgametomenu();
             }
             else
             {
@@ -1544,5 +1544,5 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
     }
 
     if (game.teleport_to_new_area)
-        script.teleport(dwgfx, game, map,	obj, help, music);
+        script.teleport();
 }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -27,11 +27,11 @@ void titlelogic()
             }
             else if (game.menudest == "gameover2")
             {
-                music.playef(11, 10);
+                music.playef(11);
             }
             else if (game.menudest == "timetrialcomplete3")
             {
-                music.playef(3, 10);
+                music.playef(3);
             }
             game.createmenu(game.menudest);
         }
@@ -120,7 +120,7 @@ void gamecompletelogic2()
         map.colstate = 10;
         game.gamestate = 1;
         graphics.fademode = 4;
-        music.playef(18, 10);
+        music.playef(18);
         game.createmenu("gamecompletecontinue");
         map.nexttowercolour();
     }
@@ -310,9 +310,9 @@ void towerlogic()
                 {
                     game.hascontrol = false;
                 }
-                if(game.timetrialcountdown == 120) music.playef(21, 10);
-                if(game.timetrialcountdown == 90) music.playef(21, 10);
-                if(game.timetrialcountdown == 60) music.playef(21, 10);
+                if(game.timetrialcountdown == 120) music.playef(21);
+                if(game.timetrialcountdown == 90) music.playef(21);
+                if(game.timetrialcountdown == 60) music.playef(21);
                 if (game.timetrialcountdown == 30)
                 {
                     switch(game.timetriallevel)
@@ -336,7 +336,7 @@ void towerlogic()
                         music.play(15);
                         break;
                     }
-                    music.playef(22, 10);
+                    music.playef(22);
                 }
             }
 
@@ -351,7 +351,7 @@ void towerlogic()
                     {
                         obj.entities[i].tile = 144;
                     }
-                    music.playef(2, 10);
+                    music.playef(2);
                 }
             }
         }
@@ -549,7 +549,7 @@ void gamelogic()
             //change player to sad
             int i = obj.getplayer();
             obj.entities[i].tile = 144;
-            music.playef(2, 10);
+            music.playef(2);
         }
         if (obj.upset > 301) obj.upset = 301;
     }
@@ -639,7 +639,7 @@ void gamelogic()
                 game.swndelay = 0;
                 if (game.swntimer >= game.swnrecord)
                 {
-                    if (game.swnmessage == 0) music.playef(25, 10);
+                    if (game.swnmessage == 0) music.playef(25);
                     game.swnmessage = 1;
                     game.swnrecord = game.swntimer;
                 }
@@ -765,7 +765,7 @@ void gamelogic()
 												NETWORK_unlockAchievement("vvvvvvsupgrav5");
                         game.swnbestrank = 1;
                         game.swnmessage = 2+30;
-                        music.playef(26, 10);
+                        music.playef(26);
                     }
                 }
                 else if (game.swntimer >= 300 && game.swnrank == 1)
@@ -776,7 +776,7 @@ void gamelogic()
 												NETWORK_unlockAchievement("vvvvvvsupgrav10");
                         game.swnbestrank = 2;
                         game.swnmessage = 2+30;
-                        music.playef(26, 10);
+                        music.playef(26);
                     }
                 }
                 else if (game.swntimer >= 450 && game.swnrank == 2)
@@ -787,7 +787,7 @@ void gamelogic()
 												NETWORK_unlockAchievement("vvvvvvsupgrav15");
                         game.swnbestrank = 3;
                         game.swnmessage = 2+30;
-                        music.playef(26, 10);
+                        music.playef(26);
                     }
                 }
                 else if (game.swntimer >= 600 && game.swnrank == 3)
@@ -798,7 +798,7 @@ void gamelogic()
 												NETWORK_unlockAchievement("vvvvvvsupgrav20");
                         game.swnbestrank = 4;
                         game.swnmessage = 2+30;
-                        music.playef(26, 10);
+                        music.playef(26);
                     }
                 }
                 else if (game.swntimer >= 900 && game.swnrank == 4)
@@ -809,7 +809,7 @@ void gamelogic()
 												NETWORK_unlockAchievement("vvvvvvsupgrav30");
                         game.swnbestrank = 5;
                         game.swnmessage = 2+30;
-                        music.playef(26, 10);
+                        music.playef(26);
                     }
                 }
                 else if (game.swntimer >= 1800 && game.swnrank == 5)
@@ -820,7 +820,7 @@ void gamelogic()
 												NETWORK_unlockAchievement("vvvvvvsupgrav60");
                         game.swnbestrank = 6;
                         game.swnmessage = 2+30;
-                        music.playef(26, 10);
+                        music.playef(26);
                     }
                 }
 
@@ -904,9 +904,9 @@ void gamelogic()
                 {
                     game.hascontrol = false;
                 }
-                if(game.timetrialcountdown == 120) music.playef(21, 10);
-                if(game.timetrialcountdown == 90) music.playef(21, 10);
-                if(game.timetrialcountdown == 60) music.playef(21, 10);
+                if(game.timetrialcountdown == 120) music.playef(21);
+                if(game.timetrialcountdown == 90) music.playef(21);
+                if(game.timetrialcountdown == 60) music.playef(21);
                 if (game.timetrialcountdown == 30)
                 {
                     switch(game.timetriallevel)
@@ -930,7 +930,7 @@ void gamelogic()
                         music.play(15);
                         break;
                     }
-                    music.playef(22, 10);
+                    music.playef(22);
                 }
             }
 
@@ -945,7 +945,7 @@ void gamelogic()
                     {
                         obj.entities[i].tile = 144;
                     }
-                    music.playef(2, 10);
+                    music.playef(2);
                 }
             }
         }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1043,13 +1043,13 @@ void gamelogic()
 					//warp lines for collision
 					obj.customwarpmodehon = false;
 					obj.customwarpmodevon = false;
-			
+
 					int i = obj.getplayer();
 					if ((game.door_down > -2 && obj.entities[i].yp >= 226-16) || (game.door_up > -2 && obj.entities[i].yp < -2+16) ||	(game.door_left > -2 && obj.entities[i].xp < -14+16) ||	(game.door_right > -2 && obj.entities[i].xp >= 308-16)){
 						//Player is leaving room
 						obj.customwarplinecheck(i);
 					}
-			
+
 					if(obj.customwarpmodehon){ map.warpy=true;
 					}else{ map.warpy=false; }
 					if(obj.customwarpmodevon){ map.warpx=true;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -13,8 +13,6 @@ void titlelogic()
 
     map.bypos -= 2;
     map.bscroll = -2;
-    //if (map.ypos <= 0) { map.ypos = 0; map.bypos = 0; map.bscroll = 0; }
-    //if (map.ypos >= 5368) { map.ypos = 5368; map.bypos = map.ypos / 2; } //700-29 * 8 = 5368
 
     if (game.menucountdown > 0)
     {
@@ -95,15 +93,6 @@ void gamecompletelogic2()
             if (game.creditposy > 30) game.creditposy = 30;
         }
     }
-    /*
-    game.creditposition--;
-    if (game.creditposition <= -1650) {
-    game.creditposition = -1650;
-    map.bscroll = 0;
-    }else {
-    map.bypos += 1; map.bscroll = +1;
-    }
-    */
 
     if (graphics.fademode == 1)
     {
@@ -361,15 +350,9 @@ void towerlogic()
         {
             for (int i = obj.nentity - 1; i >= 0;  i--)
             {
-                //Remove old platform
-                //if (obj.entities[i].isplatform) obj.removeblockat(obj.entities[i].xp, obj.entities[i].yp);
-
                 obj.updateentities(i);                // Behavioral logic
                 obj.updateentitylogic(i);                          // Basic Physics
                 obj.entitymapcollision(i);                          // Collisions with walls
-
-                //Create new platform
-                //if (obj.entities[i].isplatform) obj.movingplatformfix(i);
             }
 
             obj.entitycollisioncheck();         // Check ent v ent collisions, update states
@@ -611,7 +594,6 @@ void gamelogic()
             }
             else if (map.finalstretch && obj.entities[i].type == 2)
             {
-                //TODO: }else if (map.finallevel && map.finalstretch && obj.entities[i].type == 2) {
                 //for the final level. probably something 99% of players won't see.
                 while (obj.entities[i].state == 2) obj.updateentities(i);
                 obj.entities[i].state = 4;
@@ -1448,7 +1430,6 @@ void gamelogic()
                 break;
             case 11:
                 //Intermission 1: We're using the SuperCrewMate instead!
-                //obj.createentity(obj.entities[i].xp, obj.entities[i].yp, 24, graphics.crewcolour(game.lastsaved));
                 if(game.roomx-41==game.scmprogress)
                 {
                     switch(game.scmprogress)

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -762,7 +762,7 @@ void gamelogic()
                     game.swnrank = 1;
                     if (game.swnbestrank < 1)
                     {
-												NETWORK_unlockAchievement("vvvvvvsupgrav5");
+                        NETWORK_unlockAchievement("vvvvvvsupgrav5");
                         game.swnbestrank = 1;
                         game.swnmessage = 2+30;
                         music.playef(26);
@@ -773,7 +773,7 @@ void gamelogic()
                     game.swnrank = 2;
                     if (game.swnbestrank < 2)
                     {
-												NETWORK_unlockAchievement("vvvvvvsupgrav10");
+                        NETWORK_unlockAchievement("vvvvvvsupgrav10");
                         game.swnbestrank = 2;
                         game.swnmessage = 2+30;
                         music.playef(26);
@@ -784,7 +784,7 @@ void gamelogic()
                     game.swnrank = 3;
                     if (game.swnbestrank < 3)
                     {
-												NETWORK_unlockAchievement("vvvvvvsupgrav15");
+                        NETWORK_unlockAchievement("vvvvvvsupgrav15");
                         game.swnbestrank = 3;
                         game.swnmessage = 2+30;
                         music.playef(26);
@@ -795,7 +795,7 @@ void gamelogic()
                     game.swnrank = 4;
                     if (game.swnbestrank < 4)
                     {
-												NETWORK_unlockAchievement("vvvvvvsupgrav20");
+                        NETWORK_unlockAchievement("vvvvvvsupgrav20");
                         game.swnbestrank = 4;
                         game.swnmessage = 2+30;
                         music.playef(26);
@@ -806,7 +806,7 @@ void gamelogic()
                     game.swnrank = 5;
                     if (game.swnbestrank < 5)
                     {
-												NETWORK_unlockAchievement("vvvvvvsupgrav30");
+                        NETWORK_unlockAchievement("vvvvvvsupgrav30");
                         game.swnbestrank = 5;
                         game.swnmessage = 2+30;
                         music.playef(26);
@@ -817,7 +817,7 @@ void gamelogic()
                     game.swnrank = 6;
                     if (game.swnbestrank < 6)
                     {
-												NETWORK_unlockAchievement("vvvvvvsupgrav60");
+                        NETWORK_unlockAchievement("vvvvvvsupgrav60");
                         game.swnbestrank = 6;
                         game.swnmessage = 2+30;
                         music.playef(26);
@@ -1037,24 +1037,24 @@ void gamelogic()
         obj.cleanup();
 
         //Using warplines?
-				if (obj.customwarpmode) {
-					//Rewritten system for mobile update: basically, the new logic is to
-					//check if the player is leaving the map, and if so do a special check against
-					//warp lines for collision
-					obj.customwarpmodehon = false;
-					obj.customwarpmodevon = false;
+        if (obj.customwarpmode) {
+            //Rewritten system for mobile update: basically, the new logic is to
+            //check if the player is leaving the map, and if so do a special check against
+            //warp lines for collision
+            obj.customwarpmodehon = false;
+            obj.customwarpmodevon = false;
 
-					int i = obj.getplayer();
-					if ((game.door_down > -2 && obj.entities[i].yp >= 226-16) || (game.door_up > -2 && obj.entities[i].yp < -2+16) ||	(game.door_left > -2 && obj.entities[i].xp < -14+16) ||	(game.door_right > -2 && obj.entities[i].xp >= 308-16)){
-						//Player is leaving room
-						obj.customwarplinecheck(i);
-					}
+            int i = obj.getplayer();
+            if ((game.door_down > -2 && obj.entities[i].yp >= 226-16) || (game.door_up > -2 && obj.entities[i].yp < -2+16) ||	(game.door_left > -2 && obj.entities[i].xp < -14+16) ||	(game.door_right > -2 && obj.entities[i].xp >= 308-16)){
+            //Player is leaving room
+            obj.customwarplinecheck(i);
+        }
 
-					if(obj.customwarpmodehon){ map.warpy=true;
-					}else{ map.warpy=false; }
-					if(obj.customwarpmodevon){ map.warpx=true;
-					}else{ map.warpx=false; }
-				}
+        if(obj.customwarpmodehon){ map.warpy=true;
+        }else{ map.warpy=false; }
+        if(obj.customwarpmodevon){ map.warpx=true;
+        }else{ map.warpx=false; }
+        }
 
         //Finally: Are we changing room?
         if (map.warpx && map.warpy)

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1361,7 +1361,7 @@ void gamelogic()
             {
             case 6:
                 obj.createentity(obj.entities[i].xp, 121.0f, 15.0f,1);  //Y=121, the floor in that particular place!
-                j = obj.getcompanion(6);
+                j = obj.getcompanion();
                 obj.entities[j].vx = obj.entities[i].vx;
                 obj.entities[j].dir = obj.entities[i].dir;
                 break;
@@ -1376,7 +1376,7 @@ void gamelogic()
                     {
                         obj.createentity(obj.entities[i].xp, 86.0f, 16.0f, 1);  //Y=86, the ROOF in that particular place!
                     }
-                    j = obj.getcompanion(7);
+                    j = obj.getcompanion();
                     obj.entities[j].vx = obj.entities[i].vx;
                     obj.entities[j].dir = obj.entities[i].dir;
                 }
@@ -1387,14 +1387,14 @@ void gamelogic()
                     if (game.roomx == 102)
                     {
                         obj.createentity(310, 177, 17, 1);
-                        j = obj.getcompanion(8);
+                        j = obj.getcompanion();
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
                     }
                     else
                     {
                         obj.createentity(obj.entities[i].xp, 177.0f, 17.0f, 1);
-                        j = obj.getcompanion(8);
+                        j = obj.getcompanion();
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
                     }
@@ -1411,7 +1411,7 @@ void gamelogic()
                     {
                         obj.createentity(obj.entities[i].xp, 185.0f, 18.0f, 15, 0, 1);
                     }
-                    j = obj.getcompanion(9);
+                    j = obj.getcompanion();
                     obj.entities[j].vx = obj.entities[i].vx;
                     obj.entities[j].dir = obj.entities[i].dir;
                 }
@@ -1423,7 +1423,7 @@ void gamelogic()
                     if (obj.flags[59] == 0)
                     {
                         obj.createentity(225.0f, 169.0f, 18, graphics.crewcolour(game.lastsaved), 0, 10);
-                        j = obj.getcompanion(10);
+                        j = obj.getcompanion();
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
                     }
@@ -1433,7 +1433,7 @@ void gamelogic()
                     if (obj.flags[59] == 1)
                     {
                         obj.createentity(160.0f, 177.0f, 18, graphics.crewcolour(game.lastsaved), 0, 18, 1);
-                        j = obj.getcompanion(10);
+                        j = obj.getcompanion();
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
                     }
@@ -1441,7 +1441,7 @@ void gamelogic()
                     {
                         obj.flags[59] = 1;
                         obj.createentity(obj.entities[i].xp, -20.0f, 18.0f, graphics.crewcolour(game.lastsaved), 0, 10, 0);
-                        j = obj.getcompanion(10);
+                        j = obj.getcompanion();
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
                     }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -114,7 +114,7 @@ void gamecompletelogic2(Graphics& dwgfx, Game& game, entityclass& obj,  musiccla
         game.deletequick();
         int tmp=music.currentsong;
         music.currentsong=4;
-        game.savetele(map,obj,music);
+        game.savetele();
         music.currentsong=tmp;
         game.telegotoship();
         //Return to game
@@ -254,7 +254,7 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
         {
             if (map.resumedelay <= 0)
             {
-                game.lifesequence(obj);
+                game.lifesequence();
                 if (game.lifeseq == 0) map.cameramode = 1;
             }
             else
@@ -268,14 +268,14 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
     {
         map.colsuperstate = 1;
         map.cameramode = 2;
-        game.deathsequence(map, obj, music);
+        game.deathsequence();
         game.deathseq--;
         if (game.deathseq <= 0)
         {
             if (game.nodeathmode)
             {
                 game.deathseq = 1;
-                game.gethardestroom(map);
+                game.gethardestroom();
                 //start depressing sequence here...
                 if (game.gameoverdelay <= -10 && dwgfx.fademode==0) dwgfx.fademode = 2;
                 if (dwgfx.fademode == 1) script.resetgametomenu(dwgfx, game, map, obj, help, music);
@@ -297,7 +297,7 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
     else
     {
         //State machine for game logic
-        game.updatestate(dwgfx, map, obj, help, music);
+        game.updatestate();
 
 
         //Time trial stuff
@@ -571,7 +571,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
         obj.upset = 0;
     }
 
-    game.lifesequence(obj);
+    game.lifesequence();
 
 
     if (game.deathseq != -1)
@@ -647,14 +647,14 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             }
         }
 
-        game.deathsequence(map, obj, music);
+        game.deathsequence();
         game.deathseq--;
         if (game.deathseq <= 0)
         {
             if (game.nodeathmode)
             {
                 game.deathseq = 1;
-                game.gethardestroom(map);
+                game.gethardestroom();
                 //start depressing sequence here...
                 if (game.gameoverdelay <= -10 && dwgfx.fademode==0) dwgfx.fademode = 2;
                 if (dwgfx.fademode == 1) script.resetgametomenu(dwgfx, game, map, obj, help, music);
@@ -672,7 +672,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     }
                 }
 
-                game.gethardestroom(map);
+                game.gethardestroom();
                 game.hascontrol = true;
 
 
@@ -715,7 +715,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             }
         }
         //State machine for game logic
-        game.updatestate(dwgfx, map, obj, help, music);
+        game.updatestate();
         if (game.startscript)
         {
             script.load(game.newscript);

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -116,7 +116,6 @@ void gamecompletelogic2()
         music.currentsong=4;
         game.savetele();
         music.currentsong=tmp;
-        game.telegotoship();
         //Return to game
         map.colstate = 10;
         game.gamestate = 1;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -351,8 +351,8 @@ void towerlogic()
             for (int i = obj.nentity - 1; i >= 0;  i--)
             {
                 obj.updateentities(i);                // Behavioral logic
-                obj.updateentitylogic(i);                          // Basic Physics
-                obj.entitymapcollision(i);                          // Collisions with walls
+                obj.updateentitylogic(i);             // Basic Physics
+                obj.entitymapcollision(i);            // Collisions with walls
             }
 
             obj.entitycollisioncheck();         // Check ent v ent collisions, update states
@@ -947,8 +947,8 @@ void gamelogic()
                             obj.removeblockat(obj.entities[i].xp, obj.entities[i].yp);
 
                             obj.updateentities(i);                // Behavioral logic
-                            obj.updateentitylogic(i);                          // Basic Physics
-                            obj.entitymapcollision(i);                          // Collisions with walls
+                            obj.updateentitylogic(i);             // Basic Physics
+                            obj.entitymapcollision(i);            // Collisions with walls
 
                             obj.createblock(0, obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
                             if (game.supercrewmate)
@@ -976,8 +976,8 @@ void gamelogic()
                             obj.removeblockat(obj.entities[ie].xp, obj.entities[ie].yp);
 
                             obj.updateentities(ie);                // Behavioral logic
-                            obj.updateentitylogic(ie);                          // Basic Physics
-                            obj.entitymapcollision(ie);                          // Collisions with walls
+                            obj.updateentitylogic(ie);             // Basic Physics
+                            obj.entitymapcollision(ie);            // Collisions with walls
 
                             obj.hormovingplatformfix(ie);
                         }
@@ -1007,8 +1007,8 @@ void gamelogic()
                 if (!obj.entities[ie].isplatform)
                 {
                     obj.updateentities(ie);          // Behavioral logic
-                    obj.updateentitylogic(ie);                    // Basic Physics
-                    obj.entitymapcollision(ie);                    // Collisions with walls
+                    obj.updateentitylogic(ie);       // Basic Physics
+                    obj.entitymapcollision(ie);      // Collisions with walls
                 }
             }
 

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -365,18 +365,18 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
                 //Remove old platform
                 //if (obj.entities[i].isplatform) obj.removeblockat(obj.entities[i].xp, obj.entities[i].yp);
 
-                obj.updateentities(i, help, game, music);                // Behavioral logic
-                obj.updateentitylogic(i, game);                          // Basic Physics
-                obj.entitymapcollision(i, map);                          // Collisions with walls
+                obj.updateentities(i);                // Behavioral logic
+                obj.updateentitylogic(i);                          // Basic Physics
+                obj.entitymapcollision(i);                          // Collisions with walls
 
                 //Create new platform
-                //if (obj.entities[i].isplatform) obj.movingplatformfix(i, map);
+                //if (obj.entities[i].isplatform) obj.movingplatformfix(i);
             }
 
-            obj.entitycollisioncheck(dwgfx, game, map, music);         // Check ent v ent collisions, update states
+            obj.entitycollisioncheck();         // Check ent v ent collisions, update states
             //special for tower: is the player touching any spike blocks?
             int player = obj.getplayer();
-            if(obj.checktowerspikes(player, map) && dwgfx.fademode==0)
+            if(obj.checktowerspikes(player) && dwgfx.fademode==0)
             {
                 game.deathseq = 30;
             }
@@ -607,14 +607,14 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             {
                 //ok, unfortunate case where the disappearing platform hasn't fully disappeared. Accept a little
                 //graphical uglyness to avoid breaking the room!
-                while (obj.entities[i].state == 2) obj.updateentities(i, help, game, music);
+                while (obj.entities[i].state == 2) obj.updateentities(i);
                 obj.entities[i].state = 4;
             }
             else if (map.finalstretch && obj.entities[i].type == 2)
             {
                 //TODO: }else if (map.finallevel && map.finalstretch && obj.entities[i].type == 2) {
                 //for the final level. probably something 99% of players won't see.
-                while (obj.entities[i].state == 2) obj.updateentities(i, help, game, music);
+                while (obj.entities[i].state == 2) obj.updateentities(i);
                 obj.entities[i].state = 4;
             }
             else if (obj.entities[i].type == 23 && game.swnmode && game.deathseq<15)
@@ -750,7 +750,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 }
                 else
                 {
-                    obj.generateswnwave(game, help, 0);
+                    obj.generateswnwave(0);
                 }
             }
             else if(game.swngame==1)   //super gravitron game
@@ -825,7 +825,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     }
                 }
 
-                obj.generateswnwave(game, help, 1);
+                obj.generateswnwave(1);
 
                 game.swncoldelay--;
                 if(game.swncoldelay<=0)
@@ -859,7 +859,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             else if (game.swngame == 4)    //create top line
             {
                 game.swngame = 3;
-                obj.createentity(game, -8, 84 - 32, 11, 8);  // (horizontal gravity line)
+                obj.createentity(-8, 84 - 32, 11, 8);  // (horizontal gravity line)
                 music.niceplay(2);
                 game.swndeaths = game.deathcounts;
             }
@@ -965,19 +965,19 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                         {
                             obj.removeblockat(obj.entities[i].xp, obj.entities[i].yp);
 
-                            obj.updateentities(i, help, game, music);                // Behavioral logic
-                            obj.updateentitylogic(i, game);                          // Basic Physics
-                            obj.entitymapcollision(i, map);                          // Collisions with walls
+                            obj.updateentities(i);                // Behavioral logic
+                            obj.updateentitylogic(i);                          // Basic Physics
+                            obj.entitymapcollision(i);                          // Collisions with walls
 
                             obj.createblock(0, obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
                             if (game.supercrewmate)
                             {
-                                obj.movingplatformfix(i, map);
-                                obj.scmmovingplatformfix(i, map);
+                                obj.movingplatformfix(i);
+                                obj.scmmovingplatformfix(i);
                             }
                             else
                             {
-                                obj.movingplatformfix(i, map);
+                                obj.movingplatformfix(i);
                             }
                         }
                     }
@@ -994,29 +994,29 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                         {
                             obj.removeblockat(obj.entities[ie].xp, obj.entities[ie].yp);
 
-                            obj.updateentities(ie, help, game, music);                // Behavioral logic
-                            obj.updateentitylogic(ie, game);                          // Basic Physics
-                            obj.entitymapcollision(ie, map);                          // Collisions with walls
+                            obj.updateentities(ie);                // Behavioral logic
+                            obj.updateentitylogic(ie);                          // Basic Physics
+                            obj.entitymapcollision(ie);                          // Collisions with walls
 
-                            obj.hormovingplatformfix(ie, map);
+                            obj.hormovingplatformfix(ie);
                         }
                     }
                 }
                 //is the player standing on a moving platform?
                 int i = obj.getplayer();
-                float j = obj.entitycollideplatformfloor(map, i);
+                float j = obj.entitycollideplatformfloor(i);
                 if (j > -1000)
                 {
                     obj.entities[i].newxp = obj.entities[i].xp + j;
-                    obj.entitymapcollision(i, map);
+                    obj.entitymapcollision(i);
                 }
                 else
                 {
-                    j = obj.entitycollideplatformroof(map, i);
+                    j = obj.entitycollideplatformroof(i);
                     if (j > -1000)
                     {
                         obj.entities[i].newxp = obj.entities[i].xp + j;
-                        obj.entitymapcollision(i, map);
+                        obj.entitymapcollision(i);
                     }
                 }
             }
@@ -1025,13 +1025,13 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             {
                 if (!obj.entities[ie].isplatform)
                 {
-                    obj.updateentities(ie, help, game, music);          // Behavioral logic
-                    obj.updateentitylogic(ie, game);                    // Basic Physics
-                    obj.entitymapcollision(ie, map);                    // Collisions with walls
+                    obj.updateentities(ie);          // Behavioral logic
+                    obj.updateentitylogic(ie);                    // Basic Physics
+                    obj.entitymapcollision(ie);                    // Collisions with walls
                 }
             }
 
-            obj.entitycollisioncheck(dwgfx, game, map, music);         // Check ent v ent collisions, update states
+            obj.entitycollisioncheck();         // Check ent v ent collisions, update states
         }
 
         //now! let's clean up removed entities
@@ -1360,7 +1360,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             switch(game.companion)
             {
             case 6:
-                obj.createentity(game, obj.entities[i].xp, 121.0f, 15.0f,1);  //Y=121, the floor in that particular place!
+                obj.createentity(obj.entities[i].xp, 121.0f, 15.0f,1);  //Y=121, the floor in that particular place!
                 j = obj.getcompanion(6);
                 obj.entities[j].vx = obj.entities[i].vx;
                 obj.entities[j].dir = obj.entities[i].dir;
@@ -1370,11 +1370,11 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 {
                     if (game.roomx == 110)
                     {
-                        obj.createentity(game, 320, 86, 16, 1);  //Y=86, the ROOF in that particular place!
+                        obj.createentity(320, 86, 16, 1);  //Y=86, the ROOF in that particular place!
                     }
                     else
                     {
-                        obj.createentity(game, obj.entities[i].xp, 86.0f, 16.0f, 1);  //Y=86, the ROOF in that particular place!
+                        obj.createentity(obj.entities[i].xp, 86.0f, 16.0f, 1);  //Y=86, the ROOF in that particular place!
                     }
                     j = obj.getcompanion(7);
                     obj.entities[j].vx = obj.entities[i].vx;
@@ -1386,14 +1386,14 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 {
                     if (game.roomx == 102)
                     {
-                        obj.createentity(game, 310, 177, 17, 1);
+                        obj.createentity(310, 177, 17, 1);
                         j = obj.getcompanion(8);
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
                     }
                     else
                     {
-                        obj.createentity(game, obj.entities[i].xp, 177.0f, 17.0f, 1);
+                        obj.createentity(obj.entities[i].xp, 177.0f, 17.0f, 1);
                         j = obj.getcompanion(8);
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
@@ -1405,11 +1405,11 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 {
                     if (game.roomx == 110 && obj.entities[i].xp<20)
                     {
-                        obj.createentity(game, 100, 185, 18, 15, 0, 1);
+                        obj.createentity(100, 185, 18, 15, 0, 1);
                     }
                     else
                     {
-                        obj.createentity(game, obj.entities[i].xp, 185.0f, 18.0f, 15, 0, 1);
+                        obj.createentity(obj.entities[i].xp, 185.0f, 18.0f, 15, 0, 1);
                     }
                     j = obj.getcompanion(9);
                     obj.entities[j].vx = obj.entities[i].vx;
@@ -1422,7 +1422,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 {
                     if (obj.flags[59] == 0)
                     {
-                        obj.createentity(game, 225.0f, 169.0f, 18, dwgfx.crewcolour(game.lastsaved), 0, 10);
+                        obj.createentity(225.0f, 169.0f, 18, dwgfx.crewcolour(game.lastsaved), 0, 10);
                         j = obj.getcompanion(10);
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
@@ -1432,7 +1432,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 {
                     if (obj.flags[59] == 1)
                     {
-                        obj.createentity(game, 160.0f, 177.0f, 18, dwgfx.crewcolour(game.lastsaved), 0, 18, 1);
+                        obj.createentity(160.0f, 177.0f, 18, dwgfx.crewcolour(game.lastsaved), 0, 18, 1);
                         j = obj.getcompanion(10);
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
@@ -1440,7 +1440,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     else
                     {
                         obj.flags[59] = 1;
-                        obj.createentity(game, obj.entities[i].xp, -20.0f, 18.0f, dwgfx.crewcolour(game.lastsaved), 0, 10, 0);
+                        obj.createentity(obj.entities[i].xp, -20.0f, 18.0f, dwgfx.crewcolour(game.lastsaved), 0, 10, 0);
                         j = obj.getcompanion(10);
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
@@ -1449,60 +1449,60 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 break;
             case 11:
                 //Intermission 1: We're using the SuperCrewMate instead!
-                //obj.createentity(game, obj.entities[i].xp, obj.entities[i].yp, 24, dwgfx.crewcolour(game.lastsaved));
+                //obj.createentity(obj.entities[i].xp, obj.entities[i].yp, 24, dwgfx.crewcolour(game.lastsaved));
                 if(game.roomx-41==game.scmprogress)
                 {
                     switch(game.scmprogress)
                     {
                     case 0:
-                        obj.createentity(game, 76, 161, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(76, 161, 24, dwgfx.crewcolour(game.lastsaved), 2);
                         break;
                     case 1:
-                        obj.createentity(game, 10, 169, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 169, 24, dwgfx.crewcolour(game.lastsaved), 2);
                         break;
                     case 2:
-                        obj.createentity(game, 10, 177, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 177, 24, dwgfx.crewcolour(game.lastsaved), 2);
                         break;
                     case 3:
                         if (game.scmmoveme)
                         {
-                            obj.createentity(game, obj.entities[obj.getplayer()].xp, 185, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                            obj.createentity(obj.entities[obj.getplayer()].xp, 185, 24, dwgfx.crewcolour(game.lastsaved), 2);
                             game.scmmoveme = false;
                         }
                         else
                         {
-                            obj.createentity(game, 10, 177, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                            obj.createentity(10, 177, 24, dwgfx.crewcolour(game.lastsaved), 2);
                         }
                         break;
                     case 4:
-                        obj.createentity(game, 10, 185, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 185, 24, dwgfx.crewcolour(game.lastsaved), 2);
                         break;
                     case 5:
-                        obj.createentity(game, 10, 185, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 185, 24, dwgfx.crewcolour(game.lastsaved), 2);
                         break;
                     case 6:
-                        obj.createentity(game, 10, 185, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 185, 24, dwgfx.crewcolour(game.lastsaved), 2);
                         break;
                     case 7:
-                        obj.createentity(game, 10, 41, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 41, 24, dwgfx.crewcolour(game.lastsaved), 2);
                         break;
                     case 8:
-                        obj.createentity(game, 10, 169, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 169, 24, dwgfx.crewcolour(game.lastsaved), 2);
                         break;
                     case 9:
-                        obj.createentity(game, 10, 169, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 169, 24, dwgfx.crewcolour(game.lastsaved), 2);
                         break;
                     case 10:
-                        obj.createentity(game, 10, 129, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 129, 24, dwgfx.crewcolour(game.lastsaved), 2);
                         break;
                     case 11:
-                        obj.createentity(game, 10, 129, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 129, 24, dwgfx.crewcolour(game.lastsaved), 2);
                         break;
                     case 12:
-                        obj.createentity(game, 10, 65, 24, dwgfx.crewcolour(game.lastsaved), 2);
+                        obj.createentity(10, 65, 24, dwgfx.crewcolour(game.lastsaved), 2);
                         break;
                     case 13:
-                        obj.createentity(game, 10, 177, 24, dwgfx.crewcolour(game.lastsaved));
+                        obj.createentity(10, 177, 24, dwgfx.crewcolour(game.lastsaved));
                         break;
                     }
                 }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -2,7 +2,6 @@
 #include "Script.h"
 #include "Network.h"
 
-extern int temp;
 extern scriptclass script;
 
 void titlelogic()
@@ -678,7 +677,7 @@ void gamelogic()
                         if (map.final_colorframe == 1)
                         {
                             map.final_colorframedelay = 40;
-                            temp = 1+int(fRandom() * 6);
+                            int temp = 1+int(fRandom() * 6);
                             if (temp == map.final_mapcol) temp = (temp + 1) % 6;
                             if (temp == 0) temp = 6;
                             map.changefinalcol(temp);
@@ -686,7 +685,7 @@ void gamelogic()
                         else if (map.final_colorframe == 2)
                         {
                             map.final_colorframedelay = 15;
-                            temp = 1+int(fRandom() * 6);
+                            int temp = 1+int(fRandom() * 6);
                             if (temp == map.final_mapcol) temp = (temp + 1) % 6;
                             if (temp == 0) temp = 6;
                             map.changefinalcol(temp);

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -290,7 +290,7 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
 
                 game.gravitycontrol = game.savegc;
                 dwgfx.textboxremove();
-                map.resetplayer(dwgfx, game, obj, music);
+                map.resetplayer();
             }
         }
     }
@@ -391,13 +391,13 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
                     if (game.door_left > -2 && obj.entities[player].xp < -14)
                     {
                         obj.entities[player].xp += 320;
-                        map.gotoroom(48, 52, dwgfx, game, obj, music);
+                        map.gotoroom(48, 52);
                     }
                     if (game.door_right > -2 && obj.entities[player].xp >= 308)
                     {
                         obj.entities[player].xp -= 320;
                         obj.entities[player].yp -= (71*8);
-                        map.gotoroom(game.roomx + 1, game.roomy+1, dwgfx, game, obj, music);
+                        map.gotoroom(game.roomx + 1, game.roomy+1);
                     }
                 }
                 else
@@ -410,18 +410,18 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
                         {
                             obj.entities[player].xp += 320;
                             obj.entities[player].yp -= (71 * 8);
-                            map.gotoroom(50, 54, dwgfx, game, obj, music);
+                            map.gotoroom(50, 54);
                         }
                         else
                         {
                             obj.entities[player].xp += 320;
-                            map.gotoroom(50, 53, dwgfx, game, obj, music);
+                            map.gotoroom(50, 53);
                         }
                     }
                     if (game.door_right > -2 && obj.entities[player].xp >= 308)
                     {
                         obj.entities[player].xp -= 320;
-                        map.gotoroom(52, 53, dwgfx, game, obj, music);
+                        map.gotoroom(52, 53);
                     }
                 }
             }
@@ -453,12 +453,12 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
                     {
                         obj.entities[player].xp += 320;
                         obj.entities[player].yp -= (671 * 8);
-                        map.gotoroom(108, 109, dwgfx, game, obj, music);
+                        map.gotoroom(108, 109);
                     }
                     if (game.door_right > -2 && obj.entities[player].xp >= 308)
                     {
                         obj.entities[player].xp -= 320;
-                        map.gotoroom(110, 104, dwgfx, game, obj, music);
+                        map.gotoroom(110, 104);
                     }
                 }
             }
@@ -678,7 +678,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
 
                 game.gravitycontrol = game.savegc;
                 dwgfx.textboxremove();
-                map.resetplayer(dwgfx, game, obj, music);
+                map.resetplayer();
             }
         }
     }
@@ -700,7 +700,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                             temp = 1+int(fRandom() * 6);
                             if (temp == map.final_mapcol) temp = (temp + 1) % 6;
                             if (temp == 0) temp = 6;
-                            map.changefinalcol(temp, obj,game);
+                            map.changefinalcol(temp);
                         }
                         else if (map.final_colorframe == 2)
                         {
@@ -708,7 +708,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                             temp = 1+int(fRandom() * 6);
                             if (temp == map.final_mapcol) temp = (temp + 1) % 6;
                             if (temp == 0) temp = 6;
-                            map.changefinalcol(temp, obj,game);
+                            map.changefinalcol(temp);
                         }
                     }
                 }
@@ -1145,12 +1145,12 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             if (game.door_down > -2 && obj.entities[player].yp >= 238)
             {
                 obj.entities[player].yp -= 240;
-                map.gotoroom(game.roomx, game.roomy + 1, dwgfx, game, obj, music);
+                map.gotoroom(game.roomx, game.roomy + 1);
             }
             if (game.door_up > -2 && obj.entities[player].yp < -2)
             {
                 obj.entities[player].yp += 240;
-                map.gotoroom(game.roomx, game.roomy - 1, dwgfx, game, obj, music);
+                map.gotoroom(game.roomx, game.roomy - 1);
             }
         }
         else if (map.warpy)
@@ -1197,12 +1197,12 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             if (game.door_left > -2 && obj.entities[player].xp < -14)
             {
                 obj.entities[player].xp += 320;
-                map.gotoroom(game.roomx - 1, game.roomy, dwgfx, game, obj, music);
+                map.gotoroom(game.roomx - 1, game.roomy);
             }
             if (game.door_right > -2 && obj.entities[player].xp >= 308)
             {
                 obj.entities[player].xp -= 320;
-                map.gotoroom(game.roomx + 1, game.roomy, dwgfx, game, obj, music);
+                map.gotoroom(game.roomx + 1, game.roomy);
             }
         }
         else
@@ -1212,22 +1212,22 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             if (game.door_down > -2 && obj.entities[player].yp >= 238)
             {
                 obj.entities[player].yp -= 240;
-                map.gotoroom(game.roomx, game.roomy + 1, dwgfx, game, obj, music);
+                map.gotoroom(game.roomx, game.roomy + 1);
             }
             if (game.door_up > -2 && obj.entities[player].yp < -2)
             {
                 obj.entities[player].yp += 240;
-                map.gotoroom(game.roomx, game.roomy - 1, dwgfx, game, obj, music);
+                map.gotoroom(game.roomx, game.roomy - 1);
             }
             if (game.door_left > -2 && obj.entities[player].xp < -14)
             {
                 obj.entities[player].xp += 320;
-                map.gotoroom(game.roomx - 1, game.roomy, dwgfx, game, obj, music);
+                map.gotoroom(game.roomx - 1, game.roomy);
             }
             if (game.door_right > -2 && obj.entities[player].xp >= 308)
             {
                 obj.entities[player].xp -= 320;
-                map.gotoroom(game.roomx + 1, game.roomy, dwgfx, game, obj, music);
+                map.gotoroom(game.roomx + 1, game.roomy);
             }
         }
 
@@ -1241,7 +1241,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
               edi2 = (edi-(edi%40))/40;
               edj2 = (edj-(edj%30))/30;
 
-              map.warpto(100+edi2, 100+edj2, obj.getplayer(), edi%40, (edj%30)+2, dwgfx, game, obj, music);
+              map.warpto(100+edi2, 100+edj2, obj.getplayer(), edi%40, (edj%30)+2);
               game.teleport = false;
 
               if (game.teleport == false)
@@ -1257,56 +1257,56 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
               {
                   int i = obj.getplayer();
                   obj.entities[i].yp = 225;
-                  map.gotoroom(119, 100, dwgfx, game, obj, music);
+                  map.gotoroom(119, 100);
                   game.teleport = false;
               }
               else if (game.roomx == 119 && game.roomy == 100)
               {
                   int i = obj.getplayer();
                   obj.entities[i].yp = 225;
-                  map.gotoroom(119, 103, dwgfx, game, obj, music);
+                  map.gotoroom(119, 103);
                   game.teleport = false;
               }
               else if (game.roomx == 119 && game.roomy == 103)
               {
                   int i = obj.getplayer();
                   obj.entities[i].xp = 0;
-                  map.gotoroom(116, 103, dwgfx, game, obj, music);
+                  map.gotoroom(116, 103);
                   game.teleport = false;
               }
               else if (game.roomx == 116 && game.roomy == 103)
               {
                   int i = obj.getplayer();
                   obj.entities[i].yp = 225;
-                  map.gotoroom(116, 100, dwgfx, game, obj, music);
+                  map.gotoroom(116, 100);
                   game.teleport = false;
               }
               else if (game.roomx == 116 && game.roomy == 100)
               {
                   int i = obj.getplayer();
                   obj.entities[i].xp = 0;
-                  map.gotoroom(114, 102, dwgfx, game, obj, music);
+                  map.gotoroom(114, 102);
                   game.teleport = false;
               }
               else if (game.roomx == 114 && game.roomy == 102)
               {
                   int i = obj.getplayer();
                   obj.entities[i].yp = 225;
-                  map.gotoroom(113, 100, dwgfx, game, obj, music);
+                  map.gotoroom(113, 100);
                   game.teleport = false;
               }
               else if (game.roomx == 116 && game.roomy == 104)
               {
                   //pre warp zone here
-                  map.warpto(107, 101, obj.getplayer(), 14, 16, dwgfx, game, obj, music);
+                  map.warpto(107, 101, obj.getplayer(), 14, 16);
               }
               else if (game.roomx == 107 && game.roomy == 101)
               {
-                  map.warpto(105, 119, obj.getplayer(), 5, 26, dwgfx, game, obj, music);
+                  map.warpto(105, 119, obj.getplayer(), 5, 26);
               }
               else if (game.roomx == 105 && game.roomy == 118)
               {
-                  map.warpto(101, 111, obj.getplayer(), 34, 6, dwgfx, game, obj, music);
+                  map.warpto(101, 111, obj.getplayer(), 34, 6);
               }
               else if (game.roomx == 101 && game.roomy == 111)
               {
@@ -1314,31 +1314,31 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                   switch(game.teleportxpos)
                   {
                   case 1:
-                      map.warpto(108, 108, obj.getplayer(), 4, 27, dwgfx, game, obj, music);
+                      map.warpto(108, 108, obj.getplayer(), 4, 27);
                       break;
                   case 2:
-                      map.warpto(101, 111, obj.getplayer(), 12, 27, dwgfx, game, obj, music);
+                      map.warpto(101, 111, obj.getplayer(), 12, 27);
                       break;
                   case 3:
-                      map.warpto(119, 111, obj.getplayer(), 31, 7, dwgfx, game, obj, music);
+                      map.warpto(119, 111, obj.getplayer(), 31, 7);
                       break;
                   case 4:
-                      map.warpto(114, 117, obj.getplayer(), 19, 16, dwgfx, game, obj, music);
+                      map.warpto(114, 117, obj.getplayer(), 19, 16);
                       break;
                   }
               }
               else if (game.roomx == 108 && game.roomy == 106)
               {
-                  map.warpto(119, 111, obj.getplayer(), 4, 27, dwgfx, game, obj, music);
+                  map.warpto(119, 111, obj.getplayer(), 4, 27);
               }
               else if (game.roomx == 100 && game.roomy == 111)
               {
-                  map.warpto(101, 111, obj.getplayer(), 24, 6, dwgfx, game, obj, music);
+                  map.warpto(101, 111, obj.getplayer(), 24, 6);
               }
               else if (game.roomx == 119 && game.roomy == 107)
               {
                   //Secret lab, to super gravitron
-                  map.warpto(119, 108, obj.getplayer(), 19, 10, dwgfx, game, obj, music);
+                  map.warpto(119, 108, obj.getplayer(), 19, 10);
               }
               if (game.teleport == false)
               {

--- a/desktop_version/src/Logic.h
+++ b/desktop_version/src/Logic.h
@@ -8,16 +8,16 @@
 #include "Music.h"
 #include "Map.h"
 
-void titlelogic(Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help, musicclass& music, mapclass& map);
+void titlelogic();
 
-void maplogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help);
+void maplogic();
 
-void gamecompletelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help);
+void gamecompletelogic();
 
-void gamecompletelogic2(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help);
+void gamecompletelogic2();
 
-void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help);
+void towerlogic();
 
-void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help);
+void gamelogic();
 
 #endif /* LOGIC_H */

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1352,27 +1352,27 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		//All the entities for here are just loaded here; it's essentially one room after all
 
 
-		obj.createentity(game, 48, 5456, 10, 1, 505007); // (savepoint)
-		obj.createentity(game, 224, 4528, 10, 1, 505017); // (savepoint)
-		obj.createentity(game, 232, 4168, 10, 0, 505027); // (savepoint)
-		obj.createentity(game, 280, 3816, 10, 1, 505037); // (savepoint)
-		obj.createentity(game, 152, 3552, 10, 1, 505047); // (savepoint)
-		obj.createentity(game, 216, 3280, 10, 0, 505057); // (savepoint)
-		obj.createentity(game, 216, 4808, 10, 1, 505067); // (savepoint)
-		obj.createentity(game, 72, 3096, 10, 0, 505077); // (savepoint)
-		obj.createentity(game, 176, 2600, 10, 0, 505087); // (savepoint)
-		obj.createentity(game, 216, 2392, 10, 0, 505097); // (savepoint)
-		obj.createentity(game, 152, 1184, 10, 1, 505107); // (savepoint)
-		obj.createentity(game, 152, 912, 10, 1, 505117); // (savepoint)
-		obj.createentity(game, 152, 536, 10, 1, 505127); // (savepoint)
-		obj.createentity(game, 120, 5136, 10, 0, 505137); // (savepoint)
-		obj.createentity(game, 144, 1824, 10, 0, 505147); // (savepoint)
-		obj.createentity(game, 72, 2904, 10, 0, 505157); // (savepoint)
-		obj.createentity(game, 224, 1648, 10, 1, 505167); // (savepoint)
-		obj.createentity(game, 112, 5280, 10, 1, 50517); // (savepoint)
+		obj.createentity(48, 5456, 10, 1, 505007); // (savepoint)
+		obj.createentity(224, 4528, 10, 1, 505017); // (savepoint)
+		obj.createentity(232, 4168, 10, 0, 505027); // (savepoint)
+		obj.createentity(280, 3816, 10, 1, 505037); // (savepoint)
+		obj.createentity(152, 3552, 10, 1, 505047); // (savepoint)
+		obj.createentity(216, 3280, 10, 0, 505057); // (savepoint)
+		obj.createentity(216, 4808, 10, 1, 505067); // (savepoint)
+		obj.createentity(72, 3096, 10, 0, 505077); // (savepoint)
+		obj.createentity(176, 2600, 10, 0, 505087); // (savepoint)
+		obj.createentity(216, 2392, 10, 0, 505097); // (savepoint)
+		obj.createentity(152, 1184, 10, 1, 505107); // (savepoint)
+		obj.createentity(152, 912, 10, 1, 505117); // (savepoint)
+		obj.createentity(152, 536, 10, 1, 505127); // (savepoint)
+		obj.createentity(120, 5136, 10, 0, 505137); // (savepoint)
+		obj.createentity(144, 1824, 10, 0, 505147); // (savepoint)
+		obj.createentity(72, 2904, 10, 0, 505157); // (savepoint)
+		obj.createentity(224, 1648, 10, 1, 505167); // (savepoint)
+		obj.createentity(112, 5280, 10, 1, 50517); // (savepoint)
 
-		obj.createentity(game, 24, 4216, 9, 7); // (shiny trinket)
-		obj.createentity(game, 280, 3216, 9, 8); // (shiny trinket)
+		obj.createentity(24, 4216, 9, 7); // (shiny trinket)
+		obj.createentity(280, 3216, 9, 8); // (shiny trinket)
 		break;
 	case 4: //The Warpzone
 		tmap = warplevel.loadlevel(rx, ry, game, obj);
@@ -1484,19 +1484,19 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 
 		tower.loadminitower2();
 
-		obj.createentity(game, 56, 556, 11, 136); // (horizontal gravity line)
-		obj.createentity(game, 184, 592, 10, 0, 50500); // (savepoint)
-		obj.createentity(game, 184, 644, 11, 88); // (horizontal gravity line)
-		obj.createentity(game, 56, 460, 11, 136); // (horizontal gravity line)
-		obj.createentity(game, 216, 440, 10, 0, 50501); // (savepoint)
-		obj.createentity(game, 104, 508, 11, 168); // (horizontal gravity line)
-		obj.createentity(game, 219, 264, 12, 56); // (vertical gravity line)
-		obj.createentity(game, 120, 332, 11, 96); // (horizontal gravity line)
-		obj.createentity(game, 219, 344, 12, 56); // (vertical gravity line)
-		obj.createentity(game, 224, 332, 11, 48); // (horizontal gravity line)
-		obj.createentity(game, 56, 212, 11, 144); // (horizontal gravity line)
-		obj.createentity(game, 32, 20, 11, 96); // (horizontal gravity line)
-		obj.createentity(game, 72, 156, 11, 200); // (horizontal gravity line)
+		obj.createentity(56, 556, 11, 136); // (horizontal gravity line)
+		obj.createentity(184, 592, 10, 0, 50500); // (savepoint)
+		obj.createentity(184, 644, 11, 88); // (horizontal gravity line)
+		obj.createentity(56, 460, 11, 136); // (horizontal gravity line)
+		obj.createentity(216, 440, 10, 0, 50501); // (savepoint)
+		obj.createentity(104, 508, 11, 168); // (horizontal gravity line)
+		obj.createentity(219, 264, 12, 56); // (vertical gravity line)
+		obj.createentity(120, 332, 11, 96); // (horizontal gravity line)
+		obj.createentity(219, 344, 12, 56); // (vertical gravity line)
+		obj.createentity(224, 332, 11, 48); // (horizontal gravity line)
+		obj.createentity(56, 212, 11, 144); // (horizontal gravity line)
+		obj.createentity(32, 20, 11, 96); // (horizontal gravity line)
+		obj.createentity(72, 156, 11, 200); // (horizontal gravity line)
 
 		int i = obj.getplayer();
 		obj.entities[i].yp += (71 * 8);
@@ -1527,19 +1527,19 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 
 		tower.loadminitower2();
 
-		obj.createentity(game, 56, 556, 11, 136); // (horizontal gravity line)
-		obj.createentity(game, 184, 592, 10, 0, 50500); // (savepoint)
-		obj.createentity(game, 184, 644, 11, 88); // (horizontal gravity line)
-		obj.createentity(game, 56, 460, 11, 136); // (horizontal gravity line)
-		obj.createentity(game, 216, 440, 10, 0, 50501); // (savepoint)
-		obj.createentity(game, 104, 508, 11, 168); // (horizontal gravity line)
-		obj.createentity(game, 219, 264, 12, 56); // (vertical gravity line)
-		obj.createentity(game, 120, 332, 11, 96); // (horizontal gravity line)
-		obj.createentity(game, 219, 344, 12, 56); // (vertical gravity line)
-		obj.createentity(game, 224, 332, 11, 48); // (horizontal gravity line)
-		obj.createentity(game, 56, 212, 11, 144); // (horizontal gravity line)
-		obj.createentity(game, 32, 20, 11, 96); // (horizontal gravity line)
-		obj.createentity(game, 72, 156, 11, 200); // (horizontal gravity line)
+		obj.createentity(56, 556, 11, 136); // (horizontal gravity line)
+		obj.createentity(184, 592, 10, 0, 50500); // (savepoint)
+		obj.createentity(184, 644, 11, 88); // (horizontal gravity line)
+		obj.createentity(56, 460, 11, 136); // (horizontal gravity line)
+		obj.createentity(216, 440, 10, 0, 50501); // (savepoint)
+		obj.createentity(104, 508, 11, 168); // (horizontal gravity line)
+		obj.createentity(219, 264, 12, 56); // (vertical gravity line)
+		obj.createentity(120, 332, 11, 96); // (horizontal gravity line)
+		obj.createentity(219, 344, 12, 56); // (vertical gravity line)
+		obj.createentity(224, 332, 11, 48); // (horizontal gravity line)
+		obj.createentity(56, 212, 11, 144); // (horizontal gravity line)
+		obj.createentity(32, 20, 11, 96); // (horizontal gravity line)
+		obj.createentity(72, 156, 11, 200); // (horizontal gravity line)
 
 		ypos = 0;
 		bypos = 0;
@@ -1663,7 +1663,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 				if(warpy){ if(by1==0 && by2==240){ by1=-100; by2=340; } }
 
 				obj.customenemy=ed.level[tsx+((ed.maxwidth)*tsy)].enemytype;
-				obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 56,
+				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 56,
 								 edentity[edi].p1, 4, bx1, by1, bx2, by2);
 				break;
 				case 2: //Platforms and Threadmills
@@ -1677,36 +1677,36 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 					if(warpx){ if(bx1==0 && bx2==320){ bx1=-100; bx2=420; } }
 					if(warpy){ if(by1==0 && by2==240){ by1=-100; by2=340; } }
 
-					obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 2,
+					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 2,
 									 edentity[edi].p1, ed.level[rx-100+((ry-100)*ed.mapwidth)].platv, bx1, by1, bx2, by2);
 				}else if(edentity[edi].p1>=5 && edentity[edi].p1<=8){ //Threadmill
-					obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 2,
+					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 2,
 									 edentity[edi].p1+3, 4);
 				}
 				break;
 				case 3: //Disappearing platforms
-				obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 3);
+				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 3);
 				break;
 				case 9:
-				obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 9, ed.findtrinket(edi));
+				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 9, ed.findtrinket(edi));
 				break;
 				case 10: //Checkpoints
-				obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 10,
+				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 10,
 								edentity[edi].p1,((rx+(ry*100))*20)+tempcheckpoints);
 				tempcheckpoints++;
 				break;
 				case 11: //Gravity Lines
 				if(edentity[edi].p1==0){ //Horizontal
-					obj.createentity(game, (edentity[edi].p2*8),(edentity[edi].y*8)- ((ry-100)*30*8)+4, 11, edentity[edi].p3);
+					obj.createentity((edentity[edi].p2*8),(edentity[edi].y*8)- ((ry-100)*30*8)+4, 11, edentity[edi].p3);
 				}else{ //Vertical
-					obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8)+3,(edentity[edi].p2*8), 12, edentity[edi].p3);
+					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8)+3,(edentity[edi].p2*8), 12, edentity[edi].p3);
 				}
 				break;
 				case 13: //Warp Tokens
-				obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 13, edentity[edi].p1, edentity[edi].p2);
+				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 13, edentity[edi].p1, edentity[edi].p2);
 				break;
 				case 15: //Collectable crewmate
-				obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8)-4,(edentity[edi].y*8)- ((ry-100)*30*8)+1, 55, ed.findcrewmate(edi), edentity[edi].p1, edentity[edi].p2);
+				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8)-4,(edentity[edi].y*8)- ((ry-100)*30*8)+1, 55, ed.findcrewmate(edi), edentity[edi].p1, edentity[edi].p2);
 				break;
 				case 17: //Roomtext!
 				{
@@ -1720,7 +1720,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 				}
 				case 18: //Terminals
 				obj.customscript=edentity[edi].scriptname;
-				obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8)+8, 20, 1);
+				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8)+8, 20, 1);
 				obj.createblock(5, (edentity[edi].x*8)- ((rx-100)*40*8)-8, (edentity[edi].y*8)- ((ry-100)*30*8)+8, 20, 16, 35);
 				break;
 				case 19: //Script Box
@@ -1732,13 +1732,13 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 				case 50: //Warp Lines
 				obj.customwarpmode=true;
 				if(edentity[edi].p1==0){ //
-					obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8)+4,(edentity[edi].p2*8), 51, edentity[edi].p3);
+					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8)+4,(edentity[edi].p2*8), 51, edentity[edi].p3);
 				}else if(edentity[edi].p1==1){ //Horizontal, right
-					obj.createentity(game, (edentity[edi].x*8)- ((rx-100)*40*8)+4,(edentity[edi].p2*8), 52, edentity[edi].p3);
+					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8)+4,(edentity[edi].p2*8), 52, edentity[edi].p3);
 				}else if(edentity[edi].p1==2){ //Vertical, top
-					obj.createentity(game, (edentity[edi].p2*8),(edentity[edi].y*8)- ((ry-100)*30*8)+7, 53, edentity[edi].p3);
+					obj.createentity((edentity[edi].p2*8),(edentity[edi].y*8)- ((ry-100)*30*8)+7, 53, edentity[edi].p3);
 				}else if(edentity[edi].p1==3){
-					obj.createentity(game, (edentity[edi].p2*8),(edentity[edi].y*8)- ((ry-100)*30*8), 54, edentity[edi].p3);
+					obj.createentity((edentity[edi].p2*8),(edentity[edi].y*8)- ((ry-100)*30*8), 54, edentity[edi].p3);
 				}
 				break;
 			}
@@ -1833,7 +1833,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 				if (contents[i + vmult[j]] == 10)
 				{
 					contents[i + vmult[j]] = 0;
-					obj.createentity(game, i * 8, j * 8, 4);
+					obj.createentity(i * 8, j * 8, 4);
 				}
 				//Directional blocks
 				if (contents[i + vmult[j]] >= 14 && contents[i + vmult[j]] <= 17)
@@ -1877,7 +1877,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		{
 			if (game.crewstats[3] && !game.crewstats[4])
 			{
-				obj.createentity(game, 87, 105, 18, 15, 0, 18);
+				obj.createentity(87, 105, 18, 15, 0, 18);
 				obj.createblock(5, 87-32, 0, 32+32+32, 240, 3);
 			}
 		}
@@ -1885,7 +1885,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		{
 			if (game.crewstats[3] && !game.crewstats[5])
 			{
-				obj.createentity(game, 140, 137, 18, 15, 0, 18);
+				obj.createentity(140, 137, 18, 15, 0, 18);
 				obj.createblock(5, 140-32, 0, 32+32+32, 240, 3);
 			}
 		}
@@ -1893,7 +1893,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		{
 			if (game.crewstats[3] && !game.crewstats[2])
 			{
-				obj.createentity(game, 235, 81, 18, 15, 0, 18);
+				obj.createentity(235, 81, 18, 15, 0, 18);
 				obj.createblock(5, 235-32, 0, 32+32+32, 240, 3);
 			}
 		}
@@ -1905,7 +1905,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			{
 				if(game.crewrescued()>4 && game.crewrescued()!=6)
 				{
-					obj.createentity(game, 175, 121, 18, 13, 0, 18);
+					obj.createentity(175, 121, 18, 13, 0, 18);
 					obj.createblock(5, 175-32, 0, 32+32+32, 240, 4);
 				}
 			}
@@ -1916,7 +1916,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			{
 				if(game.crewrescued()<=4 && game.crewrescued()!=6)
 				{
-					obj.createentity(game, 53, 161, 18, 13, 1, 18);
+					obj.createentity(53, 161, 18, 13, 1, 18);
 					obj.createblock(5, 53-32, 0, 32+32+32, 240, 4);
 				}
 			}
@@ -1929,7 +1929,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			if (game.crewstats[3])
 			{
 				//If so, red will always be at his post
-				obj.createentity(game, 107, 121, 18, 15, 0, 18);
+				obj.createentity(107, 121, 18, 15, 0, 18);
 				//What script do we use?
 				obj.createblock(5, 107-32, 0, 32+32+32, 240, 3);
 			}
@@ -1940,7 +1940,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			//First: is he rescued?
 			if (game.crewstats[2])
 			{
-				obj.createentity(game, 198, 105, 18, 14, 0, 18);
+				obj.createentity(198, 105, 18, 14, 0, 18);
 				//What script do we use?
 				obj.createblock(5, 198-32, 0, 32+32+32, 240, 2);
 			}
@@ -1951,7 +1951,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			//First: is he rescued?
 			if (game.crewstats[4])
 			{
-				obj.createentity(game, 242, 177, 18, 13, 0, 18);
+				obj.createentity(242, 177, 18, 13, 0, 18);
 				//What script do we use?
 				obj.createblock(5, 242-32, 177-20, 32+32+32, 40, 4);
 			}
@@ -1962,7 +1962,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			//First: is she rescued?
 			if (game.crewstats[1])
 			{
-				obj.createentity(game, 140, 177, 18, 20, 0, 18);
+				obj.createentity(140, 177, 18, 20, 0, 18);
 				//What script do we use?
 				obj.createblock(5, 140-32, 0, 32+32+32, 240, 1);
 			}
@@ -1974,7 +1974,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			if (game.crewstats[5])
 			{
 				//A slight varation - she's upside down
-				obj.createentity(game, 249, 62, 18, 16, 0, 18);
+				obj.createentity(249, 62, 18, 16, 0, 18);
 				j = obj.getcrewman(5);
 				obj.entities[j].rule = 7;
 				obj.entities[j].tile +=6;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1316,7 +1316,7 @@ void mapclass::loadlevel(int rx, int ry)
 	case 1: //World Map
 		tileset = 1;
 		extrarow = 1;
-		tmap = otherlevel.loadlevel(rx, ry, game, obj);
+		tmap = otherlevel.loadlevel(rx, ry);
 		fillcontent(tmap);
 		roomname = otherlevel.roomname;
 		tileset = otherlevel.roomtileset;
@@ -1329,7 +1329,7 @@ void mapclass::loadlevel(int rx, int ry)
 		}
 		break;
 	case 2: //The Lab
-		tmap = lablevel.loadlevel(rx, ry, game, obj);
+		tmap = lablevel.loadlevel(rx, ry);
 		fillcontent(tmap);
 		roomname = lablevel.roomname;
 		tileset = 1;
@@ -1375,7 +1375,7 @@ void mapclass::loadlevel(int rx, int ry)
 		obj.createentity(280, 3216, 9, 8); // (shiny trinket)
 		break;
 	case 4: //The Warpzone
-		tmap = warplevel.loadlevel(rx, ry, game, obj);
+		tmap = warplevel.loadlevel(rx, ry);
 		fillcontent(tmap);
 		roomname = warplevel.roomname;
 		tileset = 1;
@@ -1391,13 +1391,13 @@ void mapclass::loadlevel(int rx, int ry)
 		if (warpx && warpy) background = 5;
 		break;
 	case 5: //Space station
-		tmap = spacestation2.loadlevel(rx, ry, game, obj);
+		tmap = spacestation2.loadlevel(rx, ry);
 		fillcontent(tmap);
 		roomname = spacestation2.roomname;
 		tileset = 0;
 		break;
 	case 6: //final level
-		tmap = finallevel.loadlevel(finalx, finaly, game, obj);
+		tmap = finallevel.loadlevel(finalx, finaly);
 		fillcontent(tmap);
 		roomname = finallevel.roomname;
 		tileset = 1;
@@ -1550,7 +1550,7 @@ void mapclass::loadlevel(int rx, int ry)
 		break;
 	case 11: //Tower Hallways //Content is held in final level routine
 	{
-		tmap = finallevel.loadlevel(rx, ry, game, obj);
+		tmap = finallevel.loadlevel(rx, ry);
 		fillcontent(tmap);
 		roomname = finallevel.roomname;
 		tileset = 2;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -169,12 +169,6 @@ void mapclass::transformname(int t)
 {
 	//transform special names into new ones, one step at a time
 
-	/*
-	if (specialnames[3] == "") { specialnames[3] = ;
-	}else if (specialnames[3] == "") { specialnames[3] = ;
-	}
-	*/
-
 	glitchdelay--;
 	if(glitchdelay<=0)
 	{
@@ -465,7 +459,6 @@ int mapclass::finalat(int x, int y)
 		//Special case: animated tiles
 		if (final_mapcol == 1)
 		{
-			// return contents[x + vmult[y]] - (final_mapcol * 3) + (int(fRandom()*12)*40);
 			// Windows hits fRandom() == 1 frequently! For fuck sake! -flibit
 			return 737 + (std::min(int(fRandom() * 12), 11) * 40);
 		}
@@ -934,10 +927,6 @@ void mapclass::gotoroom(int rx, int ry)
 	if (finalmode)
 	{
 		//Ok, what way are we moving?
-		/*if (rx - finalx >= 1) finalx++;
-		if (rx - finalx <= -1) finalx--;
-		if (ry - finaly >= 1) finaly++;
-		if (ry - finaly <= -1) finaly--;*/
 		finalx = rx;
 		finaly = ry;
 		game.roomx = finalx;
@@ -1177,8 +1166,6 @@ std::string mapclass::currentarea(int t)
 void mapclass::loadlevel(int rx, int ry)
 {
 	int t;
-	//t = rx + (ry * 100);
-	//roomname = "[UNTITLED] (" + String(rx)+","+String(ry)+")";
 	if (!finalmode)
 	{
 		explored[rx - 100 + ((ry - 100) * 20)] = 1;
@@ -1755,14 +1742,7 @@ void mapclass::loadlevel(int rx, int ry)
 	//The room's loaded: now we fill out damage blocks based on the tiles.
 	if (towermode)
 	{
-		for (int j = 0; j < 700; j++)
-		{
-			for (int i = 0; i < 40; i++)
-			{
-				//Damage blocks
-				//if (tower.contents[i + tower.vmult[j]] >=6	&& tower.contents[i + tower.vmult[j]] <= 11) obj.createblock(2, (i * 8) + 1, j * 8, 6, 8);
-			}
-		}
+
 	}
 	else
 	{

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -3,7 +3,7 @@
 #include "MakeAndPlay.h"
 
 #if !defined(NO_CUSTOM_LEVELS)
-	extern editorclass ed;
+extern editorclass ed;
 #endif
 
 mapclass::mapclass()
@@ -1312,7 +1312,7 @@ void mapclass::loadlevel(int rx, int ry)
 	switch(t)
 	{
 	case 0:
-			#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY)
 	case 1: //World Map
 		tileset = 1;
 		extrarow = 1;
@@ -1571,7 +1571,7 @@ void mapclass::loadlevel(int rx, int ry)
 		}
 	}
 		break;
-					#endif
+#endif
 #if !defined(NO_CUSTOM_LEVELS)
 	case 12: //Custom level
 		int curlevel=(rx-100)+((ry-100)*ed.maxwidth);
@@ -1664,7 +1664,7 @@ void mapclass::loadlevel(int rx, int ry)
 
 				obj.customenemy=ed.level[tsx+((ed.maxwidth)*tsy)].enemytype;
 				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 56,
-								 edentity[edi].p1, 4, bx1, by1, bx2, by2);
+				edentity[edi].p1, 4, bx1, by1, bx2, by2);
 				break;
 				case 2: //Platforms and Threadmills
 				if(edentity[edi].p1<=4){
@@ -1678,10 +1678,10 @@ void mapclass::loadlevel(int rx, int ry)
 					if(warpy){ if(by1==0 && by2==240){ by1=-100; by2=340; } }
 
 					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 2,
-									 edentity[edi].p1, ed.level[rx-100+((ry-100)*ed.mapwidth)].platv, bx1, by1, bx2, by2);
+					edentity[edi].p1, ed.level[rx-100+((ry-100)*ed.mapwidth)].platv, bx1, by1, bx2, by2);
 				}else if(edentity[edi].p1>=5 && edentity[edi].p1<=8){ //Threadmill
 					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 2,
-									 edentity[edi].p1+3, 4);
+					edentity[edi].p1+3, 4);
 				}
 				break;
 				case 3: //Disappearing platforms
@@ -1692,7 +1692,7 @@ void mapclass::loadlevel(int rx, int ry)
 				break;
 				case 10: //Checkpoints
 				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 10,
-								edentity[edi].p1,((rx+(ry*100))*20)+tempcheckpoints);
+				edentity[edi].p1,((rx+(ry*100))*20)+tempcheckpoints);
 				tempcheckpoints++;
 				break;
 				case 11: //Gravity Lines

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -515,7 +515,7 @@ int mapclass::maptiletoenemycol(int t)
 	return 11;
 }
 
-void mapclass::changefinalcol(int t, entityclass& obj, Game& game)
+void mapclass::changefinalcol(int t)
 {
 	//change the map to colour t - for the game's final stretch.
 	//First up, the tiles. This is just a setting:
@@ -819,12 +819,12 @@ void mapclass::showship()
 	explored[4 + (11 * 20)] = 1;
 }
 
-void mapclass::resetplayer(Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music)
+void mapclass::resetplayer()
 {
 	bool was_in_tower = towermode;
 	if (game.roomx != game.saverx || game.roomy != game.savery)
 	{
-		gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		gotoroom(game.saverx, game.savery);
 	}
 
 	game.deathseq = -1;
@@ -876,16 +876,16 @@ void mapclass::resetplayer(Graphics& dwgfx, Game& game, entityclass& obj, musicc
 	}
 }
 
-void mapclass::warpto(int rx, int ry , int t, int tx, int ty, Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music)
+void mapclass::warpto(int rx, int ry , int t, int tx, int ty)
 {
-	gotoroom(rx, ry, dwgfx, game, obj, music);
+	gotoroom(rx, ry);
 	game.teleport = false;
 	obj.entities[t].xp = tx * 8;
 	obj.entities[t].yp = (ty * 8) - obj.entities[t].h;
 	game.gravitycontrol = 0;
 }
 
-void mapclass::gotoroom(int rx, int ry, Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music)
+void mapclass::gotoroom(int rx, int ry)
 {
 	//First, destroy the current room
 	obj.removeallblocks();
@@ -999,7 +999,7 @@ void mapclass::gotoroom(int rx, int ry, Graphics& dwgfx, Game& game, entityclass
 		if (game.roomx == 107 && game.roomy == 109) music.niceplay(4);
 		if (game.roomx == 108 && game.roomy == 109)
 		{
-			if (dwgfx.setflipmode)
+			if (graphics.setflipmode)
 			{
 				music.niceplay(9);
 			}
@@ -1010,7 +1010,7 @@ void mapclass::gotoroom(int rx, int ry, Graphics& dwgfx, Game& game, entityclass
 		}
 		if (game.roomx == 109)
 		{
-			if (dwgfx.setflipmode)
+			if (graphics.setflipmode)
 			{
 				music.niceplay(9);
 			}
@@ -1053,7 +1053,7 @@ void mapclass::gotoroom(int rx, int ry, Graphics& dwgfx, Game& game, entityclass
 		if (game.roomx == 104 && game.roomy == 112) music.niceplay(4);
 	}
 	temp = rx + (ry * 100);
-	loadlevel(game.roomx, game.roomy, dwgfx, game, obj, music);
+	loadlevel(game.roomx, game.roomy);
 
 
 	//Do we need to reload the background?
@@ -1061,9 +1061,9 @@ void mapclass::gotoroom(int rx, int ry, Graphics& dwgfx, Game& game, entityclass
 
 	if(redrawbg)
 	{
-		dwgfx.backgrounddrawn = false; //Used for background caching speedup
+		graphics.backgrounddrawn = false; //Used for background caching speedup
 	}
-	dwgfx.foregrounddrawn = false; //Used for background caching speedup
+	graphics.foregrounddrawn = false; //Used for background caching speedup
 
 	game.prevroomx = game.roomx;
 	game.prevroomy = game.roomy;
@@ -1174,7 +1174,7 @@ std::string mapclass::currentarea(int t)
 	return "???";
 }
 
-void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music)
+void mapclass::loadlevel(int rx, int ry)
 {
 	int t;
 	//t = rx + (ry * 100);
@@ -1287,13 +1287,13 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 						{
 							//in the secret lab! Crazy background!
 							background = 2;
-							if (rx == 116 && ry == 105) dwgfx.rcol = 1;
-							if (rx == 117 && ry == 105) dwgfx.rcol = 5;
-							if (rx == 118 && ry == 105) dwgfx.rcol = 4;
-							if (rx == 117 && ry == 106) dwgfx.rcol = 2;
-							if (rx == 118 && ry == 106) dwgfx.rcol = 0;
-							if (rx == 119 && ry == 106) dwgfx.rcol = 3;
-							if (rx == 119 && ry == 107) dwgfx.rcol = 1;
+							if (rx == 116 && ry == 105) graphics.rcol = 1;
+							if (rx == 117 && ry == 105) graphics.rcol = 5;
+							if (rx == 118 && ry == 105) graphics.rcol = 4;
+							if (rx == 117 && ry == 106) graphics.rcol = 2;
+							if (rx == 118 && ry == 106) graphics.rcol = 0;
+							if (rx == 119 && ry == 106) graphics.rcol = 3;
+							if (rx == 119 && ry == 107) graphics.rcol = 1;
 						}
 					}
 				}
@@ -1304,7 +1304,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 	if (rx == 119 && ry == 108 && !custommode)
 	{
 		background = 5;
-		dwgfx.rcol = 3;
+		graphics.rcol = 3;
 		warpx = true;
 		warpy = true;
 	}
@@ -1334,7 +1334,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		roomname = lablevel.roomname;
 		tileset = 1;
 		background = 2;
-		dwgfx.rcol = lablevel.rcol;
+		graphics.rcol = lablevel.rcol;
 		break;
 	case 3: //The Tower
 		tdrawback = true;
@@ -1380,8 +1380,8 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		roomname = warplevel.roomname;
 		tileset = 1;
 		background = 3;
-		dwgfx.rcol = warplevel.rcol;
-		dwgfx.backgrounddrawn = false;
+		graphics.rcol = warplevel.rcol;
+		graphics.backgrounddrawn = false;
 
 		warpx = warplevel.warpx;
 		warpy = warplevel.warpy;
@@ -1402,8 +1402,8 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		roomname = finallevel.roomname;
 		tileset = 1;
 		background = 3;
-		dwgfx.rcol = finallevel.rcol;
-		dwgfx.backgrounddrawn = false;
+		graphics.rcol = finallevel.rcol;
+		graphics.backgrounddrawn = false;
 
 		if (finalstretch)
 		{
@@ -1419,8 +1419,8 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			if (warpx && warpy) background = 5;
 		}
 
-		dwgfx.rcol = 6;
-		changefinalcol(final_mapcol, obj, game);
+		graphics.rcol = 6;
+		changefinalcol(final_mapcol);
 		break;
 	case 7: //Final Level, Tower 1
 		tdrawback = true;
@@ -1589,7 +1589,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 			case 2: //Lab
 			tileset = 1;
 			background = 2;
-			dwgfx.rcol = ed.level[curlevel].tilecol;
+			graphics.rcol = ed.level[curlevel].tilecol;
 			break;
 			case 3: //Warp Zone/intermission
 			tileset = 1;
@@ -1608,21 +1608,21 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		//If screen warping, then override all that:
 		bool redrawbg = game.roomx != game.prevroomx || game.roomy != game.prevroomy;
 		if(redrawbg){
-			dwgfx.backgrounddrawn = false;
+			graphics.backgrounddrawn = false;
 		}
 		if(ed.level[curlevel].warpdir>0){
 			if(ed.level[curlevel].warpdir==1){
 			warpx=true;
 			background=3;
-			dwgfx.rcol = ed.getwarpbackground(rx-100,ry-100);
+			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
 			}else if(ed.level[curlevel].warpdir==2){
 			warpy=true;
 			background=4;
-			dwgfx.rcol = ed.getwarpbackground(rx-100,ry-100);
+			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
 			}else if(ed.level[curlevel].warpdir==3){
 			warpx=true; warpy=true;
 			background = 5;
-			dwgfx.rcol = ed.getwarpbackground(rx-100,ry-100);
+			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
 			}
 		}
 

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -44,7 +44,7 @@ public:
 
     int maptiletoenemycol(int t);
 
-    void changefinalcol(int t, entityclass& obj, Game& game);
+    void changefinalcol(int t);
 
     void setcol(const int r1, const int g1, const int b1 , const int r2, const  int g2, const int b2, const int c);
 
@@ -73,15 +73,15 @@ public:
 
     void showship();
 
-    void resetplayer(Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music);
+    void resetplayer();
 
-    void warpto(int rx, int ry , int t, int tx, int ty,  Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music);
+    void warpto(int rx, int ry , int t, int tx, int ty);
 
-    void gotoroom(int rx, int ry, Graphics& dwgfx,  Game& game, entityclass& obj, musicclass& music);
+    void gotoroom(int rx, int ry);
 
     std::string currentarea(int t);
 
-    void loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music);
+    void loadlevel(int rx, int ry);
 
 
     std::vector <int> roomdeaths;

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -14,7 +14,7 @@
 #include "editor.h"
 
 #if !defined(NO_CUSTOM_LEVELS)
-	extern editorclass ed;
+extern editorclass ed;
 #endif
 
 class mapclass

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -460,11 +460,6 @@ void musicclass::changemusicarea(int x, int y)
 	}
 }
 
-void musicclass::initefchannels()
-{
-	// for (var i:int = 0; i < 16; i++) efchannel.push(new SoundChannel);
-}
-
 void musicclass::playef(int t, int offset)
 {
 	// efchannel[currentefchan] = efchan[t].play(offset);

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -233,15 +233,6 @@ void musicclass::play(int t)
 	Mix_VolumeMusic(128);
 	if (currentsong !=t)
 	{
-		if (currentsong != -1)
-		{
-			// Stop the old song first
-			// musicchannel.stop();
-			if (currentsong != 0)
-			{
-				// musicchannel.removeEventListener(Event.SOUND_COMPLETE, loopmusic);
-			}
-		}
 		if (t != -1)
 		{
 			// musicfade = 0;
@@ -249,8 +240,6 @@ void musicclass::play(int t)
 			if (currentsong == 0 || currentsong == 7 || currentsong == 16 || currentsong == 23)
 			{
 				// Level Complete theme, no fade in or repeat
-				// musicchannel = musicchan[currentsong].play(0);
-				// musicchannel.soundTransform = new SoundTransform(1.0);
 				if(Mix_FadeInMusic(musicTracks[t].m_music, 0, 0)==-1)
 				{
 					printf("Mix_PlayMusic: %s\n", Mix_GetError());
@@ -258,10 +247,6 @@ void musicclass::play(int t)
 			}
 			else
 			{
-				// musicfadein = 90;
-				// musicchannel = musicchan[currentsong].play(0);
-				// musicchannel.soundTransform = new SoundTransform(0);
-				// musicchannel.addEventListener(Event.SOUND_COMPLETE, loopmusic);
 				if (Mix_FadingMusic() == MIX_FADING_OUT) {
 					// We're already fading out
 					fadeoutqueuesong = t;
@@ -295,26 +280,18 @@ void musicclass::loopmusic()
 
 void musicclass::stopmusic()
 {
-	// musicchannel.removeEventListener(Event.SOUND_COMPLETE, stopmusic);
-	// musicchannel.stop();
 	Mix_HaltMusic();
 	currentsong = -1;
 }
 
 void musicclass::haltdasmusik()
 {
-	// musicchannel.removeEventListener(Event.SOUND_COMPLETE, stopmusic);
-	// musicchannel.stop();
-	// resumesong = currentsong;
 	Mix_HaltMusic();
 	currentsong = -1;
 }
 
 void musicclass::silencedasmusik()
 {
-	//if(currentsong>-1){
-	//	musicchannel.soundTransform = new SoundTransform(0);
-	//}
 	Mix_VolumeMusic(0) ;
 	musicVolume = 0;
 }
@@ -327,13 +304,6 @@ void musicclass::fadeMusicVolumeIn(int ms)
 
 void musicclass::fadeout()
 {
-	//if(currentsong>-1){
-	//	if (musicfade == 0) {
-	//		musicchannel.removeEventListener(Event.SOUND_COMPLETE, stopmusic);
-	//		musicfade = 61;
-	//	}
-	//}
-
 	Mix_FadeOutMusic(2000);
 	currentsong = -1;
 }
@@ -366,9 +336,6 @@ void musicclass::processmusic()
 		return;
 	}
 
-	//if (musicfade > 0) processmusicfade();
-	//if (musicfadein > 0) processmusicfadein();
-
 	if (fadeoutqueuesong != -1 && Mix_PlayingMusic() == 0) {
 		play(fadeoutqueuesong);
 		fadeoutqueuesong = -1;
@@ -384,28 +351,6 @@ void musicclass::processmusic()
 	{
 		processmusicfadein();
 	}
-
-	//musicstopother--;
-	//if (musicstopother == 1) {
-	//	musicstopother = 0;
-	//	if (currentmusicchan == 0) musicchannel2.stop();
-	//	if (currentmusicchan == 1) musicchannel.stop();
-	//}
-	//if (musicstopother < 0) musicstopother = 0;
-
-	//musicchancur--;
-	//if (musicchancur <= 0 && currentsong > -1 && musicchanlen > 0) {
-	//	musicchancur = musicchanlen;
-	//	if (currentmusicchan == 0) {
-	//		musicchannel2 = musicchan[currentsong].play();
-	//		musicstopother = 3;
-	//		currentmusicchan = 1;
-	//	}else {
-	//		musicchannel = musicchan[currentsong].play();
-	//		musicstopother = 3;
-	//		currentmusicchan = 0;
-	//	}
-	//}
 }
 
 
@@ -462,9 +407,6 @@ void musicclass::changemusicarea(int x, int y)
 
 void musicclass::playef(int t)
 {
-	// efchannel[currentefchan] = efchan[t].play(offset);
-	// currentefchan++;
-	// if (currentefchan > 15) currentefchan -= 16;
 	int channel;
 
 	channel = Mix_PlayChannel(-1, soundTracks[t].sound, 0);

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -460,7 +460,7 @@ void musicclass::changemusicarea(int x, int y)
 	}
 }
 
-void musicclass::playef(int t, int offset)
+void musicclass::playef(int t)
 {
 	// efchannel[currentefchan] = efchan[t].play(offset);
 	// currentefchan++;

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -220,7 +220,7 @@ void musicclass::init()
 
 void musicclass::play(int t)
 {
-  t = (t % 16);
+	t = (t % 16);
 
 	if(mmmmmm)
 	{

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -308,17 +308,6 @@ void musicclass::fadeout()
 	currentsong = -1;
 }
 
-void musicclass::processmusicfade()
-{
-	//musicfade--;
-	//if (musicfade > 0) {
-	//	musicchannel.soundTransform = new SoundTransform(musicfade / 60);
-	//}else {
-	//	musicchannel.stop();
-	//	currentsong = -1;
-	//}
-}
-
 void musicclass::processmusicfadein()
 {
 	musicVolume += FadeVolAmountPerFrame;

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -35,9 +35,6 @@ public:
 
 	//public var nicefade:int, nicechange:int;
 
-	// Play a sound effect! There are 16 channels, which iterate
-	void initefchannels();
-
 	void playef(int t, int offset = 0);
 
 	std::vector<SoundTrack> soundTracks;

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -35,7 +35,7 @@ public:
 
 	//public var nicefade:int, nicechange:int;
 
-	void playef(int t, int offset = 0);
+	void playef(int t);
 
 	std::vector<SoundTrack> soundTracks;
 	std::vector<MusicTrack> musicTracks;

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -26,14 +26,8 @@ public:
 
 	void changemusicarea(int x, int y);
 
-	// public var musicchan:Array = new Array();
-	// public var musicchannel:SoundChannel, musicchannel2:SoundChannel;
-	// public var currentmusicchan:int, musicchanlen:int, musicchancur:int, musicstopother:int, resumesong:int;
-	// public var currentsong:int, musicfade:int, musicfadein:int;
 	int currentsong, musicfade, musicfadein;
 	int resumesong;
-
-	//public var nicefade:int, nicechange:int;
 
 	void playef(int t);
 

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -19,7 +19,6 @@ public:
 	void silencedasmusik();
 	void fadeMusicVolumeIn(int ms);
 	void fadeout();
-	void processmusicfade();
 	void processmusicfadein();
 	void processmusic();
 	void niceplay(int t);

--- a/desktop_version/src/Otherlevel.cpp
+++ b/desktop_version/src/Otherlevel.cpp
@@ -11,7 +11,7 @@ void otherlevelclass::addline(std::string t)
 	roomtext.push_back(text);
 }
 
-std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game, entityclass& obj)
+std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry)
 {
 	int t;
 	roomtileset = 1;

--- a/desktop_version/src/Otherlevel.cpp
+++ b/desktop_version/src/Otherlevel.cpp
@@ -61,8 +61,8 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("486,486,486,486,486,486,486,486,486,608,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,606,486,486,486,486,486,486");
 		tmap.push_back("486,486,486,486,486,486,486,486,486,608,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,606,486,486,486,486,486,486");
 
-		obj.createentity(game, 72, 32, 14); //Teleporter!
-		obj.createentity(game, 216, 144, 20, 1);
+		obj.createentity(72, 32, 14); //Teleporter!
+		obj.createentity(216, 144, 20, 1);
 
 		obj.createblock(5, 216-4, 144, 20, 16, 8);
 		break;
@@ -372,7 +372,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 
-		obj.createentity(game, 152, 144, 10, 1, 9000);  // (savepoint)
+		obj.createentity(152, 144, 10, 1, 9000);  // (savepoint)
 		break;
 
 	case rn(0,10):
@@ -408,7 +408,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 
-		obj.createentity(game, 224, 96, 10, 0, 10000);  // (savepoint)
+		obj.createentity(224, 96, 10, 0, 10000);  // (savepoint)
 		break;
 
 	case rn(0,11):
@@ -444,7 +444,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 
-		obj.createentity(game, 56, 32, 13); //Warp Token
+		obj.createentity(56, 32, 13); //Warp Token
 
 		break;
 
@@ -617,7 +617,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 
-		obj.createentity(game, 120, 40, 14); //Teleporter!
+		obj.createentity(120, 40, 14); //Teleporter!
 		break;
 
 	case rn(0,17):
@@ -755,7 +755,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,603,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,603,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 
-		obj.createentity(game, 144, 136, 10, 1, 4010);  // (savepoint)
+		obj.createentity(144, 136, 10, 1, 4010);  // (savepoint)
 		break;
 
 	case rn(1,5):
@@ -791,7 +791,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 
-		obj.createentity(game, 88, 104, 10, 1, 106010);  // (savepoint)
+		obj.createentity(88, 104, 10, 1, 106010);  // (savepoint)
 		break;
 
 	case rn(1,6):
@@ -895,7 +895,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,605,236,116,116,116,116,116,116,116,116,116,116,116,116,116,116,116,116");
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,605,236,116,116,116,116,116,116,116,116,116,116,116,116,116,116,116,116");
 
-		obj.createentity(game, 152, 64, 10, 0, 9010);  // (savepoint)
+		obj.createentity(152, 64, 10, 0, 9010);  // (savepoint)
 		break;
 
 	case rn(1,10):
@@ -931,7 +931,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 
-		obj.createentity(game, 208, 120, 9, 15);  // (shiny trinket)
+		obj.createentity(208, 120, 9, 15);  // (shiny trinket)
 		break;
 
 	case rn(1,11):
@@ -967,13 +967,13 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 
-		obj.createentity(game, 40, 192, 13); //Warp Token
-		obj.createentity(game, 168, 136, 13); //Warp Token
-		obj.createentity(game, 224, 136, 13); //Warp Token
+		obj.createentity(40, 192, 13); //Warp Token
+		obj.createentity(168, 136, 13); //Warp Token
+		obj.createentity(224, 136, 13); //Warp Token
 
 
 
-		obj.createentity(game, 96, 80, 13); //Warp Token
+		obj.createentity(96, 80, 13); //Warp Token
 
 		break;
 
@@ -1044,7 +1044,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 
-		obj.createentity(game, 112, 152, 10, 1, 13010);  // (savepoint)
+		obj.createentity(112, 152, 10, 1, 13010);  // (savepoint)
 		break;
 
 	case rn(1,14):
@@ -1148,7 +1148,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,617,415,295,295,295,295,295");
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,617,415,295,295,295,295,295");
 
-		obj.createentity(game, 280, 120, 10, 1, 16010);  // (savepoint)
+		obj.createentity(280, 120, 10, 1, 16010);  // (savepoint)
 		break;
 
 	case rn(2,2):
@@ -1184,7 +1184,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("483,483,483,483,483,483,483,483,483,605,49,0,0,0,0,0,0,50,603,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 		tmap.push_back("483,483,483,483,483,483,483,483,483,605,49,0,0,0,0,0,0,50,603,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 
-		obj.createentity(game, 56, 32, 10, 1, 2020);  // (savepoint)
+		obj.createentity(56, 32, 10, 1, 2020);  // (savepoint)
 		break;
 
 	case rn(2,3):
@@ -1288,7 +1288,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 40, 88, 10, 1, 6020);  // (savepoint)
+		obj.createentity(40, 88, 10, 1, 6020);  // (savepoint)
 		break;
 
 	case rn(2,8):
@@ -1394,26 +1394,26 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 			tmap.push_back("113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113");
 			tmap.push_back("113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113");
 
-			obj.createentity(game, 40, 32, 22, 0);  // (shiny trinket)
-			obj.createentity(game, 64, 32, 22, 1);  // (shiny trinket)
-			obj.createentity(game, 88, 32, 22, 2);  // (shiny trinket)
-			obj.createentity(game, 40, 80, 22, 3);  // (shiny trinket)
-			obj.createentity(game, 64, 80, 22, 4);  // (shiny trinket)
-			obj.createentity(game, 88, 80, 22, 5);  // (shiny trinket)
-			obj.createentity(game, 112, 80, 22, 6);  // (shiny trinket)
-			obj.createentity(game, 40, 128, 22, 7);  // (shiny trinket)
-			obj.createentity(game, 64, 128, 22, 8);  // (shiny trinket)
-			obj.createentity(game, 88, 128, 22, 9);  // (shiny trinket)
-			obj.createentity(game, 112, 128, 22, 10);  // (shiny trinket)
-			obj.createentity(game, 136, 128, 22, 11);  // (shiny trinket)
-			obj.createentity(game, 40, 176, 22, 12);  // (shiny trinket)
-			obj.createentity(game, 64, 176, 22, 13);  // (shiny trinket)
-			obj.createentity(game, 88, 176, 22, 14);  // (shiny trinket)
-			obj.createentity(game, 112, 176, 22, 15);  // (shiny trinket)
-			obj.createentity(game, 136, 176, 22, 16);  // (shiny trinket)
-			obj.createentity(game, 112, 32, 22, 17);  // (shiny trinket)
-			obj.createentity(game, 136, 80, 22, 18);  // (shiny trinket)
-			obj.createentity(game, 136, 32, 22, 19);  // (shiny trinket)
+			obj.createentity(40, 32, 22, 0);  // (shiny trinket)
+			obj.createentity(64, 32, 22, 1);  // (shiny trinket)
+			obj.createentity(88, 32, 22, 2);  // (shiny trinket)
+			obj.createentity(40, 80, 22, 3);  // (shiny trinket)
+			obj.createentity(64, 80, 22, 4);  // (shiny trinket)
+			obj.createentity(88, 80, 22, 5);  // (shiny trinket)
+			obj.createentity(112, 80, 22, 6);  // (shiny trinket)
+			obj.createentity(40, 128, 22, 7);  // (shiny trinket)
+			obj.createentity(64, 128, 22, 8);  // (shiny trinket)
+			obj.createentity(88, 128, 22, 9);  // (shiny trinket)
+			obj.createentity(112, 128, 22, 10);  // (shiny trinket)
+			obj.createentity(136, 128, 22, 11);  // (shiny trinket)
+			obj.createentity(40, 176, 22, 12);  // (shiny trinket)
+			obj.createentity(64, 176, 22, 13);  // (shiny trinket)
+			obj.createentity(88, 176, 22, 14);  // (shiny trinket)
+			obj.createentity(112, 176, 22, 15);  // (shiny trinket)
+			obj.createentity(136, 176, 22, 16);  // (shiny trinket)
+			obj.createentity(112, 32, 22, 17);  // (shiny trinket)
+			obj.createentity(136, 80, 22, 18);  // (shiny trinket)
+			obj.createentity(136, 32, 22, 19);  // (shiny trinket)
 
 			if(!game.nocutscenes && obj.flags[70]==0)
 			{
@@ -1454,7 +1454,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 			tmap.push_back("113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113");
 			tmap.push_back("113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113");
 
-			obj.createentity(game, 90, 52, 26, 0);  // (super warp)
+			obj.createentity(90, 52, 26, 0);  // (super warp)
 		}
 
 		break;
@@ -1492,7 +1492,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104");
 		tmap.push_back("104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104,104");
 
-		obj.createentity(game, 64, 64, 14); //Teleporter!
+		obj.createentity(64, 64, 14); //Teleporter!
 		break;
 
 	case rn(2,12):
@@ -1630,7 +1630,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 		tmap.push_back("489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 
-		obj.createentity(game, 240, 96, 10, 0, 15020);  // (savepoint)
+		obj.createentity(240, 96, 10, 0, 15020);  // (savepoint)
 		break;
 
 	case rn(3,2):
@@ -1666,7 +1666,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,620,0,0,0,0,618,498,498");
 		tmap.push_back("498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,620,0,0,0,0,618,498,498");
 
-		obj.createentity(game, 152, 96, 9, 16);  // (shiny trinket)
+		obj.createentity(152, 96, 9, 16);  // (shiny trinket)
 		break;
 
 	case rn(3,3):
@@ -1702,7 +1702,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501");
 		tmap.push_back("501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501");
 
-		obj.createentity(game, 24, 192, 10, 1, 3030);  // (savepoint)
+		obj.createentity(24, 192, 10, 1, 3030);  // (savepoint)
 		break;
 
 	case rn(3,5):
@@ -1874,7 +1874,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101");
 		tmap.push_back("101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101");
 
-		obj.createentity(game, 248, 168, 10, 1, 9030);  // (savepoint)
+		obj.createentity(248, 168, 10, 1, 9030);  // (savepoint)
 		break;
 
 	case rn(3,10):
@@ -1910,65 +1910,65 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,223,741,741,741,741,741,741,221,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101");
 		tmap.push_back("101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,223,741,741,741,741,741,741,221,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101,101");
 
-		obj.createentity(game, 88, 80, 21, 1); //Terminal	// UU Brothers
+		obj.createentity(88, 80, 21, 1); //Terminal	// UU Brothers
 		obj.createblock(5, 88 - 4, 80, 20, 16, 25);
 
 		if(game.stat_trinkets>=5)
 		{
-			obj.createentity(game, 128, 80, 21, 1); //Terminal
+			obj.createentity(128, 80, 21, 1); //Terminal
 			obj.createblock(5, 128 - 4, 80, 20, 16, 26);
 		}
 
 		if(game.stat_trinkets>=8)
 		{
-			obj.createentity(game, 176, 80, 21, 1); //Terminal
+			obj.createentity(176, 80, 21, 1); //Terminal
 			obj.createblock(5, 176 - 4, 80, 20, 16, 27);
 		}
 
 		if(game.stat_trinkets>=10)
 		{
-			obj.createentity(game, 216, 80, 21, 1); //Terminal
+			obj.createentity(216, 80, 21, 1); //Terminal
 			obj.createblock(5, 216 - 4, 80, 20, 16, 28);
 		}
 
 		if(game.stat_trinkets>=12)
 		{
-			obj.createentity(game, 88, 128, 21, 0); //Terminal
+			obj.createentity(88, 128, 21, 0); //Terminal
 			obj.createblock(5, 88 - 4, 128, 20, 16, 29);
 		}
 
 		if(game.stat_trinkets>=14)
 		{
-			obj.createentity(game, 128, 128, 21, 0); //Terminal
+			obj.createentity(128, 128, 21, 0); //Terminal
 			obj.createblock(5, 128 - 4, 128, 20, 16, 33);
 		}
 
 		if(game.stat_trinkets>=16)
 		{
-			obj.createentity(game, 176, 128, 21, 0); //Terminal
+			obj.createentity(176, 128, 21, 0); //Terminal
 			obj.createblock(5, 176 - 4, 128, 20, 16, 30);
 		}
 
 		if(game.stat_trinkets>=18)
 		{
-			obj.createentity(game, 216, 128, 21, 0); //Terminal
+			obj.createentity(216, 128, 21, 0); //Terminal
 			obj.createblock(5, 216 - 4, 128, 20, 16, 32);
 		}
 
 		//Special cases
 		if(game.stat_trinkets>=20)
 		{
-			obj.createentity(game, 40, 40, 21, 0); //Terminal
+			obj.createentity(40, 40, 21, 0); //Terminal
 			obj.createblock(5, 40 - 4, 40, 20, 16, 31);
 		}
 
 		if(game.stat_trinkets>=20)
 		{
-			obj.createentity(game, 264, 40, 21, 0); //Terminal
+			obj.createentity(264, 40, 21, 0); //Terminal
 			obj.createblock(5, 264 - 4, 40, 20, 16, 34);
 		}
 
-		obj.createentity(game, 152, 40, 21, 0); //Terminal (jukebox instructions)
+		obj.createentity(152, 40, 21, 0); //Terminal (jukebox instructions)
 		obj.createblock(5, 152 - 4, 40, 20, 16, 24);
 		break;
 
@@ -2039,7 +2039,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,692,0,0,0,0,0,612,492,492,492,492,492,492,492,492,492,492,492,492,492,492,614,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,692,0,0,0,0,0,612,492,492,492,492,492,492,492,492,492,492,492,492,492,492,614,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 128, 160, 10, 1, 113030);  // (savepoint)
+		obj.createentity(128, 160, 10, 1, 113030);  // (savepoint)
 		break;
 
 
@@ -2076,7 +2076,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,605,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,605,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 192, 96, 10, 0, 114030);  // (savepoint)
+		obj.createentity(192, 96, 10, 0, 114030);  // (savepoint)
 		break;
 
 	case rn(3,14):
@@ -2282,12 +2282,12 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110");
 		tmap.push_back("110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110");
 
-		obj.createentity(game, 256, 120, 20, 1); //Terminal Ship computer
+		obj.createentity(256, 120, 20, 1); //Terminal Ship computer
 		obj.createblock(5, 256 - 4, 120, 20, 16, 22);
 
-		obj.createentity(game, 256, 184, 20, 1); //Terminal
-		obj.createentity(game, 232, 184, 20, 1); //Terminal
-		obj.createentity(game, 208, 184, 20, 1); //Terminal
+		obj.createentity(256, 184, 20, 1); //Terminal
+		obj.createentity(232, 184, 20, 1); //Terminal
+		obj.createentity(208, 184, 20, 1); //Terminal
 		obj.createblock(5, 208 + 4, 184, 56, 16, 23);
 		break;
 
@@ -2392,7 +2392,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,689,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,609,489,489,489,489,489,489,489,489,489,489,489");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,689,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,609,489,489,489,489,489,489,489,489,489,489,489");
 
-		obj.createentity(game, 248, 112, 10, 1, 114040);  // (savepoint)
+		obj.createentity(248, 112, 10, 1, 114040);  // (savepoint)
 		break;
 
 	case rn(4,14):
@@ -2428,7 +2428,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,614,0,0,0,0,0,612,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,614,0,0,0,0,0,612,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 
-		obj.createentity(game, 104, 176, 10, 1, 115040);  // (savepoint)
+		obj.createentity(104, 176, 10, 1, 115040);  // (savepoint)
 		break;
 
 	case rn(4,15):
@@ -2464,7 +2464,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 
-		obj.createentity(game, 16, 40, 10, 1, 15040);  // (savepoint)
+		obj.createentity(16, 40, 10, 1, 15040);  // (savepoint)
 		break;
 
 	case rn(5,2):
@@ -2534,7 +2534,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,614,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,614,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 272, 128, 10, 0, 3050);  // (savepoint)
+		obj.createentity(272, 128, 10, 0, 3050);  // (savepoint)
 		break;
 
 	case rn(5,4):
@@ -2876,7 +2876,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 
-		obj.createentity(game, 184, 176, 10, 1, 13050);  // (savepoint)
+		obj.createentity(184, 176, 10, 1, 13050);  // (savepoint)
 		break;
 
 	case rn(5,14):
@@ -2947,7 +2947,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("486,486,486,486,486,486,486,486,527,567,568,0,0,686,0,0,606,486,486,486,486,486,486,486,527,568,0,0,0,0,0,566,567,528,486,486,486,486,486,486");
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,527,567,567,567,567,567,528,486,486,486,486,486,486,486,486,527,567,567,567,567,567,528,486,486,486,486,486,486,486,486");
 
-		obj.createentity(game, 72, 16, 9, 14);  // (shiny trinket)
+		obj.createentity(72, 16, 9, 14);  // (shiny trinket)
 		break;
 
 	case rn(5,18):
@@ -2983,7 +2983,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("489,489,611,0,0,0,0,609,489,489,611,0,0,0,0,609,489,489,611,0,0,0,0,609,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 		tmap.push_back("489,489,611,0,0,0,0,609,489,489,611,0,0,0,0,609,489,489,611,0,0,0,0,609,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 
-		obj.createentity(game, 224, 160, 13); //Warp Token
+		obj.createentity(224, 160, 13); //Warp Token
 
 		break;
 
@@ -3054,7 +3054,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 152, 152, 10, 0, 103060);  // (savepoint)
+		obj.createentity(152, 152, 10, 0, 103060);  // (savepoint)
 		break;
 
 	case rn(6,4):
@@ -3090,7 +3090,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,603,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,603,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 
-		obj.createentity(game, 128, 120, 10, 1, 4060);  // (savepoint)
+		obj.createentity(128, 120, 10, 1, 4060);  // (savepoint)
 		break;
 
 	case rn(6,5):
@@ -3194,7 +3194,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 		tmap.push_back("489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 
-		obj.createentity(game, 64, 88, 10, 1, 7060);  // (savepoint)
+		obj.createentity(64, 88, 10, 1, 7060);  // (savepoint)
 		break;
 
 	case rn(6,8):
@@ -3298,7 +3298,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,618,498,498,498,498,498,498,498,498,498");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,618,498,498,498,498,498,498,498,498,498");
 
-		obj.createentity(game, 152, 128, 10, 0, 10060);  // (savepoint)
+		obj.createentity(152, 128, 10, 0, 10060);  // (savepoint)
 		break;
 
 	case rn(6,11):
@@ -3473,11 +3473,11 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 
 		if(!game.intimetrial)
 		{
-			obj.createentity(game, 96, 48, 20, 1);//Terminal
+			obj.createentity(96, 48, 20, 1);//Terminal
 			obj.createblock(5, 96 - 4, 48, 20, 16, 12);
 		}
 
-		obj.createentity(game, 128, 216, 10, 1, 116061);  // (savepoint)
+		obj.createentity(128, 216, 10, 1, 116061);  // (savepoint)
 		break;
 
 	case rn(6,18):
@@ -3581,7 +3581,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486");
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486");
 
-		obj.createentity(game, 192, 104, 13); //Warp Token
+		obj.createentity(192, 104, 13); //Warp Token
 
 		break;
 
@@ -3618,7 +3618,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 88, 136, 10, 0, 103070);  // (savepoint)
+		obj.createentity(88, 136, 10, 0, 103070);  // (savepoint)
 		break;
 
 	case rn(7,3):
@@ -3688,7 +3688,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,527,567,567,567,528,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486");
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486");
 
-		obj.createentity(game, 208, 128, 10, 1, 4070);  // (savepoint)
+		obj.createentity(208, 128, 10, 1, 4070);  // (savepoint)
 		break;
 
 	case rn(7,5):
@@ -3860,7 +3860,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 
-		obj.createentity(game, 64, 112, 14); //Teleporter!
+		obj.createentity(64, 112, 14); //Teleporter!
 		break;
 
 	case rn(7,10):
@@ -3964,7 +3964,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,524,564,564,564,564,564,564,564,564,564,564,564,564,564,564,564,525,483,483,483,483,483,483,483,483,483,483,483");
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 
-		obj.createentity(game, 48, 192, 10, 1, 14070);  // (savepoint)
+		obj.createentity(48, 192, 10, 1, 14070);  // (savepoint)
 		break;
 
 	case rn(8,0):
@@ -4170,7 +4170,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 
-		obj.createentity(game, 80, 40, 10, 1, 5080);  // (savepoint)
+		obj.createentity(80, 40, 10, 1, 5080);  // (savepoint)
 		break;
 
 	case rn(8,6):
@@ -4206,7 +4206,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("489,489,489,489,489,489,611,0,0,0,0,609,489,489,489,489,611,0,0,0,0,0,0,609,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 		tmap.push_back("489,489,489,489,489,489,611,0,0,0,0,609,489,489,489,489,611,0,0,0,0,0,0,609,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 
-		obj.createentity(game, 96, 72, 13); //Warp Token
+		obj.createentity(96, 72, 13); //Warp Token
 
 		break;
 
@@ -4345,8 +4345,8 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,603,483,483,483,483");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,603,483,483,483,483");
 
-		obj.createentity(game, 176, 40, 14); //Teleporter!
-		obj.createentity(game, 120, 128, 20, 1);  // (terminal)
+		obj.createentity(176, 40, 14); //Teleporter!
+		obj.createentity(120, 128, 20, 1);  // (terminal)
 
 		obj.createblock(5, 120-4, 128, 20, 16, 7);
 		break;
@@ -4452,7 +4452,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("492,492,614,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,612,492,492");
 		tmap.push_back("492,492,614,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,612,492,492");
 
-		obj.createentity(game, 40, 152, 10, 1, 14080);  // (savepoint)
+		obj.createentity(40, 152, 10, 1, 14080);  // (savepoint)
 		break;
 
 	case rn(8,15):
@@ -4522,7 +4522,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("489,489,489,489,611,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,609,489,489,489,489");
 		tmap.push_back("489,489,489,489,611,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,609,489,489,489,489");
 
-		obj.createentity(game, 152, 80, 10, 1, 16080);  // (savepoint)
+		obj.createentity(152, 80, 10, 1, 16080);  // (savepoint)
 		break;
 
 	case rn(8,17):
@@ -4796,7 +4796,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,417,698,698,698,698,698,698,698,698,698,698,698,698,698,698,698,698,415,295,295,295,295,295,295,295,295,295,295,295");
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,417,698,698,698,698,698,698,698,698,698,698,698,698,698,698,698,698,415,295,295,295,295,295,295,295,295,295,295,295");
 
-		obj.createentity(game, 80, 40, 9, 17);  // (shiny trinket)
+		obj.createentity(80, 40, 9, 17);  // (shiny trinket)
 		roomtileset = 0; // (Use space station tileset)
 		break;
 
@@ -4942,7 +4942,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("516,516,638,0,0,0,630,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510");
 		tmap.push_back("516,516,638,0,0,0,630,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510,510");
 
-		obj.createentity(game, 184, 176, 10, 1, 12100);  // (savepoint)
+		obj.createentity(184, 176, 10, 1, 12100);  // (savepoint)
 		roomtileset = 0; // (Use space station tileset)
 		break;
 
@@ -5085,7 +5085,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486");
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486");
 
-		obj.createentity(game, 216, 72, 10, 1, 16100);  // (savepoint)
+		obj.createentity(216, 72, 10, 1, 16100);  // (savepoint)
 		break;
 
 	case rn(10,17):
@@ -5189,7 +5189,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,623,0,0,0,0,0,621,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501");
 		tmap.push_back("501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501,623,0,0,0,0,0,621,501,501,501,501,501,501,501,501,501,501,501,501,501,501,501");
 
-		obj.createentity(game, 40, 112, 9, 13);  // (shiny trinket)
+		obj.createentity(40, 112, 9, 13);  // (shiny trinket)
 		break;
 
 	case rn(11,0):
@@ -5362,7 +5362,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("495,495,617,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
 
-		obj.createentity(game, (8 * 8), (12 * 8), 1, 0, 0, -10000, -10000, 10000, 100000);  // Enemy
+		obj.createentity((8 * 8), (12 * 8), 1, 0, 0, -10000, -10000, 10000, 100000);  // Enemy
 		obj.nearelephant = true;
 
 		roomtileset = 0; // (Use space station tileset)
@@ -5402,7 +5402,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310");
 
 
-		obj.createentity(game, 8 * 8, -248 + (12 * 8), 1, 0, 0, -10000, -10000, 10000, 100000);  // Enemy
+		obj.createentity(8 * 8, -248 + (12 * 8), 1, 0, 0, -10000, -10000, 10000, 100000);  // Enemy
 		obj.nearelephant = true;
 
 		roomtileset = 0; // (Use space station tileset)
@@ -5716,10 +5716,10 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,412,292,292,414,698,698,698,412,292,292,292");
 
 
-		obj.createentity(game, -328 + (8 * 8), (12 * 8), 1, 0, 0, -10000, -10000, 10000, 100000);  // Enemy
+		obj.createentity(-328 + (8 * 8), (12 * 8), 1, 0, 0, -10000, -10000, 10000, 100000);  // Enemy
 		obj.nearelephant = true;
 
-		obj.createentity(game, 240, 72, 10, 1, 8120);  // (savepoint)
+		obj.createentity(240, 72, 10, 1, 8120);  // (savepoint)
 		roomtileset = 0; // (Use space station tileset)
 		break;
 
@@ -5757,7 +5757,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,217,689,689,689,215,95,95,95");
 
 
-		obj.createentity(game, -328 + (8 * 8), -248 + (12 * 8), 1, 0, 0, -10000, -10000, 10000, 100000);  // Enemy
+		obj.createentity(-328 + (8 * 8), -248 + (12 * 8), 1, 0, 0, -10000, -10000, 10000, 100000);  // Enemy
 		obj.nearelephant = true;
 
 		roomtileset = 0; // (Use space station tileset)
@@ -6003,7 +6003,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 		tmap.push_back("480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480,480");
 
-		obj.createentity(game, 48, 96, 14); //Teleporter!
+		obj.createentity(48, 96, 14); //Teleporter!
 		break;
 
 	case rn(13,14):
@@ -6039,7 +6039,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 280, 32, 20, 1); //terminal
+		obj.createentity(280, 32, 20, 1); //terminal
 		obj.createblock(5, 280-4, 32, 20, 16, 9);
 
 		roomtileset = 0; // (Use space station tileset)
@@ -6112,7 +6112,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 
-		obj.createentity(game, 80, 104, 10, 1, 16130);  // (savepoint)
+		obj.createentity(80, 104, 10, 1, 16130);  // (savepoint)
 		break;
 
 	case rn(13,17):
@@ -6148,7 +6148,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,617,0,0,0,0,0,0,0,0,615,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,617,0,0,0,0,0,0,0,0,615,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 
-		obj.createentity(game, 240, 128, 10, 1, 17130);  // (savepoint)
+		obj.createentity(240, 128, 10, 1, 17130);  // (savepoint)
 		break;
 
 	case rn(13,18):
@@ -6390,8 +6390,8 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 
-		obj.createentity(game, 176, 72, 14); //Teleporter!
-		obj.createentity(game, 88, 160, 20, 1);//terminal
+		obj.createentity(176, 72, 14); //Teleporter!
+		obj.createentity(88, 160, 20, 1);//terminal
 
 		obj.createblock(5, 88-4, 160, 20, 16, 11);
 		break;
@@ -6533,7 +6533,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,608,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,608,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 88, 96, 10, 0, 18150);  // (savepoint)
+		obj.createentity(88, 96, 10, 0, 18150);  // (savepoint)
 		break;
 
 	case rn(15,19):
@@ -6603,7 +6603,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483");
 
-		obj.createentity(game, 72, 120, 13); //Warp Token
+		obj.createentity(72, 120, 13); //Warp Token
 
 		break;
 
@@ -6641,7 +6641,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
 		roomtileset = 0; // (Use space station tileset)
-		obj.createentity(game, 176, 152, 10, 1, 14160);  // (savepoint)
+		obj.createentity(176, 152, 10, 1, 14160);  // (savepoint)
 		break;
 
 	case rn(16,17):
@@ -6779,8 +6779,8 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,617,680,680,680,680,680,680,615,495,495,495,495,495");
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,617,680,680,680,680,680,680,615,495,495,495,495,495");
 
-		obj.createentity(game, 40, 40, 14); //Teleporter!
-		obj.createentity(game, 192, 120, 20, 1);//terminal
+		obj.createentity(40, 40, 14); //Teleporter!
+		obj.createentity(192, 120, 20, 1);//terminal
 
 		obj.createblock(5, 192-4, 120, 20, 16, 10);
 		roomtileset = 0; // (Use space station tileset)
@@ -6961,7 +6961,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 112, 72, 14); //Teleporter!
+		obj.createentity(112, 72, 14); //Teleporter!
 		break;
 
 	case rn(17,18):
@@ -7031,7 +7031,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486");
 		tmap.push_back("486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486,486");
 
-		obj.createentity(game, 152, 152, 10, 0, 19170);  // (savepoint)
+		obj.createentity(152, 152, 10, 0, 19170);  // (savepoint)
 		break;
 
 	case rn(18,4):
@@ -7102,7 +7102,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
 		roomtileset = 0; // (Use space station tileset)
-		obj.createentity(game, 104, 152, 10, 1, 15180);  // (savepoint)
+		obj.createentity(104, 152, 10, 1, 15180);  // (savepoint)
 		break;
 
 	case rn(18,17):
@@ -7206,7 +7206,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("564,564,564,564,564,564,565,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("483,483,483,483,483,483,605,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 192, 176, 10, 1, 105190);  // (savepoint)
+		obj.createentity(192, 176, 10, 1, 105190);  // (savepoint)
 		break;
 
 	case rn(19,5):
@@ -7242,7 +7242,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 
-		obj.createentity(game, 40, 192, 10, 1, 106190);  // (savepoint)
+		obj.createentity(40, 192, 10, 1, 106190);  // (savepoint)
 		break;
 
 
@@ -7313,7 +7313,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498");
 		tmap.push_back("498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498");
 
-		obj.createentity(game, 72, 168, 10, 1, 111190);  // (savepoint)
+		obj.createentity(72, 168, 10, 1, 111190);  // (savepoint)
 		break;
 
 	case rn(19,11):
@@ -7451,7 +7451,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("489,489,489,489,489,489,611,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,609,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 		tmap.push_back("489,489,489,489,489,489,611,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,609,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489");
 
-		obj.createentity(game, 80, 144, 10, 1, 14190);  // (savepoint)
+		obj.createentity(80, 144, 10, 1, 14190);  // (savepoint)
 		break;
 
 	case rn(19,15):
@@ -7555,7 +7555,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,615,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,615,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 
-		obj.createentity(game, 168, 88, 10, 1, 17190);  // (savepoint)
+		obj.createentity(168, 88, 10, 1, 17190);  // (savepoint)
 		break;
 
 	case rn(19,18):
@@ -7802,23 +7802,23 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,414,0,0,0,0,0,0,0,412,292,292,292,292,292,292,292,292,292,292,292");
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,414,0,0,0,0,0,0,0,412,292,292,292,292,292,292,292,292,292,292,292");
 
-		obj.createentity(game, 256, 88, 21, 1); //Terminal
-		obj.createentity(game, 128, 88, 21, 1); //Terminal
-		obj.createentity(game, 104, 88, 21, 1); //Terminal
-		obj.createentity(game, 80, 88, 21, 1); //Terminal
-		obj.createentity(game, 128, 128, 21, 0); //Terminal
-		obj.createentity(game, 128, 192, 21, 1); //Terminal
-		obj.createentity(game, 104, 192, 21, 1); //Terminal
-		obj.createentity(game, 80, 192, 21, 1); //Terminal
+		obj.createentity(256, 88, 21, 1); //Terminal
+		obj.createentity(128, 88, 21, 1); //Terminal
+		obj.createentity(104, 88, 21, 1); //Terminal
+		obj.createentity(80, 88, 21, 1); //Terminal
+		obj.createentity(128, 128, 21, 0); //Terminal
+		obj.createentity(128, 192, 21, 1); //Terminal
+		obj.createentity(104, 192, 21, 1); //Terminal
+		obj.createentity(80, 192, 21, 1); //Terminal
 
 		if(game.insecretlab)
 		{
 			//vitellary
-			obj.createentity(game, 231, 81, 18, 14, 0, 18);
+			obj.createentity(231, 81, 18, 14, 0, 18);
 			obj.createblock(5, 231- 32, 0, 32 + 32 + 32, 240, 2);
 
 			//violet
-			obj.createentity(game,83, 126, 18, 20, 0, 18);
+			obj.createentity(83, 126, 18, 20, 0, 18);
 			obj.entities[obj.getcrewman(1)].rule = 7;
 			obj.entities[obj.getcrewman(1)].tile +=6;
 			obj.createblock(5, 83 - 32, 0, 32 + 32 + 32, 240, 1);
@@ -7858,27 +7858,27 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295");
 		tmap.push_back("295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295");
 
-		obj.createentity(game, 96, 48, 25, 0, 1); //Terminal
-		obj.createentity(game, 128, 48, 25, 0, 2); //Terminal
-		obj.createentity(game, 160, 48, 25, 0, 3); //Terminal
-		obj.createentity(game, 192, 48, 25, 0, 4); //Terminal
-		obj.createentity(game, 224, 48, 25, 0, 5); //Terminal
-		obj.createentity(game, 256, 48, 25, 0, 6); //Terminal
+		obj.createentity(96, 48, 25, 0, 1); //Terminal
+		obj.createentity(128, 48, 25, 0, 2); //Terminal
+		obj.createentity(160, 48, 25, 0, 3); //Terminal
+		obj.createentity(192, 48, 25, 0, 4); //Terminal
+		obj.createentity(224, 48, 25, 0, 5); //Terminal
+		obj.createentity(256, 48, 25, 0, 6); //Terminal
 
-		obj.createentity(game, 96, 88, 25, 1, 13); //Terminal
-		obj.createentity(game, 128, 88, 25, 1, 14); //Terminal
-		obj.createentity(game, 160, 88, 25, 1, 15); //Terminal
-		obj.createentity(game, 192, 88, 25, 1, 16); //Terminal
-		obj.createentity(game, 224, 88, 25, 1, 17); //Terminal
-		obj.createentity(game, 256, 88, 25, 1, 18); //Terminal
+		obj.createentity(96, 88, 25, 1, 13); //Terminal
+		obj.createentity(128, 88, 25, 1, 14); //Terminal
+		obj.createentity(160, 88, 25, 1, 15); //Terminal
+		obj.createentity(192, 88, 25, 1, 16); //Terminal
+		obj.createentity(224, 88, 25, 1, 17); //Terminal
+		obj.createentity(256, 88, 25, 1, 18); //Terminal
 
-		obj.createentity(game, 96, 128-3, 25, 0, 7); //Terminal
-		obj.createentity(game, 96, 168, 25, 1, 8); //Terminal
+		obj.createentity(96, 128-3, 25, 0, 7); //Terminal
+		obj.createentity(96, 168, 25, 1, 8); //Terminal
 
-		obj.createentity(game, 160, 128, 25, 0, 12); //Terminal
-		obj.createentity(game, 192, 128, 25, 0, 11); //Terminal
-		obj.createentity(game, 224, 128, 25, 0, 10); //Terminal
-		obj.createentity(game, 256, 128, 25, 0, 9); //Terminal
+		obj.createentity(160, 128, 25, 0, 12); //Terminal
+		obj.createentity(192, 128, 25, 0, 11); //Terminal
+		obj.createentity(224, 128, 25, 0, 10); //Terminal
+		obj.createentity(256, 128, 25, 0, 9); //Terminal
 		break;
 
 	case rn(16,5):
@@ -7914,8 +7914,8 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 
-		obj.createentity(game, 152, 168, 25, 0, 20); //Terminal
-		obj.createentity(game, 152, 168, 25, 0, 19); //Terminal
+		obj.createentity(152, 168, 25, 0, 20); //Terminal
+		obj.createentity(152, 168, 25, 0, 19); //Terminal
 		break;
 
 	case rn(19,6):
@@ -7951,21 +7951,21 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,411,0,0,0,0,0,0,409,289,289,289");
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,411,0,0,0,0,0,0,409,289,289,289");
 
-		obj.createentity(game, 216, 176, 21, 1); //Terminal
-		obj.createentity(game, 192, 176, 21, 1); //Terminal
-		obj.createentity(game, 168, 176, 21, 1); //Terminal
-		obj.createentity(game, 144, 176, 21, 1); //Terminal
-		obj.createentity(game, 88, 96, 21, 1); //Terminal
-		obj.createentity(game, 112, 96, 21, 1); //Terminal
-		obj.createentity(game, 136, 96, 21, 1); //Terminal
-		obj.createentity(game, 160, 96, 21, 1); //Terminal
+		obj.createentity(216, 176, 21, 1); //Terminal
+		obj.createentity(192, 176, 21, 1); //Terminal
+		obj.createentity(168, 176, 21, 1); //Terminal
+		obj.createentity(144, 176, 21, 1); //Terminal
+		obj.createentity(88, 96, 21, 1); //Terminal
+		obj.createentity(112, 96, 21, 1); //Terminal
+		obj.createentity(136, 96, 21, 1); //Terminal
+		obj.createentity(160, 96, 21, 1); //Terminal
 
 		//vertigris:
-		obj.createentity(game, 100, 169, 18, 13, 0, 18);
+		obj.createentity(100, 169, 18, 13, 0, 18);
 		obj.createblock(5, 100 - 16, 0, 32 + 32, 240, 4);
 
 		//victoria:
-		obj.createentity(game, 193, 89, 18, 16, 0, 18);
+		obj.createentity(193, 89, 18, 16, 0, 18);
 		obj.createblock(5, 193-16, 0, 32+32, 240, 5);
 		break;
 
@@ -8003,12 +8003,12 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 
-		obj.createentity(game, 72, 192, 13);  // (shiny trinket)
-		obj.createentity(game, 112, 144, 20, 1);  // (terminal)
+		obj.createentity(72, 192, 13);  // (shiny trinket)
+		obj.createentity(112, 144, 20, 1);  // (terminal)
 		obj.createblock(5, 112 - 4, 144, 20, 16, 21);
 
 		//vermilion
-		obj.createentity(game, 186, 137, 18, 15, 0, 18);
+		obj.createentity(186, 137, 18, 15, 0, 18);
 		obj.createblock(5, 186 - 32, 0, 32 + 32 + 32, 240, 3);
 
 		//naughty corner!
@@ -8051,8 +8051,8 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry , Game& game,
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 
-		obj.createentity(game, -8, 84-32, 11, 328+8);  // (horizontal gravity line)
-		obj.createentity(game, -8, 148 + 32, 11, 328+8);  // (horizontal gravity line)
+		obj.createentity(-8, 84-32, 11, 328+8);  // (horizontal gravity line)
+		obj.createentity(-8, 148 + 32, 11, 328+8);  // (horizontal gravity line)
 		obj.createblock(1, -10, 84 - 16, 340, 32, 9); //start the game
 		break;
 

--- a/desktop_version/src/Otherlevel.h
+++ b/desktop_version/src/Otherlevel.h
@@ -27,7 +27,7 @@ public:
     };
 
     void addline(std::string t);
-    std::vector<std::string> loadlevel(int rx, int ry , Game& game, entityclass& obj);
+    std::vector<std::string> loadlevel(int rx, int ry);
 
     std::string roomname;
 

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -85,8 +85,6 @@ Screen::Screen()
 	);
 
 	badSignalEffect = false;
-
-	glScreen = true;
 }
 
 void Screen::ResizeScreen(int x, int y)

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -19,18 +19,18 @@ extern "C"
 
 Screen::Screen()
 {
-    m_window = NULL;
-    m_renderer = NULL;
-    m_screenTexture = NULL;
-    m_screen = NULL;
-    isWindowed = true;
-    stretchMode = 0;
-    isFiltered = false;
-    filterSubrect.x = 1;
-    filterSubrect.y = 1;
-    filterSubrect.w = 318;
-    filterSubrect.h = 238;
-    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
+	m_window = NULL;
+	m_renderer = NULL;
+	m_screenTexture = NULL;
+	m_screen = NULL;
+	isWindowed = true;
+	stretchMode = 0;
+	isFiltered = false;
+	filterSubrect.x = 1;
+	filterSubrect.y = 1;
+	filterSubrect.w = 318;
+	filterSubrect.h = 238;
+	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
 
 	// Uncomment this next line when you need to debug -flibit
 	// SDL_SetHintWithPriority(SDL_HINT_RENDER_DRIVER, "software", SDL_HINT_OVERRIDE);
@@ -84,9 +84,9 @@ Screen::Screen()
 		240
 	);
 
-    badSignalEffect = false;
+	badSignalEffect = false;
 
-    glScreen = true;
+	glScreen = true;
 }
 
 void Screen::ResizeScreen(int x, int y)
@@ -160,30 +160,30 @@ void Screen::GetWindowSize(int* x, int* y)
 
 void Screen::UpdateScreen(SDL_Surface* buffer, SDL_Rect* rect )
 {
-    if((buffer == NULL) && (m_screen == NULL) )
-    {
-        return;
-    }
+	if((buffer == NULL) && (m_screen == NULL) )
+	{
+		return;
+	}
 
-    if(badSignalEffect)
-    {
-        buffer = ApplyFilter(buffer);
-    }
+	if(badSignalEffect)
+	{
+		buffer = ApplyFilter(buffer);
+	}
 
 
-    FillRect(m_screen, 0x000);
-    BlitSurfaceStandard(buffer,NULL,m_screen,rect);
+	FillRect(m_screen, 0x000);
+	BlitSurfaceStandard(buffer,NULL,m_screen,rect);
 
-    if(badSignalEffect)
-    {
-        SDL_FreeSurface(buffer);
-    }
+	if(badSignalEffect)
+	{
+		SDL_FreeSurface(buffer);
+	}
 
 }
 
 const SDL_PixelFormat* Screen::GetFormat()
 {
-    return m_screen->format;
+	return m_screen->format;
 }
 
 void Screen::FlipScreen()

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -230,8 +230,3 @@ void Screen::toggleLinearFilter()
 		240
 	);
 }
-
-void Screen::ClearScreen( int colour )
-{
-    //FillRect(m_screen, colour) ;
-}

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -23,7 +23,6 @@ public:
 	bool isWindowed;
 	bool isFiltered;
 	bool badSignalEffect;
-	bool glScreen;
 	int stretchMode;
 
 	SDL_Window *m_window;

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -12,7 +12,6 @@ public:
 	void GetWindowSize(int* x, int* y);
 
 	void UpdateScreen(SDL_Surface* buffer, SDL_Rect* rect);
-	void ClearScreen(int colour);
 	void FlipScreen();
 
 	const SDL_PixelFormat* GetFormat();

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3221,9 +3221,11 @@ void scriptclass::startgamemode( int t )
 		//load("intro");
 		break;
   case 22:  //play custom level (in game)
+  {
     //Initilise the level
     //First up, find the start point
-    ed.weirdloadthing(ed.ListOfMetaData[game.playcustomlevel].filename);
+    std::string filename = std::string(ed.ListOfMetaData[game.playcustomlevel].filename);
+    ed.load(filename);
     ed.findstartpoint();
 
     game.gamestate = GAMEMODE;
@@ -3263,10 +3265,13 @@ void scriptclass::startgamemode( int t )
 		graphics.fademode = 4;
     //load("intro");
   break;
+  }
   case 23: //Continue in custom level
+  {
       //Initilise the level
     //First up, find the start point
-    ed.weirdloadthing(ed.ListOfMetaData[game.playcustomlevel].filename);
+    std::string filename = std::string(ed.ListOfMetaData[game.playcustomlevel].filename);
+    ed.load(filename);
     ed.findstartpoint();
 
     game.gamestate = GAMEMODE;
@@ -3309,6 +3314,7 @@ void scriptclass::startgamemode( int t )
 		graphics.fademode = 4;
     //load("intro");
   break;
+  }
 #endif
 	case 100:
 		game.savestats();

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3224,7 +3224,7 @@ void scriptclass::startgamemode( int t )
     //Initilise the level
     //First up, find the start point
     ed.weirdloadthing(ed.ListOfMetaData[game.playcustomlevel].filename);
-    ed.findstartpoint(game);
+    ed.findstartpoint();
 
     game.gamestate = GAMEMODE;
     music.fadeout();
@@ -3253,7 +3253,7 @@ void scriptclass::startgamemode( int t )
     }
     map.gotoroom(game.saverx, game.savery);
 
-		ed.generatecustomminimap(graphics, map);
+		ed.generatecustomminimap();
 		map.customshowmm=true;
     if(ed.levmusic>0){
       music.play(ed.levmusic);
@@ -3267,7 +3267,7 @@ void scriptclass::startgamemode( int t )
       //Initilise the level
     //First up, find the start point
     ed.weirdloadthing(ed.ListOfMetaData[game.playcustomlevel].filename);
-    ed.findstartpoint(game);
+    ed.findstartpoint();
 
     game.gamestate = GAMEMODE;
     music.fadeout();
@@ -3305,7 +3305,7 @@ void scriptclass::startgamemode( int t )
       music.currentsong=-1;
 		}
 		*/
-		ed.generatecustomminimap(graphics, map);
+		ed.generatecustomminimap();
 		graphics.fademode = 4;
     //load("intro");
   break;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -717,7 +717,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "createentity")
 			{
-				obj.createentity(game, ss_toi(words[1]), ss_toi(words[2]), ss_toi(words[3]), ss_toi(words[4]), ss_toi(words[5]));
+				obj.createentity(ss_toi(words[1]), ss_toi(words[2]), ss_toi(words[3]), ss_toi(words[4]), ss_toi(words[5]));
 			}
 			else if (words[0] == "createcrewman")
 			{
@@ -786,11 +786,11 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 
 				if (ss_toi(words[5]) >= 16)
 				{
-					obj.createentity(game, ss_toi(words[1]), ss_toi(words[2]), 18, r, ss_toi(words[4]), ss_toi(words[5]), ss_toi(words[6]));
+					obj.createentity(ss_toi(words[1]), ss_toi(words[2]), 18, r, ss_toi(words[4]), ss_toi(words[5]), ss_toi(words[6]));
 				}
 				else
 				{
-					obj.createentity(game, ss_toi(words[1]), ss_toi(words[2]), 18, r, ss_toi(words[4]), ss_toi(words[5]));
+					obj.createentity(ss_toi(words[1]), ss_toi(words[2]), 18, r, ss_toi(words[4]), ss_toi(words[5]));
 				}
 			}
 			else if (words[0] == "changemood")
@@ -1810,22 +1810,22 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				i = 215;
 				if (game.crewstats[2] && game.lastsaved!=2)
 				{
-					obj.createentity(game, i, 153, 18, 14, 0, 17, 0);
+					obj.createentity(i, 153, 18, 14, 0, 17, 0);
 					i += 25;
 				}
 				if (game.crewstats[3] && game.lastsaved!=3)
 				{
-					obj.createentity(game, i, 153, 18, 15, 0, 17, 0);
+					obj.createentity(i, 153, 18, 15, 0, 17, 0);
 					i += 25;
 				}
 				if (game.crewstats[4] && game.lastsaved!=4)
 				{
-					obj.createentity(game, i, 153, 18, 13, 0, 17, 0);
+					obj.createentity(i, 153, 18, 13, 0, 17, 0);
 					i += 25;
 				}
 				if (game.crewstats[5] && game.lastsaved!=5)
 				{
-					obj.createentity(game, i, 153, 18, 16, 0, 17, 0);
+					obj.createentity(i, 153, 18, 16, 0, 17, 0);
 					i += 25;
 				}
 			}
@@ -2012,7 +2012,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 					r = 19;
 				}
 
-				obj.createentity(game, 200, 153, 18, r, 0, 19, 30);
+				obj.createentity(200, 153, 18, r, 0, 19, 30);
 				i = obj.getcrewman(game.lastsaved);
 				obj.entities[i].dir = 1;
 			}
@@ -2558,7 +2558,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -2581,7 +2581,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -2603,7 +2603,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -2642,7 +2642,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -2670,7 +2670,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -2698,7 +2698,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -2726,7 +2726,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -2754,7 +2754,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -2788,7 +2788,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -2813,7 +2813,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -2842,7 +2842,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -2878,7 +2878,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -2913,7 +2913,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -2948,7 +2948,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -2983,7 +2983,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -3018,7 +3018,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -3050,7 +3050,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -3082,7 +3082,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -3114,7 +3114,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -3146,7 +3146,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -3169,7 +3169,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -3206,7 +3206,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		if(obj.nentity==0)
 		{
-			obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
 		else
 		{
@@ -3245,7 +3245,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
     if(obj.nentity==0)
     {
-      obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+      obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
     }
     else
     {
@@ -3291,7 +3291,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
     if(obj.nentity==0)
     {
-      obj.createentity(game, game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+      obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
     }
     else
     {

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -240,7 +240,7 @@ void scriptclass::run()
 			}
 			if (words[0] == "playef")
 			{
-				music.playef(ss_toi(words[1]), ss_toi(words[2]));
+				music.playef(ss_toi(words[1]));
 			}
 			if (words[0] == "play")
 			{
@@ -1200,39 +1200,39 @@ void scriptclass::run()
 			{
 				if (words[1] == "player")
 				{
-					music.playef(11, 10);
+					music.playef(11);
 				}
 				else if (words[1] == "cyan")
 				{
-					music.playef(11, 10);
+					music.playef(11);
 				}
 				else if (words[1] == "red")
 				{
-					music.playef(16, 10);
+					music.playef(16);
 				}
 				else if (words[1] == "green")
 				{
-					music.playef(12, 10);
+					music.playef(12);
 				}
 				else if (words[1] == "yellow")
 				{
-					music.playef(14, 10);
+					music.playef(14);
 				}
 				else if (words[1] == "blue")
 				{
-					music.playef(13, 10);
+					music.playef(13);
 				}
 				else if (words[1] == "purple")
 				{
-					music.playef(15, 10);
+					music.playef(15);
 				}
 				else if (words[1] == "cry")
 				{
-					music.playef(2, 10);
+					music.playef(2);
 				}
 				else if (words[1] == "terminal")
 				{
-					music.playef(20, 10);
+					music.playef(20);
 				}
 			}
 			else if (words[0] == "blackout")
@@ -1880,7 +1880,7 @@ void scriptclass::run()
 			{
 				//music.silencedasmusik();
 				music.haltdasmusik();
-				music.playef(3,10);
+				music.playef(3);
 
 				game.trinkets++;
 				obj.collect[ss_toi(words[1])] = 1;
@@ -1916,7 +1916,7 @@ void scriptclass::run()
 			}
 			else if (words[0] == "foundlab")
 			{
-				music.playef(3,10);
+				music.playef(3);
 
 				graphics.textboxremovefast();
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -8,7 +8,7 @@
 
 scriptclass::scriptclass()
 {
-    	//Start SDL
+	//Start SDL
 
 	//Init
 	words.resize(40);
@@ -90,44 +90,44 @@ void scriptclass::run()
 				obj.entities[player].yp += ss_toi(words[2]);
 				scriptdelay = 1;
 			}
-	#if !defined(NO_CUSTOM_LEVELS)
+#if !defined(NO_CUSTOM_LEVELS)
 			if (words[0] == "warpdir")
 			{
-        int temprx=ss_toi(words[1])-1;
-        int tempry=ss_toi(words[2])-1;
-        int curlevel=temprx+(ed.maxwidth*(tempry));
-			  ed.level[curlevel].warpdir=ss_toi(words[3]);
-			  //If screen warping, then override all that:
-        graphics.backgrounddrawn = false;
+				int temprx=ss_toi(words[1])-1;
+				int tempry=ss_toi(words[2])-1;
+				int curlevel=temprx+(ed.maxwidth*(tempry));
+				ed.level[curlevel].warpdir=ss_toi(words[3]);
+				//If screen warping, then override all that:
+				graphics.backgrounddrawn = false;
 
-        //Do we update our own room?
-        if(game.roomx-100==temprx && game.roomy-100==tempry){
-          map.warpx=false; map.warpy=false;
-          if(ed.level[curlevel].warpdir==0){
-            map.background = 1;
-            //Be careful, we could be in a Lab or Warp Zone room...
-            if(ed.level[curlevel].tileset==2){
-              //Lab
-              map.background = 2;
-              graphics.rcol = ed.level[curlevel].tilecol;
-            }else if(ed.level[curlevel].tileset==3){
-              //Warp Zone
-              map.background = 6;
-            }
-          }else if(ed.level[curlevel].warpdir==1){
-            map.warpx=true;
-            map.background=3;
-            graphics.rcol = ed.getwarpbackground(temprx,tempry);
-          }else if(ed.level[curlevel].warpdir==2){
-            map.warpy=true;
-            map.background=4;
-            graphics.rcol = ed.getwarpbackground(temprx,tempry);
-          }else if(ed.level[curlevel].warpdir==3){
-            map.warpx=true; map.warpy=true;
-            map.background = 5;
-            graphics.rcol = ed.getwarpbackground(temprx,tempry);
-          }
-        }
+				//Do we update our own room?
+				if(game.roomx-100==temprx && game.roomy-100==tempry){
+					map.warpx=false; map.warpy=false;
+					if(ed.level[curlevel].warpdir==0){
+						map.background = 1;
+						//Be careful, we could be in a Lab or Warp Zone room...
+						if(ed.level[curlevel].tileset==2){
+							//Lab
+							map.background = 2;
+							graphics.rcol = ed.level[curlevel].tilecol;
+						}else if(ed.level[curlevel].tileset==3){
+							//Warp Zone
+							map.background = 6;
+						}
+					}else if(ed.level[curlevel].warpdir==1){
+						map.warpx=true;
+						map.background=3;
+						graphics.rcol = ed.getwarpbackground(temprx,tempry);
+					}else if(ed.level[curlevel].warpdir==2){
+						map.warpy=true;
+						map.background=4;
+						graphics.rcol = ed.getwarpbackground(temprx,tempry);
+					}else if(ed.level[curlevel].warpdir==3){
+						map.warpx=true; map.warpy=true;
+						map.background = 5;
+						graphics.rcol = ed.getwarpbackground(temprx,tempry);
+					}
+				}
 			}
 			if (words[0] == "ifwarp")
 			{
@@ -137,22 +137,22 @@ void scriptclass::run()
 					position--;
 				}
 			}
-	#endif
+#endif
 			if (words[0] == "destroy")
 			{
 				if(words[1]=="gravitylines"){
-				  for(int edi=0; edi<obj.nentity; edi++){
-				    if(obj.entities[edi].type==9) obj.entities[edi].active=false;
-				    if(obj.entities[edi].type==10) obj.entities[edi].active=false;
-				  }
+					for(int edi=0; edi<obj.nentity; edi++){
+						if(obj.entities[edi].type==9) obj.entities[edi].active=false;
+						if(obj.entities[edi].type==10) obj.entities[edi].active=false;
+					}
 				}else if(words[1]=="warptokens"){
-				  for(int edi=0; edi<obj.nentity; edi++){
-				    if(obj.entities[edi].type==11) obj.entities[edi].active=false;
-          }
+					for(int edi=0; edi<obj.nentity; edi++){
+						if(obj.entities[edi].type==11) obj.entities[edi].active=false;
+					}
 				}else if(words[1]=="platforms"){
-				  for(int edi=0; edi<obj.nentity; edi++){
-				    if(obj.entities[edi].rule==2 && obj.entities[edi].animate==100) obj.entities[edi].active=false;
-          }
+					for(int edi=0; edi<obj.nentity; edi++){
+						if(obj.entities[edi].rule==2 && obj.entities[edi].animate==100) obj.entities[edi].active=false;
+					}
 				}
 			}
 			if (words[0] == "customiftrinkets")
@@ -171,7 +171,7 @@ void scriptclass::run()
 					position--;
 				}
 			}
-      else if (words[0] == "customifflag")
+			else if (words[0] == "customifflag")
 			{
 				if (obj.flags[ss_toi(words[1])]==1)
 				{
@@ -182,9 +182,9 @@ void scriptclass::run()
 			if (words[0] == "custommap")
 			{
 				if(words[1]=="on"){
-				  map.customshowmm=true;
+					map.customshowmm=true;
 				}else if(words[1]=="off"){
-				  map.customshowmm=false;
+					map.customshowmm=false;
 				}
 			}
 			if (words[0] == "delay")
@@ -192,7 +192,7 @@ void scriptclass::run()
 				//USAGE: delay(frames)
 				scriptdelay = ss_toi(words[1]);
 			}
-      if (words[0] == "flag")
+			if (words[0] == "flag")
 			{
 				if(ss_toi(words[1])>=0 && ss_toi(words[1])<100){
 					if(words[2]=="on"){
@@ -254,7 +254,7 @@ void scriptclass::run()
 			{
 				music.play(music.resumesong);
 			}
-      if (words[0] == "musicfadeout")
+			if (words[0] == "musicfadeout")
 			{
 				music.fadeout();
 				music.dontquickfade = true;
@@ -532,8 +532,8 @@ void scriptclass::run()
 				}
 
 				if(i==0 && words[1]!="player" && words[1]!="cyan"){
-				  //Requested crewmate is not actually on screen
-          words[2] = "donothing";
+					//Requested crewmate is not actually on screen
+					words[2] = "donothing";
 					j = -1;
 					textx = -500;
 					texty = -500;
@@ -3214,107 +3214,107 @@ void scriptclass::startgamemode( int t )
 		}
 		map.gotoroom(game.saverx, game.savery);
 		if(ed.levmusic>0){
-		  music.play(ed.levmusic);
+			music.play(ed.levmusic);
 		}else{
-		  music.currentsong=-1;
+			music.currentsong=-1;
 		}
 		//load("intro");
 		break;
-  case 22:  //play custom level (in game)
-  {
-    //Initilise the level
-    //First up, find the start point
-    std::string filename = std::string(ed.ListOfMetaData[game.playcustomlevel].filename);
-    ed.load(filename);
-    ed.findstartpoint();
+	case 22:  //play custom level (in game)
+	{
+		//Initilise the level
+		//First up, find the start point
+		std::string filename = std::string(ed.ListOfMetaData[game.playcustomlevel].filename);
+		ed.load(filename);
+		ed.findstartpoint();
 
-    game.gamestate = GAMEMODE;
-    music.fadeout();
-    hardreset();
-    game.customstart();
-    game.jumpheld = true;
+		game.gamestate = GAMEMODE;
+		music.fadeout();
+		hardreset();
+		game.customstart();
+		game.jumpheld = true;
 
 		map.custommodeforreal = true;
-    map.custommode = true;
-    map.customx = 100;
-    map.customy = 100;
+		map.custommode = true;
+		map.customx = 100;
+		map.customy = 100;
 
-    //graphics.showcutscenebars = true;
-    //graphics.cutscenebarspos = 320;
+		//graphics.showcutscenebars = true;
+		//graphics.cutscenebarspos = 320;
 
-    //set flipmode
-    if (graphics.setflipmode) graphics.flipmode = true;
+		//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;
 
-    if(obj.nentity==0)
-    {
-      obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
-    }
-    else
-    {
-      map.resetplayer();
-    }
-    map.gotoroom(game.saverx, game.savery);
+		if(obj.nentity==0)
+		{
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+		}
+		else
+		{
+			map.resetplayer();
+		}
+		map.gotoroom(game.saverx, game.savery);
 
 		ed.generatecustomminimap();
 		map.customshowmm=true;
-    if(ed.levmusic>0){
-      music.play(ed.levmusic);
-    }else{
-      music.currentsong=-1;
+		if(ed.levmusic>0){
+			music.play(ed.levmusic);
+		}else{
+			music.currentsong=-1;
 		}
 		graphics.fademode = 4;
-    //load("intro");
-  break;
-  }
-  case 23: //Continue in custom level
-  {
-      //Initilise the level
-    //First up, find the start point
-    std::string filename = std::string(ed.ListOfMetaData[game.playcustomlevel].filename);
-    ed.load(filename);
-    ed.findstartpoint();
+		//load("intro");
+		break;
+	}
+	case 23: //Continue in custom level
+	{
+		//Initilise the level
+		//First up, find the start point
+		std::string filename = std::string(ed.ListOfMetaData[game.playcustomlevel].filename);
+		ed.load(filename);
+		ed.findstartpoint();
 
-    game.gamestate = GAMEMODE;
-    music.fadeout();
-    hardreset();
+		game.gamestate = GAMEMODE;
+		music.fadeout();
+		hardreset();
 		map.custommodeforreal = true;
-    map.custommode = true;
-    map.customx = 100;
-    map.customy = 100;
+		map.custommode = true;
+		map.customx = 100;
+		map.customy = 100;
 
-    game.customstart();
+		game.customstart();
 		game.customloadquick(ed.ListOfMetaData[game.playcustomlevel].filename);
-    game.jumpheld = true;
-    game.gravitycontrol = game.savegc;
+		game.jumpheld = true;
+		game.gravitycontrol = game.savegc;
 
 
-    //graphics.showcutscenebars = true;
-    //graphics.cutscenebarspos = 320;
+		//graphics.showcutscenebars = true;
+		//graphics.cutscenebarspos = 320;
 
-    //set flipmode
-    if (graphics.setflipmode) graphics.flipmode = true;
+		//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;
 
-    if(obj.nentity==0)
-    {
-      obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
-    }
-    else
-    {
-      map.resetplayer();
-    }
-    map.gotoroom(game.saverx, game.savery);
-    /* Handled by load
-    if(ed.levmusic>0){
-      music.play(ed.levmusic);
-    }else{
-      music.currentsong=-1;
+		if(obj.nentity==0)
+		{
+			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
+		}
+		else
+		{
+			map.resetplayer();
+		}
+		map.gotoroom(game.saverx, game.savery);
+		/* Handled by load
+		if(ed.levmusic>0){
+			music.play(ed.levmusic);
+		}else{
+			music.currentsong=-1;
 		}
 		*/
 		ed.generatecustomminimap();
 		graphics.fademode = 4;
-    //load("intro");
-  break;
-  }
+		//load("intro");
+		break;
+	}
 #endif
 	case 100:
 		game.savestats();
@@ -3524,8 +3524,8 @@ void scriptclass::hardreset()
 	game.state = 0;
 	game.statedelay = 0;
 
-  game.hascontrol = true;
-  game.advancetext = false;
+	game.hascontrol = true;
+	game.advancetext = false;
 
 	game.pausescript = false;
 
@@ -3536,7 +3536,7 @@ void scriptclass::hardreset()
 	graphics.showcutscenebars = false;
 	graphics.cutscenebarspos = 0;
 
-  //mapclass
+	//mapclass
 	map.warpx = false;
 	map.warpy = false;
 	map.showteleporters = false;
@@ -3584,9 +3584,9 @@ void scriptclass::hardreset()
 		obj.flags[i] = false;
 	}
 
-  for (i = 0; i < 6; i++){
-    obj.customcrewmoods[i]=1;
-  }
+	for (i = 0; i < 6; i++){
+		obj.customcrewmoods[i]=1;
+	}
 
 	for (i = 0; i < 100; i++)
 	{

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -280,7 +280,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			if (words[0] == "gotoroom")
 			{
 				//USAGE: gotoroom(x,y) (manually add 100)
-				map.gotoroom(ss_toi(words[1])+100, ss_toi(words[2])+100, dwgfx, game, obj, music);
+				map.gotoroom(ss_toi(words[1])+100, ss_toi(words[2])+100);
 			}
 			if (words[0] == "cutscene")
 			{
@@ -1462,7 +1462,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			{
 				map.resetnames();
 				map.resetmap();
-				map.resetplayer(dwgfx, game, obj, music);
+				map.resetplayer();
 				map.tdrawback = true;
 
 				obj.resetallflags();
@@ -1518,7 +1518,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				map.finaly = ss_toi(words[2]);
 				game.roomx = map.finalx;
 				game.roomy = map.finaly;
-				map.gotoroom(game.roomx, game.roomy, dwgfx, game, obj, music);
+				map.gotoroom(game.roomx, game.roomy);
 			}
 			else if (words[0] == "rescued")
 			{
@@ -1983,7 +1983,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				game.savepoint = 0;
 				game.gravitycontrol = 0;
 
-				map.gotoroom(46, 54, dwgfx, game, obj, music);
+				map.gotoroom(46, 54);
 			}
 			else if (words[0] == "telesave")
 			{
@@ -2562,9 +2562,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intro");
 		break;
@@ -2585,9 +2585,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 		dwgfx.fademode = 4;
 		break;
 	case 2: //Load Quicksave
@@ -2607,13 +2607,13 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 		//a very special case for here needs to ensure that the tower is set correctly
 		if (map.towermode)
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 
 			i = obj.getplayer();
 			map.ypos = obj.entities[i].yp - 120;
@@ -2646,9 +2646,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 		dwgfx.fademode = 4;
 		break;
 	case 4:
@@ -2674,9 +2674,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 		dwgfx.fademode = 4;
 		break;
 	case 5:
@@ -2702,9 +2702,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 		dwgfx.fademode = 4;
 		break;
 	case 6:
@@ -2730,9 +2730,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 		dwgfx.fademode = 4;
 		break;
 	case 7:
@@ -2758,9 +2758,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 		dwgfx.fademode = 4;
 		break;
 	case 8:
@@ -2792,9 +2792,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 		dwgfx.fademode = 4;
 		break;
 	case 9:
@@ -2817,9 +2817,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 
 		load("intro");
@@ -2846,9 +2846,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 
 		load("intro");
@@ -2882,9 +2882,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 		music.play(11);
 		dwgfx.fademode = 4;
 		break;
@@ -2917,9 +2917,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intermission_1");
 		break;
@@ -2952,9 +2952,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intermission_1");
 		break;
@@ -2987,9 +2987,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intermission_1");
 		break;
@@ -3022,9 +3022,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intermission_1");
 		break;
@@ -3054,9 +3054,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intermission_2");
 		break;
@@ -3086,9 +3086,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intermission_2");
 		break;
@@ -3118,9 +3118,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intermission_2");
 		break;
@@ -3150,9 +3150,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 
 		load("intermission_2");
 		break;
@@ -3173,9 +3173,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 		dwgfx.fademode = 4;
 		break;
 	case 21:  //play custom level (in editor)
@@ -3210,9 +3210,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		else
 		{
-			map.resetplayer(dwgfx, game, obj, music);
+			map.resetplayer();
 		}
-		map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+		map.gotoroom(game.saverx, game.savery);
 		if(ed.levmusic>0){
 		  music.play(ed.levmusic);
 		}else{
@@ -3249,9 +3249,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
     }
     else
     {
-      map.resetplayer(dwgfx, game, obj, music);
+      map.resetplayer();
     }
-    map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+    map.gotoroom(game.saverx, game.savery);
 
 		ed.generatecustomminimap(dwgfx, map);
 		map.customshowmm=true;
@@ -3295,9 +3295,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
     }
     else
     {
-      map.resetplayer(dwgfx, game, obj, music);
+      map.resetplayer();
     }
-    map.gotoroom(game.saverx, game.savery, dwgfx, game, obj, music);
+    map.gotoroom(game.saverx, game.savery);
     /* Handled by load
     if(ed.levmusic>0){
       music.play(ed.levmusic);
@@ -3342,7 +3342,7 @@ void scriptclass::teleport( Graphics& dwgfx, Game& game, mapclass& map, entitycl
 	}
 
 	game.gravitycontrol = 0;
-	map.gotoroom(100+game.teleport_to_x, 100+game.teleport_to_y, dwgfx, game, obj, music);
+	map.gotoroom(100+game.teleport_to_x, 100+game.teleport_to_y);
 	j = obj.getteleporter();
 	obj.entities[j].state = 2;
 	game.teleport_to_new_area = false;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1987,7 +1987,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "telesave")
 			{
-				if (!game.intimetrial && !game.nodeathmode && !game.inintermission) game.savetele(map, obj, music);
+				if (!game.intimetrial && !game.nodeathmode && !game.inintermission) game.savetele();
 			}
 			else if (words[0] == "createlastrescued")
 			{
@@ -2548,7 +2548,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 	case 0:  //Normal new game
 		game.gamestate = GAMEMODE;
 		hardreset(key, dwgfx, game, map, obj, help, music);
-		game.start(obj, music);
+		game.start();
 		game.jumpheld = true;
 		dwgfx.showcutscenebars = true;
 		dwgfx.cutscenebarspos = 320;
@@ -2571,8 +2571,8 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 	case 1:
 		game.gamestate = GAMEMODE;
 		hardreset(key, dwgfx, game, map, obj, help, music);
-		game.start(obj, music);
-		game.loadtele(map, obj, music);
+		game.start();
+		game.loadtele();
 		game.gravitycontrol = game.savegc;
 		game.jumpheld = true;
 
@@ -2593,8 +2593,8 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 	case 2: //Load Quicksave
 		game.gamestate = GAMEMODE;
 		hardreset(key, dwgfx, game, map, obj, help, music);
-		game.start(obj, music);
-		game.loadquick(map, obj, music);
+		game.start();
+		game.loadquick();
 		game.gravitycontrol = game.savegc;
 		game.jumpheld = true;
 
@@ -2636,7 +2636,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		music.fadeout();
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
@@ -2664,7 +2664,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		music.fadeout();
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
@@ -2692,7 +2692,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		music.fadeout();
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
@@ -2720,7 +2720,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		music.fadeout();
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
@@ -2748,7 +2748,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		music.fadeout();
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
@@ -2782,7 +2782,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
@@ -2801,11 +2801,11 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.gamestate = GAMEMODE;
 		hardreset(key, dwgfx, game, map, obj, help, music);
 		game.nodeathmode = true;
-		game.start(obj, music);
+		game.start();
 		game.jumpheld = true;
 		dwgfx.showcutscenebars = true;
 		dwgfx.cutscenebarspos = 320;
-		//game.starttest(obj, music);
+		//game.starttest();
 		//music.play(4);
 
 		//set flipmode
@@ -2830,11 +2830,11 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.nodeathmode = true;
 		game.nocutscenes = true;
 
-		game.start(obj, music);
+		game.start();
 		game.jumpheld = true;
 		dwgfx.showcutscenebars = true;
 		dwgfx.cutscenebarspos = 320;
-		//game.starttest(obj, music);
+		//game.starttest();
 		//music.play(4);
 
 		//set flipmode
@@ -2857,7 +2857,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.gamestate = GAMEMODE;
 		hardreset(key, dwgfx, game, map, obj, help, music);
 
-		game.startspecial(0, obj, music);
+		game.startspecial(0);
 		game.jumpheld = true;
 
 		//Secret lab, so reveal the map, give them all 20 trinkets
@@ -2906,7 +2906,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
@@ -2941,7 +2941,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
@@ -2976,7 +2976,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
@@ -3011,7 +3011,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
@@ -3043,7 +3043,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
@@ -3075,7 +3075,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
@@ -3107,7 +3107,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
@@ -3139,7 +3139,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
@@ -3190,7 +3190,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 				ed.kludgewarpdir[i+(j*ed.maxwidth)]=ed.level[i+(j*ed.maxwidth)].warpdir;
 			}
 		}
-		game.customstart(obj, music);
+		game.customstart();
 		game.jumpheld = true;
 
 
@@ -3229,7 +3229,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
     game.gamestate = GAMEMODE;
     music.fadeout();
     hardreset(key, dwgfx, game, map, obj, help, music);
-    game.customstart(obj, music);
+    game.customstart();
     game.jumpheld = true;
 
 		map.custommodeforreal = true;
@@ -3277,8 +3277,8 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
     map.customx = 100;
     map.customy = 100;
 
-    game.customstart(obj, music);
-		game.customloadquick(ed.ListOfMetaData[game.playcustomlevel].filename, map, obj, music);
+    game.customstart();
+		game.customloadquick(ed.ListOfMetaData[game.playcustomlevel].filename);
     game.jumpheld = true;
     game.gravitycontrol = game.savegc;
 
@@ -3311,7 +3311,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
   break;
 #endif
 	case 100:
-		game.savestats(map, dwgfx);
+		game.savestats();
 
 		SDL_Quit();
 		exit(0);
@@ -3422,7 +3422,7 @@ void scriptclass::teleport( Graphics& dwgfx, Game& game, mapclass& map, entitycl
 				dwgfx.createtextbox("    Game Saved    ", -1, 12, 174, 174, 174);
 				dwgfx.textboxtimer(25);
 			}
-			game.savetele(map, obj, music);
+			game.savetele();
 		}
 	}
 }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1271,7 +1271,6 @@ void scriptclass::run()
 					game.gamestate = 5;
 					graphics.menuoffset = 240; //actually this should count the roomname
 					if (map.extrarow) graphics.menuoffset -= 10;
-					//graphics.menubuffer.copyPixels(graphics.screenbuffer, graphics.screenbuffer.rect, graphics.tl, null, null, false);
 
 					graphics.resumegamemode = false;
 
@@ -2805,8 +2804,6 @@ void scriptclass::startgamemode( int t )
 		game.jumpheld = true;
 		graphics.showcutscenebars = true;
 		graphics.cutscenebarspos = 320;
-		//game.starttest();
-		//music.play(4);
 
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
@@ -2834,8 +2831,6 @@ void scriptclass::startgamemode( int t )
 		game.jumpheld = true;
 		graphics.showcutscenebars = true;
 		graphics.cutscenebarspos = 320;
-		//game.starttest();
-		//music.play(4);
 
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
@@ -3198,9 +3193,6 @@ void scriptclass::startgamemode( int t )
 		map.customx = 100;
 		map.customy = 100;
 
-		//graphics.showcutscenebars = true;
-		//graphics.cutscenebarspos = 320;
-
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
 
@@ -3218,7 +3210,6 @@ void scriptclass::startgamemode( int t )
 		}else{
 			music.currentsong=-1;
 		}
-		//load("intro");
 		break;
 	case 22:  //play custom level (in game)
 	{
@@ -3238,9 +3229,6 @@ void scriptclass::startgamemode( int t )
 		map.custommode = true;
 		map.customx = 100;
 		map.customy = 100;
-
-		//graphics.showcutscenebars = true;
-		//graphics.cutscenebarspos = 320;
 
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
@@ -3263,7 +3251,6 @@ void scriptclass::startgamemode( int t )
 			music.currentsong=-1;
 		}
 		graphics.fademode = 4;
-		//load("intro");
 		break;
 	}
 	case 23: //Continue in custom level
@@ -3288,9 +3275,6 @@ void scriptclass::startgamemode( int t )
 		game.gravitycontrol = game.savegc;
 
 
-		//graphics.showcutscenebars = true;
-		//graphics.cutscenebarspos = 320;
-
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
 
@@ -3303,16 +3287,8 @@ void scriptclass::startgamemode( int t )
 			map.resetplayer();
 		}
 		map.gotoroom(game.saverx, game.savery);
-		/* Handled by load
-		if(ed.levmusic>0){
-			music.play(ed.levmusic);
-		}else{
-			music.currentsong=-1;
-		}
-		*/
 		ed.generatecustomminimap();
 		graphics.fademode = 4;
-		//load("intro");
 		break;
 	}
 #endif

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -66,7 +66,7 @@ void scriptclass::tokenize( std::string t )
 	}
 }
 
-void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void scriptclass::run()
 {
 	while(running && scriptdelay<=0 && !game.pausescript)
 	{
@@ -98,7 +98,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         int curlevel=temprx+(ed.maxwidth*(tempry));
 			  ed.level[curlevel].warpdir=ss_toi(words[3]);
 			  //If screen warping, then override all that:
-        dwgfx.backgrounddrawn = false;
+        graphics.backgrounddrawn = false;
 
         //Do we update our own room?
         if(game.roomx-100==temprx && game.roomy-100==tempry){
@@ -109,7 +109,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
             if(ed.level[curlevel].tileset==2){
               //Lab
               map.background = 2;
-              dwgfx.rcol = ed.level[curlevel].tilecol;
+              graphics.rcol = ed.level[curlevel].tilecol;
             }else if(ed.level[curlevel].tileset==3){
               //Warp Zone
               map.background = 6;
@@ -117,15 +117,15 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
           }else if(ed.level[curlevel].warpdir==1){
             map.warpx=true;
             map.background=3;
-            dwgfx.rcol = ed.getwarpbackground(temprx,tempry);
+            graphics.rcol = ed.getwarpbackground(temprx,tempry);
           }else if(ed.level[curlevel].warpdir==2){
             map.warpy=true;
             map.background=4;
-            dwgfx.rcol = ed.getwarpbackground(temprx,tempry);
+            graphics.rcol = ed.getwarpbackground(temprx,tempry);
           }else if(ed.level[curlevel].warpdir==3){
             map.warpx=true; map.warpy=true;
             map.background = 5;
-            dwgfx.rcol = ed.getwarpbackground(temprx,tempry);
+            graphics.rcol = ed.getwarpbackground(temprx,tempry);
           }
         }
 			}
@@ -284,17 +284,17 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			if (words[0] == "cutscene")
 			{
-				dwgfx.showcutscenebars = true;
+				graphics.showcutscenebars = true;
 			}
 			if (words[0] == "endcutscene")
 			{
-				dwgfx.showcutscenebars = false;
+				graphics.showcutscenebars = false;
 			}
 			if (words[0] == "untilbars")
 			{
-				if (dwgfx.showcutscenebars)
+				if (graphics.showcutscenebars)
 				{
-					if (dwgfx.cutscenebarspos < 360)
+					if (graphics.cutscenebarspos < 360)
 					{
 						scriptdelay = 1;
 						position--;
@@ -302,7 +302,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				}
 				else
 				{
-					if (dwgfx.cutscenebarspos > 0)
+					if (graphics.cutscenebarspos > 0)
 					{
 						scriptdelay = 1;
 						position--;
@@ -573,17 +573,17 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "flipme")
 			{
-				if(dwgfx.flipmode) texty += 2*(120 - texty) - 8*(txtnumlines+2);
+				if(graphics.flipmode) texty += 2*(120 - texty) - 8*(txtnumlines+2);
 			}
 			else if (words[0] == "speak_active")
 			{
 				//Ok, actually display the textbox we've initilised now!
-				dwgfx.createtextbox(txt[0], textx, texty, r, g, b);
+				graphics.createtextbox(txt[0], textx, texty, r, g, b);
 				if (txtnumlines > 1)
 				{
 					for (i = 1; i < txtnumlines; i++)
 					{
-						dwgfx.addline(txt[i]);
+						graphics.addline(txt[i]);
 					}
 				}
 
@@ -592,23 +592,23 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				{
 					//position to the left of the player
 					textx += 10000;
-					textx -= dwgfx.textboxwidth();
+					textx -= graphics.textboxwidth();
 					textx += 16;
-					dwgfx.textboxmoveto(textx);
+					graphics.textboxmoveto(textx);
 				}
 
 				if (textx == -500 || textx == -1)
 				{
-					dwgfx.textboxcenterx();
+					graphics.textboxcenterx();
 				}
 
 				if (texty == -500)
 				{
-					dwgfx.textboxcentery();
+					graphics.textboxcentery();
 				}
 
-				dwgfx.textboxadjust();
-				dwgfx.textboxactive();
+				graphics.textboxadjust();
+				graphics.textboxactive();
 
 				if (!game.backgroundtext)
 				{
@@ -623,12 +623,12 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			else if (words[0] == "speak")
 			{
 				//Exactly as above, except don't make the textbox active (so we can use multiple textboxes)
-				dwgfx.createtextbox(txt[0], textx, texty, r, g, b);
+				graphics.createtextbox(txt[0], textx, texty, r, g, b);
 				if (txtnumlines > 1)
 				{
 					for (i = 1; i < txtnumlines; i++)
 					{
-						dwgfx.addline(txt[i]);
+						graphics.addline(txt[i]);
 					}
 				}
 
@@ -637,23 +637,23 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				{
 					//position to the left of the player
 					textx += 10000;
-					textx -= dwgfx.textboxwidth();
+					textx -= graphics.textboxwidth();
 					textx += 16;
-					dwgfx.textboxmoveto(textx);
+					graphics.textboxmoveto(textx);
 				}
 
 				if (textx == -500 || textx == -1)
 				{
-					dwgfx.textboxcenterx();
+					graphics.textboxcenterx();
 				}
 
 				if (texty == -500)
 				{
-					dwgfx.textboxcentery();
+					graphics.textboxcentery();
 				}
 
-				dwgfx.textboxadjust();
-				//dwgfx.textboxactive();
+				graphics.textboxadjust();
+				//graphics.textboxactive();
 
 				if (!game.backgroundtext)
 				{
@@ -667,13 +667,13 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "endtext")
 			{
-				dwgfx.textboxremove();
+				graphics.textboxremove();
 				game.hascontrol = true;
 				game.advancetext = false;
 			}
 			else if (words[0] == "endtextfast")
 			{
-				dwgfx.textboxremovefast();
+				graphics.textboxremovefast();
 				game.hascontrol = true;
 				game.advancetext = false;
 			}
@@ -1261,7 +1261,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "textboxactive")
 			{
-				dwgfx.textboxactive();
+				graphics.textboxactive();
 			}
 			else if (words[0] == "gamemode")
 			{
@@ -1269,17 +1269,17 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				{
 					//TODO this draw the teleporter screen. This is a problem. :(
 					game.gamestate = 5;
-					dwgfx.menuoffset = 240; //actually this should count the roomname
-					if (map.extrarow) dwgfx.menuoffset -= 10;
-					//dwgfx.menubuffer.copyPixels(dwgfx.screenbuffer, dwgfx.screenbuffer.rect, dwgfx.tl, null, null, false);
+					graphics.menuoffset = 240; //actually this should count the roomname
+					if (map.extrarow) graphics.menuoffset -= 10;
+					//graphics.menubuffer.copyPixels(graphics.screenbuffer, graphics.screenbuffer.rect, graphics.tl, null, null, false);
 
-					dwgfx.resumegamemode = false;
+					graphics.resumegamemode = false;
 
 					game.useteleporter = false; //good heavens don't actually use it
 				}
 				else if (words[1] == "game")
 				{
-					dwgfx.resumegamemode = true;
+					graphics.resumegamemode = true;
 				}
 			}
 			else if (words[0] == "ifexplored")
@@ -1430,20 +1430,20 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "befadein")
 			{
-				dwgfx.fadeamount = 0;
-				dwgfx.fademode= 0;
+				graphics.fadeamount = 0;
+				graphics.fademode= 0;
 			}
 			else if (words[0] == "fadein")
 			{
-				dwgfx.fademode = 4;
+				graphics.fademode = 4;
 			}
 			else if (words[0] == "fadeout")
 			{
-				dwgfx.fademode = 2;
+				graphics.fademode = 2;
 			}
 			else if (words[0] == "untilfade")
 			{
-				if (dwgfx.fademode>1)
+				if (graphics.fademode>1)
 				{
 					scriptdelay = 1;
 					position--;
@@ -1508,7 +1508,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			else if (words[0] == "rollcredits")
 			{
 				game.gamestate = 6;
-				dwgfx.fademode = 4;
+				graphics.fademode = 4;
 				game.creditposition = 0;
 			}
 			else if (words[0] == "finalmode")
@@ -1885,12 +1885,12 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				game.trinkets++;
 				obj.collect[ss_toi(words[1])] = 1;
 
-				dwgfx.textboxremovefast();
+				graphics.textboxremovefast();
 
-				dwgfx.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
-				dwgfx.addline("");
-				dwgfx.addline("You have found a shiny trinket!");
-				dwgfx.textboxcenterx();
+				graphics.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
+				graphics.addline("");
+				graphics.addline("You have found a shiny trinket!");
+				graphics.textboxcenterx();
 
 				std::string usethisnum;
 				if (map.custommode)
@@ -1901,8 +1901,8 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				{
 					usethisnum = "Twenty";
 				}
-				dwgfx.createtextbox(" " + help.number(game.trinkets) + " out of " + usethisnum + " ", 50, 135, 174, 174, 174);
-				dwgfx.textboxcenterx();
+				graphics.createtextbox(" " + help.number(game.trinkets) + " out of " + usethisnum + " ", 50, 135, 174, 174, 174);
+				graphics.textboxcenterx();
 
 				if (!game.backgroundtext)
 				{
@@ -1918,13 +1918,13 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			{
 				music.playef(3,10);
 
-				dwgfx.textboxremovefast();
+				graphics.textboxremovefast();
 
-				dwgfx.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
-				dwgfx.addline("");
-				dwgfx.addline("You have found the secret lab!");
-				dwgfx.textboxcenterx();
-				dwgfx.textboxcentery();
+				graphics.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
+				graphics.addline("");
+				graphics.addline("You have found the secret lab!");
+				graphics.textboxcenterx();
+				graphics.textboxcentery();
 
 				if (!game.backgroundtext)
 				{
@@ -1938,15 +1938,15 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "foundlab2")
 			{
-				dwgfx.textboxremovefast();
+				graphics.textboxremovefast();
 
-				dwgfx.createtextbox("The secret lab is separate from", 50, 85, 174, 174, 174);
-				dwgfx.addline("the rest of the game. You can");
-				dwgfx.addline("now come back here at any time");
-				dwgfx.addline("by selecting the new SECRET LAB");
-				dwgfx.addline("option in the play menu.");
-				dwgfx.textboxcenterx();
-				dwgfx.textboxcentery();
+				graphics.createtextbox("The secret lab is separate from", 50, 85, 174, 174, 174);
+				graphics.addline("the rest of the game. You can");
+				graphics.addline("now come back here at any time");
+				graphics.addline("by selecting the new SECRET LAB");
+				graphics.addline("option in the play menu.");
+				graphics.textboxcenterx();
+				graphics.textboxcentery();
 
 				if (!game.backgroundtext)
 				{
@@ -2532,29 +2532,29 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 	}
 }
 
-void scriptclass::resetgametomenu( Graphics& dwgfx, Game& game,mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void scriptclass::resetgametomenu()
 {
 	game.gamestate = TITLEMODE;
-	dwgfx.flipmode = false;
+	graphics.flipmode = false;
 	obj.nentity = 0;
-	dwgfx.fademode = 4;
+	graphics.fademode = 4;
 	game.createmenu("gameover");
 }
 
-void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void scriptclass::startgamemode( int t )
 {
 	switch(t)
 	{
 	case 0:  //Normal new game
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.start();
 		game.jumpheld = true;
-		dwgfx.showcutscenebars = true;
-		dwgfx.cutscenebarspos = 320;
+		graphics.showcutscenebars = true;
+		graphics.cutscenebarspos = 320;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 
 		if(obj.nentity==0)
 		{
@@ -2570,14 +2570,14 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 1:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.start();
 		game.loadtele();
 		game.gravitycontrol = game.savegc;
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 
 		if(obj.nentity==0)
 		{
@@ -2588,18 +2588,18 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 			map.resetplayer();
 		}
 		map.gotoroom(game.saverx, game.savery);
-		dwgfx.fademode = 4;
+		graphics.fademode = 4;
 		break;
 	case 2: //Load Quicksave
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.start();
 		game.loadquick();
 		game.gravitycontrol = game.savegc;
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 
 		if(obj.nentity==0)
 		{
@@ -2621,11 +2621,11 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 			map.cameramode = 0;
 			map.colsuperstate = 0;
 		}
-		dwgfx.fademode = 4;
+		graphics.fademode = 4;
 		break;
 	case 3:
 		//Start Time Trial 1
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2639,7 +2639,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
@@ -2649,11 +2649,11 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 			map.resetplayer();
 		}
 		map.gotoroom(game.saverx, game.savery);
-		dwgfx.fademode = 4;
+		graphics.fademode = 4;
 		break;
 	case 4:
 		//Start Time Trial 2
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2667,7 +2667,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
@@ -2677,11 +2677,11 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 			map.resetplayer();
 		}
 		map.gotoroom(game.saverx, game.savery);
-		dwgfx.fademode = 4;
+		graphics.fademode = 4;
 		break;
 	case 5:
 		//Start Time Trial 3 tow
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2695,7 +2695,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
@@ -2705,11 +2705,11 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 			map.resetplayer();
 		}
 		map.gotoroom(game.saverx, game.savery);
-		dwgfx.fademode = 4;
+		graphics.fademode = 4;
 		break;
 	case 6:
 		//Start Time Trial 4 station
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2723,7 +2723,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
@@ -2733,11 +2733,11 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 			map.resetplayer();
 		}
 		map.gotoroom(game.saverx, game.savery);
-		dwgfx.fademode = 4;
+		graphics.fademode = 4;
 		break;
 	case 7:
 		//Start Time Trial 5 warp
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2751,7 +2751,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
@@ -2761,11 +2761,11 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 			map.resetplayer();
 		}
 		map.gotoroom(game.saverx, game.savery);
-		dwgfx.fademode = 4;
+		graphics.fademode = 4;
 		break;
 	case 8:
 		//Start Time Trial 6// final level!
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2785,7 +2785,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
@@ -2795,21 +2795,21 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 			map.resetplayer();
 		}
 		map.gotoroom(game.saverx, game.savery);
-		dwgfx.fademode = 4;
+		graphics.fademode = 4;
 		break;
 	case 9:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.nodeathmode = true;
 		game.start();
 		game.jumpheld = true;
-		dwgfx.showcutscenebars = true;
-		dwgfx.cutscenebarspos = 320;
+		graphics.showcutscenebars = true;
+		graphics.cutscenebarspos = 320;
 		//game.starttest();
 		//music.play(4);
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 
 		if(obj.nentity==0)
 		{
@@ -2826,19 +2826,19 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 10:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		game.nodeathmode = true;
 		game.nocutscenes = true;
 
 		game.start();
 		game.jumpheld = true;
-		dwgfx.showcutscenebars = true;
-		dwgfx.cutscenebarspos = 320;
+		graphics.showcutscenebars = true;
+		graphics.cutscenebarspos = 320;
 		//game.starttest();
 		//music.play(4);
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 
 		if(obj.nentity==0)
 		{
@@ -2855,7 +2855,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 11:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 
 		game.startspecial(0);
 		game.jumpheld = true;
@@ -2874,7 +2874,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.showteleporters = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 
 		if(obj.nentity==0)
 		{
@@ -2886,11 +2886,11 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		}
 		map.gotoroom(game.saverx, game.savery);
 		music.play(11);
-		dwgfx.fademode = 4;
+		graphics.fademode = 4;
 		break;
 	case 12:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		music.fadeout();
 
 		game.lastsaved = 2;
@@ -2910,7 +2910,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 		if(obj.nentity==0)
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
@@ -2925,7 +2925,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 13:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		music.fadeout();
 
 		game.lastsaved = 3;
@@ -2945,7 +2945,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 		if(obj.nentity==0)
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
@@ -2960,7 +2960,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 14:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		music.fadeout();
 
 		game.lastsaved = 4;
@@ -2980,7 +2980,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 		if(obj.nentity==0)
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
@@ -2995,7 +2995,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 15:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		music.fadeout();
 
 		game.lastsaved = 5;
@@ -3015,7 +3015,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 		if(obj.nentity==0)
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
@@ -3030,7 +3030,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 16:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		music.fadeout();
 
 		game.lastsaved = 2;
@@ -3047,7 +3047,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 		if(obj.nentity==0)
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
@@ -3062,7 +3062,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 17:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		music.fadeout();
 
 		game.lastsaved = 3;
@@ -3079,7 +3079,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 		if(obj.nentity==0)
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
@@ -3094,7 +3094,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 18:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		music.fadeout();
 
 		game.lastsaved = 4;
@@ -3111,7 +3111,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 		if(obj.nentity==0)
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
@@ -3126,7 +3126,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 19:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		music.fadeout();
 
 		game.lastsaved = 5;
@@ -3143,7 +3143,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		game.jumpheld = true;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 		if(obj.nentity==0)
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
@@ -3159,14 +3159,14 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 #if !defined(NO_CUSTOM_LEVELS)
 	case 20:
 		//Level editor
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		ed.reset();
 		music.fadeout();
 
 		game.gamestate = EDITORMODE;
 		game.jumpheld = true;
 
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
+		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
 		if(obj.nentity==0)
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
@@ -3176,12 +3176,12 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 			map.resetplayer();
 		}
 		map.gotoroom(game.saverx, game.savery);
-		dwgfx.fademode = 4;
+		graphics.fademode = 4;
 		break;
 	case 21:  //play custom level (in editor)
 		game.gamestate = GAMEMODE;
 		music.fadeout();
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset();
 		//If warpdir() is used during playtesting, we need to set it back after!
 		for (int j = 0; j < ed.maxheight; j++)
 		{
@@ -3198,11 +3198,11 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.customx = 100;
 		map.customy = 100;
 
-		//dwgfx.showcutscenebars = true;
-		//dwgfx.cutscenebarspos = 320;
+		//graphics.showcutscenebars = true;
+		//graphics.cutscenebarspos = 320;
 
 		//set flipmode
-		if (dwgfx.setflipmode) dwgfx.flipmode = true;
+		if (graphics.setflipmode) graphics.flipmode = true;
 
 		if(obj.nentity==0)
 		{
@@ -3228,7 +3228,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
     game.gamestate = GAMEMODE;
     music.fadeout();
-    hardreset(key, dwgfx, game, map, obj, help, music);
+    hardreset();
     game.customstart();
     game.jumpheld = true;
 
@@ -3237,11 +3237,11 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
     map.customx = 100;
     map.customy = 100;
 
-    //dwgfx.showcutscenebars = true;
-    //dwgfx.cutscenebarspos = 320;
+    //graphics.showcutscenebars = true;
+    //graphics.cutscenebarspos = 320;
 
     //set flipmode
-    if (dwgfx.setflipmode) dwgfx.flipmode = true;
+    if (graphics.setflipmode) graphics.flipmode = true;
 
     if(obj.nentity==0)
     {
@@ -3253,14 +3253,14 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
     }
     map.gotoroom(game.saverx, game.savery);
 
-		ed.generatecustomminimap(dwgfx, map);
+		ed.generatecustomminimap(graphics, map);
 		map.customshowmm=true;
     if(ed.levmusic>0){
       music.play(ed.levmusic);
     }else{
       music.currentsong=-1;
 		}
-		dwgfx.fademode = 4;
+		graphics.fademode = 4;
     //load("intro");
   break;
   case 23: //Continue in custom level
@@ -3271,7 +3271,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
     game.gamestate = GAMEMODE;
     music.fadeout();
-    hardreset(key, dwgfx, game, map, obj, help, music);
+    hardreset();
 		map.custommodeforreal = true;
     map.custommode = true;
     map.customx = 100;
@@ -3283,11 +3283,11 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
     game.gravitycontrol = game.savegc;
 
 
-    //dwgfx.showcutscenebars = true;
-    //dwgfx.cutscenebarspos = 320;
+    //graphics.showcutscenebars = true;
+    //graphics.cutscenebarspos = 320;
 
     //set flipmode
-    if (dwgfx.setflipmode) dwgfx.flipmode = true;
+    if (graphics.setflipmode) graphics.flipmode = true;
 
     if(obj.nentity==0)
     {
@@ -3305,8 +3305,8 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
       music.currentsong=-1;
 		}
 		*/
-		ed.generatecustomminimap(dwgfx, map);
-		dwgfx.fademode = 4;
+		ed.generatecustomminimap(graphics, map);
+		graphics.fademode = 4;
     //load("intro");
   break;
 #endif
@@ -3319,7 +3319,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 	}
 }
 
-void scriptclass::teleport( Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void scriptclass::teleport()
 {
 	//er, ok! Teleport to a new area, so!
 	//A general rule of thumb: if you teleport with a companion, get rid of them!
@@ -3402,7 +3402,7 @@ void scriptclass::teleport( Graphics& dwgfx, Game& game, mapclass& map, entitycl
 	else
 	{
 		//change music based on location
-		if (dwgfx.setflipmode && game.teleport_to_x == 11 && game.teleport_to_y == 4)
+		if (graphics.setflipmode && game.teleport_to_x == 11 && game.teleport_to_y == 4)
 		{
 			music.niceplay(9);
 		}
@@ -3412,22 +3412,22 @@ void scriptclass::teleport( Graphics& dwgfx, Game& game, mapclass& map, entitycl
 		}
 		if (!game.intimetrial && !game.nodeathmode && !game.inintermission)
 		{
-			if (dwgfx.flipmode)
+			if (graphics.flipmode)
 			{
-				dwgfx.createtextbox("    Game Saved    ", -1, 202, 174, 174, 174);
-				dwgfx.textboxtimer(25);
+				graphics.createtextbox("    Game Saved    ", -1, 202, 174, 174, 174);
+				graphics.textboxtimer(25);
 			}
 			else
 			{
-				dwgfx.createtextbox("    Game Saved    ", -1, 12, 174, 174, 174);
-				dwgfx.textboxtimer(25);
+				graphics.createtextbox("    Game Saved    ", -1, 12, 174, 174, 174);
+				graphics.textboxtimer(25);
 			}
 			game.savetele();
 		}
 	}
 }
 
-void scriptclass::hardreset( KeyPoll& key, Graphics& dwgfx, Game& game,mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void scriptclass::hardreset()
 {
 	//Game:
 	game.hascontrol = true;
@@ -3524,11 +3524,11 @@ void scriptclass::hardreset( KeyPoll& key, Graphics& dwgfx, Game& game,mapclass&
 	game.pausescript = false;
 
 	//dwgraphicsclass
-	dwgfx.backgrounddrawn = false;
-	dwgfx.textboxremovefast();
-	dwgfx.flipmode = false; //This will be reset if needs be elsewhere
-	dwgfx.showcutscenebars = false;
-	dwgfx.cutscenebarspos = 0;
+	graphics.backgrounddrawn = false;
+	graphics.textboxremovefast();
+	graphics.flipmode = false; //This will be reset if needs be elsewhere
+	graphics.showcutscenebars = false;
+	graphics.cutscenebarspos = 0;
 
   //mapclass
 	map.warpx = false;

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -7,9 +7,6 @@
 #include "Enums.h"
 
 
-class KeyPoll; class Graphics; class Game; class mapclass; class entityclass; class UtilityClass;class musicclass;
-
-
 class scriptclass
 {
 public:
@@ -30,20 +27,15 @@ public:
 
     void tokenize(std::string t);
 
-    void run(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-             entityclass& obj, UtilityClass& help, musicclass& music);
+    void run();
 
-    void resetgametomenu(Graphics& dwgfx, Game& game,mapclass& map,
-                         entityclass& obj, UtilityClass& help, musicclass& music);
+    void resetgametomenu();
 
-    void startgamemode(int t, KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                       entityclass& obj, UtilityClass& help, musicclass& music);
+    void startgamemode(int t);
 
-    void teleport(Graphics& dwgfx, Game& game, mapclass& map,
-                  entityclass& obj, UtilityClass& help, musicclass& music);
+    void teleport();
 
-    void hardreset(KeyPoll& key, Graphics& dwgfx, Game& game,mapclass& map,
-                   entityclass& obj, UtilityClass& help, musicclass& music);
+    void hardreset();
 
     //Script contents
     std::vector<std::string> commands;

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -14,8 +14,8 @@ public:
 
     scriptclass();
 
-	void load(std::string t);
-	void loadother(std::string t);
+    void load(std::string t);
+    void loadother(std::string t);
 
 
     void inline add(std::string t)

--- a/desktop_version/src/Scripts.cpp
+++ b/desktop_version/src/Scripts.cpp
@@ -14,7 +14,7 @@ void scriptclass::load(std::string t)
     commands.clear();
     running = true;
 
-	int maxlength = (std::min(int(t.length()),7));
+    int maxlength = (std::min(int(t.length()),7));
     std::string customstring="";
     for(int i=0; i<maxlength; i++){
       customstring+=t[i];
@@ -694,7 +694,7 @@ void scriptclass::load(std::string t)
 
         add("endcutscene()");
         add("untilbars()");
-		return;
+        return;
     }
     if (t == "communicationstation")
     {
@@ -1091,7 +1091,7 @@ void scriptclass::load(std::string t)
 
         add("changeplayercolour(yellow)");
         add("gotoroom(15,9)");
-		//(6*8)-21
+        //(6*8)-21
         add("gotoposition(300,27,0)");
 
         add("hideplayer()");

--- a/desktop_version/src/Scripts.cpp
+++ b/desktop_version/src/Scripts.cpp
@@ -100,7 +100,7 @@ void scriptclass::load(std::string t)
             if(customtextmode==1){ add("endtext"); customtextmode=0;}
             add("flash(5)");
             add("shake(20)");
-            add("playef(9,10)");
+            add("playef(9)");
           }else if(words[0] == "sad" || words[0] == "cry"){
             if(customtextmode==1){ add("endtext"); customtextmode=0;}
             if(words[1]=="player"){
@@ -326,7 +326,7 @@ void scriptclass::load(std::string t)
 
         add("flash(5)");
         add("shake(20)");
-        add("playef(9,10)");
+        add("playef(9)");
         add("musicfadeout()");
         add("changemood(player,1)");
         add("delay(15)");
@@ -359,7 +359,7 @@ void scriptclass::load(std::string t)
 
         add("flash(5)");
         add("shake(50)");
-        add("playef(9,10)");
+        add("playef(9)");
         add("changemood(green,1)");
         add("changemood(purple,1)");
         add("alarmon");
@@ -381,7 +381,7 @@ void scriptclass::load(std::string t)
 
         add("flash(5)");
         add("shake(50)");
-        add("playef(9,10)");
+        add("playef(9)");
         add("changeai(green,followposition,-60)");
         add("changeai(purple,followposition,-60)");
         add("squeak(player)");
@@ -397,7 +397,7 @@ void scriptclass::load(std::string t)
 
         add("flash(5)");
         add("shake(50)");
-        add("playef(9,10)");
+        add("playef(9)");
         add("gotoroom(3,10)");
         add("gotoposition(310,177,0)");
         add("createcrewman(208,177,green,1,followposition,120)");
@@ -416,7 +416,7 @@ void scriptclass::load(std::string t)
         //and the next!
         add("flash(5)");
         add("shake(50)");
-        add("playef(9,10)");
+        add("playef(9)");
         add("gotoroom(3,11)");
         add("gotoposition(140,0,0)");
 
@@ -443,7 +443,7 @@ void scriptclass::load(std::string t)
         //final room:
         add("flash(5)");
         add("shake(80)");
-        add("playef(9,10)");
+        add("playef(9)");
         add("gotoroom(2,11)");
         add("gotoposition(265,153,0)");
 
@@ -480,7 +480,7 @@ void scriptclass::load(std::string t)
         add("alarmoff");
         add("flash(5)");
         add("shake(20)");
-        add("playef(10,10)");
+        add("playef(10)");
         add("blackout()");
         add("changemood(player,0)");
         add("changedir(player,1)");
@@ -488,7 +488,7 @@ void scriptclass::load(std::string t)
         add("delay(100)");
         add("blackon()");
         add("shake(20)");
-        add("playef(10,10)");
+        add("playef(10)");
 
         //Finally, appear at the start of the game:
         add("gotoroom(13,5)");
@@ -1723,7 +1723,7 @@ void scriptclass::load(std::string t)
 
         add("flash(5)");
         add("shake(20)");
-        add("playef(9,10)");
+        add("playef(9)");
         add("showplayer()");
         add("play(8)");
 
@@ -1744,19 +1744,19 @@ void scriptclass::load(std::string t)
 
         add("flash(5)");
         add("shake(20)");
-        add("playef(9,10)");
+        add("playef(9)");
 
         add("delay(35)");
 
         add("flash(5)");
         add("shake(20)");
-        add("playef(9,10)");
+        add("playef(9)");
 
         add("delay(25)");
 
         add("flash(5)");
         add("shake(20)");
-        add("playef(10,10)");
+        add("playef(10)");
 
         add("showplayer()");
         add("play(8)");
@@ -2949,7 +2949,7 @@ void scriptclass::load(std::string t)
         add("setcheckpoint()");
         add("flash(5)");
         add("shake(20)");
-        add("playef(10,10)");
+        add("playef(10)");
 
         add("showplayer()");
         add("play(8)");
@@ -2971,19 +2971,19 @@ void scriptclass::load(std::string t)
 
         add("flash(5)");
         add("shake(20)");
-        add("playef(9,10)");
+        add("playef(9)");
 
         add("delay(35)");
 
         add("flash(5)");
         add("shake(20)");
-        add("playef(9,10)");
+        add("playef(9)");
 
         add("delay(25)");
 
         add("flash(5)");
         add("shake(20)");
-        add("playef(10,10)");
+        add("playef(10)");
 
         add("showplayer()");
         add("play(8)");
@@ -3020,7 +3020,7 @@ void scriptclass::load(std::string t)
 
         add("flash(5)");
         add("shake(20)");
-        add("playef(10,10)");
+        add("playef(10)");
         add("delay(15)");
 
         add("changedir(player,0)");
@@ -3060,7 +3060,7 @@ void scriptclass::load(std::string t)
 
         add("flash(5)");
         add("shake(20)");
-        add("playef(10,10)");
+        add("playef(10)");
         add("delay(15)");
 
         add("changedir(player,0)");
@@ -3100,7 +3100,7 @@ void scriptclass::load(std::string t)
 
         add("flash(5)");
         add("shake(20)");
-        add("playef(10,10)");
+        add("playef(10)");
         add("delay(15)");
 
         add("changedir(player,0)");
@@ -3140,7 +3140,7 @@ void scriptclass::load(std::string t)
 
         add("flash(5)");
         add("shake(20)");
-        add("playef(10,10)");
+        add("playef(10)");
         add("delay(15)");
 
         add("changedir(player,0)");
@@ -6066,7 +6066,7 @@ void scriptclass::load(std::string t)
 
         add("flash(5)");
         add("shake(20)");
-        add("playef(9,10)");
+        add("playef(9)");
 
         add("musicfadeout()");
 
@@ -6087,7 +6087,7 @@ void scriptclass::load(std::string t)
 
         add("flash(5)");
         add("shake(20)");
-        add("playef(9,10)");
+        add("playef(9)");
         add("alarmon");
 
         add("delay(30)");
@@ -6106,7 +6106,7 @@ void scriptclass::load(std::string t)
 
         add("flash(5)");
         add("shake(50)");
-        add("playef(9,10)");
+        add("playef(9)");
         add("gotoroom(3,10)");
         add("gotoposition(40,177,0)");
         add("createcrewman(208,177,green,1,followposition,120)");
@@ -6125,7 +6125,7 @@ void scriptclass::load(std::string t)
         //and the next!
         add("flash(5)");
         add("shake(50)");
-        add("playef(9,10)");
+        add("playef(9)");
         add("gotoroom(3,11)");
         add("gotoposition(140,0,0)");
 
@@ -6152,7 +6152,7 @@ void scriptclass::load(std::string t)
         //final room:
         add("flash(5)");
         add("alarmoff");
-        add("playef(9,10)");
+        add("playef(9)");
         add("gotoroom(2,11)");
         add("gotoposition(265,153,0)");
 
@@ -6299,7 +6299,7 @@ void scriptclass::load(std::string t)
 
         add("flash(5)");
         add("shake(20)");
-        add("playef(10,10)");
+        add("playef(10)");
         add("blackout()");
 
         add("delay(45)");
@@ -6309,37 +6309,37 @@ void scriptclass::load(std::string t)
         add("changedir(player,1)");
         add("flash(5)");
         add("shake(20)");
-        add("playef(10,10)");
+        add("playef(10)");
         add("blackon()");
 
         add("delay(15)");
         add("flash(5)");
         add("shake(20)");
-        add("playef(10,10)");
+        add("playef(10)");
         add("createcrewman(28,65,purple,0,faceright)");
 
         add("delay(15)");
         add("flash(5)");
         add("shake(20)");
-        add("playef(10,10)");
+        add("playef(10)");
         add("createcrewman(145,169,yellow,0,faceleft)");
 
         add("delay(15)");
         add("flash(5)");
         add("shake(20)");
-        add("playef(10,10)");
+        add("playef(10)");
         add("createcrewman(32,169,red,0,faceright)");
 
         add("delay(15)");
         add("flash(5)");
         add("shake(20)");
-        add("playef(10,10)");
+        add("playef(10)");
         add("createcrewman(96,149,green,0,faceleft)");
 
         add("delay(15)");
         add("flash(5)");
         add("shake(20)");
-        add("playef(10,10)");
+        add("playef(10)");
         add("createcrewman(155,57,blue,0,faceleft)");
 
         add("delay(45)");
@@ -6436,7 +6436,7 @@ void scriptclass::load(std::string t)
         add("delay(5)");
         add("flash(10)");
         add("shake(20)");
-        add("playef(24,10)");
+        add("playef(24)");
         add("gotoroom(17,6)");
         add("vvvvvvman()");
 
@@ -6447,7 +6447,7 @@ void scriptclass::load(std::string t)
         add("walk(right,6)");
         add("flash(10)");
         add("shake(20)");
-        add("playef(23,10)");
+        add("playef(23)");
         add("altstates(2)");
         add("gotoroom(17,6)");
 
@@ -6456,7 +6456,7 @@ void scriptclass::load(std::string t)
         add("walk(right,12)");
         add("flash(10)");
         add("shake(20)");
-        add("playef(23,10)");
+        add("playef(23)");
         add("altstates(0)");
         add("gotoroom(17,6)");
 
@@ -6471,7 +6471,7 @@ void scriptclass::load(std::string t)
         add("delay(20)");
         add("flash(10)");
         add("shake(20)");
-        add("playef(24,10)");
+        add("playef(24)");
         add("undovvvvvvman()");
         add("createcrewman(30,99,purple,0,faceright)");
         add("createcrewman(65,119,yellow,0,faceright)");
@@ -6543,11 +6543,11 @@ void scriptclass::load(std::string t)
         add("delay(21)");
         add("changeai(yellow,faceright)");
         add("flipgravity(yellow)");
-        add("playef(0,10)");
+        add("playef(0)");
         add("delay(2)");
         add("changeai(purple,faceright)");
         add("flipgravity(purple)");
-        add("playef(0,10)");
+        add("playef(0)");
 
         add("delay(48)");
 

--- a/desktop_version/src/Spacestation2.cpp
+++ b/desktop_version/src/Spacestation2.cpp
@@ -51,10 +51,10 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,276,277,277,277,277,277,278,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 96, 40, 10, 0, 450500);  // (savepoint)
+		obj.createentity(96, 40, 10, 0, 450500);  // (savepoint)
 		if(game.intimetrial)
 		{
-			obj.createentity(game, 136, 92, 11, 48);  // (horizontal gravity line)
+			obj.createentity(136, 92, 11, 48);  // (horizontal gravity line)
 		}
 
 		roomname = "Outer Hull"; //If not yet in level, use "The Space Station";
@@ -128,14 +128,14 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("107,107,107,107,107,107,229,689,689,689,689,227,107,107,107,107,107,107,107,148,188,188,188,188,188,188,188,188,188,188,188,188,188,188,188,188,149,107,107,107");
 		tmap.push_back("107,107,107,107,107,107,229,689,689,689,689,227,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107");
 
-		obj.createentity(game, 128, 176, 10, 1, 449490);  // (savepoint)
-		obj.createentity(game, 160, 192, 3);  //Disappearing Platform
-		obj.createentity(game, 192, 192, 3);  //Disappearing Platform
-		obj.createentity(game, 224, 192, 3);  //Disappearing Platform
-		obj.createentity(game, 256, 192, 3);  //Disappearing Platform
-		obj.createentity(game, 216-4, 168, 1, 0, 4, 160, 88, 256, 192);  // Enemy, bounded
-		obj.createentity(game, 184-24, 96, 1, 1, 4, 160, 88, 256, 192);  // Enemy, bounded
-		obj.createentity(game, 256, 8, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 176, 10, 1, 449490);  // (savepoint)
+		obj.createentity(160, 192, 3);  //Disappearing Platform
+		obj.createentity(192, 192, 3);  //Disappearing Platform
+		obj.createentity(224, 192, 3);  //Disappearing Platform
+		obj.createentity(256, 192, 3);  //Disappearing Platform
+		obj.createentity(216-4, 168, 1, 0, 4, 160, 88, 256, 192);  // Enemy, bounded
+		obj.createentity(184-24, 96, 1, 1, 4, 160, 88, 256, 192);  // Enemy, bounded
+		obj.createentity(256, 8, 2, 10, 4);  //Big Threadmill, >>>>>>
 		roomname = "Boldly To Go";
 		break;
 
@@ -172,7 +172,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("289,289,289,289,289,289,411,680,680,680,680,409,289,289,411,680,680,680,680,680,409,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289");
 		tmap.push_back("289,289,289,289,289,289,411,680,680,680,680,409,289,289,411,680,680,680,680,680,409,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289");
 
-		obj.createentity(game, 192, 96, 9, 2);  // (shiny trinket)
+		obj.createentity(192, 96, 9, 2);  // (shiny trinket)
 		roomname = "One Way Room";
 		break;
 
@@ -209,23 +209,23 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("92,92,92,92,92,92,214,0,0,803,683,212,92,92,214,683,683,683,683,683,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,212,92,92,92");
 		tmap.push_back("92,92,92,92,92,92,214,0,0,803,683,212,92,92,214,683,683,683,683,683,172,173,173,173,173,173,173,173,173,173,173,174,0,0,0,0,212,92,92,92");
 
-		obj.createentity(game, 56, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 120, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 184, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 88, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 216, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 280, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 32, 10, 0, 447490);  // (savepoint)
-		obj.createentity(game, 288, 160, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 280, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 160, 216, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 224, 216, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 248, 24, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 120, 168, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 184, 168, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 216, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 152, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 224, 120, 10, 0, 447491);  // (savepoint)
+		obj.createentity(56, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(120, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(184, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(88, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(216, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(280, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 32, 10, 0, 447490);  // (savepoint)
+		obj.createentity(288, 160, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(280, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(160, 216, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(224, 216, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(248, 24, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(120, 168, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(184, 168, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(216, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(152, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(224, 120, 10, 0, 447491);  // (savepoint)
 
 		roomname = "Conveying a New Idea";
 		break;
@@ -263,23 +263,23 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("98,98,98,220,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,218,98,98,220,0,0,0,0,218,98,98,98");
 		tmap.push_back("98,98,98,220,0,0,0,0,178,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,179,140,98,98,220,0,0,0,0,218,98,98,98");
 
-		obj.createentity(game, 0, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 96, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 160, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 168, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 168, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 160, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 160, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 0, 160, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 0, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 216, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 216, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 216, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 0, 168, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 112, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(0, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(96, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(160, 24, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 168, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 168, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 160, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 160, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(0, 160, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(0, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 216, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 216, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 216, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(0, 168, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 72, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 112, 2, 8, 4);  //Threadmill, >>>
 		roomname = "Upstream Downstream";
 		break;
 
@@ -316,13 +316,13 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 
 		obj.platformtile = 119;
-		obj.createentity(game, 64, 72, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
-		obj.createentity(game, 96, 80, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
-		obj.createentity(game, 128, 88, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
-		obj.createentity(game, 160, 96, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
-		obj.createentity(game, 192, 104, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
-		obj.createentity(game, 224, 112, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
-		obj.createentity(game, 264, 96, 10, 1, 448500);  // (savepoint)
+		obj.createentity(64, 72, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
+		obj.createentity(96, 80, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
+		obj.createentity(128, 88, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
+		obj.createentity(160, 96, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
+		obj.createentity(192, 104, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
+		obj.createentity(224, 112, 2, 0, 4, 64, 72, 256, 160);  // Platform, bounded
+		obj.createentity(264, 96, 10, 1, 448500);  // (savepoint)
 		roomname = "The High Road is Low";
 		break;
 
@@ -358,13 +358,13 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,235,8,8,8,8,233,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113");
 		tmap.push_back("113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,154,194,194,194,194,155,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113,113");
 
-		obj.createentity(game, 144, 200, 3, 51);  //Disappearing Platform
-		obj.createentity(game, 24, 16, 10, 0, 449500);  // (savepoint)
-		obj.createentity(game, 280, 16, 10, 0, 449501);  // (savepoint)
-		obj.createentity(game, 0, 8, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 8, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 224, 8, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 288, 8, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(144, 200, 3, 51);  //Disappearing Platform
+		obj.createentity(24, 16, 10, 0, 449500);  // (savepoint)
+		obj.createentity(280, 16, 10, 0, 449501);  // (savepoint)
+		obj.createentity(0, 8, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 8, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(224, 8, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(288, 8, 2, 9, 4);  //Threadmill, <<<
 		roomname = "Give Me A V";
 		break;
 
@@ -400,20 +400,20 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("83,83,83,124,164,164,164,164,164,164,164,164,164,164,164,164,164,164,164,164,164,164,164,164,125,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83");
 		tmap.push_back("83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83");
 
-		obj.createentity(game, 0, 8, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 64, 8, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 8, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 192, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 256, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 152, 88, 10, 1, 449510);  // (savepoint)
-		obj.createentity(game, 152, 120, 10, 0, 449511);  // (savepoint)
-		obj.createentity(game, 128, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 256, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 32, 208, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 64, 208, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 208, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(0, 8, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(64, 8, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 8, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(192, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(256, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(152, 88, 10, 1, 449510);  // (savepoint)
+		obj.createentity(152, 120, 10, 0, 449511);  // (savepoint)
+		obj.createentity(128, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(256, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(32, 208, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(64, 208, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 208, 2, 10, 4);  //Big Threadmill, >>>>>>
 		roomname = "Select Track";
 		break;
 
@@ -449,21 +449,21 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 		tmap.push_back("283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 
-		obj.createentity(game, 0, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 256, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 152, 128, 1, 0, 5, 72, 120, 256, 200);  // Enemy, bounded
-		obj.createentity(game, 240, 168, 1, 1, 5, 72, 120, 256, 200);  // Enemy, bounded
-		obj.createentity(game, 72, 168, 1, 1, 5, 72, 120, 256, 200);  // Enemy, bounded
-		obj.createentity(game, 0, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 256, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 32, 3,10);  //Disappearing Platform
-		obj.createentity(game, 96, 32, 3,10);  //Disappearing Platform
-		obj.createentity(game, 192, 32, 3,10);  //Disappearing Platform
-		obj.createentity(game, 224, 32, 3,10);  //Disappearing Platform
+		obj.createentity(0, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(256, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(152, 128, 1, 0, 5, 72, 120, 256, 200);  // Enemy, bounded
+		obj.createentity(240, 168, 1, 1, 5, 72, 120, 256, 200);  // Enemy, bounded
+		obj.createentity(72, 168, 1, 1, 5, 72, 120, 256, 200);  // Enemy, bounded
+		obj.createentity(0, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(256, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 32, 3,10);  //Disappearing Platform
+		obj.createentity(96, 32, 3,10);  //Disappearing Platform
+		obj.createentity(192, 32, 3,10);  //Disappearing Platform
+		obj.createentity(224, 32, 3,10);  //Disappearing Platform
 		roomname = "You Chose... Poorly";
 		break;
 
@@ -499,16 +499,16 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107");
 		tmap.push_back("107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107");
 
-		obj.createentity(game, 0, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 64, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 192, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 256, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 152, 120, 10, 0, 449530);  // (savepoint)
-		obj.createentity(game, 0, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 256, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(0, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(64, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(192, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(256, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(152, 120, 10, 0, 449530);  // (savepoint)
+		obj.createentity(0, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(256, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
 		roomname = "Hyperspace Bypass 5";
 		break;
 
@@ -545,14 +545,14 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92");
 
 		obj.platformtile = 319;
-		obj.createentity(game, 0, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 64, 104, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 0, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 112, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 136, 104, 2, 0, 5, 136, 88, 200, 152);  // Platform, bounded
-		obj.createentity(game, 168, 104, 2, 0, 5, 136, 88, 200, 152);  // Platform, bounded
-		obj.createentity(game, 80, 112, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 80, 104, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(0, 104, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(64, 104, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(0, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 112, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(136, 104, 2, 0, 5, 136, 88, 200, 152);  // Platform, bounded
+		obj.createentity(168, 104, 2, 0, 5, 136, 88, 200, 152);  // Platform, bounded
+		obj.createentity(80, 112, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(80, 104, 2, 9, 4);  //Threadmill, <<<
 		roomname = "Plain Sailing from Here On";
 		break;
 
@@ -590,14 +590,14 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,483,605,0,0,0,0,0,0,0,0,603,483,483,483");
 
 		obj.platformtile = 10;
-		obj.createentity(game, 264, 128, 10, 0, 448540);  // (savepoint)
-		obj.createentity(game, 192, 32, 3, 10);  //Disappearing Platform
-		obj.createentity(game, 32, 176, 2, 3, 4);  // Platform
-		obj.createentity(game, 256, 120, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 224, 184, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 0, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 16, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 104, 24, 10, 0, 448541);  // (savepoint)
+		obj.createentity(264, 128, 10, 0, 448540);  // (savepoint)
+		obj.createentity(192, 32, 3, 10);  //Disappearing Platform
+		obj.createentity(32, 176, 2, 3, 4);  // Platform
+		obj.createentity(256, 120, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(224, 184, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(0, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 16, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(104, 24, 10, 0, 448541);  // (savepoint)
 		roomname = "Ha Ha Ha Not Really";
 		break;
 
@@ -635,18 +635,18 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("510,510,510,510,510,510,510,510,632,0,0,0,0,818,698,698,630,510,510,510,510,510,510,632,698,698,820,0,0,0,0,630,510,510,510,510,510,510,510,510");
 
 		obj.platformtile = 279;
-		obj.createentity(game, 32, 168, 9, 3);  // (shiny trinket)
-		obj.createentity(game, 16, 112, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 0, 112, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 0, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 256, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 96, 32, 2, 3, 4);  // Platform
-		obj.createentity(game, 240, 88, 2, 2, 4);  // Platform
-		obj.createentity(game, 128, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 152, 168, 10, 1, 448530);  // (savepoint)
-		obj.createentity(game, 72, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 184, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 48, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(32, 168, 9, 3);  // (shiny trinket)
+		obj.createentity(16, 112, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(0, 112, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(0, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(256, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(96, 32, 2, 3, 4);  // Platform
+		obj.createentity(240, 88, 2, 2, 4);  // Platform
+		obj.createentity(128, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(152, 168, 10, 1, 448530);  // (savepoint)
+		obj.createentity(72, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(184, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(48, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
 
 		roomname="You Just Keep Coming Back";
 		break;
@@ -684,16 +684,16 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289");
 
 		obj.platformtile = 359;
-		obj.createentity(game, 256, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 256, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 0, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 0, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 120, 104, 2, 0, 4, 96, 64, 224, 160);  // Platform, bounded
-		obj.createentity(game, 168, 80, 2, 0, 4, 96, 64, 224, 160);  // Platform, bounded
-		obj.createentity(game, 72, 64, 10, 1, 448520);  // (savepoint)
-		obj.createentity(game, 232, 64, 10, 1, 448521);  // (savepoint)
-		obj.createentity(game, 232, 144, 10, 0, 448522);  // (savepoint)
-		obj.createentity(game, 72, 144, 10, 0, 448523);  // (savepoint)
+		obj.createentity(256, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(256, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(0, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(0, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(120, 104, 2, 0, 4, 96, 64, 224, 160);  // Platform, bounded
+		obj.createentity(168, 80, 2, 0, 4, 96, 64, 224, 160);  // Platform, bounded
+		obj.createentity(72, 64, 10, 1, 448520);  // (savepoint)
+		obj.createentity(232, 64, 10, 1, 448521);  // (savepoint)
+		obj.createentity(232, 144, 10, 0, 448522);  // (savepoint)
+		obj.createentity(72, 144, 10, 0, 448523);  // (savepoint)
 		roomname = "Gordian Knot";
 		break;
 
@@ -730,20 +730,20 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313");
 		tmap.push_back("313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313");
 
-		obj.createentity(game, 256, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 192, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 64, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 256, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 96, 40, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 160, 40, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 32, 40, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 72, 80, 10, 1, 448510);  // (savepoint)
-		obj.createentity(game, 104, 128, 1, 0, 5, 104, 120, 288, 200);  // Enemy, bounded
-		obj.createentity(game, 160+8, 168, 1, 1, 5, 104, 120, 288, 200);  // Enemy, bounded
-		obj.createentity(game, 216+16, 128, 1, 0, 5, 104, 120, 288, 200);  // Enemy, bounded
+		obj.createentity(256, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(192, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(64, 112, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(256, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(96, 40, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(160, 40, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(32, 40, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(72, 80, 10, 1, 448510);  // (savepoint)
+		obj.createentity(104, 128, 1, 0, 5, 104, 120, 288, 200);  // Enemy, bounded
+		obj.createentity(160+8, 168, 1, 1, 5, 104, 120, 288, 200);  // Enemy, bounded
+		obj.createentity(216+16, 128, 1, 0, 5, 104, 120, 288, 200);  // Enemy, bounded
 
 		roomname = "Backsliders";
 		break;
@@ -780,16 +780,16 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("283,283,283,283,283,283,283,405,0,0,0,0,363,364,364,364,325,283,283,283,283,283,283,283,283,283,283,283,283,324,364,364,364,364,364,364,364,364,364,364");
 		tmap.push_back("283,283,283,283,283,283,283,405,0,0,0,0,403,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 
-		obj.createentity(game, 72, 184, 10, 0, 447510);  // (savepoint)
-		obj.createentity(game, 80, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 144, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 208, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(72, 184, 10, 0, 447510);  // (savepoint)
+		obj.createentity(80, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(144, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(208, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
 
-		obj.createentity(game, 24 - 8, 144 - 8, 1, 10, 0);  // Enemy
+		obj.createentity(24 - 8, 144 - 8, 1, 10, 0);  // Enemy
 
-		obj.createentity(game, 24 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 8 + (117 * 3), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 8 + (117 * 3), 144 - 8, 1, 10, 1);  // Enemy
 
 		//LIES emitter starts here
 		roomname = "The Cuckoo";
@@ -827,15 +827,15 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("391,391,391,391,391,391,391,391,391,391,352,351,391,391,391,391,391,391,391,391,352,310,310,351,391,391,391,391,391,391,391,391,391,391,391,391,391,391,391,391");
 		tmap.push_back("310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310");
 
-		obj.createentity(game, 8, 200, 10, 1, 447520);  // (savepoint)
-		obj.createentity(game, 200, 192, 9, 4);  // (shiny trinket)
-		obj.createentity(game, 232, 96, 10, 1, 447521);  // (savepoint)
+		obj.createentity(8, 200, 10, 1, 447520);  // (savepoint)
+		obj.createentity(200, 192, 9, 4);  // (shiny trinket)
+		obj.createentity(232, 96, 10, 1, 447521);  // (savepoint)
 
-		obj.createentity(game, 24 - 60 - 8, 144 - 8, 1, 10, 0);  // Enemy
+		obj.createentity(24 - 60 - 8, 144 - 8, 1, 10, 0);  // Enemy
 
-		obj.createentity(game, 24 - 60 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 60 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 60 - 8 + (117 * 3), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + (117 * 3), 144 - 8, 1, 10, 1);  // Enemy
 		//LIES Emitter, manually positioned
 		roomname = "Clarion Call";
 		break;
@@ -872,11 +872,11 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,232,0,0,0,0,230,110,110,110,110,110,110,110,110,110,110,110,110,110,110");
 		tmap.push_back("110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,110,232,0,0,0,0,230,110,110,110,110,110,110,110,110,110,110,110,110,110,110");
 
-		obj.createentity(game, 176, 104, 10, 0, 446510);  // (savepoint)
+		obj.createentity(176, 104, 10, 0, 446510);  // (savepoint)
 
-		obj.createentity(game, 7 * 8, 17 * 8, 1, 12, 0);  // Enemy
+		obj.createentity(7 * 8, 17 * 8, 1, 12, 0);  // Enemy
 
-		obj.createentity(game, 7*8, 2*8, 1, 12, 1);  // Enemy
+		obj.createentity(7*8, 2*8, 1, 12, 1);  // Enemy
 		//FACTORY emitter starts here
 		roomname = "The Solution is Dilution";
 		break;
@@ -913,12 +913,12 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("92,92,92,92,92,92,214,683,683,683,683,683,172,173,134,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92");
 		tmap.push_back("92,92,92,92,92,92,214,683,683,683,683,683,212,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92");
 
-		obj.createentity(game, 96, 168, 10, 0, 445510);  // (savepoint)
+		obj.createentity(96, 168, 10, 0, 445510);  // (savepoint)
 
-		obj.createentity(game, 7 * 8, 36 * 8, 1, 12, 0);  // Enemy
+		obj.createentity(7 * 8, 36 * 8, 1, 12, 0);  // Enemy
 
-		obj.createentity(game, 7 * 8, (36 * 8)-108, 1, 12, 1);  // Enemy
-		obj.createentity(game, 7 * 8, (36 * 8)-216, 1, 12, 1);  // Enemy
+		obj.createentity(7 * 8, (36 * 8)-108, 1, 12, 1);  // Enemy
+		obj.createentity(7 * 8, (36 * 8)-216, 1, 12, 1);  // Enemy
 		//FACTORY emitter starts here (manually placed)
 
 		roomname = "Lighter Than Air";
@@ -957,19 +957,19 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("292,292,292,292,333,373,374,701,701,701,701,701,412,292,292,292,292,292,292,292,414,0,0,0,0,372,373,373,373,373,373,373,373,373,373,373,373,334,292,292");
 		tmap.push_back("292,292,292,292,292,292,414,701,701,701,701,701,412,292,292,292,292,292,292,292,414,0,0,0,0,412,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 
-		obj.createentity(game, 224, 200, 10, 1, 444510);  // (savepoint)
+		obj.createentity(224, 200, 10, 1, 444510);  // (savepoint)
 
-		obj.createentity(game, 56, 40, 1, 0, 2);  // Enemy //collector
+		obj.createentity(56, 40, 1, 0, 2);  // Enemy //collector
 
-		obj.createentity(game, 7 * 8, 36 * 8, 1, 12, 0);  // Enemy
+		obj.createentity(7 * 8, 36 * 8, 1, 12, 0);  // Enemy
 
-		obj.createentity(game, 7 * 8, (36 * 8)-108, 1, 12, 1);  // Enemy
-		obj.createentity(game, 7 * 8, (36 * 8)-216, 1, 12, 1);  // Enemy
+		obj.createentity(7 * 8, (36 * 8)-108, 1, 12, 1);  // Enemy
+		obj.createentity(7 * 8, (36 * 8)-216, 1, 12, 1);  // Enemy
 		//FACTORY emitter starts here (manually placed)
 
 		if(!game.intimetrial)
 		{
-			obj.createentity(game, 18 * 8, (5 * 8) + 4, 14); //Teleporter!
+			obj.createentity(18 * 8, (5 * 8) + 4, 14); //Teleporter!
 		}
 		roomname = "Level Complete!";
 		break;
@@ -1041,11 +1041,11 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("98,98,98,98,220,0,0,0,0,0,800,680,680,680,680,680,680,680,680,680,802,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("98,98,98,98,220,0,0,0,0,0,800,680,680,680,680,680,680,680,680,680,802,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 248 - 4, 160 - 48, 1, 1, 0);  // Enemy
-		obj.createentity(game, 124, 120, 20, 1);  // (terminal)
+		obj.createentity(248 - 4, 160 - 48, 1, 1, 0);  // Enemy
+		obj.createentity(124, 120, 20, 1);  // (terminal)
 		obj.createblock(5, 124-4, 120, 20, 16, 14);
 
-		obj.createentity(game, 156, 40, 20, 1);  // (terminal)
+		obj.createentity(156, 40, 20, 1);  // (terminal)
 		obj.createblock(5, 156-4, 40, 20, 16, 15);
 
 		roomname = "The Hanged Man, Reversed";
@@ -1083,7 +1083,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,330,370,371,0,0,0,0,369,370,331,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289");
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,411,0,0,0,0,409,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289");
 
-		obj.createentity(game, 152, 120, 10, 0, 445530);  // (savepoint)
+		obj.createentity(152, 120, 10, 0, 445530);  // (savepoint)
 		roomname = "doomS";
 		break;
 
@@ -1119,12 +1119,12 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("170,170,170,170,170,170,131,89,89,130,170,170,170,170,170,170,170,170,131,89,89,130,170,170,170,170,170,170,170,170,131,89,89,130,170,170,170,170,170,170");
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 
-		obj.createentity(game, 24-60-8, 144-8, 1, 10, 0);  // Enemy
+		obj.createentity(24-60-8, 144-8, 1, 10, 0);  // Enemy
 		//LIES Emitter, manually positioned
 
-		obj.createentity(game, 24 - 60 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 60 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 60 - 8 + (117 * 3), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + (117 * 3), 144 - 8, 1, 10, 1);  // Enemy
 
 		roomname = "Chinese Rooms";
 		break;
@@ -1161,7 +1161,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 152, 96, 10, 1, 446530);  // (savepoint)
+		obj.createentity(152, 96, 10, 1, 446530);  // (savepoint)
 		roomname = "Swoop";
 		break;
 
@@ -1197,11 +1197,11 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,229,0,0,0,0,227,229,0,0,0,0,0,0");
 		tmap.push_back("107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,107,229,0,0,0,0,227,229,0,0,0,0,0,0");
 
-		obj.createentity(game, 64, 40, 10, 1, 446520);  // (savepoint)
-		obj.createentity(game, 208, 88, 3, 827);  //Disappearing Platform
-		obj.createentity(game, 152, 160, 3, 827);  //Disappearing Platform
-		obj.createentity(game, 96, 88, 3, 827);  //Disappearing Platform
-		obj.createentity(game, 40, 160, 3, 827);  //Disappearing Platform
+		obj.createentity(64, 40, 10, 1, 446520);  // (savepoint)
+		obj.createentity(208, 88, 3, 827);  //Disappearing Platform
+		obj.createentity(152, 160, 3, 827);  //Disappearing Platform
+		obj.createentity(96, 88, 3, 827);  //Disappearing Platform
+		obj.createentity(40, 160, 3, 827);  //Disappearing Platform
 		roomname = "Manic Mine";
 		break;
 
@@ -1273,26 +1273,26 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,435,0,0,0,0,0,0,0,0,0,0,433,313,313,313,313,313,313,313,313,313,313,313,313");
 		tmap.push_back("313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,313,354,394,394,394,394,394,394,394,394,394,394,355,313,313,313,313,313,313,313,313,313,313,313,313");
 
-		obj.createentity(game, 144-4, 208, 1, 1, 6);  // Enemy
-		obj.createentity(game, 128+4, 8, 1, 0, 6);  // Enemy
-		obj.createentity(game, 64, 200, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 216, 200, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 96, 160, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 160, 160, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 208, 160, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 248, 184, 10, 1, 445540);  // (savepoint)
-		obj.createentity(game, 184, 24, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 64, 64, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 152, 64, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 152, 88, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 64, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 96, 136, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 160, 136, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 184, 136, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 152, 24, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 104, 200, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 104, 136, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 104, 160, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(144-4, 208, 1, 1, 6);  // Enemy
+		obj.createentity(128+4, 8, 1, 0, 6);  // Enemy
+		obj.createentity(64, 200, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(216, 200, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(96, 160, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(160, 160, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(208, 160, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(248, 184, 10, 1, 445540);  // (savepoint)
+		obj.createentity(184, 24, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(64, 64, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(152, 64, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(152, 88, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(64, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(96, 136, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(160, 136, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(184, 136, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(152, 24, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(104, 200, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(104, 136, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(104, 160, 2, 9, 4);  //Threadmill, <<<
 
 		roomname = "$eeing Dollar $ign$";
 		break;
@@ -1329,19 +1329,19 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("0,0,0,0,0,206,86,208,0,0,818,698,206,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,208,698,698,820,0,0,206,86,86,86,86");
 		tmap.push_back("0,0,0,0,0,206,86,208,0,0,818,698,206,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,208,698,698,820,0,0,206,86,86,86,86");
 
-		obj.createentity(game, 184, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 248, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 312, 56, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 152, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 216, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 280, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 280, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 272, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 64, 152, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 120, 152, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 96, 192, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 152, 192, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 240, 88, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(184, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(248, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(312, 56, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(152, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(216, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(280, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(280, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(272, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(64, 152, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(120, 152, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(96, 192, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(152, 192, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(240, 88, 2, 9, 4);  //Threadmill, <<<
 		roomname = "Parabolica";
 		break;
 
@@ -1377,23 +1377,23 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("167,167,167,167,128,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86");
 		tmap.push_back("86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86");
 
-		obj.createentity(game, 96, 80, 10, 1, 447540);  // (savepoint)
-		obj.createentity(game, 64, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 112, 184, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 176, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 224, 184, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 232, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 288, 128, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 288, 184, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 120, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 168, 112, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 208, 168, 10, 1, 447541);  // (savepoint)
+		obj.createentity(96, 80, 10, 1, 447540);  // (savepoint)
+		obj.createentity(64, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(112, 184, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(176, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(224, 184, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(232, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(288, 128, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(288, 184, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(120, 112, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(168, 112, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(208, 168, 10, 1, 447541);  // (savepoint)
 
-		obj.createentity(game, 24 - 60 - 8, 144 - 8, 1, 10, 0);  // Enemy
+		obj.createentity(24 - 60 - 8, 144 - 8, 1, 10, 0);  // Enemy
 
-		obj.createentity(game, 24 - 60 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 60 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 60 - 8 + (117 * 3), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + (117 * 3), 144 - 8, 1, 10, 1);  // Enemy
 
 		//LIES Emitter, manually positioned
 		roomname = "Spikes Do!";
@@ -1431,10 +1431,10 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 64, 152, 10, 1, 446540);  // (savepoint)
-		obj.createentity(game, 120, 72, 3, 707);  //Disappearing Platform
-		obj.createentity(game, 248, 72, 3, 707);  //Disappearing Platform
-		obj.createentity(game, 184, 200, 3, 707);  //Disappearing Platform
+		obj.createentity(64, 152, 10, 1, 446540);  // (savepoint)
+		obj.createentity(120, 72, 3, 707);  //Disappearing Platform
+		obj.createentity(248, 72, 3, 707);  //Disappearing Platform
+		obj.createentity(184, 200, 3, 707);  //Disappearing Platform
 		roomname = "What Lies Beneath?";
 		break;
 
@@ -1470,18 +1470,18 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 
-		obj.createentity(game, 0, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 112, 128, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 0, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 184, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 152, 168, 10, 1, 447550);  // (savepoint)
+		obj.createentity(0, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 128, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(112, 128, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(0, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(184, 184, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(152, 168, 10, 1, 447550);  // (savepoint)
 
-		obj.createentity(game, 264, 136, 1, 0, 2);  // Enemy //Collector
-		obj.createentity(game, 24 - 60 - 8, 144 - 8, 1, 10, 0);  // Enemy
-		obj.createentity(game, 24 - 60 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
-		obj.createentity(game, 24 - 60 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(264, 136, 1, 0, 2);  // Enemy //Collector
+		obj.createentity(24 - 60 - 8, 144 - 8, 1, 10, 0);  // Enemy
+		obj.createentity(24 - 60 - 8 + 117, 144 - 8, 1, 10, 1);  // Enemy
+		obj.createentity(24 - 60 - 8 + (117 * 2), 144 - 8, 1, 10, 1);  // Enemy
 		//LIES Emitter, manually positioned, collector!
 		roomname = "Chipper Cipher";
 		break;
@@ -1518,7 +1518,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("0,0,0,0,0,0,0,803,683,683,683,683,683,683,683,624,504,626,683,683,683,683,683,683,683,805,0,0,0,0,0,624,504,504,504,504,504,504,504,504");
 		tmap.push_back("0,0,0,0,0,0,0,803,683,683,683,683,683,683,683,624,504,626,683,683,683,683,683,683,683,805,0,0,0,0,0,624,504,504,504,504,504,504,504,504");
 
-		obj.createentity(game, 40, 72, 3, 787);  //Disappearing Platform
+		obj.createentity(40, 72, 3, 787);  //Disappearing Platform
 		roomname = "If You Fall Up";
 		break;
 
@@ -1555,9 +1555,9 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,620,695,695,695,695,618,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498,498");
 
 		obj.platformtile = 159;
-		obj.createentity(game, 24, 80, 2, 3, 6);  // Platform
-		obj.createentity(game, 64, 176, 10, 0, 445550);  // (savepoint)
-		obj.createentity(game, 216 - 4, 192, 10, 1, 445551);  // (savepoint)
+		obj.createentity(24, 80, 2, 3, 6);  // Platform
+		obj.createentity(64, 176, 10, 0, 445550);  // (savepoint)
+		obj.createentity(216 - 4, 192, 10, 1, 445551);  // (savepoint)
 		roomname = "Just Pick Yourself Down";
 		break;
 
@@ -1594,37 +1594,37 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,408,0,0,0,0,406,286");
 		tmap.push_back("286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,408,0,0,0,0,406,286");
 
-		obj.createentity(game, 32, 40, 10, 1, 444560);  // (savepoint)
-		obj.createentity(game, 56, 24, 10, 0, 444551);  // (savepoint)
-		obj.createentity(game, 80, 40, 10, 1, 444552);  // (savepoint)
-		obj.createentity(game, 104, 24, 10, 0, 444553);  // (savepoint)
-		obj.createentity(game, 128, 40, 10, 1, 444554);  // (savepoint)
-		obj.createentity(game, 152, 24, 10, 0, 444555);  // (savepoint)
-		obj.createentity(game, 176, 40, 10, 1, 444556);  // (savepoint)
-		obj.createentity(game, 200, 24, 10, 0, 444557);  // (savepoint)
-		obj.createentity(game, 224, 40, 10, 1, 444558);  // (savepoint)
-		obj.createentity(game, 248, 24, 10, 0, 444559);  // (savepoint)
-		obj.createentity(game, 272, 40, 10, 1, 444550);  // (savepoint)
-		obj.createentity(game, 0, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 256, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 0, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 64, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 128, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 192, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 256, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 0, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 64, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 192, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 240, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 0, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 64, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 192, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 240, 128, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(32, 40, 10, 1, 444560);  // (savepoint)
+		obj.createentity(56, 24, 10, 0, 444551);  // (savepoint)
+		obj.createentity(80, 40, 10, 1, 444552);  // (savepoint)
+		obj.createentity(104, 24, 10, 0, 444553);  // (savepoint)
+		obj.createentity(128, 40, 10, 1, 444554);  // (savepoint)
+		obj.createentity(152, 24, 10, 0, 444555);  // (savepoint)
+		obj.createentity(176, 40, 10, 1, 444556);  // (savepoint)
+		obj.createentity(200, 24, 10, 0, 444557);  // (savepoint)
+		obj.createentity(224, 40, 10, 1, 444558);  // (savepoint)
+		obj.createentity(248, 24, 10, 0, 444559);  // (savepoint)
+		obj.createentity(272, 40, 10, 1, 444550);  // (savepoint)
+		obj.createentity(0, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(256, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(0, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(64, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(128, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(192, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(256, 56, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(0, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(64, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(192, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(240, 88, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(0, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(64, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(192, 128, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(240, 128, 2, 9, 4);  //Threadmill, <<<
 		roomname = "The Warning";
 		break;
 
@@ -1661,13 +1661,13 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("420,49,0,0,0,0,50,418,298,420,0,0,0,0,0,0,0,0,0,0,50,418,298,298,298,298,420,49,0,0,0,0,0,0,0,0,0,0,418,298");
 		tmap.push_back("420,49,0,0,0,0,50,418,298,420,0,0,0,0,0,0,0,0,0,0,50,418,298,298,298,298,420,49,0,0,0,0,0,0,0,0,0,0,418,298");
 
-		obj.createentity(game, 176, 80, 3, 55);  //Disappearing Platform
-		obj.createentity(game, 0, 56, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 16, 56, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 72, 72, 10, 1, 444561);  // (savepoint)
-		obj.createentity(game, 8, 144, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 48, 144, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 0, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(176, 80, 3, 55);  //Disappearing Platform
+		obj.createentity(0, 56, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(16, 56, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(72, 72, 10, 1, 444561);  // (savepoint)
+		obj.createentity(8, 144, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(48, 144, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(0, 16, 2, 10, 4);  //Big Threadmill, >>>>>>
 
 
 		roomname = "Getting Here is Half the Fun";
@@ -1880,10 +1880,10 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("89,89,89,89,89,89,211,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,169,170,170,170,170,170,170,170,131,89,89");
 		tmap.push_back("89,89,89,89,89,89,130,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,131,89,89,89,89,89,89,89,89,89,89");
 
-		obj.createentity(game, 224, 144, 9, 5);  // (shiny trinket)
-		obj.createentity(game, 96, 152, 10, 1, 450560);  // (savepoint)
+		obj.createentity(224, 144, 9, 5);  // (shiny trinket)
+		obj.createentity(96, 152, 10, 1, 450560);  // (savepoint)
 
-		obj.createentity(game, 24, 152, 20, 1);  // (terminal)
+		obj.createentity(24, 152, 20, 1);  // (terminal)
 		obj.createblock(5, 24-4, 152, 20, 16, 16);
 		roomname = "Doing Things The Hard Way";
 		break;
@@ -1923,8 +1923,8 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("495,495,495,495,495,495,495,495,495,495,495,495,495,495,617,0,0,0,0,0,0,0,0,0,0,615,495,495,495,495,495,495,495,495,495,495,495,495,495,495");
 
 		obj.platformtile = 707;
-		obj.createentity(game, 272, 40, 2, 14, 2);  // Platform
-		obj.createentity(game, 240, 40, 3, 707);  //Disappearing Platform
+		obj.createentity(272, 40, 2, 14, 2);  // Platform
+		obj.createentity(240, 40, 3, 707);  //Disappearing Platform
 
 		if(game.intimetrial && game.timetriallevel > 0)
 		{
@@ -1965,11 +1965,11 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("301,301,301,301,301,301,301,423,0,0,0,0,421,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301");
 		tmap.push_back("301,301,301,301,301,301,301,423,0,0,0,0,421,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301,301");
 
-		obj.createentity(game, 0, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 64, 168, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 72, 128, 10, 1, 443560);  // (savepoint)
+		obj.createentity(0, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(64, 168, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(72, 128, 10, 1, 443560);  // (savepoint)
 
-		obj.createentity(game, (21 * 8), (9 * 8), 14); //Teleporter!
+		obj.createentity((21 * 8), (9 * 8), 14); //Teleporter!
 
 		if(game.intimetrial)
 		{
@@ -2026,16 +2026,16 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86");
 		tmap.push_back("86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86");
 
-		obj.createentity(game, 0, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 63, 64-16, 1, 3, 4, 64, 0, 256, 204);  // Enemy, bounded
-		obj.createentity(game, 256-28, 80, 1, 2, 4, 64, 0, 256, 204);  // Enemy, bounded
-		obj.createentity(game, 48, 168, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 104, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 152, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 240, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 288, 168, 2, 9, 4);  //Threadmill, <<<
-		obj.createentity(game, 160 - 48, 184 - 8, 1, 3, 5);// , 160, 0, 320, 240);  // Enemy, bounded
-		obj.createentity(game, 160 - 28 + 48, 184 - 8, 1, 2, 5);// , 0, 0, 160, 240);  // Enemy, bounded
+		obj.createentity(0, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(63, 64-16, 1, 3, 4, 64, 0, 256, 204);  // Enemy, bounded
+		obj.createentity(256-28, 80, 1, 2, 4, 64, 0, 256, 204);  // Enemy, bounded
+		obj.createentity(48, 168, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(104, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(152, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(240, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(288, 168, 2, 9, 4);  //Threadmill, <<<
+		obj.createentity(160 - 48, 184 - 8, 1, 3, 5);// , 160, 0, 320, 240);  // Enemy, bounded
+		obj.createentity(160 - 28 + 48, 184 - 8, 1, 2, 5);// , 0, 0, 160, 240);  // Enemy, bounded
 		roomname = "Brass Sent Us Under The Top";
 		break;
 
@@ -2071,13 +2071,13 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507");
 		tmap.push_back("507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507,507");
 
-		obj.createentity(game, 64, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 128, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 192, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 256, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 32+4, 48, 10, 0, 443540);  // (savepoint)
-		obj.createentity(game, 208-4, 48, 1, 0, 3, 104, 40, 324, 136);  // Enemy, bounded
-		obj.createentity(game, 136 + 4, 96, 10, 1, 443541);  // (savepoint)
+		obj.createentity(64, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(128, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(192, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(256, 168, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(32+4, 48, 10, 0, 443540);  // (savepoint)
+		obj.createentity(208-4, 48, 1, 0, 3, 104, 40, 324, 136);  // Enemy, bounded
+		obj.createentity(136 + 4, 96, 10, 1, 443541);  // (savepoint)
 
 		roomname = "The Tomb of Mad Carew";
 		break;
@@ -2114,8 +2114,8 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("310,310,310,310,432,0,0,0,0,0,812,692,430,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,432,0,0,0,0,0,0,430,310,310,310,310");
 		tmap.push_back("310,310,310,310,432,0,0,0,0,0,812,692,430,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,432,0,0,0,0,0,0,430,310,310,310,310");
 
-		obj.createentity(game, 56, 144, 10, 0, 443520);  // (savepoint)
-		obj.createentity(game, 152, 80, 10, 1, 443521);  // (savepoint)
+		obj.createentity(56, 144, 10, 0, 443520);  // (savepoint)
+		obj.createentity(152, 80, 10, 1, 443521);  // (savepoint)
 		roomname = "The Sensible Room";
 		break;
 
@@ -2151,7 +2151,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 
-		obj.createentity(game, 0, -200, 1, 16, 6, -64, -500, 320 + 64, 340);
+		obj.createentity(0, -200, 1, 16, 6, -64, -500, 320 + 64, 340);
 		roomname = "B-B-B-Busted";
 		break;
 
@@ -2188,8 +2188,8 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("286,286,286,327,367,367,367,367,328,286,286,327,367,367,367,367,328,286,286,327,367,367,367,367,328,286,286,327,367,367,367,367,328,286,286,286,286,286,286,286");
 		tmap.push_back("286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 
-		obj.createentity(game, 280, 192, 10, 1, 443500);  // (savepoint)
-		obj.createentity(game, 64, 80, 10, 1, 443501);  // (savepoint)
+		obj.createentity(280, 192, 10, 1, 443500);  // (savepoint)
+		obj.createentity(64, 80, 10, 1, 443501);  // (savepoint)
 
 		if(!game.nocutscenes)
 		{
@@ -2239,12 +2239,12 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492");
 
 		obj.platformtile = 747;
-		obj.createentity(game, 120, 72, 3, 747);  //Disappearing Platform
-		obj.createentity(game, 120, 112, 3, 747);  //Disappearing Platform
-		obj.createentity(game, 120, 128, 3, 747);  //Disappearing Platform
-		obj.createentity(game, 88, 72, 2, 15, 4);  // Platform
-		obj.createentity(game, 192, 128, 9, 6);  // (shiny trinket)
-		obj.createentity(game, 240, 136, 10, 0, 443490);  // (savepoint)
+		obj.createentity(120, 72, 3, 747);  //Disappearing Platform
+		obj.createentity(120, 112, 3, 747);  //Disappearing Platform
+		obj.createentity(120, 128, 3, 747);  //Disappearing Platform
+		obj.createentity(88, 72, 2, 15, 4);  // Platform
+		obj.createentity(192, 128, 9, 6);  // (shiny trinket)
+		obj.createentity(240, 136, 10, 0, 443490);  // (savepoint)
 		roomname = "Prize for the Reckless";
 		if(game.nodeathmode)
 		{
@@ -2288,16 +2288,16 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 
-		obj.createentity(game, 152, 32, 10, 1, 443480);  // (savepoint)
-		obj.createentity(game, 152, 184, 10, 0, 443481);  // (savepoint)
-		obj.createentity(game, 272, 120, 1, 2, 8);  // Enemy
-		obj.createentity(game, 32, 96, 1, 3, 8);  // Enemy
-		obj.createentity(game, 104, 80, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 168, 80, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 232, 80, 2, 8, 4);  //Threadmill, >>>
-		obj.createentity(game, 56, 144, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 120, 144, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 184, 144, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(152, 32, 10, 1, 443480);  // (savepoint)
+		obj.createentity(152, 184, 10, 0, 443481);  // (savepoint)
+		obj.createentity(272, 120, 1, 2, 8);  // Enemy
+		obj.createentity(32, 96, 1, 3, 8);  // Enemy
+		obj.createentity(104, 80, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(168, 80, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(232, 80, 2, 8, 4);  //Threadmill, >>>
+		obj.createentity(56, 144, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(120, 144, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(184, 144, 2, 8, 4);  //Threadmill, >>>
 		roomname = "A Deception";
 		break;
 
@@ -2334,12 +2334,12 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("310,310,432,692,692,692,692,430,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310,310");
 
 		obj.platformtile = 239;
-		obj.createentity(game, 88, 112, 2, 0, 4, 88, 64, 264, 168);  // Platform, bounded
-		obj.createentity(game, 136, 112, 2, 1, 4, 88, 64, 264, 168);  // Platform, bounded
-		obj.createentity(game, 184, 112, 2, 0, 4, 88, 64, 264, 168);  // Platform, bounded
-		obj.createentity(game, 232, 112, 2, 1, 4, 88, 64, 264, 168);  // Platform, bounded
-		obj.createentity(game, 56, 64, 10, 0, 442480);  // (savepoint)
-		obj.createentity(game, 280, 152, 10, 1, 442481);  // (savepoint)
+		obj.createentity(88, 112, 2, 0, 4, 88, 64, 264, 168);  // Platform, bounded
+		obj.createentity(136, 112, 2, 1, 4, 88, 64, 264, 168);  // Platform, bounded
+		obj.createentity(184, 112, 2, 0, 4, 88, 64, 264, 168);  // Platform, bounded
+		obj.createentity(232, 112, 2, 1, 4, 88, 64, 264, 168);  // Platform, bounded
+		obj.createentity(56, 64, 10, 0, 442480);  // (savepoint)
+		obj.createentity(280, 152, 10, 1, 442481);  // (savepoint)
 
 		roomname = "Down Under";
 		break;
@@ -2376,10 +2376,10 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("295,417,779,779,779,779,415,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,417,698,698,698,820,0,0,415,295,295,295,295,295");
 		tmap.push_back("295,417,698,698,698,698,415,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,417,698,698,698,820,0,0,415,295,295,295,295,295");
 
-		obj.createentity(game, 16, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
-		obj.createentity(game, 104, 184, 2, 11, 4);  //Big Threadmill, <<<<<<
-		obj.createentity(game, 144, 168, 10, 1, 442490);  // (savepoint)
-		obj.createentity(game, 24, 112, 10, 0, 442491);  // (savepoint)
+		obj.createentity(16, 104, 2, 10, 4);  //Big Threadmill, >>>>>>
+		obj.createentity(104, 184, 2, 11, 4);  //Big Threadmill, <<<<<<
+		obj.createentity(144, 168, 10, 1, 442490);  // (savepoint)
+		obj.createentity(24, 112, 10, 0, 442491);  // (savepoint)
 		roomname = "Shenanigan";
 		break;
 
@@ -2415,13 +2415,13 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,611,0,0,0,809,689,689,609,489,489,489,489,489");
 		tmap.push_back("489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,489,611,0,0,0,809,689,689,609,489,489,489,489,489");
 
-		obj.createentity(game, 192, 88, 10, 0, 441490);  // (savepoint)
+		obj.createentity(192, 88, 10, 0, 441490);  // (savepoint)
 
 		if(!game.intimetrial)
 		{
 			if(game.companion==0 && obj.flags[10]==0 &&  !game.crewstats[2])   //also need to check if he's rescued in a previous game
 			{
-				obj.createentity(game, 42, 86, 16, 0);
+				obj.createentity(42, 86, 16, 0);
 				obj.createblock(1, 0, 0, 140, 240, 34);
 			}
 		}
@@ -2460,7 +2460,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298");
 		tmap.push_back("298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298,298");
 
-		obj.createentity(game, (5 * 8) - 4, (8 * 8) + 4, 14); //Teleporter!
+		obj.createentity((5 * 8) - 4, (8 * 8) + 4, 14); //Teleporter!
 
 		if(game.intimetrial)
 		{
@@ -2501,8 +2501,8 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,414,0,0,0,0,412,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 		tmap.push_back("292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,414,0,0,0,0,412,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 
-		obj.createentity(game, 40, 24, 10, 0, 442530);  // (savepoint)
-		obj.createentity(game, 264, 24, 10, 0, 442531);  // (savepoint)
+		obj.createentity(40, 24, 10, 0, 442530);  // (savepoint)
+		obj.createentity(264, 24, 10, 0, 442531);  // (savepoint)
 
 		roomname = "Driller";
 		break;
@@ -2539,24 +2539,24 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,214,0,0,0,0,0,0,172,173,134,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92");
 		tmap.push_back("92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,214,0,0,0,0,0,0,212,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92");
 
-		obj.createentity(game, 128, 80, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 160, 80, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 192, 80, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 128, 88, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 160, 88, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 192, 88, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 128, 96, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 128, 104, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 128, 112, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 128, 120, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 160, 96, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 160, 104, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 160, 112, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 160, 120, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 192, 96, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 192, 104, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 192, 112, 3, 867);  //Disappearing Platform
-		obj.createentity(game, 192, 120, 3, 867);  //Disappearing Platform
+		obj.createentity(128, 80, 3, 867);  //Disappearing Platform
+		obj.createentity(160, 80, 3, 867);  //Disappearing Platform
+		obj.createentity(192, 80, 3, 867);  //Disappearing Platform
+		obj.createentity(128, 88, 3, 867);  //Disappearing Platform
+		obj.createentity(160, 88, 3, 867);  //Disappearing Platform
+		obj.createentity(192, 88, 3, 867);  //Disappearing Platform
+		obj.createentity(128, 96, 3, 867);  //Disappearing Platform
+		obj.createentity(128, 104, 3, 867);  //Disappearing Platform
+		obj.createentity(128, 112, 3, 867);  //Disappearing Platform
+		obj.createentity(128, 120, 3, 867);  //Disappearing Platform
+		obj.createentity(160, 96, 3, 867);  //Disappearing Platform
+		obj.createentity(160, 104, 3, 867);  //Disappearing Platform
+		obj.createentity(160, 112, 3, 867);  //Disappearing Platform
+		obj.createentity(160, 120, 3, 867);  //Disappearing Platform
+		obj.createentity(192, 96, 3, 867);  //Disappearing Platform
+		obj.createentity(192, 104, 3, 867);  //Disappearing Platform
+		obj.createentity(192, 112, 3, 867);  //Disappearing Platform
+		obj.createentity(192, 120, 3, 867);  //Disappearing Platform
 
 		if(!game.nocutscenes)
 		{
@@ -2601,8 +2601,8 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,217,0,0,809,689,689,689,689,689,215,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95");
 		tmap.push_back("95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,217,0,0,809,689,689,689,689,689,215,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95");
 
-		obj.createentity(game, 144, 40, 3);  //Disappearing Platform
-		obj.createentity(game, 200, 128, 3);  //Disappearing Platform
+		obj.createentity(144, 40, 3);  //Disappearing Platform
+		obj.createentity(200, 128, 3);  //Disappearing Platform
 		roomname = "Boo! Think Fast!";
 		break;
 
@@ -2638,12 +2638,12 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("495,495,495,495,495,617,0,0,0,0,0,0,615,495,617,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,615,495,495,495,495");
 		tmap.push_back("495,495,495,495,495,617,0,0,0,0,0,0,615,495,536,576,576,576,576,576,576,576,576,576,576,576,576,576,576,576,576,576,576,576,576,537,495,495,495,495");
 
-		obj.createentity(game, 288, 160, 10, 1, 442500);  // (savepoint)
+		obj.createentity(288, 160, 10, 1, 442500);  // (savepoint)
 
 
-		obj.createentity(game, 135, 75, 2, 0, 3, 100, 70, 320, 160);
-		obj.createentity(game, 185, 110, 2, 0, 3, 100, 70, 320, 160);
-		obj.createentity(game, 235, 145, 2, 0, 3, 100, 70, 320, 160);
+		obj.createentity(135, 75, 2, 0, 3, 100, 70, 320, 160);
+		obj.createentity(185, 110, 2, 0, 3, 100, 70, 320, 160);
+		obj.createentity(235, 145, 2, 0, 3, 100, 70, 320, 160);
 		roomname = "Stop and Reflect";
 		break;
 
@@ -2680,11 +2680,11 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86");
 
 		obj.platformtile = 207;
-		obj.createentity(game, 112-4, 200-4, 1, 1, 6, 104, 144, 264, 240);  // Enemy, bounded
-		obj.createentity(game, 176-4, 152, 1, 0, 6, 104, 144, 264, 240);  // Enemy, bounded
-		obj.createentity(game, 240-4, 200-4, 1, 1, 6, 104, 144, 264, 240);  // Enemy, bounded
-		obj.createentity(game, 64, 48, 2, 3, 4);  // Platform
-		obj.createentity(game, 272, 152, 9, 1);  // (shiny trinket)
+		obj.createentity(112-4, 200-4, 1, 1, 6, 104, 144, 264, 240);  // Enemy, bounded
+		obj.createentity(176-4, 152, 1, 0, 6, 104, 144, 264, 240);  // Enemy, bounded
+		obj.createentity(240-4, 200-4, 1, 1, 6, 104, 144, 264, 240);  // Enemy, bounded
+		obj.createentity(64, 48, 2, 3, 4);  // Platform
+		obj.createentity(272, 152, 9, 1);  // (shiny trinket)
 
 		if(!game.nocutscenes)
 		{
@@ -2726,14 +2726,14 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("92,92,92,92,92,214,683,683,683,683,683,683,212,92,214,683,683,683,212,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92");
 		tmap.push_back("92,92,92,92,92,214,683,683,683,683,683,683,212,92,133,173,173,173,134,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92,92");
 
-		obj.createentity(game, 120+2, 8, 1, 0, 3);  // Enemy
-		obj.createentity(game, 264+2, 8, 1, 0, 3);  // Enemy
-		obj.createentity(game, 120+2, 208-4, 1, 1, 3);  // Enemy
-		obj.createentity(game, 192+2, 176-4, 1, 1, 3);  // Enemy
-		obj.createentity(game, 192+2, 40, 1, 0, 3);  // Enemy
+		obj.createentity(120+2, 8, 1, 0, 3);  // Enemy
+		obj.createentity(264+2, 8, 1, 0, 3);  // Enemy
+		obj.createentity(120+2, 208-4, 1, 1, 3);  // Enemy
+		obj.createentity(192+2, 176-4, 1, 1, 3);  // Enemy
+		obj.createentity(192+2, 40, 1, 0, 3);  // Enemy
 
-		obj.createentity(game, 64, 80, 10, 1, 441501);  // (savepoint)
-		obj.createentity(game, 64, 136, 10, 0, 441502);  // (savepoint)
+		obj.createentity(64, 80, 10, 1, 441501);  // (savepoint)
+		obj.createentity(64, 136, 10, 0, 441502);  // (savepoint)
 
 		roomname = "The Yes Men";
 		break;
@@ -2771,12 +2771,12 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("283,283,283,283,283,405,0,0,0,0,0,0,403,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283");
 
 		obj.platformtile = 10;
-		obj.createentity(game, 136-32, 64, 3, 10);  //Disappearing Platform
-		obj.createentity(game, 136, 64, 3, 10);  //Disappearing Platform
-		obj.createentity(game, 136+32, 64, 3, 10);  //Disappearing Platform
-		obj.createentity(game, 56, 104, 10, 1, 440500);  // (savepoint)
-		obj.createentity(game, 56, 152, 2, 3, 3);  // Platform
-		obj.createentity(game, 280, 192, 10, 1, 440501);  // (savepoint)
+		obj.createentity(136-32, 64, 3, 10);  //Disappearing Platform
+		obj.createentity(136, 64, 3, 10);  //Disappearing Platform
+		obj.createentity(136+32, 64, 3, 10);  //Disappearing Platform
+		obj.createentity(56, 104, 10, 1, 440500);  // (savepoint)
+		obj.createentity(56, 152, 2, 3, 3);  // Platform
+		obj.createentity(280, 192, 10, 1, 440501);  // (savepoint)
 
 		roomname = "Gantry and Dolly";
 		break;
@@ -2813,13 +2813,13 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("495,495,495,495,495,495,495,495,495,617,680,680,680,680,680,680,680,680,680,615,495,495,495,495,617,680,680,680,680,680,680,680,680,680,680,615,495,495,495,495");
 		tmap.push_back("495,495,495,495,495,495,495,495,495,536,576,576,576,576,576,576,576,576,576,537,495,495,495,495,536,576,576,576,576,576,576,576,576,576,576,537,495,495,495,495");
 
-		obj.createentity(game, 88, 104, 21, 1);  // (savepoint)
-		obj.createentity(game, 112, 104, 21, 1, 440511);  // (savepoint)
-		obj.createentity(game, 136, 88, 1, 0, 0);  // Enemy //the radar dish
-		//obj.createentity(game, 176, 104, 10, 1, 440512);  // (savepoint)
-		obj.createentity(game, 200, 104, 21, 1);  // (savepoint)
-		obj.createentity(game, 224, 104, 21, 1);  // (savepoint)
-		obj.createentity(game, 256, 32, 1, 0, 0);  // Enemy //in this case, the transmitter
+		obj.createentity(88, 104, 21, 1);  // (savepoint)
+		obj.createentity(112, 104, 21, 1, 440511);  // (savepoint)
+		obj.createentity(136, 88, 1, 0, 0);  // Enemy //the radar dish
+		//obj.createentity(176, 104, 10, 1, 440512);  // (savepoint)
+		obj.createentity(200, 104, 21, 1);  // (savepoint)
+		obj.createentity(224, 104, 21, 1);  // (savepoint)
+		obj.createentity(256, 32, 1, 0, 0);  // Enemy //in this case, the transmitter
 
 		if(!game.intimetrial)
 		{
@@ -2861,8 +2861,8 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("292,292,292,292,292,414,0,0,0,0,0,0,412,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 		tmap.push_back("292,292,292,292,292,414,0,0,0,0,0,0,412,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292,292");
 
-		obj.createentity(game, 200, 32, 1, 0, 8);  // Enemy
-		obj.createentity(game, 168, 104, 10, 1, 439500);  // (savepoint)
+		obj.createentity(200, 32, 1, 0, 8);  // Enemy
+		obj.createentity(168, 104, 10, 1, 439500);  // (savepoint)
 
 		roomname = "Security Sweep";
 		break;
@@ -2899,12 +2899,12 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,136,176,176,176,176,176,176,176,176,176,137,95,95");
 		tmap.push_back("95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95,95");
 
-		obj.createentity(game, 24, 168, 10, 1, 439510);  // (savepoint)
-		obj.createentity(game, 280, 48, 10, 0, 439511);  // (savepoint)
-		obj.createentity(game, 80, 88, 1, 3, 3);  // Enemy
-		obj.createentity(game, 224 - 16, 128, 1, 2, 3);  // Enemy
+		obj.createentity(24, 168, 10, 1, 439510);  // (savepoint)
+		obj.createentity(280, 48, 10, 0, 439511);  // (savepoint)
+		obj.createentity(80, 88, 1, 3, 3);  // Enemy
+		obj.createentity(224 - 16, 128, 1, 2, 3);  // Enemy
 
-		obj.createentity(game, 256-4, 200, 20, 1);  // (terminal)
+		obj.createentity(256-4, 200, 20, 1);  // (terminal)
 		obj.createblock(5, 256-8, 200, 20, 16, 6);
 		roomname = "Linear Collider";
 		break;
@@ -2941,8 +2941,8 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,411,0,0,0,0,409,289,289,289,289,289,289,289,289,289");
 		tmap.push_back("289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,289,411,0,0,0,0,409,289,289,289,289,289,289,289,289,289");
 
-		obj.createentity(game, 192, 48, 10, 0, 439520);  // (savepoint)
-		obj.createentity(game, 112, 160, 10, 1, 439521);  // (savepoint)
+		obj.createentity(192, 48, 10, 0, 439520);  // (savepoint)
+		obj.createentity(112, 160, 10, 1, 439521);  // (savepoint)
 		roomname = "Atmospheric Filtering Unit";
 		break;
 
@@ -2980,11 +2980,11 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 
 		roomname = "Traffic Jam";
 
-		obj.createentity(game, 45, 118, 1, 1, 4);
-		obj.createentity(game, 205, 118, 1, 1, 4);
-		obj.createentity(game, 125, 18, 1, 0, 4);
+		obj.createentity(45, 118, 1, 1, 4);
+		obj.createentity(205, 118, 1, 1, 4);
+		obj.createentity(125, 18, 1, 0, 4);
 
-		obj.createentity(game, 232, 184, 10, 0, 1);
+		obj.createentity(232, 184, 10, 0, 1);
 		break;
 
 	case rn(53,40):
@@ -3053,7 +3053,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 		tmap.push_back("286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286,286");
 
-		obj.createentity(game, 152, 168, 10, 1, 441530);  // (savepoint)
+		obj.createentity(152, 168, 10, 1, 441530);  // (savepoint)
 
 		if(!game.nocutscenes)
 		{
@@ -3171,8 +3171,8 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& gam
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89");
 
-		obj.createentity(game, 216, 144, 10, 1, 440520);  // (savepoint)
-		obj.createentity(game, 16, 136, 9, 0);  // (shiny trinket)
+		obj.createentity(216, 144, 10, 1, 440520);  // (savepoint)
+		obj.createentity(16, 136, 9, 0);  // (shiny trinket)
 
 		roomname = "It's a Secret to Nobody";
 		break;

--- a/desktop_version/src/Spacestation2.cpp
+++ b/desktop_version/src/Spacestation2.cpp
@@ -2,7 +2,7 @@
 
 #include "MakeAndPlay.h"
 
-std::vector<std::string> spacestation2class::loadlevel(int rx, int ry, Game& game, entityclass& obj)
+std::vector<std::string> spacestation2class::loadlevel(int rx, int ry)
 {
 	int t;
 	rx -= 100;

--- a/desktop_version/src/Spacestation2.cpp
+++ b/desktop_version/src/Spacestation2.cpp
@@ -14,7 +14,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry)
 	t = rx + (ry * 100);
 
 	std::vector<std::string> tmap;
-	roomname = "Untitled room ["+UtilityClass::String(rx) + "," + UtilityClass::String(ry)+"]";
+	roomname = "Untitled room ["+help.String(rx) + "," + help.String(ry)+"]";
 
 	switch(t)
 	{

--- a/desktop_version/src/Spacestation2.h
+++ b/desktop_version/src/Spacestation2.h
@@ -10,7 +10,7 @@
 class spacestation2class
 {
 public:
-	std::vector<std::string> loadlevel(int rx, int ry, Game& game, entityclass& obj);
+	std::vector<std::string> loadlevel(int rx, int ry);
 	std::string roomname;
 };
 

--- a/desktop_version/src/TerminalScripts.cpp
+++ b/desktop_version/src/TerminalScripts.cpp
@@ -389,7 +389,7 @@ void scriptclass::loadother(std::string t)
     {
 
 
-        //add("delay(15)");	add("flash(5)"); add("shake(20)"); add("playef(9,10)");
+        //add("delay(15)");	add("flash(5)"); add("shake(20)"); add("playef(9)");
 
         add("text(gray,0,114,3)");
         add("          -= WARNING =-         ");

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -132,7 +132,7 @@ std::string UtilityClass::twodigits( int t )
 std::string UtilityClass::timestring( int t )
 {
 	//given a time t in frames, return a time in seconds
-	tempstring = "";
+	std::string tempstring = "";
 	temp = (t - (t % 30)) / 30;
 	if (temp < 60)   //less than one minute
 	{

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -39,7 +39,6 @@ public:
     int globaltemp;
     int temp;
     int temp2;
-    std::string tempstring;
     std::vector<int> splitseconds;
 };
 

--- a/desktop_version/src/WarpClass.cpp
+++ b/desktop_version/src/WarpClass.cpp
@@ -1022,9 +1022,6 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry)
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		//roomname = "Outer Space";
-
-		game.test = true;
-		game.teststring = "ERROR: Map not found in Warp Area";
 		break;
 #else
 	default:

--- a/desktop_version/src/WarpClass.cpp
+++ b/desktop_version/src/WarpClass.cpp
@@ -2,7 +2,7 @@
 
 #include "MakeAndPlay.h"
 
-std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entityclass& obj)
+std::vector<std::string> warpclass::loadlevel(int rx, int ry)
 {
 	int t;
 

--- a/desktop_version/src/WarpClass.cpp
+++ b/desktop_version/src/WarpClass.cpp
@@ -55,7 +55,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("120,120,120,120,120,120,120,120,120,120,120,120,120,200,80,202,0,0,0,0,0,0,0,0,200,80,202,120,120,120,120,120,120,120,120,120,120,120,120,120");
 		tmap.push_back("120,120,120,120,120,120,120,120,120,120,120,120,120,200,80,202,0,0,0,0,0,0,0,0,200,80,202,120,120,120,120,120,120,120,120,120,120,120,120,120");
 
-		obj.createentity(game, 288, 168, 10, 1, 50500);  // (savepoint)
+		obj.createentity(288, 168, 10, 1, 50500);  // (savepoint)
 
 		if(game.intimetrial)
 		{
@@ -136,9 +136,9 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("83,83,83,83,83,205,0,0,0,0,203,83,83,83,83,83,83,205,0,0,0,0,203,83,83,83,83,83,83,205,0,0,0,0,203,83,83,83,83,83");
 		tmap.push_back("83,83,83,83,83,205,0,0,0,0,203,83,83,83,83,83,83,205,0,0,0,0,203,83,83,83,83,83,83,205,0,0,0,0,203,83,83,83,83,83");
 
-		obj.createentity(game, 248, 80, 10, 1, 51510);  // (savepoint)
-		obj.createentity(game, 136, 128, 1, 3, 3, 128, 120, 288, 152);  // Enemy, bounded
-		obj.createentity(game, 104, 192, 10, 1, 51511);  // (savepoint)
+		obj.createentity(248, 80, 10, 1, 51510);  // (savepoint)
+		obj.createentity(136, 128, 1, 3, 3, 128, 120, 288, 152);  // Enemy, bounded
+		obj.createentity(104, 192, 10, 1, 51511);  // (savepoint)
 		rcol = 1;
 		warpy = true;
 		roomname = "Take the Red Pill";
@@ -176,11 +176,11 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("135,135,135,135,135,135,135,135,135,135,215,95,217,215,95,95,95,95,95,95,95,95,95,217,215,95,217,135,135,135,135,135,135,135,135,135,135,135,135,135");
 		tmap.push_back("135,135,135,135,135,135,135,135,135,135,215,95,217,215,95,95,95,95,95,95,95,95,95,217,215,95,217,135,135,135,135,135,135,135,135,135,135,135,135,135");
 
-		obj.createentity(game, 32, 24, 1, 3, 4, -56, -40, 384, 312);  // Enemy, bounded
-		obj.createentity(game, 96, 24, 1, 3, 4, -56, -40, 384, 312);  // Enemy, bounded
-		obj.createentity(game, 160, 24, 1, 3, 4, -56, -40, 384, 312);  // Enemy, bounded
-		obj.createentity(game, 224, 24, 1, 3, 4, -56, -40, 384, 312);  // Enemy, bounded
-		obj.createentity(game, 232, 152, 10, 1, 51520);  // (savepoint)
+		obj.createentity(32, 24, 1, 3, 4, -56, -40, 384, 312);  // Enemy, bounded
+		obj.createentity(96, 24, 1, 3, 4, -56, -40, 384, 312);  // Enemy, bounded
+		obj.createentity(160, 24, 1, 3, 4, -56, -40, 384, 312);  // Enemy, bounded
+		obj.createentity(224, 24, 1, 3, 4, -56, -40, 384, 312);  // Enemy, bounded
+		obj.createentity(232, 152, 10, 1, 51520);  // (savepoint)
 		rcol = 5;
 		warpx = true;
 		roomname = "Short Circuit";
@@ -218,7 +218,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("213,212,92,214,172,174,0,0,0,0,0,0,212,214,0,0,0,0,0,0,212,214,0,0,0,0,0,0,212,214,0,0,0,0,0,0,212,92,92,92");
 		tmap.push_back("213,212,92,214,252,254,0,0,0,0,0,0,212,214,0,0,0,0,0,0,212,214,0,0,0,0,0,0,212,214,0,0,0,0,0,0,212,92,92,92");
 
-		obj.createentity(game, 32, 16, 10, 0, 50520);  // (savepoint)
+		obj.createentity(32, 16, 10, 0, 50520);  // (savepoint)
 		rcol = 4;
 		warpy = true;
 		roomname = "As you like it";
@@ -257,7 +257,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,209,211,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,209,211,0,0,0,0,0");
 		tmap.push_back("170,170,170,170,170,170,170,170,170,170,170,170,170,170,171,209,211,169,170,170,170,170,170,170,170,170,170,170,170,170,170,170,171,209,211,169,170,170,170,170");
 
-		obj.createentity(game, 16, 120, 10, 1, 50530);  // (savepoint)
+		obj.createentity(16, 120, 10, 1, 50530);  // (savepoint)
 		rcol = 3;
 		warpx = true;
 		roomname = "Maze With No Entrance";
@@ -295,7 +295,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("126,126,126,126,206,86,208,0,0,0,166,167,168,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,166,167");
 		tmap.push_back("126,126,126,126,206,86,208,0,0,0,206,86,208,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,206,86");
 
-		obj.createentity(game, 64, 152, 10, 0, 49530);  // (savepoint)
+		obj.createentity(64, 152, 10, 0, 49530);  // (savepoint)
 		rcol = 2;
 		warpy = true;
 		roomname = "As we go up, we go down";
@@ -333,10 +333,10 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("161,161,161,161,161,161,161,161,161,162,200,202,0,0,0,0,160,161,161,161,161,161,161,161,161,161,161,161,161,161,161,161,161,161,161,162,200,202,160,161");
 		tmap.push_back("80,80,80,80,80,80,80,80,80,202,200,202,0,0,0,0,200,80,80,80,80,80,80,80,80,80,80,80,80,80,80,80,80,80,80,202,200,202,200,80");
 
-		obj.createentity(game, 296, 64, 10, 1, 49540);  // (savepoint)
-		obj.createentity(game, 152-4-15+8, 32, 1, 0, 6, 128, 32, 288, 200);  // Enemy, bounded
-		obj.createentity(game, 240-4-15+8, 186, 1, 1, 6, 128, 32, 288, 200);  // Enemy, bounded
-		obj.createentity(game, 296, 152, 10, 0, 49541);  // (savepoint)
+		obj.createentity(296, 64, 10, 1, 49540);  // (savepoint)
+		obj.createentity(152-4-15+8, 32, 1, 0, 6, 128, 32, 288, 200);  // Enemy, bounded
+		obj.createentity(240-4-15+8, 186, 1, 1, 6, 128, 32, 288, 200);  // Enemy, bounded
+		obj.createentity(296, 152, 10, 0, 49541);  // (savepoint)
 		rcol = 0;
 		warpx = true;
 		roomname = "Time to get serious";
@@ -376,7 +376,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("86,86,208,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,206,86,86");
 		if(!game.intimetrial)
 		{
-			obj.createentity(game, (7 * 8) + 4, (6 * 8), 14); //Teleporter!
+			obj.createentity((7 * 8) + 4, (6 * 8), 14); //Teleporter!
 		}
 		rcol = 2;
 		warpy = true;
@@ -415,10 +415,10 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("212,92,92,214,212,92,92,214,172,173,173,174,0,0,0,0,0,0,0,0,212,92,92,214,212,92,92,214,212,92,92,214,212,92,92,214,212,92,92,214");
 		tmap.push_back("212,92,92,214,212,92,92,214,212,92,92,214,172,173,173,174,0,0,0,0,212,92,92,214,212,92,92,214,212,92,92,214,212,92,92,214,212,92,92,214");
 
-		obj.createentity(game, 96, 72, 1, 3, 8, 64, 56, 256, 152);  // Enemy, bounded
-		obj.createentity(game, 240, 120, 1, 2, 8, 64, 56, 256, 152);  // Enemy, bounded
-		obj.createentity(game, 72, 16, 10, 0, 50550);  // (savepoint)
-		obj.createentity(game, 264, 176, 10, 1, 50551);  // (savepoint)
+		obj.createentity(96, 72, 1, 3, 8, 64, 56, 256, 152);  // Enemy, bounded
+		obj.createentity(240, 120, 1, 2, 8, 64, 56, 256, 152);  // Enemy, bounded
+		obj.createentity(72, 16, 10, 0, 50550);  // (savepoint)
+		obj.createentity(264, 176, 10, 1, 50551);  // (savepoint)
 		rcol = 4;
 		warpx = true;
 		roomname = "Ascending and Descending";
@@ -456,12 +456,12 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("83,83,83,205,0,0,0,0,203,205,0,0,0,0,203,205,0,0,0,0,163,165,0,0,0,0,163,165,0,0,0,0,203,205,0,0,0,0,203,83");
 		tmap.push_back("83,83,83,205,0,0,0,0,203,205,0,0,0,0,203,205,0,0,0,0,203,205,0,0,0,0,203,205,0,0,0,0,203,205,0,0,0,0,203,83");
 
-		obj.createentity(game, 280, 24, 1, 2, 3, 128, 16, 304, 216);  // Enemy, bounded
-		obj.createentity(game, 136, 192, 1, 3, 3, 128, 16, 304, 216);  // Enemy, bounded
-		obj.createentity(game, 40, 8, 1, 0, 10, 24, -56, 120, 280);  // Enemy, bounded
-		obj.createentity(game, 88, 8, 1, 0, 10, 24, -40, 120, 272);  // Enemy, bounded
-		obj.createentity(game, 256, 128, 10, 1, 51550);  // (savepoint)
-		obj.createentity(game, 136, 32, 10, 1, 51551);  // (savepoint)
+		obj.createentity(280, 24, 1, 2, 3, 128, 16, 304, 216);  // Enemy, bounded
+		obj.createentity(136, 192, 1, 3, 3, 128, 16, 304, 216);  // Enemy, bounded
+		obj.createentity(40, 8, 1, 0, 10, 24, -56, 120, 280);  // Enemy, bounded
+		obj.createentity(88, 8, 1, 0, 10, 24, -40, 120, 272);  // Enemy, bounded
+		obj.createentity(256, 128, 10, 1, 51550);  // (savepoint)
+		obj.createentity(136, 32, 10, 1, 51551);  // (savepoint)
 		rcol = 1;
 		warpy = true;
 		roomname = "Shockwave Rider";
@@ -499,13 +499,13 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,171,169,170,170,171,169,170,170,170,170,170,170,170,170,171,0,0,0,0,169,170,170,170");
 		tmap.push_back("89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,89,211,209,89,89,211,209,89,89,89,89,89,89,89,89,211,0,0,0,0,209,89,89,89");
 
-		obj.createentity(game, 296, 32, 10, 1, 51540);  // (savepoint)
-		obj.createentity(game, 184, 192, 1, 18, 48, -800, -24, 4000, 264);  // Enemy, bounded
-		obj.createentity(game, 88, 136, 1, 17, 48, -800, -32, 4000, 272);  // Enemy, bounded
-		obj.createentity(game, 184, 80, 1, 18, 48, -800, -32, 4000, 272);  // Enemy, bounded
+		obj.createentity(296, 32, 10, 1, 51540);  // (savepoint)
+		obj.createentity(184, 192, 1, 18, 48, -800, -24, 4000, 264);  // Enemy, bounded
+		obj.createentity(88, 136, 1, 17, 48, -800, -32, 4000, 272);  // Enemy, bounded
+		obj.createentity(184, 80, 1, 18, 48, -800, -32, 4000, 272);  // Enemy, bounded
 
 
-		obj.createentity(game, 8, 32, 20, 1);  // (terminal)
+		obj.createentity(8, 32, 20, 1);  // (terminal)
 		obj.createblock(5, 8-8, 32, 20, 16, 17);
 
 		rcol = 3;
@@ -545,18 +545,18 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("176,176,176,177,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,175,177,0,0,0,0,175,176,176,176");
 		tmap.push_back("95,95,95,217,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,255,257,0,0,0,0,215,95,95,95");
 
-		obj.createentity(game, 288, 200, 10, 1, 52540);  // (savepoint)
-		obj.createentity(game, 48, 16, 1, 1, 10, 0, -40, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 64, 16+8+4+2, 1, 1, 10, 0, -48, 320, 280);  // Enemy, bounded
-		obj.createentity(game, 80, 16+16+8+4, 1, 1, 10, 0, -40, 320, 280);  // Enemy, bounded
-		obj.createentity(game, 96, 16+24+12+6, 1, 1, 10, 0, -40, 320, 304);  // Enemy, bounded
-		obj.createentity(game, 112, 16+32+16+8, 1, 1, 10, 0, -48, 320, 288);  // Enemy, bounded
-		obj.createentity(game, 128, 16+40+20+10, 1, 1, 10, 0, -40, 320, 280);  // Enemy, bounded
-		obj.createentity(game, 144, 16+48+24+12, 1, 1, 10, 0, -56, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 160, 16+56+28+14, 1, 1, 10, 0, -48, 320, 288);  // Enemy, bounded
-		obj.createentity(game, 176, 16+64+32+16, 1, 1, 10, 0, -48, 320, 296);  // Enemy, bounded
-		obj.createentity(game, 192, 16+72+36+18, 1, 1, 10, 0, -40, 320, 280);  // Enemy, bounded
-		obj.createentity(game, 208, 16+80+40+20, 1, 1, 10, 0, -48, 320, 280);  // Enemy, bounded
+		obj.createentity(288, 200, 10, 1, 52540);  // (savepoint)
+		obj.createentity(48, 16, 1, 1, 10, 0, -40, 320, 296);  // Enemy, bounded
+		obj.createentity(64, 16+8+4+2, 1, 1, 10, 0, -48, 320, 280);  // Enemy, bounded
+		obj.createentity(80, 16+16+8+4, 1, 1, 10, 0, -40, 320, 280);  // Enemy, bounded
+		obj.createentity(96, 16+24+12+6, 1, 1, 10, 0, -40, 320, 304);  // Enemy, bounded
+		obj.createentity(112, 16+32+16+8, 1, 1, 10, 0, -48, 320, 288);  // Enemy, bounded
+		obj.createentity(128, 16+40+20+10, 1, 1, 10, 0, -40, 320, 280);  // Enemy, bounded
+		obj.createentity(144, 16+48+24+12, 1, 1, 10, 0, -56, 320, 296);  // Enemy, bounded
+		obj.createentity(160, 16+56+28+14, 1, 1, 10, 0, -48, 320, 288);  // Enemy, bounded
+		obj.createentity(176, 16+64+32+16, 1, 1, 10, 0, -48, 320, 296);  // Enemy, bounded
+		obj.createentity(192, 16+72+36+18, 1, 1, 10, 0, -40, 320, 280);  // Enemy, bounded
+		obj.createentity(208, 16+80+40+20, 1, 1, 10, 0, -48, 320, 280);  // Enemy, bounded
 		rcol = 5;
 		warpy = true;
 		roomname = "Mind The Gap";
@@ -594,17 +594,17 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167,167");
 		tmap.push_back("86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86,86");
 
-		obj.createentity(game, 152, 200, 10, 1, 52530);  // (savepoint)
-		obj.createentity(game, 248, 48, 1, 3, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 152, 48, 1, 3, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 152, 96, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 56, 96, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 104, 144, 1, 3, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 200, 144, 1, 3, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 280, 16, 9, 12); //Shiny Trinket
+		obj.createentity(152, 200, 10, 1, 52530);  // (savepoint)
+		obj.createentity(248, 48, 1, 3, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(152, 48, 1, 3, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(152, 96, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(56, 96, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(104, 144, 1, 3, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(200, 144, 1, 3, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(280, 16, 9, 12); //Shiny Trinket
 
 
-		obj.createentity(game, 24, 200, 20, 1);  // (terminal)
+		obj.createentity(24, 200, 20, 1);  // (terminal)
 		obj.createblock(5, 24-8, 200, 20, 16, 18);
 		rcol = 2;
 		warpx = true;
@@ -643,7 +643,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("83,83,205,0,0,0,0,203,205,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,203,205,0,0,0,0,203,205,0,0,0,0,203,83,83");
 		tmap.push_back("83,83,205,0,0,0,0,203,205,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,203,205,0,0,0,0,203,205,0,0,0,0,203,83,83");
 
-		obj.createentity(game, 152, 112, 13);
+		obj.createentity(152, 112, 13);
 		rcol = 1;
 		warpx = true;
 		warpy = true;
@@ -682,8 +682,8 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("0,0,212,92,214,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,212,92,214,0,0");
 		tmap.push_back("0,0,212,92,214,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,212,92,214,0,0");
 
-		obj.createentity(game, 152, 112, 13);
-		obj.createentity(game, 152, 152, 10, 0, 49550);  // (savepoint)
+		obj.createentity(152, 112, 13);
+		obj.createentity(152, 152, 10, 0, 49550);  // (savepoint)
 		rcol = 4;
 		warpx = true;
 		warpy = true;
@@ -722,8 +722,8 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 152, 112, 13);
-		obj.createentity(game, 136, 40, 10, 1, 52550);  // (savepoint)
+		obj.createentity(152, 112, 13);
+		obj.createentity(136, 40, 10, 1, 52550);  // (savepoint)
 		rcol = 3;
 		warpx = true;
 		warpy = true;
@@ -762,8 +762,8 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,215,95,217,216,216,216,216,215,95,217,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 		tmap.push_back("0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,215,95,217,216,216,216,216,215,95,217,0,0,0,0,0,0,0,0,0,0,0,0,0,0");
 
-		obj.createentity(game, 152, 112, 13);
-		obj.createentity(game, 288, 120, 10, 1, 52520);  // (savepoint)
+		obj.createentity(152, 112, 13);
+		obj.createentity(288, 120, 10, 1, 52520);  // (savepoint)
 		rcol = 5;
 		warpx = true;
 		warpy = true;
@@ -802,12 +802,12 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("83,83,83,83,83,83,83,83,83,83,83,83,83,205,163,164,164,164,164,164,164,164,164,164,164,165,0,0,0,0,203,83,83,83,83,83,83,83,83,83");
 		tmap.push_back("83,83,83,83,83,83,83,83,83,83,83,83,83,205,203,83,83,83,83,83,83,83,83,83,83,205,0,0,0,0,203,83,83,83,83,83,83,83,83,83");
 
-		obj.createentity(game, 152, 112, 13);
-		obj.createentity(game, 24, 128, 10, 1, 52510);  // (savepoint)
-		obj.createentity(game, 56, 48, 1, 0, 10, -16, -16, 336, 256);  // Enemy, bounded
-		obj.createentity(game, 264, 48, 1, 0, 10, -16, -16, 336, 256);  // Enemy, bounded
-		obj.createentity(game, 152, 48, 1, 2, 8, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 152, 176, 1, 2, 8, -24, -16, 344, 256);  // Enemy, bounded
+		obj.createentity(152, 112, 13);
+		obj.createentity(24, 128, 10, 1, 52510);  // (savepoint)
+		obj.createentity(56, 48, 1, 0, 10, -16, -16, 336, 256);  // Enemy, bounded
+		obj.createentity(264, 48, 1, 0, 10, -16, -16, 336, 256);  // Enemy, bounded
+		obj.createentity(152, 48, 1, 2, 8, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(152, 176, 1, 2, 8, -24, -16, 344, 256);  // Enemy, bounded
 		rcol = 1;
 		warpx = true;
 		warpy = true;
@@ -846,13 +846,13 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		tmap.push_back("86,86,86,86,86,208,0,0,0,0,206,208,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,206,208,0,0,0,0,206,86,86,86,86,86");
 		tmap.push_back("86,86,86,86,86,208,0,0,0,0,206,208,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,206,208,0,0,0,0,206,86,86,86,86,86");
 
-		obj.createentity(game, 152, 112, 13);
-		obj.createentity(game, 248, 16, 1, 0, 10, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 64, 16, 1, 0, 10, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 200, 56, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 152, 56, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 104, 56, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
-		obj.createentity(game, 152, 152, 10, 0, 49520);  // (savepoint)
+		obj.createentity(152, 112, 13);
+		obj.createentity(248, 16, 1, 0, 10, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(64, 16, 1, 0, 10, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(200, 56, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(152, 56, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(104, 56, 1, 2, 5, -24, -24, 344, 256);  // Enemy, bounded
+		obj.createentity(152, 152, 10, 0, 49520);  // (savepoint)
 		rcol = 2;
 		warpx = true;
 		warpy = true;
@@ -933,7 +933,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 
 		obj.entities[obj.nentity].active = true;
 		obj.nentity++;
-		obj.createentity(game, 14 * 8, (8 * 8) + 4, 14); //Teleporter!
+		obj.createentity(14 * 8, (8 * 8) + 4, 14); //Teleporter!
 		obj.entities[obj.nentity - 2].active = false;
 
 		if(game.intimetrial)
@@ -982,7 +982,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry , Game& game, entit
 		{
 			if(game.companion==0 && obj.flags[11]==0 && !game.crewstats[4])   //also need to check if he's rescued in a previous game
 			{
-				obj.createentity(game, 255, 121, 15, 0);
+				obj.createentity(255, 121, 15, 0);
 				obj.createblock(1, 215, 0, 160, 240, 35);
 			}
 		}

--- a/desktop_version/src/WarpClass.cpp
+++ b/desktop_version/src/WarpClass.cpp
@@ -18,7 +18,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry)
 	warpx = false;
 	warpy = false;
 
-	roomname = "Untitled room ["+UtilityClass::String(rx) + "," + UtilityClass::String(ry)+"]";
+	roomname = "Untitled room ["+help.String(rx) + "," + help.String(ry)+"]";
 
 	switch(t)
 	{

--- a/desktop_version/src/WarpClass.h
+++ b/desktop_version/src/WarpClass.h
@@ -10,7 +10,7 @@
 class warpclass
 {
 public:
-	std::vector<std::string> loadlevel(int rx, int ry , Game& game, entityclass& obj);
+	std::vector<std::string> loadlevel(int rx, int ry);
 	std::string roomname;
 	int coin, rcol;
 	bool warpx, warpy;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -8,7 +8,6 @@
 #include "KeyPoll.h"
 #include "Map.h"
 #include "Script.h"
-//#include "UtilityClass.h"
 #include "time.h"
 
 #include "tinyxml.h"
@@ -1149,12 +1148,6 @@ int editorclass::backfree( int x, int y )
         {
             return 0;
         }
-        else
-        {
-            //if(contents[x+(levx*40)+vmult[y+(levy*30)]]>=2 && contents[x+(levx*40)+vmult[y+(levy*30)]]<80){
-            //		return 0;
-            //}
-        }
     }
     return 1;
 }
@@ -1294,21 +1287,6 @@ int editorclass::backmatch( int x, int y )
     // 5 1 6
     // 2 X 4
     // 7 3 8
-    /*
-    if(at(x-1,y)>=80 && at(x,y-1)>=80) return 10;
-    if(at(x+1,y)>=80 && at(x,y-1)>=80) return 11;
-    if(at(x-1,y)>=80 && at(x,y+1)>=80) return 12;
-    if(at(x+1,y)>=80 && at(x,y+1)>=80) return 13;
-
-    if(at(x,y-1)>=80) return 1;
-    if(at(x-1,y)>=80) return 2;
-    if(at(x,y+1)>=80) return 3;
-    if(at(x+1,y)>=80) return 4;
-    if(at(x-1,y-1)>=80) return 5;
-    if(at(x+1,y-1)>=80) return 6;
-    if(at(x-1,y+1)>=80) return 7;
-    if(at(x+1,y+1)>=80) return 8;
-    */
     if(backfree(x-1,y)==0 && backfree(x,y-1)==0 && backfree(x+1,y)==0 && backfree(x,y+1)==0) return 0;
 
     if(backfree(x-1,y)==0 && backfree(x,y-1)==0) return 10;
@@ -1879,7 +1857,6 @@ void editorclass::load(std::string& _path)
     gethooks();
     countstuff();
     version=2;
-    //saveconvertor();
 }
 
 void editorclass::save(std::string& _path)
@@ -1909,7 +1886,6 @@ void editorclass::save(std::string& _path)
     timeinfo = localtime ( &rawtime );
 
     std::string timeAndDate = asctime (timeinfo);
-    //timeAndDate += dateStr;
 
     EditorData::GetInstance().timeModified =  timeAndDate;
     if(EditorData::GetInstance().timeModified == "")
@@ -1981,18 +1957,6 @@ void editorclass::save(std::string& _path)
     msg->LinkEndChild( new TiXmlText( contentsString.c_str() ));
     data->LinkEndChild( msg );
 
-
-    //Old save format
-    /*
-    std::string contentsString;
-    for(int i = 0; i < contents.size(); i++ )
-    {
-    	contentsString += help.String(contents[i]) + ",";
-    }
-    msg = new TiXmlElement( "contents" );
-    msg->LinkEndChild( new TiXmlText( contentsString.c_str() ));
-    data->LinkEndChild( msg );
-    */
 
     msg = new TiXmlElement( "edEntities" );
     for(size_t i = 0; i < edentity.size(); i++)
@@ -2235,9 +2199,6 @@ void editorclass::generatecustomminimap()
 
 void editorrender()
 {
-    //TODO
-    //graphics.backbuffer.lock();
-
     //Draw grid
 
     FillRect(graphics.backBuffer, 0, 0, 320,240, graphics.getRGB(0,0,0));
@@ -2262,7 +2223,6 @@ void editorrender()
     }
 
     //Or draw background
-    //graphics.drawbackground(1);
     if(!ed.settingsmod)
     {
         switch(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir)
@@ -2361,8 +2321,6 @@ void editorrender()
             switch(edentity[i].t)
             {
             case 1: //Entities
-                //FillRect(graphics.backBuffer, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), 16,16, graphics.getRGB(64,32,64));
-                //graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),ed.getenemyframe(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype),164,48,48);
                 graphics.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),ed.getenemyframe(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype),ed.entcol);
                 if(edentity[i].p1==0) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "V", 255, 255, 255 - help.glow, false);
                 if(edentity[i].p1==1) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "^", 255, 255, 255 - help.glow, false);
@@ -2406,7 +2364,6 @@ void editorrender()
 
                 if(edentity[i].p1>=7)
                 {
-                    //FillRect(graphics.backBuffer, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), 32,8, graphics.getBGR(64,128,64));
                     tpoint.x = (edentity[i].x*8)- (ed.levx*40*8)+32;
                     tpoint.y = (edentity[i].y*8)- (ed.levy*30*8);
                     drawRect = graphics.tiles_rect;
@@ -2434,8 +2391,6 @@ void editorrender()
                 }
                 break;
             case 3: //Disappearing Platform
-                //FillRect(graphics.backBuffer, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), 32,8, graphics.getBGR(64,64,128));
-
                 tpoint.x = (edentity[i].x*8)- (ed.levx*40*8);
                 tpoint.y = (edentity[i].y*8)- (ed.levy*30*8);
                 drawRect = graphics.tiles_rect;
@@ -2656,9 +2611,6 @@ void editorrender()
         }
     }
 
-    //Draw connecting map guidelines
-    //TODO
-
     //Draw Cursor
     switch(ed.drawmode)
     {
@@ -2852,7 +2804,6 @@ void editorrender()
         case 0:
             graphics.Print(16,28,"**** VVVVVV SCRIPT EDITOR ****", 123, 111, 218, true);
             graphics.Print(16,44,"PRESS ESC TO RETURN TO MENU", 123, 111, 218, true);
-            //graphics.Print(16,60,"READY.", 123, 111, 218, false);
 
             if(!ed.hooklist.empty())
             {
@@ -3065,15 +3016,6 @@ void editorrender()
         }
 
         graphics.drawmenu(tr, tg, tb, 15);
-
-        /*
-        graphics.Print(4, 224, "Enter name to save map as:", 255,255,255, false);
-        if(ed.entframe<2){
-          graphics.Print(4, 232, ed.filename+"_", 196, 196, 255 - help.glow, true);
-        }else{
-          graphics.Print(4, 232, ed.filename+" ", 196, 196, 255 - help.glow, true);
-        }
-        */
     }
     else if(ed.scripttextmod)
     {
@@ -3463,21 +3405,7 @@ void editorrender()
             graphics.bprint(2,2, "P: Start Point",196, 196, 255 - help.glow);
             break;
         }
-
-        //graphics.Print(254, 2, "F1: HELP", 196, 196, 255 - help.glow, false);
     }
-
-    /*
-    for(size_t i=0; i<script.customscript.size(); i++){
-      graphics.Print(0,i*8,script.customscript[i],255,255,255);
-    }
-    graphics.Print(0,8*script.customscript.size(),help.String(script.customscript.size()),255,255,255);
-
-    for(size_t i=0; i<ed.hooklist.size(); i++){
-      graphics.Print(260,i*8,ed.hooklist[i],255,255,255);
-    }
-    graphics.Print(260,8*ed.hooklist.size(),help.String(ed.hooklist.size()),255,255,255);
-    */
 
     if(ed.notedelay>0)
     {
@@ -3503,7 +3431,6 @@ void editorrender()
     {
         graphics.render();
     }
-    //graphics.backbuffer.unlock();
 }
 
 void editorlogic()
@@ -3545,7 +3472,6 @@ void editorlogic()
 
 void editorinput()
 {
-    //TODO Mouse Input!
     game.mx = (float) key.mx;
     game.my = (float) key.my;
     ed.tilex=(game.mx - (game.mx%8))/8;
@@ -3573,7 +3499,6 @@ void editorinput()
     }
     if (key.isDown(KEYBOARD_z) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v))
     {
-        // || key.isDown(KEYBOARD_UP) || key.isDown(KEYBOARD_DOWN)
         game.press_action = true;
     };
 
@@ -4480,13 +4405,6 @@ void editorinput()
                         ed.returneditoralpha = 1000; // Let's start it higher than 255 since it gets clamped
                         script.startgamemode(21);
                     }
-                    //Return to game
-                    //game.gamestate=GAMEMODE;
-                    /*if(graphics.fademode==0)
-                    {
-                    graphics.fademode = 2;
-                    music.fadeout();
-                    }*/
                 }
             }
 
@@ -5242,12 +5160,11 @@ void editorinput()
                     else if(ed.contents[temp]==2 || ed.contents[temp]>=680)
                     {
                         //Fix background
-                        ed.contents[temp]=713;//ed.backbase(ed.levx,ed.levy);
+                        ed.contents[temp]=713;
                     }
                     else if(ed.contents[temp]>0)
                     {
                         //Fix tiles
-                        //ed.contents[temp]=ed.warpzoneedgetile(i,j)+ed.base(ed.levx,ed.levy);
                         ed.contents[temp]=ed.edgetile(i,j)+ed.base(ed.levx,ed.levy);
                     }
                 }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2301,7 +2301,7 @@ void editorrender()
             for (int i = 0; i < 40; i++)
             {
                 temp=ed.contents[i + (ed.levx*40) + ed.vmult[j+(ed.levy*30)]];
-                if(temp>0) graphics.drawtile(i*8,j*8,temp,0,0,0);
+                if(temp>0) graphics.drawtile(i*8,j*8,temp);
             }
         }
     }
@@ -2740,11 +2740,11 @@ void editorrender()
             {
                 for(int i=0; i<40; i++)
                 {
-                    graphics.drawtile(i*8,0-t2,(temp+1200+i)%1200,0,0,0);
-                    graphics.drawtile(i*8,8-t2,(temp+1200+40+i)%1200,0,0,0);
-                    graphics.drawtile(i*8,16-t2,(temp+1200+80+i)%1200,0,0,0);
-                    graphics.drawtile(i*8,24-t2,(temp+1200+120+i)%1200,0,0,0);
-                    graphics.drawtile(i*8,32-t2,(temp+1200+160+i)%1200,0,0,0);
+                    graphics.drawtile(i*8,0-t2,(temp+1200+i)%1200);
+                    graphics.drawtile(i*8,8-t2,(temp+1200+40+i)%1200);
+                    graphics.drawtile(i*8,16-t2,(temp+1200+80+i)%1200);
+                    graphics.drawtile(i*8,24-t2,(temp+1200+120+i)%1200);
+                    graphics.drawtile(i*8,32-t2,(temp+1200+160+i)%1200);
                 }
             }
             else
@@ -2772,7 +2772,7 @@ void editorrender()
 
             if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
             {
-                graphics.drawtile(45,45-t2,ed.dmtile,0,0,0);
+                graphics.drawtile(45,45-t2,ed.dmtile);
             }
             else
             {
@@ -2788,7 +2788,7 @@ void editorrender()
 
             if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
             {
-                graphics.drawtile(45,12,ed.dmtile,0,0,0);
+                graphics.drawtile(45,12,ed.dmtile);
             }
             else
             {
@@ -3179,19 +3179,19 @@ void editorrender()
                 }
                 FillRect(graphics.backBuffer, 4+(ed.drawmode*tg), 209,20,20,graphics.getRGB(64,64,64));
                 //0:
-                graphics.drawtile(tx,ty,83,0,0,0);
-                graphics.drawtile(tx+8,ty,83,0,0,0);
-                graphics.drawtile(tx,ty+8,83,0,0,0);
-                graphics.drawtile(tx+8,ty+8,83,0,0,0);
+                graphics.drawtile(tx,ty,83);
+                graphics.drawtile(tx+8,ty,83);
+                graphics.drawtile(tx,ty+8,83);
+                graphics.drawtile(tx+8,ty+8,83);
                 //1:
                 tx+=tg;
-                graphics.drawtile(tx,ty,680,0,0,0);
-                graphics.drawtile(tx+8,ty,680,0,0,0);
-                graphics.drawtile(tx,ty+8,680,0,0,0);
-                graphics.drawtile(tx+8,ty+8,680,0,0,0);
+                graphics.drawtile(tx,ty,680);
+                graphics.drawtile(tx+8,ty,680);
+                graphics.drawtile(tx,ty+8,680);
+                graphics.drawtile(tx+8,ty+8,680);
                 //2:
                 tx+=tg;
-                graphics.drawtile(tx+4,ty+4,8,0,0,0);
+                graphics.drawtile(tx+4,ty+4,8);
                 //3:
                 tx+=tg;
                 graphics.drawsprite(tx,ty,22,196,196,196);
@@ -3200,16 +3200,16 @@ void editorrender()
                 graphics.drawsprite(tx,ty,21,196,196,196);
                 //5:
                 tx+=tg;
-                graphics.drawtile(tx,ty+4,3,0,0,0);
-                graphics.drawtile(tx+8,ty+4,4,0,0,0);
+                graphics.drawtile(tx,ty+4,3);
+                graphics.drawtile(tx+8,ty+4,4);
                 //6:
                 tx+=tg;
-                graphics.drawtile(tx,ty+4,24,0,0,0);
-                graphics.drawtile(tx+8,ty+4,24,0,0,0);
+                graphics.drawtile(tx,ty+4,24);
+                graphics.drawtile(tx+8,ty+4,24);
                 //7:
                 tx+=tg;
-                graphics.drawtile(tx,ty+4,1,0,0,0);
-                graphics.drawtile(tx+8,ty+4,1,0,0,0);
+                graphics.drawtile(tx,ty+4,1);
+                graphics.drawtile(tx+8,ty+4,1);
                 //8:
                 tx+=tg;
                 graphics.drawsprite(tx,ty,78+ed.entframe,196,196,196);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -954,7 +954,7 @@ void editorclass::placetilelocal( int x, int y, int t )
 int editorclass::base( int x, int y )
 {
     //Return the base tile for the given tileset and colour
-    temp=x+(y*maxwidth);
+    int temp=x+(y*maxwidth);
     if(level[temp].tileset==0)  //Space Station
     {
         if(level[temp].tilecol>=22)
@@ -992,7 +992,7 @@ int editorclass::base( int x, int y )
 int editorclass::backbase( int x, int y )
 {
     //Return the base tile for the background of the given tileset and colour
-    temp=x+(y*maxwidth);
+    int temp=x+(y*maxwidth);
     if(level[temp].tileset==0)  //Space Station
     {
         //Pick depending on tilecol
@@ -2073,8 +2073,6 @@ void fillboxabs( int x, int y, int x2, int y2, int c )
 
 
 extern editorclass ed;
-
-extern int temp;
 
 extern scriptclass script;
 
@@ -5079,7 +5077,7 @@ void editorinput()
             {
                 for(int i=0; i<40; i++)
                 {
-                    temp=i+(ed.levx*40) + ed.vmult[j+(ed.levy*30)];
+                    int temp=i+(ed.levx*40) + ed.vmult[j+(ed.levy*30)];
                     if(ed.contents[temp]>=3 && ed.contents[temp]<80)
                     {
                         //Fix spikes
@@ -5103,7 +5101,7 @@ void editorinput()
             {
                 for(int i=0; i<40; i++)
                 {
-                    temp=i+(ed.levx*40) + ed.vmult[j+(ed.levy*30)];
+                    int temp=i+(ed.levx*40) + ed.vmult[j+(ed.levy*30)];
                     if(ed.contents[temp]>=3 && ed.contents[temp]<80)
                     {
                         //Fix spikes
@@ -5127,7 +5125,7 @@ void editorinput()
             {
                 for(int i=0; i<40; i++)
                 {
-                    temp=i+(ed.levx*40) + ed.vmult[j+(ed.levy*30)];
+                    int temp=i+(ed.levx*40) + ed.vmult[j+(ed.levy*30)];
                     if(ed.contents[temp]>=3 && ed.contents[temp]<80)
                     {
                         //Fix spikes
@@ -5151,7 +5149,7 @@ void editorinput()
             {
                 for(int i=0; i<40; i++)
                 {
-                    temp=i+(ed.levx*40) + ed.vmult[j+(ed.levy*30)];
+                    int temp=i+(ed.levx*40) + ed.vmult[j+(ed.levy*30)];
                     if(ed.contents[temp]>=3 && ed.contents[temp]<80)
                     {
                         //Fix spikes
@@ -5175,7 +5173,7 @@ void editorinput()
             {
                 for(int i=0; i<40; i++)
                 {
-                    temp=i+(ed.levx*40) + ed.vmult[j+(ed.levy*30)];
+                    int temp=i+(ed.levx*40) + ed.vmult[j+(ed.levy*30)];
                     if(ed.contents[temp]>=3 && ed.contents[temp]<80)
                     {
                         //Fix spikes

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -344,14 +344,6 @@ void editorclass::reset()
     returneditoralpha = 0;
 }
 
-void editorclass::weirdloadthing(std::string t)
-{
-    //Stupid pointless function because I hate C++ and everything to do with it
-    //It's even stupider now that I don't need to append .vvvvvv anymore! bah, whatever
-    //t=t+".vvvvvv";
-    load(t);
-}
-
 void editorclass::gethooks()
 {
     //Scan through the script and create a hooks list based on it

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2312,7 +2312,7 @@ void editorrender()
             for (int i = 0; i < 40; i++)
             {
                 temp=ed.contents[i + (ed.levx*40) + ed.vmult[j+(ed.levy*30)]];
-                if(temp>0) graphics.drawtile2(i*8,j*8,temp,0,0,0);
+                if(temp>0) graphics.drawtile2(i*8,j*8,temp);
             }
         }
     }
@@ -2751,11 +2751,11 @@ void editorrender()
             {
                 for(int i=0; i<40; i++)
                 {
-                    graphics.drawtile2(i*8,0-t2,(temp+1200+i)%1200,0,0,0);
-                    graphics.drawtile2(i*8,8-t2,(temp+1200+40+i)%1200,0,0,0);
-                    graphics.drawtile2(i*8,16-t2,(temp+1200+80+i)%1200,0,0,0);
-                    graphics.drawtile2(i*8,24-t2,(temp+1200+120+i)%1200,0,0,0);
-                    graphics.drawtile2(i*8,32-t2,(temp+1200+160+i)%1200,0,0,0);
+                    graphics.drawtile2(i*8,0-t2,(temp+1200+i)%1200);
+                    graphics.drawtile2(i*8,8-t2,(temp+1200+40+i)%1200);
+                    graphics.drawtile2(i*8,16-t2,(temp+1200+80+i)%1200);
+                    graphics.drawtile2(i*8,24-t2,(temp+1200+120+i)%1200);
+                    graphics.drawtile2(i*8,32-t2,(temp+1200+160+i)%1200);
                 }
             }
             //Highlight our little block
@@ -2776,7 +2776,7 @@ void editorrender()
             }
             else
             {
-                graphics.drawtile2(45,45-t2,ed.dmtile,0,0,0);
+                graphics.drawtile2(45,45-t2,ed.dmtile);
             }
         }
         else
@@ -2792,7 +2792,7 @@ void editorrender()
             }
             else
             {
-                graphics.drawtile2(45,12,ed.dmtile,0,0,0);
+                graphics.drawtile2(45,12,ed.dmtile);
             }
         }
     }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2270,22 +2270,22 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
     }
 
     //Or draw background
-    //dwgfx.drawbackground(1, map);
+    //dwgfx.drawbackground(1);
     if(!ed.settingsmod)
     {
         switch(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir)
         {
         case 1:
             dwgfx.rcol=ed.getwarpbackground(ed.levx, ed.levy);
-            dwgfx.drawbackground(3, map);
+            dwgfx.drawbackground(3);
             break;
         case 2:
             dwgfx.rcol=ed.getwarpbackground(ed.levx, ed.levy);
-            dwgfx.drawbackground(4, map);
+            dwgfx.drawbackground(4);
             break;
         case 3:
             dwgfx.rcol=ed.getwarpbackground(ed.levx, ed.levy);
-            dwgfx.drawbackground(5, map);
+            dwgfx.drawbackground(5);
             break;
         default:
             break;
@@ -2371,7 +2371,7 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             case 1: //Entities
                 //FillRect(dwgfx.backBuffer, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), 16,16, dwgfx.getRGB(64,32,64));
                 //dwgfx.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),ed.getenemyframe(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype),164,48,48);
-                dwgfx.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),ed.getenemyframe(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype),ed.entcol,help);
+                dwgfx.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),ed.getenemyframe(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype),ed.entcol);
                 if(edentity[i].p1==0) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "V", 255, 255, 255 - help.glow, false);
                 if(edentity[i].p1==1) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "^", 255, 255, 255 - help.glow, false);
                 if(edentity[i].p1==2) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "<", 255, 255, 255 - help.glow, false);
@@ -2517,17 +2517,17 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                 }
                 break;
             case 15: //Crewmates
-                dwgfx.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),144,obj.crewcolour(edentity[i].p1), help);
+                dwgfx.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),144,obj.crewcolour(edentity[i].p1));
                 fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,24,dwgfx.getRGB(164,164,164));
                 break;
             case 16: //Start
                 if(edentity[i].p1==0)  //Left
                 {
-                    dwgfx.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),0,obj.crewcolour(0), help);
+                    dwgfx.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),0,obj.crewcolour(0));
                 }
                 else if(edentity[i].p1==1)
                 {
-                    dwgfx.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),3,obj.crewcolour(0), help);
+                    dwgfx.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),3,obj.crewcolour(0));
                 }
                 fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,24,dwgfx.getRGB(164,255,255));
                 if(ed.entframe<2)
@@ -2910,7 +2910,7 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
     }
     else if(ed.settingsmod)
     {
-        if(!game.colourblindmode) dwgfx.drawtowerbackgroundsolo(map);
+        if(!game.colourblindmode) dwgfx.drawtowerbackgroundsolo();
 
         int tr = map.r - (help.glow / 4) - int(fRandom() * 4);
         int tg = map.g - (help.glow / 4) - int(fRandom() * 4);
@@ -3072,7 +3072,7 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             dwgfx.bigprint( -1, 110, "quitting?", tr, tg, tb, true);
         }
 
-        dwgfx.drawmenu(game, tr, tg, tb, 15);
+        dwgfx.drawmenu(tr, tg, tb, 15);
 
         /*
         dwgfx.Print(4, 224, "Enter name to save map as:", 255,255,255, false);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3486,11 +3486,6 @@ void editorrender()
         graphics.Print(0,121, ed.note,196-((45-ed.notedelay)*4), 196-((45-ed.notedelay)*4), 196-((45-ed.notedelay)*4), true);
     }
 
-    if (game.test)
-    {
-        graphics.bprint(5, 5, game.teststring, 196, 196, 255 - help.glow, false);
-    }
-
     graphics.drawfade();
 
     if (game.flashlight > 0 && !game.noflashingmode)

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1935,7 +1935,7 @@ void editorclass::save(std::string& _path)
     msg->LinkEndChild( meta );
 
     meta = new TiXmlElement( "Created" );
-    meta->LinkEndChild( new TiXmlText( UtilityClass::String(version).c_str() ));
+    meta->LinkEndChild( new TiXmlText( help.String(version).c_str() ));
     msg->LinkEndChild( meta );
 
     meta = new TiXmlElement( "Modified" );
@@ -1943,7 +1943,7 @@ void editorclass::save(std::string& _path)
     msg->LinkEndChild( meta );
 
     meta = new TiXmlElement( "Modifiers" );
-    meta->LinkEndChild( new TiXmlText( UtilityClass::String(version).c_str() ));
+    meta->LinkEndChild( new TiXmlText( help.String(version).c_str() ));
     msg->LinkEndChild( meta );
 
     meta = new TiXmlElement( "Desc1" );
@@ -1965,15 +1965,15 @@ void editorclass::save(std::string& _path)
     data->LinkEndChild( msg );
 
     msg = new TiXmlElement( "mapwidth" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(mapwidth).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(mapwidth).c_str() ));
     data->LinkEndChild( msg );
 
     msg = new TiXmlElement( "mapheight" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(mapheight).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(mapheight).c_str() ));
     data->LinkEndChild( msg );
 
     msg = new TiXmlElement( "levmusic" );
-    msg->LinkEndChild( new TiXmlText( UtilityClass::String(levmusic).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(levmusic).c_str() ));
     data->LinkEndChild( msg );
 
     //New save format
@@ -1982,7 +1982,7 @@ void editorclass::save(std::string& _path)
     {
         for(int x = 0; x < mapwidth*40; x++ )
         {
-            contentsString += UtilityClass::String(contents[x + (maxwidth*40*y)]) + ",";
+            contentsString += help.String(contents[x + (maxwidth*40*y)]) + ",";
         }
     }
     msg = new TiXmlElement( "contents" );
@@ -1995,7 +1995,7 @@ void editorclass::save(std::string& _path)
     std::string contentsString;
     for(int i = 0; i < contents.size(); i++ )
     {
-    	contentsString += UtilityClass::String(contents[i]) + ",";
+    	contentsString += help.String(contents[i]) + ",";
     }
     msg = new TiXmlElement( "contents" );
     msg->LinkEndChild( new TiXmlText( contentsString.c_str() ));

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -4059,7 +4059,7 @@ void editorinput()
                         }
                         else if (game.currentmenuoption == 4)
                         {
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("ed_settings");
                             map.nexttowercolour();
                         }
@@ -4069,14 +4069,14 @@ void editorinput()
                         if (game.currentmenuoption == 0)
                         {
                             //Change level description stuff
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("ed_desc");
                             map.nexttowercolour();
                         }
                         else if (game.currentmenuoption == 1)
                         {
                             //Enter script editormode
-                            music.playef(11, 10);
+                            music.playef(11);
                             ed.scripteditmod=true;
                             ed.clearscriptbuffer();
                             key.enabletextentry();
@@ -4090,7 +4090,7 @@ void editorinput()
                         }
                         else if (game.currentmenuoption == 2)
                         {
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("ed_music");
                             map.nexttowercolour();
                             if(ed.levmusic>0) music.play(ed.levmusic);
@@ -4127,7 +4127,7 @@ void editorinput()
                         }
                         else if (game.currentmenuoption == 5)
                         {
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("ed_quit");
                             map.nexttowercolour();
                         }
@@ -4149,11 +4149,11 @@ void editorinput()
                             {
                                 music.haltdasmusik();
                             }
-                            music.playef(11, 10);
+                            music.playef(11);
                         }
                         else if (game.currentmenuoption == 1)
                         {
-                            music.playef(11, 10);
+                            music.playef(11);
                             music.fadeout();
                             game.createmenu("ed_settings");
                             map.nexttowercolour();
@@ -4181,14 +4181,14 @@ void editorinput()
                         else if (game.currentmenuoption == 1)
                         {
                             //Quit without saving
-                            music.playef(11, 10);
+                            music.playef(11);
                             music.fadeout();
                             graphics.fademode = 2;
                         }
                         else if (game.currentmenuoption == 2)
                         {
                             //Go back to editor
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("ed_settings");
                             map.nexttowercolour();
                         }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -4491,7 +4491,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         music.stopmusic();
                         dwgfx.backgrounddrawn=false;
                         ed.returneditoralpha = 1000; // Let's start it higher than 255 since it gets clamped
-                        script.startgamemode(21, key, dwgfx, game, map, obj, help, music);
+                        script.startgamemode(21);
                     }
                     //Return to game
                     //game.gamestate=GAMEMODE;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1527,7 +1527,7 @@ int editorclass::spikedir( int x, int y )
     return 8;
 }
 
-void editorclass::findstartpoint(Game& game)
+void editorclass::findstartpoint()
 {
     //Ok! Scan the room for the closest checkpoint
     int testeditor=-1;
@@ -2099,20 +2099,20 @@ bool edentclear( int xp, int yp )
     return true;
 }
 
-void fillbox( Graphics& dwgfx, int x, int y, int x2, int y2, int c )
+void fillbox( int x, int y, int x2, int y2, int c )
 {
-    FillRect(dwgfx.backBuffer, x, y, x2-x, 1, c);
-    FillRect(dwgfx.backBuffer, x, y2-1, x2-x, 1, c);
-    FillRect(dwgfx.backBuffer, x, y, 1, y2-y, c);
-    FillRect(dwgfx.backBuffer, x2-1, y, 1, y2-y, c);
+    FillRect(graphics.backBuffer, x, y, x2-x, 1, c);
+    FillRect(graphics.backBuffer, x, y2-1, x2-x, 1, c);
+    FillRect(graphics.backBuffer, x, y, 1, y2-y, c);
+    FillRect(graphics.backBuffer, x2-1, y, 1, y2-y, c);
 }
 
-void fillboxabs( Graphics& dwgfx, int x, int y, int x2, int y2, int c )
+void fillboxabs( int x, int y, int x2, int y2, int c )
 {
-    FillRect(dwgfx.backBuffer, x, y, x2, 1, c);
-    FillRect(dwgfx.backBuffer, x, y+y2-1, x2, 1, c);
-    FillRect(dwgfx.backBuffer, x, y, 1, y2, c);
-    FillRect(dwgfx.backBuffer, x+x2-1, y, 1, y2, c);
+    FillRect(graphics.backBuffer, x, y, x2, 1, c);
+    FillRect(graphics.backBuffer, x, y+y2-1, x2, 1, c);
+    FillRect(graphics.backBuffer, x, y, 1, y2, c);
+    FillRect(graphics.backBuffer, x+x2-1, y, 1, y2, c);
 }
 
 
@@ -2122,7 +2122,7 @@ extern int temp;
 
 extern scriptclass script;
 
-void editorclass::generatecustomminimap(Graphics& dwgfx, mapclass& map)
+void editorclass::generatecustomminimap()
 {
     map.customwidth=mapwidth;
     map.customheight=mapheight;
@@ -2157,7 +2157,7 @@ void editorclass::generatecustomminimap(Graphics& dwgfx, mapclass& map)
         map.custommmysize=180-(map.custommmyoff*2);
     }
 
-    FillRect(dwgfx.images[12], dwgfx.getRGB(0,0,0));
+    FillRect(graphics.images[12], graphics.getRGB(0,0,0));
 
     int tm=0;
     int temp=0;
@@ -2181,7 +2181,7 @@ void editorclass::generatecustomminimap(Graphics& dwgfx, mapclass& map)
                         if(temp>=1)
                         {
                             //Fill in this pixel
-                            FillRect(dwgfx.images[12], (i2*48)+i, (j2*36)+j, 1, 1, dwgfx.getRGB(tm, tm, tm));
+                            FillRect(graphics.images[12], (i2*48)+i, (j2*36)+j, 1, 1, graphics.getRGB(tm, tm, tm));
                         }
                     }
                 }
@@ -2207,7 +2207,7 @@ void editorclass::generatecustomminimap(Graphics& dwgfx, mapclass& map)
                         if(temp>=1)
                         {
                             //Fill in this pixel
-                            FillRect(dwgfx.images[12], (i2*24)+i, (j2*18)+j, 1, 1, dwgfx.getRGB(tm, tm, tm));
+                            FillRect(graphics.images[12], (i2*24)+i, (j2*18)+j, 1, 1, graphics.getRGB(tm, tm, tm));
                         }
                     }
                 }
@@ -2232,7 +2232,7 @@ void editorclass::generatecustomminimap(Graphics& dwgfx, mapclass& map)
                         if(temp>=1)
                         {
                             //Fill in this pixel
-                            FillRect(dwgfx.images[12], (i2*12)+i, (j2*9)+j, 1, 1, dwgfx.getRGB(tm, tm, tm));
+                            FillRect(graphics.images[12], (i2*12)+i, (j2*9)+j, 1, 1, graphics.getRGB(tm, tm, tm));
                         }
                     }
                 }
@@ -2241,51 +2241,51 @@ void editorclass::generatecustomminimap(Graphics& dwgfx, mapclass& map)
     }
 }
 
-void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help )
+void editorrender()
 {
     //TODO
-    //dwgfx.backbuffer.lock();
+    //graphics.backbuffer.lock();
 
     //Draw grid
 
-    FillRect(dwgfx.backBuffer, 0, 0, 320,240, dwgfx.getRGB(0,0,0));
+    FillRect(graphics.backBuffer, 0, 0, 320,240, graphics.getRGB(0,0,0));
     for(int j=0; j<30; j++)
     {
         for(int i=0; i<40; i++)
         {
-            fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(8,8,8)); //a simple grid
-            if(i%4==0) fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(16,16,16));
-            if(j%4==0) fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(16,16,16));
+            fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(8,8,8)); //a simple grid
+            if(i%4==0) fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(16,16,16));
+            if(j%4==0) fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(16,16,16));
 
             //Minor guides
-            if(i==9) fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(24,24,24));
-            if(i==30) fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(24,24,24));
-            if(j==6 || j==7) fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(24,24,24));
-            if(j==21 || j==22) fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(24,24,24));
+            if(i==9) fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(24,24,24));
+            if(i==30) fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(24,24,24));
+            if(j==6 || j==7) fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(24,24,24));
+            if(j==21 || j==22) fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(24,24,24));
 
             //Major guides
-            if(i==20 || i==19) fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(32,32,32));
-            if(j==14) fillbox(dwgfx, i*8, j*8, (i*8)+7, (j*8)+7, dwgfx.getRGB(32,32,32));
+            if(i==20 || i==19) fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(32,32,32));
+            if(j==14) fillbox(i*8, j*8, (i*8)+7, (j*8)+7, graphics.getRGB(32,32,32));
         }
     }
 
     //Or draw background
-    //dwgfx.drawbackground(1);
+    //graphics.drawbackground(1);
     if(!ed.settingsmod)
     {
         switch(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir)
         {
         case 1:
-            dwgfx.rcol=ed.getwarpbackground(ed.levx, ed.levy);
-            dwgfx.drawbackground(3);
+            graphics.rcol=ed.getwarpbackground(ed.levx, ed.levy);
+            graphics.drawbackground(3);
             break;
         case 2:
-            dwgfx.rcol=ed.getwarpbackground(ed.levx, ed.levy);
-            dwgfx.drawbackground(4);
+            graphics.rcol=ed.getwarpbackground(ed.levx, ed.levy);
+            graphics.drawbackground(4);
             break;
         case 3:
-            dwgfx.rcol=ed.getwarpbackground(ed.levx, ed.levy);
-            dwgfx.drawbackground(5);
+            graphics.rcol=ed.getwarpbackground(ed.levx, ed.levy);
+            graphics.drawbackground(5);
             break;
         default:
             break;
@@ -2301,7 +2301,7 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             for (int i = 0; i < 40; i++)
             {
                 temp=ed.contents[i + (ed.levx*40) + ed.vmult[j+(ed.levy*30)]];
-                if(temp>0) dwgfx.drawtile(i*8,j*8,temp,0,0,0);
+                if(temp>0) graphics.drawtile(i*8,j*8,temp,0,0,0);
             }
         }
     }
@@ -2312,7 +2312,7 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             for (int i = 0; i < 40; i++)
             {
                 temp=ed.contents[i + (ed.levx*40) + ed.vmult[j+(ed.levy*30)]];
-                if(temp>0) dwgfx.drawtile2(i*8,j*8,temp,0,0,0);
+                if(temp>0) graphics.drawtile2(i*8,j*8,temp,0,0,0);
             }
         }
     }
@@ -2325,12 +2325,12 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
         //left edge
         if(ed.freewrap((ed.levx*40)-1,j+(ed.levy*30))==1)
         {
-            FillRect(dwgfx.backBuffer, 0,j*8, 2,8, dwgfx.getRGB(255,255,255-help.glow));
+            FillRect(graphics.backBuffer, 0,j*8, 2,8, graphics.getRGB(255,255,255-help.glow));
         }
         //right edge
         if(ed.freewrap((ed.levx*40)+40,j+(ed.levy*30))==1)
         {
-            FillRect(dwgfx.backBuffer, 318,j*8, 2,8, dwgfx.getRGB(255,255,255-help.glow));
+            FillRect(graphics.backBuffer, 318,j*8, 2,8, graphics.getRGB(255,255,255-help.glow));
         }
     }
 
@@ -2338,12 +2338,12 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
     {
         if(ed.freewrap((ed.levx*40)+i,(ed.levy*30)-1)==1)
         {
-            FillRect(dwgfx.backBuffer, i*8,0, 8,2, dwgfx.getRGB(255,255,255-help.glow));
+            FillRect(graphics.backBuffer, i*8,0, 8,2, graphics.getRGB(255,255,255-help.glow));
         }
 
         if(ed.freewrap((ed.levx*40)+i,30+(ed.levy*30))==1)
         {
-            FillRect(dwgfx.backBuffer, i*8,238, 8,2, dwgfx.getRGB(255,255,255-help.glow));
+            FillRect(graphics.backBuffer, i*8,238, 8,2, graphics.getRGB(255,255,255-help.glow));
         }
     }
 
@@ -2369,111 +2369,111 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             switch(edentity[i].t)
             {
             case 1: //Entities
-                //FillRect(dwgfx.backBuffer, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), 16,16, dwgfx.getRGB(64,32,64));
-                //dwgfx.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),ed.getenemyframe(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype),164,48,48);
-                dwgfx.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),ed.getenemyframe(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype),ed.entcol);
-                if(edentity[i].p1==0) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "V", 255, 255, 255 - help.glow, false);
-                if(edentity[i].p1==1) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "^", 255, 255, 255 - help.glow, false);
-                if(edentity[i].p1==2) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "<", 255, 255, 255 - help.glow, false);
-                if(edentity[i].p1==3) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, ">", 255, 255, 255 - help.glow, false);
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,dwgfx.getBGR(255,164,255));
+                //FillRect(graphics.backBuffer, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), 16,16, graphics.getRGB(64,32,64));
+                //graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),ed.getenemyframe(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype),164,48,48);
+                graphics.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),ed.getenemyframe(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype),ed.entcol);
+                if(edentity[i].p1==0) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "V", 255, 255, 255 - help.glow, false);
+                if(edentity[i].p1==1) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "^", 255, 255, 255 - help.glow, false);
+                if(edentity[i].p1==2) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "<", 255, 255, 255 - help.glow, false);
+                if(edentity[i].p1==3) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, ">", 255, 255, 255 - help.glow, false);
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,graphics.getBGR(255,164,255));
                 break;
             case 2: //Threadmills & platforms
                 tpoint.x = (edentity[i].x*8)- (ed.levx*40*8);
                 tpoint.y = (edentity[i].y*8)- (ed.levy*30*8);
-                drawRect = dwgfx.tiles_rect;
+                drawRect = graphics.tiles_rect;
                 drawRect.x += tpoint.x;
                 drawRect.y += tpoint.y;
-                BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                 drawRect.x += 8;
-                BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                 drawRect.x += 8;
-                BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                 drawRect.x += 8;
-                BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL,dwgfx.backBuffer, &drawRect);
+                BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL,graphics.backBuffer, &drawRect);
 
                 if(edentity[i].p1<=4)
                 {
-                    if(edentity[i].p1==0) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+12,(edentity[i].y*8)- (ed.levy*30*8), "V", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                    if(edentity[i].p1==1) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+12,(edentity[i].y*8)- (ed.levy*30*8), "^", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                    if(edentity[i].p1==2) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+12,(edentity[i].y*8)- (ed.levy*30*8), "<", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                    if(edentity[i].p1==3) dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+12,(edentity[i].y*8)- (ed.levy*30*8), ">", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),32,8,dwgfx.getBGR(255,255,255));
+                    if(edentity[i].p1==0) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+12,(edentity[i].y*8)- (ed.levy*30*8), "V", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                    if(edentity[i].p1==1) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+12,(edentity[i].y*8)- (ed.levy*30*8), "^", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                    if(edentity[i].p1==2) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+12,(edentity[i].y*8)- (ed.levy*30*8), "<", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                    if(edentity[i].p1==3) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+12,(edentity[i].y*8)- (ed.levy*30*8), ">", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),32,8,graphics.getBGR(255,255,255));
                 }
 
                 if(edentity[i].p1==5)
                 {
-                    dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), ">>>>", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),32,8,dwgfx.getBGR(255,255,255));
+                    graphics.Print((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), ">>>>", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),32,8,graphics.getBGR(255,255,255));
                 }
                 else if(edentity[i].p1==6)
                 {
-                    dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), "<<<<", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),32,8,dwgfx.getBGR(255,255,255));
+                    graphics.Print((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), "<<<<", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),32,8,graphics.getBGR(255,255,255));
                 }
 
                 if(edentity[i].p1>=7)
                 {
-                    //FillRect(dwgfx.backBuffer, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), 32,8, dwgfx.getBGR(64,128,64));
+                    //FillRect(graphics.backBuffer, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), 32,8, graphics.getBGR(64,128,64));
                     tpoint.x = (edentity[i].x*8)- (ed.levx*40*8)+32;
                     tpoint.y = (edentity[i].y*8)- (ed.levy*30*8);
-                    drawRect = dwgfx.tiles_rect;
+                    drawRect = graphics.tiles_rect;
                     drawRect.x += tpoint.x;
                     drawRect.y += tpoint.y;
-                    BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                    BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                     drawRect.x += 8;
-                    BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                    BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                     drawRect.x += 8;
-                    BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                    BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                     drawRect.x += 8;
-                    BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL,dwgfx.backBuffer, &drawRect);
+                    BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL,graphics.backBuffer, &drawRect);
 
                 }
 
                 if(edentity[i].p1==7)
                 {
-                    dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8), "> > > > ", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),64,8,dwgfx.getBGR(255,255,255));
+                    graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8), "> > > > ", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),64,8,graphics.getBGR(255,255,255));
                 }
                 else if(edentity[i].p1==8)
                 {
-                    dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8), "< < < < ", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),64,8,dwgfx.getBGR(255,255,255));
+                    graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8), "< < < < ", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),64,8,graphics.getBGR(255,255,255));
                 }
                 break;
             case 3: //Disappearing Platform
-                //FillRect(dwgfx.backBuffer, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), 32,8, dwgfx.getBGR(64,64,128));
+                //FillRect(graphics.backBuffer, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), 32,8, graphics.getBGR(64,64,128));
 
                 tpoint.x = (edentity[i].x*8)- (ed.levx*40*8);
                 tpoint.y = (edentity[i].y*8)- (ed.levy*30*8);
-                drawRect = dwgfx.tiles_rect;
+                drawRect = graphics.tiles_rect;
                 drawRect.x += tpoint.x;
                 drawRect.y += tpoint.y;
-                BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                 drawRect.x += 8;
-                BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                 drawRect.x += 8;
-                BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL, dwgfx.backBuffer, &drawRect);
+                BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                 drawRect.x += 8;
-                BlitSurfaceStandard(dwgfx.entcolours[obj.customplatformtile],NULL,dwgfx.backBuffer, &drawRect);
+                BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL,graphics.backBuffer, &drawRect);
 
-                dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), "////", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),32,8,dwgfx.getBGR(255,255,255));
+                graphics.Print((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), "////", 255 - help.glow, 255 - help.glow, 255 - help.glow, false);
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),32,8,graphics.getBGR(255,255,255));
                 break;
             case 9: //Shiny Trinket
-                dwgfx.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),22,196,196,196);
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,dwgfx.getRGB(164,164,255));
+                graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),22,196,196,196);
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,graphics.getRGB(164,164,255));
                 break;
             case 10: //Checkpoints
                 if(edentity[i].p1==0)  //From roof
                 {
-                    dwgfx.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),20,196,196,196);
+                    graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),20,196,196,196);
                 }
                 else if(edentity[i].p1==1)   //From floor
                 {
-                    dwgfx.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),21,196,196,196);
+                    graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),21,196,196,196);
                 }
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,dwgfx.getRGB(164,164,255));
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,graphics.getRGB(164,164,255));
                 break;
             case 11: //Gravity lines
                 if(edentity[i].p1==0)  //Horizontal
@@ -2484,8 +2484,8 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                     while(ed.spikefree(tx,ty)==0) tx--;
                     while(ed.spikefree(tx2,ty)==0) tx2++;
                     tx++;
-                    FillRect(dwgfx.backBuffer, (tx*8),(ty*8)+4, (tx2-tx)*8,1, dwgfx.getRGB(194,194,194));
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,dwgfx.getRGB(164,255,164));
+                    FillRect(graphics.backBuffer, (tx*8),(ty*8)+4, (tx2-tx)*8,1, graphics.getRGB(194,194,194));
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(164,255,164));
                     edentity[i].p2=tx;
                     edentity[i].p3=(tx2-tx)*8;
                 }
@@ -2497,74 +2497,74 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                     while(ed.spikefree(tx,ty)==0) ty--;
                     while(ed.spikefree(tx,ty2)==0) ty2++;
                     ty++;
-                    FillRect(dwgfx.backBuffer, (tx*8)+3,(ty*8), 1,(ty2-ty)*8, dwgfx.getRGB(194,194,194));
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,dwgfx.getRGB(164,255,164));
+                    FillRect(graphics.backBuffer, (tx*8)+3,(ty*8), 1,(ty2-ty)*8, graphics.getRGB(194,194,194));
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(164,255,164));
                     edentity[i].p2=ty;
                     edentity[i].p3=(ty2-ty)*8;
                 }
                 break;
             case 13://Warp tokens
-                dwgfx.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),18+(ed.entframe%2),196,196,196);
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,dwgfx.getRGB(164,164,255));
+                graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),18+(ed.entframe%2),196,196,196);
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,graphics.getRGB(164,164,255));
                 if(ed.temp==i)
                 {
-                    dwgfx.bprint((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)-8,
+                    graphics.bprint((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)-8,
                                 "("+help.String(((edentity[i].p1-int(edentity[i].p1%40))/40)+1)+","+help.String(((edentity[i].p2-int(edentity[i].p2%30))/30)+1)+")",210,210,255);
                 }
                 else
                 {
-                    dwgfx.bprint((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)-8,help.String(ed.findwarptoken(i)),210,210,255);
+                    graphics.bprint((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)-8,help.String(ed.findwarptoken(i)),210,210,255);
                 }
                 break;
             case 15: //Crewmates
-                dwgfx.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),144,obj.crewcolour(edentity[i].p1));
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,24,dwgfx.getRGB(164,164,164));
+                graphics.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),144,obj.crewcolour(edentity[i].p1));
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,24,graphics.getRGB(164,164,164));
                 break;
             case 16: //Start
                 if(edentity[i].p1==0)  //Left
                 {
-                    dwgfx.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),0,obj.crewcolour(0));
+                    graphics.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),0,obj.crewcolour(0));
                 }
                 else if(edentity[i].p1==1)
                 {
-                    dwgfx.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),3,obj.crewcolour(0));
+                    graphics.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),3,obj.crewcolour(0));
                 }
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,24,dwgfx.getRGB(164,255,255));
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,24,graphics.getRGB(164,255,255));
                 if(ed.entframe<2)
                 {
-                    dwgfx.bprint((edentity[i].x*8)- (ed.levx*40*8)-12,(edentity[i].y*8)- (ed.levy*30*8)-8,"START",255,255,255);
+                    graphics.bprint((edentity[i].x*8)- (ed.levx*40*8)-12,(edentity[i].y*8)- (ed.levy*30*8)-8,"START",255,255,255);
                 }
                 else
                 {
-                    dwgfx.bprint((edentity[i].x*8)- (ed.levx*40*8)-12,(edentity[i].y*8)- (ed.levy*30*8)-8,"START",196,196,196);
+                    graphics.bprint((edentity[i].x*8)- (ed.levx*40*8)-12,(edentity[i].y*8)- (ed.levy*30*8)-8,"START",196,196,196);
                 }
                 break;
             case 17: //Roomtext
                 if(edentity[i].scriptname.length()<1)
                 {
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,dwgfx.getRGB(96,96,96));
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(96,96,96));
                 }
                 else
                 {
                     int length = utf8::unchecked::distance(edentity[i].scriptname.begin(), edentity[i].scriptname.end());
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),length*8,8,dwgfx.getRGB(96,96,96));
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),length*8,8,graphics.getRGB(96,96,96));
                 }
-                dwgfx.Print((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), edentity[i].scriptname, 196, 196, 255 - help.glow);
+                graphics.Print((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8), edentity[i].scriptname, 196, 196, 255 - help.glow);
                 break;
             case 18: //Terminals
-                dwgfx.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)+8,17,96,96,96);
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,24,dwgfx.getRGB(164,164,164));
+                graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)+8,17,96,96,96);
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,24,graphics.getRGB(164,164,164));
                 if(ed.temp==i)
                 {
-                    dwgfx.bprint((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)-8,edentity[i].scriptname,210,210,255);
+                    graphics.bprint((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)-8,edentity[i].scriptname,210,210,255);
                 }
                 break;
             case 19: //Script Triggers
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),edentity[i].p1*8,edentity[i].p2*8,dwgfx.getRGB(255,164,255));
-                fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,dwgfx.getRGB(255,255,255));
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),edentity[i].p1*8,edentity[i].p2*8,graphics.getRGB(255,164,255));
+                fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(255,255,255));
                 if(ed.temp==i)
                 {
-                    dwgfx.bprint((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)-8,edentity[i].scriptname,210,210,255);
+                    graphics.bprint((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8)-8,edentity[i].scriptname,210,210,255);
                 }
                 break;
             case 50: //Warp lines
@@ -2576,8 +2576,8 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                     while(ed.free(tx,ty)==0) tx--;
                     while(ed.free(tx2,ty)==0) tx2++;
                     tx++;
-                    fillboxabs(dwgfx, (tx*8),(ty*8)+1, (tx2-tx)*8,6, dwgfx.getRGB(255,255,194));
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,dwgfx.getRGB(255,255,164));
+                    fillboxabs((tx*8),(ty*8)+1, (tx2-tx)*8,6, graphics.getRGB(255,255,194));
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(255,255,164));
                     edentity[i].p2=tx;
                     edentity[i].p3=(tx2-tx)*8;
                 }
@@ -2589,8 +2589,8 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                     while(ed.free(tx,ty)==0) ty--;
                     while(ed.free(tx,ty2)==0) ty2++;
                     ty++;
-                    fillboxabs(dwgfx, (tx*8)+1,(ty*8), 6,(ty2-ty)*8, dwgfx.getRGB(255,255,194));
-                    fillboxabs(dwgfx, (edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,dwgfx.getRGB(255,255,164));
+                    fillboxabs((tx*8)+1,(ty*8), 6,(ty2-ty)*8, graphics.getRGB(255,255,194));
+                    fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(255,255,164));
                     edentity[i].p2=ty;
                     edentity[i].p3=(ty2-ty)*8;
                 }
@@ -2605,16 +2605,16 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             ty=(edentity[i].p2-(edentity[i].p2%30))/30;
             if(tx==ed.levx && ty==ed.levy)
             {
-                dwgfx.drawsprite((edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8),18+(ed.entframe%2),64,64,64);
-                fillboxabs(dwgfx, (edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8),16,16,dwgfx.getRGB(64,64,96));
+                graphics.drawsprite((edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8),18+(ed.entframe%2),64,64,64);
+                fillboxabs((edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8),16,16,graphics.getRGB(64,64,96));
                 if(ed.tilex+(ed.levx*40)==edentity[i].p1 && ed.tiley+(ed.levy*30)==edentity[i].p2)
                 {
-                    dwgfx.bprint((edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8)-8,
+                    graphics.bprint((edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8)-8,
                                 "("+help.String(((edentity[i].x-int(edentity[i].x%40))/40)+1)+","+help.String(((edentity[i].y-int(edentity[i].y%30))/30)+1)+")",190,190,225);
                 }
                 else
                 {
-                    dwgfx.bprint((edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8)-8,help.String(ed.findwarptoken(i)),190,190,225);
+                    graphics.bprint((edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8)-8,help.String(ed.findwarptoken(i)),190,190,225);
                 }
             }
         }
@@ -2624,20 +2624,20 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
     {
         if(ed.boundarymod==1)
         {
-            fillboxabs(dwgfx, ed.tilex*8, ed.tiley*8, 8,8,dwgfx.getRGB(255-(help.glow/2),191+(help.glow),210+(help.glow/2)));
-            fillboxabs(dwgfx, (ed.tilex*8)+2, (ed.tiley*8)+2, 4,4,dwgfx.getRGB(128-(help.glow/4),100+(help.glow/2),105+(help.glow/4)));
+            fillboxabs(ed.tilex*8, ed.tiley*8, 8,8,graphics.getRGB(255-(help.glow/2),191+(help.glow),210+(help.glow/2)));
+            fillboxabs((ed.tilex*8)+2, (ed.tiley*8)+2, 4,4,graphics.getRGB(128-(help.glow/4),100+(help.glow/2),105+(help.glow/4)));
         }
         else if(ed.boundarymod==2)
         {
             if((ed.tilex*8)+8<=ed.boundx1 || (ed.tiley*8)+8<=ed.boundy1)
             {
-                fillboxabs(dwgfx, ed.boundx1, ed.boundy1, 8, 8,dwgfx.getRGB(255-(help.glow/2),191+(help.glow),210+(help.glow/2)));
-                fillboxabs(dwgfx, ed.boundx1+2, ed.boundy1+2, 4, 4,dwgfx.getRGB(128-(help.glow/4),100+(help.glow/2),105+(help.glow/4)));
+                fillboxabs(ed.boundx1, ed.boundy1, 8, 8,graphics.getRGB(255-(help.glow/2),191+(help.glow),210+(help.glow/2)));
+                fillboxabs(ed.boundx1+2, ed.boundy1+2, 4, 4,graphics.getRGB(128-(help.glow/4),100+(help.glow/2),105+(help.glow/4)));
             }
             else
             {
-                fillboxabs(dwgfx, ed.boundx1, ed.boundy1, (ed.tilex*8)+8-ed.boundx1,(ed.tiley*8)+8-ed.boundy1,dwgfx.getRGB(255-(help.glow/2),191+(help.glow),210+(help.glow/2)));
-                fillboxabs(dwgfx, ed.boundx1+2, ed.boundy1+2, (ed.tilex*8)+8-ed.boundx1-4,(ed.tiley*8)+8-ed.boundy1-4,dwgfx.getRGB(128-(help.glow/4),100+(help.glow/2),105+(help.glow/4)));
+                fillboxabs(ed.boundx1, ed.boundy1, (ed.tilex*8)+8-ed.boundx1,(ed.tiley*8)+8-ed.boundy1,graphics.getRGB(255-(help.glow/2),191+(help.glow),210+(help.glow/2)));
+                fillboxabs(ed.boundx1+2, ed.boundy1+2, (ed.tilex*8)+8-ed.boundx1-4,(ed.tiley*8)+8-ed.boundy1-4,graphics.getRGB(128-(help.glow/4),100+(help.glow/2),105+(help.glow/4)));
             }
         }
     }
@@ -2648,19 +2648,19 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
         if(ed.level[tmp].enemyx1!=0 && ed.level[tmp].enemyy1!=0
                 && ed.level[tmp].enemyx2!=320 && ed.level[tmp].enemyy2!=240)
         {
-            fillboxabs(dwgfx,  ed.level[tmp].enemyx1, ed.level[tmp].enemyy1,
+            fillboxabs( ed.level[tmp].enemyx1, ed.level[tmp].enemyy1,
                        ed.level[tmp].enemyx2-ed.level[tmp].enemyx1,
                        ed.level[tmp].enemyy2-ed.level[tmp].enemyy1,
-                       dwgfx.getBGR(255-(help.glow/2),64,64));
+                       graphics.getBGR(255-(help.glow/2),64,64));
         }
 
         if(ed.level[tmp].platx1!=0 && ed.level[tmp].platy1!=0
                 && ed.level[tmp].platx2!=320 && ed.level[tmp].platy2!=240)
         {
-            fillboxabs(dwgfx,  ed.level[tmp].platx1, ed.level[tmp].platy1,
+            fillboxabs( ed.level[tmp].platx1, ed.level[tmp].platy1,
                        ed.level[tmp].platx2-ed.level[tmp].platx1,
                        ed.level[tmp].platy2-ed.level[tmp].platy1,
-                       dwgfx.getBGR(64,64,255-(help.glow/2)));
+                       graphics.getBGR(64,64,255-(help.glow/2)));
         }
     }
 
@@ -2676,33 +2676,33 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
     case 9:
     case 10:
     case 12: //Single point
-        fillboxabs(dwgfx, (ed.tilex*8),(ed.tiley*8),8,8, dwgfx.getRGB(200,32,32));
+        fillboxabs((ed.tilex*8),(ed.tiley*8),8,8, graphics.getRGB(200,32,32));
         break;
     case 3:
     case 4:
     case 8:
     case 13://2x2
-        fillboxabs(dwgfx, (ed.tilex*8),(ed.tiley*8),16,16, dwgfx.getRGB(200,32,32));
+        fillboxabs((ed.tilex*8),(ed.tiley*8),16,16, graphics.getRGB(200,32,32));
         break;
     case 5:
     case 6:
     case 7://Platform
-        fillboxabs(dwgfx, (ed.tilex*8),(ed.tiley*8),32,8, dwgfx.getRGB(200,32,32));
+        fillboxabs((ed.tilex*8),(ed.tiley*8),32,8, graphics.getRGB(200,32,32));
         break;
     case 14: //X if not on edge
         if(ed.tilex==0 || ed.tilex==39 || ed.tiley==0 || ed.tiley==29)
         {
-            fillboxabs(dwgfx, (ed.tilex*8),(ed.tiley*8),8,8, dwgfx.getRGB(200,32,32));
+            fillboxabs((ed.tilex*8),(ed.tiley*8),8,8, graphics.getRGB(200,32,32));
         }
         else
         {
-            dwgfx.Print((ed.tilex*8),(ed.tiley*8),"X",255,0,0);
+            graphics.Print((ed.tilex*8),(ed.tiley*8),"X",255,0,0);
         }
         break;
     case 11:
     case 15:
     case 16: //2x3
-        fillboxabs(dwgfx, (ed.tilex*8),(ed.tiley*8),16,24, dwgfx.getRGB(200,32,32));
+        fillboxabs((ed.tilex*8),(ed.tiley*8),16,24, graphics.getRGB(200,32,32));
         break;
     }
 
@@ -2710,11 +2710,11 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
     {
         if(ed.zmod && ed.drawmode<2)
         {
-            fillboxabs(dwgfx, (ed.tilex*8)-8,(ed.tiley*8)-8,24,24, dwgfx.getRGB(200,32,32));
+            fillboxabs((ed.tilex*8)-8,(ed.tiley*8)-8,24,24, graphics.getRGB(200,32,32));
         }
         else if(ed.xmod && ed.drawmode<2)
         {
-            fillboxabs(dwgfx, (ed.tilex*8)-16,(ed.tiley*8)-16,24+16,24+16, dwgfx.getRGB(200,32,32));
+            fillboxabs((ed.tilex*8)-16,(ed.tiley*8)-16,24+16,24+16, graphics.getRGB(200,32,32));
         }
     }
 
@@ -2734,65 +2734,65 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             //Draw five lines of the editor
             temp=ed.dmtile-(ed.dmtile%40);
             temp-=80;
-            FillRect(dwgfx.backBuffer, 0,-t2,320,40, dwgfx.getRGB(0,0,0));
-            FillRect(dwgfx.backBuffer, 0,-t2+40,320,2, dwgfx.getRGB(255,255,255));
+            FillRect(graphics.backBuffer, 0,-t2,320,40, graphics.getRGB(0,0,0));
+            FillRect(graphics.backBuffer, 0,-t2+40,320,2, graphics.getRGB(255,255,255));
             if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
             {
                 for(int i=0; i<40; i++)
                 {
-                    dwgfx.drawtile(i*8,0-t2,(temp+1200+i)%1200,0,0,0);
-                    dwgfx.drawtile(i*8,8-t2,(temp+1200+40+i)%1200,0,0,0);
-                    dwgfx.drawtile(i*8,16-t2,(temp+1200+80+i)%1200,0,0,0);
-                    dwgfx.drawtile(i*8,24-t2,(temp+1200+120+i)%1200,0,0,0);
-                    dwgfx.drawtile(i*8,32-t2,(temp+1200+160+i)%1200,0,0,0);
+                    graphics.drawtile(i*8,0-t2,(temp+1200+i)%1200,0,0,0);
+                    graphics.drawtile(i*8,8-t2,(temp+1200+40+i)%1200,0,0,0);
+                    graphics.drawtile(i*8,16-t2,(temp+1200+80+i)%1200,0,0,0);
+                    graphics.drawtile(i*8,24-t2,(temp+1200+120+i)%1200,0,0,0);
+                    graphics.drawtile(i*8,32-t2,(temp+1200+160+i)%1200,0,0,0);
                 }
             }
             else
             {
                 for(int i=0; i<40; i++)
                 {
-                    dwgfx.drawtile2(i*8,0-t2,(temp+1200+i)%1200,0,0,0);
-                    dwgfx.drawtile2(i*8,8-t2,(temp+1200+40+i)%1200,0,0,0);
-                    dwgfx.drawtile2(i*8,16-t2,(temp+1200+80+i)%1200,0,0,0);
-                    dwgfx.drawtile2(i*8,24-t2,(temp+1200+120+i)%1200,0,0,0);
-                    dwgfx.drawtile2(i*8,32-t2,(temp+1200+160+i)%1200,0,0,0);
+                    graphics.drawtile2(i*8,0-t2,(temp+1200+i)%1200,0,0,0);
+                    graphics.drawtile2(i*8,8-t2,(temp+1200+40+i)%1200,0,0,0);
+                    graphics.drawtile2(i*8,16-t2,(temp+1200+80+i)%1200,0,0,0);
+                    graphics.drawtile2(i*8,24-t2,(temp+1200+120+i)%1200,0,0,0);
+                    graphics.drawtile2(i*8,32-t2,(temp+1200+160+i)%1200,0,0,0);
                 }
             }
             //Highlight our little block
-            fillboxabs(dwgfx,((ed.dmtile%40)*8)-2,16-2,12,12,dwgfx.getRGB(196, 196, 255 - help.glow));
-            fillboxabs(dwgfx,((ed.dmtile%40)*8)-1,16-1,10,10,dwgfx.getRGB(0,0,0));
+            fillboxabs(((ed.dmtile%40)*8)-2,16-2,12,12,graphics.getRGB(196, 196, 255 - help.glow));
+            fillboxabs(((ed.dmtile%40)*8)-1,16-1,10,10,graphics.getRGB(0,0,0));
         }
 
         if(ed.dmtileeditor>0 && t2<=30)
         {
-            dwgfx.bprint(2, 45-t2, "Tile:", 196, 196, 255 - help.glow, false);
-            dwgfx.bprint(58, 45-t2, help.String(ed.dmtile), 196, 196, 255 - help.glow, false);
-            FillRect(dwgfx.backBuffer, 44,44-t2,10,10, dwgfx.getRGB(196, 196, 255 - help.glow));
-            FillRect(dwgfx.backBuffer, 45,45-t2,8,8, dwgfx.getRGB(0,0,0));
+            graphics.bprint(2, 45-t2, "Tile:", 196, 196, 255 - help.glow, false);
+            graphics.bprint(58, 45-t2, help.String(ed.dmtile), 196, 196, 255 - help.glow, false);
+            FillRect(graphics.backBuffer, 44,44-t2,10,10, graphics.getRGB(196, 196, 255 - help.glow));
+            FillRect(graphics.backBuffer, 45,45-t2,8,8, graphics.getRGB(0,0,0));
 
             if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
             {
-                dwgfx.drawtile(45,45-t2,ed.dmtile,0,0,0);
+                graphics.drawtile(45,45-t2,ed.dmtile,0,0,0);
             }
             else
             {
-                dwgfx.drawtile2(45,45-t2,ed.dmtile,0,0,0);
+                graphics.drawtile2(45,45-t2,ed.dmtile,0,0,0);
             }
         }
         else
         {
-            dwgfx.bprint(2, 12, "Tile:", 196, 196, 255 - help.glow, false);
-            dwgfx.bprint(58, 12, help.String(ed.dmtile), 196, 196, 255 - help.glow, false);
-            FillRect(dwgfx.backBuffer, 44,11,10,10, dwgfx.getRGB(196, 196, 255 - help.glow));
-            FillRect(dwgfx.backBuffer, 45,12,8,8, dwgfx.getRGB(0,0,0));
+            graphics.bprint(2, 12, "Tile:", 196, 196, 255 - help.glow, false);
+            graphics.bprint(58, 12, help.String(ed.dmtile), 196, 196, 255 - help.glow, false);
+            FillRect(graphics.backBuffer, 44,11,10,10, graphics.getRGB(196, 196, 255 - help.glow));
+            FillRect(graphics.backBuffer, 45,12,8,8, graphics.getRGB(0,0,0));
 
             if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
             {
-                dwgfx.drawtile(45,12,ed.dmtile,0,0,0);
+                graphics.drawtile(45,12,ed.dmtile,0,0,0);
             }
             else
             {
-                dwgfx.drawtile2(45,12,ed.dmtile,0,0,0);
+                graphics.drawtile2(45,12,ed.dmtile,0,0,0);
             }
         }
     }
@@ -2805,47 +2805,47 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
     {
         if(ed.boundarymod==1)
         {
-            FillRect(dwgfx.backBuffer, 0,230,320,240, dwgfx.getRGB(32,32,32));
-            FillRect(dwgfx.backBuffer, 0,231,320,240, dwgfx.getRGB(0,0,0));
+            FillRect(graphics.backBuffer, 0,230,320,240, graphics.getRGB(32,32,32));
+            FillRect(graphics.backBuffer, 0,231,320,240, graphics.getRGB(0,0,0));
             switch(ed.boundarytype)
             {
             case 0:
-                dwgfx.Print(4, 232, "SCRIPT BOX: Click on top left", 255,255,255, false);
+                graphics.Print(4, 232, "SCRIPT BOX: Click on top left", 255,255,255, false);
                 break;
             case 1:
-                dwgfx.Print(4, 232, "ENEMY BOUNDS: Click on top left", 255,255,255, false);
+                graphics.Print(4, 232, "ENEMY BOUNDS: Click on top left", 255,255,255, false);
                 break;
             case 2:
-                dwgfx.Print(4, 232, "PLATFORM BOUNDS: Click on top left", 255,255,255, false);
+                graphics.Print(4, 232, "PLATFORM BOUNDS: Click on top left", 255,255,255, false);
                 break;
             case 3:
-                dwgfx.Print(4, 232, "COPY TILES: Click on top left", 255,255,255, false);
+                graphics.Print(4, 232, "COPY TILES: Click on top left", 255,255,255, false);
                 break;
             default:
-                dwgfx.Print(4, 232, "Click on top left", 255,255,255, false);
+                graphics.Print(4, 232, "Click on top left", 255,255,255, false);
                 break;
             }
         }
         else if(ed.boundarymod==2)
         {
-            FillRect(dwgfx.backBuffer, 0,230,320,240, dwgfx.getRGB(32,32,32));
-            FillRect(dwgfx.backBuffer, 0,231,320,240, dwgfx.getRGB(0,0,0));
+            FillRect(graphics.backBuffer, 0,230,320,240, graphics.getRGB(32,32,32));
+            FillRect(graphics.backBuffer, 0,231,320,240, graphics.getRGB(0,0,0));
             switch(ed.boundarytype)
             {
             case 0:
-                dwgfx.Print(4, 232, "SCRIPT BOX: Click on bottom right", 255,255,255, false);
+                graphics.Print(4, 232, "SCRIPT BOX: Click on bottom right", 255,255,255, false);
                 break;
             case 1:
-                dwgfx.Print(4, 232, "ENEMY BOUNDS: Click on bottom right", 255,255,255, false);
+                graphics.Print(4, 232, "ENEMY BOUNDS: Click on bottom right", 255,255,255, false);
                 break;
             case 2:
-                dwgfx.Print(4, 232, "PLATFORM BOUNDS: Click on bottom right", 255,255,255, false);
+                graphics.Print(4, 232, "PLATFORM BOUNDS: Click on bottom right", 255,255,255, false);
                 break;
             case 3:
-                dwgfx.Print(4, 232, "COPY TILES: Click on bottom right", 255,255,255, false);
+                graphics.Print(4, 232, "COPY TILES: Click on bottom right", 255,255,255, false);
                 break;
             default:
-                dwgfx.Print(4, 232, "Click on bottom right", 255,255,255, false);
+                graphics.Print(4, 232, "Click on bottom right", 255,255,255, false);
                 break;
             }
         }
@@ -2853,14 +2853,14 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
     else if(ed.scripteditmod)
     {
         //Elaborate C64 BASIC menu goes here!
-        FillRect(dwgfx.backBuffer, 0,0,320,240, dwgfx.getBGR(123, 111, 218));
-        FillRect(dwgfx.backBuffer, 14,16,292,208, dwgfx.getRGB(162,48,61));
+        FillRect(graphics.backBuffer, 0,0,320,240, graphics.getBGR(123, 111, 218));
+        FillRect(graphics.backBuffer, 14,16,292,208, graphics.getRGB(162,48,61));
         switch(ed.scripthelppage)
         {
         case 0:
-            dwgfx.Print(16,28,"**** VVVVVV SCRIPT EDITOR ****", 123, 111, 218, true);
-            dwgfx.Print(16,44,"PRESS ESC TO RETURN TO MENU", 123, 111, 218, true);
-            //dwgfx.Print(16,60,"READY.", 123, 111, 218, false);
+            graphics.Print(16,28,"**** VVVVVV SCRIPT EDITOR ****", 123, 111, 218, true);
+            graphics.Print(16,44,"PRESS ESC TO RETURN TO MENU", 123, 111, 218, true);
+            //graphics.Print(16,60,"READY.", 123, 111, 218, false);
 
             if(!ed.hooklist.empty())
             {
@@ -2872,45 +2872,45 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                         {
                             std::string tstring="> " + ed.hooklist[(ed.hooklist.size()-1)-(ed.hookmenupage+i)] + " <";
                             std::transform(tstring.begin(), tstring.end(),tstring.begin(), ::toupper);
-                            dwgfx.Print(16,68+(i*16),tstring,123, 111, 218, true);
+                            graphics.Print(16,68+(i*16),tstring,123, 111, 218, true);
                         }
                         else
                         {
-                            dwgfx.Print(16,68+(i*16),ed.hooklist[(ed.hooklist.size()-1)-(ed.hookmenupage+i)],123, 111, 218, true);
+                            graphics.Print(16,68+(i*16),ed.hooklist[(ed.hooklist.size()-1)-(ed.hookmenupage+i)],123, 111, 218, true);
                         }
                     }
                 }
             }
             else
             {
-                dwgfx.Print(16,110,"NO SCRIPT IDS FOUND", 123, 111, 218, true);
-                dwgfx.Print(16,130,"CREATE A SCRIPT WITH EITHER", 123, 111, 218, true);
-                dwgfx.Print(16,140,"THE TERMINAL OR SCRIPT BOX TOOLS", 123, 111, 218, true);
+                graphics.Print(16,110,"NO SCRIPT IDS FOUND", 123, 111, 218, true);
+                graphics.Print(16,130,"CREATE A SCRIPT WITH EITHER", 123, 111, 218, true);
+                graphics.Print(16,140,"THE TERMINAL OR SCRIPT BOX TOOLS", 123, 111, 218, true);
             }
             break;
         case 1:
             //Current scriptname
-            FillRect(dwgfx.backBuffer, 14,226,292,12, dwgfx.getRGB(162,48,61));
-            dwgfx.Print(16,228,"CURRENT SCRIPT: " + ed.sbscript, 123, 111, 218, true);
+            FillRect(graphics.backBuffer, 14,226,292,12, graphics.getRGB(162,48,61));
+            graphics.Print(16,228,"CURRENT SCRIPT: " + ed.sbscript, 123, 111, 218, true);
             //Draw text
             for(int i=0; i<25; i++)
             {
                 if(i+ed.pagey<(int)ed.sb.size())
                 {
-                    dwgfx.Print(16,20+(i*8),ed.sb[i+ed.pagey], 123, 111, 218, false);
+                    graphics.Print(16,20+(i*8),ed.sb[i+ed.pagey], 123, 111, 218, false);
                 }
             }
             //Draw cursor
             if(ed.entframe<2)
             {
-                dwgfx.Print(16+(ed.sbx*8),20+(ed.sby*8),"_",123, 111, 218, false);
+                graphics.Print(16+(ed.sbx*8),20+(ed.sby*8),"_",123, 111, 218, false);
             }
             break;
         }
     }
     else if(ed.settingsmod)
     {
-        if(!game.colourblindmode) dwgfx.drawtowerbackgroundsolo();
+        if(!game.colourblindmode) graphics.drawtowerbackgroundsolo();
 
         int tr = map.r - (help.glow / 4) - int(fRandom() * 4);
         int tg = map.g - (help.glow / 4) - int(fRandom() * 4);
@@ -2923,7 +2923,7 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
         if(tb>255) tb=255;
         if (game.currentmenuname == "ed_settings")
         {
-            dwgfx.bigprint( -1, 75, "Map Settings", tr, tg, tb, true);
+            graphics.bigprint( -1, 75, "Map Settings", tr, tg, tb, true);
         }
         else if (game.currentmenuname=="ed_desc")
         {
@@ -2931,242 +2931,242 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             {
                 if(ed.entframe<2)
                 {
-                    dwgfx.bigprint( -1, 35, key.keybuffer+"_", tr, tg, tb, true);
+                    graphics.bigprint( -1, 35, key.keybuffer+"_", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.bigprint( -1, 35, key.keybuffer+" ", tr, tg, tb, true);
+                    graphics.bigprint( -1, 35, key.keybuffer+" ", tr, tg, tb, true);
                 }
             }
             else
             {
-                dwgfx.bigprint( -1, 35, EditorData::GetInstance().title, tr, tg, tb, true);
+                graphics.bigprint( -1, 35, EditorData::GetInstance().title, tr, tg, tb, true);
             }
             if(ed.creatormod)
             {
                 if(ed.entframe<2)
                 {
-                    dwgfx.Print( -1, 60, "by " + key.keybuffer+ "_", tr, tg, tb, true);
+                    graphics.Print( -1, 60, "by " + key.keybuffer+ "_", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 60, "by " + key.keybuffer+ " ", tr, tg, tb, true);
+                    graphics.Print( -1, 60, "by " + key.keybuffer+ " ", tr, tg, tb, true);
                 }
             }
             else
             {
-                dwgfx.Print( -1, 60, "by " + EditorData::GetInstance().creator, tr, tg, tb, true);
+                graphics.Print( -1, 60, "by " + EditorData::GetInstance().creator, tr, tg, tb, true);
             }
             if(ed.websitemod)
             {
                 if(ed.entframe<2)
                 {
-                    dwgfx.Print( -1, 70, key.keybuffer+"_", tr, tg, tb, true);
+                    graphics.Print( -1, 70, key.keybuffer+"_", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 70, key.keybuffer+" ", tr, tg, tb, true);
+                    graphics.Print( -1, 70, key.keybuffer+" ", tr, tg, tb, true);
                 }
             }
             else
             {
-                dwgfx.Print( -1, 70, ed.website, tr, tg, tb, true);
+                graphics.Print( -1, 70, ed.website, tr, tg, tb, true);
             }
             if(ed.desc1mod)
             {
                 if(ed.entframe<2)
                 {
-                    dwgfx.Print( -1, 90, key.keybuffer+"_", tr, tg, tb, true);
+                    graphics.Print( -1, 90, key.keybuffer+"_", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 90, key.keybuffer+" ", tr, tg, tb, true);
+                    graphics.Print( -1, 90, key.keybuffer+" ", tr, tg, tb, true);
                 }
             }
             else
             {
-                dwgfx.Print( -1, 90, ed.Desc1, tr, tg, tb, true);
+                graphics.Print( -1, 90, ed.Desc1, tr, tg, tb, true);
             }
             if(ed.desc2mod)
             {
                 if(ed.entframe<2)
                 {
-                    dwgfx.Print( -1, 100, key.keybuffer+"_", tr, tg, tb, true);
+                    graphics.Print( -1, 100, key.keybuffer+"_", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 100, key.keybuffer+" ", tr, tg, tb, true);
+                    graphics.Print( -1, 100, key.keybuffer+" ", tr, tg, tb, true);
                 }
             }
             else
             {
-                dwgfx.Print( -1, 100, ed.Desc2, tr, tg, tb, true);
+                graphics.Print( -1, 100, ed.Desc2, tr, tg, tb, true);
             }
             if(ed.desc3mod)
             {
                 if(ed.entframe<2)
                 {
-                    dwgfx.Print( -1, 110, key.keybuffer+"_", tr, tg, tb, true);
+                    graphics.Print( -1, 110, key.keybuffer+"_", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 110, key.keybuffer+" ", tr, tg, tb, true);
+                    graphics.Print( -1, 110, key.keybuffer+" ", tr, tg, tb, true);
                 }
             }
             else
             {
-                dwgfx.Print( -1, 110, ed.Desc3, tr, tg, tb, true);
+                graphics.Print( -1, 110, ed.Desc3, tr, tg, tb, true);
             }
         }
         else if (game.currentmenuname == "ed_music")
         {
-            dwgfx.bigprint( -1, 65, "Map Music", tr, tg, tb, true);
+            graphics.bigprint( -1, 65, "Map Music", tr, tg, tb, true);
 
-            dwgfx.Print( -1, 85, "Current map music:", tr, tg, tb, true);
+            graphics.Print( -1, 85, "Current map music:", tr, tg, tb, true);
             switch(ed.levmusic)
             {
             case 0:
-                dwgfx.Print( -1, 120, "No background music", tr, tg, tb, true);
+                graphics.Print( -1, 120, "No background music", tr, tg, tb, true);
                 break;
             case 1:
-                dwgfx.Print( -1, 120, "1: Pushing Onwards", tr, tg, tb, true);
+                graphics.Print( -1, 120, "1: Pushing Onwards", tr, tg, tb, true);
                 break;
             case 2:
-                dwgfx.Print( -1, 120, "2: Positive Force", tr, tg, tb, true);
+                graphics.Print( -1, 120, "2: Positive Force", tr, tg, tb, true);
                 break;
             case 3:
-                dwgfx.Print( -1, 120, "3: Potential for Anything", tr, tg, tb, true);
+                graphics.Print( -1, 120, "3: Potential for Anything", tr, tg, tb, true);
                 break;
             case 4:
-                dwgfx.Print( -1, 120, "4: Passion for Exploring", tr, tg, tb, true);
+                graphics.Print( -1, 120, "4: Passion for Exploring", tr, tg, tb, true);
                 break;
             case 6:
-                dwgfx.Print( -1, 120, "5: Presenting VVVVVV", tr, tg, tb, true);
+                graphics.Print( -1, 120, "5: Presenting VVVVVV", tr, tg, tb, true);
                 break;
             case 8:
-                dwgfx.Print( -1, 120, "6: Predestined Fate", tr, tg, tb, true);
+                graphics.Print( -1, 120, "6: Predestined Fate", tr, tg, tb, true);
                 break;
             case 10:
-                dwgfx.Print( -1, 120, "7: Popular Potpourri", tr, tg, tb, true);
+                graphics.Print( -1, 120, "7: Popular Potpourri", tr, tg, tb, true);
                 break;
             case 11:
-                dwgfx.Print( -1, 120, "8: Pipe Dream", tr, tg, tb, true);
+                graphics.Print( -1, 120, "8: Pipe Dream", tr, tg, tb, true);
                 break;
             case 12:
-                dwgfx.Print( -1, 120, "9: Pressure Cooker", tr, tg, tb, true);
+                graphics.Print( -1, 120, "9: Pressure Cooker", tr, tg, tb, true);
                 break;
             case 13:
-                dwgfx.Print( -1, 120, "10: Paced Energy", tr, tg, tb, true);
+                graphics.Print( -1, 120, "10: Paced Energy", tr, tg, tb, true);
                 break;
             case 14:
-                dwgfx.Print( -1, 120, "11: Piercing the Sky", tr, tg, tb, true);
+                graphics.Print( -1, 120, "11: Piercing the Sky", tr, tg, tb, true);
                 break;
             default:
-                dwgfx.Print( -1, 120, "?: something else", tr, tg, tb, true);
+                graphics.Print( -1, 120, "?: something else", tr, tg, tb, true);
                 break;
             }
         }
         else if (game.currentmenuname == "ed_quit")
         {
-            dwgfx.bigprint( -1, 90, "Save before", tr, tg, tb, true);
-            dwgfx.bigprint( -1, 110, "quitting?", tr, tg, tb, true);
+            graphics.bigprint( -1, 90, "Save before", tr, tg, tb, true);
+            graphics.bigprint( -1, 110, "quitting?", tr, tg, tb, true);
         }
 
-        dwgfx.drawmenu(tr, tg, tb, 15);
+        graphics.drawmenu(tr, tg, tb, 15);
 
         /*
-        dwgfx.Print(4, 224, "Enter name to save map as:", 255,255,255, false);
+        graphics.Print(4, 224, "Enter name to save map as:", 255,255,255, false);
         if(ed.entframe<2){
-          dwgfx.Print(4, 232, ed.filename+"_", 196, 196, 255 - help.glow, true);
+          graphics.Print(4, 232, ed.filename+"_", 196, 196, 255 - help.glow, true);
         }else{
-          dwgfx.Print(4, 232, ed.filename+" ", 196, 196, 255 - help.glow, true);
+          graphics.Print(4, 232, ed.filename+" ", 196, 196, 255 - help.glow, true);
         }
         */
     }
     else if(ed.scripttextmod)
     {
-        FillRect(dwgfx.backBuffer, 0,221,320,240, dwgfx.getRGB(32,32,32));
-        FillRect(dwgfx.backBuffer, 0,222,320,240, dwgfx.getRGB(0,0,0));
-        dwgfx.Print(4, 224, "Enter script id name:", 255,255,255, false);
+        FillRect(graphics.backBuffer, 0,221,320,240, graphics.getRGB(32,32,32));
+        FillRect(graphics.backBuffer, 0,222,320,240, graphics.getRGB(0,0,0));
+        graphics.Print(4, 224, "Enter script id name:", 255,255,255, false);
         if(ed.entframe<2)
         {
-            dwgfx.Print(4, 232, edentity[ed.textent].scriptname+"_", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, edentity[ed.textent].scriptname+"_", 196, 196, 255 - help.glow, true);
         }
         else
         {
-            dwgfx.Print(4, 232, edentity[ed.textent].scriptname+" ", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, edentity[ed.textent].scriptname+" ", 196, 196, 255 - help.glow, true);
         }
     }
     else if(ed.savemod)
     {
-        FillRect(dwgfx.backBuffer, 0,221,320,240, dwgfx.getRGB(32,32,32));
-        FillRect(dwgfx.backBuffer, 0,222,320,240, dwgfx.getRGB(0,0,0));
-        dwgfx.Print(4, 224, "Enter filename to save map as:", 255,255,255, false);
+        FillRect(graphics.backBuffer, 0,221,320,240, graphics.getRGB(32,32,32));
+        FillRect(graphics.backBuffer, 0,222,320,240, graphics.getRGB(0,0,0));
+        graphics.Print(4, 224, "Enter filename to save map as:", 255,255,255, false);
         if(ed.entframe<2)
         {
-            dwgfx.Print(4, 232, ed.filename+"_", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, ed.filename+"_", 196, 196, 255 - help.glow, true);
         }
         else
         {
-            dwgfx.Print(4, 232, ed.filename+" ", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, ed.filename+" ", 196, 196, 255 - help.glow, true);
         }
     }
     else if(ed.loadmod)
     {
-        FillRect(dwgfx.backBuffer, 0,221,320,240, dwgfx.getRGB(32,32,32));
-        FillRect(dwgfx.backBuffer, 0,222,320,240, dwgfx.getRGB(0,0,0));
-        dwgfx.Print(4, 224, "Enter map filename to load:", 255,255,255, false);
+        FillRect(graphics.backBuffer, 0,221,320,240, graphics.getRGB(32,32,32));
+        FillRect(graphics.backBuffer, 0,222,320,240, graphics.getRGB(0,0,0));
+        graphics.Print(4, 224, "Enter map filename to load:", 255,255,255, false);
         if(ed.entframe<2)
         {
-            dwgfx.Print(4, 232, ed.filename+"_", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, ed.filename+"_", 196, 196, 255 - help.glow, true);
         }
         else
         {
-            dwgfx.Print(4, 232, ed.filename+" ", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, ed.filename+" ", 196, 196, 255 - help.glow, true);
         }
     }
     else if(ed.roomnamemod)
     {
-        FillRect(dwgfx.backBuffer, 0,221,320,240, dwgfx.getRGB(32,32,32));
-        FillRect(dwgfx.backBuffer, 0,222,320,240, dwgfx.getRGB(0,0,0));
-        dwgfx.Print(4, 224, "Enter new room name:", 255,255,255, false);
+        FillRect(graphics.backBuffer, 0,221,320,240, graphics.getRGB(32,32,32));
+        FillRect(graphics.backBuffer, 0,222,320,240, graphics.getRGB(0,0,0));
+        graphics.Print(4, 224, "Enter new room name:", 255,255,255, false);
         if(ed.entframe<2)
         {
-            dwgfx.Print(4, 232, ed.level[ed.levx+(ed.levy*ed.maxwidth)].roomname+"_", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, ed.level[ed.levx+(ed.levy*ed.maxwidth)].roomname+"_", 196, 196, 255 - help.glow, true);
         }
         else
         {
-            dwgfx.Print(4, 232, ed.level[ed.levx+(ed.levy*ed.maxwidth)].roomname+" ", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, ed.level[ed.levx+(ed.levy*ed.maxwidth)].roomname+" ", 196, 196, 255 - help.glow, true);
         }
     }
     else if(ed.roomtextmod)
     {
-        FillRect(dwgfx.backBuffer, 0,221,320,240, dwgfx.getRGB(32,32,32));
-        FillRect(dwgfx.backBuffer, 0,222,320,240, dwgfx.getRGB(0,0,0));
-        dwgfx.Print(4, 224, "Enter text string:", 255,255,255, false);
+        FillRect(graphics.backBuffer, 0,221,320,240, graphics.getRGB(32,32,32));
+        FillRect(graphics.backBuffer, 0,222,320,240, graphics.getRGB(0,0,0));
+        graphics.Print(4, 224, "Enter text string:", 255,255,255, false);
         if(ed.entframe<2)
         {
-            dwgfx.Print(4, 232, edentity[ed.textent].scriptname+"_", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, edentity[ed.textent].scriptname+"_", 196, 196, 255 - help.glow, true);
         }
         else
         {
-            dwgfx.Print(4, 232, edentity[ed.textent].scriptname+" ", 196, 196, 255 - help.glow, true);
+            graphics.Print(4, 232, edentity[ed.textent].scriptname+" ", 196, 196, 255 - help.glow, true);
         }
     }
     else if(ed.warpmod)
     {
         //placing warp token
-        FillRect(dwgfx.backBuffer, 0,221,320,240, dwgfx.getRGB(32,32,32));
-        FillRect(dwgfx.backBuffer, 0,222,320,240, dwgfx.getRGB(0,0,0));
-        dwgfx.Print(4, 224, "Left click to place warp destination", 196, 196, 255 - help.glow, false);
-        dwgfx.Print(4, 232, "Right click to cancel", 196, 196, 255 - help.glow, false);
+        FillRect(graphics.backBuffer, 0,221,320,240, graphics.getRGB(32,32,32));
+        FillRect(graphics.backBuffer, 0,222,320,240, graphics.getRGB(0,0,0));
+        graphics.Print(4, 224, "Left click to place warp destination", 196, 196, 255 - help.glow, false);
+        graphics.Print(4, 232, "Right click to cancel", 196, 196, 255 - help.glow, false);
     }
     else
     {
         if(ed.spacemod)
         {
-            FillRect(dwgfx.backBuffer, 0,208,320,240, dwgfx.getRGB(32,32,32));
-            FillRect(dwgfx.backBuffer, 0,209,320,240, dwgfx.getRGB(0,0,0));
+            FillRect(graphics.backBuffer, 0,208,320,240, graphics.getRGB(32,32,32));
+            FillRect(graphics.backBuffer, 0,209,320,240, graphics.getRGB(0,0,0));
 
             //Draw little icons for each thingy
             int tx=6, ty=211, tg=32;
@@ -3175,192 +3175,192 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             {
                 for(int i=0; i<10; i++)
                 {
-                    FillRect(dwgfx.backBuffer, 4+(i*tg), 209,20,20,dwgfx.getRGB(32,32,32));
+                    FillRect(graphics.backBuffer, 4+(i*tg), 209,20,20,graphics.getRGB(32,32,32));
                 }
-                FillRect(dwgfx.backBuffer, 4+(ed.drawmode*tg), 209,20,20,dwgfx.getRGB(64,64,64));
+                FillRect(graphics.backBuffer, 4+(ed.drawmode*tg), 209,20,20,graphics.getRGB(64,64,64));
                 //0:
-                dwgfx.drawtile(tx,ty,83,0,0,0);
-                dwgfx.drawtile(tx+8,ty,83,0,0,0);
-                dwgfx.drawtile(tx,ty+8,83,0,0,0);
-                dwgfx.drawtile(tx+8,ty+8,83,0,0,0);
+                graphics.drawtile(tx,ty,83,0,0,0);
+                graphics.drawtile(tx+8,ty,83,0,0,0);
+                graphics.drawtile(tx,ty+8,83,0,0,0);
+                graphics.drawtile(tx+8,ty+8,83,0,0,0);
                 //1:
                 tx+=tg;
-                dwgfx.drawtile(tx,ty,680,0,0,0);
-                dwgfx.drawtile(tx+8,ty,680,0,0,0);
-                dwgfx.drawtile(tx,ty+8,680,0,0,0);
-                dwgfx.drawtile(tx+8,ty+8,680,0,0,0);
+                graphics.drawtile(tx,ty,680,0,0,0);
+                graphics.drawtile(tx+8,ty,680,0,0,0);
+                graphics.drawtile(tx,ty+8,680,0,0,0);
+                graphics.drawtile(tx+8,ty+8,680,0,0,0);
                 //2:
                 tx+=tg;
-                dwgfx.drawtile(tx+4,ty+4,8,0,0,0);
+                graphics.drawtile(tx+4,ty+4,8,0,0,0);
                 //3:
                 tx+=tg;
-                dwgfx.drawsprite(tx,ty,22,196,196,196);
+                graphics.drawsprite(tx,ty,22,196,196,196);
                 //4:
                 tx+=tg;
-                dwgfx.drawsprite(tx,ty,21,196,196,196);
+                graphics.drawsprite(tx,ty,21,196,196,196);
                 //5:
                 tx+=tg;
-                dwgfx.drawtile(tx,ty+4,3,0,0,0);
-                dwgfx.drawtile(tx+8,ty+4,4,0,0,0);
+                graphics.drawtile(tx,ty+4,3,0,0,0);
+                graphics.drawtile(tx+8,ty+4,4,0,0,0);
                 //6:
                 tx+=tg;
-                dwgfx.drawtile(tx,ty+4,24,0,0,0);
-                dwgfx.drawtile(tx+8,ty+4,24,0,0,0);
+                graphics.drawtile(tx,ty+4,24,0,0,0);
+                graphics.drawtile(tx+8,ty+4,24,0,0,0);
                 //7:
                 tx+=tg;
-                dwgfx.drawtile(tx,ty+4,1,0,0,0);
-                dwgfx.drawtile(tx+8,ty+4,1,0,0,0);
+                graphics.drawtile(tx,ty+4,1,0,0,0);
+                graphics.drawtile(tx+8,ty+4,1,0,0,0);
                 //8:
                 tx+=tg;
-                dwgfx.drawsprite(tx,ty,78+ed.entframe,196,196,196);
+                graphics.drawsprite(tx,ty,78+ed.entframe,196,196,196);
                 //9:
                 tx+=tg;
-                FillRect(dwgfx.backBuffer, tx+2,ty+8,12,1,dwgfx.getRGB(255,255,255));
+                FillRect(graphics.backBuffer, tx+2,ty+8,12,1,graphics.getRGB(255,255,255));
 
                 for(int i=0; i<9; i++)
                 {
-                    fillboxabs(dwgfx, 4+(i*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                    dwgfx.Print(22+(i*tg)-4, 225-4,help.String(i+1),164,164,164,false);
+                    fillboxabs(4+(i*tg), 209,20,20,graphics.getRGB(96,96,96));
+                    graphics.Print(22+(i*tg)-4, 225-4,help.String(i+1),164,164,164,false);
                 }
 
-                if(ed.drawmode==9)dwgfx.Print(22+(ed.drawmode*tg)-4, 225-4,"0",255,255,255,false);
+                if(ed.drawmode==9)graphics.Print(22+(ed.drawmode*tg)-4, 225-4,"0",255,255,255,false);
 
-                fillboxabs(dwgfx, 4+(9*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                dwgfx.Print(22+(9*tg)-4, 225-4, "0",164,164,164,false);
+                fillboxabs(4+(9*tg), 209,20,20,graphics.getRGB(96,96,96));
+                graphics.Print(22+(9*tg)-4, 225-4, "0",164,164,164,false);
 
-                fillboxabs(dwgfx, 4+(ed.drawmode*tg), 209,20,20,dwgfx.getRGB(200,200,200));
+                fillboxabs(4+(ed.drawmode*tg), 209,20,20,graphics.getRGB(200,200,200));
                 if(ed.drawmode<9)
                 {
-                    dwgfx.Print(22+(ed.drawmode*tg)-4, 225-4,help.String(ed.drawmode+1),255,255,255,false);
+                    graphics.Print(22+(ed.drawmode*tg)-4, 225-4,help.String(ed.drawmode+1),255,255,255,false);
                 }
 
-                dwgfx.Print(4, 232, "1/2", 196, 196, 255 - help.glow, false);
+                graphics.Print(4, 232, "1/2", 196, 196, 255 - help.glow, false);
             }
             else
             {
                 for(int i=0; i<7; i++)
                 {
-                    FillRect(dwgfx.backBuffer, 4+(i*tg), 209,20,20,dwgfx.getRGB(32,32,32));
+                    FillRect(graphics.backBuffer, 4+(i*tg), 209,20,20,graphics.getRGB(32,32,32));
                 }
-                FillRect(dwgfx.backBuffer, 4+((ed.drawmode-10)*tg), 209,20,20,dwgfx.getRGB(64,64,64));
+                FillRect(graphics.backBuffer, 4+((ed.drawmode-10)*tg), 209,20,20,graphics.getRGB(64,64,64));
                 //10:
-                dwgfx.Print(tx,ty,"A",196, 196, 255 - help.glow, false);
-                dwgfx.Print(tx+8,ty,"B",196, 196, 255 - help.glow, false);
-                dwgfx.Print(tx,ty+8,"C",196, 196, 255 - help.glow, false);
-                dwgfx.Print(tx+8,ty+8,"D",196, 196, 255 - help.glow, false);
+                graphics.Print(tx,ty,"A",196, 196, 255 - help.glow, false);
+                graphics.Print(tx+8,ty,"B",196, 196, 255 - help.glow, false);
+                graphics.Print(tx,ty+8,"C",196, 196, 255 - help.glow, false);
+                graphics.Print(tx+8,ty+8,"D",196, 196, 255 - help.glow, false);
                 //11:
                 tx+=tg;
-                dwgfx.drawsprite(tx,ty,17,196,196,196);
+                graphics.drawsprite(tx,ty,17,196,196,196);
                 //12:
                 tx+=tg;
-                fillboxabs(dwgfx, tx+4,ty+4,8,8,dwgfx.getRGB(96,96,96));
+                fillboxabs(tx+4,ty+4,8,8,graphics.getRGB(96,96,96));
                 //13:
                 tx+=tg;
-                dwgfx.drawsprite(tx,ty,18+(ed.entframe%2),196,196,196);
+                graphics.drawsprite(tx,ty,18+(ed.entframe%2),196,196,196);
                 //14:
                 tx+=tg;
-                FillRect(dwgfx.backBuffer, tx+6,ty+2,4,12,dwgfx.getRGB(255,255,255));
+                FillRect(graphics.backBuffer, tx+6,ty+2,4,12,graphics.getRGB(255,255,255));
                 //15:
                 tx+=tg;
-                dwgfx.drawsprite(tx,ty,186,75, 75, 255- help.glow/4 - (fRandom()*20));
+                graphics.drawsprite(tx,ty,186,75, 75, 255- help.glow/4 - (fRandom()*20));
                 //16:
                 tx+=tg;
-                dwgfx.drawsprite(tx,ty,184,160- help.glow/2 - (fRandom()*20), 200- help.glow/2, 220 - help.glow);
+                graphics.drawsprite(tx,ty,184,160- help.glow/2 - (fRandom()*20), 200- help.glow/2, 220 - help.glow);
 
-                if(ed.drawmode==10)dwgfx.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"R",255,255,255,false);
-                if(ed.drawmode==11)dwgfx.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"T",255,255,255,false);
-                if(ed.drawmode==12)dwgfx.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"Y",255,255,255,false);
-                if(ed.drawmode==13)dwgfx.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"U",255,255,255,false);
-                if(ed.drawmode==14)dwgfx.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"I",255,255,255,false);
-                if(ed.drawmode==15)dwgfx.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"O",255,255,255,false);
-                if(ed.drawmode==16)dwgfx.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"P",255,255,255,false);
+                if(ed.drawmode==10)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"R",255,255,255,false);
+                if(ed.drawmode==11)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"T",255,255,255,false);
+                if(ed.drawmode==12)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"Y",255,255,255,false);
+                if(ed.drawmode==13)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"U",255,255,255,false);
+                if(ed.drawmode==14)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"I",255,255,255,false);
+                if(ed.drawmode==15)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"O",255,255,255,false);
+                if(ed.drawmode==16)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"P",255,255,255,false);
 
-                fillboxabs(dwgfx, 4+(0*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                dwgfx.Print(22+(0*tg)-4, 225-4, "R",164,164,164,false);
-                fillboxabs(dwgfx, 4+(1*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                dwgfx.Print(22+(1*tg)-4, 225-4, "T",164,164,164,false);
-                fillboxabs(dwgfx, 4+(2*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                dwgfx.Print(22+(2*tg)-4, 225-4, "Y",164,164,164,false);
-                fillboxabs(dwgfx, 4+(3*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                dwgfx.Print(22+(3*tg)-4, 225-4, "U",164,164,164,false);
-                fillboxabs(dwgfx, 4+(4*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                dwgfx.Print(22+(4*tg)-4, 225-4, "I",164,164,164,false);
-                fillboxabs(dwgfx, 4+(5*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                dwgfx.Print(22+(5*tg)-4, 225-4, "O",164,164,164,false);
-                fillboxabs(dwgfx, 4+(6*tg), 209,20,20,dwgfx.getRGB(96,96,96));
-                dwgfx.Print(22+(6*tg)-4, 225-4, "P",164,164,164,false);
+                fillboxabs(4+(0*tg), 209,20,20,graphics.getRGB(96,96,96));
+                graphics.Print(22+(0*tg)-4, 225-4, "R",164,164,164,false);
+                fillboxabs(4+(1*tg), 209,20,20,graphics.getRGB(96,96,96));
+                graphics.Print(22+(1*tg)-4, 225-4, "T",164,164,164,false);
+                fillboxabs(4+(2*tg), 209,20,20,graphics.getRGB(96,96,96));
+                graphics.Print(22+(2*tg)-4, 225-4, "Y",164,164,164,false);
+                fillboxabs(4+(3*tg), 209,20,20,graphics.getRGB(96,96,96));
+                graphics.Print(22+(3*tg)-4, 225-4, "U",164,164,164,false);
+                fillboxabs(4+(4*tg), 209,20,20,graphics.getRGB(96,96,96));
+                graphics.Print(22+(4*tg)-4, 225-4, "I",164,164,164,false);
+                fillboxabs(4+(5*tg), 209,20,20,graphics.getRGB(96,96,96));
+                graphics.Print(22+(5*tg)-4, 225-4, "O",164,164,164,false);
+                fillboxabs(4+(6*tg), 209,20,20,graphics.getRGB(96,96,96));
+                graphics.Print(22+(6*tg)-4, 225-4, "P",164,164,164,false);
 
-                dwgfx.Print(4, 232, "2/2", 196, 196, 255 - help.glow, false);
+                graphics.Print(4, 232, "2/2", 196, 196, 255 - help.glow, false);
             }
 
-            dwgfx.Print(128, 232, "< and > keys change tool", 196, 196, 255 - help.glow, false);
+            graphics.Print(128, 232, "< and > keys change tool", 196, 196, 255 - help.glow, false);
 
-            FillRect(dwgfx.backBuffer, 0,198,120,10, dwgfx.getRGB(32,32,32));
-            FillRect(dwgfx.backBuffer, 0,199,119,9, dwgfx.getRGB(0,0,0));
+            FillRect(graphics.backBuffer, 0,198,120,10, graphics.getRGB(32,32,32));
+            FillRect(graphics.backBuffer, 0,199,119,9, graphics.getRGB(0,0,0));
             switch(ed.drawmode)
             {
             case 0:
-                dwgfx.bprint(2,199, "1: Walls",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "1: Walls",196, 196, 255 - help.glow);
                 break;
             case 1:
-                dwgfx.bprint(2,199, "2: Backing",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "2: Backing",196, 196, 255 - help.glow);
                 break;
             case 2:
-                dwgfx.bprint(2,199, "3: Spikes",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "3: Spikes",196, 196, 255 - help.glow);
                 break;
             case 3:
-                dwgfx.bprint(2,199, "4: Trinkets",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "4: Trinkets",196, 196, 255 - help.glow);
                 break;
             case 4:
-                dwgfx.bprint(2,199, "5: Checkpoint",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "5: Checkpoint",196, 196, 255 - help.glow);
                 break;
             case 5:
-                dwgfx.bprint(2,199, "6: Disappear",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "6: Disappear",196, 196, 255 - help.glow);
                 break;
             case 6:
-                dwgfx.bprint(2,199, "7: Conveyors",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "7: Conveyors",196, 196, 255 - help.glow);
                 break;
             case 7:
-                dwgfx.bprint(2,199, "8: Moving",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "8: Moving",196, 196, 255 - help.glow);
                 break;
             case 8:
-                dwgfx.bprint(2,199, "9: Enemies",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "9: Enemies",196, 196, 255 - help.glow);
                 break;
             case 9:
-                dwgfx.bprint(2,199, "0: Grav Line",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "0: Grav Line",196, 196, 255 - help.glow);
                 break;
             case 10:
-                dwgfx.bprint(2,199, "R: Roomtext",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "R: Roomtext",196, 196, 255 - help.glow);
                 break;
             case 11:
-                dwgfx.bprint(2,199, "T: Terminal",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "T: Terminal",196, 196, 255 - help.glow);
                 break;
             case 12:
-                dwgfx.bprint(2,199, "Y: Script Box",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "Y: Script Box",196, 196, 255 - help.glow);
                 break;
             case 13:
-                dwgfx.bprint(2,199, "U: Warp Token",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "U: Warp Token",196, 196, 255 - help.glow);
                 break;
             case 14:
-                dwgfx.bprint(2,199, "I: Warp Lines",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "I: Warp Lines",196, 196, 255 - help.glow);
                 break;
             case 15:
-                dwgfx.bprint(2,199, "O: Crewmate",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "O: Crewmate",196, 196, 255 - help.glow);
                 break;
             case 16:
-                dwgfx.bprint(2,199, "P: Start Point",196, 196, 255 - help.glow);
+                graphics.bprint(2,199, "P: Start Point",196, 196, 255 - help.glow);
                 break;
             }
 
-            FillRect(dwgfx.backBuffer, 260,198,80,10, dwgfx.getRGB(32,32,32));
-            FillRect(dwgfx.backBuffer, 261,199,80,9, dwgfx.getRGB(0,0,0));
-            dwgfx.bprint(268,199, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);
+            FillRect(graphics.backBuffer, 260,198,80,10, graphics.getRGB(32,32,32));
+            FillRect(graphics.backBuffer, 261,199,80,9, graphics.getRGB(0,0,0));
+            graphics.bprint(268,199, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);
 
         }
         else
         {
-            //FillRect(dwgfx.backBuffer, 0,230,72,240, dwgfx.RGB(32,32,32));
-            //FillRect(dwgfx.backBuffer, 0,231,71,240, dwgfx.RGB(0,0,0));
+            //FillRect(graphics.backBuffer, 0,230,72,240, graphics.RGB(32,32,32));
+            //FillRect(graphics.backBuffer, 0,231,71,240, graphics.RGB(0,0,0));
             if(ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname!="")
             {
                 if(ed.tiley<28)
@@ -3371,45 +3371,45 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                 {
                     if(ed.roomnamehide<12) ed.roomnamehide++;
                 }
-                if (dwgfx.translucentroomname)
+                if (graphics.translucentroomname)
                 {
-                    dwgfx.footerrect.y = 230+ed.roomnamehide;
-                    SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
+                    graphics.footerrect.y = 230+ed.roomnamehide;
+                    SDL_BlitSurface(graphics.footerbuffer, NULL, graphics.backBuffer, &graphics.footerrect);
                 }
                 else
                 {
-                    FillRect(dwgfx.backBuffer, 0,230+ed.roomnamehide,320,10, dwgfx.getRGB(0,0,0));
+                    FillRect(graphics.backBuffer, 0,230+ed.roomnamehide,320,10, graphics.getRGB(0,0,0));
                 }
-                dwgfx.bprint(5,231+ed.roomnamehide,ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname, 196, 196, 255 - help.glow, true);
-                dwgfx.bprint(4, 222, "SPACE ^  SHIFT ^", 196, 196, 255 - help.glow, false);
-                dwgfx.bprint(268,222, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);
+                graphics.bprint(5,231+ed.roomnamehide,ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname, 196, 196, 255 - help.glow, true);
+                graphics.bprint(4, 222, "SPACE ^  SHIFT ^", 196, 196, 255 - help.glow, false);
+                graphics.bprint(268,222, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);
             }
             else
             {
-                dwgfx.bprint(4, 232, "SPACE ^  SHIFT ^", 196, 196, 255 - help.glow, false);
-                dwgfx.bprint(268,232, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);
+                graphics.bprint(4, 232, "SPACE ^  SHIFT ^", 196, 196, 255 - help.glow, false);
+                graphics.bprint(268,232, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);
             }
         }
 
         if(ed.shiftmenu)
         {
-            fillboxabs(dwgfx, 0, 127,161+8,140,dwgfx.getRGB(64,64,64));
-            FillRect(dwgfx.backBuffer, 0,128,160+8,140, dwgfx.getRGB(0,0,0));
-            dwgfx.Print(4, 130, "F1: Change Tileset",164,164,164,false);
-            dwgfx.Print(4, 140, "F2: Change Colour",164,164,164,false);
-            dwgfx.Print(4, 150, "F3: Change Enemies",164,164,164,false);
-            dwgfx.Print(4, 160, "F4: Enemy Bounds",164,164,164,false);
-            dwgfx.Print(4, 170, "F5: Platform Bounds",164,164,164,false);
+            fillboxabs(0, 127,161+8,140,graphics.getRGB(64,64,64));
+            FillRect(graphics.backBuffer, 0,128,160+8,140, graphics.getRGB(0,0,0));
+            graphics.Print(4, 130, "F1: Change Tileset",164,164,164,false);
+            graphics.Print(4, 140, "F2: Change Colour",164,164,164,false);
+            graphics.Print(4, 150, "F3: Change Enemies",164,164,164,false);
+            graphics.Print(4, 160, "F4: Enemy Bounds",164,164,164,false);
+            graphics.Print(4, 170, "F5: Platform Bounds",164,164,164,false);
 
-            dwgfx.Print(4, 190, "F10: Direct Mode",164,164,164,false);
+            graphics.Print(4, 190, "F10: Direct Mode",164,164,164,false);
 
-            dwgfx.Print(4, 210, "W: Change Warp Dir",164,164,164,false);
-            dwgfx.Print(4, 220, "E: Change Roomname",164,164,164,false);
+            graphics.Print(4, 210, "W: Change Warp Dir",164,164,164,false);
+            graphics.Print(4, 220, "E: Change Roomname",164,164,164,false);
 
-            fillboxabs(dwgfx, 220, 207,100,60,dwgfx.getRGB(64,64,64));
-            FillRect(dwgfx.backBuffer, 221,208,160,60, dwgfx.getRGB(0,0,0));
-            dwgfx.Print(224, 210, "S: Save Map",164,164,164,false);
-            dwgfx.Print(224, 220, "L: Load Map",164,164,164,false);
+            fillboxabs(220, 207,100,60,graphics.getRGB(64,64,64));
+            FillRect(graphics.backBuffer, 221,208,160,60, graphics.getRGB(0,0,0));
+            graphics.Print(224, 210, "S: Save Map",164,164,164,false);
+            graphics.Print(224, 220, "L: Load Map",164,164,164,false);
         }
     }
 
@@ -3420,106 +3420,106 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
         switch(ed.drawmode)
         {
         case 0:
-            dwgfx.bprint(2,2, "1: Walls",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "1: Walls",196, 196, 255 - help.glow);
             break;
         case 1:
-            dwgfx.bprint(2,2, "2: Backing",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "2: Backing",196, 196, 255 - help.glow);
             break;
         case 2:
-            dwgfx.bprint(2,2, "3: Spikes",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "3: Spikes",196, 196, 255 - help.glow);
             break;
         case 3:
-            dwgfx.bprint(2,2, "4: Trinkets",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "4: Trinkets",196, 196, 255 - help.glow);
             break;
         case 4:
-            dwgfx.bprint(2,2, "5: Checkpoint",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "5: Checkpoint",196, 196, 255 - help.glow);
             break;
         case 5:
-            dwgfx.bprint(2,2, "6: Disappear",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "6: Disappear",196, 196, 255 - help.glow);
             break;
         case 6:
-            dwgfx.bprint(2,2, "7: Conveyors",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "7: Conveyors",196, 196, 255 - help.glow);
             break;
         case 7:
-            dwgfx.bprint(2,2, "8: Moving",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "8: Moving",196, 196, 255 - help.glow);
             break;
         case 8:
-            dwgfx.bprint(2,2, "9: Enemies",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "9: Enemies",196, 196, 255 - help.glow);
             break;
         case 9:
-            dwgfx.bprint(2,2, "0: Grav Line",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "0: Grav Line",196, 196, 255 - help.glow);
             break;
         case 10:
-            dwgfx.bprint(2,2, "R: Roomtext",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "R: Roomtext",196, 196, 255 - help.glow);
             break;
         case 11:
-            dwgfx.bprint(2,2, "T: Terminal",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "T: Terminal",196, 196, 255 - help.glow);
             break;
         case 12:
-            dwgfx.bprint(2,2, "Y: Script Box",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "Y: Script Box",196, 196, 255 - help.glow);
             break;
         case 13:
-            dwgfx.bprint(2,2, "U: Warp Token",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "U: Warp Token",196, 196, 255 - help.glow);
             break;
         case 14:
-            dwgfx.bprint(2,2, "I: Warp Lines",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "I: Warp Lines",196, 196, 255 - help.glow);
             break;
         case 15:
-            dwgfx.bprint(2,2, "O: Crewmate",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "O: Crewmate",196, 196, 255 - help.glow);
             break;
         case 16:
-            dwgfx.bprint(2,2, "P: Start Point",196, 196, 255 - help.glow);
+            graphics.bprint(2,2, "P: Start Point",196, 196, 255 - help.glow);
             break;
         }
 
-        //dwgfx.Print(254, 2, "F1: HELP", 196, 196, 255 - help.glow, false);
+        //graphics.Print(254, 2, "F1: HELP", 196, 196, 255 - help.glow, false);
     }
 
     /*
     for(size_t i=0; i<script.customscript.size(); i++){
-      dwgfx.Print(0,i*8,script.customscript[i],255,255,255);
+      graphics.Print(0,i*8,script.customscript[i],255,255,255);
     }
-    dwgfx.Print(0,8*script.customscript.size(),help.String(script.customscript.size()),255,255,255);
+    graphics.Print(0,8*script.customscript.size(),help.String(script.customscript.size()),255,255,255);
 
     for(size_t i=0; i<ed.hooklist.size(); i++){
-      dwgfx.Print(260,i*8,ed.hooklist[i],255,255,255);
+      graphics.Print(260,i*8,ed.hooklist[i],255,255,255);
     }
-    dwgfx.Print(260,8*ed.hooklist.size(),help.String(ed.hooklist.size()),255,255,255);
+    graphics.Print(260,8*ed.hooklist.size(),help.String(ed.hooklist.size()),255,255,255);
     */
 
     if(ed.notedelay>0)
     {
-        FillRect(dwgfx.backBuffer, 0,115,320,18, dwgfx.getRGB(92,92,92));
-        FillRect(dwgfx.backBuffer, 0,116,320,16, dwgfx.getRGB(0,0,0));
-        dwgfx.Print(0,121, ed.note,196-((45-ed.notedelay)*4), 196-((45-ed.notedelay)*4), 196-((45-ed.notedelay)*4), true);
+        FillRect(graphics.backBuffer, 0,115,320,18, graphics.getRGB(92,92,92));
+        FillRect(graphics.backBuffer, 0,116,320,16, graphics.getRGB(0,0,0));
+        graphics.Print(0,121, ed.note,196-((45-ed.notedelay)*4), 196-((45-ed.notedelay)*4), 196-((45-ed.notedelay)*4), true);
     }
 
     if (game.test)
     {
-        dwgfx.bprint(5, 5, game.teststring, 196, 196, 255 - help.glow, false);
+        graphics.bprint(5, 5, game.teststring, 196, 196, 255 - help.glow, false);
     }
 
-    dwgfx.drawfade();
+    graphics.drawfade();
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
-        dwgfx.flashlight();
+        graphics.flashlight();
     }
 
     if (game.screenshake > 0  && !game.noflashingmode)
     {
         game.screenshake--;
-        dwgfx.screenshake();
+        graphics.screenshake();
     }
     else
     {
-        dwgfx.render();
+        graphics.render();
     }
-    //dwgfx.backbuffer.unlock();
+    //graphics.backbuffer.unlock();
 }
 
-void editorlogic( KeyPoll& key, Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music, mapclass& map, UtilityClass& help )
+void editorlogic()
 {
     //Misc
     help.updateglow();
@@ -3539,24 +3539,24 @@ void editorlogic( KeyPoll& key, Graphics& dwgfx, Game& game, entityclass& obj, m
         ed.notedelay--;
     }
 
-    if (dwgfx.fademode == 1)
+    if (graphics.fademode == 1)
     {
         //Return to game
         map.nexttowercolour();
         map.colstate = 10;
         game.gamestate = 1;
-        dwgfx.fademode = 4;
+        graphics.fademode = 4;
         music.stopmusic();
         music.play(6);
         map.nexttowercolour();
         ed.settingsmod=false;
-        dwgfx.backgrounddrawn=false;
+        graphics.backgrounddrawn=false;
         game.createmenu("mainmenu");
     }
 }
 
 
-void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void editorinput()
 {
     //TODO Mouse Input!
     game.mx = (float) key.mx;
@@ -3566,7 +3566,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
     if (game.stretchMode == 1) {
         // In this mode specifically, we have to fix the mouse coordinates
         int winwidth, winheight;
-        dwgfx.screenbuffer->GetWindowSize(&winwidth, &winheight);
+        graphics.screenbuffer->GetWindowSize(&winwidth, &winheight);
         ed.tilex = ed.tilex * 320 / winwidth;
         ed.tiley = ed.tiley * 240 / winheight;
     }
@@ -3632,7 +3632,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
         {
 
             ed.settingsmod=!ed.settingsmod;
-            dwgfx.backgrounddrawn=false;
+            graphics.backgrounddrawn=false;
 
             game.createmenu("ed_settings");
             map.nexttowercolour();
@@ -3912,7 +3912,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                     if(ed.saveandquit)
                     {
                         //quit editor
-                        dwgfx.fademode = 2;
+                        graphics.fademode = 2;
                     }
                 }
                 else if(ed.loadmod)
@@ -4099,7 +4099,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         {
                             //Load level
                             ed.settingsmod=false;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                             map.nexttowercolour();
 
                             ed.loadmod=true;
@@ -4108,13 +4108,13 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                             key.keybuffer=ed.filename;
                             ed.keydelay=6;
                             game.mapheld=true;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                         }
                         else if (game.currentmenuoption == 4)
                         {
                             //Save level
                             ed.settingsmod=false;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                             map.nexttowercolour();
 
                             ed.savemod=true;
@@ -4123,7 +4123,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                             key.keybuffer=ed.filename;
                             ed.keydelay=6;
                             game.mapheld=true;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                         }
                         else if (game.currentmenuoption == 5)
                         {
@@ -4167,7 +4167,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                             ed.saveandquit=true;
 
                             ed.settingsmod=false;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                             map.nexttowercolour();
 
                             ed.savemod=true;
@@ -4176,14 +4176,14 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                             key.keybuffer=ed.filename;
                             ed.keydelay=6;
                             game.mapheld=true;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                         }
                         else if (game.currentmenuoption == 1)
                         {
                             //Quit without saving
                             music.playef(11, 10);
                             music.fadeout();
-                            dwgfx.fademode = 2;
+                            graphics.fademode = 2;
                         }
                         else if (game.currentmenuoption == 2)
                         {
@@ -4203,7 +4203,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
             if(key.keymap[SDLK_F1] && ed.keydelay==0)
             {
                 ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset++;
-                dwgfx.backgrounddrawn=false;
+                graphics.backgrounddrawn=false;
                 if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset>=5) ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset=0;
                 if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
                 {
@@ -4248,7 +4248,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
             if(key.keymap[SDLK_F2] && ed.keydelay==0)
             {
                 ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol++;
-                dwgfx.backgrounddrawn=false;
+                graphics.backgrounddrawn=false;
                 if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
                 {
                     if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol>=32) ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol=0;
@@ -4297,7 +4297,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                     ed.level[ed.levx+(ed.levy*ed.maxwidth)].directmode=1;
                     ed.note="Direct Mode Enabled";
                 }
-                dwgfx.backgrounddrawn=false;
+                graphics.backgrounddrawn=false;
 
                 ed.notedelay=45;
                 ed.updatetiles=true;
@@ -4348,25 +4348,25 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                     {
                         ed.note="Room warping disabled";
                         ed.notedelay=45;
-                        dwgfx.backgrounddrawn=false;
+                        graphics.backgrounddrawn=false;
                     }
                     else if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir==1)
                     {
                         ed.note="Room warps horizontally";
                         ed.notedelay=45;
-                        dwgfx.backgrounddrawn=false;
+                        graphics.backgrounddrawn=false;
                     }
                     else if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir==2)
                     {
                         ed.note="Room warps vertically";
                         ed.notedelay=45;
-                        dwgfx.backgrounddrawn=false;
+                        graphics.backgrounddrawn=false;
                     }
                     else if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir==3)
                     {
                         ed.note="Room warps in all directions";
                         ed.notedelay=45;
-                        dwgfx.backgrounddrawn=false;
+                        graphics.backgrounddrawn=false;
                     }
                 }
                 ed.keydelay=6;
@@ -4390,7 +4390,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                 key.keybuffer=ed.filename;
                 ed.keydelay=6;
                 game.mapheld=true;
-                dwgfx.backgrounddrawn=false;
+                graphics.backgrounddrawn=false;
             }
 
             if(key.keymap[SDLK_l] && ed.keydelay==0)
@@ -4401,7 +4401,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                 key.keybuffer=ed.filename;
                 ed.keydelay=6;
                 game.mapheld=true;
-                dwgfx.backgrounddrawn=false;
+                graphics.backgrounddrawn=false;
             }
 
             if(!game.press_map) game.mapheld=false;
@@ -4489,15 +4489,15 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         }
 
                         music.stopmusic();
-                        dwgfx.backgrounddrawn=false;
+                        graphics.backgrounddrawn=false;
                         ed.returneditoralpha = 1000; // Let's start it higher than 255 since it gets clamped
                         script.startgamemode(21);
                     }
                     //Return to game
                     //game.gamestate=GAMEMODE;
-                    /*if(dwgfx.fademode==0)
+                    /*if(graphics.fademode==0)
                     {
-                    dwgfx.fademode = 2;
+                    graphics.fademode = 2;
                     music.fadeout();
                     }*/
                 }
@@ -4625,7 +4625,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         if(key.keymap[SDLK_UP])
                         {
                             ed.keydelay=6;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                             ed.levy--;
                             ed.updatetiles=true;
                             ed.changeroom=true;
@@ -4633,7 +4633,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         else if(key.keymap[SDLK_DOWN])
                         {
                             ed.keydelay=6;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                             ed.levy++;
                             ed.updatetiles=true;
                             ed.changeroom=true;
@@ -4641,7 +4641,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         else if(key.keymap[SDLK_LEFT])
                         {
                             ed.keydelay=6;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                             ed.levx--;
                             ed.updatetiles=true;
                             ed.changeroom=true;
@@ -4649,7 +4649,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         else if(key.keymap[SDLK_RIGHT])
                         {
                             ed.keydelay=6;
-                            dwgfx.backgrounddrawn=false;
+                            graphics.backgrounddrawn=false;
                             ed.levx++;
                             ed.updatetiles=true;
                             ed.changeroom=true;
@@ -4908,7 +4908,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                                 ed.textentry=true;
                                 key.enabletextentry();
                                 key.keybuffer="";
-                                dwgfx.backgrounddrawn=false;
+                                graphics.backgrounddrawn=false;
                                 addedentity(ed.tilex+ (ed.levx*40),ed.tiley+ (ed.levy*30),17);
                                 ed.lclickdelay=1;
                             }

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -7,7 +7,7 @@
 #include <string>
 #include "Script.h"
 
-class KeyPoll; class Graphics; class Game; class mapclass; class entityclass; class UtilityClass;
+class KeyPoll; class Graphics; class Game; class mapclass; class entityclass; class UtilityClass; class musicclass;
 
 
 class edentities{

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -7,9 +7,6 @@
 #include <string>
 #include "Script.h"
 
-class KeyPoll; class Graphics; class Game; class mapclass; class entityclass; class UtilityClass; class musicclass;
-
-
 class edentities{
 public:
 	int x, y, t;
@@ -129,7 +126,7 @@ class editorclass{
 
   void load(std::string& _path);
   void save(std::string& _path);
-  void generatecustomminimap(Graphics& dwgfx, mapclass& map);
+  void generatecustomminimap();
   int edgetile(int x, int y);
   int warpzoneedgetile(int x, int y);
   int outsideedgetile(int x, int y);
@@ -142,7 +139,7 @@ class editorclass{
   int findcrewmate(int t);
   int findwarptoken(int t);
   void countstuff();
-  void findstartpoint(Game& game);
+  void findstartpoint();
   void weirdloadthing(std::string t);
   int getlevelcol(int t);
   int getenemycol(int t);
@@ -245,16 +242,15 @@ int edentat(int xp, int yp);
 
 bool edentclear(int xp, int yp);
 
-void fillbox(Graphics& dwgfx, int x, int y, int x2, int y2, int c);
+void fillbox(int x, int y, int x2, int y2, int c);
 
-void fillboxabs(Graphics& dwgfx, int x, int y, int x2, int y2, int c);
+void fillboxabs(int x, int y, int x2, int y2, int c);
 
-void editorrender(KeyPoll& key, Graphics& dwgfx, Game& game,  mapclass& map, entityclass& obj, UtilityClass& help);
+void editorrender();
 
-void editorlogic(KeyPoll& key, Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help);
+void editorlogic();
 
-void editorinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                 entityclass& obj, UtilityClass& help, musicclass& music);
+void editorinput();
 
 #endif /* EDITOR_H */
 

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -140,7 +140,6 @@ class editorclass{
   int findwarptoken(int t);
   void countstuff();
   void findstartpoint();
-  void weirdloadthing(std::string t);
   int getlevelcol(int t);
   int getenemycol(int t);
   int entcol;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -376,7 +376,7 @@ int main(int argc, char *argv[])
                 //Render
                 titlerender(graphics, map, game, obj, help, music);
                 ////Logic
-                titlelogic(graphics, game, obj, help, music, map);
+                titlelogic();
                 break;
             case GAMEMODE:
                 if (map.towermode)
@@ -391,7 +391,7 @@ int main(int argc, char *argv[])
                     //{
                     //}
                     towerrender(graphics, game, map, obj, help);
-                    towerlogic(graphics, game,  obj,  music, map, help);
+                    towerlogic();
 
                 }
                 else
@@ -411,7 +411,7 @@ int main(int argc, char *argv[])
                         gameinput(key, graphics, game, map, obj, help, music);
                         //}
                         gamerender(graphics,map, game,  obj, help);
-                        gamelogic(graphics, game,obj, music, map,  help);
+                        gamelogic();
 
 
                     }
@@ -426,7 +426,7 @@ int main(int argc, char *argv[])
                     {
                         mapinput(key, graphics, game, map, obj, help, music);
                     }
-                    maplogic(graphics, game, obj ,music , map, help );
+                    maplogic();
                     break;
                 case TELEPORTERMODE:
                     teleporterrender(graphics, game, map, obj, help);
@@ -449,21 +449,21 @@ int main(int argc, char *argv[])
                             gameinput(key, graphics, game, map, obj, help, music);
                         }
                     }
-                    maplogic(graphics, game,  obj, music, map, help);
+                    maplogic();
                     break;
                 case GAMECOMPLETE:
                     gamecompleterender(graphics, game, obj, help, map);
                     //Input
                     gamecompleteinput(key, graphics, game, map, obj, help, music);
                     //Logic
-                    gamecompletelogic(graphics, game,  obj, music, map, help);
+                    gamecompletelogic();
                     break;
                 case GAMECOMPLETE2:
                     gamecompleterender2(graphics, game, obj, help);
                     //Input
                     gamecompleteinput2(key, graphics, game, map, obj, help, music);
                     //Logic
-                    gamecompletelogic2(graphics, game,  obj, music, map, help);
+                    gamecompletelogic2();
                     break;
                 case CLICKTOSTART:
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -112,18 +112,14 @@ int main(int argc, char *argv[])
 
 
 
-    //UtilityClass help;
     // Load Ini
 
 
-    //Graphics graphics;
     graphics.init();
 
 
 
-    //musicclass music;
     music.init();
-    //Game game;
     game.init();
     game.infocus = true;
 
@@ -171,21 +167,10 @@ int main(int argc, char *argv[])
     graphics.tempBuffer = SDL_CreateRGBSurface(SDL_SWSURFACE ,320 ,240 ,fmt->BitsPerPixel,fmt->Rmask,fmt->Gmask,fmt->Bmask,fmt->Amask  );
     SDL_SetSurfaceBlendMode(graphics.tempBuffer, SDL_BLENDMODE_NONE);
 
-    //Make a temporary rectangle to hold the offsets
-    // SDL_Rect offset;
-    //Give the offsets to the rectangle
-    // offset.x = 60;
-    // offset.y = 80;
-
-    //game.gamestate = TITLEMODE;
-    //game.gamestate=EDITORMODE;
-    game.gamestate = PRELOADER; //Remember to uncomment this later!
+    game.gamestate = PRELOADER;
 
     game.menustart = false;
     game.mainmenu = 0;
-
-    //KeyPoll key;
-    //mapclass map;
 
     map.ypos = (700-29) * 8;
     map.bypos = map.ypos / 2;
@@ -242,31 +227,7 @@ int main(int argc, char *argv[])
     if(game.bestrank[4]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_warp_fixed");
     if(game.bestrank[5]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_final_fixed");
 
-    //entityclass obj;
     obj.init();
-
-    //Quick hack to start in final level ---- //Might be useful to leave this commented in for testing
-    /*
-    //game.gamestate=GAMEMODE;
-    //game.start(obj,music);
-    //script.startgamemode(8);
-   // map.finalmode = true; //Enable final level mode
-    //map.finalx = 41; map.finaly = 52; //Midpoint
-    //map.finalstretch = true;
-    //map.final_colormode = true;
-    //map.final_mapcol = 0;
-    //map.final_colorframe = 0;
-
-    //game.starttest(obj, music);
-
-    game.savex = 5 * 8; game.savey = 15 * 8; game.saverx = 41; game.savery = 52;
-    game.savegc = 0; game.savedir = 1;
-    game.state = 0; game.deathseq = -1; game.lifeseq = 10;
-    //obj.createentity(game, game.savex, game.savey, 0);
-    map.gotoroom(game.saverx, game.savery, graphics, game, obj, music);
-    //music.play(1);
-    */
-    //End hack here ----
 
     volatile Uint32 time, timePrev = 0;
     game.infocus = true;
@@ -380,14 +341,6 @@ int main(int argc, char *argv[])
                 if (map.towermode)
                 {
                     gameinput();
-
-                    //if(game.recording==1)
-                    //{
-                    // ///recordinput();
-                    //}
-                    //else
-                    //{
-                    //}
                     towerrender();
                     towerlogic();
 
@@ -397,7 +350,6 @@ int main(int argc, char *argv[])
 
                     if (game.recording == 1)
                     {
-                        //recordinput();
                     }
                     else
                     {
@@ -407,7 +359,6 @@ int main(int argc, char *argv[])
                         }
 
                         gameinput();
-                        //}
                         gamerender();
                         gamelogic();
 
@@ -418,7 +369,6 @@ int main(int argc, char *argv[])
                     maprender();
                     if (game.recording == 1)
                     {
-                        //recordinput(); //will implement this later if it's actually needed
                     }
                     else
                     {
@@ -430,7 +380,6 @@ int main(int argc, char *argv[])
                     teleporterrender();
                     if (game.recording == 1)
                     {
-                        //recordinput();
                     }
                     else
                     {
@@ -464,24 +413,7 @@ int main(int argc, char *argv[])
                     gamecompletelogic2();
                     break;
                 case CLICKTOSTART:
-
-                    //dwgfx.bprint(5, 115, "[Click to start]", 196 - help.glow, 196 - help.glow, 255 - help.glow, true);
-                    //dwgfx.drawgui(help);
-                    //dwgfx.render();
-                    //dwgfx.backbuffer.unlock();
-
                     help.updateglow();
-                    // if (key.click) {
-                    //  dwgfx.textboxremove();
-                    // }
-                    // if (dwgfx.ntextbox == 0) {
-                    //  //music.play(6);
-                    //  map.ypos = (700-29) * 8;
-                    //  map.bypos = map.ypos / 2;
-                    //  map.cameramode = 0;
-
-                    //  game.gamestate = TITLEMODE;
-                    // }
                     break;
                 default:
 
@@ -526,12 +458,9 @@ int main(int argc, char *argv[])
 
         if (game.muted)
         {
-            //if (game.globalsound == 1)
-            //{
-                game.globalsound = 0;
-                Mix_VolumeMusic(0) ;
-                Mix_Volume(-1,0);
-            //}
+            game.globalsound = 0;
+            Mix_VolumeMusic(0) ;
+            Mix_Volume(-1,0);
         }
 
         if (!game.muted && game.globalsound == 0)
@@ -551,18 +480,8 @@ int main(int argc, char *argv[])
         graphics.processfade();
         game.gameclock();
         gameScreen.FlipScreen();
-
-        //SDL_FillRect( SDL_GetVideoSurface(), NULL, 0 );
     }
 
-
-    //SDL_Delay(300);
-
-    //TODO
-    //Free the loaded image
-    //SDL_FreeSurface( gameScreen );
-
-    //Quit SDL
     game.savestats();
     NETWORK_shutdown();
     SDL_Quit();

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -374,7 +374,7 @@ int main(int argc, char *argv[])
                 //Input
                 titleinput();
                 //Render
-                titlerender(graphics, map, game, obj, help, music);
+                titlerender();
                 ////Logic
                 titlelogic();
                 break;
@@ -390,7 +390,7 @@ int main(int argc, char *argv[])
                     //else
                     //{
                     //}
-                    towerrender(graphics, game, map, obj, help);
+                    towerrender();
                     towerlogic();
 
                 }
@@ -410,14 +410,14 @@ int main(int argc, char *argv[])
 
                         gameinput();
                         //}
-                        gamerender(graphics,map, game,  obj, help);
+                        gamerender();
                         gamelogic();
 
 
                     }
                     break;
                 case MAPMODE:
-                    maprender(graphics, game, map, obj, help);
+                    maprender();
                     if (game.recording == 1)
                     {
                         //recordinput(); //will implement this later if it's actually needed
@@ -429,7 +429,7 @@ int main(int argc, char *argv[])
                     maplogic();
                     break;
                 case TELEPORTERMODE:
-                    teleporterrender(graphics, game, map, obj, help);
+                    teleporterrender();
                     if (game.recording == 1)
                     {
                         //recordinput();
@@ -452,14 +452,14 @@ int main(int argc, char *argv[])
                     maplogic();
                     break;
                 case GAMECOMPLETE:
-                    gamecompleterender(graphics, game, obj, help, map);
+                    gamecompleterender();
                     //Input
                     gamecompleteinput();
                     //Logic
                     gamecompletelogic();
                     break;
                 case GAMECOMPLETE2:
-                    gamecompleterender2(graphics, game, obj, help);
+                    gamecompleterender2();
                     //Input
                     gamecompleteinput2();
                     //Logic

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -363,11 +363,11 @@ int main(int argc, char *argv[])
             case EDITORMODE:
 				graphics.flipmode = false;
                 //Input
-                editorinput(key, graphics, game, map, obj, help, music);
+                editorinput();
                 //Render
-                editorrender(key, graphics, game, map, obj, help);
+                editorrender();
                 ////Logic
-                editorlogic(key, graphics, game, obj, music, map, help);
+                editorlogic();
                 break;
         #endif
             case TITLEMODE:

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -249,7 +249,7 @@ int main(int argc, char *argv[])
     /*
     //game.gamestate=GAMEMODE;
 		//game.start(obj,music);
-		//script.startgamemode(8, key, graphics, game, map, obj, help, music);
+		//script.startgamemode(8);
    // map.finalmode = true; //Enable final level mode
 		//map.finalx = 41; map.finaly = 52; //Midpoint
 		//map.finalstretch = true;
@@ -405,7 +405,7 @@ int main(int argc, char *argv[])
                     {
                         if (script.running)
                         {
-                            script.run(key, graphics, game, map, obj, help, music);
+                            script.run();
                         }
 
                         gameinput(key, graphics, game, map, obj, help, music);
@@ -444,7 +444,7 @@ int main(int argc, char *argv[])
                         {
                             if (script.running)
                             {
-                                script.run(key, graphics, game, map, obj, help, music);
+                                script.run();
                             }
                             gameinput(key, graphics, game, map, obj, help, music);
                         }

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -357,7 +357,7 @@ int main(int argc, char *argv[])
             {
             case PRELOADER:
                 //Render
-                preloaderrender(graphics, game, help);
+                preloaderrender();
                 break;
         #if !defined(NO_CUSTOM_LEVELS)
             case EDITORMODE:

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
     map.bypos = map.ypos / 2;
 
     //Moved screensetting init here from main menu V2.1
-    game.loadstats(map, graphics);
+    game.loadstats();
     if (game.skipfakeload)
         game.gamestate = TITLEMODE;
 		if(game.usingmmmmmm==0) music.usingmmmmmm=false;
@@ -500,7 +500,7 @@ int main(int argc, char *argv[])
         if (game.savemystats)
         {
             game.savemystats = false;
-            game.savestats(map, graphics);
+            game.savestats();
         }
 
         //Mute button
@@ -565,7 +565,7 @@ int main(int argc, char *argv[])
     //SDL_FreeSurface( gameScreen );
 
     //Quit SDL
-    game.savestats(map, graphics);
+    game.savestats();
     NETWORK_shutdown();
     SDL_Quit();
     FILESYSTEM_deinit();

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -372,7 +372,7 @@ int main(int argc, char *argv[])
         #endif
             case TITLEMODE:
                 //Input
-                titleinput(key, graphics, map, game, obj, help, music);
+                titleinput();
                 //Render
                 titlerender(graphics, map, game, obj, help, music);
                 ////Logic
@@ -381,11 +381,11 @@ int main(int argc, char *argv[])
             case GAMEMODE:
                 if (map.towermode)
                 {
-					gameinput(key, graphics, game, map, obj, help, music);
+					gameinput();
 
                     //if(game.recording==1)
                     //{
-                    // ///recordinput(key, graphics, game, map, obj, help, music);
+                    // ///recordinput();
                     //}
                     //else
                     //{
@@ -399,7 +399,7 @@ int main(int argc, char *argv[])
 
                     if (game.recording == 1)
                     {
-                        //recordinput(key, dwgfx, game, map, obj, help, music);
+                        //recordinput();
                     }
                     else
                     {
@@ -408,7 +408,7 @@ int main(int argc, char *argv[])
                             script.run();
                         }
 
-                        gameinput(key, graphics, game, map, obj, help, music);
+                        gameinput();
                         //}
                         gamerender(graphics,map, game,  obj, help);
                         gamelogic();
@@ -420,11 +420,11 @@ int main(int argc, char *argv[])
                     maprender(graphics, game, map, obj, help);
                     if (game.recording == 1)
                     {
-                        //recordinput(key, dwgfx, game, map, obj, help, music); //will implement this later if it's actually needed
+                        //recordinput(); //will implement this later if it's actually needed
                     }
                     else
                     {
-                        mapinput(key, graphics, game, map, obj, help, music);
+                        mapinput();
                     }
                     maplogic();
                     break;
@@ -432,13 +432,13 @@ int main(int argc, char *argv[])
                     teleporterrender(graphics, game, map, obj, help);
                     if (game.recording == 1)
                     {
-                        //recordinput(key, graphics, game, map, obj, help, music);
+                        //recordinput();
                     }
                     else
                     {
                         if(game.useteleporter)
                         {
-                            teleporterinput(key, graphics, game, map, obj, help, music);
+                            teleporterinput();
                         }
                         else
                         {
@@ -446,7 +446,7 @@ int main(int argc, char *argv[])
                             {
                                 script.run();
                             }
-                            gameinput(key, graphics, game, map, obj, help, music);
+                            gameinput();
                         }
                     }
                     maplogic();
@@ -454,14 +454,14 @@ int main(int argc, char *argv[])
                 case GAMECOMPLETE:
                     gamecompleterender(graphics, game, obj, help, map);
                     //Input
-                    gamecompleteinput(key, graphics, game, map, obj, help, music);
+                    gamecompleteinput();
                     //Logic
                     gamecompletelogic();
                     break;
                 case GAMECOMPLETE2:
                     gamecompleterender2(graphics, game, obj, help);
                     //Input
-                    gamecompleteinput2(key, graphics, game, map, obj, help, music);
+                    gamecompleteinput2();
                     //Logic
                     gamecompletelogic2();
                     break;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -274,8 +274,6 @@ int main(int argc, char *argv[])
 
     while(!key.quitProgram)
     {
-		//gameScreen.ClearScreen(0x00);
-
         time = SDL_GetTicks();
 
         // Update network per frame.

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -32,8 +32,8 @@
 scriptclass script;
 
 #if !defined(NO_CUSTOM_LEVELS)
-    std::vector<edentities> edentity;
-    editorclass ed;
+std::vector<edentities> edentity;
+editorclass ed;
 #endif
 
 UtilityClass help;
@@ -78,34 +78,34 @@ int main(int argc, char *argv[])
 
     Screen gameScreen;
 
-	printf("\t\t\n");
-	printf("\t\t\n");
-	printf("\t\t       VVVVVV\n");
-	printf("\t\t\n");
-	printf("\t\t\n");
-	printf("\t\t  8888888888888888  \n");
-	printf("\t\t88888888888888888888\n");
-	printf("\t\t888888    8888    88\n");
-	printf("\t\t888888    8888    88\n");
-	printf("\t\t88888888888888888888\n");
-	printf("\t\t88888888888888888888\n");
-	printf("\t\t888888            88\n");
-	printf("\t\t88888888        8888\n");
-	printf("\t\t  8888888888888888  \n");
-	printf("\t\t      88888888      \n");
-	printf("\t\t  8888888888888888  \n");
-	printf("\t\t88888888888888888888\n");
-	printf("\t\t88888888888888888888\n");
-	printf("\t\t88888888888888888888\n");
-	printf("\t\t8888  88888888  8888\n");
-	printf("\t\t8888  88888888  8888\n");
-	printf("\t\t    888888888888    \n");
-	printf("\t\t    8888    8888    \n");
-	printf("\t\t  888888    888888  \n");
-	printf("\t\t  888888    888888  \n");
-	printf("\t\t  888888    888888  \n");
-	printf("\t\t\n");
-	printf("\t\t\n");
+    printf("\t\t\n");
+    printf("\t\t\n");
+    printf("\t\t       VVVVVV\n");
+    printf("\t\t\n");
+    printf("\t\t\n");
+    printf("\t\t  8888888888888888  \n");
+    printf("\t\t88888888888888888888\n");
+    printf("\t\t888888    8888    88\n");
+    printf("\t\t888888    8888    88\n");
+    printf("\t\t88888888888888888888\n");
+    printf("\t\t88888888888888888888\n");
+    printf("\t\t888888            88\n");
+    printf("\t\t88888888        8888\n");
+    printf("\t\t  8888888888888888  \n");
+    printf("\t\t      88888888      \n");
+    printf("\t\t  8888888888888888  \n");
+    printf("\t\t88888888888888888888\n");
+    printf("\t\t88888888888888888888\n");
+    printf("\t\t88888888888888888888\n");
+    printf("\t\t8888  88888888  8888\n");
+    printf("\t\t8888  88888888  8888\n");
+    printf("\t\t    888888888888    \n");
+    printf("\t\t    8888    8888    \n");
+    printf("\t\t  888888    888888  \n");
+    printf("\t\t  888888    888888  \n");
+    printf("\t\t  888888    888888  \n");
+    printf("\t\t\n");
+    printf("\t\t\n");
 
     //Set up screen
 
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
     graphics.towerbuffer =  SDL_CreateRGBSurface(SDL_SWSURFACE ,320 ,240 ,fmt->BitsPerPixel,fmt->Rmask,fmt->Gmask,fmt->Bmask,fmt->Amask  );
     SDL_SetSurfaceBlendMode(graphics.towerbuffer, SDL_BLENDMODE_NONE);
 
-	graphics.tempBuffer = SDL_CreateRGBSurface(SDL_SWSURFACE ,320 ,240 ,fmt->BitsPerPixel,fmt->Rmask,fmt->Gmask,fmt->Bmask,fmt->Amask  );
+    graphics.tempBuffer = SDL_CreateRGBSurface(SDL_SWSURFACE ,320 ,240 ,fmt->BitsPerPixel,fmt->Rmask,fmt->Gmask,fmt->Bmask,fmt->Amask  );
     SDL_SetSurfaceBlendMode(graphics.tempBuffer, SDL_BLENDMODE_NONE);
 
     //Make a temporary rectangle to hold the offsets
@@ -194,53 +194,53 @@ int main(int argc, char *argv[])
     game.loadstats();
     if (game.skipfakeload)
         game.gamestate = TITLEMODE;
-		if(game.usingmmmmmm==0) music.usingmmmmmm=false;
-		if(game.usingmmmmmm==1) music.usingmmmmmm=true;
+    if(game.usingmmmmmm==0) music.usingmmmmmm=false;
+    if(game.usingmmmmmm==1) music.usingmmmmmm=true;
     if (game.slowdown == 0) game.slowdown = 30;
 
     switch(game.slowdown){
-      case 30: game.gameframerate=34; break;
-      case 24: game.gameframerate=41; break;
-      case 18: game.gameframerate=55; break;
-      case 12: game.gameframerate=83; break;
-      default: game.gameframerate=34; break;
+        case 30: game.gameframerate=34; break;
+        case 24: game.gameframerate=41; break;
+        case 18: game.gameframerate=55; break;
+        case 12: game.gameframerate=83; break;
+        default: game.gameframerate=34; break;
     }
 
-		//Check to see if you've already unlocked some achievements here from before the update
-		if (game.swnbestrank > 0){
-		  if(game.swnbestrank >= 1) NETWORK_unlockAchievement("vvvvvvsupgrav5");
-			if(game.swnbestrank >= 2) NETWORK_unlockAchievement("vvvvvvsupgrav10");
-			if(game.swnbestrank >= 3) NETWORK_unlockAchievement("vvvvvvsupgrav15");
-			if(game.swnbestrank >= 4) NETWORK_unlockAchievement("vvvvvvsupgrav20");
-			if(game.swnbestrank >= 5) NETWORK_unlockAchievement("vvvvvvsupgrav30");
-			if(game.swnbestrank >= 6) NETWORK_unlockAchievement("vvvvvvsupgrav60");
-		}
+    //Check to see if you've already unlocked some achievements here from before the update
+    if (game.swnbestrank > 0){
+        if(game.swnbestrank >= 1) NETWORK_unlockAchievement("vvvvvvsupgrav5");
+        if(game.swnbestrank >= 2) NETWORK_unlockAchievement("vvvvvvsupgrav10");
+        if(game.swnbestrank >= 3) NETWORK_unlockAchievement("vvvvvvsupgrav15");
+        if(game.swnbestrank >= 4) NETWORK_unlockAchievement("vvvvvvsupgrav20");
+        if(game.swnbestrank >= 5) NETWORK_unlockAchievement("vvvvvvsupgrav30");
+        if(game.swnbestrank >= 6) NETWORK_unlockAchievement("vvvvvvsupgrav60");
+    }
 
-		if(game.unlock[5]) NETWORK_unlockAchievement("vvvvvvgamecomplete");
-		if(game.unlock[19]) NETWORK_unlockAchievement("vvvvvvgamecompleteflip");
-		if(game.unlock[20]) NETWORK_unlockAchievement("vvvvvvmaster");
+    if(game.unlock[5]) NETWORK_unlockAchievement("vvvvvvgamecomplete");
+    if(game.unlock[19]) NETWORK_unlockAchievement("vvvvvvgamecompleteflip");
+    if(game.unlock[20]) NETWORK_unlockAchievement("vvvvvvmaster");
 
-		if (game.bestgamedeaths > -1) {
-			if (game.bestgamedeaths <= 500) {
-				NETWORK_unlockAchievement("vvvvvvcomplete500");
-			}
-			if (game.bestgamedeaths <= 250) {
-				NETWORK_unlockAchievement("vvvvvvcomplete250");
-			}
-			if (game.bestgamedeaths <= 100) {
-				NETWORK_unlockAchievement("vvvvvvcomplete100");
-			}
-			if (game.bestgamedeaths <= 50) {
-				NETWORK_unlockAchievement("vvvvvvcomplete50");
-			}
-		}
+    if (game.bestgamedeaths > -1) {
+        if (game.bestgamedeaths <= 500) {
+            NETWORK_unlockAchievement("vvvvvvcomplete500");
+        }
+        if (game.bestgamedeaths <= 250) {
+            NETWORK_unlockAchievement("vvvvvvcomplete250");
+        }
+        if (game.bestgamedeaths <= 100) {
+            NETWORK_unlockAchievement("vvvvvvcomplete100");
+        }
+        if (game.bestgamedeaths <= 50) {
+            NETWORK_unlockAchievement("vvvvvvcomplete50");
+        }
+    }
 
-		if(game.bestrank[0]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_station1_fixed");
-		if(game.bestrank[1]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_lab_fixed");
-		if(game.bestrank[2]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_tower_fixed");
-		if(game.bestrank[3]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_station2_fixed");
-		if(game.bestrank[4]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_warp_fixed");
-		if(game.bestrank[5]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_final_fixed");
+    if(game.bestrank[0]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_station1_fixed");
+    if(game.bestrank[1]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_lab_fixed");
+    if(game.bestrank[2]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_tower_fixed");
+    if(game.bestrank[3]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_station2_fixed");
+    if(game.bestrank[4]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_warp_fixed");
+    if(game.bestrank[5]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_final_fixed");
 
     //entityclass obj;
     obj.init();
@@ -248,24 +248,24 @@ int main(int argc, char *argv[])
     //Quick hack to start in final level ---- //Might be useful to leave this commented in for testing
     /*
     //game.gamestate=GAMEMODE;
-		//game.start(obj,music);
-		//script.startgamemode(8);
+    //game.start(obj,music);
+    //script.startgamemode(8);
    // map.finalmode = true; //Enable final level mode
-		//map.finalx = 41; map.finaly = 52; //Midpoint
-		//map.finalstretch = true;
-		//map.final_colormode = true;
-		//map.final_mapcol = 0;
-		//map.final_colorframe = 0;
+    //map.finalx = 41; map.finaly = 52; //Midpoint
+    //map.finalstretch = true;
+    //map.final_colormode = true;
+    //map.final_mapcol = 0;
+    //map.final_colorframe = 0;
 
-		//game.starttest(obj, music);
+    //game.starttest(obj, music);
 
     game.savex = 5 * 8; game.savey = 15 * 8; game.saverx = 41; game.savery = 52;
     game.savegc = 0; game.savedir = 1;
     game.state = 0; game.deathseq = -1; game.lifeseq = 10;
-		//obj.createentity(game, game.savex, game.savey, 0);
-		map.gotoroom(game.saverx, game.savery, graphics, game, obj, music);
-		//music.play(1);
-		*/
+    //obj.createentity(game, game.savex, game.savey, 0);
+    map.gotoroom(game.saverx, game.savery, graphics, game, obj, music);
+    //music.play(1);
+    */
     //End hack here ----
 
     volatile Uint32 time, timePrev = 0;
@@ -282,23 +282,23 @@ int main(int argc, char *argv[])
         //framerate limit to 30
         Uint32 timetaken = time - timePrev;
         if(game.gamestate==EDITORMODE)
-		{
-          if (timetaken < 24)
-          {
-              volatile Uint32 delay = 24 - timetaken;
-              SDL_Delay( delay );
-              time = SDL_GetTicks();
-          }
-          timePrev = time;
+        {
+            if (timetaken < 24)
+            {
+                volatile Uint32 delay = 24 - timetaken;
+                SDL_Delay( delay );
+                time = SDL_GetTicks();
+            }
+            timePrev = time;
 
         }else{
-          if (timetaken < game.gameframerate)
-          {
-              volatile Uint32 delay = game.gameframerate - timetaken;
-              SDL_Delay( delay );
-              time = SDL_GetTicks();
-          }
-          timePrev = time;
+            if (timetaken < game.gameframerate)
+            {
+                volatile Uint32 delay = game.gameframerate - timetaken;
+                SDL_Delay( delay );
+                time = SDL_GetTicks();
+            }
+            timePrev = time;
 
         }
 
@@ -357,9 +357,9 @@ int main(int argc, char *argv[])
                 //Render
                 preloaderrender();
                 break;
-        #if !defined(NO_CUSTOM_LEVELS)
+#if !defined(NO_CUSTOM_LEVELS)
             case EDITORMODE:
-				graphics.flipmode = false;
+                graphics.flipmode = false;
                 //Input
                 editorinput();
                 //Render
@@ -367,7 +367,7 @@ int main(int argc, char *argv[])
                 ////Logic
                 editorlogic();
                 break;
-        #endif
+#endif
             case TITLEMODE:
                 //Input
                 titleinput();
@@ -379,7 +379,7 @@ int main(int argc, char *argv[])
             case GAMEMODE:
                 if (map.towermode)
                 {
-					gameinput();
+                    gameinput();
 
                     //if(game.recording==1)
                     //{
@@ -502,11 +502,11 @@ int main(int argc, char *argv[])
         }
 
         //Mute button
-    #if !defined(NO_CUSTOM_LEVELS)
+#if !defined(NO_CUSTOM_LEVELS)
         bool inEditor = ed.textentry || ed.scripthelppage == 1;
-    #else
+#else
         bool inEditor = false;
-    #endif
+#endif
         if (key.isDown(KEYBOARD_m) && game.mutebutton<=0 && !inEditor)
         {
             game.mutebutton = 8;
@@ -556,7 +556,7 @@ int main(int argc, char *argv[])
     }
 
 
-	  //SDL_Delay(300);
+    //SDL_Delay(300);
 
     //TODO
     //Free the loaded image

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -348,8 +348,27 @@ int main(int argc, char *argv[])
                 else
                 {
 
-                    if (game.recording == 1)
+                    if (script.running)
                     {
+                        script.run();
+                    }
+
+                    gameinput();
+                    gamerender();
+                    gamelogic();
+
+
+                    break;
+                case MAPMODE:
+                    maprender();
+                    mapinput();
+                    maplogic();
+                    break;
+                case TELEPORTERMODE:
+                    teleporterrender();
+                    if(game.useteleporter)
+                    {
+                        teleporterinput();
                     }
                     else
                     {
@@ -357,44 +376,7 @@ int main(int argc, char *argv[])
                         {
                             script.run();
                         }
-
                         gameinput();
-                        gamerender();
-                        gamelogic();
-
-
-                    }
-                    break;
-                case MAPMODE:
-                    maprender();
-                    if (game.recording == 1)
-                    {
-                    }
-                    else
-                    {
-                        mapinput();
-                    }
-                    maplogic();
-                    break;
-                case TELEPORTERMODE:
-                    teleporterrender();
-                    if (game.recording == 1)
-                    {
-                    }
-                    else
-                    {
-                        if(game.useteleporter)
-                        {
-                            teleporterinput();
-                        }
-                        else
-                        {
-                            if (script.running)
-                            {
-                                script.run();
-                            }
-                            gameinput();
-                        }
                     }
                     maplogic();
                     break;

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -11,10 +11,10 @@ int pre_temprectx=0, pre_temprecty=0, pre_temprectw=320, pre_temprecth=240;
 
 void preloaderrender()
 {
-	//TODO
-	//graphics.backbuffer.lock();
+  //TODO
+  //graphics.backbuffer.lock();
 
-	//Draw grid
+  //Draw grid
 
   //pre_transition = -10;	pre_fakepercent = 100;
 
@@ -33,44 +33,44 @@ void preloaderrender()
       pre_coltimer = 8;
     }
     switch(pre_curcol) {
-	case 0:
-		pre_lightcol = graphics.RGBflip(0xBF,0x59,0x6F);
-		pre_darkcol = graphics.RGBflip(0x88,0x3E,0x53);
-		break;
-	case 1:
-		pre_lightcol = graphics.RGBflip(0x6C,0xBC,0x5C);
-		pre_darkcol = graphics.RGBflip(0x50,0x86,0x40);
-		break;
-	case 2:
-		pre_lightcol = graphics.RGBflip(0x5D,0x57,0xAA);
-		pre_darkcol = graphics.RGBflip(0x2F,0x2F,0x6C);
-		break;
-	case 3:
-		pre_lightcol = graphics.RGBflip(0xB7,0xBA,0x5E);
-		pre_darkcol = graphics.RGBflip(0x84,0x83,0x42);
-		break;
-	case 4:
-		pre_lightcol = graphics.RGBflip(0x57,0x90,0xAA);
-		pre_darkcol = graphics.RGBflip(0x2F,0x5B,0x6C);
-		break;
-	case 5:
-		pre_lightcol = graphics.RGBflip(0x90,0x61,0xB1);
-		pre_darkcol = graphics.RGBflip(0x58,0x3D,0x71);
-		break;
-	default:
-		pre_lightcol = graphics.RGBflip(0x00,0x00,0x00);
-		pre_darkcol = graphics.RGBflip(0x08,0x00,0x00);
-		break;
+    case 0:
+      pre_lightcol = graphics.RGBflip(0xBF,0x59,0x6F);
+      pre_darkcol = graphics.RGBflip(0x88,0x3E,0x53);
+      break;
+    case 1:
+      pre_lightcol = graphics.RGBflip(0x6C,0xBC,0x5C);
+      pre_darkcol = graphics.RGBflip(0x50,0x86,0x40);
+      break;
+    case 2:
+      pre_lightcol = graphics.RGBflip(0x5D,0x57,0xAA);
+      pre_darkcol = graphics.RGBflip(0x2F,0x2F,0x6C);
+      break;
+    case 3:
+      pre_lightcol = graphics.RGBflip(0xB7,0xBA,0x5E);
+      pre_darkcol = graphics.RGBflip(0x84,0x83,0x42);
+      break;
+    case 4:
+      pre_lightcol = graphics.RGBflip(0x57,0x90,0xAA);
+      pre_darkcol = graphics.RGBflip(0x2F,0x5B,0x6C);
+      break;
+    case 5:
+      pre_lightcol = graphics.RGBflip(0x90,0x61,0xB1);
+      pre_darkcol = graphics.RGBflip(0x58,0x3D,0x71);
+      break;
+    default:
+      pre_lightcol = graphics.RGBflip(0x00,0x00,0x00);
+      pre_darkcol = graphics.RGBflip(0x08,0x00,0x00);
+      break;
     }
 
     for (int i = 0; i < 18; i++) {
       pre_temprecty = (i * 16)- pre_offset;
       if (i % 2 == 0)
-	  {
+      {
         FillRect(graphics.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, pre_lightcol);
       }
-	  else
-	  {
+      else
+      {
         FillRect(graphics.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, pre_darkcol);
       }
     }
@@ -90,7 +90,7 @@ void preloaderrender()
   }else if (pre_transition <= -10) {
     game.gamestate=TITLEMODE;
   }else if (pre_transition < 5) {
-	  FillRect(graphics.backBuffer, 0, 0, 320,240, graphics.getBGR(0,0,0));
+    FillRect(graphics.backBuffer, 0, 0, 320,240, graphics.getBGR(0,0,0));
   }else if (pre_transition < 20) {
     pre_temprecty = 0;
     pre_temprecth = 240;
@@ -100,27 +100,27 @@ void preloaderrender()
     graphics.Print(282-(15*8), 204, "LOADING... 100%", 124, 112, 218, false);
   }
 
-	if (game.test)
-	{
-		graphics.Print(5, 5, game.teststring, 196, 196, 255 - help.glow, false);
-	}
+  if (game.test)
+  {
+    graphics.Print(5, 5, game.teststring, 196, 196, 255 - help.glow, false);
+  }
 
-	graphics.drawfade();
+  graphics.drawfade();
 
-	if (game.flashlight > 0 && !game.noflashingmode)
-	{
-		game.flashlight--;
-		graphics.flashlight();
-	}
+  if (game.flashlight > 0 && !game.noflashingmode)
+  {
+    game.flashlight--;
+    graphics.flashlight();
+  }
 
-	if (game.screenshake > 0  && !game.noflashingmode)
-	{
-		game.screenshake--;
-		graphics.screenshake();
-	}
-	else
-	{
-		graphics.render();
-	}
-	//graphics.backbuffer.unlock();
+  if (game.screenshake > 0  && !game.noflashingmode)
+  {
+    game.screenshake--;
+    graphics.screenshake();
+  }
+  else
+  {
+    graphics.render();
+  }
+  //graphics.backbuffer.unlock();
 }

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -100,11 +100,6 @@ void preloaderrender()
     graphics.Print(282-(15*8), 204, "LOADING... 100%", 124, 112, 218, false);
   }
 
-  if (game.test)
-  {
-    graphics.Print(5, 5, game.teststring, 196, 196, 255 - help.glow, false);
-  }
-
   graphics.drawfade();
 
   if (game.flashlight > 0 && !game.noflashingmode)

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -11,13 +11,6 @@ int pre_temprectx=0, pre_temprecty=0, pre_temprectw=320, pre_temprecth=240;
 
 void preloaderrender()
 {
-  //TODO
-  //graphics.backbuffer.lock();
-
-  //Draw grid
-
-  //pre_transition = -10;	pre_fakepercent = 100;
-
   if (pre_transition < 30) pre_transition--;
   if(pre_transition>=30){
     pre_fakepercent++;
@@ -117,5 +110,4 @@ void preloaderrender()
   {
     graphics.render();
   }
-  //graphics.backbuffer.unlock();
 }

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -65,7 +65,7 @@ void preloaderrender()
 
     for (int i = 0; i < 18; i++) {
       pre_temprecty = (i * 16)- pre_offset;
-      if (i % 2 == 0) 
+      if (i % 2 == 0)
 	  {
         FillRect(graphics.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, pre_lightcol);
       }

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -9,10 +9,10 @@ int pre_darkcol=0, pre_lightcol=0, pre_curcol=0, pre_coltimer=0, pre_offset=0;
 int pre_frontrectx=30, pre_frontrecty=20, pre_frontrectw=260, pre_frontrecth=200;
 int pre_temprectx=0, pre_temprecty=0, pre_temprectw=320, pre_temprecth=240;
 
-void preloaderrender(Graphics& dwgfx, Game& game, UtilityClass& help)
+void preloaderrender()
 {
 	//TODO
-	//dwgfx.backbuffer.lock();
+	//graphics.backbuffer.lock();
 
 	//Draw grid
 
@@ -34,32 +34,32 @@ void preloaderrender(Graphics& dwgfx, Game& game, UtilityClass& help)
     }
     switch(pre_curcol) {
 	case 0:
-		pre_lightcol = dwgfx.RGBflip(0xBF,0x59,0x6F);
-		pre_darkcol = dwgfx.RGBflip(0x88,0x3E,0x53);
+		pre_lightcol = graphics.RGBflip(0xBF,0x59,0x6F);
+		pre_darkcol = graphics.RGBflip(0x88,0x3E,0x53);
 		break;
 	case 1:
-		pre_lightcol = dwgfx.RGBflip(0x6C,0xBC,0x5C);
-		pre_darkcol = dwgfx.RGBflip(0x50,0x86,0x40);
+		pre_lightcol = graphics.RGBflip(0x6C,0xBC,0x5C);
+		pre_darkcol = graphics.RGBflip(0x50,0x86,0x40);
 		break;
 	case 2:
-		pre_lightcol = dwgfx.RGBflip(0x5D,0x57,0xAA);
-		pre_darkcol = dwgfx.RGBflip(0x2F,0x2F,0x6C);
+		pre_lightcol = graphics.RGBflip(0x5D,0x57,0xAA);
+		pre_darkcol = graphics.RGBflip(0x2F,0x2F,0x6C);
 		break;
 	case 3:
-		pre_lightcol = dwgfx.RGBflip(0xB7,0xBA,0x5E);
-		pre_darkcol = dwgfx.RGBflip(0x84,0x83,0x42);
+		pre_lightcol = graphics.RGBflip(0xB7,0xBA,0x5E);
+		pre_darkcol = graphics.RGBflip(0x84,0x83,0x42);
 		break;
 	case 4:
-		pre_lightcol = dwgfx.RGBflip(0x57,0x90,0xAA);
-		pre_darkcol = dwgfx.RGBflip(0x2F,0x5B,0x6C);
+		pre_lightcol = graphics.RGBflip(0x57,0x90,0xAA);
+		pre_darkcol = graphics.RGBflip(0x2F,0x5B,0x6C);
 		break;
 	case 5:
-		pre_lightcol = dwgfx.RGBflip(0x90,0x61,0xB1);
-		pre_darkcol = dwgfx.RGBflip(0x58,0x3D,0x71);
+		pre_lightcol = graphics.RGBflip(0x90,0x61,0xB1);
+		pre_darkcol = graphics.RGBflip(0x58,0x3D,0x71);
 		break;
 	default:
-		pre_lightcol = dwgfx.RGBflip(0x00,0x00,0x00);
-		pre_darkcol = dwgfx.RGBflip(0x08,0x00,0x00);
+		pre_lightcol = graphics.RGBflip(0x00,0x00,0x00);
+		pre_darkcol = graphics.RGBflip(0x08,0x00,0x00);
 		break;
     }
 
@@ -67,20 +67,20 @@ void preloaderrender(Graphics& dwgfx, Game& game, UtilityClass& help)
       pre_temprecty = (i * 16)- pre_offset;
       if (i % 2 == 0) 
 	  {
-        FillRect(dwgfx.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, pre_lightcol);
+        FillRect(graphics.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, pre_lightcol);
       }
 	  else
 	  {
-        FillRect(dwgfx.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, pre_darkcol);
+        FillRect(graphics.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, pre_darkcol);
       }
     }
 
-    FillRect(dwgfx.backBuffer, pre_frontrectx, pre_frontrecty, pre_frontrectw,pre_frontrecth, dwgfx.getBGR(0x3E,0x31,0xA2));
+    FillRect(graphics.backBuffer, pre_frontrectx, pre_frontrecty, pre_frontrectw,pre_frontrecth, graphics.getBGR(0x3E,0x31,0xA2));
 
     if(pre_fakepercent==100){
-      dwgfx.Print(282-(15*8), 204, "LOADING... " + help.String(int(pre_fakepercent))+"%", 124, 112, 218, false);
+      graphics.Print(282-(15*8), 204, "LOADING... " + help.String(int(pre_fakepercent))+"%", 124, 112, 218, false);
     }else{
-      dwgfx.Print(282-(14*8), 204, "LOADING... " + help.String(int(pre_fakepercent))+"%", 124, 112, 218, false);
+      graphics.Print(282-(14*8), 204, "LOADING... " + help.String(int(pre_fakepercent))+"%", 124, 112, 218, false);
     }
 
     //Render
@@ -90,37 +90,37 @@ void preloaderrender(Graphics& dwgfx, Game& game, UtilityClass& help)
   }else if (pre_transition <= -10) {
     game.gamestate=TITLEMODE;
   }else if (pre_transition < 5) {
-	  FillRect(dwgfx.backBuffer, 0, 0, 320,240, dwgfx.getBGR(0,0,0));
+	  FillRect(graphics.backBuffer, 0, 0, 320,240, graphics.getBGR(0,0,0));
   }else if (pre_transition < 20) {
     pre_temprecty = 0;
     pre_temprecth = 240;
-    FillRect(dwgfx.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, 0x000000);
-    FillRect(dwgfx.backBuffer, pre_frontrectx, pre_frontrecty, pre_frontrectw,pre_frontrecth, dwgfx.getBGR(0x3E,0x31,0xA2));
+    FillRect(graphics.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, 0x000000);
+    FillRect(graphics.backBuffer, pre_frontrectx, pre_frontrecty, pre_frontrectw,pre_frontrecth, graphics.getBGR(0x3E,0x31,0xA2));
 
-    dwgfx.Print(282-(15*8), 204, "LOADING... 100%", 124, 112, 218, false);
+    graphics.Print(282-(15*8), 204, "LOADING... 100%", 124, 112, 218, false);
   }
 
 	if (game.test)
 	{
-		dwgfx.Print(5, 5, game.teststring, 196, 196, 255 - help.glow, false);
+		graphics.Print(5, 5, game.teststring, 196, 196, 255 - help.glow, false);
 	}
 
-	dwgfx.drawfade();
+	graphics.drawfade();
 
 	if (game.flashlight > 0 && !game.noflashingmode)
 	{
 		game.flashlight--;
-		dwgfx.flashlight();
+		graphics.flashlight();
 	}
 
 	if (game.screenshake > 0  && !game.noflashingmode)
 	{
 		game.screenshake--;
-		dwgfx.screenshake();
+		graphics.screenshake();
 	}
 	else
 	{
-		dwgfx.render();
+		graphics.render();
 	}
-	//dwgfx.backbuffer.unlock();
+	//graphics.backbuffer.unlock();
 }

--- a/desktop_version/src/preloader.h
+++ b/desktop_version/src/preloader.h
@@ -5,6 +5,6 @@
 #include "Game.h"
 #include "UtilityClass.h"
 
-void preloaderrender(Graphics& dwgfx, Game& game, UtilityClass& help);
+void preloaderrender();
 
 #endif /* PRELOADER_H */

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -1499,7 +1499,7 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
             for (int i = 0; i < obj.nentity; i++)
             {
                 //Is this entity on the ground? (needed for jumping)
-                if (obj.entitycollidefloor(map, i))
+                if (obj.entitycollidefloor(i))
                 {
                     obj.entities[i].onground = 2;
                 }
@@ -1508,7 +1508,7 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
                     obj.entities[i].onground--;
                 }
 
-                if (obj.entitycollideroof(map, i))
+                if (obj.entitycollideroof(i))
                 {
                     obj.entities[i].onroof = 2;
                 }
@@ -1518,7 +1518,7 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
                 }
 
                 //Animate the entities
-                obj.animateentities(i, game, help);
+                obj.animateentities(i);
             }
         }
 
@@ -2758,7 +2758,7 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
         for (int i = 0; i < obj.nentity; i++)
         {
             //Is this entity on the ground? (needed for jumping)
-            if (obj.entitycollidefloor(map, i))
+            if (obj.entitycollidefloor(i))
             {
                 obj.entities[i].onground = 2;
             }
@@ -2767,7 +2767,7 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
                 obj.entities[i].onground--;
             }
 
-            if (obj.entitycollideroof(map, i))
+            if (obj.entitycollideroof(i))
             {
                 obj.entities[i].onroof = 2;
             }
@@ -2777,7 +2777,7 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
             }
 
             //Animate the entities
-            obj.animateentities(i, game, help);
+            obj.animateentities(i);
         }
     }
 

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -22,15 +22,15 @@ int tb;
 
 std::string tempstring;
 
-void updategraphicsmode(Game& game, Graphics& dwgfx)
+void updategraphicsmode()
 {
     swfStage = stage;
 }
 
-void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, UtilityClass& help, musicclass& music)
+void titlerender()
 {
 
-    FillRect(dwgfx.backBuffer, 0,0,dwgfx.backBuffer->w, dwgfx.backBuffer->h, 0x00000000 );
+    FillRect(graphics.backBuffer, 0,0,graphics.backBuffer->w, graphics.backBuffer->h, 0x00000000 );
 
     if (!game.menustart)
     {
@@ -39,29 +39,29 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
         tb = 164 - (help.glow / 2) - int(fRandom() * 4);
 
         temp = 50;
-        dwgfx.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
 				#if defined(MAKEANDPLAY)
-					dwgfx.Print(-1,temp+35,"     MAKE AND PLAY EDITION",tr, tg, tb, true);
+					graphics.Print(-1,temp+35,"     MAKE AND PLAY EDITION",tr, tg, tb, true);
 				#endif
 
-        dwgfx.Print(5, 175, "[ Press ACTION to Start ]", tr, tg, tb, true);
-        dwgfx.Print(5, 195, "ACTION = Space, Z, or V", int(tr*0.5f), int(tg*0.5f), int(tb*0.5f), true);
+        graphics.Print(5, 175, "[ Press ACTION to Start ]", tr, tg, tb, true);
+        graphics.Print(5, 195, "ACTION = Space, Z, or V", int(tr*0.5f), int(tg*0.5f), int(tb*0.5f), true);
 
-        //dwgfx.Print(5, 215, "Press CTRL-F for Fullscreen", tr, tg, tb, true);
+        //graphics.Print(5, 215, "Press CTRL-F for Fullscreen", tr, tg, tb, true);
 
-        /*dwgfx.Print(5, 5, "IGF WIP Build, 29th Oct '09", tr, tg, tb, true);
-        dwgfx.Print(5, 200, "Game by Terry Cavanagh", tr, tg, tb, true);
-        dwgfx.Print(5, 210, "Music by Magnus P~lsson", tr, tg, tb, true);
-        dwgfx.Print(5, 220, "Roomnames by Bennett Foddy", tr, tg, tb, true);*/
+        /*graphics.Print(5, 5, "IGF WIP Build, 29th Oct '09", tr, tg, tb, true);
+        graphics.Print(5, 200, "Game by Terry Cavanagh", tr, tg, tb, true);
+        graphics.Print(5, 210, "Music by Magnus P~lsson", tr, tg, tb, true);
+        graphics.Print(5, 220, "Roomnames by Bennett Foddy", tr, tg, tb, true);*/
     }
     else
     {
-        if(!game.colourblindmode) dwgfx.drawtowerbackgroundsolo();
+        if(!game.colourblindmode) graphics.drawtowerbackgroundsolo();
 
         tr = map.r - (help.glow / 4) - int(fRandom() * 4);
         tg = map.g - (help.glow / 4) - int(fRandom() * 4);
@@ -77,26 +77,26 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
 
         if(game.currentmenuname=="mainmenu")
         {
-            dwgfx.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
-            dwgfx.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
-            dwgfx.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
-            dwgfx.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
-            dwgfx.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
-            dwgfx.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
+            graphics.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
+            graphics.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
+            graphics.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
+            graphics.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
+            graphics.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
+            graphics.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
 						#if defined(MAKEANDPLAY)
-							dwgfx.Print(-1,temp+35,"     MAKE AND PLAY EDITION",tr, tg, tb, true);
+							graphics.Print(-1,temp+35,"     MAKE AND PLAY EDITION",tr, tg, tb, true);
 						#endif
-            dwgfx.Print( 310 - (4*8), 230, "v2.2", tr/2, tg/2, tb/2);
+            graphics.Print( 310 - (4*8), 230, "v2.2", tr/2, tg/2, tb/2);
 
 						if(music.mmmmmm){
-						  dwgfx.Print( 10, 230, "[MMMMMM Mod Installed]", tr/2, tg/2, tb/2);
+						  graphics.Print( 10, 230, "[MMMMMM Mod Installed]", tr/2, tg/2, tb/2);
 						}
         }
     #if !defined(NO_CUSTOM_LEVELS)
         else if (game.currentmenuname == "levellist")
         {
           if(ed.ListOfMetaData.size()==0){
-          dwgfx.Print( -1, 100, "ERROR: No levels found.", tr, tg, tb, true);
+          graphics.Print( -1, 100, "ERROR: No levels found.", tr, tg, tb, true);
           }
           int tmp=game.currentmenuoption+(game.levelpage*8);
           if(tmp>=0 && tmp < (int) ed.ListOfMetaData.size()){ // FIXME: size_t/int! -flibit
@@ -104,20 +104,20 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
             if(game.nummenuoptions - game.currentmenuoption<=2){
 
             }else{
-              dwgfx.bigprint( -1, 15, ed.ListOfMetaData[tmp].title, tr, tg, tb, true);
-              dwgfx.Print( -1, 40, "by " + ed.ListOfMetaData[tmp].creator, tr, tg, tb, true);
-              dwgfx.Print( -1, 50, ed.ListOfMetaData[tmp].website, tr, tg, tb, true);
-              dwgfx.Print( -1, 70, ed.ListOfMetaData[tmp].Desc1, tr, tg, tb, true);
-              dwgfx.Print( -1, 80, ed.ListOfMetaData[tmp].Desc2, tr, tg, tb, true);
-              dwgfx.Print( -1, 90, ed.ListOfMetaData[tmp].Desc3, tr, tg, tb, true);
+              graphics.bigprint( -1, 15, ed.ListOfMetaData[tmp].title, tr, tg, tb, true);
+              graphics.Print( -1, 40, "by " + ed.ListOfMetaData[tmp].creator, tr, tg, tb, true);
+              graphics.Print( -1, 50, ed.ListOfMetaData[tmp].website, tr, tg, tb, true);
+              graphics.Print( -1, 70, ed.ListOfMetaData[tmp].Desc1, tr, tg, tb, true);
+              graphics.Print( -1, 80, ed.ListOfMetaData[tmp].Desc2, tr, tg, tb, true);
+              graphics.Print( -1, 90, ed.ListOfMetaData[tmp].Desc3, tr, tg, tb, true);
             }
           }
         }
     #endif
         else if (game.currentmenuname == "errornostart")
         {
-          dwgfx.Print( -1, 65, "ERROR: This level has", tr, tg, tb, true);
-          dwgfx.Print( -1, 75, "no start point!", tr, tg, tb, true);
+          graphics.Print( -1, 65, "ERROR: This level has", tr, tg, tb, true);
+          graphics.Print( -1, 75, "no start point!", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "options")
         {
@@ -125,65 +125,65 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
 						#if defined(MAKEANDPLAY)
 							if (game.currentmenuoption == 0)
 							{
-									dwgfx.bigprint( -1, 30, "Accessibility", tr, tg, tb, true);
-									dwgfx.Print( -1, 65, "Disable screen effects, enable", tr, tg, tb, true);
-									dwgfx.Print( -1, 75, "slowdown modes or invincibility", tr, tg, tb, true);
+									graphics.bigprint( -1, 30, "Accessibility", tr, tg, tb, true);
+									graphics.Print( -1, 65, "Disable screen effects, enable", tr, tg, tb, true);
+									graphics.Print( -1, 75, "slowdown modes or invincibility", tr, tg, tb, true);
 							}
 							else if (game.currentmenuoption == 1)
 							{
-								dwgfx.bigprint( -1, 30, "Game Pad Options", tr, tg, tb, true);
-								dwgfx.Print( -1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
-								dwgfx.Print( -1, 75, "and adjust sensitivity", tr, tg, tb, true);
+								graphics.bigprint( -1, 30, "Game Pad Options", tr, tg, tb, true);
+								graphics.Print( -1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
+								graphics.Print( -1, 75, "and adjust sensitivity", tr, tg, tb, true);
 							}
 							else if (game.currentmenuoption == 2)
 							{
-									dwgfx.bigprint( -1, 30, "Clear Data", tr, tg, tb, true);
-									dwgfx.Print( -1, 65, "Delete your save data", tr, tg, tb, true);
-									dwgfx.Print( -1, 75, "and unlocked play modes", tr, tg, tb, true);
+									graphics.bigprint( -1, 30, "Clear Data", tr, tg, tb, true);
+									graphics.Print( -1, 65, "Delete your save data", tr, tg, tb, true);
+									graphics.Print( -1, 75, "and unlocked play modes", tr, tg, tb, true);
 							}else if (game.currentmenuoption == 3){
 								if(music.mmmmmm){
-									dwgfx.bigprint( -1, 30, "Soundtrack", tr, tg, tb, true);
-									dwgfx.Print( -1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);
+									graphics.bigprint( -1, 30, "Soundtrack", tr, tg, tb, true);
+									graphics.Print( -1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);
 									if(music.usingmmmmmm){
-										dwgfx.Print( -1, 85, "Current soundtrack: MMMMMM", tr, tg, tb, true);
+										graphics.Print( -1, 85, "Current soundtrack: MMMMMM", tr, tg, tb, true);
 									}else{
-										dwgfx.Print( -1, 85, "Current soundtrack: PPPPPP", tr, tg, tb, true);
+										graphics.Print( -1, 85, "Current soundtrack: PPPPPP", tr, tg, tb, true);
 									}
 								}
 							}
 						#elif !defined(MAKEANDPLAY)
 							if (game.currentmenuoption == 0)
 							{
-									dwgfx.bigprint( -1, 30, "Accessibility", tr, tg, tb, true);
-									dwgfx.Print( -1, 65, "Disable screen effects, enable", tr, tg, tb, true);
-									dwgfx.Print( -1, 75, "slowdown modes or invincibility", tr, tg, tb, true);
+									graphics.bigprint( -1, 30, "Accessibility", tr, tg, tb, true);
+									graphics.Print( -1, 65, "Disable screen effects, enable", tr, tg, tb, true);
+									graphics.Print( -1, 75, "slowdown modes or invincibility", tr, tg, tb, true);
 							}
 							else if (game.currentmenuoption == 1)
 							{
-									dwgfx.bigprint( -1, 30, "Unlock Play Modes", tr, tg, tb, true);
-									dwgfx.Print( -1, 65, "Unlock parts of the game normally", tr, tg, tb, true);
-									dwgfx.Print( -1, 75, "unlocked as you progress", tr, tg, tb, true);
+									graphics.bigprint( -1, 30, "Unlock Play Modes", tr, tg, tb, true);
+									graphics.Print( -1, 65, "Unlock parts of the game normally", tr, tg, tb, true);
+									graphics.Print( -1, 75, "unlocked as you progress", tr, tg, tb, true);
 							}
 							else if (game.currentmenuoption == 2)
 							{
-								dwgfx.bigprint( -1, 30, "Game Pad Options", tr, tg, tb, true);
-								dwgfx.Print( -1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
-								dwgfx.Print( -1, 75, "and adjust sensitivity", tr, tg, tb, true);
+								graphics.bigprint( -1, 30, "Game Pad Options", tr, tg, tb, true);
+								graphics.Print( -1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
+								graphics.Print( -1, 75, "and adjust sensitivity", tr, tg, tb, true);
 							}
 							else if (game.currentmenuoption == 3)
 							{
-									dwgfx.bigprint( -1, 30, "Clear Data", tr, tg, tb, true);
-									dwgfx.Print( -1, 65, "Delete your save data", tr, tg, tb, true);
-									dwgfx.Print( -1, 75, "and unlocked play modes", tr, tg, tb, true);
+									graphics.bigprint( -1, 30, "Clear Data", tr, tg, tb, true);
+									graphics.Print( -1, 65, "Delete your save data", tr, tg, tb, true);
+									graphics.Print( -1, 75, "and unlocked play modes", tr, tg, tb, true);
 							}else if (game.currentmenuoption == 4)
 							{
 							if(music.mmmmmm){
-									dwgfx.bigprint( -1, 30, "Soundtrack", tr, tg, tb, true);
-									dwgfx.Print( -1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);
+									graphics.bigprint( -1, 30, "Soundtrack", tr, tg, tb, true);
+									graphics.Print( -1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);
 									if(music.usingmmmmmm){
-										dwgfx.Print( -1, 85, "Current soundtrack: MMMMMM", tr, tg, tb, true);
+										graphics.Print( -1, 85, "Current soundtrack: MMMMMM", tr, tg, tb, true);
 									}else{
-										dwgfx.Print( -1, 85, "Current soundtrack: PPPPPP", tr, tg, tb, true);
+										graphics.Print( -1, 85, "Current soundtrack: PPPPPP", tr, tg, tb, true);
 									}
 							}
 							}
@@ -193,94 +193,94 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
         {
           if (game.currentmenuoption == 0)
           {
-              dwgfx.bigprint( -1, 30, "Toggle Fullscreen", tr, tg, tb, true);
-              dwgfx.Print( -1, 65, "Change to fullscreen/windowed mode.", tr, tg, tb, true);
+              graphics.bigprint( -1, 30, "Toggle Fullscreen", tr, tg, tb, true);
+              graphics.Print( -1, 65, "Change to fullscreen/windowed mode.", tr, tg, tb, true);
 
               if(game.fullscreen){
-                dwgfx.Print( -1, 85, "Current mode: FULLSCREEN", tr, tg, tb, true);
+                graphics.Print( -1, 85, "Current mode: FULLSCREEN", tr, tg, tb, true);
               }else{
-                dwgfx.Print( -1, 85, "Current mode: WINDOWED", tr, tg, tb, true);
+                graphics.Print( -1, 85, "Current mode: WINDOWED", tr, tg, tb, true);
               }
 
           }else if (game.currentmenuoption == 1)
                 {
-                    dwgfx.bigprint( -1, 30, "Toggle Letterbox", tr, tg, tb, true);
-                    dwgfx.Print( -1, 65, "Choose letterbox/stretch/integer mode.", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "Toggle Letterbox", tr, tg, tb, true);
+                    graphics.Print( -1, 65, "Choose letterbox/stretch/integer mode.", tr, tg, tb, true);
 
               if(game.stretchMode == 2){
-                dwgfx.Print( -1, 85, "Current mode: INTEGER", tr, tg, tb, true);
+                graphics.Print( -1, 85, "Current mode: INTEGER", tr, tg, tb, true);
               }else if (game.stretchMode == 1){
-                dwgfx.Print( -1, 85, "Current mode: STRETCH", tr, tg, tb, true);
+                graphics.Print( -1, 85, "Current mode: STRETCH", tr, tg, tb, true);
               }else{
-                dwgfx.Print( -1, 85, "Current mode: LETTERBOX", tr, tg, tb, true);
+                graphics.Print( -1, 85, "Current mode: LETTERBOX", tr, tg, tb, true);
               }
           }else if (game.currentmenuoption == 2)
                 {
-                    dwgfx.bigprint( -1, 30, "Toggle Filter", tr, tg, tb, true);
-                    dwgfx.Print( -1, 65, "Change to nearest/linear filter.", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "Toggle Filter", tr, tg, tb, true);
+                    graphics.Print( -1, 65, "Change to nearest/linear filter.", tr, tg, tb, true);
 
               if(game.useLinearFilter){
-                dwgfx.Print( -1, 85, "Current mode: LINEAR", tr, tg, tb, true);
+                graphics.Print( -1, 85, "Current mode: LINEAR", tr, tg, tb, true);
               }else{
-                dwgfx.Print( -1, 85, "Current mode: NEAREST", tr, tg, tb, true);
+                graphics.Print( -1, 85, "Current mode: NEAREST", tr, tg, tb, true);
               }
 
                 } else if (game.currentmenuoption == 3)
                 {
-                    dwgfx.bigprint( -1, 30, "Analogue Mode", tr, tg, tb, true);
-                    dwgfx.Print( -1, 65, "There is nothing wrong with your", tr, tg, tb, true);
-                    dwgfx.Print( -1, 75, "television set. Do not attempt to", tr, tg, tb, true);
-                    dwgfx.Print( -1, 85, "adjust the picture.", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "Analogue Mode", tr, tg, tb, true);
+                    graphics.Print( -1, 65, "There is nothing wrong with your", tr, tg, tb, true);
+                    graphics.Print( -1, 75, "television set. Do not attempt to", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "adjust the picture.", tr, tg, tb, true);
                 }
           else if (game.currentmenuoption == 4)
           {
-              dwgfx.bigprint(-1, 30, "Toggle Mouse Cursor", tr, tg, tb, true);
-              dwgfx.Print(-1, 65, "Show/hide the system mouse cursor.", tr, tg, tb, true);
+              graphics.bigprint(-1, 30, "Toggle Mouse Cursor", tr, tg, tb, true);
+              graphics.Print(-1, 65, "Show/hide the system mouse cursor.", tr, tg, tb, true);
 
-              if (dwgfx.showmousecursor) {
-                  dwgfx.Print(-1, 85, "Current mode: SHOW", tr, tg, tb, true);
+              if (graphics.showmousecursor) {
+                  graphics.Print(-1, 85, "Current mode: SHOW", tr, tg, tb, true);
               }
               else {
-                  dwgfx.Print(-1, 85, "Current mode: HIDE", tr/2, tg/2, tb/2, true);
+                  graphics.Print(-1, 85, "Current mode: HIDE", tr/2, tg/2, tb/2, true);
               }
           }
         }
         else if (game.currentmenuname == "credits")
         {
-            dwgfx.Print( -1, 50, "VVVVVV is a game by", tr, tg, tb, true);
-            dwgfx.bigprint( 40, 65, "Terry Cavanagh", tr, tg, tb, true, 2);
+            graphics.Print( -1, 50, "VVVVVV is a game by", tr, tg, tb, true);
+            graphics.bigprint( 40, 65, "Terry Cavanagh", tr, tg, tb, true, 2);
 
-            dwgfx.drawimagecol(7, -1, 86, tr *0.75, tg *0.75, tb *0.75, true);
-            //dwgfx.Print( 40, 85, "http://www.distractionware.com", tr, tg, tb, true);
+            graphics.drawimagecol(7, -1, 86, tr *0.75, tg *0.75, tb *0.75, true);
+            //graphics.Print( 40, 85, "http://www.distractionware.com", tr, tg, tb, true);
 
-            dwgfx.Print( -1, 120, "and features music by", tr, tg, tb, true);
-            dwgfx.bigprint( 40, 135, "Magnus P~lsson", tr, tg, tb, true, 2);
-            dwgfx.drawimagecol(8, -1, 156, tr *0.75, tg *0.75, tb *0.75, true);
-            //dwgfx.Print( 40, 155, "http://souleye.madtracker.net", tr, tg, tb, true);
+            graphics.Print( -1, 120, "and features music by", tr, tg, tb, true);
+            graphics.bigprint( 40, 135, "Magnus P~lsson", tr, tg, tb, true, 2);
+            graphics.drawimagecol(8, -1, 156, tr *0.75, tg *0.75, tb *0.75, true);
+            //graphics.Print( 40, 155, "http://souleye.madtracker.net", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "credits2")
         {
-            dwgfx.Print( -1, 50, "Roomnames are by", tr, tg, tb, true);
-            dwgfx.bigprint( 40, 65, "Bennett Foddy", tr, tg, tb, true);
-            dwgfx.drawimagecol(9, -1, 86, tr*0.75, tg *0.75, tb *0.75, true);
-            //dwgfx.Print( 40, 80, "http://www.distractionware.com", tr, tg, tb);
-            dwgfx.Print( -1, 110, "C++ version by", tr, tg, tb, true);
-            dwgfx.bigprint( 40, 125, "Simon Roth", tr, tg, tb, true);
-						dwgfx.bigprint( 40, 145, "Ethan Lee", tr, tg, tb, true);
-           //dwgfx.drawimagecol(11, -1, 156, tr*0.75, tg *0.75, tb *0.75, true);
+            graphics.Print( -1, 50, "Roomnames are by", tr, tg, tb, true);
+            graphics.bigprint( 40, 65, "Bennett Foddy", tr, tg, tb, true);
+            graphics.drawimagecol(9, -1, 86, tr*0.75, tg *0.75, tb *0.75, true);
+            //graphics.Print( 40, 80, "http://www.distractionware.com", tr, tg, tb);
+            graphics.Print( -1, 110, "C++ version by", tr, tg, tb, true);
+            graphics.bigprint( 40, 125, "Simon Roth", tr, tg, tb, true);
+						graphics.bigprint( 40, 145, "Ethan Lee", tr, tg, tb, true);
+           //graphics.drawimagecol(11, -1, 156, tr*0.75, tg *0.75, tb *0.75, true);
         }
         else if (game.currentmenuname == "credits25")
         {
-            dwgfx.Print( -1, 40, "Beta Testing by", tr, tg, tb, true);
-            dwgfx.bigprint( 40, 55, "Sam Kaplan", tr, tg, tb, true);
-            dwgfx.bigprint( 40, 75, "Pauli Kohberger", tr, tg, tb, true);
-            dwgfx.Print( -1, 130, "Ending Picture by", tr, tg, tb, true);
-            dwgfx.bigprint( 40, 145, "Pauli Kohberger", tr, tg, tb, true);
+            graphics.Print( -1, 40, "Beta Testing by", tr, tg, tb, true);
+            graphics.bigprint( 40, 55, "Sam Kaplan", tr, tg, tb, true);
+            graphics.bigprint( 40, 75, "Pauli Kohberger", tr, tg, tb, true);
+            graphics.Print( -1, 130, "Ending Picture by", tr, tg, tb, true);
+            graphics.bigprint( 40, 145, "Pauli Kohberger", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "credits3")
         {
-            dwgfx.Print( -1, 20, "VVVVVV is supported by", tr, tg, tb, true);
-            dwgfx.Print( 40, 30, "the following patrons", tr, tg, tb, true);
+            graphics.Print( -1, 20, "VVVVVV is supported by", tr, tg, tb, true);
+            graphics.Print( 40, 30, "the following patrons", tr, tg, tb, true);
 
             int startidx = game.current_credits_list_index;
             int endidx = std::min(startidx + 9, (int)game.superpatrons.size());
@@ -290,14 +290,14 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
 
             for (int i = startidx; i < endidx; ++i)
             {
-                dwgfx.Print(xofs, yofs, game.superpatrons[i], tr, tg, tb);
+                graphics.Print(xofs, yofs, game.superpatrons[i], tr, tg, tb);
                 xofs += 4;
                 yofs += 14;
             }
         }
         else if (game.currentmenuname == "credits4")
         {
-            dwgfx.Print( -1, 20, "and also by", tr, tg, tb, true);
+            graphics.Print( -1, 20, "and also by", tr, tg, tb, true);
 
             int startidx = game.current_credits_list_index;
             int endidx = std::min(startidx + 14, (int)game.patrons.size());
@@ -310,14 +310,14 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
 
             for (int i = startidx; i < endidx; ++i)
             {
-                dwgfx.Print(80, yofs, game.patrons[i], tr, tg, tb);
+                graphics.Print(80, yofs, game.patrons[i], tr, tg, tb);
                 yofs += 10;
             }
         }
         else if (game.currentmenuname == "credits5")
         {
-            dwgfx.Print( -1, 20, "With contributions on", tr, tg, tb, true);
-            dwgfx.Print( 40, 30, "GitHub from", tr, tg, tb, true);
+            graphics.Print( -1, 20, "With contributions on", tr, tg, tb, true);
+            graphics.Print( 40, 30, "GitHub from", tr, tg, tb, true);
 
             int startidx = game.current_credits_list_index;
             int endidx = std::min(startidx + 9, (int)game.githubfriends.size());
@@ -331,101 +331,101 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
 
             for (int i = startidx; i < endidx; ++i)
             {
-                dwgfx.Print(xofs, yofs, game.githubfriends[i], tr, tg, tb);
+                graphics.Print(xofs, yofs, game.githubfriends[i], tr, tg, tb);
                 xofs += 4;
                 yofs += 14;
             }
         }
         else if (game.currentmenuname == "credits6")
         {
-            dwgfx.Print( -1, 20, "and thanks also to:", tr, tg, tb, true);
+            graphics.Print( -1, 20, "and thanks also to:", tr, tg, tb, true);
 
-            dwgfx.bigprint(80, 60, "You!", tr, tg, tb, true);
+            graphics.bigprint(80, 60, "You!", tr, tg, tb, true);
 
-            dwgfx.Print( 80, 100, "Your support makes it possible", tr, tg, tb,true);
-            dwgfx.Print( 80, 110,"for me to continue making the", tr, tg, tb,true);
-            dwgfx.Print( 80, 120,"games I want to make, now", tr, tg, tb,true);
-            dwgfx.Print( 80, 130, "and into the future.", tr, tg, tb, true);
+            graphics.Print( 80, 100, "Your support makes it possible", tr, tg, tb,true);
+            graphics.Print( 80, 110,"for me to continue making the", tr, tg, tb,true);
+            graphics.Print( 80, 120,"games I want to make, now", tr, tg, tb,true);
+            graphics.Print( 80, 130, "and into the future.", tr, tg, tb, true);
 
-            dwgfx.Print( 80, 150,"Thank you!", tr, tg, tb,true);
+            graphics.Print( 80, 150,"Thank you!", tr, tg, tb,true);
         }
         else if (game.currentmenuname == "setinvincibility")
         {
-            dwgfx.Print( -1, 100, "Are you sure you want to ", tr, tg, tb, true);
-            dwgfx.Print( -1, 110, "enable invincibility?", tr, tg, tb, true);
+            graphics.Print( -1, 100, "Are you sure you want to ", tr, tg, tb, true);
+            graphics.Print( -1, 110, "enable invincibility?", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "setslowdown1")
         {
-            dwgfx.Print( -1, 90, "Warning! Changing the game speed", tr, tg, tb, true);
-            dwgfx.Print( -1, 100, "requires a game restart, and will", tr, tg, tb, true);
-            dwgfx.Print( -1, 110, "delete your current saves.", tr, tg, tb, true);
-            dwgfx.Print( -1, 120, "Is this ok?", tr, tg, tb, true);
+            graphics.Print( -1, 90, "Warning! Changing the game speed", tr, tg, tb, true);
+            graphics.Print( -1, 100, "requires a game restart, and will", tr, tg, tb, true);
+            graphics.Print( -1, 110, "delete your current saves.", tr, tg, tb, true);
+            graphics.Print( -1, 120, "Is this ok?", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "setslowdown2")
         {
-            dwgfx.bigprint( -1, 40, "Game Speed", tr, tg, tb, true);
-            dwgfx.Print( -1, 75, "Select a new game speed below.", tr, tg, tb, true);
+            graphics.bigprint( -1, 40, "Game Speed", tr, tg, tb, true);
+            graphics.Print( -1, 75, "Select a new game speed below.", tr, tg, tb, true);
             if (game.gameframerate==34)
             {
-                dwgfx.Print( -1, 105, "Game speed is normal.", tr/2, tg/2, tb/2, true);
+                graphics.Print( -1, 105, "Game speed is normal.", tr/2, tg/2, tb/2, true);
             }
             else if (game.gameframerate==41)
             {
-                dwgfx.Print( -1, 105, "Game speed is at 80%", tr, tg, tb, true);
+                graphics.Print( -1, 105, "Game speed is at 80%", tr, tg, tb, true);
             }
             else if (game.gameframerate==55)
             {
-                dwgfx.Print( -1, 105, "Game speed is at 60%", tr, tg, tb, true);
+                graphics.Print( -1, 105, "Game speed is at 60%", tr, tg, tb, true);
             }
             else if (game.gameframerate==83)
             {
-                dwgfx.Print( -1, 105, "Game speed is at 40%", tr, tg, tb, true);
+                graphics.Print( -1, 105, "Game speed is at 40%", tr, tg, tb, true);
             }
         }
         else if (game.currentmenuname == "newgamewarning")
         {
-            dwgfx.Print( -1, 100, "Are you sure? This will", tr, tg, tb, true);
-            dwgfx.Print( -1, 110, "delete your current saves...", tr, tg, tb, true);
+            graphics.Print( -1, 100, "Are you sure? This will", tr, tg, tb, true);
+            graphics.Print( -1, 110, "delete your current saves...", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "cleardatamenu")
         {
-            dwgfx.Print( -1, 100, "Are you sure you want to", tr, tg, tb, true);
-            dwgfx.Print( -1, 110, "delete all your saved data?", tr, tg, tb, true);
+            graphics.Print( -1, 100, "Are you sure you want to", tr, tg, tb, true);
+            graphics.Print( -1, 110, "delete all your saved data?", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "startnodeathmode")
         {
-            dwgfx.Print( -1, 45, "Good luck!", tr, tg, tb, true);
-            dwgfx.Print( -1, 80, "You cannot save in this mode.", tr, tg, tb, true);
-            dwgfx.Print( -1, 100, "Would you like to disable the", tr, tg, tb, true);
-            dwgfx.Print( -1, 112, "cutscenes during the game?", tr, tg, tb, true);
+            graphics.Print( -1, 45, "Good luck!", tr, tg, tb, true);
+            graphics.Print( -1, 80, "You cannot save in this mode.", tr, tg, tb, true);
+            graphics.Print( -1, 100, "Would you like to disable the", tr, tg, tb, true);
+            graphics.Print( -1, 112, "cutscenes during the game?", tr, tg, tb, true);
         }
 		else if (game.currentmenuname == "controller")
 		{
-			dwgfx.bigprint( -1, 30, "Game Pad", tr, tg, tb, true);
-			dwgfx.Print( -1, 55, "Change controller options.", tr, tg, tb, true);
+			graphics.bigprint( -1, 30, "Game Pad", tr, tg, tb, true);
+			graphics.Print( -1, 55, "Change controller options.", tr, tg, tb, true);
 			if (game.currentmenuoption == 0)
 			{
 				switch(game.controllerSensitivity)
 				{
 				case 0:
-					dwgfx.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
-					dwgfx.Print( -1, 95, "[]..................", tr, tg, tb, true);
+					graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
+					graphics.Print( -1, 95, "[]..................", tr, tg, tb, true);
 					break;
 				case 1:
-					dwgfx.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
-					dwgfx.Print( -1, 95, ".....[].............", tr, tg, tb, true);
+					graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
+					graphics.Print( -1, 95, ".....[].............", tr, tg, tb, true);
 					break;
 				case 2:
-					dwgfx.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
-					dwgfx.Print( -1, 95, ".........[].........", tr, tg, tb, true);
+					graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
+					graphics.Print( -1, 95, ".........[].........", tr, tg, tb, true);
 					break;
 				case 3:
-					dwgfx.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
-					dwgfx.Print( -1, 95, ".............[].....", tr, tg, tb, true);
+					graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
+					graphics.Print( -1, 95, ".............[].....", tr, tg, tb, true);
 					break;
 				case 4:
-					dwgfx.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
-					dwgfx.Print( -1, 95, "..................[]", tr, tg, tb, true);
+					graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
+					graphics.Print( -1, 95, "..................[]", tr, tg, tb, true);
 					break;
 				}
 			}
@@ -433,9 +433,9 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                                 game.currentmenuoption == 2 ||
                                 game.currentmenuoption == 3     )
 			{
-				dwgfx.Print( -1, 85, "Flip is bound to: " + std::string(UtilityClass::GCString(game.controllerButton_flip)) , tr, tg, tb, true);
-				dwgfx.Print( -1, 95, "Enter is bound to: "  + std::string(UtilityClass::GCString(game.controllerButton_map)), tr, tg, tb, true);
-				dwgfx.Print( -1, 105, "Menu is bound to: " + std::string(UtilityClass::GCString(game.controllerButton_esc)) , tr, tg, tb, true);
+				graphics.Print( -1, 85, "Flip is bound to: " + std::string(UtilityClass::GCString(game.controllerButton_flip)) , tr, tg, tb, true);
+				graphics.Print( -1, 95, "Enter is bound to: "  + std::string(UtilityClass::GCString(game.controllerButton_map)), tr, tg, tb, true);
+				graphics.Print( -1, 105, "Menu is bound to: " + std::string(UtilityClass::GCString(game.controllerButton_esc)) , tr, tg, tb, true);
 			}
 
 
@@ -444,238 +444,238 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
         {
             if (game.currentmenuoption == 0)
             {
-                dwgfx.bigprint( -1, 40, "Backgrounds", tr, tg, tb, true);
+                graphics.bigprint( -1, 40, "Backgrounds", tr, tg, tb, true);
                 if (!game.colourblindmode)
                 {
-                    dwgfx.Print( -1, 75, "Backgrounds are ON.", tr, tg, tb, true);
+                    graphics.Print( -1, 75, "Backgrounds are ON.", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 75, "Backgrounds are OFF.", tr/2, tg/2, tb/2, true);
+                    graphics.Print( -1, 75, "Backgrounds are OFF.", tr/2, tg/2, tb/2, true);
                 }
             }
             else if (game.currentmenuoption == 1)
             {
-                dwgfx.bigprint( -1, 40, "Screen Effects", tr, tg, tb, true);
-                dwgfx.Print( -1, 75, "Disables screen shakes and flashes.", tr, tg, tb, true);
+                graphics.bigprint( -1, 40, "Screen Effects", tr, tg, tb, true);
+                graphics.Print( -1, 75, "Disables screen shakes and flashes.", tr, tg, tb, true);
                 if (!game.noflashingmode)
                 {
-                    dwgfx.Print( -1, 85, "Screen Effects are ON.", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "Screen Effects are ON.", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 85, "Screen Effects are OFF.", tr/2, tg/2, tb/2, true);
+                    graphics.Print( -1, 85, "Screen Effects are OFF.", tr/2, tg/2, tb/2, true);
                 }
             }
             else if (game.currentmenuoption == 2)
             {
-                dwgfx.bigprint( -1, 40, "Text Outline", tr, tg, tb, true);
-                dwgfx.Print( -1, 75, "Disables outline on game text", tr, tg, tb, true);
+                graphics.bigprint( -1, 40, "Text Outline", tr, tg, tb, true);
+                graphics.Print( -1, 75, "Disables outline on game text", tr, tg, tb, true);
                 // FIXME: Maybe do an outlined print instead? -flibit
-                if (!dwgfx.notextoutline)
+                if (!graphics.notextoutline)
                 {
-                    dwgfx.Print( -1, 85, "Text outlines are ON.", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "Text outlines are ON.", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 85, "Text outlines are OFF.", tr/2, tg/2, tb/2, true);
+                    graphics.Print( -1, 85, "Text outlines are OFF.", tr/2, tg/2, tb/2, true);
                 }
             }
             else if (game.currentmenuoption == 3)
             {
-                dwgfx.bigprint( -1, 40, "Invincibility", tr, tg, tb, true);
-                dwgfx.Print( -1, 75, "Provided to help disabled gamers", tr, tg, tb, true);
-                dwgfx.Print( -1, 85, "explore the game. Can cause glitches.", tr, tg, tb, true);
+                graphics.bigprint( -1, 40, "Invincibility", tr, tg, tb, true);
+                graphics.Print( -1, 75, "Provided to help disabled gamers", tr, tg, tb, true);
+                graphics.Print( -1, 85, "explore the game. Can cause glitches.", tr, tg, tb, true);
                 if (map.invincibility)
                 {
-                    dwgfx.Print( -1, 105, "Invincibility is ON.", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "Invincibility is ON.", tr, tg, tb, true);
                 }
                 else
                 {
-                    dwgfx.Print( -1, 105, "Invincibility is off.", tr/2, tg/2, tb/2, true);
+                    graphics.Print( -1, 105, "Invincibility is off.", tr/2, tg/2, tb/2, true);
                 }
             }
             else if (game.currentmenuoption == 4)
             {
-                dwgfx.bigprint( -1, 40, "Game Speed", tr, tg, tb, true);
-                dwgfx.Print( -1, 75, "May be useful for disabled gamers", tr, tg, tb, true);
-                dwgfx.Print( -1, 85, "using one switch devices.", tr, tg, tb, true);
+                graphics.bigprint( -1, 40, "Game Speed", tr, tg, tb, true);
+                graphics.Print( -1, 75, "May be useful for disabled gamers", tr, tg, tb, true);
+                graphics.Print( -1, 85, "using one switch devices.", tr, tg, tb, true);
                 if (game.gameframerate==34)
                 {
-                    dwgfx.Print( -1, 105, "Game speed is normal.", tr/2, tg/2, tb/2, true);
+                    graphics.Print( -1, 105, "Game speed is normal.", tr/2, tg/2, tb/2, true);
                 }
                 else if (game.gameframerate==41)
                 {
-                    dwgfx.Print( -1, 105, "Game speed is at 80%", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "Game speed is at 80%", tr, tg, tb, true);
                 }
                 else if (game.gameframerate==55)
                 {
-                    dwgfx.Print( -1, 105, "Game speed is at 60%", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "Game speed is at 60%", tr, tg, tb, true);
                 }
                 else if (game.gameframerate==83)
                 {
-                    dwgfx.Print( -1, 105, "Game speed is at 40%", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "Game speed is at 40%", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 5)
             {
-                dwgfx.bigprint(-1, 30, "Fake Load Screen", tr, tg, tb, true);
+                graphics.bigprint(-1, 30, "Fake Load Screen", tr, tg, tb, true);
                 if (game.skipfakeload)
-                    dwgfx.Print(-1, 75, "Fake loading screen is OFF", tr/2, tg/2, tb/2, true);
+                    graphics.Print(-1, 75, "Fake loading screen is OFF", tr/2, tg/2, tb/2, true);
                 else
-                    dwgfx.Print(-1, 75, "Fake loading screen is ON", tr, tg, tb, true);
+                    graphics.Print(-1, 75, "Fake loading screen is ON", tr, tg, tb, true);
             }
             else if (game.currentmenuoption == 6)
             {
-                dwgfx.bigprint(-1, 30, "Room Name BG", tr, tg, tb, true);
-                dwgfx.Print( -1, 75, "Lets you see through what is behind", tr, tg, tb, true);
-                dwgfx.Print( -1, 85, "the name at the bottom of the screen.", tr, tg, tb, true);
-                if (dwgfx.translucentroomname)
-                    dwgfx.Print(-1, 105, "Room name background is TRANSLUCENT", tr/2, tg/2, tb/2, true);
+                graphics.bigprint(-1, 30, "Room Name BG", tr, tg, tb, true);
+                graphics.Print( -1, 75, "Lets you see through what is behind", tr, tg, tb, true);
+                graphics.Print( -1, 85, "the name at the bottom of the screen.", tr, tg, tb, true);
+                if (graphics.translucentroomname)
+                    graphics.Print(-1, 105, "Room name background is TRANSLUCENT", tr/2, tg/2, tb/2, true);
                 else
-                    dwgfx.Print(-1, 105, "Room name background is OPAQUE", tr, tg, tb, true);
+                    graphics.Print(-1, 105, "Room name background is OPAQUE", tr, tg, tb, true);
             }
         }
         else if (game.currentmenuname == "playint1" || game.currentmenuname == "playint2")
         {
-            dwgfx.Print( -1, 65, "Who do you want to play", tr, tg, tb, true);
-            dwgfx.Print( -1, 75, "the level with?", tr, tg, tb, true);
+            graphics.Print( -1, 65, "Who do you want to play", tr, tg, tb, true);
+            graphics.Print( -1, 75, "the level with?", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "playmodes")
         {
             if (game.currentmenuoption == 0)
             {
-                dwgfx.bigprint( -1, 30, "Time Trials", tr, tg, tb, true);
-                dwgfx.Print( -1, 65, "Replay any level in the game in", tr, tg, tb, true);
-                dwgfx.Print( -1, 75, "a competitive time trial mode.", tr, tg, tb, true);
+                graphics.bigprint( -1, 30, "Time Trials", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Replay any level in the game in", tr, tg, tb, true);
+                graphics.Print( -1, 75, "a competitive time trial mode.", tr, tg, tb, true);
 
                 if (game.gameframerate > 34 || map.invincibility)
                 {
-                    dwgfx.Print( -1, 105, "Time Trials are not available", tr, tg, tb, true);
-                    dwgfx.Print( -1, 115, "with slowdown or invincibility.", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "Time Trials are not available", tr, tg, tb, true);
+                    graphics.Print( -1, 115, "with slowdown or invincibility.", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 1)
             {
-                dwgfx.bigprint( -1, 30, "Intermissions", tr, tg, tb, true);
-                dwgfx.Print( -1, 65, "Replay the intermission levels.", tr, tg, tb, true);
+                graphics.bigprint( -1, 30, "Intermissions", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Replay the intermission levels.", tr, tg, tb, true);
 
                 if (!game.unlock[15] && !game.unlock[16])
                 {
-                    dwgfx.Print( -1, 95, "TO UNLOCK: Complete the", tr, tg, tb, true);
-                    dwgfx.Print( -1, 105, "intermission levels in-game.", tr, tg, tb, true);
+                    graphics.Print( -1, 95, "TO UNLOCK: Complete the", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "intermission levels in-game.", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 2)
             {
-                dwgfx.bigprint( -1, 30, "No Death Mode", tr, tg, tb, true);
-                dwgfx.Print( -1, 65, "Play the entire game", tr, tg, tb, true);
-                dwgfx.Print( -1, 75, "without dying once.", tr, tg, tb, true);
+                graphics.bigprint( -1, 30, "No Death Mode", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Play the entire game", tr, tg, tb, true);
+                graphics.Print( -1, 75, "without dying once.", tr, tg, tb, true);
 
                 if (game.gameframerate > 34 || map.invincibility)
                 {
-                    dwgfx.Print( -1, 105, "No death mode is not available", tr, tg, tb, true);
-                    dwgfx.Print( -1, 115, "with slowdown or invincibility.", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "No death mode is not available", tr, tg, tb, true);
+                    graphics.Print( -1, 115, "with slowdown or invincibility.", tr, tg, tb, true);
                 }
                 else if (!game.unlock[17])
                 {
-                    dwgfx.Print( -1, 105, "TO UNLOCK: Achieve an S-rank or", tr, tg, tb, true);
-                    dwgfx.Print( -1, 115, "above in at least 4 time trials.", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "TO UNLOCK: Achieve an S-rank or", tr, tg, tb, true);
+                    graphics.Print( -1, 115, "above in at least 4 time trials.", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 3)
             {
-                dwgfx.bigprint( -1, 30, "Flip Mode", tr, tg, tb, true);
-                dwgfx.Print( -1, 65, "Flip the entire game vertically.", tr, tg, tb, true);
-                dwgfx.Print( -1, 75, "Compatible with other game modes.", tr, tg, tb, true);
+                graphics.bigprint( -1, 30, "Flip Mode", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Flip the entire game vertically.", tr, tg, tb, true);
+                graphics.Print( -1, 75, "Compatible with other game modes.", tr, tg, tb, true);
 
                 if (game.unlock[18])
                 {
-                    if (dwgfx.setflipmode)
+                    if (graphics.setflipmode)
                     {
-                        dwgfx.Print( -1, 105, "Currently ENABLED!", tr, tg, tb, true);
+                        graphics.Print( -1, 105, "Currently ENABLED!", tr, tg, tb, true);
                     }
                     else
                     {
-                        dwgfx.Print( -1, 105, "Currently Disabled.", tr/2, tg/2, tb/2, true);
+                        graphics.Print( -1, 105, "Currently Disabled.", tr/2, tg/2, tb/2, true);
                     }
                 }
                 else
                 {
-                    dwgfx.Print( -1, 105, "TO UNLOCK: Complete the game.", tr, tg, tb, true);
+                    graphics.Print( -1, 105, "TO UNLOCK: Complete the game.", tr, tg, tb, true);
                 }
             }
         }
         else if (game.currentmenuname == "youwannaquit")
         {
-            dwgfx.Print( -1, 75, "Are you sure you want to quit?", tr, tg, tb, true);
+            graphics.Print( -1, 75, "Are you sure you want to quit?", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "continue")
         {
-            dwgfx.crewframedelay--;
-            if (dwgfx.crewframedelay <= 0)
+            graphics.crewframedelay--;
+            if (graphics.crewframedelay <= 0)
             {
-                dwgfx.crewframedelay = 8;
-                dwgfx.crewframe = (dwgfx.crewframe + 1) % 2;
+                graphics.crewframedelay = 8;
+                graphics.crewframe = (graphics.crewframe + 1) % 2;
             }
             if (game.currentmenuoption == 0)
             {
                 //Show teleporter save info
-                dwgfx.drawpixeltextbox(25, 65-20, 270, 90, 34,12, 65, 185, 207,0,4);
+                graphics.drawpixeltextbox(25, 65-20, 270, 90, 34,12, 65, 185, 207,0,4);
 
-                dwgfx.bigprint(-1, 20, "Tele Save", tr, tg, tb, true);
-                dwgfx.Print(0, 80-20, game.tele_currentarea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
+                graphics.bigprint(-1, 20, "Tele Save", tr, tg, tb, true);
+                graphics.Print(0, 80-20, game.tele_currentarea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
                 for (int i = 0; i < 6; i++)
                 {
-                    dwgfx.drawcrewman(169-(3*42)+(i*42), 95-20, i, game.tele_crewstats[i], true);
+                    graphics.drawcrewman(169-(3*42)+(i*42), 95-20, i, game.tele_crewstats[i], true);
                 }
-                dwgfx.Print(160 - 84, 132-20, game.tele_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-                dwgfx.Print(160 + 40, 132-20, help.number(game.tele_trinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                graphics.Print(160 - 84, 132-20, game.tele_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                graphics.Print(160 + 40, 132-20, help.number(game.tele_trinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                dwgfx.drawspritesetcol(50, 126-20, 50, 18);
-                dwgfx.drawspritesetcol(175, 126-20, 22, 18);
+                graphics.drawspritesetcol(50, 126-20, 50, 18);
+                graphics.drawspritesetcol(175, 126-20, 22, 18);
             }
             else if (game.currentmenuoption == 1)
             {
                 //Show quick save info
-                dwgfx.drawpixeltextbox(25, 65-20, 270, 90, 34,12, 65, 185, 207,0,4);
+                graphics.drawpixeltextbox(25, 65-20, 270, 90, 34,12, 65, 185, 207,0,4);
 
-                dwgfx.bigprint(-1, 20, "Quick Save", tr, tg, tb, true);
-                dwgfx.Print(0, 80-20, game.quick_currentarea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
+                graphics.bigprint(-1, 20, "Quick Save", tr, tg, tb, true);
+                graphics.Print(0, 80-20, game.quick_currentarea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
                 for (int i = 0; i < 6; i++)
                 {
-                    dwgfx.drawcrewman(169-(3*42)+(i*42), 95-20, i, game.quick_crewstats[i], true);
+                    graphics.drawcrewman(169-(3*42)+(i*42), 95-20, i, game.quick_crewstats[i], true);
                 }
-                dwgfx.Print(160 - 84, 132-20, game.quick_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-                dwgfx.Print(160 + 40, 132-20, help.number(game.quick_trinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                graphics.Print(160 - 84, 132-20, game.quick_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                graphics.Print(160 + 40, 132-20, help.number(game.quick_trinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                dwgfx.drawspritesetcol(50, 126-20, 50, 18);
-                dwgfx.drawspritesetcol(175, 126-20, 22, 18);
+                graphics.drawspritesetcol(50, 126-20, 50, 18);
+                graphics.drawspritesetcol(175, 126-20, 22, 18);
             }
         }
         else if (game.currentmenuname == "gameover" || game.currentmenuname == "gameover2")
         {
-            dwgfx.bigprint( -1, 25, "GAME OVER", tr, tg, tb, true, 3);
+            graphics.bigprint( -1, 25, "GAME OVER", tr, tg, tb, true, 3);
 
-            dwgfx.crewframedelay--;
-            if (dwgfx.crewframedelay <= 0)
+            graphics.crewframedelay--;
+            if (graphics.crewframedelay <= 0)
             {
-                dwgfx.crewframedelay = 8;
-                dwgfx.crewframe = (dwgfx.crewframe + 1) % 2;
+                graphics.crewframedelay = 8;
+                graphics.crewframe = (graphics.crewframe + 1) % 2;
             }
             for (int i = 0; i < 6; i++)
             {
-                dwgfx.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], true);
+                graphics.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], true);
             }
             tempstring = "You rescued " + help.number(game.crewrescued()) + " crewmates";
-            dwgfx.Print(0, 100, tempstring, tr, tg, tb, true);
+            graphics.Print(0, 100, tempstring, tr, tg, tb, true);
 
             tempstring = "and found " + help.number(game.trinkets) + " trinkets.";
-            dwgfx.Print(0, 110, tempstring, tr, tg, tb, true);
+            graphics.Print(0, 110, tempstring, tr, tg, tb, true);
 
             tempstring = "You managed to reach:";
-            dwgfx.Print(0, 145, tempstring, tr, tg, tb, true);
-            dwgfx.Print(0, 155, game.hardestroom, tr, tg, tb, true);
+            graphics.Print(0, 145, tempstring, tr, tg, tb, true);
+            graphics.Print(0, 155, game.hardestroom, tr, tg, tb, true);
 
             if (game.crewrescued() == 1)
             {
@@ -702,68 +702,68 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 tempstring = "Er, how did you do that?";
             }
 
-            dwgfx.Print(0, 190, tempstring, tr, tg, tb, true);
+            graphics.Print(0, 190, tempstring, tr, tg, tb, true);
         }
         else if (game.currentmenuname == "nodeathmodecomplete" || game.currentmenuname == "nodeathmodecomplete2")
         {
-            dwgfx.bigprint( -1, 8, "WOW", tr, tg, tb, true, 4);
+            graphics.bigprint( -1, 8, "WOW", tr, tg, tb, true, 4);
 
-            dwgfx.crewframedelay--;
-            if (dwgfx.crewframedelay <= 0)
+            graphics.crewframedelay--;
+            if (graphics.crewframedelay <= 0)
             {
-                dwgfx.crewframedelay = 8;
-                dwgfx.crewframe = (dwgfx.crewframe + 1) % 2;
+                graphics.crewframedelay = 8;
+                graphics.crewframe = (graphics.crewframe + 1) % 2;
             }
             for (int i = 0; i < 6; i++)
             {
-                dwgfx.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], true);
+                graphics.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], true);
             }
             tempstring = "You rescued all the crewmates!";
-            dwgfx.Print(0, 100, tempstring, tr, tg, tb, true);
+            graphics.Print(0, 100, tempstring, tr, tg, tb, true);
 
             tempstring = "And you found " + help.number(game.trinkets) + " trinkets.";
-            dwgfx.Print(0, 110, tempstring, tr, tg, tb, true);
+            graphics.Print(0, 110, tempstring, tr, tg, tb, true);
 
-            dwgfx.Print(0, 160, "A new trophy has been awarded and", tr, tg, tb, true);
-            dwgfx.Print(0, 170, "placed in the secret lab to", tr, tg, tb, true);
-            dwgfx.Print(0, 180, "acknowledge your achievement!", tr, tg, tb, true);
+            graphics.Print(0, 160, "A new trophy has been awarded and", tr, tg, tb, true);
+            graphics.Print(0, 170, "placed in the secret lab to", tr, tg, tb, true);
+            graphics.Print(0, 180, "acknowledge your achievement!", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "timetrialcomplete" || game.currentmenuname == "timetrialcomplete2"
                  || game.currentmenuname == "timetrialcomplete3" || game.currentmenuname == "timetrialcomplete4")
         {
-            dwgfx.bigprint( -1, 20, "Results", tr, tg, tb, true, 3);
+            graphics.bigprint( -1, 20, "Results", tr, tg, tb, true, 3);
 
             tempstring = game.resulttimestring() + " / " + game.partimestring();
 
-            dwgfx.drawspritesetcol(30, 80-15, 50, 22);
-            dwgfx.Print(65, 80-15, "TIME TAKEN:", 255, 255, 255);
-            dwgfx.Print(65, 90-15, tempstring, tr, tg, tb);
+            graphics.drawspritesetcol(30, 80-15, 50, 22);
+            graphics.Print(65, 80-15, "TIME TAKEN:", 255, 255, 255);
+            graphics.Print(65, 90-15, tempstring, tr, tg, tb);
             if (game.timetrialresulttime <= game.timetrialpar)
             {
-                dwgfx.Print(220, 85-15, "+1 Rank!", 255, 255, 255);
+                graphics.Print(220, 85-15, "+1 Rank!", 255, 255, 255);
             }
 
             tempstring = help.String(game.deathcounts);
-            dwgfx.drawspritesetcol(30-4, 80+20-4, 12, 22);
-            dwgfx.Print(65, 80+20, "NUMBER OF DEATHS:", 255, 255, 255);
-            dwgfx.Print(65, 90+20, tempstring, tr, tg, tb);
+            graphics.drawspritesetcol(30-4, 80+20-4, 12, 22);
+            graphics.Print(65, 80+20, "NUMBER OF DEATHS:", 255, 255, 255);
+            graphics.Print(65, 90+20, tempstring, tr, tg, tb);
             if (game.deathcounts == 0)
             {
-                dwgfx.Print(220, 85+20, "+1 Rank!", 255, 255, 255);
+                graphics.Print(220, 85+20, "+1 Rank!", 255, 255, 255);
             }
 
             tempstring = help.String(game.trinkets) + " of " + help.String(game.timetrialshinytarget);
-            dwgfx.drawspritesetcol(30, 80+55, 22, 22);
-            dwgfx.Print(65, 80+55, "SHINY TRINKETS:", 255, 255, 255);
-            dwgfx.Print(65, 90+55, tempstring, tr, tg, tb);
+            graphics.drawspritesetcol(30, 80+55, 22, 22);
+            graphics.Print(65, 80+55, "SHINY TRINKETS:", 255, 255, 255);
+            graphics.Print(65, 90+55, tempstring, tr, tg, tb);
             if (game.trinkets >= game.timetrialshinytarget)
             {
-                dwgfx.Print(220, 85+55, "+1 Rank!", 255, 255, 255);
+                graphics.Print(220, 85+55, "+1 Rank!", 255, 255, 255);
             }
 
             if (game.currentmenuname == "timetrialcomplete2" || game.currentmenuname == "timetrialcomplete3")
             {
-                dwgfx.bigprint( 100, 175, "Rank:", tr, tg, tb, false, 2);
+                graphics.bigprint( 100, 175, "Rank:", tr, tg, tb, false, 2);
             }
 
             if (game.currentmenuname == "timetrialcomplete3")
@@ -771,25 +771,25 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 switch(game.timetrialrank)
                 {
                 case 0:
-                    dwgfx.bigprint( 195, 165, "B", 255, 255, 255, false, 4);
+                    graphics.bigprint( 195, 165, "B", 255, 255, 255, false, 4);
                     break;
                 case 1:
-                    dwgfx.bigprint( 195, 165, "A", 255, 255, 255, false, 4);
+                    graphics.bigprint( 195, 165, "A", 255, 255, 255, false, 4);
                     break;
                 case 2:
-                    dwgfx.bigprint( 195, 165, "S", 255, 255, 255, false, 4);
+                    graphics.bigprint( 195, 165, "S", 255, 255, 255, false, 4);
                     break;
                 case 3:
-                    dwgfx.bigprint( 195, 165, "V", 255, 255, 255, false, 4);
+                    graphics.bigprint( 195, 165, "V", 255, 255, 255, false, 4);
                     break;
                 }
             }
         }
         else if (game.currentmenuname == "unlockmenutrials")
         {
-            dwgfx.bigprint( -1, 30, "Unlock Time Trials", tr, tg, tb, true);
-            dwgfx.Print( -1, 65, "You can unlock each time", tr, tg, tb, true);
-            dwgfx.Print( -1, 75, "trial separately.", tr, tg, tb, true);
+            graphics.bigprint( -1, 30, "Unlock Time Trials", tr, tg, tb, true);
+            graphics.Print( -1, 65, "You can unlock each time", tr, tg, tb, true);
+            graphics.Print( -1, 75, "trial separately.", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "timetrials")
         {
@@ -797,36 +797,36 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
             {
                 if(game.unlock[9])
                 {
-                    dwgfx.bigprint( -1, 30, "Space Station 1", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "Space Station 1", tr, tg, tb, true);
                     if (game.besttimes[0] == -1)
                     {
-                        dwgfx.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
+                        graphics.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
                     }
                     else
                     {
-                        dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
-                        dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
-                        dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[0]), tr, tg, tb);
-                        dwgfx.Print( 110, 75, help.String(game.besttrinkets[0])+"/2", tr, tg, tb);
-                        dwgfx.Print( 110, 85,help.String(game.bestlives[0]), tr, tg, tb);
+                        graphics.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
+                        graphics.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
+                        graphics.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
+                        graphics.Print( 110, 65, game.timetstring(game.besttimes[0]), tr, tg, tb);
+                        graphics.Print( 110, 75, help.String(game.besttrinkets[0])+"/2", tr, tg, tb);
+                        graphics.Print( 110, 85,help.String(game.bestlives[0]), tr, tg, tb);
 
 
-                        dwgfx.Print( 170, 65, "PAR TIME    1:15", tr, tg, tb);
-                        dwgfx.Print( 170, 85, "Best Rank", tr, tg, tb);
+                        graphics.Print( 170, 65, "PAR TIME    1:15", tr, tg, tb);
+                        graphics.Print( 170, 85, "Best Rank", tr, tg, tb);
                         switch(game.bestrank[0])
                         {
                         case 0:
-                            dwgfx.bigprint( 275, 82, "B", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "B", 225, 225, 225);
                             break;
                         case 1:
-                            dwgfx.bigprint( 275, 82, "A", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "A", 225, 225, 225);
                             break;
                         case 2:
-                            dwgfx.bigprint( 275, 82, "S", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "S", 225, 225, 225);
                             break;
                         case 3:
-                            dwgfx.bigprint( 275, 82, "V", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "V", 225, 225, 225);
                             break;
                         }
                     }
@@ -834,46 +834,46 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 }
                 else
                 {
-                    dwgfx.bigprint( -1, 30, "???", tr, tg, tb, true);
-                    dwgfx.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
-                    dwgfx.Print( -1, 75, "Rescue Violet", tr, tg, tb, true);
-                    dwgfx.Print( -1, 85, "Find three trinkets", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "???", tr, tg, tb, true);
+                    graphics.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
+                    graphics.Print( -1, 75, "Rescue Violet", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "Find three trinkets", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 1)
             {
                 if(game.unlock[10])
                 {
-                    dwgfx.bigprint( -1, 30, "The Laboratory", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "The Laboratory", tr, tg, tb, true);
                     if (game.besttimes[1] == -1)
                     {
-                        dwgfx.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
+                        graphics.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
                     }
                     else
                     {
-                        dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
-                        dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
-                        dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[1]), tr, tg, tb);
-                        dwgfx.Print( 110, 75, help.String(game.besttrinkets[1])+"/4", tr, tg, tb);
-                        dwgfx.Print( 110, 85, help.String(game.bestlives[1]), tr, tg, tb);
+                        graphics.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
+                        graphics.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
+                        graphics.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
+                        graphics.Print( 110, 65, game.timetstring(game.besttimes[1]), tr, tg, tb);
+                        graphics.Print( 110, 75, help.String(game.besttrinkets[1])+"/4", tr, tg, tb);
+                        graphics.Print( 110, 85, help.String(game.bestlives[1]), tr, tg, tb);
 
 
-                        dwgfx.Print( 170, 65, "PAR TIME    2:45", tr, tg, tb);
-                        dwgfx.Print( 170, 85, "Best Rank", tr, tg, tb);
+                        graphics.Print( 170, 65, "PAR TIME    2:45", tr, tg, tb);
+                        graphics.Print( 170, 85, "Best Rank", tr, tg, tb);
                         switch(game.bestrank[1])
                         {
                         case 0:
-                            dwgfx.bigprint( 275, 82, "B", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "B", 225, 225, 225);
                             break;
                         case 1:
-                            dwgfx.bigprint( 275, 82, "A", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "A", 225, 225, 225);
                             break;
                         case 2:
-                            dwgfx.bigprint( 275, 82, "S", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "S", 225, 225, 225);
                             break;
                         case 3:
-                            dwgfx.bigprint( 275, 82, "V", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "V", 225, 225, 225);
                             break;
                         }
                     }
@@ -881,46 +881,46 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 }
                 else
                 {
-                    dwgfx.bigprint( -1, 30, "???", tr, tg, tb, true);
-                    dwgfx.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
-                    dwgfx.Print( -1, 75, "Rescue Victoria", tr, tg, tb, true);
-                    dwgfx.Print( -1, 85, "Find six trinkets", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "???", tr, tg, tb, true);
+                    graphics.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
+                    graphics.Print( -1, 75, "Rescue Victoria", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "Find six trinkets", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 2)
             {
                 if(game.unlock[11])
                 {
-                    dwgfx.bigprint( -1, 30, "The Tower", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "The Tower", tr, tg, tb, true);
                     if (game.besttimes[2] == -1)
                     {
-                        dwgfx.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
+                        graphics.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
                     }
                     else
                     {
-                        dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
-                        dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
-                        dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[2]), tr, tg, tb);
-                        dwgfx.Print( 110, 75, help.String(game.besttrinkets[2])+"/2", tr, tg, tb);
-                        dwgfx.Print( 110, 85, help.String(game.bestlives[2]), tr, tg, tb);
+                        graphics.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
+                        graphics.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
+                        graphics.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
+                        graphics.Print( 110, 65, game.timetstring(game.besttimes[2]), tr, tg, tb);
+                        graphics.Print( 110, 75, help.String(game.besttrinkets[2])+"/2", tr, tg, tb);
+                        graphics.Print( 110, 85, help.String(game.bestlives[2]), tr, tg, tb);
 
 
-                        dwgfx.Print( 170, 65, "PAR TIME    1:45", tr, tg, tb);
-                        dwgfx.Print( 170, 85, "Best Rank", tr, tg, tb);
+                        graphics.Print( 170, 65, "PAR TIME    1:45", tr, tg, tb);
+                        graphics.Print( 170, 85, "Best Rank", tr, tg, tb);
                         switch(game.bestrank[2])
                         {
                         case 0:
-                            dwgfx.bigprint( 275, 82, "B", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "B", 225, 225, 225);
                             break;
                         case 1:
-                            dwgfx.bigprint( 275, 82, "A", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "A", 225, 225, 225);
                             break;
                         case 2:
-                            dwgfx.bigprint( 275, 82, "S", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "S", 225, 225, 225);
                             break;
                         case 3:
-                            dwgfx.bigprint( 275, 82, "V", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "V", 225, 225, 225);
                             break;
                         }
                     }
@@ -928,46 +928,46 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 }
                 else
                 {
-                    dwgfx.bigprint( -1, 30, "???", tr, tg, tb, true);
-                    dwgfx.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
-                    dwgfx.Print( -1, 75, "Rescue Vermilion", tr, tg, tb, true);
-                    dwgfx.Print( -1, 85, "Find nine trinkets", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "???", tr, tg, tb, true);
+                    graphics.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
+                    graphics.Print( -1, 75, "Rescue Vermilion", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "Find nine trinkets", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 3)
             {
                 if(game.unlock[12])
                 {
-                    dwgfx.bigprint( -1, 30, "Space Station 2", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "Space Station 2", tr, tg, tb, true);
                     if (game.besttimes[3] == -1)
                     {
-                        dwgfx.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
+                        graphics.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
                     }
                     else
                     {
-                        dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
-                        dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
-                        dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[3]), tr, tg, tb);
-                        dwgfx.Print( 110, 75, help.String(game.besttrinkets[3])+"/5", tr, tg, tb);
-                        dwgfx.Print( 110, 85, help.String(game.bestlives[3]), tr, tg, tb);
+                        graphics.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
+                        graphics.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
+                        graphics.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
+                        graphics.Print( 110, 65, game.timetstring(game.besttimes[3]), tr, tg, tb);
+                        graphics.Print( 110, 75, help.String(game.besttrinkets[3])+"/5", tr, tg, tb);
+                        graphics.Print( 110, 85, help.String(game.bestlives[3]), tr, tg, tb);
 
 
-                        dwgfx.Print( 170, 65, "PAR TIME    3:20", tr, tg, tb);
-                        dwgfx.Print( 170, 85, "Best Rank", tr, tg, tb);
+                        graphics.Print( 170, 65, "PAR TIME    3:20", tr, tg, tb);
+                        graphics.Print( 170, 85, "Best Rank", tr, tg, tb);
                         switch(game.bestrank[3])
                         {
                         case 0:
-                            dwgfx.bigprint( 275, 82, "B", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "B", 225, 225, 225);
                             break;
                         case 1:
-                            dwgfx.bigprint( 275, 82, "A", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "A", 225, 225, 225);
                             break;
                         case 2:
-                            dwgfx.bigprint( 275, 82, "S", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "S", 225, 225, 225);
                             break;
                         case 3:
-                            dwgfx.bigprint( 275, 82, "V", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "V", 225, 225, 225);
                             break;
                         }
                     }
@@ -975,46 +975,46 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 }
                 else
                 {
-                    dwgfx.bigprint( -1, 30, "???", tr, tg, tb, true);
-                    dwgfx.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
-                    dwgfx.Print( -1, 75, "Rescue Vitellary", tr, tg, tb, true);
-                    dwgfx.Print( -1, 85, "Find twelve trinkets", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "???", tr, tg, tb, true);
+                    graphics.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
+                    graphics.Print( -1, 75, "Rescue Vitellary", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "Find twelve trinkets", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 4)
             {
                 if(game.unlock[13])
                 {
-                    dwgfx.bigprint( -1, 30, "The Warp Zone", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "The Warp Zone", tr, tg, tb, true);
                     if (game.besttimes[4] == -1)
                     {
-                        dwgfx.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
+                        graphics.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
                     }
                     else
                     {
-                        dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
-                        dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
-                        dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[4]), tr, tg, tb);
-                        dwgfx.Print( 110, 75, help.String(game.besttrinkets[4])+"/1", tr, tg, tb);
-                        dwgfx.Print( 110, 85, help.String(game.bestlives[4]), tr, tg, tb);
+                        graphics.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
+                        graphics.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
+                        graphics.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
+                        graphics.Print( 110, 65, game.timetstring(game.besttimes[4]), tr, tg, tb);
+                        graphics.Print( 110, 75, help.String(game.besttrinkets[4])+"/1", tr, tg, tb);
+                        graphics.Print( 110, 85, help.String(game.bestlives[4]), tr, tg, tb);
 
 
-                        dwgfx.Print( 170, 65, "PAR TIME    2:00", tr, tg, tb);
-                        dwgfx.Print( 170, 85, "Best Rank", tr, tg, tb);
+                        graphics.Print( 170, 65, "PAR TIME    2:00", tr, tg, tb);
+                        graphics.Print( 170, 85, "Best Rank", tr, tg, tb);
                         switch(game.bestrank[4])
                         {
                         case 0:
-                            dwgfx.bigprint( 275, 82, "B", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "B", 225, 225, 225);
                             break;
                         case 1:
-                            dwgfx.bigprint( 275, 82, "A", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "A", 225, 225, 225);
                             break;
                         case 2:
-                            dwgfx.bigprint( 275, 82, "S", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "S", 225, 225, 225);
                             break;
                         case 3:
-                            dwgfx.bigprint( 275, 82, "V", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "V", 225, 225, 225);
                             break;
                         }
                     }
@@ -1022,46 +1022,46 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 }
                 else
                 {
-                    dwgfx.bigprint( -1, 30, "???", tr, tg, tb, true);
-                    dwgfx.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
-                    dwgfx.Print( -1, 75, "Rescue Verdigris", tr, tg, tb, true);
-                    dwgfx.Print( -1, 85, "Find fifteen trinkets", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "???", tr, tg, tb, true);
+                    graphics.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
+                    graphics.Print( -1, 75, "Rescue Verdigris", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "Find fifteen trinkets", tr, tg, tb, true);
                 }
             }
             else if (game.currentmenuoption == 5)
             {
                 if(game.unlock[14])
                 {
-                    dwgfx.bigprint( -1, 30, "The Final Level", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "The Final Level", tr, tg, tb, true);
                     if (game.besttimes[5] == -1)
                     {
-                        dwgfx.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
+                        graphics.Print( -1, 75, "Not yet attempted", tr, tg, tb, true);
                     }
                     else
                     {
-                        dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
-                        dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
-                        dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[5]), tr, tg, tb);
-                        dwgfx.Print( 110, 75, help.String(game.besttrinkets[5])+"/1", tr, tg, tb);
-                        dwgfx.Print( 110, 85, help.String(game.bestlives[5]), tr, tg, tb);
+                        graphics.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
+                        graphics.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
+                        graphics.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
+                        graphics.Print( 110, 65, game.timetstring(game.besttimes[5]), tr, tg, tb);
+                        graphics.Print( 110, 75, help.String(game.besttrinkets[5])+"/1", tr, tg, tb);
+                        graphics.Print( 110, 85, help.String(game.bestlives[5]), tr, tg, tb);
 
 
-                        dwgfx.Print( 170, 65, "PAR TIME    2:15", tr, tg, tb);
-                        dwgfx.Print( 170, 85, "Best Rank", tr, tg, tb);
+                        graphics.Print( 170, 65, "PAR TIME    2:15", tr, tg, tb);
+                        graphics.Print( 170, 85, "Best Rank", tr, tg, tb);
                         switch(game.bestrank[5])
                         {
                         case 0:
-                            dwgfx.bigprint( 275, 82, "B", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "B", 225, 225, 225);
                             break;
                         case 1:
-                            dwgfx.bigprint( 275, 82, "A", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "A", 225, 225, 225);
                             break;
                         case 2:
-                            dwgfx.bigprint( 275, 82, "S", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "S", 225, 225, 225);
                             break;
                         case 3:
-                            dwgfx.bigprint( 275, 82, "V", 225, 225, 225);
+                            graphics.bigprint( 275, 82, "V", 225, 225, 225);
                             break;
                         }
                     }
@@ -1069,105 +1069,105 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 }
                 else
                 {
-                    dwgfx.bigprint( -1, 30, "???", tr, tg, tb, true);
-                    dwgfx.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
-                    dwgfx.Print( -1, 75, "Complete the game", tr, tg, tb, true);
-                    dwgfx.Print( -1, 85, "Find eighteen trinkets", tr, tg, tb, true);
+                    graphics.bigprint( -1, 30, "???", tr, tg, tb, true);
+                    graphics.Print( -1, 60, "TO UNLOCK:", tr, tg, tb, true);
+                    graphics.Print( -1, 75, "Complete the game", tr, tg, tb, true);
+                    graphics.Print( -1, 85, "Find eighteen trinkets", tr, tg, tb, true);
                 }
             }
         }
         else if (game.currentmenuname == "gamecompletecontinue")
         {
-            dwgfx.bigprint( -1, 25, "Congratulations!", tr, tg, tb, true, 2);
+            graphics.bigprint( -1, 25, "Congratulations!", tr, tg, tb, true, 2);
 
-            dwgfx.Print( -1, 45, "Your save files have been updated.", tr, tg, tb, true);
+            graphics.Print( -1, 45, "Your save files have been updated.", tr, tg, tb, true);
 
-            dwgfx.Print( -1, 110, "If you want to keep exploring", tr, tg, tb, true);
-            dwgfx.Print( -1, 120, "the game, select CONTINUE", tr, tg, tb, true);
-            dwgfx.Print( -1, 130, "from the play menu.", tr, tg, tb, true);
+            graphics.Print( -1, 110, "If you want to keep exploring", tr, tg, tb, true);
+            graphics.Print( -1, 120, "the game, select CONTINUE", tr, tg, tb, true);
+            graphics.Print( -1, 130, "from the play menu.", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "unlockmenu")
         {
-            dwgfx.bigprint( -1, 25, "Unlock Play Modes", tr, tg, tb, true, 2);
+            graphics.bigprint( -1, 25, "Unlock Play Modes", tr, tg, tb, true, 2);
 
-            dwgfx.Print( -1, 55, "From here, you may unlock parts", tr, tg, tb, true);
-            dwgfx.Print( -1, 65, "of the game that are normally", tr, tg, tb, true);
-            dwgfx.Print( -1, 75, "unlocked as you play.", tr, tg, tb, true);
+            graphics.Print( -1, 55, "From here, you may unlock parts", tr, tg, tb, true);
+            graphics.Print( -1, 65, "of the game that are normally", tr, tg, tb, true);
+            graphics.Print( -1, 75, "unlocked as you play.", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "unlocktimetrial")
         {
-            dwgfx.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
+            graphics.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
 
-            dwgfx.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
-            dwgfx.Print( -1, 135, "a new Time Trial.", tr, tg, tb, true);
+            graphics.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
+            graphics.Print( -1, 135, "a new Time Trial.", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "unlocktimetrials")
         {
-            dwgfx.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
+            graphics.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
 
-            dwgfx.Print( -1, 125, "Your have unlocked some", tr, tg, tb, true);
-            dwgfx.Print( -1, 135, "new Time Trials.", tr, tg, tb, true);
+            graphics.Print( -1, 125, "Your have unlocked some", tr, tg, tb, true);
+            graphics.Print( -1, 135, "new Time Trials.", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "unlocknodeathmode")
         {
-            dwgfx.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
+            graphics.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
 
-            dwgfx.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
-            dwgfx.Print( -1, 135, "No Death Mode.", tr, tg, tb, true);
+            graphics.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
+            graphics.Print( -1, 135, "No Death Mode.", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "unlockflipmode")
         {
-            dwgfx.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
+            graphics.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
 
-            dwgfx.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
-            dwgfx.Print( -1, 135, "Flip Mode.", tr, tg, tb, true);
+            graphics.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
+            graphics.Print( -1, 135, "Flip Mode.", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "unlockintermission")
         {
-            dwgfx.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
+            graphics.bigprint( -1, 45, "Congratulations!", tr, tg, tb, true, 2);
 
-            dwgfx.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
-            dwgfx.Print( -1, 135, "the intermission levels.", tr, tg, tb, true);
+            graphics.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
+            graphics.Print( -1, 135, "the intermission levels.", tr, tg, tb, true);
         }else if (game.currentmenuname == "playerworlds")
         {   
-						dwgfx.tempstring = FILESYSTEM_getUserLevelDirectory();
-						if(dwgfx.tempstring.length()>80){
-							dwgfx.Print( -1, 160, "To install new player levels, copy", tr, tg, tb, true);
-							dwgfx.Print( -1, 170, "the .vvvvvv files to this folder:", tr, tg, tb, true);
-							dwgfx.Print( 320-((dwgfx.tempstring.length()-80)*8), 190, dwgfx.tempstring.substr(0,dwgfx.tempstring.length()-80), tr, tg, tb);
-							dwgfx.Print( 0, 200, dwgfx.tempstring.substr(dwgfx.tempstring.length()-80,40), tr, tg, tb);
-							dwgfx.Print( 0, 210, dwgfx.tempstring.substr(dwgfx.tempstring.length()-40,40), tr, tg, tb);
-						}else if(dwgfx.tempstring.length()>40){
-							dwgfx.Print( -1, 170, "To install new player levels, copy", tr, tg, tb, true);
-							dwgfx.Print( -1, 180, "the .vvvvvv files to this folder:", tr, tg, tb, true);
-							dwgfx.Print( 320-((dwgfx.tempstring.length()-40)*8), 200, dwgfx.tempstring.substr(0,dwgfx.tempstring.length()-40), tr, tg, tb);
-							dwgfx.Print( 0, 210, dwgfx.tempstring.substr(dwgfx.tempstring.length()-40,40), tr, tg, tb);
+						graphics.tempstring = FILESYSTEM_getUserLevelDirectory();
+						if(graphics.tempstring.length()>80){
+							graphics.Print( -1, 160, "To install new player levels, copy", tr, tg, tb, true);
+							graphics.Print( -1, 170, "the .vvvvvv files to this folder:", tr, tg, tb, true);
+							graphics.Print( 320-((graphics.tempstring.length()-80)*8), 190, graphics.tempstring.substr(0,graphics.tempstring.length()-80), tr, tg, tb);
+							graphics.Print( 0, 200, graphics.tempstring.substr(graphics.tempstring.length()-80,40), tr, tg, tb);
+							graphics.Print( 0, 210, graphics.tempstring.substr(graphics.tempstring.length()-40,40), tr, tg, tb);
+						}else if(graphics.tempstring.length()>40){
+							graphics.Print( -1, 170, "To install new player levels, copy", tr, tg, tb, true);
+							graphics.Print( -1, 180, "the .vvvvvv files to this folder:", tr, tg, tb, true);
+							graphics.Print( 320-((graphics.tempstring.length()-40)*8), 200, graphics.tempstring.substr(0,graphics.tempstring.length()-40), tr, tg, tb);
+							graphics.Print( 0, 210, graphics.tempstring.substr(graphics.tempstring.length()-40,40), tr, tg, tb);
 						}else{
-							dwgfx.Print( -1, 180, "To install new player levels, copy", tr, tg, tb, true);
-							dwgfx.Print( -1, 190, "the .vvvvvv files to this folder:", tr, tg, tb, true);
-							dwgfx.Print( 320-(dwgfx.tempstring.length()*8), 210, dwgfx.tempstring, tr, tg, tb);
+							graphics.Print( -1, 180, "To install new player levels, copy", tr, tg, tb, true);
+							graphics.Print( -1, 190, "the .vvvvvv files to this folder:", tr, tg, tb, true);
+							graphics.Print( 320-(graphics.tempstring.length()*8), 210, graphics.tempstring, tr, tg, tb);
 						}
         }
 
         /*
         switch(game.mainmenu) {
         	case 0:
-        		dwgfx.Print(5, 115, "[ NEW GAME ]", tr, tg, tb, true);
+        		graphics.Print(5, 115, "[ NEW GAME ]", tr, tg, tb, true);
         	break;
         	case 1:
         		if (game.telesummary == "") {
-        			dwgfx.Print(5, 115, "[ no teleporter save ]", tr/3, tg/3, tb/3, true);
+        			graphics.Print(5, 115, "[ no teleporter save ]", tr/3, tg/3, tb/3, true);
         		}else {
-        			dwgfx.Print(5, 115, "[ RESTORE FROM LAST TELEPORTER ]", tr, tg, tb, true);
-        			dwgfx.Print(5, 125, game.telesummary, tr, tg, tb, true);
+        			graphics.Print(5, 115, "[ RESTORE FROM LAST TELEPORTER ]", tr, tg, tb, true);
+        			graphics.Print(5, 125, game.telesummary, tr, tg, tb, true);
         		}
         	break;
         	case 2:
         		if (game.quicksummary == "") {
-        			dwgfx.Print(5, 115, "[ no quicksave ]", tr/3, tg/3, tb/3, true);
+        			graphics.Print(5, 115, "[ no quicksave ]", tr/3, tg/3, tb/3, true);
         		}else {
-        			dwgfx.Print(5, 115, "[ RESTORE FROM LAST QUICKSAVE ]", tr, tg, tb, true);
-        			dwgfx.Print(5, 125, game.quicksummary, tr, tg, tb, true);
+        			graphics.Print(5, 115, "[ RESTORE FROM LAST QUICKSAVE ]", tr, tg, tb, true);
+        			graphics.Print(5, 125, game.quicksummary, tr, tg, tb, true);
         		}
         	break;
         }
@@ -1184,72 +1184,72 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
         if(tb>255) tb=255;
         if (game.currentmenuname == "timetrials" || game.currentmenuname == "unlockmenutrials")
         {
-            dwgfx.drawmenu(tr, tg, tb, 15);
+            graphics.drawmenu(tr, tg, tb, 15);
         }
         else if (game.currentmenuname == "unlockmenu")
         {
-            dwgfx.drawmenu(tr, tg, tb, 15);
+            graphics.drawmenu(tr, tg, tb, 15);
         }
         else if (game.currentmenuname == "playmodes")
         {
-            dwgfx.drawmenu(tr, tg, tb, 20);
+            graphics.drawmenu(tr, tg, tb, 20);
         }
         else if (game.currentmenuname == "mainmenu")
         {
-            dwgfx.drawmenu(tr, tg, tb, 15);
+            graphics.drawmenu(tr, tg, tb, 15);
         }
         else if (game.currentmenuname == "playerworlds")
         {
-            dwgfx.drawmenu(tr, tg, tb, 15);
+            graphics.drawmenu(tr, tg, tb, 15);
         }
         else if (game.currentmenuname == "levellist")
         {
-            dwgfx.drawlevelmenu(tr, tg, tb, 5);
+            graphics.drawlevelmenu(tr, tg, tb, 5);
         }
         else
         {
-            dwgfx.drawmenu(tr, tg, tb);
+            graphics.drawmenu(tr, tg, tb);
         }
 
-        //dwgfx.Print(5, 228, "Left/Right to Choose, V to Select", tr, tg, tb, true);
+        //graphics.Print(5, 228, "Left/Right to Choose, V to Select", tr, tg, tb, true);
     }
 
     if (game.test)
     {
-        dwgfx.Print(5, 5, game.teststring, 196, 196, 255, false);
+        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
     }
 
-    dwgfx.drawfade();
+    graphics.drawfade();
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
-        dwgfx.flashlight();
+        graphics.flashlight();
     }
 
     if (game.screenshake > 0  && !game.noflashingmode)
     {
         game.screenshake--;
-        dwgfx.screenshake();
+        graphics.screenshake();
     }
     else
     {
-        dwgfx.render();
+        graphics.render();
     }
-    //dwgfx.backbuffer.unlock();
+    //graphics.backbuffer.unlock();
 }
 
-void gamecompleterender(Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help, mapclass& map)
+void gamecompleterender()
 {
-    //dwgfx.backbuffer.lock();
-    FillRect(dwgfx.backBuffer, 0x000000);
+    //graphics.backbuffer.lock();
+    FillRect(graphics.backBuffer, 0x000000);
 
-    if(!game.colourblindmode) dwgfx.drawtowerbackgroundsolo();
-    //dwgfx.drawtowermap();
+    if(!game.colourblindmode) graphics.drawtowerbackgroundsolo();
+    //graphics.drawtowermap();
 
     for (int i = 0; i < 6; i++)
     {
-        //dwgfx.drawsprite((160-96)+ i * 32, 10, 23, 96+(i*10)+(random()*16), 196-(help.glow)-(random()*16), 255 - (help.glow*2));
+        //graphics.drawsprite((160-96)+ i * 32, 10, 23, 96+(i*10)+(random()*16), 196-(help.glow)-(random()*16), 255 - (help.glow*2));
     }
 
     tr = map.r - (help.glow / 4) - fRandom() * 4;
@@ -1265,164 +1265,164 @@ void gamecompleterender(Graphics& dwgfx, Game& game, entityclass& obj, UtilityCl
 
     //rendering starts... here!
 
-    if (dwgfx.onscreen(220 + game.creditposition))
+    if (graphics.onscreen(220 + game.creditposition))
     {
         temp = 220 + game.creditposition;
-        dwgfx.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
-        dwgfx.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
+        graphics.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
     }
 
-    if (dwgfx.onscreen(290 + game.creditposition)) dwgfx.bigprint( -1, 290 + game.creditposition, "Starring", tr, tg, tb, true, 2);
+    if (graphics.onscreen(290 + game.creditposition)) graphics.bigprint( -1, 290 + game.creditposition, "Starring", tr, tg, tb, true, 2);
 
-    if (dwgfx.onscreen(320 + game.creditposition))
+    if (graphics.onscreen(320 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 320 + game.creditposition, 0, true);
-        dwgfx.Print(100, 330 + game.creditposition, "Captain Viridian", tr, tg, tb);
+        graphics.drawcrewman(70, 320 + game.creditposition, 0, true);
+        graphics.Print(100, 330 + game.creditposition, "Captain Viridian", tr, tg, tb);
     }
-    if (dwgfx.onscreen(350 + game.creditposition))
+    if (graphics.onscreen(350 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 350 + game.creditposition, 1, true);
-        dwgfx.Print(100, 360 + game.creditposition, "Doctor Violet", tr, tg, tb);
+        graphics.drawcrewman(70, 350 + game.creditposition, 1, true);
+        graphics.Print(100, 360 + game.creditposition, "Doctor Violet", tr, tg, tb);
     }
-    if (dwgfx.onscreen(380 + game.creditposition))
+    if (graphics.onscreen(380 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 380 + game.creditposition, 2, true);
-        dwgfx.Print(100, 390 + game.creditposition, "Professor Vitellary", tr, tg, tb);
+        graphics.drawcrewman(70, 380 + game.creditposition, 2, true);
+        graphics.Print(100, 390 + game.creditposition, "Professor Vitellary", tr, tg, tb);
     }
-    if (dwgfx.onscreen(410 + game.creditposition))
+    if (graphics.onscreen(410 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 410 + game.creditposition, 3, true);
-        dwgfx.Print(100, 420 + game.creditposition, "Officer Vermilion", tr, tg, tb);
+        graphics.drawcrewman(70, 410 + game.creditposition, 3, true);
+        graphics.Print(100, 420 + game.creditposition, "Officer Vermilion", tr, tg, tb);
     }
-    if (dwgfx.onscreen(440 + game.creditposition))
+    if (graphics.onscreen(440 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 440 + game.creditposition, 4, true);
-        dwgfx.Print(100, 450 + game.creditposition, "Chief Verdigris", tr, tg, tb);
+        graphics.drawcrewman(70, 440 + game.creditposition, 4, true);
+        graphics.Print(100, 450 + game.creditposition, "Chief Verdigris", tr, tg, tb);
     }
-    if (dwgfx.onscreen(470 + game.creditposition))
+    if (graphics.onscreen(470 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 470 + game.creditposition, 5, true);
-        dwgfx.Print(100, 480 + game.creditposition, "Doctor Victoria", tr, tg, tb);
-    }
-
-    if (dwgfx.onscreen(520 + game.creditposition)) dwgfx.bigprint( -1, 520 + game.creditposition, "Credits", tr, tg, tb, true, 3);
-
-    if (dwgfx.onscreen(560 + game.creditposition))
-    {
-        dwgfx.Print(40, 560 + game.creditposition, "Created by", tr, tg, tb);
-        dwgfx.bigprint(60, 570 + game.creditposition, "Terry Cavanagh", tr, tg, tb);
+        graphics.drawcrewman(70, 470 + game.creditposition, 5, true);
+        graphics.Print(100, 480 + game.creditposition, "Doctor Victoria", tr, tg, tb);
     }
 
-    if (dwgfx.onscreen(600 + game.creditposition))
+    if (graphics.onscreen(520 + game.creditposition)) graphics.bigprint( -1, 520 + game.creditposition, "Credits", tr, tg, tb, true, 3);
+
+    if (graphics.onscreen(560 + game.creditposition))
     {
-        dwgfx.Print(40, 600 + game.creditposition, "With Music by", tr, tg, tb);
-        dwgfx.bigprint(60, 610 + game.creditposition, "Magnus P~lsson", tr, tg, tb);
+        graphics.Print(40, 560 + game.creditposition, "Created by", tr, tg, tb);
+        graphics.bigprint(60, 570 + game.creditposition, "Terry Cavanagh", tr, tg, tb);
     }
 
-    if (dwgfx.onscreen(640 + game.creditposition))
+    if (graphics.onscreen(600 + game.creditposition))
     {
-        dwgfx.Print(40, 640 + game.creditposition, "Rooms Named by", tr, tg, tb);
-        dwgfx.bigprint(60, 650 + game.creditposition, "Bennett Foddy", tr, tg, tb);
+        graphics.Print(40, 600 + game.creditposition, "With Music by", tr, tg, tb);
+        graphics.bigprint(60, 610 + game.creditposition, "Magnus P~lsson", tr, tg, tb);
     }
 
-    if (dwgfx.onscreen(680 + game.creditposition))
+    if (graphics.onscreen(640 + game.creditposition))
     {
-        dwgfx.Print(40, 680 + game.creditposition, "C++ Port by", tr, tg, tb);
-        dwgfx.bigprint(60, 690 + game.creditposition, "Simon Roth", tr, tg, tb);
-        dwgfx.bigprint(60, 710 + game.creditposition, "Ethan Lee", tr, tg, tb);
+        graphics.Print(40, 640 + game.creditposition, "Rooms Named by", tr, tg, tb);
+        graphics.bigprint(60, 650 + game.creditposition, "Bennett Foddy", tr, tg, tb);
+    }
+
+    if (graphics.onscreen(680 + game.creditposition))
+    {
+        graphics.Print(40, 680 + game.creditposition, "C++ Port by", tr, tg, tb);
+        graphics.bigprint(60, 690 + game.creditposition, "Simon Roth", tr, tg, tb);
+        graphics.bigprint(60, 710 + game.creditposition, "Ethan Lee", tr, tg, tb);
     }
 
 
-    if (dwgfx.onscreen(740 + game.creditposition))
+    if (graphics.onscreen(740 + game.creditposition))
     {
-        dwgfx.Print(40, 740 + game.creditposition, "Beta Testing by", tr, tg, tb);
-        dwgfx.bigprint(60, 750 + game.creditposition, "Sam Kaplan", tr, tg, tb);
-        dwgfx.bigprint(60, 770 + game.creditposition, "Pauli Kohberger", tr, tg, tb);
+        graphics.Print(40, 740 + game.creditposition, "Beta Testing by", tr, tg, tb);
+        graphics.bigprint(60, 750 + game.creditposition, "Sam Kaplan", tr, tg, tb);
+        graphics.bigprint(60, 770 + game.creditposition, "Pauli Kohberger", tr, tg, tb);
     }
 
-    if (dwgfx.onscreen(800 + game.creditposition))
+    if (graphics.onscreen(800 + game.creditposition))
     {
-        dwgfx.Print(40, 800 + game.creditposition, "Ending Picture by", tr, tg, tb);
-        dwgfx.bigprint(60, 810 + game.creditposition, "Pauli Kohberger", tr, tg, tb);
+        graphics.Print(40, 800 + game.creditposition, "Ending Picture by", tr, tg, tb);
+        graphics.bigprint(60, 810 + game.creditposition, "Pauli Kohberger", tr, tg, tb);
     }
 
-    if (dwgfx.onscreen(890 + game.creditposition)) dwgfx.bigprint( -1, 870 + game.creditposition, "Patrons", tr, tg, tb, true, 3);
+    if (graphics.onscreen(890 + game.creditposition)) graphics.bigprint( -1, 870 + game.creditposition, "Patrons", tr, tg, tb, true, 3);
 
     int creditOffset = 930;
 
     for (size_t i = 0; i < game.superpatrons.size(); i += 1)
     {
-        if (dwgfx.onscreen(creditOffset + game.creditposition))
+        if (graphics.onscreen(creditOffset + game.creditposition))
         {
-            dwgfx.Print(-1, creditOffset + game.creditposition, game.superpatrons[i], tr, tg, tb, true);
+            graphics.Print(-1, creditOffset + game.creditposition, game.superpatrons[i], tr, tg, tb, true);
         }
         creditOffset += 10;
     }
 
     creditOffset += 10;
-    if (dwgfx.onscreen(creditOffset + game.creditposition)) dwgfx.Print( -1, creditOffset + game.creditposition, "and", tr, tg, tb, true);
+    if (graphics.onscreen(creditOffset + game.creditposition)) graphics.Print( -1, creditOffset + game.creditposition, "and", tr, tg, tb, true);
     creditOffset += 20;
 
     for (size_t i = 0; i < game.patrons.size(); i += 1)
     {
-        if (dwgfx.onscreen(creditOffset + game.creditposition))
+        if (graphics.onscreen(creditOffset + game.creditposition))
         {
-            dwgfx.Print(-1, creditOffset + game.creditposition, game.patrons[i], tr, tg, tb, true);
+            graphics.Print(-1, creditOffset + game.creditposition, game.patrons[i], tr, tg, tb, true);
         }
         creditOffset += 10;
     }
 
     creditOffset += 20;
-    if (dwgfx.onscreen(creditOffset + game.creditposition)) dwgfx.bigprint(40, creditOffset + game.creditposition, "GitHub Contributors", tr, tg, tb, true);
+    if (graphics.onscreen(creditOffset + game.creditposition)) graphics.bigprint(40, creditOffset + game.creditposition, "GitHub Contributors", tr, tg, tb, true);
     creditOffset += 30;
 
     for (size_t i = 0; i < game.githubfriends.size(); i += 1)
     {
-        if (dwgfx.onscreen(creditOffset + game.creditposition))
+        if (graphics.onscreen(creditOffset + game.creditposition))
         {
-            dwgfx.Print(-1, creditOffset + game.creditposition, game.githubfriends[i], tr, tg, tb, true);
+            graphics.Print(-1, creditOffset + game.creditposition, game.githubfriends[i], tr, tg, tb, true);
         }
         creditOffset += 10;
     }
 
     creditOffset += 140;
-    if (dwgfx.onscreen(creditOffset + game.creditposition)) dwgfx.bigprint( -1, creditOffset + game.creditposition, "Thanks for playing!", tr, tg, tb, true, 2);
+    if (graphics.onscreen(creditOffset + game.creditposition)) graphics.bigprint( -1, creditOffset + game.creditposition, "Thanks for playing!", tr, tg, tb, true, 2);
 
     if (game.test)
     {
-        dwgfx.Print(5, 5, game.teststring, 196, 196, 255, false);
+        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
     }
 
-    dwgfx.drawfade();
+    graphics.drawfade();
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
-        dwgfx.flashlight();
+        graphics.flashlight();
     }
 
     if (game.screenshake > 0 && !game.noflashingmode)
     {
         game.screenshake--;
-        dwgfx.screenshake();
+        graphics.screenshake();
     }
     else
     {
-        dwgfx.render();
+        graphics.render();
     }
-    //dwgfx.backbuffer.unlock();
+    //graphics.backbuffer.unlock();
 }
 
-void gamecompleterender2(Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help)
+void gamecompleterender2()
 {
-    //dwgfx.backbuffer.lock();
-    FillRect(dwgfx.backBuffer, 0x000000);
+    //graphics.backbuffer.lock();
+    FillRect(graphics.backBuffer, 0x000000);
 
-    dwgfx.drawimage(10, 0, 0);
+    graphics.drawimage(10, 0, 0);
 
     for (int j = 0; j < 30; j++)
     {
@@ -1432,43 +1432,43 @@ void gamecompleterender2(Graphics& dwgfx, Game& game, entityclass& obj, UtilityC
             {
                 if (i > game.creditposx)
                 {
-                    FillRect(dwgfx.backBuffer, i * 8, j * 8, 8, 8, 0, 0, 0);
+                    FillRect(graphics.backBuffer, i * 8, j * 8, 8, 8, 0, 0, 0);
                 }
             }
 
             if (j > game.creditposy)
             {
-                FillRect(dwgfx.backBuffer, i * 8, j * 8, 8, 8, 0, 0, 0);
+                FillRect(graphics.backBuffer, i * 8, j * 8, 8, 8, 0, 0, 0);
             }
         }
     }
 
     if (game.test)
     {
-        dwgfx.Print(5, 5, game.teststring, 196, 196, 255, false);
+        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
     }
 
-    dwgfx.drawfade();
+    graphics.drawfade();
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
-        dwgfx.flashlight();
+        graphics.flashlight();
     }
 
     if (game.screenshake > 0 && !game.noflashingmode)
     {
         game.screenshake--;
-        dwgfx.screenshake();
+        graphics.screenshake();
     }
     else
     {
-        dwgfx.render();
+        graphics.render();
     }
-    //dwgfx.backbuffer.unlock();
+    //graphics.backbuffer.unlock();
 }
 
-void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, UtilityClass& help)
+void gamerender()
 {
 
 
@@ -1478,19 +1478,19 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
 
         if(!game.colourblindmode)
 		{
-        dwgfx.drawbackground(map.background);
+        graphics.drawbackground(map.background);
 		}
 		else
 		{
-			FillRect(dwgfx.backBuffer,0x00000);
+			FillRect(graphics.backBuffer,0x00000);
 		}
         if (map.final_colormode)
 		{
-        	dwgfx.drawfinalmap();
+        	graphics.drawfinalmap();
         }
         else
 		{
-        dwgfx.drawmap();
+        graphics.drawmap();
         }
 
 
@@ -1522,34 +1522,34 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
             }
         }
 
-        dwgfx.drawentities();
+        graphics.drawentities();
     }
 
     /*for(int i=0; i<obj.nblocks; i++){
     if (obj.blocks[i].active) {
-    		dwgfx.backbuffer.fillRect(obj.blocks[i].rect, 0xDDDDDD);
+    		graphics.backbuffer.fillRect(obj.blocks[i].rect, 0xDDDDDD);
     }
       }*/
-    //dwgfx.drawminimap(game, map);
+    //graphics.drawminimap(game, map);
 
     if(map.extrarow==0 || (map.custommode && map.roomname!=""))
     {
-        dwgfx.footerrect.y = 230;
-        if (dwgfx.translucentroomname)
+        graphics.footerrect.y = 230;
+        if (graphics.translucentroomname)
         {
-            SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
+            SDL_BlitSurface(graphics.footerbuffer, NULL, graphics.backBuffer, &graphics.footerrect);
         }
         else
         {
-            FillRect(dwgfx.backBuffer, dwgfx.footerrect, 0);
+            FillRect(graphics.backBuffer, graphics.footerrect, 0);
         }
 
         if (map.finalmode)
         {
         	map.glitchname = map.getglitchname(game.roomx, game.roomy);
-          dwgfx.bprint(5, 231, map.glitchname, 196, 196, 255 - help.glow, true);
+          graphics.bprint(5, 231, map.glitchname, 196, 196, 255 - help.glow, true);
         }else{
-          dwgfx.bprint(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
+          graphics.bprint(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
         }
     }
 
@@ -1558,14 +1558,14 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
         //Draw room text!
         for (size_t i = 0; i < map.roomtext.size(); i++)
         {
-            dwgfx.Print(map.roomtext[i].x*8, (map.roomtext[i].y*8), map.roomtext[i].text, 196, 196, 255 - help.glow);
+            graphics.Print(map.roomtext[i].x*8, (map.roomtext[i].y*8), map.roomtext[i].text, 196, 196, 255 - help.glow);
         }
     }
 
 #if !defined(NO_CUSTOM_LEVELS)
      if(map.custommode && !map.custommodeforreal && !game.advancetext){
         //Return to level editor
-        dwgfx.bprintalpha(5, 5, "[Press ENTER to return to editor]", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), ed.returneditoralpha, false);
+        graphics.bprintalpha(5, 5, "[Press ENTER to return to editor]", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), ed.returneditoralpha, false);
         if (ed.returneditoralpha > 0) {
             ed.returneditoralpha -= 15;
         }
@@ -1573,29 +1573,29 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
 #endif
 
 
-    dwgfx.cutscenebars();
-    dwgfx.drawfade();
-	BlitSurfaceStandard(dwgfx.backBuffer, NULL, dwgfx.tempBuffer, NULL);
+    graphics.cutscenebars();
+    graphics.drawfade();
+	BlitSurfaceStandard(graphics.backBuffer, NULL, graphics.tempBuffer, NULL);
 
-    dwgfx.drawgui();
-    if (dwgfx.flipmode)
+    graphics.drawgui();
+    if (graphics.flipmode)
     {
-        if (game.advancetext) dwgfx.bprint(5, 228, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+        if (game.advancetext) graphics.bprint(5, 228, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
     else
     {
-        if (game.advancetext) dwgfx.bprint(5, 5, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+        if (game.advancetext) graphics.bprint(5, 5, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
 
     if (game.readytotele > 100 && !game.advancetext && game.hascontrol && !script.running && !game.intimetrial)
     {
-        if(dwgfx.flipmode)
+        if(graphics.flipmode)
         {
-            dwgfx.bprint(5, 20, "- Press ENTER to Teleport -", game.readytotele - 20 - (help.glow / 2), game.readytotele - 20 - (help.glow / 2), game.readytotele, true);
+            graphics.bprint(5, 20, "- Press ENTER to Teleport -", game.readytotele - 20 - (help.glow / 2), game.readytotele - 20 - (help.glow / 2), game.readytotele, true);
         }
         else
         {
-            dwgfx.bprint(5, 210, "- Press ENTER to Teleport -", game.readytotele - 20 - (help.glow / 2), game.readytotele - 20 - (help.glow / 2), game.readytotele, true);
+            graphics.bprint(5, 210, "- Press ENTER to Teleport -", game.readytotele - 20 - (help.glow / 2), game.readytotele - 20 - (help.glow / 2), game.readytotele, true);
         }
     }
 
@@ -1604,56 +1604,56 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
         if (game.swngame == 0)
         {
             tempstring = help.timestring(game.swntimer);
-            dwgfx.bigprint( -1, 20, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
+            graphics.bigprint( -1, 20, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
         }
         else if (game.swngame == 1)
         {
             if (game.swnmessage == 0)
             {
                 tempstring = help.timestring(game.swntimer);
-                dwgfx.Print( 10, 10, "Current Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
-                dwgfx.bigprint( 25, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
+                graphics.Print( 10, 10, "Current Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
+                graphics.bigprint( 25, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
                 tempstring = help.timestring(game.swnrecord);
-                dwgfx.Print( 240, 10, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
-                dwgfx.bigrprint( 300, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
+                graphics.Print( 240, 10, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
+                graphics.bigrprint( 300, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
 
                 switch(game.swnbestrank)
                 {
                 case 0:
-                    dwgfx.Print( -1, 204, "Next Trophy at 5 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+                    graphics.Print( -1, 204, "Next Trophy at 5 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
                     break;
                 case 1:
-                    dwgfx.Print( -1, 204, "Next Trophy at 10 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+                    graphics.Print( -1, 204, "Next Trophy at 10 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
                     break;
                 case 2:
-                    dwgfx.Print( -1, 204, "Next Trophy at 15 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+                    graphics.Print( -1, 204, "Next Trophy at 15 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
                     break;
                 case 3:
-                    dwgfx.Print( -1, 204, "Next Trophy at 20 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+                    graphics.Print( -1, 204, "Next Trophy at 20 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
                     break;
                 case 4:
-                    dwgfx.Print( -1, 204, "Next Trophy at 30 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+                    graphics.Print( -1, 204, "Next Trophy at 30 seconds", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
                     break;
                 case 5:
-                    dwgfx.Print( -1, 204, "Next Trophy at 1 minute", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+                    graphics.Print( -1, 204, "Next Trophy at 1 minute", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
                     break;
                 case 6:
-                    dwgfx.Print( -1, 204, "All Trophies collected!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+                    graphics.Print( -1, 204, "All Trophies collected!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
                     break;
                 }
             }
             else if (game.swnmessage == 1)
             {
                 tempstring = help.timestring(game.swntimer);
-                dwgfx.Print( 10, 10, "Current Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
-                dwgfx.bigprint( 25, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
+                graphics.Print( 10, 10, "Current Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
+                graphics.bigprint( 25, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
                 tempstring = help.timestring(game.swnrecord);
                 if (int(game.deathseq / 5) % 2 == 1)
                 {
-                    dwgfx.Print( 240, 10, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
-                    dwgfx.bigrprint( 300, 24, tempstring, 128 - (help.glow), 220 - (help.glow), 128 - (help.glow / 2), false, 2);
+                    graphics.Print( 240, 10, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
+                    graphics.bigrprint( 300, 24, tempstring, 128 - (help.glow), 220 - (help.glow), 128 - (help.glow / 2), false, 2);
 
-                    dwgfx.bigprint( -1, 200, "New Record!", 128 - (help.glow), 220 - (help.glow), 128 - (help.glow / 2), true, 2);
+                    graphics.bigprint( -1, 200, "New Record!", 128 - (help.glow), 220 - (help.glow), 128 - (help.glow / 2), true, 2);
                 }
             }
             else if (game.swnmessage >= 2)
@@ -1661,33 +1661,33 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
                 game.swnmessage--;
                 if (game.swnmessage == 2) game.swnmessage = 0;
                 tempstring = help.timestring(game.swntimer);
-                dwgfx.Print( 10, 10, "Current Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
-                dwgfx.bigprint( 25, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
+                graphics.Print( 10, 10, "Current Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
+                graphics.bigprint( 25, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
                 tempstring = help.timestring(game.swnrecord);
-                dwgfx.Print( 240, 10, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
-                dwgfx.bigrprint( 300, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
+                graphics.Print( 240, 10, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
+                graphics.bigrprint( 300, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
 
                 if (int(game.swnmessage / 5) % 2 == 1)
                 {
-                    dwgfx.bigprint( -1, 200, "New Trophy!", 220 - (help.glow), 128 - (help.glow), 128 - (help.glow / 2), true, 2);
+                    graphics.bigprint( -1, 200, "New Trophy!", 220 - (help.glow), 128 - (help.glow), 128 - (help.glow / 2), true, 2);
                 }
             }
 
-            dwgfx.Print( 20, 228, "[Press ENTER to stop]", 160 - (help.glow/2), 160 - (help.glow/2), 160 - (help.glow/2), true);
+            graphics.Print( 20, 228, "[Press ENTER to stop]", 160 - (help.glow/2), 160 - (help.glow/2), 160 - (help.glow/2), true);
         }
         else if(game.swngame==2)
         {
             if (int(game.swndelay / 15) % 2 == 1 || game.swndelay >= 120)
             {
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.bigprint( -1, 30, "Survive for", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
-                    dwgfx.bigprint( -1, 10, "60 seconds!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
+                    graphics.bigprint( -1, 30, "Survive for", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
+                    graphics.bigprint( -1, 10, "60 seconds!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
                 }
                 else
                 {
-                    dwgfx.bigprint( -1, 10, "Survive for", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
-                    dwgfx.bigprint( -1, 30, "60 seconds!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
+                    graphics.bigprint( -1, 10, "Survive for", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
+                    graphics.bigprint( -1, 30, "60 seconds!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
                 }
             }
         }
@@ -1695,21 +1695,21 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
         {
             if (game.swndelay >= 60)
             {
-                dwgfx.bigprint( -1, 20, "SUPER GRAVITRON", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
+                graphics.bigprint( -1, 20, "SUPER GRAVITRON", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
 
                 tempstring = help.timestring(game.swnrecord);
-                dwgfx.Print( 240, 190, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
-                dwgfx.bigrprint( 300, 205, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
+                graphics.Print( 240, 190, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+                graphics.bigrprint( 300, 205, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
             }
             else	if (int(game.swndelay / 10) % 2 == 1)
             {
-                dwgfx.bigprint( -1, 20, "SUPER GRAVITRON", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
-                dwgfx.bigprint( -1, 200, "GO!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 3);
+                graphics.bigprint( -1, 20, "SUPER GRAVITRON", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
+                graphics.bigprint( -1, 200, "GO!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 3);
             }
         }
     }
 
-    if (game.intimetrial && dwgfx.fademode==0)
+    if (game.intimetrial && graphics.fademode==0)
     {
         //Draw countdown!
         if (game.timetrialcountdown > 0)
@@ -1717,69 +1717,69 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
             if (game.timetrialcountdown < 30)
             {
                 game.resetgameclock();
-                if (int(game.timetrialcountdown / 4) % 2 == 0) dwgfx.bigprint( -1, 100, "Go!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
+                if (int(game.timetrialcountdown / 4) % 2 == 0) graphics.bigprint( -1, 100, "Go!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
             else if (game.timetrialcountdown < 60)
             {
-                dwgfx.bigprint( -1, 100, "1", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
+                graphics.bigprint( -1, 100, "1", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
             else if (game.timetrialcountdown < 90)
             {
-                dwgfx.bigprint( -1, 100, "2", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
+                graphics.bigprint( -1, 100, "2", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
             else if (game.timetrialcountdown < 120)
             {
-                dwgfx.bigprint( -1, 100, "3", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
+                graphics.bigprint( -1, 100, "3", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
         }
         else
         {
             //Draw OSD stuff
-            dwgfx.bprint(6, 18, "TIME :",  255,255,255);
-            dwgfx.bprint(6, 30, "DEATH:",  255, 255, 255);
-            dwgfx.bprint(6, 42, "SHINY:",  255,255,255);
+            graphics.bprint(6, 18, "TIME :",  255,255,255);
+            graphics.bprint(6, 30, "DEATH:",  255, 255, 255);
+            graphics.bprint(6, 42, "SHINY:",  255,255,255);
 
             if(game.timetrialparlost)
             {
-                dwgfx.bprint(56, 18, game.timestring(),  196, 80, 80);
+                graphics.bprint(56, 18, game.timestring(),  196, 80, 80);
             }
             else
             {
-                dwgfx.bprint(56, 18, game.timestring(),  196, 196, 196);
+                graphics.bprint(56, 18, game.timestring(),  196, 196, 196);
             }
             if(game.deathcounts>0)
             {
-                dwgfx.bprint(56, 30,help.String(game.deathcounts),  196, 80, 80);
+                graphics.bprint(56, 30,help.String(game.deathcounts),  196, 80, 80);
             }
             else
             {
-                dwgfx.bprint(56, 30,help.String(game.deathcounts),  196, 196, 196);
+                graphics.bprint(56, 30,help.String(game.deathcounts),  196, 196, 196);
             }
             if(game.trinkets<game.timetrialshinytarget)
             {
-                dwgfx.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 80, 80);
+                graphics.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 80, 80);
             }
             else
             {
-                dwgfx.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 196, 196);
+                graphics.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 196, 196);
             }
 
             if(game.timetrialparlost)
             {
-                dwgfx.bprint(195, 214, "PAR TIME:",  80, 80, 80);
-                dwgfx.bprint(275, 214, game.partimestring(),  80, 80, 80);
+                graphics.bprint(195, 214, "PAR TIME:",  80, 80, 80);
+                graphics.bprint(275, 214, game.partimestring(),  80, 80, 80);
             }
             else
             {
-                dwgfx.bprint(195, 214, "PAR TIME:",  255, 255, 255);
-                dwgfx.bprint(275, 214, game.partimestring(),  196, 196, 196);
+                graphics.bprint(195, 214, "PAR TIME:",  255, 255, 255);
+                graphics.bprint(275, 214, game.partimestring(),  196, 196, 196);
             }
         }
     }
 
     if (game.activeactivity > -1)
     {
-        //dwgfx.backbuffer.fillRect(new Rectangle(0, 0, 320, 18), 0x000000);
+        //graphics.backbuffer.fillRect(new Rectangle(0, 0, 320, 18), 0x000000);
         game.activity_lastprompt = obj.blocks[game.activeactivity].prompt;
         game.activity_r = obj.blocks[game.activeactivity].r;
         game.activity_g = obj.blocks[game.activeactivity].g;
@@ -1789,31 +1789,31 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
         {
             game.act_fade++;
         }
-        dwgfx.drawtextbox(16, 4, 36, 3, game.activity_r*(game.act_fade/10.0f), game.activity_g*(game.act_fade/10.0f), game.activity_b*(game.act_fade/10.0f));
-        dwgfx.Print(5, 12, game.activity_lastprompt, game.activity_r*(game.act_fade/10.0f), game.activity_g*(game.act_fade/10.0f), game.activity_b*(game.act_fade/10.0f), true);
+        graphics.drawtextbox(16, 4, 36, 3, game.activity_r*(game.act_fade/10.0f), game.activity_g*(game.act_fade/10.0f), game.activity_b*(game.act_fade/10.0f));
+        graphics.Print(5, 12, game.activity_lastprompt, game.activity_r*(game.act_fade/10.0f), game.activity_g*(game.act_fade/10.0f), game.activity_b*(game.act_fade/10.0f), true);
     }
     else
     {
         if(game.act_fade>5)
         {
-            dwgfx.drawtextbox(16, 4, 36, 3, game.activity_r*(game.act_fade/10.0f), game.activity_g*(game.act_fade/10.0f), game.activity_b*(game.act_fade/10.0f));
-            dwgfx.Print(5, 12, game.activity_lastprompt, game.activity_r*(game.act_fade/10.0f), game.activity_g*(game.act_fade/10.0f), game.activity_b*(game.act_fade/10.0f), true);
+            graphics.drawtextbox(16, 4, 36, 3, game.activity_r*(game.act_fade/10.0f), game.activity_g*(game.act_fade/10.0f), game.activity_b*(game.act_fade/10.0f));
+            graphics.Print(5, 12, game.activity_lastprompt, game.activity_r*(game.act_fade/10.0f), game.activity_g*(game.act_fade/10.0f), game.activity_b*(game.act_fade/10.0f), true);
             game.act_fade--;
         }
     }
 
     if (obj.trophytext > 0)
     {
-        dwgfx.drawtrophytext();
+        graphics.drawtrophytext();
         obj.trophytext--;
     }
 
-    //dwgfx.rprint(5, 231,help.String(game.coins), 255 - help.glow/2, 255 - help.glow/2, 196, true);
-    //dwgfx.drawhuetile(311, 230, 48, 1);
+    //graphics.rprint(5, 231,help.String(game.coins), 255 - help.glow/2, 255 - help.glow/2, 196, true);
+    //graphics.drawhuetile(311, 230, 48, 1);
 
     //Level complete image
     //if (game.state >= 3007) {
-    //	dwgfx.drawimage(0, 0, 12, true);
+    //	graphics.drawimage(0, 0, 12, true);
     //}
 
     //state changes
@@ -1829,7 +1829,7 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
     for (int i = 0; i < obj.nentity; i++) {
     	game.tempstring =help.String(obj.entities[i].type) +", (" +help.String(obj.entities[i].xp) + "," +help.String(obj.entities[i].yp) + ")";
     	game.tempstring += " state:" +obj.entities[i].state + ", delay:" + obj.entities[i].statedelay;
-    	dwgfx.Print(5, 5 + i * 8, game.tempstring, 255, 255, 255);
+    	graphics.Print(5, 5 + i * 8, game.tempstring, 255, 255, 255);
     }
     */
 
@@ -1844,9 +1844,9 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
 
     //Special thing for loading:
     /*
-    if(dwgfx.fademode==1){
+    if(graphics.fademode==1){
       if(game.mainmenu==22){
-        dwgfx.Print(5, 225, "Loading...", 196, 196, 255 - help.glow, false);
+        graphics.Print(5, 225, "Loading...", 196, 196, 255 - help.glow, false);
       }
     }
     */
@@ -1854,113 +1854,113 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
 
     if (game.test)
     {
-        dwgfx.Print(5, 5, game.teststring, 196, 196, 255, false);
+        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
     }
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
-        dwgfx.flashlight();
+        graphics.flashlight();
     }
 
     if (game.screenshake > 0 && !game.noflashingmode)
     {
         game.screenshake--;
-        dwgfx.screenshake();
+        graphics.screenshake();
     }
     else
     {
-        dwgfx.render();
+        graphics.render();
     }
 
-    //dwgfx.backbuffer.unlock();
+    //graphics.backbuffer.unlock();
 }
 
-void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help)
+void maprender()
 {
-    //dwgfx.backbuffer.lock();
+    //graphics.backbuffer.lock();
 
 
-    dwgfx.drawgui();
+    graphics.drawgui();
 
     //draw screen alliteration
     //Roomname:
 	//CRASH
     temp = map.area(game.roomx, game.roomy);
-    if (temp < 2 && !map.custommode && dwgfx.fademode==0)
+    if (temp < 2 && !map.custommode && graphics.fademode==0)
     {
         if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111)
         {
-            dwgfx.Print(5, 2, "The Ship", 196, 196, 255 - help.glow, true);
+            graphics.Print(5, 2, "The Ship", 196, 196, 255 - help.glow, true);
         }
         else
         {
-            dwgfx.Print(5, 2, "Dimension VVVVVV", 196, 196, 255 - help.glow, true);
+            graphics.Print(5, 2, "Dimension VVVVVV", 196, 196, 255 - help.glow, true);
         }
     }
     else
     {
       if (map.finalmode){
         map.glitchname = map.getglitchname(game.roomx, game.roomy);
-        dwgfx.Print(5, 2, map.glitchname, 196, 196, 255 - help.glow, true);
+        graphics.Print(5, 2, map.glitchname, 196, 196, 255 - help.glow, true);
       }else{
-        dwgfx.Print(5, 2, map.roomname, 196, 196, 255 - help.glow, true);
+        graphics.Print(5, 2, map.roomname, 196, 196, 255 - help.glow, true);
       }
     }
 
     //Background color
-    //dwgfx.drawfillrect(0, 12, 320, 240, 10, 24, 26);
-    FillRect(dwgfx.backBuffer,0, 12, 320, 240, 10, 24, 26 );
+    //graphics.drawfillrect(0, 12, 320, 240, 10, 24, 26);
+    FillRect(graphics.backBuffer,0, 12, 320, 240, 10, 24, 26 );
 
-    dwgfx.crewframedelay--;
-    if (dwgfx.crewframedelay <= 0)
+    graphics.crewframedelay--;
+    if (graphics.crewframedelay <= 0)
     {
-        dwgfx.crewframedelay = 8;
-        dwgfx.crewframe = (dwgfx.crewframe + 1) % 2;
+        graphics.crewframedelay = 8;
+        graphics.crewframe = (graphics.crewframe + 1) % 2;
     }
 
 
 
     //Menubar:
-    dwgfx.drawtextbox( -10, 212, 42, 3, 65, 185, 207);
+    graphics.drawtextbox( -10, 212, 42, 3, 65, 185, 207);
     switch(game.menupage)
     {
     case 0:
-        dwgfx.Print(30 - 8, 220, "[MAP]", 196, 196, 255 - help.glow);
+        graphics.Print(30 - 8, 220, "[MAP]", 196, 196, 255 - help.glow);
         if (game.insecretlab)
         {
-            dwgfx.Print(103, 220, "GRAV", 64, 64, 64);
+            graphics.Print(103, 220, "GRAV", 64, 64, 64);
         }
         else if (obj.flags[67] == 1 && !map.custommode)
         {
-            dwgfx.Print(103, 220, "SHIP", 64,64,64);
+            graphics.Print(103, 220, "SHIP", 64,64,64);
         }
         else
         {
-            dwgfx.Print(103, 220, "CREW", 64,64,64);
+            graphics.Print(103, 220, "CREW", 64,64,64);
         }
-        dwgfx.Print(185-4, 220, "STATS", 64,64,64);
-        dwgfx.Print(258, 220, "SAVE", 64,64,64);
+        graphics.Print(185-4, 220, "STATS", 64,64,64);
+        graphics.Print(258, 220, "SAVE", 64,64,64);
 
         if (map.finalmode || (map.custommode&&!map.customshowmm))
         {
             //draw the map image
-            dwgfx.drawpixeltextbox(35, 16, 250, 190, 32,24, 65, 185, 207,4,0);
-            dwgfx.drawimage(1, 40, 21, false);
+            graphics.drawpixeltextbox(35, 16, 250, 190, 32,24, 65, 185, 207,4,0);
+            graphics.drawimage(1, 40, 21, false);
             for (int j = 0; j < 20; j++)
             {
                 for (int i = 0; i < 20; i++)
                 {
-                    dwgfx.drawimage(2, 40 + (i * 12), 21 + (j * 9), false);
+                    graphics.drawimage(2, 40 + (i * 12), 21 + (j * 9), false);
                 }
             }
-            dwgfx.Print(-1, 105, "NO SIGNAL", 245, 245, 245, true);
+            graphics.Print(-1, 105, "NO SIGNAL", 245, 245, 245, true);
         }
         else if(map.custommode)
         {
           //draw the map image
-          dwgfx.drawcustompixeltextbox(35+map.custommmxoff, 16+map.custommmyoff, map.custommmxsize+10, map.custommmysize+10, (map.custommmxsize+10)/8, (map.custommmysize+10)/8, 65, 185, 207,4,0);
-          dwgfx.drawpartimage(12, 40+map.custommmxoff, 21+map.custommmyoff, map.custommmxsize,map.custommmysize);
+          graphics.drawcustompixeltextbox(35+map.custommmxoff, 16+map.custommmyoff, map.custommmxsize+10, map.custommmysize+10, (map.custommmxsize+10)/8, (map.custommmysize+10)/8, 65, 185, 207,4,0);
+          graphics.drawpartimage(12, 40+map.custommmxoff, 21+map.custommmyoff, map.custommmxsize,map.custommmysize);
 
           //Black out here
           if(map.customzoom==4){
@@ -1968,25 +1968,25 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
               for (int i = 0; i < map.customwidth; i++){
                 if(map.explored[i+(j*20)]==0){
                   //Draw the fog of war on the map
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + (j * 36), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + (j * 36), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + 9 + (j * 36), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + 9+ (j * 36), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + (j * 36), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + (j * 36), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + 9 + (j * 36), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + 9+ (j * 36), false);
 
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 48) + 24, map.custommmyoff+21 + (j * 36), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 48) + 24, map.custommmyoff+21 + (j * 36), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 48) + 24, map.custommmyoff+ 21 + 9 + (j * 36), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 48) + 24, map.custommmyoff+21 + 9+ (j * 36), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 48) + 24, map.custommmyoff+21 + (j * 36), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48) + 24, map.custommmyoff+21 + (j * 36), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 48) + 24, map.custommmyoff+ 21 + 9 + (j * 36), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48) + 24, map.custommmyoff+21 + 9+ (j * 36), false);
 
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + (j * 36)+18, false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + (j * 36)+18, false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + 9 + (j * 36)+18, false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + 9+ (j * 36)+18, false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + (j * 36)+18, false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + (j * 36)+18, false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + 9 + (j * 36)+18, false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + 9+ (j * 36)+18, false);
 
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 48) + 24, map.custommmyoff+21 + (j * 36)+18, false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 48) + 24, map.custommmyoff+21 + (j * 36)+18, false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 48) + 24, map.custommmyoff+21 + 9 + (j * 36)+18, false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 48) + 24, map.custommmyoff+21 + 9+ (j * 36)+18, false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 48) + 24, map.custommmyoff+21 + (j * 36)+18, false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48) + 24, map.custommmyoff+21 + (j * 36)+18, false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 48) + 24, map.custommmyoff+21 + 9 + (j * 36)+18, false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48) + 24, map.custommmyoff+21 + 9+ (j * 36)+18, false);
                 }
               }
             }
@@ -1995,10 +1995,10 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
               for (int i = 0; i < map.customwidth; i++){
                 if(map.explored[i+(j*20)]==0){
                   //Draw the fog of war on the map
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 24), map.custommmyoff+21 + (j * 18), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 24), map.custommmyoff+21 + (j * 18), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 24), map.custommmyoff+21 + 9 + (j * 18), false);
-                  dwgfx.drawimage(2, map.custommmxoff+40 + 12 + (i * 24), map.custommmyoff+21 + 9+ (j * 18), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 24), map.custommmyoff+21 + (j * 18), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 24), map.custommmyoff+21 + (j * 18), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 24), map.custommmyoff+21 + 9 + (j * 18), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 24), map.custommmyoff+21 + 9+ (j * 18), false);
                 }
               }
             }
@@ -2007,7 +2007,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
               for (int i = 0; i < map.customwidth; i++){
                 if(map.explored[i+(j*20)]==0){
                   //Draw the fog of war on the map
-                  dwgfx.drawimage(2, map.custommmxoff+40 + (i * 12), map.custommmyoff+21 + (j * 9), false);
+                  graphics.drawimage(2, map.custommmxoff+40 + (i * 12), map.custommmyoff+21 + (j * 9), false);
                 }
               }
             }
@@ -2030,34 +2030,34 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
           if(map.customzoom==4){
             if(map.cursorstate==1){
               if (int(map.cursordelay / 4) % 2 == 0){
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 48) +map.custommmxoff, 21 + ((game.roomy - 100) * 36)+map.custommmyoff , 48 , 36 , 255,255,255);
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 48) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 36) + 2+map.custommmyoff, 48 - 4, 36 - 4, 255,255,255);
+                graphics.drawrect(40 + ((game.roomx - 100) * 48) +map.custommmxoff, 21 + ((game.roomy - 100) * 36)+map.custommmyoff , 48 , 36 , 255,255,255);
+                graphics.drawrect(40 + ((game.roomx - 100) * 48) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 36) + 2+map.custommmyoff, 48 - 4, 36 - 4, 255,255,255);
               }
             }else if (map.cursorstate == 2){
               if (int(map.cursordelay / 15) % 2 == 0){
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 48) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 36) + 2+map.custommmyoff, 48 - 4, 36 - 4, 16, 245 - (help.glow), 245 - (help.glow));
+                graphics.drawrect(40 + ((game.roomx - 100) * 48) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 36) + 2+map.custommmyoff, 48 - 4, 36 - 4, 16, 245 - (help.glow), 245 - (help.glow));
               }
             }
           }else if(map.customzoom==2){
             if(map.cursorstate==1){
               if (int(map.cursordelay / 4) % 2 == 0){
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 24)+map.custommmxoff , 21 + ((game.roomy - 100) * 18)+map.custommmyoff , 24 , 18 , 255,255,255);
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 24) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 18) + 2+map.custommmyoff, 24 - 4, 18 - 4, 255,255,255);
+                graphics.drawrect(40 + ((game.roomx - 100) * 24)+map.custommmxoff , 21 + ((game.roomy - 100) * 18)+map.custommmyoff , 24 , 18 , 255,255,255);
+                graphics.drawrect(40 + ((game.roomx - 100) * 24) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 18) + 2+map.custommmyoff, 24 - 4, 18 - 4, 255,255,255);
               }
             }else if (map.cursorstate == 2){
               if (int(map.cursordelay / 15) % 2 == 0){
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 24) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 18) + 2+map.custommmyoff, 24 - 4, 18 - 4, 16, 245 - (help.glow), 245 - (help.glow));
+                graphics.drawrect(40 + ((game.roomx - 100) * 24) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 18) + 2+map.custommmyoff, 24 - 4, 18 - 4, 16, 245 - (help.glow), 245 - (help.glow));
               }
             }
           }else{
             if(map.cursorstate==1){
               if (int(map.cursordelay / 4) % 2 == 0){
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 12)+map.custommmxoff , 21 + ((game.roomy - 100) * 9)+map.custommmyoff , 12 , 9 , 255,255,255);
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 9) + 2+map.custommmyoff, 12 - 4, 9 - 4, 255,255,255);
+                graphics.drawrect(40 + ((game.roomx - 100) * 12)+map.custommmxoff , 21 + ((game.roomy - 100) * 9)+map.custommmyoff , 12 , 9 , 255,255,255);
+                graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 9) + 2+map.custommmyoff, 12 - 4, 9 - 4, 255,255,255);
               }
             }else if (map.cursorstate == 2){
               if (int(map.cursordelay / 15) % 2 == 0){
-                dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 9) + 2+map.custommmyoff, 12 - 4, 9 - 4, 16, 245 - (help.glow), 245 - (help.glow));
+                graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2+map.custommmxoff, 21 + ((game.roomy - 100) * 9) + 2+map.custommmyoff, 12 - 4, 9 - 4, 16, 245 - (help.glow), 245 - (help.glow));
               }
             }
           }
@@ -2065,8 +2065,8 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
         else
         {
             //draw the map image
-            dwgfx.drawpixeltextbox(35, 16, 250, 190, 32,24, 65, 185, 207,4,0);
-            dwgfx.drawimage(1, 40, 21, false);
+            graphics.drawpixeltextbox(35, 16, 250, 190, 32,24, 65, 185, 207,4,0);
+            graphics.drawimage(1, 40, 21, false);
 
             //black out areas we can't see yet
             for (int j = 0; j < 20; j++)
@@ -2076,7 +2076,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                     if(map.explored[i+(j*20)]==0)
                     {
                         //Draw the fog of war on the map
-                        dwgfx.drawimage(2, 40 + (i * 12), 21 + (j * 9), false);
+                        graphics.drawimage(2, 40 + (i * 12), 21 + (j * 9), false);
                     }
                 }
             }
@@ -2087,7 +2087,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                 /*if (map.ypos > (0.57 * (680 * 8))) {
                 	i = int(map.ypos - (0.57 * (680 * 8)));
                 	i = int((i / (0.43 * (680 * 8)))*9);
-                	dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + i + 2, 12 - 4, 9 - 4, 16, 245 - (help.glow * 2), 245 - (help.glow * 2));
+                	graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + i + 2, 12 - 4, 9 - 4, 16, 245 - (help.glow * 2), 245 - (help.glow * 2));
                 }*/
                 if (map.cursorstate == 0)
                 {
@@ -2103,8 +2103,8 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                     map.cursordelay++;
                     if (int(map.cursordelay / 4) % 2 == 0)
                     {
-                        dwgfx.drawrect(40 + ((game.roomx - 100) * 12) , 21 , 12, 180, 255,255,255);
-                        dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2 , 21  + 2, 12 - 4, 180 - 4, 255,255,255);
+                        graphics.drawrect(40 + ((game.roomx - 100) * 12) , 21 , 12, 180, 255,255,255);
+                        graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2 , 21  + 2, 12 - 4, 180 - 4, 255,255,255);
                     }
                     if (map.cursordelay > 30) map.cursorstate = 2;
                 }
@@ -2113,7 +2113,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                     map.cursordelay++;
                     if (int(map.cursordelay / 15) % 2 == 0)
                     {
-                        dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2 , 21  + 2, 12 - 4, 180 - 4,16, 245 - (help.glow), 245 - (help.glow));
+                        graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2 , 21  + 2, 12 - 4, 180 - 4,16, 245 - (help.glow), 245 - (help.glow));
                     }
                 }
             }
@@ -2133,8 +2133,8 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                     map.cursordelay++;
                     if (int(map.cursordelay / 4) % 2 == 0)
                     {
-                        dwgfx.drawrect(40 + ((game.roomx - 100) * 12) , 21 + ((game.roomy - 100) * 9) , 12 , 9 , 255,255,255);
-                        dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + ((game.roomy - 100) * 9) + 2, 12 - 4, 9 - 4, 255,255,255);
+                        graphics.drawrect(40 + ((game.roomx - 100) * 12) , 21 + ((game.roomy - 100) * 9) , 12 , 9 , 255,255,255);
+                        graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + ((game.roomy - 100) * 9) + 2, 12 - 4, 9 - 4, 255,255,255);
                     }
                     if (map.cursordelay > 30) map.cursorstate = 2;
                 }
@@ -2143,7 +2143,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                     map.cursordelay++;
                     if (int(map.cursordelay / 15) % 2 == 0)
                     {
-                        dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + ((game.roomy - 100) * 9) + 2, 12 - 4, 9 - 4, 16, 245 - (help.glow), 245 - (help.glow));
+                        graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + ((game.roomy - 100) * 9) + 2, 12 - 4, 9 - 4, 16, 245 - (help.glow), 245 - (help.glow));
                     }
                 }
             }
@@ -2154,16 +2154,16 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                 if (map.showteleporters && map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)] > 0)
                 {
                     temp = 1126 + map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)];
-                    if (dwgfx.flipmode) temp += 3;
-                    dwgfx.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
+                    if (graphics.flipmode) temp += 3;
+                    graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
                 }
                 else if(map.showtargets && map.explored[map.teleporters[i].x+(20*map.teleporters[i].y)]==0)
                 {
                     temp = 1126 + map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)];
-                    if (dwgfx.flipmode) temp += 3;
-                    dwgfx.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
+                    if (graphics.flipmode) temp += 3;
+                    graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
                 }
-                //dwgfx.drawtile(40+3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), 1086); //for shiny trinkets, do later
+                //graphics.drawtile(40+3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), 1086); //for shiny trinkets, do later
             }
 
             if (map.showtrinkets)
@@ -2173,8 +2173,8 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                     if (obj.collect[i] == 0)
                     {
                         temp = 1086;
-                        if (dwgfx.flipmode) temp += 3;
-                        dwgfx.drawtile(40 + 3 + (map.shinytrinkets[i].x * 12), 22 + (map.shinytrinkets[i].y * 9),	temp);
+                        if (graphics.flipmode) temp += 3;
+                        graphics.drawtile(40 + 3 + (map.shinytrinkets[i].x * 12), 22 + (map.shinytrinkets[i].y * 9),	temp);
                     }
                 }
             }
@@ -2183,159 +2183,159 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
     case 1:
         if (game.insecretlab)
         {
-            dwgfx.Print(30, 220, "MAP", 64,64,64);
-            dwgfx.Print(103-8, 220, "[GRAV]", 196, 196, 255 - help.glow);
-            dwgfx.Print(185-4, 220, "STATS", 64,64,64);
-            dwgfx.Print(258, 220, "SAVE", 64, 64, 64);
+            graphics.Print(30, 220, "MAP", 64,64,64);
+            graphics.Print(103-8, 220, "[GRAV]", 196, 196, 255 - help.glow);
+            graphics.Print(185-4, 220, "STATS", 64,64,64);
+            graphics.Print(258, 220, "SAVE", 64, 64, 64);
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.Print(0, 174, "SUPER GRAVITRON HIGHSCORE", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 174, "SUPER GRAVITRON HIGHSCORE", 196, 196, 255 - help.glow, true);
 
                 tempstring = help.timestring(game.swnrecord);
-                dwgfx.Print( 240, 124, "Best Time", 196, 196, 255 - help.glow, true);
-                dwgfx.bigrprint( 300, 94, tempstring, 196, 196, 255 - help.glow, true, 2);
+                graphics.Print( 240, 124, "Best Time", 196, 196, 255 - help.glow, true);
+                graphics.bigrprint( 300, 94, tempstring, 196, 196, 255 - help.glow, true, 2);
 
                 switch(game.swnbestrank)
                 {
                 case 0:
-                    dwgfx.Print( -1, 40, "Next Trophy at 5 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 40, "Next Trophy at 5 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 1:
-                    dwgfx.Print( -1, 40, "Next Trophy at 10 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 40, "Next Trophy at 10 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 2:
-                    dwgfx.Print( -1, 40, "Next Trophy at 15 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 40, "Next Trophy at 15 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 3:
-                    dwgfx.Print( -1, 40, "Next Trophy at 20 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 40, "Next Trophy at 20 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 4:
-                    dwgfx.Print( -1, 40, "Next Trophy at 30 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 40, "Next Trophy at 30 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 5:
-                    dwgfx.Print( -1, 40, "Next Trophy at 1 minute", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 40, "Next Trophy at 1 minute", 196, 196, 255 - help.glow, true);
                     break;
                 case 6:
-                    dwgfx.Print( -1, 40, "All Trophies collected!", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 40, "All Trophies collected!", 196, 196, 255 - help.glow, true);
                     break;
                 }
             }
             else
             {
-                dwgfx.Print(0, 40, "SUPER GRAVITRON HIGHSCORE", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 40, "SUPER GRAVITRON HIGHSCORE", 196, 196, 255 - help.glow, true);
 
                 tempstring = help.timestring(game.swnrecord);
-                dwgfx.Print( 240, 90, "Best Time", 196, 196, 255 - help.glow, true);
-                dwgfx.bigrprint( 300, 104, tempstring, 196, 196, 255 - help.glow, true, 2);
+                graphics.Print( 240, 90, "Best Time", 196, 196, 255 - help.glow, true);
+                graphics.bigrprint( 300, 104, tempstring, 196, 196, 255 - help.glow, true, 2);
 
                 switch(game.swnbestrank)
                 {
                 case 0:
-                    dwgfx.Print( -1, 174, "Next Trophy at 5 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 174, "Next Trophy at 5 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 1:
-                    dwgfx.Print( -1, 174, "Next Trophy at 10 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 174, "Next Trophy at 10 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 2:
-                    dwgfx.Print( -1, 174, "Next Trophy at 15 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 174, "Next Trophy at 15 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 3:
-                    dwgfx.Print( -1, 174, "Next Trophy at 20 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 174, "Next Trophy at 20 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 4:
-                    dwgfx.Print( -1, 174, "Next Trophy at 30 seconds", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 174, "Next Trophy at 30 seconds", 196, 196, 255 - help.glow, true);
                     break;
                 case 5:
-                    dwgfx.Print( -1, 174, "Next Trophy at 1 minute", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 174, "Next Trophy at 1 minute", 196, 196, 255 - help.glow, true);
                     break;
                 case 6:
-                    dwgfx.Print( -1, 174, "All Trophies collected!", 196, 196, 255 - help.glow, true);
+                    graphics.Print( -1, 174, "All Trophies collected!", 196, 196, 255 - help.glow, true);
                     break;
                 }
             }
         }
         else if (obj.flags[67] == 1 && !map.custommode)
         {
-            dwgfx.Print(30, 220, "MAP", 64,64,64);
-            dwgfx.Print(103-8, 220, "[SHIP]", 196, 196, 255 - help.glow);
-            dwgfx.Print(185-4, 220, "STATS", 64,64,64);
-            dwgfx.Print(258, 220, "SAVE", 64, 64, 64);
+            graphics.Print(30, 220, "MAP", 64,64,64);
+            graphics.Print(103-8, 220, "[SHIP]", 196, 196, 255 - help.glow);
+            graphics.Print(185-4, 220, "STATS", 64,64,64);
+            graphics.Print(258, 220, "SAVE", 64, 64, 64);
 
-            dwgfx.Print(0, 105, "Press ACTION to warp to the ship.", 196, 196, 255 - help.glow, true);
+            graphics.Print(0, 105, "Press ACTION to warp to the ship.", 196, 196, 255 - help.glow, true);
         }
     #if !defined(NO_CUSTOM_LEVELS)
         else if(map.custommode){
-          dwgfx.Print(30, 220, "MAP", 64,64,64);
-            dwgfx.Print(103-8, 220, "[CREW]", 196, 196, 255 - help.glow);
-            dwgfx.Print(185-4, 220, "STATS", 64,64,64);
-            dwgfx.Print(258, 220, "SAVE", 64, 64, 64);
+          graphics.Print(30, 220, "MAP", 64,64,64);
+            graphics.Print(103-8, 220, "[CREW]", 196, 196, 255 - help.glow);
+            graphics.Print(185-4, 220, "STATS", 64,64,64);
+            graphics.Print(258, 220, "SAVE", 64, 64, 64);
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-              dwgfx.bigprint( -1, 220-45, ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 220-70, "by " + ed.ListOfMetaData[game.playcustomlevel].creator, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 220-80, ed.ListOfMetaData[game.playcustomlevel].website, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 220-100, ed.ListOfMetaData[game.playcustomlevel].Desc1, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 220-110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 220-120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
+              graphics.bigprint( -1, 220-45, ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 220-70, "by " + ed.ListOfMetaData[game.playcustomlevel].creator, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 220-80, ed.ListOfMetaData[game.playcustomlevel].website, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 220-100, ed.ListOfMetaData[game.playcustomlevel].Desc1, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 220-110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 220-120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
 
               if(map.customcrewmates-game.crewmates==1){
-                dwgfx.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmate remains", 196, 196, 255 - help.glow, true);
+                graphics.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmate remains", 196, 196, 255 - help.glow, true);
               }else if(map.customcrewmates-game.crewmates>0){
-                dwgfx.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmates remain", 196, 196, 255 - help.glow, true);
+                graphics.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmates remain", 196, 196, 255 - help.glow, true);
               }
             }
             else
             {
-              dwgfx.bigprint( -1, 45, ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 70, "by " + ed.ListOfMetaData[game.playcustomlevel].creator, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 80, ed.ListOfMetaData[game.playcustomlevel].website, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 100, ed.ListOfMetaData[game.playcustomlevel].Desc1, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
-              dwgfx.Print( -1, 120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
+              graphics.bigprint( -1, 45, ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 70, "by " + ed.ListOfMetaData[game.playcustomlevel].creator, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 80, ed.ListOfMetaData[game.playcustomlevel].website, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 100, ed.ListOfMetaData[game.playcustomlevel].Desc1, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
+              graphics.Print( -1, 120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
 
               if(map.customcrewmates-game.crewmates==1){
-                dwgfx.Print(1,165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmate remains", 196, 196, 255 - help.glow, true);
+                graphics.Print(1,165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmate remains", 196, 196, 255 - help.glow, true);
               }else if(map.customcrewmates-game.crewmates>0){
-                dwgfx.Print(1,165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmates remain", 196, 196, 255 - help.glow, true);
+                graphics.Print(1,165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmates remain", 196, 196, 255 - help.glow, true);
               }
             }
         }
     #endif
         else
         {
-            dwgfx.Print(30, 220, "MAP", 64,64,64);
-            dwgfx.Print(103-8, 220, "[CREW]", 196, 196, 255 - help.glow);
-            dwgfx.Print(185-4, 220, "STATS", 64,64,64);
-            dwgfx.Print(258, 220, "SAVE", 64, 64, 64);
+            graphics.Print(30, 220, "MAP", 64,64,64);
+            graphics.Print(103-8, 220, "[CREW]", 196, 196, 255 - help.glow);
+            graphics.Print(185-4, 220, "STATS", 64,64,64);
+            graphics.Print(258, 220, "SAVE", 64, 64, 64);
 
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
                 for (int i = 0; i < 3; i++)
                 {
-                    dwgfx.drawcrewman(16, 32 + (i * 64), 2-i, game.crewstats[2-i]);
+                    graphics.drawcrewman(16, 32 + (i * 64), 2-i, game.crewstats[2-i]);
                     if (game.crewstats[(2-i)])
                     {
-                        dwgfx.printcrewname(44, 32 + (i * 64)+4+10, 2-i);
-                        dwgfx.printcrewnamestatus(44, 32 + (i * 64)+4, 2-i);
+                        graphics.printcrewname(44, 32 + (i * 64)+4+10, 2-i);
+                        graphics.printcrewnamestatus(44, 32 + (i * 64)+4, 2-i);
                     }
                     else
                     {
-                        dwgfx.printcrewnamedark(44, 32 + (i * 64)+4+10, 2-i);
-                        dwgfx.Print(44, 32 + (i * 64) + 4, "Missing...", 64,64,64);
+                        graphics.printcrewnamedark(44, 32 + (i * 64)+4+10, 2-i);
+                        graphics.Print(44, 32 + (i * 64) + 4, "Missing...", 64,64,64);
                     }
 
-                    dwgfx.drawcrewman(16+160, 32 + (i * 64), (2-i)+3, game.crewstats[(2-i)+3]);
+                    graphics.drawcrewman(16+160, 32 + (i * 64), (2-i)+3, game.crewstats[(2-i)+3]);
                     if (game.crewstats[(2-i)+3])
                     {
-                        dwgfx.printcrewname(44+160, 32 + (i * 64)+4+10, (2-i)+3);
-                        dwgfx.printcrewnamestatus(44+160, 32 + (i * 64)+4, (2-i)+3);
+                        graphics.printcrewname(44+160, 32 + (i * 64)+4+10, (2-i)+3);
+                        graphics.printcrewnamestatus(44+160, 32 + (i * 64)+4, (2-i)+3);
                     }
                     else
                     {
-                        dwgfx.printcrewnamedark(44+160, 32 + (i * 64)+4+10, (2-i)+3);
-                        dwgfx.Print(44+160, 32 + (i * 64) + 4, "Missing...", 64,64,64);
+                        graphics.printcrewnamedark(44+160, 32 + (i * 64)+4+10, (2-i)+3);
+                        graphics.Print(44+160, 32 + (i * 64) + 4, "Missing...", 64,64,64);
                     }
                 }
             }
@@ -2343,334 +2343,334 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
             {
                 for (int i = 0; i < 3; i++)
                 {
-                    dwgfx.drawcrewman(16, 32 + (i * 64), i, game.crewstats[i]);
+                    graphics.drawcrewman(16, 32 + (i * 64), i, game.crewstats[i]);
                     if (game.crewstats[i])
                     {
-                        dwgfx.printcrewname(44, 32 + (i * 64)+4, i);
-                        dwgfx.printcrewnamestatus(44, 32 + (i * 64)+4+10, i);
+                        graphics.printcrewname(44, 32 + (i * 64)+4, i);
+                        graphics.printcrewnamestatus(44, 32 + (i * 64)+4+10, i);
                     }
                     else
                     {
-                        dwgfx.printcrewnamedark(44, 32 + (i * 64)+4, i);
-                        dwgfx.Print(44, 32 + (i * 64) + 4 + 10, "Missing...", 64,64,64);
+                        graphics.printcrewnamedark(44, 32 + (i * 64)+4, i);
+                        graphics.Print(44, 32 + (i * 64) + 4 + 10, "Missing...", 64,64,64);
                     }
 
-                    dwgfx.drawcrewman(16+160, 32 + (i * 64), i+3, game.crewstats[i+3]);
+                    graphics.drawcrewman(16+160, 32 + (i * 64), i+3, game.crewstats[i+3]);
                     if (game.crewstats[i+3])
                     {
-                        dwgfx.printcrewname(44+160, 32 + (i * 64)+4, i+3);
-                        dwgfx.printcrewnamestatus(44+160, 32 + (i * 64)+4+10, i+3);
+                        graphics.printcrewname(44+160, 32 + (i * 64)+4, i+3);
+                        graphics.printcrewnamestatus(44+160, 32 + (i * 64)+4+10, i+3);
                     }
                     else
                     {
-                        dwgfx.printcrewnamedark(44+160, 32 + (i * 64)+4, i+3);
-                        dwgfx.Print(44+160, 32 + (i * 64) + 4 + 10, "Missing...", 64,64,64);
+                        graphics.printcrewnamedark(44+160, 32 + (i * 64)+4, i+3);
+                        graphics.Print(44+160, 32 + (i * 64) + 4 + 10, "Missing...", 64,64,64);
                     }
                 }
             }
         }
         break;
     case 2:
-        dwgfx.Print(30, 220, "MAP", 64,64,64);
+        graphics.Print(30, 220, "MAP", 64,64,64);
         if (game.insecretlab)
         {
-            dwgfx.Print(103, 220, "GRAV", 64, 64, 64);
+            graphics.Print(103, 220, "GRAV", 64, 64, 64);
         }
         else if (obj.flags[67] == 1 && !map.custommode)
         {
-            dwgfx.Print(103, 220, "SHIP", 64,64,64);
+            graphics.Print(103, 220, "SHIP", 64,64,64);
         }
         else
         {
-            dwgfx.Print(103, 220, "CREW", 64,64,64);
+            graphics.Print(103, 220, "CREW", 64,64,64);
         }
-        dwgfx.Print(185-12, 220, "[STATS]", 196, 196, 255 - help.glow);
-        dwgfx.Print(258, 220, "SAVE", 64, 64, 64);
+        graphics.Print(185-12, 220, "[STATS]", 196, 196, 255 - help.glow);
+        graphics.Print(258, 220, "SAVE", 64, 64, 64);
 
         if(map.custommode){
-          if (dwgfx.flipmode)
+          if (graphics.flipmode)
           {
-              dwgfx.Print(0, 164, "[Trinkets found]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 152, help.number(game.trinkets) + " out of " + help.number(map.customtrinkets), 96,96,96, true);
+              graphics.Print(0, 164, "[Trinkets found]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 152, help.number(game.trinkets) + " out of " + help.number(map.customtrinkets), 96,96,96, true);
 
-              dwgfx.Print(0, 114, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 102,help.String(game.deathcounts),  96,96,96, true);
+              graphics.Print(0, 114, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 102,help.String(game.deathcounts),  96,96,96, true);
 
-              dwgfx.Print(0, 64, "[Time Taken]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 52, game.timestring(),  96, 96, 96, true);
+              graphics.Print(0, 64, "[Time Taken]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 52, game.timestring(),  96, 96, 96, true);
           }
           else
           {
-              dwgfx.Print(0, 52, "[Trinkets found]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 64, help.number(game.trinkets) + " out of "+help.number(map.customtrinkets), 96,96,96, true);
+              graphics.Print(0, 52, "[Trinkets found]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 64, help.number(game.trinkets) + " out of "+help.number(map.customtrinkets), 96,96,96, true);
 
-              dwgfx.Print(0, 102, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 114,help.String(game.deathcounts),  96,96,96, true);
+              graphics.Print(0, 102, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 114,help.String(game.deathcounts),  96,96,96, true);
 
-              dwgfx.Print(0, 152, "[Time Taken]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 164, game.timestring(),  96, 96, 96, true);
+              graphics.Print(0, 152, "[Time Taken]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 164, game.timestring(),  96, 96, 96, true);
           }
         }else{
-          if (dwgfx.flipmode)
+          if (graphics.flipmode)
           {
-              dwgfx.Print(0, 164, "[Trinkets found]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 152, help.number(game.trinkets) + " out of Twenty", 96,96,96, true);
+              graphics.Print(0, 164, "[Trinkets found]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 152, help.number(game.trinkets) + " out of Twenty", 96,96,96, true);
 
-              dwgfx.Print(0, 114, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 102,help.String(game.deathcounts),  96,96,96, true);
+              graphics.Print(0, 114, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 102,help.String(game.deathcounts),  96,96,96, true);
 
-              dwgfx.Print(0, 64, "[Time Taken]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 52, game.timestring(),  96, 96, 96, true);
+              graphics.Print(0, 64, "[Time Taken]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 52, game.timestring(),  96, 96, 96, true);
           }
           else
           {
-              dwgfx.Print(0, 52, "[Trinkets found]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 64, help.number(game.trinkets) + " out of Twenty", 96,96,96, true);
+              graphics.Print(0, 52, "[Trinkets found]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 64, help.number(game.trinkets) + " out of Twenty", 96,96,96, true);
 
-              dwgfx.Print(0, 102, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 114,help.String(game.deathcounts),  96,96,96, true);
+              graphics.Print(0, 102, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 114,help.String(game.deathcounts),  96,96,96, true);
 
-              dwgfx.Print(0, 152, "[Time Taken]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 164, game.timestring(),  96, 96, 96, true);
+              graphics.Print(0, 152, "[Time Taken]", 196, 196, 255 - help.glow, true);
+              graphics.Print(0, 164, game.timestring(),  96, 96, 96, true);
           }
         }
         break;
     case 3:
-        dwgfx.Print(30, 220, "MAP", 64,64,64);
+        graphics.Print(30, 220, "MAP", 64,64,64);
         if (game.insecretlab)
         {
-            dwgfx.Print(103, 220, "GRAV", 64, 64, 64);
+            graphics.Print(103, 220, "GRAV", 64, 64, 64);
         }
         else if (obj.flags[67] == 1 && !map.custommode)
         {
-            dwgfx.Print(103, 220, "SHIP", 64,64,64);
+            graphics.Print(103, 220, "SHIP", 64,64,64);
         }
         else
         {
-            dwgfx.Print(103, 220, "CREW", 64,64,64);
+            graphics.Print(103, 220, "CREW", 64,64,64);
         }
-        dwgfx.Print(185-4, 220, "STATS", 64,64,64);
-        dwgfx.Print(258 - 8, 220, "[SAVE]", 196, 196, 255 - help.glow);
+        graphics.Print(185-4, 220, "STATS", 64,64,64);
+        graphics.Print(258 - 8, 220, "[SAVE]", 196, 196, 255 - help.glow);
 
         if (game.inintermission)
         {
-            dwgfx.Print(0, 115, "Cannot Save in Level Replay", 146, 146, 180, true);
+            graphics.Print(0, 115, "Cannot Save in Level Replay", 146, 146, 180, true);
         }
         else if (game.nodeathmode)
         {
-            dwgfx.Print(0, 115, "Cannot Save in No Death Mode", 146, 146, 180, true);
+            graphics.Print(0, 115, "Cannot Save in No Death Mode", 146, 146, 180, true);
         }
         else if (game.intimetrial)
         {
-            dwgfx.Print(0, 115, "Cannot Save in Time Trial", 146, 146, 180, true);
+            graphics.Print(0, 115, "Cannot Save in Time Trial", 146, 146, 180, true);
         }
         else if (game.insecretlab)
         {
-            dwgfx.Print(0, 115, "Cannot Save in Secret Lab", 146, 146, 180, true);
+            graphics.Print(0, 115, "Cannot Save in Secret Lab", 146, 146, 180, true);
         }
         else if (map.custommode)
         {
           if (game.gamesaved)
             {
-                dwgfx.Print(0, 36, "Game saved ok!", 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2), true);
+                graphics.Print(0, 36, "Game saved ok!", 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2), true);
 
-                dwgfx.drawpixeltextbox(25, 65, 270, 90, 34,12, 65, 185, 207,0,4);
+                graphics.drawpixeltextbox(25, 65, 270, 90, 34,12, 65, 185, 207,0,4);
 
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.Print(0, 122, game.customleveltitle, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
-                    dwgfx.Print(160 - 84, 78, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-                    dwgfx.Print(160 + 40, 78, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(0, 122, game.customleveltitle, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
+                    graphics.Print(160 - 84, 78, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(160 + 40, 78, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    dwgfx.drawspritesetcol(50, 74, 50, 18);
-                    dwgfx.drawspritesetcol(175, 74, 22, 18);
+                    graphics.drawspritesetcol(50, 74, 50, 18);
+                    graphics.drawspritesetcol(175, 74, 22, 18);
                 }
                 else
                 {
-                    dwgfx.Print(0, 90, game.customleveltitle, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
-                    dwgfx.Print(160 - 84, 132, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-                    dwgfx.Print(160 + 40, 132, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(0, 90, game.customleveltitle, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
+                    graphics.Print(160 - 84, 132, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(160 + 40, 132, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    dwgfx.drawspritesetcol(50, 126, 50, 18);
-                    dwgfx.drawspritesetcol(175, 126, 22, 18);
+                    graphics.drawspritesetcol(50, 126, 50, 18);
+                    graphics.drawspritesetcol(175, 126, 22, 18);
                 }
             }
             else
             {
-                dwgfx.Print(0, 80, "[Press ACTION to save your game]", 255 - (help.glow * 2), 255 - (help.glow * 2), 255 - help.glow, true);
+                graphics.Print(0, 80, "[Press ACTION to save your game]", 255 - (help.glow * 2), 255 - (help.glow * 2), 255 - help.glow, true);
             }
         }
         else
         {
-            if (dwgfx.flipmode)
+            if (graphics.flipmode)
             {
-                dwgfx.Print(0, 186, "(Note: The game is autosaved", 146, 146, 180, true);
-                dwgfx.Print(0, 174, "at every teleporter.)", 146, 146, 180, true);
+                graphics.Print(0, 186, "(Note: The game is autosaved", 146, 146, 180, true);
+                graphics.Print(0, 174, "at every teleporter.)", 146, 146, 180, true);
             }
             else
             {
-                dwgfx.Print(0, 174, "(Note: The game is autosaved", 146, 146, 180, true);
-                dwgfx.Print(0, 186, "at every teleporter.)", 146, 146, 180, true);
+                graphics.Print(0, 174, "(Note: The game is autosaved", 146, 146, 180, true);
+                graphics.Print(0, 186, "at every teleporter.)", 146, 146, 180, true);
             }
 
             if (game.gamesaved)
             {
-                dwgfx.Print(0, 36, "Game saved ok!", 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2), true);
+                graphics.Print(0, 36, "Game saved ok!", 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2), true);
 
-                dwgfx.drawpixeltextbox(25, 65, 270, 90, 34,12, 65, 185, 207,0,4);
+                graphics.drawpixeltextbox(25, 65, 270, 90, 34,12, 65, 185, 207,0,4);
 
-                if (dwgfx.flipmode)
+                if (graphics.flipmode)
                 {
-                    dwgfx.Print(0, 132, game.savearea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
+                    graphics.Print(0, 132, game.savearea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
                     for (int i = 0; i < 6; i++)
                     {
-                        dwgfx.drawcrewman(169-(3*42)+(i*42), 98, i, game.crewstats[i], true);
+                        graphics.drawcrewman(169-(3*42)+(i*42), 98, i, game.crewstats[i], true);
                     }
-                    dwgfx.Print(160 - 84, 78, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-                    dwgfx.Print(160 + 40, 78, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(160 - 84, 78, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(160 + 40, 78, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    dwgfx.drawspritesetcol(50, 74, 50, 18);
-                    dwgfx.drawspritesetcol(175, 74, 22, 18);
+                    graphics.drawspritesetcol(50, 74, 50, 18);
+                    graphics.drawspritesetcol(175, 74, 22, 18);
                 }
                 else
                 {
-                    dwgfx.Print(0, 80, game.savearea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
+                    graphics.Print(0, 80, game.savearea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
                     for (int i = 0; i < 6; i++)
                     {
-                        dwgfx.drawcrewman(169-(3*42)+(i*42), 95, i, game.crewstats[i], true);
+                        graphics.drawcrewman(169-(3*42)+(i*42), 95, i, game.crewstats[i], true);
                     }
-                    dwgfx.Print(160 - 84, 132, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-                    dwgfx.Print(160 + 40, 132, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(160 - 84, 132, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(160 + 40, 132, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    dwgfx.drawspritesetcol(50, 126, 50, 18);
-                    dwgfx.drawspritesetcol(175, 126, 22, 18);
+                    graphics.drawspritesetcol(50, 126, 50, 18);
+                    graphics.drawspritesetcol(175, 126, 22, 18);
                 }
             }
             else
             {
-                dwgfx.Print(0, 80, "[Press ACTION to save your game]", 255 - (help.glow * 2), 255 - (help.glow * 2), 255 - help.glow, true);
+                graphics.Print(0, 80, "[Press ACTION to save your game]", 255 - (help.glow * 2), 255 - (help.glow * 2), 255 - help.glow, true);
 
                 if (game.quicksummary != "")
                 {
-                    if (dwgfx.flipmode)
+                    if (graphics.flipmode)
                     {
-                        dwgfx.Print(0, 110, "Last Save:", 164 - (help.glow / 4), 164 - (help.glow / 4), 164, true);
-                        dwgfx.Print(0, 100, game.quicksummary, 164  - (help.glow / 4), 164 - (help.glow / 4), 164, true);
+                        graphics.Print(0, 110, "Last Save:", 164 - (help.glow / 4), 164 - (help.glow / 4), 164, true);
+                        graphics.Print(0, 100, game.quicksummary, 164  - (help.glow / 4), 164 - (help.glow / 4), 164, true);
                     }
                     else
                     {
-                        dwgfx.Print(0, 100, "Last Save:", 164 - (help.glow / 4), 164 - (help.glow / 4), 164, true);
-                        dwgfx.Print(0, 110, game.quicksummary, 164  - (help.glow / 4), 164 - (help.glow / 4), 164, true);
+                        graphics.Print(0, 100, "Last Save:", 164 - (help.glow / 4), 164 - (help.glow / 4), 164, true);
+                        graphics.Print(0, 110, game.quicksummary, 164  - (help.glow / 4), 164 - (help.glow / 4), 164, true);
                     }
                 }
             }
         }
         break;
     case 10:
-        dwgfx.Print(128, 220, "[ QUIT ]", 196, 196, 255 - help.glow);
+        graphics.Print(128, 220, "[ QUIT ]", 196, 196, 255 - help.glow);
 
-        if (dwgfx.flipmode)
+        if (graphics.flipmode)
         {
             if (game.intimetrial || game.insecretlab || game.nodeathmode || game.menukludge)
             {
-                dwgfx.Print(0, 135, "Return to main menu?", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 135, "Return to main menu?", 196, 196, 255 - help.glow, true);
             }
             else
             {
-                dwgfx.Print(0, 142, "Do you want to quit? You will", 196, 196, 255 - help.glow, true);
-                dwgfx.Print(0, 130, "lose any unsaved progress.", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 142, "Do you want to quit? You will", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 130, "lose any unsaved progress.", 196, 196, 255 - help.glow, true);
             }
 
-            dwgfx.Print(80-16, 88, "[ NO, KEEP PLAYING ]", 196, 196, 255 - help.glow);
-            dwgfx.Print(80 + 32, 76, "yes, quit to menu",  96, 96, 96);
+            graphics.Print(80-16, 88, "[ NO, KEEP PLAYING ]", 196, 196, 255 - help.glow);
+            graphics.Print(80 + 32, 76, "yes, quit to menu",  96, 96, 96);
         }
         else
         {
 
             if (game.intimetrial || game.insecretlab || game.nodeathmode || game.menukludge)
             {
-                dwgfx.Print(0, 80, "Return to main menu?", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 80, "Return to main menu?", 196, 196, 255 - help.glow, true);
             }
             else
             {
-                dwgfx.Print(0, 76, "Do you want to quit? You will", 196, 196, 255 - help.glow, true);
-                dwgfx.Print(0, 88, "lose any unsaved progress.", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 76, "Do you want to quit? You will", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 88, "lose any unsaved progress.", 196, 196, 255 - help.glow, true);
             }
 
-            dwgfx.Print(80-16, 130, "[ NO, KEEP PLAYING ]", 196, 196, 255 - help.glow);
-            dwgfx.Print(80 + 32, 142, "yes, quit to menu",  96, 96, 96);
+            graphics.Print(80-16, 130, "[ NO, KEEP PLAYING ]", 196, 196, 255 - help.glow);
+            graphics.Print(80 + 32, 142, "yes, quit to menu",  96, 96, 96);
 
         }
         break;
     case 11:
-        dwgfx.Print(128, 220, "[ QUIT ]", 196, 196, 255 - help.glow);
+        graphics.Print(128, 220, "[ QUIT ]", 196, 196, 255 - help.glow);
 
-        if (dwgfx.flipmode)
+        if (graphics.flipmode)
         {
             if (game.intimetrial || game.insecretlab || game.nodeathmode || game.menukludge)
             {
-                dwgfx.Print(0, 135, "Return to main menu?", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 135, "Return to main menu?", 196, 196, 255 - help.glow, true);
             }
             else
             {
-                dwgfx.Print(0, 142, "Do you want to quit? You will", 196, 196, 255 - help.glow, true);
-                dwgfx.Print(0, 130, "lose any unsaved progress.", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 142, "Do you want to quit? You will", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 130, "lose any unsaved progress.", 196, 196, 255 - help.glow, true);
             }
 
-            dwgfx.Print(80, 88, "no, keep playing", 96,96,96);
-            dwgfx.Print(80+32-16, 76, "[ YES, QUIT TO MENU ]",  196, 196, 255 - help.glow);
+            graphics.Print(80, 88, "no, keep playing", 96,96,96);
+            graphics.Print(80+32-16, 76, "[ YES, QUIT TO MENU ]",  196, 196, 255 - help.glow);
         }
         else
         {
             if (game.intimetrial || game.insecretlab || game.nodeathmode || game.menukludge)
             {
-                dwgfx.Print(0, 80, "Return to main menu?", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 80, "Return to main menu?", 196, 196, 255 - help.glow, true);
             }
             else
             {
-                dwgfx.Print(0, 76, "Do you want to quit? You will", 196, 196, 255 - help.glow, true);
-                dwgfx.Print(0, 88, "lose any unsaved progress.", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 76, "Do you want to quit? You will", 196, 196, 255 - help.glow, true);
+                graphics.Print(0, 88, "lose any unsaved progress.", 196, 196, 255 - help.glow, true);
             }
 
-            dwgfx.Print(80, 130, "no, keep playing", 96,96,96);
-            dwgfx.Print(80+32-16, 142, "[ YES, QUIT TO MENU ]", 196, 196, 255 - help.glow);
+            graphics.Print(80, 130, "no, keep playing", 96,96,96);
+            graphics.Print(80+32-16, 142, "[ YES, QUIT TO MENU ]", 196, 196, 255 - help.glow);
         }
         break;
     case 20:
-        dwgfx.Print(128, 220, "[ GRAVITRON ]", 196, 196, 255 - help.glow, true);
+        graphics.Print(128, 220, "[ GRAVITRON ]", 196, 196, 255 - help.glow, true);
 
-        if (dwgfx.flipmode)
+        if (graphics.flipmode)
         {
-            dwgfx.Print(0, 76, "the secret laboratory?", 196, 196, 255 - help.glow, true);
-            dwgfx.Print(0, 88, "Do you want to return to", 196, 196, 255 - help.glow, true);
-            dwgfx.Print(80-16, 142, "[ NO, KEEP PLAYING ]", 196, 196, 255 - help.glow);
-            dwgfx.Print(80 + 32, 130, "yes, return",  96, 96, 96);
+            graphics.Print(0, 76, "the secret laboratory?", 196, 196, 255 - help.glow, true);
+            graphics.Print(0, 88, "Do you want to return to", 196, 196, 255 - help.glow, true);
+            graphics.Print(80-16, 142, "[ NO, KEEP PLAYING ]", 196, 196, 255 - help.glow);
+            graphics.Print(80 + 32, 130, "yes, return",  96, 96, 96);
         }
         else
         {
-            dwgfx.Print(0, 76, "Do you want to return to", 196, 196, 255 - help.glow, true);
-            dwgfx.Print(0, 88, "the secret laboratory?", 196, 196, 255 - help.glow, true);
-            dwgfx.Print(80-16, 130, "[ NO, KEEP PLAYING ]", 196, 196, 255 - help.glow);
-            dwgfx.Print(80 + 32, 142, "yes, return",  96, 96, 96);
+            graphics.Print(0, 76, "Do you want to return to", 196, 196, 255 - help.glow, true);
+            graphics.Print(0, 88, "the secret laboratory?", 196, 196, 255 - help.glow, true);
+            graphics.Print(80-16, 130, "[ NO, KEEP PLAYING ]", 196, 196, 255 - help.glow);
+            graphics.Print(80 + 32, 142, "yes, return",  96, 96, 96);
         }
 
         break;
     case 21:
-        dwgfx.Print(128, 220, "[ GRAVITRON ]", 196, 196, 255 - help.glow, true);
+        graphics.Print(128, 220, "[ GRAVITRON ]", 196, 196, 255 - help.glow, true);
 
-        if (dwgfx.flipmode)
+        if (graphics.flipmode)
         {
-            dwgfx.Print(0, 76, "the secret laboratory?", 196, 196, 255 - help.glow, true);
-            dwgfx.Print(0, 88, "Do you want to return to", 196, 196, 255 - help.glow, true);
-            dwgfx.Print(80, 142, "no, keep playing", 96, 96, 96);
-            dwgfx.Print(80 + 32-16, 130, "[ YES, RETURN ]",  196, 196, 255 - help.glow);
+            graphics.Print(0, 76, "the secret laboratory?", 196, 196, 255 - help.glow, true);
+            graphics.Print(0, 88, "Do you want to return to", 196, 196, 255 - help.glow, true);
+            graphics.Print(80, 142, "no, keep playing", 96, 96, 96);
+            graphics.Print(80 + 32-16, 130, "[ YES, RETURN ]",  196, 196, 255 - help.glow);
         }
         else
         {
-            dwgfx.Print(0, 76, "Do you want to return to", 196, 196, 255 - help.glow, true);
-            dwgfx.Print(0, 88, "the secret laboratory?", 196, 196, 255 - help.glow, true);
-            dwgfx.Print(80, 130, "no, keep playing", 96, 96, 96);
-            dwgfx.Print(80 + 32-16, 142, "[ YES, RETURN ]",  196, 196, 255 - help.glow);
+            graphics.Print(0, 76, "Do you want to return to", 196, 196, 255 - help.glow, true);
+            graphics.Print(0, 88, "the secret laboratory?", 196, 196, 255 - help.glow, true);
+            graphics.Print(80, 130, "no, keep playing", 96, 96, 96);
+            graphics.Print(80 + 32-16, 142, "[ YES, RETURN ]",  196, 196, 255 - help.glow);
         }
 
     }
@@ -2678,27 +2678,27 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
 
 
 
-    dwgfx.drawfade();
+    graphics.drawfade();
 
     if (game.test)
     {
-        dwgfx.Print(5, 5, game.teststring, 196, 196, 255, false);
+        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
     }
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
-        dwgfx.flashlight();
+        graphics.flashlight();
     }
 
-    if (dwgfx.resumegamemode)
+    if (graphics.resumegamemode)
     {
-        dwgfx.menuoffset += 25;
+        graphics.menuoffset += 25;
         if (map.extrarow)
         {
-            if (dwgfx.menuoffset >= 230)
+            if (graphics.menuoffset >= 230)
             {
-                dwgfx.menuoffset = 230;
+                graphics.menuoffset = 230;
                 //go back to gamemode!
                 game.mapheld = true;
                 game.gamestate = GAMEMODE;
@@ -2706,51 +2706,51 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
         }
         else
         {
-            if (dwgfx.menuoffset >= 240)
+            if (graphics.menuoffset >= 240)
             {
-                dwgfx.menuoffset = 240;
+                graphics.menuoffset = 240;
                 //go back to gamemode!
                 game.mapheld = true;
                 game.gamestate = GAMEMODE;
             }
         }
-        dwgfx.menuoffrender();
+        graphics.menuoffrender();
     }
-    else if (dwgfx.menuoffset > 0)
+    else if (graphics.menuoffset > 0)
     {
-        dwgfx.menuoffset -= 25;
-        if (dwgfx.menuoffset < 0) dwgfx.menuoffset = 0;
-        dwgfx.menuoffrender();
+        graphics.menuoffset -= 25;
+        if (graphics.menuoffset < 0) graphics.menuoffset = 0;
+        graphics.menuoffrender();
     }
     else
     {
         if (game.screenshake > 0 && !game.noflashingmode)
         {
             game.screenshake--;
-            dwgfx.screenshake();
+            graphics.screenshake();
         }
         else
         {
-            dwgfx.render();
+            graphics.render();
         }
     }
 
-    //dwgfx.backbuffer.unlock();
+    //graphics.backbuffer.unlock();
 }
 
-void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help)
+void towerrender()
 {
 
-    FillRect(dwgfx.backBuffer, 0x000000);
+    FillRect(graphics.backBuffer, 0x000000);
 
     if (!game.colourblindmode)
     {
-        dwgfx.drawtowerbackground();
-        dwgfx.drawtowermap();
+        graphics.drawtowerbackground();
+        graphics.drawtowermap();
     }
     else
     {
-        dwgfx.drawtowermap_nobackground();
+        graphics.drawtowermap_nobackground();
     }
 
     if(!game.completestop)
@@ -2781,45 +2781,45 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
         }
     }
 
-    dwgfx.drawtowerentities();
+    graphics.drawtowerentities();
 
-    dwgfx.drawtowerspikes();
+    graphics.drawtowerspikes();
 
 
     /*for(int i=0; i<obj.nblocks; i++){
     if (obj.blocks[i].active) {
-    		dwgfx.backbuffer.fillRect(obj.blocks[i].rect, 0xDDDDDD);
+    		graphics.backbuffer.fillRect(obj.blocks[i].rect, 0xDDDDDD);
     }
       }*/
-    dwgfx.cutscenebars();
-    BlitSurfaceStandard(dwgfx.backBuffer, NULL, dwgfx.tempBuffer, NULL);
+    graphics.cutscenebars();
+    BlitSurfaceStandard(graphics.backBuffer, NULL, graphics.tempBuffer, NULL);
 
-    dwgfx.drawgui();
-    if (dwgfx.flipmode)
+    graphics.drawgui();
+    if (graphics.flipmode)
     {
-        if (game.advancetext) dwgfx.bprint(5, 228, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+        if (game.advancetext) graphics.bprint(5, 228, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
     else
     {
-        if (game.advancetext) dwgfx.bprint(5, 5, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+        if (game.advancetext) graphics.bprint(5, 5, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
 
 
-    dwgfx.footerrect.y = 230;
-    if (dwgfx.translucentroomname)
+    graphics.footerrect.y = 230;
+    if (graphics.translucentroomname)
     {
-        SDL_BlitSurface(dwgfx.footerbuffer, NULL, dwgfx.backBuffer, &dwgfx.footerrect);
+        SDL_BlitSurface(graphics.footerbuffer, NULL, graphics.backBuffer, &graphics.footerrect);
     }
     else
     {
-        FillRect(dwgfx.backBuffer, dwgfx.footerrect, 0);
+        FillRect(graphics.backBuffer, graphics.footerrect, 0);
     }
-    dwgfx.bprint(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
+    graphics.bprint(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
 
-    //dwgfx.rprint(5, 231,help.String(game.coins), 255 - help.glow/2, 255 - help.glow/2, 196, true);
-    //dwgfx.drawhuetile(311, 230, 48, 1);
+    //graphics.rprint(5, 231,help.String(game.coins), 255 - help.glow/2, 255 - help.glow/2, 196, true);
+    //graphics.drawhuetile(311, 230, 48, 1);
 
-    if (game.intimetrial && dwgfx.fademode==0)
+    if (game.intimetrial && graphics.fademode==0)
     {
         //Draw countdown!
         if (game.timetrialcountdown > 0)
@@ -2827,120 +2827,120 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
             if (game.timetrialcountdown < 30)
             {
                 game.resetgameclock();
-                if (int(game.timetrialcountdown / 4) % 2 == 0) dwgfx.bigprint( -1, 100, "Go!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
+                if (int(game.timetrialcountdown / 4) % 2 == 0) graphics.bigprint( -1, 100, "Go!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
             else if (game.timetrialcountdown < 60)
             {
-                dwgfx.bigprint( -1, 100, "1", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
+                graphics.bigprint( -1, 100, "1", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
             else if (game.timetrialcountdown < 90)
             {
-                dwgfx.bigprint( -1, 100, "2", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
+                graphics.bigprint( -1, 100, "2", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
             else if (game.timetrialcountdown < 120)
             {
-                dwgfx.bigprint( -1, 100, "3", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
+                graphics.bigprint( -1, 100, "3", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
         }
         else
         {
             //Draw OSD stuff
-            dwgfx.bprint(6, 18, "TIME :",  255,255,255);
-            dwgfx.bprint(6, 30, "DEATH:",  255, 255, 255);
-            dwgfx.bprint(6, 42, "SHINY:",  255,255,255);
+            graphics.bprint(6, 18, "TIME :",  255,255,255);
+            graphics.bprint(6, 30, "DEATH:",  255, 255, 255);
+            graphics.bprint(6, 42, "SHINY:",  255,255,255);
 
             if(game.timetrialparlost)
             {
-                dwgfx.bprint(56, 18, game.timestring(),  196, 80, 80);
+                graphics.bprint(56, 18, game.timestring(),  196, 80, 80);
             }
             else
             {
-                dwgfx.bprint(56, 18, game.timestring(),  196, 196, 196);
+                graphics.bprint(56, 18, game.timestring(),  196, 196, 196);
             }
             if(game.deathcounts>0)
             {
-                dwgfx.bprint(56, 30,help.String(game.deathcounts),  196, 80, 80);
+                graphics.bprint(56, 30,help.String(game.deathcounts),  196, 80, 80);
             }
             else
             {
-                dwgfx.bprint(56, 30,help.String(game.deathcounts),  196, 196, 196);
+                graphics.bprint(56, 30,help.String(game.deathcounts),  196, 196, 196);
             }
             if(game.trinkets<game.timetrialshinytarget)
             {
-                dwgfx.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 80, 80);
+                graphics.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 80, 80);
             }
             else
             {
-                dwgfx.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 196, 196);
+                graphics.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 196, 196);
             }
 
             if(game.timetrialparlost)
             {
-                dwgfx.bprint(195, 214, "PAR TIME:",  80, 80, 80);
-                dwgfx.bprint(275, 214, game.partimestring(),  80, 80, 80);
+                graphics.bprint(195, 214, "PAR TIME:",  80, 80, 80);
+                graphics.bprint(275, 214, game.partimestring(),  80, 80, 80);
             }
             else
             {
-                dwgfx.bprint(195, 214, "PAR TIME:",  255, 255, 255);
-                dwgfx.bprint(275, 214, game.partimestring(),  196, 196, 196);
+                graphics.bprint(195, 214, "PAR TIME:",  255, 255, 255);
+                graphics.bprint(275, 214, game.partimestring(),  196, 196, 196);
             }
         }
     }
 
-    dwgfx.drawfade();
+    graphics.drawfade();
 
     if (game.test)
     {
-        dwgfx.Print(5, 5, game.teststring, 196, 196, 255, false);
+        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
     }
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
-        dwgfx.flashlight();
+        graphics.flashlight();
     }
 
     if (game.screenshake > 0 && !game.noflashingmode)
     {
         game.screenshake--;
-        dwgfx.screenshake();
+        graphics.screenshake();
     }
     else
     {
-        dwgfx.render();
+        graphics.render();
     }
 }
 
-void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help)
+void teleporterrender()
 {
-    //dwgfx.backbuffer.lock();
+    //graphics.backbuffer.lock();
     int tempx;
     int tempy;
     //draw screen alliteration
     //Roomname:
     temp = map.area(game.roomx, game.roomy);
-    if (temp < 2 && !map.custommode && dwgfx.fademode==0)
+    if (temp < 2 && !map.custommode && graphics.fademode==0)
     {
         if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111)
         {
-            dwgfx.Print(5, 2, "The Ship", 196, 196, 255 - help.glow, true);
+            graphics.Print(5, 2, "The Ship", 196, 196, 255 - help.glow, true);
         }
         else
         {
-            dwgfx.Print(5, 2, "Dimension VVVVVV", 196, 196, 255 - help.glow, true);
+            graphics.Print(5, 2, "Dimension VVVVVV", 196, 196, 255 - help.glow, true);
         }
     }
     else
     {
-        dwgfx.Print(5, 2, map.roomname, 196, 196, 255 - help.glow, true);
+        graphics.Print(5, 2, map.roomname, 196, 196, 255 - help.glow, true);
     }
 
     //Background color
-    FillRect(dwgfx.backBuffer, 0, 12, 320, 240, 10, 24, 26);
+    FillRect(graphics.backBuffer, 0, 12, 320, 240, 10, 24, 26);
 
     //draw the map image
-    dwgfx.drawpixeltextbox(35, 16, 250, 190, 32,24, 65, 185, 207,4,0);
-    dwgfx.drawimage(1, 40, 21, false);
+    graphics.drawpixeltextbox(35, 16, 250, 190, 32,24, 65, 185, 207,4,0);
+    graphics.drawimage(1, 40, 21, false);
     //black out areas we can't see yet
     for (int j = 0; j < 20; j++)
     {
@@ -2948,8 +2948,8 @@ void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& o
         {
             if(map.explored[i+(j*20)]==0)
             {
-                //dwgfx.drawfillrect(10 + (i * 12), 21 + (j * 9), 12, 9, 16, 16, 16);
-                dwgfx.drawimage(2, 40 + (i * 12), 21 + (j * 9), false);
+                //graphics.drawfillrect(10 + (i * 12), 21 + (j * 9), 12, 9, 16, 16, 16);
+                graphics.drawimage(2, 40 + (i * 12), 21 + (j * 9), false);
             }
         }
     }
@@ -2958,11 +2958,11 @@ void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& o
     if (game.roomx == 109)
     {
         //tower!instead of room y, scale map.ypos
-        dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21  + 2, 12 - 4, 180 - 4, 16, 245 - (help.glow * 2), 245 - (help.glow * 2));
+        graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21  + 2, 12 - 4, 180 - 4, 16, 245 - (help.glow * 2), 245 - (help.glow * 2));
     }
     else
     {
-        dwgfx.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + ((game.roomy - 100) * 9) + 2, 12 - 4, 9 - 4, 16, 245 - (help.glow * 2), 245 - (help.glow * 2));
+        graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + ((game.roomy - 100) * 9) + 2, 12 - 4, 9 - 4, 16, 245 - (help.glow * 2), 245 - (help.glow * 2));
     }
 
     if (game.useteleporter)
@@ -2972,8 +2972,8 @@ void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& o
         //draw the coordinates //destination
         int tempx = map.teleporters[game.teleport_to_teleporter].x;
         int tempy = map.teleporters[game.teleport_to_teleporter].y;
-        dwgfx.drawrect(40 + (tempx * 12) + 1, 21 + (tempy * 9) + 1, 12 - 2, 9 - 2, 245 - (help.glow * 2), 16, 16);
-        dwgfx.drawrect(40 + (tempx * 12) + 3, 21 + (tempy * 9) + 3, 12 - 6, 9 - 6, 245 - (help.glow * 2), 16, 16);
+        graphics.drawrect(40 + (tempx * 12) + 1, 21 + (tempy * 9) + 1, 12 - 2, 9 - 2, 245 - (help.glow * 2), 16, 16);
+        graphics.drawrect(40 + (tempx * 12) + 3, 21 + (tempy * 9) + 3, 12 - 6, 9 - 6, 245 - (help.glow * 2), 16, 16);
     }
 
     //draw legend details
@@ -2982,16 +2982,16 @@ void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& o
         if (map.showteleporters && map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)] > 0)
         {
             temp = 1126 + map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)];
-            if (dwgfx.flipmode) temp += 3;
-            dwgfx.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
+            if (graphics.flipmode) temp += 3;
+            graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
         }
         else if(map.showtargets && map.explored[map.teleporters[i].x+(20*map.teleporters[i].y)]==0)
         {
             temp = 1126 + map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)];
-            if (dwgfx.flipmode) temp += 3;
-            dwgfx.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
+            if (graphics.flipmode) temp += 3;
+            graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
         }
-        //dwgfx.drawtile(40+3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), 1086); //for shiny trinkets, do later
+        //graphics.drawtile(40+3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), 1086); //for shiny trinkets, do later
     }
 
     if (map.showtrinkets)
@@ -3001,8 +3001,8 @@ void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& o
             if (obj.collect[i] == 0)
             {
                 temp = 1086;
-                if (dwgfx.flipmode) temp += 3;
-                dwgfx.drawtile(40 + 3 + (map.shinytrinkets[i].x * 12), 22 + (map.shinytrinkets[i].y * 9),	temp);
+                if (graphics.flipmode) temp += 3;
+                graphics.drawtile(40 + 3 + (map.shinytrinkets[i].x * 12), 22 + (map.shinytrinkets[i].y * 9),	temp);
             }
         }
     }
@@ -3013,51 +3013,51 @@ void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& o
     {
         //colour in the legend
         temp = 1128;
-        if (dwgfx.flipmode) temp += 3;
-        dwgfx.drawtile(40 + 3 + (tempx * 12), 22 + (tempy * 9), temp);
+        if (graphics.flipmode) temp += 3;
+        graphics.drawtile(40 + 3 + (tempx * 12), 22 + (tempy * 9), temp);
     }
 
-    dwgfx.cutscenebars();
+    graphics.cutscenebars();
 
 
     if (game.useteleporter)
     {
         //Instructions!
-        dwgfx.Print(5, 210, "Press Left/Right to choose a Teleporter", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
-        dwgfx.Print(5, 225, "Press ENTER to Teleport", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+        graphics.Print(5, 210, "Press Left/Right to choose a Teleporter", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+        graphics.Print(5, 225, "Press ENTER to Teleport", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
 
-    dwgfx.drawgui();
+    graphics.drawgui();
 
-    if (dwgfx.flipmode)
+    if (graphics.flipmode)
     {
-        if (game.advancetext) dwgfx.bprint(5, 228, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+        if (game.advancetext) graphics.bprint(5, 228, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
     else
     {
-        if (game.advancetext) dwgfx.bprint(5, 5, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
+        if (game.advancetext) graphics.bprint(5, 5, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
 
 
     if (game.test)
     {
-        dwgfx.Print(5, 5, game.teststring, 196, 196, 255, false);
+        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
     }
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
-        dwgfx.flashlight();
+        graphics.flashlight();
     }
 
-    if (dwgfx.resumegamemode)
+    if (graphics.resumegamemode)
     {
-        dwgfx.menuoffset += 25;
+        graphics.menuoffset += 25;
         if (map.extrarow)
         {
-            if (dwgfx.menuoffset >= 230)
+            if (graphics.menuoffset >= 230)
             {
-                dwgfx.menuoffset = 230;
+                graphics.menuoffset = 230;
                 //go back to gamemode!
                 game.mapheld = true;
                 game.gamestate = GAMEMODE;
@@ -3065,34 +3065,34 @@ void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& o
         }
         else
         {
-            if (dwgfx.menuoffset >= 240)
+            if (graphics.menuoffset >= 240)
             {
-                dwgfx.menuoffset = 240;
+                graphics.menuoffset = 240;
                 //go back to gamemode!
                 game.mapheld = true;
                 game.gamestate = GAMEMODE;
             }
         }
-        dwgfx.menuoffrender();
+        graphics.menuoffrender();
     }
-    else if (dwgfx.menuoffset > 0)
+    else if (graphics.menuoffset > 0)
     {
-        dwgfx.menuoffset -= 25;
-        if (dwgfx.menuoffset < 0) dwgfx.menuoffset = 0;
-        dwgfx.menuoffrender();
+        graphics.menuoffset -= 25;
+        if (graphics.menuoffset < 0) graphics.menuoffset = 0;
+        graphics.menuoffrender();
     }
     else
     {
         if (game.screenshake > 0 && !game.noflashingmode)
         {
             game.screenshake--;
-            dwgfx.screenshake();
+            graphics.screenshake();
         }
         else
         {
-            dwgfx.render();
+            graphics.render();
         }
     }
 
-    //dwgfx.backbuffer.unlock();
+    //graphics.backbuffer.unlock();
 }

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -426,9 +426,9 @@ void titlerender()
                                 game.currentmenuoption == 2 ||
                                 game.currentmenuoption == 3     )
 			{
-				graphics.Print( -1, 85, "Flip is bound to: " + std::string(UtilityClass::GCString(game.controllerButton_flip)) , tr, tg, tb, true);
-				graphics.Print( -1, 95, "Enter is bound to: "  + std::string(UtilityClass::GCString(game.controllerButton_map)), tr, tg, tb, true);
-				graphics.Print( -1, 105, "Menu is bound to: " + std::string(UtilityClass::GCString(game.controllerButton_esc)) , tr, tg, tb, true);
+				graphics.Print( -1, 85, "Flip is bound to: " + std::string(help.GCString(game.controllerButton_flip)) , tr, tg, tb, true);
+				graphics.Print( -1, 95, "Enter is bound to: "  + std::string(help.GCString(game.controllerButton_map)), tr, tg, tb, true);
+				graphics.Print( -1, 105, "Menu is bound to: " + std::string(help.GCString(game.controllerButton_esc)) , tr, tg, tb, true);
 			}
 
 

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -61,7 +61,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
     }
     else
     {
-        if(!game.colourblindmode) dwgfx.drawtowerbackgroundsolo(map);
+        if(!game.colourblindmode) dwgfx.drawtowerbackgroundsolo();
 
         tr = map.r - (help.glow / 4) - int(fRandom() * 4);
         tg = map.g - (help.glow / 4) - int(fRandom() * 4);
@@ -627,13 +627,13 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 dwgfx.Print(0, 80-20, game.tele_currentarea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
                 for (int i = 0; i < 6; i++)
                 {
-                    dwgfx.drawcrewman(169-(3*42)+(i*42), 95-20, i, game.tele_crewstats[i], help, true);
+                    dwgfx.drawcrewman(169-(3*42)+(i*42), 95-20, i, game.tele_crewstats[i], true);
                 }
                 dwgfx.Print(160 - 84, 132-20, game.tele_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
                 dwgfx.Print(160 + 40, 132-20, help.number(game.tele_trinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                dwgfx.drawspritesetcol(50, 126-20, 50, 18, help);
-                dwgfx.drawspritesetcol(175, 126-20, 22, 18, help);
+                dwgfx.drawspritesetcol(50, 126-20, 50, 18);
+                dwgfx.drawspritesetcol(175, 126-20, 22, 18);
             }
             else if (game.currentmenuoption == 1)
             {
@@ -644,13 +644,13 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                 dwgfx.Print(0, 80-20, game.quick_currentarea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
                 for (int i = 0; i < 6; i++)
                 {
-                    dwgfx.drawcrewman(169-(3*42)+(i*42), 95-20, i, game.quick_crewstats[i], help, true);
+                    dwgfx.drawcrewman(169-(3*42)+(i*42), 95-20, i, game.quick_crewstats[i], true);
                 }
                 dwgfx.Print(160 - 84, 132-20, game.quick_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
                 dwgfx.Print(160 + 40, 132-20, help.number(game.quick_trinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                dwgfx.drawspritesetcol(50, 126-20, 50, 18, help);
-                dwgfx.drawspritesetcol(175, 126-20, 22, 18, help);
+                dwgfx.drawspritesetcol(50, 126-20, 50, 18);
+                dwgfx.drawspritesetcol(175, 126-20, 22, 18);
             }
         }
         else if (game.currentmenuname == "gameover" || game.currentmenuname == "gameover2")
@@ -665,7 +665,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
             }
             for (int i = 0; i < 6; i++)
             {
-                dwgfx.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], help, true);
+                dwgfx.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], true);
             }
             tempstring = "You rescued " + help.number(game.crewrescued()) + " crewmates";
             dwgfx.Print(0, 100, tempstring, tr, tg, tb, true);
@@ -716,7 +716,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
             }
             for (int i = 0; i < 6; i++)
             {
-                dwgfx.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], help, true);
+                dwgfx.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], true);
             }
             tempstring = "You rescued all the crewmates!";
             dwgfx.Print(0, 100, tempstring, tr, tg, tb, true);
@@ -735,7 +735,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
 
             tempstring = game.resulttimestring() + " / " + game.partimestring();
 
-            dwgfx.drawspritesetcol(30, 80-15, 50, 22, help);
+            dwgfx.drawspritesetcol(30, 80-15, 50, 22);
             dwgfx.Print(65, 80-15, "TIME TAKEN:", 255, 255, 255);
             dwgfx.Print(65, 90-15, tempstring, tr, tg, tb);
             if (game.timetrialresulttime <= game.timetrialpar)
@@ -744,7 +744,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
             }
 
             tempstring = help.String(game.deathcounts);
-            dwgfx.drawspritesetcol(30-4, 80+20-4, 12, 22, help);
+            dwgfx.drawspritesetcol(30-4, 80+20-4, 12, 22);
             dwgfx.Print(65, 80+20, "NUMBER OF DEATHS:", 255, 255, 255);
             dwgfx.Print(65, 90+20, tempstring, tr, tg, tb);
             if (game.deathcounts == 0)
@@ -753,7 +753,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
             }
 
             tempstring = help.String(game.trinkets) + " of " + help.String(game.timetrialshinytarget);
-            dwgfx.drawspritesetcol(30, 80+55, 22, 22, help);
+            dwgfx.drawspritesetcol(30, 80+55, 22, 22);
             dwgfx.Print(65, 80+55, "SHINY TRINKETS:", 255, 255, 255);
             dwgfx.Print(65, 90+55, tempstring, tr, tg, tb);
             if (game.trinkets >= game.timetrialshinytarget)
@@ -1184,31 +1184,31 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
         if(tb>255) tb=255;
         if (game.currentmenuname == "timetrials" || game.currentmenuname == "unlockmenutrials")
         {
-            dwgfx.drawmenu(game, tr, tg, tb, 15);
+            dwgfx.drawmenu(tr, tg, tb, 15);
         }
         else if (game.currentmenuname == "unlockmenu")
         {
-            dwgfx.drawmenu(game, tr, tg, tb, 15);
+            dwgfx.drawmenu(tr, tg, tb, 15);
         }
         else if (game.currentmenuname == "playmodes")
         {
-            dwgfx.drawmenu(game, tr, tg, tb, 20);
+            dwgfx.drawmenu(tr, tg, tb, 20);
         }
         else if (game.currentmenuname == "mainmenu")
         {
-            dwgfx.drawmenu(game, tr, tg, tb, 15);
+            dwgfx.drawmenu(tr, tg, tb, 15);
         }
         else if (game.currentmenuname == "playerworlds")
         {
-            dwgfx.drawmenu(game, tr, tg, tb, 15);
+            dwgfx.drawmenu(tr, tg, tb, 15);
         }
         else if (game.currentmenuname == "levellist")
         {
-            dwgfx.drawlevelmenu(game, tr, tg, tb, 5);
+            dwgfx.drawlevelmenu(tr, tg, tb, 5);
         }
         else
         {
-            dwgfx.drawmenu(game, tr, tg, tb);
+            dwgfx.drawmenu(tr, tg, tb);
         }
 
         //dwgfx.Print(5, 228, "Left/Right to Choose, V to Select", tr, tg, tb, true);
@@ -1244,8 +1244,8 @@ void gamecompleterender(Graphics& dwgfx, Game& game, entityclass& obj, UtilityCl
     //dwgfx.backbuffer.lock();
     FillRect(dwgfx.backBuffer, 0x000000);
 
-    if(!game.colourblindmode) dwgfx.drawtowerbackgroundsolo(map);
-    //dwgfx.drawtowermap(map);
+    if(!game.colourblindmode) dwgfx.drawtowerbackgroundsolo();
+    //dwgfx.drawtowermap();
 
     for (int i = 0; i < 6; i++)
     {
@@ -1280,32 +1280,32 @@ void gamecompleterender(Graphics& dwgfx, Game& game, entityclass& obj, UtilityCl
 
     if (dwgfx.onscreen(320 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 320 + game.creditposition, 0, true, help);
+        dwgfx.drawcrewman(70, 320 + game.creditposition, 0, true);
         dwgfx.Print(100, 330 + game.creditposition, "Captain Viridian", tr, tg, tb);
     }
     if (dwgfx.onscreen(350 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 350 + game.creditposition, 1, true, help);
+        dwgfx.drawcrewman(70, 350 + game.creditposition, 1, true);
         dwgfx.Print(100, 360 + game.creditposition, "Doctor Violet", tr, tg, tb);
     }
     if (dwgfx.onscreen(380 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 380 + game.creditposition, 2, true, help);
+        dwgfx.drawcrewman(70, 380 + game.creditposition, 2, true);
         dwgfx.Print(100, 390 + game.creditposition, "Professor Vitellary", tr, tg, tb);
     }
     if (dwgfx.onscreen(410 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 410 + game.creditposition, 3, true, help);
+        dwgfx.drawcrewman(70, 410 + game.creditposition, 3, true);
         dwgfx.Print(100, 420 + game.creditposition, "Officer Vermilion", tr, tg, tb);
     }
     if (dwgfx.onscreen(440 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 440 + game.creditposition, 4, true, help);
+        dwgfx.drawcrewman(70, 440 + game.creditposition, 4, true);
         dwgfx.Print(100, 450 + game.creditposition, "Chief Verdigris", tr, tg, tb);
     }
     if (dwgfx.onscreen(470 + game.creditposition))
     {
-        dwgfx.drawcrewman(70, 470 + game.creditposition, 5, true, help);
+        dwgfx.drawcrewman(70, 470 + game.creditposition, 5, true);
         dwgfx.Print(100, 480 + game.creditposition, "Doctor Victoria", tr, tg, tb);
     }
 
@@ -1478,7 +1478,7 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
 
         if(!game.colourblindmode)
 		{
-        dwgfx.drawbackground(map.background, map);
+        dwgfx.drawbackground(map.background);
 		}
 		else
 		{
@@ -1486,11 +1486,11 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
 		}
         if (map.final_colormode)
 		{
-        	dwgfx.drawfinalmap(map);
+        	dwgfx.drawfinalmap();
         }
         else
 		{
-        dwgfx.drawmap(map);
+        dwgfx.drawmap();
         }
 
 
@@ -1522,7 +1522,7 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
             }
         }
 
-        dwgfx.drawentities(map, obj, help);
+        dwgfx.drawentities();
     }
 
     /*for(int i=0; i<obj.nblocks; i++){
@@ -1577,7 +1577,7 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
     dwgfx.drawfade();
 	BlitSurfaceStandard(dwgfx.backBuffer, NULL, dwgfx.tempBuffer, NULL);
 
-    dwgfx.drawgui(help);
+    dwgfx.drawgui();
     if (dwgfx.flipmode)
     {
         if (game.advancetext) dwgfx.bprint(5, 228, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
@@ -1804,7 +1804,7 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
 
     if (obj.trophytext > 0)
     {
-        dwgfx.drawtrophytext(obj, help);
+        dwgfx.drawtrophytext();
         obj.trophytext--;
     }
 
@@ -1881,7 +1881,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
     //dwgfx.backbuffer.lock();
 
 
-    dwgfx.drawgui(help);
+    dwgfx.drawgui();
 
     //draw screen alliteration
     //Roomname:
@@ -2314,7 +2314,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
             {
                 for (int i = 0; i < 3; i++)
                 {
-                    dwgfx.drawcrewman(16, 32 + (i * 64), 2-i, game.crewstats[2-i], help);
+                    dwgfx.drawcrewman(16, 32 + (i * 64), 2-i, game.crewstats[2-i]);
                     if (game.crewstats[(2-i)])
                     {
                         dwgfx.printcrewname(44, 32 + (i * 64)+4+10, 2-i);
@@ -2326,7 +2326,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                         dwgfx.Print(44, 32 + (i * 64) + 4, "Missing...", 64,64,64);
                     }
 
-                    dwgfx.drawcrewman(16+160, 32 + (i * 64), (2-i)+3, game.crewstats[(2-i)+3], help);
+                    dwgfx.drawcrewman(16+160, 32 + (i * 64), (2-i)+3, game.crewstats[(2-i)+3]);
                     if (game.crewstats[(2-i)+3])
                     {
                         dwgfx.printcrewname(44+160, 32 + (i * 64)+4+10, (2-i)+3);
@@ -2343,7 +2343,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
             {
                 for (int i = 0; i < 3; i++)
                 {
-                    dwgfx.drawcrewman(16, 32 + (i * 64), i, game.crewstats[i], help);
+                    dwgfx.drawcrewman(16, 32 + (i * 64), i, game.crewstats[i]);
                     if (game.crewstats[i])
                     {
                         dwgfx.printcrewname(44, 32 + (i * 64)+4, i);
@@ -2355,7 +2355,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                         dwgfx.Print(44, 32 + (i * 64) + 4 + 10, "Missing...", 64,64,64);
                     }
 
-                    dwgfx.drawcrewman(16+160, 32 + (i * 64), i+3, game.crewstats[i+3], help);
+                    dwgfx.drawcrewman(16+160, 32 + (i * 64), i+3, game.crewstats[i+3]);
                     if (game.crewstats[i+3])
                     {
                         dwgfx.printcrewname(44+160, 32 + (i * 64)+4, i+3);
@@ -2482,8 +2482,8 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                     dwgfx.Print(160 - 84, 78, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
                     dwgfx.Print(160 + 40, 78, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    dwgfx.drawspritesetcol(50, 74, 50, 18, help);
-                    dwgfx.drawspritesetcol(175, 74, 22, 18, help);
+                    dwgfx.drawspritesetcol(50, 74, 50, 18);
+                    dwgfx.drawspritesetcol(175, 74, 22, 18);
                 }
                 else
                 {
@@ -2491,8 +2491,8 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                     dwgfx.Print(160 - 84, 132, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
                     dwgfx.Print(160 + 40, 132, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    dwgfx.drawspritesetcol(50, 126, 50, 18, help);
-                    dwgfx.drawspritesetcol(175, 126, 22, 18, help);
+                    dwgfx.drawspritesetcol(50, 126, 50, 18);
+                    dwgfx.drawspritesetcol(175, 126, 22, 18);
                 }
             }
             else
@@ -2524,26 +2524,26 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
                     dwgfx.Print(0, 132, game.savearea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
                     for (int i = 0; i < 6; i++)
                     {
-                        dwgfx.drawcrewman(169-(3*42)+(i*42), 98, i, game.crewstats[i], help, true);
+                        dwgfx.drawcrewman(169-(3*42)+(i*42), 98, i, game.crewstats[i], true);
                     }
                     dwgfx.Print(160 - 84, 78, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
                     dwgfx.Print(160 + 40, 78, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    dwgfx.drawspritesetcol(50, 74, 50, 18, help);
-                    dwgfx.drawspritesetcol(175, 74, 22, 18, help);
+                    dwgfx.drawspritesetcol(50, 74, 50, 18);
+                    dwgfx.drawspritesetcol(175, 74, 22, 18);
                 }
                 else
                 {
                     dwgfx.Print(0, 80, game.savearea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
                     for (int i = 0; i < 6; i++)
                     {
-                        dwgfx.drawcrewman(169-(3*42)+(i*42), 95, i, game.crewstats[i], help, true);
+                        dwgfx.drawcrewman(169-(3*42)+(i*42), 95, i, game.crewstats[i], true);
                     }
                     dwgfx.Print(160 - 84, 132, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
                     dwgfx.Print(160 + 40, 132, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    dwgfx.drawspritesetcol(50, 126, 50, 18, help);
-                    dwgfx.drawspritesetcol(175, 126, 22, 18, help);
+                    dwgfx.drawspritesetcol(50, 126, 50, 18);
+                    dwgfx.drawspritesetcol(175, 126, 22, 18);
                 }
             }
             else
@@ -2745,12 +2745,12 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
 
     if (!game.colourblindmode)
     {
-        dwgfx.drawtowerbackground(map);
-        dwgfx.drawtowermap(map);
+        dwgfx.drawtowerbackground();
+        dwgfx.drawtowermap();
     }
     else
     {
-        dwgfx.drawtowermap_nobackground(map);
+        dwgfx.drawtowermap_nobackground();
     }
 
     if(!game.completestop)
@@ -2781,9 +2781,9 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
         }
     }
 
-    dwgfx.drawtowerentities(map, obj, help);
+    dwgfx.drawtowerentities();
 
-    dwgfx.drawtowerspikes(map);
+    dwgfx.drawtowerspikes();
 
 
     /*for(int i=0; i<obj.nblocks; i++){
@@ -2794,7 +2794,7 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
     dwgfx.cutscenebars();
     BlitSurfaceStandard(dwgfx.backBuffer, NULL, dwgfx.tempBuffer, NULL);
 
-    dwgfx.drawgui(help);
+    dwgfx.drawgui();
     if (dwgfx.flipmode)
     {
         if (game.advancetext) dwgfx.bprint(5, 228, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
@@ -3027,7 +3027,7 @@ void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& o
         dwgfx.Print(5, 225, "Press ENTER to Teleport", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
 
-    dwgfx.drawgui(help);
+    dwgfx.drawgui();
 
     if (dwgfx.flipmode)
     {

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -733,7 +733,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
         {
             dwgfx.bigprint( -1, 20, "Results", tr, tg, tb, true, 3);
 
-            tempstring = game.resulttimestring(help) + " / " + game.partimestring(help);
+            tempstring = game.resulttimestring() + " / " + game.partimestring();
 
             dwgfx.drawspritesetcol(30, 80-15, 50, 22, help);
             dwgfx.Print(65, 80-15, "TIME TAKEN:", 255, 255, 255);
@@ -807,7 +807,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                         dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
                         dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
                         dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[0], help), tr, tg, tb);
+                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[0]), tr, tg, tb);
                         dwgfx.Print( 110, 75, help.String(game.besttrinkets[0])+"/2", tr, tg, tb);
                         dwgfx.Print( 110, 85,help.String(game.bestlives[0]), tr, tg, tb);
 
@@ -854,7 +854,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                         dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
                         dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
                         dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[1], help), tr, tg, tb);
+                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[1]), tr, tg, tb);
                         dwgfx.Print( 110, 75, help.String(game.besttrinkets[1])+"/4", tr, tg, tb);
                         dwgfx.Print( 110, 85, help.String(game.bestlives[1]), tr, tg, tb);
 
@@ -901,7 +901,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                         dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
                         dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
                         dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[2], help), tr, tg, tb);
+                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[2]), tr, tg, tb);
                         dwgfx.Print( 110, 75, help.String(game.besttrinkets[2])+"/2", tr, tg, tb);
                         dwgfx.Print( 110, 85, help.String(game.bestlives[2]), tr, tg, tb);
 
@@ -948,7 +948,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                         dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
                         dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
                         dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[3], help), tr, tg, tb);
+                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[3]), tr, tg, tb);
                         dwgfx.Print( 110, 75, help.String(game.besttrinkets[3])+"/5", tr, tg, tb);
                         dwgfx.Print( 110, 85, help.String(game.bestlives[3]), tr, tg, tb);
 
@@ -995,7 +995,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                         dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
                         dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
                         dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[4], help), tr, tg, tb);
+                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[4]), tr, tg, tb);
                         dwgfx.Print( 110, 75, help.String(game.besttrinkets[4])+"/1", tr, tg, tb);
                         dwgfx.Print( 110, 85, help.String(game.bestlives[4]), tr, tg, tb);
 
@@ -1042,7 +1042,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
                         dwgfx.Print( 16, 65, "BEST TIME  ", tr, tg, tb);
                         dwgfx.Print( 16, 75, "BEST SHINY ", tr, tg, tb);
                         dwgfx.Print( 16, 85, "BEST LIVES ", tr, tg, tb);
-                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[5], help), tr, tg, tb);
+                        dwgfx.Print( 110, 65, game.timetstring(game.besttimes[5]), tr, tg, tb);
                         dwgfx.Print( 110, 75, help.String(game.besttrinkets[5])+"/1", tr, tg, tb);
                         dwgfx.Print( 110, 85, help.String(game.bestlives[5]), tr, tg, tb);
 
@@ -1741,11 +1741,11 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
 
             if(game.timetrialparlost)
             {
-                dwgfx.bprint(56, 18, game.timestring(help),  196, 80, 80);
+                dwgfx.bprint(56, 18, game.timestring(),  196, 80, 80);
             }
             else
             {
-                dwgfx.bprint(56, 18, game.timestring(help),  196, 196, 196);
+                dwgfx.bprint(56, 18, game.timestring(),  196, 196, 196);
             }
             if(game.deathcounts>0)
             {
@@ -1767,12 +1767,12 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
             if(game.timetrialparlost)
             {
                 dwgfx.bprint(195, 214, "PAR TIME:",  80, 80, 80);
-                dwgfx.bprint(275, 214, game.partimestring(help),  80, 80, 80);
+                dwgfx.bprint(275, 214, game.partimestring(),  80, 80, 80);
             }
             else
             {
                 dwgfx.bprint(195, 214, "PAR TIME:",  255, 255, 255);
-                dwgfx.bprint(275, 214, game.partimestring(help),  196, 196, 196);
+                dwgfx.bprint(275, 214, game.partimestring(),  196, 196, 196);
             }
         }
     }
@@ -2397,7 +2397,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
               dwgfx.Print(0, 102,help.String(game.deathcounts),  96,96,96, true);
 
               dwgfx.Print(0, 64, "[Time Taken]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 52, game.timestring(help),  96, 96, 96, true);
+              dwgfx.Print(0, 52, game.timestring(),  96, 96, 96, true);
           }
           else
           {
@@ -2408,7 +2408,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
               dwgfx.Print(0, 114,help.String(game.deathcounts),  96,96,96, true);
 
               dwgfx.Print(0, 152, "[Time Taken]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 164, game.timestring(help),  96, 96, 96, true);
+              dwgfx.Print(0, 164, game.timestring(),  96, 96, 96, true);
           }
         }else{
           if (dwgfx.flipmode)
@@ -2420,7 +2420,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
               dwgfx.Print(0, 102,help.String(game.deathcounts),  96,96,96, true);
 
               dwgfx.Print(0, 64, "[Time Taken]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 52, game.timestring(help),  96, 96, 96, true);
+              dwgfx.Print(0, 52, game.timestring(),  96, 96, 96, true);
           }
           else
           {
@@ -2431,7 +2431,7 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
               dwgfx.Print(0, 114,help.String(game.deathcounts),  96,96,96, true);
 
               dwgfx.Print(0, 152, "[Time Taken]", 196, 196, 255 - help.glow, true);
-              dwgfx.Print(0, 164, game.timestring(help),  96, 96, 96, true);
+              dwgfx.Print(0, 164, game.timestring(),  96, 96, 96, true);
           }
         }
         break;
@@ -2851,11 +2851,11 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
 
             if(game.timetrialparlost)
             {
-                dwgfx.bprint(56, 18, game.timestring(help),  196, 80, 80);
+                dwgfx.bprint(56, 18, game.timestring(),  196, 80, 80);
             }
             else
             {
-                dwgfx.bprint(56, 18, game.timestring(help),  196, 196, 196);
+                dwgfx.bprint(56, 18, game.timestring(),  196, 196, 196);
             }
             if(game.deathcounts>0)
             {
@@ -2877,12 +2877,12 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
             if(game.timetrialparlost)
             {
                 dwgfx.bprint(195, 214, "PAR TIME:",  80, 80, 80);
-                dwgfx.bprint(275, 214, game.partimestring(help),  80, 80, 80);
+                dwgfx.bprint(275, 214, game.partimestring(),  80, 80, 80);
             }
             else
             {
                 dwgfx.bprint(195, 214, "PAR TIME:",  255, 255, 255);
-                dwgfx.bprint(275, 214, game.partimestring(help),  196, 196, 196);
+                dwgfx.bprint(275, 214, game.partimestring(),  196, 196, 196);
             }
         }
     }

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -1207,11 +1207,6 @@ void titlerender()
         //graphics.Print(5, 228, "Left/Right to Choose, V to Select", tr, tg, tb, true);
     }
 
-    if (game.test)
-    {
-        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
-    }
-
     graphics.drawfade();
 
     if (game.flashlight > 0 && !game.noflashingmode)
@@ -1385,11 +1380,6 @@ void gamecompleterender()
     creditOffset += 140;
     if (graphics.onscreen(creditOffset + game.creditposition)) graphics.bigprint( -1, creditOffset + game.creditposition, "Thanks for playing!", tr, tg, tb, true, 2);
 
-    if (game.test)
-    {
-        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
-    }
-
     graphics.drawfade();
 
     if (game.flashlight > 0 && !game.noflashingmode)
@@ -1434,11 +1424,6 @@ void gamecompleterender2()
                 FillRect(graphics.backBuffer, i * 8, j * 8, 8, 8, 0, 0, 0);
             }
         }
-    }
-
-    if (game.test)
-    {
-        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
     }
 
     graphics.drawfade();
@@ -1844,11 +1829,6 @@ void gamerender()
     }
     */
 
-
-    if (game.test)
-    {
-        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
-    }
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
@@ -2673,11 +2653,6 @@ void maprender()
 
     graphics.drawfade();
 
-    if (game.test)
-    {
-        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
-    }
-
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
@@ -2882,11 +2857,6 @@ void towerrender()
 
     graphics.drawfade();
 
-    if (game.test)
-    {
-        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
-    }
-
     if (game.flashlight > 0 && !game.noflashingmode)
     {
         game.flashlight--;
@@ -3031,11 +3001,6 @@ void teleporterrender()
         if (game.advancetext) graphics.bprint(5, 5, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
 
-
-    if (game.test)
-    {
-        graphics.Print(5, 5, game.teststring, 196, 196, 255, false);
-    }
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -12,8 +12,6 @@
 
 extern scriptclass script;
 
-Stage stage;
-Stage swfStage;
 int temp;
 
 int tr;
@@ -24,7 +22,6 @@ std::string tempstring;
 
 void updategraphicsmode()
 {
-    swfStage = stage;
 }
 
 void titlerender()

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -114,7 +114,7 @@ void titlerender()
         }
         else if (game.currentmenuname == "options")
         {
-				
+
 						#if defined(MAKEANDPLAY)
 							if (game.currentmenuoption == 0)
 							{
@@ -1122,7 +1122,7 @@ void titlerender()
             graphics.Print( -1, 125, "Your have unlocked", tr, tg, tb, true);
             graphics.Print( -1, 135, "the intermission levels.", tr, tg, tb, true);
         }else if (game.currentmenuname == "playerworlds")
-        {   
+        {
 						graphics.tempstring = FILESYSTEM_getUserLevelDirectory();
 						if(graphics.tempstring.length()>80){
 							graphics.Print( -1, 160, "To install new player levels, copy", tr, tg, tb, true);

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -12,8 +12,6 @@
 
 extern scriptclass script;
 
-int temp;
-
 int tr;
 int tg;
 int tb;
@@ -29,7 +27,7 @@ void titlerender()
         tg = 164 - (help.glow / 2) - int(fRandom() * 4);
         tb = 164 - (help.glow / 2) - int(fRandom() * 4);
 
-        temp = 50;
+        int temp = 50;
         graphics.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
         graphics.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
         graphics.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
@@ -57,7 +55,7 @@ void titlerender()
         if (tb < 0) tb = 0;
         if(tb>255) tb=255;
 
-        temp = 50;
+        int temp = 50;
 
         if(game.currentmenuname=="mainmenu")
         {
@@ -1209,7 +1207,7 @@ void gamecompleterender()
 
     if (graphics.onscreen(220 + game.creditposition))
     {
-        temp = 220 + game.creditposition;
+        int temp = 220 + game.creditposition;
         graphics.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
         graphics.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
         graphics.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
@@ -1753,7 +1751,7 @@ void maprender()
 
     //draw screen alliteration
     //Roomname:
-    temp = map.area(game.roomx, game.roomy);
+    int temp = map.area(game.roomx, game.roomy);
     if (temp < 2 && !map.custommode && graphics.fademode==0)
     {
         if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111)
@@ -2014,13 +2012,13 @@ void maprender()
             {
                 if (map.showteleporters && map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)] > 0)
                 {
-                    temp = 1126 + map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)];
+                    int temp = 1126 + map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)];
                     if (graphics.flipmode) temp += 3;
                     graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
                 }
                 else if(map.showtargets && map.explored[map.teleporters[i].x+(20*map.teleporters[i].y)]==0)
                 {
-                    temp = 1126 + map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)];
+                    int temp = 1126 + map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)];
                     if (graphics.flipmode) temp += 3;
                     graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
                 }
@@ -2032,7 +2030,7 @@ void maprender()
                 {
                     if (obj.collect[i] == 0)
                     {
-                        temp = 1086;
+                        int temp = 1086;
                         if (graphics.flipmode) temp += 3;
                         graphics.drawtile(40 + 3 + (map.shinytrinkets[i].x * 12), 22 + (map.shinytrinkets[i].y * 9),	temp);
                     }
@@ -2757,7 +2755,7 @@ void teleporterrender()
     int tempy;
     //draw screen alliteration
     //Roomname:
-    temp = map.area(game.roomx, game.roomy);
+    int temp = map.area(game.roomx, game.roomy);
     if (temp < 2 && !map.custommode && graphics.fademode==0)
     {
         if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111)

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -18,8 +18,6 @@ int tr;
 int tg;
 int tb;
 
-std::string tempstring;
-
 void titlerender()
 {
 
@@ -660,6 +658,7 @@ void titlerender()
             {
                 graphics.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], true);
             }
+            std::string tempstring;
             tempstring = "You rescued " + help.number(game.crewrescued()) + " crewmates";
             graphics.Print(0, 100, tempstring, tr, tg, tb, true);
 
@@ -711,7 +710,7 @@ void titlerender()
             {
                 graphics.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], true);
             }
-            tempstring = "You rescued all the crewmates!";
+            std::string tempstring = "You rescued all the crewmates!";
             graphics.Print(0, 100, tempstring, tr, tg, tb, true);
 
             tempstring = "And you found " + help.number(game.trinkets) + " trinkets.";
@@ -726,7 +725,7 @@ void titlerender()
         {
             graphics.bigprint( -1, 20, "Results", tr, tg, tb, true, 3);
 
-            tempstring = game.resulttimestring() + " / " + game.partimestring();
+            std::string tempstring = game.resulttimestring() + " / " + game.partimestring();
 
             graphics.drawspritesetcol(30, 80-15, 50, 22);
             graphics.Print(65, 80-15, "TIME TAKEN:", 255, 255, 255);
@@ -1123,22 +1122,22 @@ void titlerender()
             graphics.Print( -1, 135, "the intermission levels.", tr, tg, tb, true);
         }else if (game.currentmenuname == "playerworlds")
         {
-            graphics.tempstring = FILESYSTEM_getUserLevelDirectory();
-            if(graphics.tempstring.length()>80){
+            std::string tempstring = FILESYSTEM_getUserLevelDirectory();
+            if(tempstring.length()>80){
                 graphics.Print( -1, 160, "To install new player levels, copy", tr, tg, tb, true);
                 graphics.Print( -1, 170, "the .vvvvvv files to this folder:", tr, tg, tb, true);
-                graphics.Print( 320-((graphics.tempstring.length()-80)*8), 190, graphics.tempstring.substr(0,graphics.tempstring.length()-80), tr, tg, tb);
-                graphics.Print( 0, 200, graphics.tempstring.substr(graphics.tempstring.length()-80,40), tr, tg, tb);
-                graphics.Print( 0, 210, graphics.tempstring.substr(graphics.tempstring.length()-40,40), tr, tg, tb);
-            }else if(graphics.tempstring.length()>40){
+                graphics.Print( 320-((tempstring.length()-80)*8), 190, tempstring.substr(0,tempstring.length()-80), tr, tg, tb);
+                graphics.Print( 0, 200, tempstring.substr(tempstring.length()-80,40), tr, tg, tb);
+                graphics.Print( 0, 210, tempstring.substr(tempstring.length()-40,40), tr, tg, tb);
+            }else if(tempstring.length()>40){
                 graphics.Print( -1, 170, "To install new player levels, copy", tr, tg, tb, true);
                 graphics.Print( -1, 180, "the .vvvvvv files to this folder:", tr, tg, tb, true);
-                graphics.Print( 320-((graphics.tempstring.length()-40)*8), 200, graphics.tempstring.substr(0,graphics.tempstring.length()-40), tr, tg, tb);
-                graphics.Print( 0, 210, graphics.tempstring.substr(graphics.tempstring.length()-40,40), tr, tg, tb);
+                graphics.Print( 320-((tempstring.length()-40)*8), 200, tempstring.substr(0,tempstring.length()-40), tr, tg, tb);
+                graphics.Print( 0, 210, tempstring.substr(tempstring.length()-40,40), tr, tg, tb);
             }else{
                 graphics.Print( -1, 180, "To install new player levels, copy", tr, tg, tb, true);
                 graphics.Print( -1, 190, "the .vvvvvv files to this folder:", tr, tg, tb, true);
-                graphics.Print( 320-(graphics.tempstring.length()*8), 210, graphics.tempstring, tr, tg, tb);
+                graphics.Print( 320-(tempstring.length()*8), 210, tempstring, tr, tg, tb);
             }
         }
 
@@ -1581,14 +1580,14 @@ void gamerender()
     {
         if (game.swngame == 0)
         {
-            tempstring = help.timestring(game.swntimer);
+            std::string tempstring = help.timestring(game.swntimer);
             graphics.bigprint( -1, 20, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
         }
         else if (game.swngame == 1)
         {
             if (game.swnmessage == 0)
             {
-                tempstring = help.timestring(game.swntimer);
+                std::string tempstring = help.timestring(game.swntimer);
                 graphics.Print( 10, 10, "Current Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
                 graphics.bigprint( 25, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
                 tempstring = help.timestring(game.swnrecord);
@@ -1622,7 +1621,7 @@ void gamerender()
             }
             else if (game.swnmessage == 1)
             {
-                tempstring = help.timestring(game.swntimer);
+                std::string tempstring = help.timestring(game.swntimer);
                 graphics.Print( 10, 10, "Current Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
                 graphics.bigprint( 25, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
                 tempstring = help.timestring(game.swnrecord);
@@ -1638,7 +1637,7 @@ void gamerender()
             {
                 game.swnmessage--;
                 if (game.swnmessage == 2) game.swnmessage = 0;
-                tempstring = help.timestring(game.swntimer);
+                std::string tempstring = help.timestring(game.swntimer);
                 graphics.Print( 10, 10, "Current Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false);
                 graphics.bigprint( 25, 24, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), false, 2);
                 tempstring = help.timestring(game.swnrecord);
@@ -1675,7 +1674,7 @@ void gamerender()
             {
                 graphics.bigprint( -1, 20, "SUPER GRAVITRON", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
 
-                tempstring = help.timestring(game.swnrecord);
+                std::string tempstring = help.timestring(game.swnrecord);
                 graphics.Print( 240, 190, "Best Time", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
                 graphics.bigrprint( 300, 205, tempstring, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 2);
             }
@@ -2165,7 +2164,7 @@ void maprender()
             {
                 graphics.Print(0, 174, "SUPER GRAVITRON HIGHSCORE", 196, 196, 255 - help.glow, true);
 
-                tempstring = help.timestring(game.swnrecord);
+                std::string tempstring = help.timestring(game.swnrecord);
                 graphics.Print( 240, 124, "Best Time", 196, 196, 255 - help.glow, true);
                 graphics.bigrprint( 300, 94, tempstring, 196, 196, 255 - help.glow, true, 2);
 
@@ -2198,7 +2197,7 @@ void maprender()
             {
                 graphics.Print(0, 40, "SUPER GRAVITRON HIGHSCORE", 196, 196, 255 - help.glow, true);
 
-                tempstring = help.timestring(game.swnrecord);
+                std::string tempstring = help.timestring(game.swnrecord);
                 graphics.Print( 240, 90, "Best Time", 196, 196, 255 - help.glow, true);
                 graphics.bigrprint( 300, 104, tempstring, 196, 196, 255 - help.glow, true, 2);
 

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -42,13 +42,6 @@ void titlerender()
 
         graphics.Print(5, 175, "[ Press ACTION to Start ]", tr, tg, tb, true);
         graphics.Print(5, 195, "ACTION = Space, Z, or V", int(tr*0.5f), int(tg*0.5f), int(tb*0.5f), true);
-
-        //graphics.Print(5, 215, "Press CTRL-F for Fullscreen", tr, tg, tb, true);
-
-        /*graphics.Print(5, 5, "IGF WIP Build, 29th Oct '09", tr, tg, tb, true);
-        graphics.Print(5, 200, "Game by Terry Cavanagh", tr, tg, tb, true);
-        graphics.Print(5, 210, "Music by Magnus P~lsson", tr, tg, tb, true);
-        graphics.Print(5, 220, "Roomnames by Bennett Foddy", tr, tg, tb, true);*/
     }
     else
     {
@@ -242,23 +235,19 @@ void titlerender()
             graphics.bigprint( 40, 65, "Terry Cavanagh", tr, tg, tb, true, 2);
 
             graphics.drawimagecol(7, -1, 86, tr *0.75, tg *0.75, tb *0.75, true);
-            //graphics.Print( 40, 85, "http://www.distractionware.com", tr, tg, tb, true);
 
             graphics.Print( -1, 120, "and features music by", tr, tg, tb, true);
             graphics.bigprint( 40, 135, "Magnus P~lsson", tr, tg, tb, true, 2);
             graphics.drawimagecol(8, -1, 156, tr *0.75, tg *0.75, tb *0.75, true);
-            //graphics.Print( 40, 155, "http://souleye.madtracker.net", tr, tg, tb, true);
         }
         else if (game.currentmenuname == "credits2")
         {
             graphics.Print( -1, 50, "Roomnames are by", tr, tg, tb, true);
             graphics.bigprint( 40, 65, "Bennett Foddy", tr, tg, tb, true);
             graphics.drawimagecol(9, -1, 86, tr*0.75, tg *0.75, tb *0.75, true);
-            //graphics.Print( 40, 80, "http://www.distractionware.com", tr, tg, tb);
             graphics.Print( -1, 110, "C++ version by", tr, tg, tb, true);
             graphics.bigprint( 40, 125, "Simon Roth", tr, tg, tb, true);
             graphics.bigprint( 40, 145, "Ethan Lee", tr, tg, tb, true);
-           //graphics.drawimagecol(11, -1, 156, tr*0.75, tg *0.75, tb *0.75, true);
         }
         else if (game.currentmenuname == "credits25")
         {
@@ -1141,30 +1130,6 @@ void titlerender()
             }
         }
 
-        /*
-        switch(game.mainmenu) {
-            case 0:
-                graphics.Print(5, 115, "[ NEW GAME ]", tr, tg, tb, true);
-            break;
-            case 1:
-                if (game.telesummary == "") {
-                    graphics.Print(5, 115, "[ no teleporter save ]", tr/3, tg/3, tb/3, true);
-                }else {
-                    graphics.Print(5, 115, "[ RESTORE FROM LAST TELEPORTER ]", tr, tg, tb, true);
-                    graphics.Print(5, 125, game.telesummary, tr, tg, tb, true);
-                }
-            break;
-            case 2:
-                if (game.quicksummary == "") {
-                    graphics.Print(5, 115, "[ no quicksave ]", tr/3, tg/3, tb/3, true);
-                }else {
-                    graphics.Print(5, 115, "[ RESTORE FROM LAST QUICKSAVE ]", tr, tg, tb, true);
-                    graphics.Print(5, 125, game.quicksummary, tr, tg, tb, true);
-                }
-            break;
-        }
-        */
-
         tr = int(tr * .8f);
         tg = int(tg * .8f);
         tb = int(tb * .8f);
@@ -1202,8 +1167,6 @@ void titlerender()
         {
             graphics.drawmenu(tr, tg, tb);
         }
-
-        //graphics.Print(5, 228, "Left/Right to Choose, V to Select", tr, tg, tb, true);
     }
 
     graphics.drawfade();
@@ -1223,21 +1186,13 @@ void titlerender()
     {
         graphics.render();
     }
-    //graphics.backbuffer.unlock();
 }
 
 void gamecompleterender()
 {
-    //graphics.backbuffer.lock();
     FillRect(graphics.backBuffer, 0x000000);
 
     if(!game.colourblindmode) graphics.drawtowerbackgroundsolo();
-    //graphics.drawtowermap();
-
-    for (int i = 0; i < 6; i++)
-    {
-        //graphics.drawsprite((160-96)+ i * 32, 10, 23, 96+(i*10)+(random()*16), 196-(help.glow)-(random()*16), 255 - (help.glow*2));
-    }
 
     tr = map.r - (help.glow / 4) - fRandom() * 4;
     tg = map.g - (help.glow / 4) - fRandom() * 4;
@@ -1396,12 +1351,10 @@ void gamecompleterender()
     {
         graphics.render();
     }
-    //graphics.backbuffer.unlock();
 }
 
 void gamecompleterender2()
 {
-    //graphics.backbuffer.lock();
     FillRect(graphics.backBuffer, 0x000000);
 
     graphics.drawimage(10, 0, 0);
@@ -1442,7 +1395,6 @@ void gamecompleterender2()
     {
         graphics.render();
     }
-    //graphics.backbuffer.unlock();
 }
 
 void gamerender()
@@ -1501,13 +1453,6 @@ void gamerender()
 
         graphics.drawentities();
     }
-
-    /*for(int i=0; i<obj.nblocks; i++){
-    if (obj.blocks[i].active) {
-        graphics.backbuffer.fillRect(obj.blocks[i].rect, 0xDDDDDD);
-    }
-      }*/
-    //graphics.drawminimap(game, map);
 
     if(map.extrarow==0 || (map.custommode && map.roomname!=""))
     {
@@ -1756,7 +1701,6 @@ void gamerender()
 
     if (game.activeactivity > -1)
     {
-        //graphics.backbuffer.fillRect(new Rectangle(0, 0, 320, 18), 0x000000);
         game.activity_lastprompt = obj.blocks[game.activeactivity].prompt;
         game.activity_r = obj.blocks[game.activeactivity].r;
         game.activity_g = obj.blocks[game.activeactivity].g;
@@ -1785,49 +1729,6 @@ void gamerender()
         obj.trophytext--;
     }
 
-    //graphics.rprint(5, 231,help.String(game.coins), 255 - help.glow/2, 255 - help.glow/2, 196, true);
-    //graphics.drawhuetile(311, 230, 48, 1);
-
-    //Level complete image
-    //if (game.state >= 3007) {
-    //	graphics.drawimage(0, 0, 12, true);
-    //}
-
-    //state changes
-
-    /*
-    game.test = true;
-    if (game.teststring !=help.String(game.state)) trace(game.state);
-    game.teststring =help.String(game.state);
-    */
-
-    //Detail entity info for debuging
-    /*
-    for (int i = 0; i < obj.nentity; i++) {
-        game.tempstring =help.String(obj.entities[i].type) +", (" +help.String(obj.entities[i].xp) + "," +help.String(obj.entities[i].yp) + ")";
-        game.tempstring += " state:" +obj.entities[i].state + ", delay:" + obj.entities[i].statedelay;
-        graphics.Print(5, 5 + i * 8, game.tempstring, 255, 255, 255);
-    }
-    */
-
-    /*
-    game.test = true;
-    game.teststring =help.String(int(obj.entities[obj.getplayer()].xp)) + "," +help.String(int(obj.entities[obj.getplayer()].yp));
-    game.teststring += "   [" +help.String(game.roomx) + "," +help.String(game.roomy) + "]";
-    */
-
-    //game.test = true;
-    //game.teststring = "Current room deaths: " +help.String(game.currentroomdeaths);
-
-    //Special thing for loading:
-    /*
-    if(graphics.fademode==1){
-      if(game.mainmenu==22){
-        graphics.Print(5, 225, "Loading...", 196, 196, 255 - help.glow, false);
-      }
-    }
-    */
-
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
@@ -1844,20 +1745,14 @@ void gamerender()
     {
         graphics.render();
     }
-
-    //graphics.backbuffer.unlock();
 }
 
 void maprender()
 {
-    //graphics.backbuffer.lock();
-
-
     graphics.drawgui();
 
     //draw screen alliteration
     //Roomname:
-    //CRASH
     temp = map.area(game.roomx, game.roomy);
     if (temp < 2 && !map.custommode && graphics.fademode==0)
     {
@@ -1881,7 +1776,6 @@ void maprender()
     }
 
     //Background color
-    //graphics.drawfillrect(0, 12, 320, 240, 10, 24, 26);
     FillRect(graphics.backBuffer,0, 12, 320, 240, 10, 24, 26 );
 
     graphics.crewframedelay--;
@@ -2056,11 +1950,6 @@ void maprender()
             if (game.roomx == 109)
             {
                 //tower!instead of room y, scale map.ypos
-                /*if (map.ypos > (0.57 * (680 * 8))) {
-                    i = int(map.ypos - (0.57 * (680 * 8)));
-                    i = int((i / (0.43 * (680 * 8)))*9);
-                    graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + i + 2, 12 - 4, 9 - 4, 16, 245 - (help.glow * 2), 245 - (help.glow * 2));
-                }*/
                 if (map.cursorstate == 0)
                 {
                     map.cursordelay++;
@@ -2135,7 +2024,6 @@ void maprender()
                     if (graphics.flipmode) temp += 3;
                     graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
                 }
-                //graphics.drawtile(40+3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), 1086); //for shiny trinkets, do later
             }
 
             if (map.showtrinkets)
@@ -2701,8 +2589,6 @@ void maprender()
             graphics.render();
         }
     }
-
-    //graphics.backbuffer.unlock();
 }
 
 void towerrender()
@@ -2753,11 +2639,6 @@ void towerrender()
     graphics.drawtowerspikes();
 
 
-    /*for(int i=0; i<obj.nblocks; i++){
-    if (obj.blocks[i].active) {
-        graphics.backbuffer.fillRect(obj.blocks[i].rect, 0xDDDDDD);
-    }
-      }*/
     graphics.cutscenebars();
     BlitSurfaceStandard(graphics.backBuffer, NULL, graphics.tempBuffer, NULL);
 
@@ -2782,9 +2663,6 @@ void towerrender()
         FillRect(graphics.backBuffer, graphics.footerrect, 0);
     }
     graphics.bprint(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
-
-    //graphics.rprint(5, 231,help.String(game.coins), 255 - help.glow/2, 255 - help.glow/2, 196, true);
-    //graphics.drawhuetile(311, 230, 48, 1);
 
     if (game.intimetrial && graphics.fademode==0)
     {
@@ -2875,7 +2753,6 @@ void towerrender()
 
 void teleporterrender()
 {
-    //graphics.backbuffer.lock();
     int tempx;
     int tempy;
     //draw screen alliteration
@@ -2953,7 +2830,6 @@ void teleporterrender()
             if (graphics.flipmode) temp += 3;
             graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
         }
-        //graphics.drawtile(40+3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), 1086); //for shiny trinkets, do later
     }
 
     if (map.showtrinkets)
@@ -3050,6 +2926,4 @@ void teleporterrender()
             graphics.render();
         }
     }
-
-    //graphics.backbuffer.unlock();
 }

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -20,10 +20,6 @@ int tb;
 
 std::string tempstring;
 
-void updategraphicsmode()
-{
-}
-
 void titlerender()
 {
 

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -38,9 +38,9 @@ void titlerender()
         graphics.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
         graphics.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
         graphics.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
-				#if defined(MAKEANDPLAY)
-					graphics.Print(-1,temp+35,"     MAKE AND PLAY EDITION",tr, tg, tb, true);
-				#endif
+#if defined(MAKEANDPLAY)
+        graphics.Print(-1,temp+35,"     MAKE AND PLAY EDITION",tr, tg, tb, true);
+#endif
 
         graphics.Print(5, 175, "[ Press ACTION to Start ]", tr, tg, tb, true);
         graphics.Print(5, 195, "ACTION = Space, Z, or V", int(tr*0.5f), int(tg*0.5f), int(tb*0.5f), true);
@@ -76,16 +76,16 @@ void titlerender()
             graphics.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
             graphics.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
             graphics.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
-						#if defined(MAKEANDPLAY)
-							graphics.Print(-1,temp+35,"     MAKE AND PLAY EDITION",tr, tg, tb, true);
-						#endif
+#if defined(MAKEANDPLAY)
+            graphics.Print(-1,temp+35,"     MAKE AND PLAY EDITION",tr, tg, tb, true);
+#endif
             graphics.Print( 310 - (4*8), 230, "v2.2", tr/2, tg/2, tb/2);
 
-						if(music.mmmmmm){
-						  graphics.Print( 10, 230, "[MMMMMM Mod Installed]", tr/2, tg/2, tb/2);
-						}
+            if(music.mmmmmm){
+                graphics.Print( 10, 230, "[MMMMMM Mod Installed]", tr/2, tg/2, tb/2);
+            }
         }
-    #if !defined(NO_CUSTOM_LEVELS)
+#if !defined(NO_CUSTOM_LEVELS)
         else if (game.currentmenuname == "levellist")
         {
           if(ed.ListOfMetaData.size()==0){
@@ -106,7 +106,7 @@ void titlerender()
             }
           }
         }
-    #endif
+#endif
         else if (game.currentmenuname == "errornostart")
         {
           graphics.Print( -1, 65, "ERROR: This level has", tr, tg, tb, true);
@@ -115,72 +115,72 @@ void titlerender()
         else if (game.currentmenuname == "options")
         {
 
-						#if defined(MAKEANDPLAY)
-							if (game.currentmenuoption == 0)
-							{
-									graphics.bigprint( -1, 30, "Accessibility", tr, tg, tb, true);
-									graphics.Print( -1, 65, "Disable screen effects, enable", tr, tg, tb, true);
-									graphics.Print( -1, 75, "slowdown modes or invincibility", tr, tg, tb, true);
-							}
-							else if (game.currentmenuoption == 1)
-							{
-								graphics.bigprint( -1, 30, "Game Pad Options", tr, tg, tb, true);
-								graphics.Print( -1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
-								graphics.Print( -1, 75, "and adjust sensitivity", tr, tg, tb, true);
-							}
-							else if (game.currentmenuoption == 2)
-							{
-									graphics.bigprint( -1, 30, "Clear Data", tr, tg, tb, true);
-									graphics.Print( -1, 65, "Delete your save data", tr, tg, tb, true);
-									graphics.Print( -1, 75, "and unlocked play modes", tr, tg, tb, true);
-							}else if (game.currentmenuoption == 3){
-								if(music.mmmmmm){
-									graphics.bigprint( -1, 30, "Soundtrack", tr, tg, tb, true);
-									graphics.Print( -1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);
-									if(music.usingmmmmmm){
-										graphics.Print( -1, 85, "Current soundtrack: MMMMMM", tr, tg, tb, true);
-									}else{
-										graphics.Print( -1, 85, "Current soundtrack: PPPPPP", tr, tg, tb, true);
-									}
-								}
-							}
-						#elif !defined(MAKEANDPLAY)
-							if (game.currentmenuoption == 0)
-							{
-									graphics.bigprint( -1, 30, "Accessibility", tr, tg, tb, true);
-									graphics.Print( -1, 65, "Disable screen effects, enable", tr, tg, tb, true);
-									graphics.Print( -1, 75, "slowdown modes or invincibility", tr, tg, tb, true);
-							}
-							else if (game.currentmenuoption == 1)
-							{
-									graphics.bigprint( -1, 30, "Unlock Play Modes", tr, tg, tb, true);
-									graphics.Print( -1, 65, "Unlock parts of the game normally", tr, tg, tb, true);
-									graphics.Print( -1, 75, "unlocked as you progress", tr, tg, tb, true);
-							}
-							else if (game.currentmenuoption == 2)
-							{
-								graphics.bigprint( -1, 30, "Game Pad Options", tr, tg, tb, true);
-								graphics.Print( -1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
-								graphics.Print( -1, 75, "and adjust sensitivity", tr, tg, tb, true);
-							}
-							else if (game.currentmenuoption == 3)
-							{
-									graphics.bigprint( -1, 30, "Clear Data", tr, tg, tb, true);
-									graphics.Print( -1, 65, "Delete your save data", tr, tg, tb, true);
-									graphics.Print( -1, 75, "and unlocked play modes", tr, tg, tb, true);
-							}else if (game.currentmenuoption == 4)
-							{
-							if(music.mmmmmm){
-									graphics.bigprint( -1, 30, "Soundtrack", tr, tg, tb, true);
-									graphics.Print( -1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);
-									if(music.usingmmmmmm){
-										graphics.Print( -1, 85, "Current soundtrack: MMMMMM", tr, tg, tb, true);
-									}else{
-										graphics.Print( -1, 85, "Current soundtrack: PPPPPP", tr, tg, tb, true);
-									}
-							}
-							}
-						#endif
+#if defined(MAKEANDPLAY)
+            if (game.currentmenuoption == 0)
+            {
+                graphics.bigprint( -1, 30, "Accessibility", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Disable screen effects, enable", tr, tg, tb, true);
+                graphics.Print( -1, 75, "slowdown modes or invincibility", tr, tg, tb, true);
+            }
+            else if (game.currentmenuoption == 1)
+            {
+                graphics.bigprint( -1, 30, "Game Pad Options", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
+                graphics.Print( -1, 75, "and adjust sensitivity", tr, tg, tb, true);
+            }
+            else if (game.currentmenuoption == 2)
+            {
+                graphics.bigprint( -1, 30, "Clear Data", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Delete your save data", tr, tg, tb, true);
+                graphics.Print( -1, 75, "and unlocked play modes", tr, tg, tb, true);
+            }else if (game.currentmenuoption == 3){
+                if(music.mmmmmm){
+                    graphics.bigprint( -1, 30, "Soundtrack", tr, tg, tb, true);
+                    graphics.Print( -1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);
+                    if(music.usingmmmmmm){
+                        graphics.Print( -1, 85, "Current soundtrack: MMMMMM", tr, tg, tb, true);
+                    }else{
+                        graphics.Print( -1, 85, "Current soundtrack: PPPPPP", tr, tg, tb, true);
+                    }
+                }
+            }
+#elif !defined(MAKEANDPLAY)
+            if (game.currentmenuoption == 0)
+            {
+                graphics.bigprint( -1, 30, "Accessibility", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Disable screen effects, enable", tr, tg, tb, true);
+                graphics.Print( -1, 75, "slowdown modes or invincibility", tr, tg, tb, true);
+            }
+            else if (game.currentmenuoption == 1)
+            {
+                graphics.bigprint( -1, 30, "Unlock Play Modes", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Unlock parts of the game normally", tr, tg, tb, true);
+                graphics.Print( -1, 75, "unlocked as you progress", tr, tg, tb, true);
+            }
+            else if (game.currentmenuoption == 2)
+            {
+                graphics.bigprint( -1, 30, "Game Pad Options", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
+                graphics.Print( -1, 75, "and adjust sensitivity", tr, tg, tb, true);
+            }
+            else if (game.currentmenuoption == 3)
+            {
+                graphics.bigprint( -1, 30, "Clear Data", tr, tg, tb, true);
+                graphics.Print( -1, 65, "Delete your save data", tr, tg, tb, true);
+                graphics.Print( -1, 75, "and unlocked play modes", tr, tg, tb, true);
+            }else if (game.currentmenuoption == 4)
+            {
+                if(music.mmmmmm){
+                    graphics.bigprint( -1, 30, "Soundtrack", tr, tg, tb, true);
+                    graphics.Print( -1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);
+                    if(music.usingmmmmmm){
+                        graphics.Print( -1, 85, "Current soundtrack: MMMMMM", tr, tg, tb, true);
+                    }else{
+                        graphics.Print( -1, 85, "Current soundtrack: PPPPPP", tr, tg, tb, true);
+                    }
+                }
+            }
+#endif
         }
         else if (game.currentmenuname == "graphicoptions")
         {
@@ -259,7 +259,7 @@ void titlerender()
             //graphics.Print( 40, 80, "http://www.distractionware.com", tr, tg, tb);
             graphics.Print( -1, 110, "C++ version by", tr, tg, tb, true);
             graphics.bigprint( 40, 125, "Simon Roth", tr, tg, tb, true);
-						graphics.bigprint( 40, 145, "Ethan Lee", tr, tg, tb, true);
+            graphics.bigprint( 40, 145, "Ethan Lee", tr, tg, tb, true);
            //graphics.drawimagecol(11, -1, 156, tr*0.75, tg *0.75, tb *0.75, true);
         }
         else if (game.currentmenuname == "credits25")
@@ -392,47 +392,47 @@ void titlerender()
             graphics.Print( -1, 100, "Would you like to disable the", tr, tg, tb, true);
             graphics.Print( -1, 112, "cutscenes during the game?", tr, tg, tb, true);
         }
-		else if (game.currentmenuname == "controller")
-		{
-			graphics.bigprint( -1, 30, "Game Pad", tr, tg, tb, true);
-			graphics.Print( -1, 55, "Change controller options.", tr, tg, tb, true);
-			if (game.currentmenuoption == 0)
-			{
-				switch(game.controllerSensitivity)
-				{
-				case 0:
-					graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
-					graphics.Print( -1, 95, "[]..................", tr, tg, tb, true);
-					break;
-				case 1:
-					graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
-					graphics.Print( -1, 95, ".....[].............", tr, tg, tb, true);
-					break;
-				case 2:
-					graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
-					graphics.Print( -1, 95, ".........[].........", tr, tg, tb, true);
-					break;
-				case 3:
-					graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
-					graphics.Print( -1, 95, ".............[].....", tr, tg, tb, true);
-					break;
-				case 4:
-					graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
-					graphics.Print( -1, 95, "..................[]", tr, tg, tb, true);
-					break;
-				}
-			}
-			if (    game.currentmenuoption == 1 ||
+        else if (game.currentmenuname == "controller")
+        {
+            graphics.bigprint( -1, 30, "Game Pad", tr, tg, tb, true);
+            graphics.Print( -1, 55, "Change controller options.", tr, tg, tb, true);
+            if (game.currentmenuoption == 0)
+            {
+                switch(game.controllerSensitivity)
+                {
+                case 0:
+                    graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
+                    graphics.Print( -1, 95, "[]..................", tr, tg, tb, true);
+                    break;
+                case 1:
+                    graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
+                    graphics.Print( -1, 95, ".....[].............", tr, tg, tb, true);
+                    break;
+                case 2:
+                    graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
+                    graphics.Print( -1, 95, ".........[].........", tr, tg, tb, true);
+                    break;
+                case 3:
+                    graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
+                    graphics.Print( -1, 95, ".............[].....", tr, tg, tb, true);
+                    break;
+                case 4:
+                    graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);
+                    graphics.Print( -1, 95, "..................[]", tr, tg, tb, true);
+                    break;
+                }
+            }
+            if (    game.currentmenuoption == 1 ||
                                 game.currentmenuoption == 2 ||
                                 game.currentmenuoption == 3     )
-			{
-				graphics.Print( -1, 85, "Flip is bound to: " + std::string(help.GCString(game.controllerButton_flip)) , tr, tg, tb, true);
-				graphics.Print( -1, 95, "Enter is bound to: "  + std::string(help.GCString(game.controllerButton_map)), tr, tg, tb, true);
-				graphics.Print( -1, 105, "Menu is bound to: " + std::string(help.GCString(game.controllerButton_esc)) , tr, tg, tb, true);
-			}
+            {
+                graphics.Print( -1, 85, "Flip is bound to: " + std::string(help.GCString(game.controllerButton_flip)) , tr, tg, tb, true);
+                graphics.Print( -1, 95, "Enter is bound to: "  + std::string(help.GCString(game.controllerButton_map)), tr, tg, tb, true);
+                graphics.Print( -1, 105, "Menu is bound to: " + std::string(help.GCString(game.controllerButton_esc)) , tr, tg, tb, true);
+            }
 
 
-		}
+        }
         else if (game.currentmenuname == "accessibility")
         {
             if (game.currentmenuoption == 0)
@@ -1123,46 +1123,46 @@ void titlerender()
             graphics.Print( -1, 135, "the intermission levels.", tr, tg, tb, true);
         }else if (game.currentmenuname == "playerworlds")
         {
-						graphics.tempstring = FILESYSTEM_getUserLevelDirectory();
-						if(graphics.tempstring.length()>80){
-							graphics.Print( -1, 160, "To install new player levels, copy", tr, tg, tb, true);
-							graphics.Print( -1, 170, "the .vvvvvv files to this folder:", tr, tg, tb, true);
-							graphics.Print( 320-((graphics.tempstring.length()-80)*8), 190, graphics.tempstring.substr(0,graphics.tempstring.length()-80), tr, tg, tb);
-							graphics.Print( 0, 200, graphics.tempstring.substr(graphics.tempstring.length()-80,40), tr, tg, tb);
-							graphics.Print( 0, 210, graphics.tempstring.substr(graphics.tempstring.length()-40,40), tr, tg, tb);
-						}else if(graphics.tempstring.length()>40){
-							graphics.Print( -1, 170, "To install new player levels, copy", tr, tg, tb, true);
-							graphics.Print( -1, 180, "the .vvvvvv files to this folder:", tr, tg, tb, true);
-							graphics.Print( 320-((graphics.tempstring.length()-40)*8), 200, graphics.tempstring.substr(0,graphics.tempstring.length()-40), tr, tg, tb);
-							graphics.Print( 0, 210, graphics.tempstring.substr(graphics.tempstring.length()-40,40), tr, tg, tb);
-						}else{
-							graphics.Print( -1, 180, "To install new player levels, copy", tr, tg, tb, true);
-							graphics.Print( -1, 190, "the .vvvvvv files to this folder:", tr, tg, tb, true);
-							graphics.Print( 320-(graphics.tempstring.length()*8), 210, graphics.tempstring, tr, tg, tb);
-						}
+            graphics.tempstring = FILESYSTEM_getUserLevelDirectory();
+            if(graphics.tempstring.length()>80){
+                graphics.Print( -1, 160, "To install new player levels, copy", tr, tg, tb, true);
+                graphics.Print( -1, 170, "the .vvvvvv files to this folder:", tr, tg, tb, true);
+                graphics.Print( 320-((graphics.tempstring.length()-80)*8), 190, graphics.tempstring.substr(0,graphics.tempstring.length()-80), tr, tg, tb);
+                graphics.Print( 0, 200, graphics.tempstring.substr(graphics.tempstring.length()-80,40), tr, tg, tb);
+                graphics.Print( 0, 210, graphics.tempstring.substr(graphics.tempstring.length()-40,40), tr, tg, tb);
+            }else if(graphics.tempstring.length()>40){
+                graphics.Print( -1, 170, "To install new player levels, copy", tr, tg, tb, true);
+                graphics.Print( -1, 180, "the .vvvvvv files to this folder:", tr, tg, tb, true);
+                graphics.Print( 320-((graphics.tempstring.length()-40)*8), 200, graphics.tempstring.substr(0,graphics.tempstring.length()-40), tr, tg, tb);
+                graphics.Print( 0, 210, graphics.tempstring.substr(graphics.tempstring.length()-40,40), tr, tg, tb);
+            }else{
+                graphics.Print( -1, 180, "To install new player levels, copy", tr, tg, tb, true);
+                graphics.Print( -1, 190, "the .vvvvvv files to this folder:", tr, tg, tb, true);
+                graphics.Print( 320-(graphics.tempstring.length()*8), 210, graphics.tempstring, tr, tg, tb);
+            }
         }
 
         /*
         switch(game.mainmenu) {
-        	case 0:
-        		graphics.Print(5, 115, "[ NEW GAME ]", tr, tg, tb, true);
-        	break;
-        	case 1:
-        		if (game.telesummary == "") {
-        			graphics.Print(5, 115, "[ no teleporter save ]", tr/3, tg/3, tb/3, true);
-        		}else {
-        			graphics.Print(5, 115, "[ RESTORE FROM LAST TELEPORTER ]", tr, tg, tb, true);
-        			graphics.Print(5, 125, game.telesummary, tr, tg, tb, true);
-        		}
-        	break;
-        	case 2:
-        		if (game.quicksummary == "") {
-        			graphics.Print(5, 115, "[ no quicksave ]", tr/3, tg/3, tb/3, true);
-        		}else {
-        			graphics.Print(5, 115, "[ RESTORE FROM LAST QUICKSAVE ]", tr, tg, tb, true);
-        			graphics.Print(5, 125, game.quicksummary, tr, tg, tb, true);
-        		}
-        	break;
+            case 0:
+                graphics.Print(5, 115, "[ NEW GAME ]", tr, tg, tb, true);
+            break;
+            case 1:
+                if (game.telesummary == "") {
+                    graphics.Print(5, 115, "[ no teleporter save ]", tr/3, tg/3, tb/3, true);
+                }else {
+                    graphics.Print(5, 115, "[ RESTORE FROM LAST TELEPORTER ]", tr, tg, tb, true);
+                    graphics.Print(5, 125, game.telesummary, tr, tg, tb, true);
+                }
+            break;
+            case 2:
+                if (game.quicksummary == "") {
+                    graphics.Print(5, 115, "[ no quicksave ]", tr/3, tg/3, tb/3, true);
+                }else {
+                    graphics.Print(5, 115, "[ RESTORE FROM LAST QUICKSAVE ]", tr, tg, tb, true);
+                    graphics.Print(5, 125, game.quicksummary, tr, tg, tb, true);
+                }
+            break;
         }
         */
 
@@ -1470,20 +1470,20 @@ void gamerender()
     {
 
         if(!game.colourblindmode)
-		{
-        graphics.drawbackground(map.background);
-		}
-		else
-		{
-			FillRect(graphics.backBuffer,0x00000);
-		}
-        if (map.final_colormode)
-		{
-        	graphics.drawfinalmap();
+        {
+            graphics.drawbackground(map.background);
         }
         else
-		{
-        graphics.drawmap();
+        {
+            FillRect(graphics.backBuffer,0x00000);
+        }
+        if (map.final_colormode)
+        {
+            graphics.drawfinalmap();
+        }
+        else
+        {
+            graphics.drawmap();
         }
 
 
@@ -1520,7 +1520,7 @@ void gamerender()
 
     /*for(int i=0; i<obj.nblocks; i++){
     if (obj.blocks[i].active) {
-    		graphics.backbuffer.fillRect(obj.blocks[i].rect, 0xDDDDDD);
+        graphics.backbuffer.fillRect(obj.blocks[i].rect, 0xDDDDDD);
     }
       }*/
     //graphics.drawminimap(game, map);
@@ -1539,10 +1539,10 @@ void gamerender()
 
         if (map.finalmode)
         {
-        	map.glitchname = map.getglitchname(game.roomx, game.roomy);
-          graphics.bprint(5, 231, map.glitchname, 196, 196, 255 - help.glow, true);
+            map.glitchname = map.getglitchname(game.roomx, game.roomy);
+            graphics.bprint(5, 231, map.glitchname, 196, 196, 255 - help.glow, true);
         }else{
-          graphics.bprint(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
+            graphics.bprint(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
         }
     }
 
@@ -1568,7 +1568,7 @@ void gamerender()
 
     graphics.cutscenebars();
     graphics.drawfade();
-	BlitSurfaceStandard(graphics.backBuffer, NULL, graphics.tempBuffer, NULL);
+    BlitSurfaceStandard(graphics.backBuffer, NULL, graphics.tempBuffer, NULL);
 
     graphics.drawgui();
     if (graphics.flipmode)
@@ -1820,9 +1820,9 @@ void gamerender()
     //Detail entity info for debuging
     /*
     for (int i = 0; i < obj.nentity; i++) {
-    	game.tempstring =help.String(obj.entities[i].type) +", (" +help.String(obj.entities[i].xp) + "," +help.String(obj.entities[i].yp) + ")";
-    	game.tempstring += " state:" +obj.entities[i].state + ", delay:" + obj.entities[i].statedelay;
-    	graphics.Print(5, 5 + i * 8, game.tempstring, 255, 255, 255);
+        game.tempstring =help.String(obj.entities[i].type) +", (" +help.String(obj.entities[i].xp) + "," +help.String(obj.entities[i].yp) + ")";
+        game.tempstring += " state:" +obj.entities[i].state + ", delay:" + obj.entities[i].statedelay;
+        graphics.Print(5, 5 + i * 8, game.tempstring, 255, 255, 255);
     }
     */
 
@@ -1878,7 +1878,7 @@ void maprender()
 
     //draw screen alliteration
     //Roomname:
-	//CRASH
+    //CRASH
     temp = map.area(game.roomx, game.roomy);
     if (temp < 2 && !map.custommode && graphics.fademode==0)
     {
@@ -2078,9 +2078,9 @@ void maprender()
             {
                 //tower!instead of room y, scale map.ypos
                 /*if (map.ypos > (0.57 * (680 * 8))) {
-                	i = int(map.ypos - (0.57 * (680 * 8)));
-                	i = int((i / (0.43 * (680 * 8)))*9);
-                	graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + i + 2, 12 - 4, 9 - 4, 16, 245 - (help.glow * 2), 245 - (help.glow * 2));
+                    i = int(map.ypos - (0.57 * (680 * 8)));
+                    i = int((i / (0.43 * (680 * 8)))*9);
+                    graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + i + 2, 12 - 4, 9 - 4, 16, 245 - (help.glow * 2), 245 - (help.glow * 2));
                 }*/
                 if (map.cursorstate == 0)
                 {
@@ -2257,45 +2257,45 @@ void maprender()
 
             graphics.Print(0, 105, "Press ACTION to warp to the ship.", 196, 196, 255 - help.glow, true);
         }
-    #if !defined(NO_CUSTOM_LEVELS)
+#if !defined(NO_CUSTOM_LEVELS)
         else if(map.custommode){
-          graphics.Print(30, 220, "MAP", 64,64,64);
+            graphics.Print(30, 220, "MAP", 64,64,64);
             graphics.Print(103-8, 220, "[CREW]", 196, 196, 255 - help.glow);
             graphics.Print(185-4, 220, "STATS", 64,64,64);
             graphics.Print(258, 220, "SAVE", 64, 64, 64);
 
             if (graphics.flipmode)
             {
-              graphics.bigprint( -1, 220-45, ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
-              graphics.Print( -1, 220-70, "by " + ed.ListOfMetaData[game.playcustomlevel].creator, 196, 196, 255 - help.glow, true);
-              graphics.Print( -1, 220-80, ed.ListOfMetaData[game.playcustomlevel].website, 196, 196, 255 - help.glow, true);
-              graphics.Print( -1, 220-100, ed.ListOfMetaData[game.playcustomlevel].Desc1, 196, 196, 255 - help.glow, true);
-              graphics.Print( -1, 220-110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
-              graphics.Print( -1, 220-120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
+                graphics.bigprint( -1, 220-45, ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
+                graphics.Print( -1, 220-70, "by " + ed.ListOfMetaData[game.playcustomlevel].creator, 196, 196, 255 - help.glow, true);
+                graphics.Print( -1, 220-80, ed.ListOfMetaData[game.playcustomlevel].website, 196, 196, 255 - help.glow, true);
+                graphics.Print( -1, 220-100, ed.ListOfMetaData[game.playcustomlevel].Desc1, 196, 196, 255 - help.glow, true);
+                graphics.Print( -1, 220-110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
+                graphics.Print( -1, 220-120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
 
-              if(map.customcrewmates-game.crewmates==1){
-                graphics.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmate remains", 196, 196, 255 - help.glow, true);
-              }else if(map.customcrewmates-game.crewmates>0){
-                graphics.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmates remain", 196, 196, 255 - help.glow, true);
-              }
+                if(map.customcrewmates-game.crewmates==1){
+                    graphics.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmate remains", 196, 196, 255 - help.glow, true);
+                }else if(map.customcrewmates-game.crewmates>0){
+                    graphics.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmates remain", 196, 196, 255 - help.glow, true);
+                }
             }
             else
             {
-              graphics.bigprint( -1, 45, ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
-              graphics.Print( -1, 70, "by " + ed.ListOfMetaData[game.playcustomlevel].creator, 196, 196, 255 - help.glow, true);
-              graphics.Print( -1, 80, ed.ListOfMetaData[game.playcustomlevel].website, 196, 196, 255 - help.glow, true);
-              graphics.Print( -1, 100, ed.ListOfMetaData[game.playcustomlevel].Desc1, 196, 196, 255 - help.glow, true);
-              graphics.Print( -1, 110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
-              graphics.Print( -1, 120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
+                graphics.bigprint( -1, 45, ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
+                graphics.Print( -1, 70, "by " + ed.ListOfMetaData[game.playcustomlevel].creator, 196, 196, 255 - help.glow, true);
+                graphics.Print( -1, 80, ed.ListOfMetaData[game.playcustomlevel].website, 196, 196, 255 - help.glow, true);
+                graphics.Print( -1, 100, ed.ListOfMetaData[game.playcustomlevel].Desc1, 196, 196, 255 - help.glow, true);
+                graphics.Print( -1, 110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
+                graphics.Print( -1, 120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
 
-              if(map.customcrewmates-game.crewmates==1){
-                graphics.Print(1,165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmate remains", 196, 196, 255 - help.glow, true);
-              }else if(map.customcrewmates-game.crewmates>0){
-                graphics.Print(1,165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmates remain", 196, 196, 255 - help.glow, true);
-              }
+                if(map.customcrewmates-game.crewmates==1){
+                    graphics.Print(1,165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmate remains", 196, 196, 255 - help.glow, true);
+                }else if(map.customcrewmates-game.crewmates>0){
+                    graphics.Print(1,165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmates remain", 196, 196, 255 - help.glow, true);
+                }
             }
         }
-    #endif
+#endif
         else
         {
             graphics.Print(30, 220, "MAP", 64,64,64);
@@ -2463,7 +2463,7 @@ void maprender()
         }
         else if (map.custommode)
         {
-          if (game.gamesaved)
+            if (game.gamesaved)
             {
                 graphics.Print(0, 36, "Game saved ok!", 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2), true);
 
@@ -2781,7 +2781,7 @@ void towerrender()
 
     /*for(int i=0; i<obj.nblocks; i++){
     if (obj.blocks[i].active) {
-    		graphics.backbuffer.fillRect(obj.blocks[i].rect, 0xDDDDDD);
+        graphics.backbuffer.fillRect(obj.blocks[i].rect, 0xDDDDDD);
     }
       }*/
     graphics.cutscenebars();
@@ -2961,7 +2961,7 @@ void teleporterrender()
     if (game.useteleporter)
     {
         //Draw the chosen destination coordinate!
-		//TODO
+        //TODO
         //draw the coordinates //destination
         int tempx = map.teleporters[game.teleport_to_teleporter].x;
         int tempy = map.teleporters[game.teleport_to_teleporter].y;
@@ -3000,8 +3000,8 @@ void teleporterrender()
         }
     }
 
-	tempx = map.teleporters[game.teleport_to_teleporter].x;
-	tempy = map.teleporters[game.teleport_to_teleporter].y;
+    tempx = map.teleporters[game.teleport_to_teleporter].x;
+    tempy = map.teleporters[game.teleport_to_teleporter].y;
     if (game.useteleporter && ((help.slowsine%16)>8))
     {
         //colour in the legend

--- a/desktop_version/src/titlerender.h
+++ b/desktop_version/src/titlerender.h
@@ -8,8 +8,6 @@
 #include "Map.h"
 #include "Script.h"
 
-extern int temp;
-
 void titlerender();
 
 void towerrender();

--- a/desktop_version/src/titlerender.h
+++ b/desktop_version/src/titlerender.h
@@ -18,18 +18,18 @@ extern Stage stage;
 extern Stage swfStage;
 extern int temp;
 
-void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, UtilityClass& help, musicclass& music);
+void titlerender();
 
-void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help);
+void towerrender();
 
-void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, UtilityClass& help);
+void gamerender();
 
-void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help);
+void maprender();
 
-void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help);
+void teleporterrender();
 
-void gamecompleterender(Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help, mapclass& map);
+void gamecompleterender();
 
-void gamecompleterender2(Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help);
+void gamecompleterender2();
 
 #endif /* TITLERENDERER_H */

--- a/desktop_version/src/titlerender.h
+++ b/desktop_version/src/titlerender.h
@@ -14,8 +14,6 @@ public:
     int frameRate;
 };
 
-extern Stage stage;
-extern Stage swfStage;
 extern int temp;
 
 void titlerender();

--- a/desktop_version/src/titlerender.h
+++ b/desktop_version/src/titlerender.h
@@ -8,12 +8,6 @@
 #include "Map.h"
 #include "Script.h"
 
-class Stage
-{
-public:
-    int frameRate;
-};
-
 extern int temp;
 
 void titlerender();


### PR DESCRIPTION
## Changes:

### Summary

This PR is a re-do of #178, except this time everything is not in one commit. It has been split up into 62 commits. Also it contains more cleanups that I had missed before.

`dwgfx`, `map`, `obj`, `music`, `key`, and `help` are no longer passed around as parameters in any function that needs them. Additionally, all `dwgfx` has been renamed to `graphics` since it's a clearer name (I'm not sure what the "dw" in "dwgraphics" stands for, and it sounds like a remnant from the Flash days).

Additionally, since this change affects pretty much the entire codebase, I also took it upon myself to clean up mixed indentation, remove outdated comments, remove useless or unused functions, remove unused parameters, remove unused stuff like testing code and input recording code, and remove the `temp` global file-level variable and move `tempstring` off of class objects. Also, all expressions of the form `UtilityClass::`*`something`* have been changed to `help.`*`something`*.

The standard of indentation I want is to at least have files be consistent with their indentation. A file can indent with tabs or spaces, but it ought to be at least consistent. The annoying part is when you suddenly start switching indentation in the middle of a function. The exception here is `Graphics.cpp`, which switches to tabs starting from `Graphics::setcol()`, which I thought was fine because it wasn't in the middle of a function, and it consistently uses tabs below `Graphics::setcol()` and spaces above, so it's fine.

The following functions had unused parameters:
 - `entityclass::getcompanion()`
 - `Graphics::Hitest()`
 - `Graphics::drawtile()`
 - `Graphics::drawtile2()`
 - `musicclass::playef()`

The following functions or variables were unused or useless:
 - `entityclass::checkdirectional()`
 - `Game::telegotoship()`
 - `Game::sfpsmode`
 - `Game::telecookieexists`
 - `Game::quickcookieexists`
 - `stage`
 - `swfStage`
 - `class Stage`
 - `updategraphicsmode()`
 - `Screen::ClearScreen()`
 - `musicclass::initefchannels()`
 - `Screen::glScreen`
 - `editorclass::weirdloadthing()` (instead, make a copy of the string and use `editorclass::load()`)
 - `musicclass::processmusicfade()`

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
