### PR TITLE
Un-fix songs 0 and 7 looping and fading in if using PPPPPP while mmmmmm.vvv is present

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -236,7 +236,6 @@ void musicclass::play(int t)
 	{
 		if (t != -1)
 		{
-			// musicfade = 0;
 			currentsong = t;
 			if (currentsong == 0 || currentsong == 7 || (!map.custommode && (currentsong == 16 || currentsong == 23)))
 			{

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -269,15 +269,6 @@ void musicclass::play(int t)
 	}
 }
 
-void musicclass::loopmusic()
-{
-	//musicchannel.removeEventListener(Event.SOUND_COMPLETE, loopmusic);
-	//if(currentsong>-1){
-	//	musicchannel = musicchan[currentsong].play();
-	//	musicchannel.addEventListener(Event.SOUND_COMPLETE, loopmusic);
-	//}
-}
-
 void musicclass::stopmusic()
 {
 	Mix_HaltMusic();

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include "Music.h"
 #include "BinaryBlob.h"
+#include "Map.h"
 
 void musicclass::init()
 {
@@ -237,7 +238,7 @@ void musicclass::play(int t)
 		{
 			// musicfade = 0;
 			currentsong = t;
-			if (currentsong == 0 || currentsong == 7 || currentsong == 16 || currentsong == 23)
+			if (currentsong == 0 || currentsong == 7 || (!map.custommode && (currentsong == 16 || currentsong == 23)))
 			{
 				// Level Complete theme, no fade in or repeat
 				if(Mix_FadeInMusic(musicTracks[t].m_music, 0, 0)==-1)

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -269,12 +269,6 @@ void musicclass::play(int t)
 	}
 }
 
-void musicclass::stopmusic()
-{
-	Mix_HaltMusic();
-	currentsong = -1;
-}
-
 void musicclass::haltdasmusik()
 {
 	Mix_HaltMusic();

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -13,7 +13,6 @@ public:
 	void init();
 
 	void play(int t);
-	void loopmusic();
 	void stopmusic();
 	void haltdasmusik();
 	void silencedasmusik();

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -13,7 +13,6 @@ public:
 	void init();
 
 	void play(int t);
-	void stopmusic();
 	void haltdasmusik();
 	void silencedasmusik();
 	void fadeMusicVolumeIn(int ms);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3458,7 +3458,7 @@ void editorlogic()
         map.colstate = 10;
         game.gamestate = 1;
         graphics.fademode = 4;
-        music.stopmusic();
+        music.haltdasmusik();
         music.play(6);
         map.nexttowercolour();
         ed.settingsmod=false;
@@ -4398,7 +4398,7 @@ void editorinput()
                             game.edsavedir=1-edentity[testeditor].p1;
                         }
 
-                        music.stopmusic();
+                        music.haltdasmusik();
                         graphics.backgrounddrawn=false;
                         ed.returneditoralpha = 1000; // Let's start it higher than 255 since it gets clamped
                         script.startgamemode(21);


### PR DESCRIPTION
## Changes:

* **Un-fix songs 0 and 7 looping and fading in if you are using PPPPPP while you have an `mmmmmm.vvv` file**

  As discussed earlier in [#164](https://github.com/TerryCavanagh/VVVVVV/pull/164#issuecomment-607977519), some levels have utilized this bug to create two extra looping tracks.

  This only un-fixes it in custom levels.

* **Clean up some more unused/duplicate code**

  I've removed `musicclass::loopmusic()`, `musicclass::stopmusic()`, and another outdated comment.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
