### PR TITLE
Fix undefined behavior when backspacing in script list with 0 scripts

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3596,7 +3596,7 @@ void editorinput()
 
             if(!key.keymap[SDLK_BACKSPACE]) ed.deletekeyheld=0;
 
-            if(key.keymap[SDLK_BACKSPACE] && ed.deletekeyheld==0)
+            if(key.keymap[SDLK_BACKSPACE] && ed.deletekeyheld==0 && !ed.hooklist.empty())
             {
                 ed.deletekeyheld=1;
                 music.playef(2);


### PR DESCRIPTION
## Changes:

* **Fix undefined behavior when pressing Backspace in the script list with 0 scripts**

  The problem is that it would index out-of-bounds if you did this, but this UB hasn't caused an exception until my change to refactor script-related vectors by removing their separate length-trackers (#169).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
