### PR TITLE
Refactor entities, blocks, and textboxes to not use the 'active' system and to not use separate length-trackers

### DIFF
--- a/desktop_version/src/BlockV.cpp
+++ b/desktop_version/src/BlockV.cpp
@@ -34,3 +34,68 @@ void blockclass::rectset(const int xi, const int yi, const int wi, const int hi)
 	rect.w = wi;
 	rect.h = hi;
 }
+
+void blockclass::setblockcolour( std::string col )
+{
+	if (col == "cyan")
+	{
+		r = 164;
+		g = 164;
+		b = 255;
+	}
+	else if (col == "red")
+	{
+		r = 255;
+		g = 60;
+		b = 60;
+	}
+	else if (col == "green")
+	{
+		r = 144;
+		g = 255;
+		b = 144;
+	}
+	else if (col == "yellow")
+	{
+		r = 255;
+		g = 255;
+		b = 134;
+	}
+	else if (col == "blue")
+	{
+		r = 95;
+		g = 95;
+		b = 255;
+	}
+	else if (col == "purple")
+	{
+		r = 255;
+		g = 134;
+		b = 255;
+	}
+	else if (col == "white")
+	{
+		r = 244;
+		g = 244;
+		b = 244;
+	}
+	else if (col == "gray")
+	{
+		r = 174;
+		g = 174;
+		b = 174;
+	}
+	else if (col == "orange")
+	{
+		r = 255;
+		g = 130;
+		b = 20;
+	}
+	else
+	{
+		//use a gray
+		r = 174;
+		g = 174;
+		b = 174;
+	}
+}

--- a/desktop_version/src/BlockV.cpp
+++ b/desktop_version/src/BlockV.cpp
@@ -7,7 +7,6 @@ blockclass::blockclass()
 
 void blockclass::clear()
 {
-	active = false;
 	type = 0;
 	trigger = 0;
 

--- a/desktop_version/src/BlockV.cpp
+++ b/desktop_version/src/BlockV.cpp
@@ -2,11 +2,6 @@
 
 blockclass::blockclass()
 {
-	clear();
-}
-
-void blockclass::clear()
-{
 	type = 0;
 	trigger = 0;
 

--- a/desktop_version/src/BlockV.h
+++ b/desktop_version/src/BlockV.h
@@ -12,6 +12,8 @@ public:
     void clear();
 
     void rectset(const int xi, const int yi, const int wi, const int hi);
+
+    void setblockcolour(std::string col);
 public:
     //Fundamentals
     bool active;

--- a/desktop_version/src/BlockV.h
+++ b/desktop_version/src/BlockV.h
@@ -16,7 +16,6 @@ public:
     void setblockcolour(std::string col);
 public:
     //Fundamentals
-    bool active;
     SDL_Rect rect;
     int type;
     int trigger;

--- a/desktop_version/src/BlockV.h
+++ b/desktop_version/src/BlockV.h
@@ -9,8 +9,6 @@ class blockclass
 public:
     blockclass();
 
-    void clear();
-
     void rectset(const int xi, const int yi, const int wi, const int hi);
 
     void setblockcolour(std::string col);

--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -2,12 +2,6 @@
 
 entclass::entclass()
 {
-	clear();
-}
-
-void entclass::clear()
-{
-	// Set all values to a default, required for creating a new entity
 	invis = false;
 	type = 0;
 	size = 0;

--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -8,7 +8,6 @@ entclass::entclass()
 void entclass::clear()
 {
 	// Set all values to a default, required for creating a new entity
-	active = false;
 	invis = false;
 	type = 0;
 	size = 0;

--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -86,3 +86,88 @@ bool entclass::outside()
 	}
 	return false;
 }
+
+void entclass::setenemy( int t )
+{
+	switch(t)
+	{
+	case 0:
+		//lies emitter
+		if( (para)==0)
+		{
+			tile = 60;
+			animate = 2;
+			colour = 6;
+			behave = 10;
+			w = 32;
+			h = 32;
+			x1 = -200;
+		}
+		else if ( (para) == 1)
+		{
+			yp += 10;
+			tile = 63;
+			animate = 100; //LIES
+			colour = 6;
+			behave = 11;
+			para = 9; //destroyed when outside
+			x1 = -200;
+			x2 = 400;
+			w = 26;
+			h = 10;
+			cx = 1;
+			cy = 1;
+		}
+		else if ( (para) == 2)
+		{
+			tile = 62;
+			animate = 100;
+			colour = 6;
+			behave = -1;
+			w = 32;
+			h = 32;
+		}
+		break;
+	case 1:
+		//FACTORY emitter
+		if( (para)==0)
+		{
+			tile = 72;
+			animate = 3;
+			size = 9;
+			colour = 6;
+			behave = 12;
+			w = 64;
+			h = 40;
+			cx = 0;
+			cy = 24;
+		}
+		else if ( (para) == 1)
+		{
+			xp += 4;
+			yp -= 4;
+			tile = 76;
+			animate = 100; // Clouds
+			colour = 6;
+			behave = 13;
+			para = -6; //destroyed when outside
+			x2 = 400;
+			w = 32;
+			h = 12;
+			cx = 0;
+			cy = 6;
+		}
+		else if ( (para) == 2)
+		{
+			tile = 77;
+			animate = 100;
+			colour = 6;
+			behave = -1;
+			w = 32;
+			h = 16;
+		}
+		break;
+	default:
+		break;
+	}
+}

--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -171,3 +171,337 @@ void entclass::setenemy( int t )
 		break;
 	}
 }
+
+void entclass::setenemyroom( int rx, int ry )
+{
+	//Simple function to initilise simple enemies
+	rx -= 100;
+	ry -= 100;
+	switch(rn(rx, ry))
+	{
+		//Space Station 1
+	case rn(12, 3):  //Security Drone
+		tile = 36;
+		colour = 8;
+		animate = 1;
+		break;
+	case rn(13, 3):  //Wavelengths
+		tile = 32;
+		colour = 7;
+		animate = 1;
+		w = 32;
+		break;
+	case rn(15, 3):  //Traffic
+		tile = 28;
+		colour = 6;
+		animate = 1;
+		w = 22;
+		h = 32;
+		break;
+	case rn(12, 5):  //The Yes Men
+		tile = 40;
+		colour = 9;
+		animate = 1;
+		w = 20;
+		h = 20;
+		break;
+	case rn(13, 6):  //Hunchbacked Guards
+		tile = 44;
+		colour = 8;
+		animate = 1;
+		w = 16;
+		h = 20;
+		break;
+	case rn(13, 4):  //Communication Station
+		harmful = false;
+		if (xp == 256)
+		{
+			//transmittor
+			tile = 104;
+			colour = 4;
+			animate = 7;
+			w = 16;
+			h = 16;
+			xp -= 24;
+			yp -= 16;
+		}
+		else
+		{
+			//radar dish
+			tile =124;
+			colour = 4;
+			animate = 6;
+			w = 32;
+			h = 32;
+			cx = 4;
+			size = 9;
+			xp -= 4;
+			yp -= 32;
+		}
+
+		break;
+		//The Lab
+	case rn(4, 0):
+		tile = 78;
+		colour = 7;
+		animate = 1;
+		w = 16;
+		h = 16;
+		break;
+	case rn(2, 0):
+		tile = 88;
+		colour = 11;
+		animate = 1;
+		w = 16;
+		h = 16;
+		break;
+		//Space Station 2
+	case rn(14, 11):
+		colour = 17;
+		break; //Lies
+	case rn(16, 11):
+		colour = 8;
+		break; //Lies
+	case rn(13, 10):
+		colour = 11;
+		break; //Factory
+	case rn(13, 9):
+		colour = 9;
+		break; //Factory
+	case rn(13, 8):
+		colour = 8;
+		break; //Factory
+	case rn(11, 13): //Truth
+		tile = 64;
+		colour = 7;
+		animate = 100;
+		w = 44;
+		h = 10;
+		size = 10;
+		break;
+	case rn(17, 7): //Brass sent us under the top
+		tile =82;
+		colour = 8;
+		animate = 5;
+		w = 28;
+		h = 32;
+		cx = 4;
+		break;
+	case rn(10, 7): // (deception)
+		tile = 92;
+		colour = 6;
+		animate = 1;
+		w = 16;
+		h = 16;
+		break;
+	case rn(14, 13): // (chose poorly)
+		tile = 56;
+		colour = 6;
+		animate = 1;
+		w = 15;
+		h = 24;
+		break;
+	case rn(13, 12): // (backsliders)
+		tile = 164;
+		colour = 7;
+		animate = 1;
+		w = 16;
+		h = 16;
+		break;
+	case rn(14, 8): // (wheel of fortune room)
+		tile = 116;
+		colour = 12;
+		animate = 1;
+		w = 32;
+		h = 32;
+		break;
+	case rn(16, 9): // (seeing dollar signs)
+		tile = 68;
+		colour = 7;
+		animate = 1;
+		w = 16;
+		h = 16;
+		break;
+	case rn(16, 7): // (tomb of mad carew)
+		tile = 106;
+		colour = 7;
+		animate = 2;
+		w = 24;
+		h = 25;
+		break;
+		//Warp Zone
+	case rn(15, 2): // (numbers)
+		tile = 100;
+		colour = 6;
+		animate = 1;
+		w = 32;
+		h = 14;
+		yp += 1;
+		break;
+	case rn(16, 2): // (Manequins)
+		tile = 52;
+		colour = 7;
+		animate = 5;
+		w = 16;
+		h = 25;
+		yp -= 4;
+		break;
+	case rn(18, 0): // (Obey)
+		tile = 51;
+		colour = 11;
+		animate = 100;
+		w = 30;
+		h = 14;
+		break;
+	case rn(19, 1): // Ascending and Descending
+		tile = 48;
+		colour = 9;
+		animate = 5;
+		w = 16;
+		h = 16;
+		break;
+	case rn(19, 2): // Shockwave Rider
+		tile = 176;
+		colour = 6;
+		animate = 1;
+		w = 16;
+		h = 16;
+		break;
+	case rn(18, 3): // Mind the gap
+		tile = 168;
+		colour = 7;
+		animate = 1;
+		w = 16;
+		h = 16;
+		break;
+	case rn(17, 3): // Edge Games
+		if (yp ==96)
+		{
+			tile = 160;
+			colour = 8;
+			animate = 1;
+			w = 16;
+			h = 16;
+		}
+		else
+		{
+			tile = 156;
+			colour = 8;
+			animate = 1;
+			w = 16;
+			h = 16;
+		}
+		break;
+	case rn(16, 0): // I love you
+		tile = 112;
+		colour = 8;
+		animate = 5;
+		w = 16;
+		h = 16;
+		break;
+	case rn(14, 2): // That's why I have to kill you
+		tile = 114;
+		colour = 6;
+		animate = 5;
+		w = 16;
+		h = 16;
+		break;
+	case rn(18, 2): // Thinking with Portals
+		//depends on direction
+		if (xp ==88)
+		{
+			tile = 54+12;
+			colour = 12;
+			animate = 100;
+			w = 60;
+			h = 16;
+			size = 10;
+		}
+		else
+		{
+			tile = 54;
+			colour = 12;
+			animate = 100;
+			w = 60;
+			h = 16;
+			size = 10;
+		}
+		break;
+		//Final level
+	case rn(50-100, 53-100):  //The Yes Men
+		tile = 40;
+		colour = 9;
+		animate = 1;
+		w = 20;
+		h = 20;
+		break;
+	case rn(48-100, 51-100):  //Wavelengths
+		tile = 32;
+		colour = 7;
+		animate = 1;
+		w = 32;
+		break;
+	case rn(43-100,52-100): // Ascending and Descending
+		tile = 48;
+		colour = 9;
+		animate = 5;
+		w = 16;
+		h = 16;
+		break;
+	case rn(46-100,51-100): //kids his age
+		tile = 88;
+		colour = 11;
+		animate = 1;
+		w = 16;
+		h = 16;
+		break;
+	case rn(43-100,51-100): // Mind the gap
+		tile = 168;
+		colour = 7;
+		animate = 1;
+		w = 16;
+		h = 16;
+		break;
+	case rn(44-100,51-100): // vertigo?
+		tile = 172;
+		colour = 7;
+		animate = 100;
+		w = 32;
+		h = 32;
+		break;
+	case rn(44-100,52-100): // (backsliders)
+		tile = 164;
+		colour = 7;
+		animate = 1;
+		w = 16;
+		h = 16;
+		break;
+	case rn(43-100, 56-100): //Intermission 1
+		tile = 88;
+		colour = 21;
+		animate = 1;
+		w = 16;
+		h = 16;
+		break;
+	case rn(45-100, 56-100): //Intermission 1
+		tile = 88;
+		colour = 21;
+		animate = 1;
+		w = 16;
+		h = 16;
+		break;
+		//The elephant
+	case rn(11, 9):
+	case rn(12, 9):
+	case rn(11, 8):
+	case rn(12, 8):
+		tile = 0;
+		colour = 102;
+		animate = 0;
+		w = 464;
+		h = 320;
+		size = 11;
+		harmful = false;
+		break;
+	}
+}

--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -505,3 +505,86 @@ void entclass::setenemyroom( int rx, int ry )
 		break;
 	}
 }
+
+void entclass::settreadmillcolour( int rx, int ry )
+{
+	rx -= 100;
+	ry -= 100;
+	rx += 50 - 12;
+	ry += 50 - 14;   //Space Station
+
+	tile = 20; //default as blue
+	switch(rn(rx, ry))
+	{
+	case rn(52, 48):
+		tile = 791;
+		break; //Cyan
+
+	case rn(49, 47):
+		tile = 24;
+		break; //Yellow
+	case rn(56, 44):
+		tile = 24;
+		break; //Yellow
+	case rn(54, 49):
+		tile = 24;
+		break; //Yellow
+
+	case rn(49, 49):
+		tile = 36;
+		break; //Green
+	case rn(55, 44):
+		tile = 36;
+		break; //Green
+	case rn(54, 43):
+		tile = 36;
+		break; //Green
+	case rn(53, 49):
+		tile = 36;
+		break; //Green
+	case rn(54, 45):
+		tile = 711;
+		break; //Green (special)
+	case rn(51, 48):
+		tile = 711;
+		break; //Green (special)
+
+	case rn(50, 49):
+		tile = 28;
+		break; //Purple
+	case rn(54, 44):
+		tile = 28;
+		break; //Purple
+	case rn(49, 42):
+		tile = 28;
+		break; //Purple
+	case rn(55, 43):
+		tile = 28;
+		break; //Purple
+	case rn(54, 47):
+		tile = 28;
+		break; //Purple
+	case rn(53, 48):
+		tile = 28;
+		break; //Purple
+
+	case rn(51, 47):
+		tile = 32;
+		break; //Red
+	case rn(52, 49):
+		tile = 32;
+		break; //Red
+	case rn(48, 43):
+		tile = 32;
+		break; //Red
+	case rn(55, 47):
+		tile = 32;
+		break; //Red
+	case rn(54, 48):
+		tile = 32;
+		break; //Red
+	default:
+		return;
+		break;
+	}
+}

--- a/desktop_version/src/Ent.h
+++ b/desktop_version/src/Ent.h
@@ -16,6 +16,8 @@ public:
 
     void setenemyroom(int rx, int ry);
 
+    void settreadmillcolour(int rx, int ry);
+
 public:
     //Fundamentals
     bool active, invis;

--- a/desktop_version/src/Ent.h
+++ b/desktop_version/src/Ent.h
@@ -20,7 +20,7 @@ public:
 
 public:
     //Fundamentals
-    bool active, invis;
+    bool invis;
     int type, size, tile, rule;
     int state, statedelay;
     int behave, animate;

--- a/desktop_version/src/Ent.h
+++ b/desktop_version/src/Ent.h
@@ -8,8 +8,6 @@ class entclass
 public:
     entclass();
 
-    void clear();
-
     bool outside();
 
     void setenemy(int t);

--- a/desktop_version/src/Ent.h
+++ b/desktop_version/src/Ent.h
@@ -1,6 +1,8 @@
 #ifndef ENT_H
 #define ENT_H
 
+#define		rn( rx,  ry) ((rx) + ((ry) * 100))
+
 class entclass
 {
 public:
@@ -11,6 +13,8 @@ public:
     bool outside();
 
     void setenemy(int t);
+
+    void setenemyroom(int rx, int ry);
 
 public:
     //Fundamentals

--- a/desktop_version/src/Ent.h
+++ b/desktop_version/src/Ent.h
@@ -10,6 +10,8 @@ public:
 
     bool outside();
 
+    void setenemy(int t);
+
 public:
     //Fundamentals
     bool active, invis;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1173,6 +1173,11 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
     }
 }
 
+void entityclass::removeentity(int t)
+{
+    entities[t].active = false;
+}
+
 void entityclass::removeallblocks()
 {
     for(int i=0; i<nblocks; i++) blocks[i].clear();

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -42,8 +42,6 @@ bool entityclass::checktowerspikes(int t)
 
 void entityclass::init()
 {
-    nblocks = 0;
-
     skipblocks = false;
     skipdirblocks = false;
     platformtile = 0;
@@ -68,7 +66,6 @@ void entityclass::init()
     }
 
     flags.resize(100);
-    blocks.resize(500);
     collect.resize(100);
     customcollect.resize(100);
 }
@@ -784,320 +781,286 @@ void entityclass::generateswnwave( int t )
 
 void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*= 0*/ )
 {
-    if(nblocks == 0)
-    {
-        //If there are no active blocks, Z=0;
-        k = 0;
-        nblocks++;
-    }
-    else
-    {
-        int i = 0;
-        k = -1;
-        while (i < nblocks)
-        {
-            if (!blocks[i].active)
-            {
-                k = i;
-                i = nblocks;
-            }
-            i++;
-        }
-        if (k == -1)
-        {
-            k = nblocks;
-            nblocks++;
-        }
-    }
+    k = blocks.size();
 
-    blocks[k].clear();
-    blocks[k].active = true;
+    blockclass block;
     switch(t)
     {
     case BLOCK: //Block
-        blocks[k].type = BLOCK;
-        blocks[k].xp = xp;
-        blocks[k].yp = yp;
-        blocks[k].wp = w;
-        blocks[k].hp = h;
-        blocks[k].rectset(xp, yp, w, h);
-
-        nblocks++;
+        block.type = BLOCK;
+        block.xp = xp;
+        block.yp = yp;
+        block.wp = w;
+        block.hp = h;
+        block.rectset(xp, yp, w, h);
         break;
     case TRIGGER: //Trigger
-        blocks[k].type = TRIGGER;
-        blocks[k].x = xp;
-        blocks[k].y = yp;
-        blocks[k].wp = w;
-        blocks[k].hp = h;
-        blocks[k].rectset(xp, yp, w, h);
-        blocks[k].trigger = trig;
-
-        nblocks++;
+        block.type = TRIGGER;
+        block.x = xp;
+        block.y = yp;
+        block.wp = w;
+        block.hp = h;
+        block.rectset(xp, yp, w, h);
+        block.trigger = trig;
         break;
     case DAMAGE: //Damage
-        blocks[k].type = DAMAGE;
-        blocks[k].x = xp;
-        blocks[k].y = yp;
-        blocks[k].wp = w;
-        blocks[k].hp = h;
-        blocks[k].rectset(xp, yp, w, h);
-
-        nblocks++;
+        block.type = DAMAGE;
+        block.x = xp;
+        block.y = yp;
+        block.wp = w;
+        block.hp = h;
+        block.rectset(xp, yp, w, h);
         break;
     case DIRECTIONAL: //Directional
-        blocks[k].type = DIRECTIONAL;
-        blocks[k].x = xp;
-        blocks[k].y = yp;
-        blocks[k].wp = w;
-        blocks[k].hp = h;
-        blocks[k].rectset(xp, yp, w, h);
-        blocks[k].trigger = trig;
-
-        nblocks++;
+        block.type = DIRECTIONAL;
+        block.x = xp;
+        block.y = yp;
+        block.wp = w;
+        block.hp = h;
+        block.rectset(xp, yp, w, h);
+        block.trigger = trig;
         break;
     case SAFE: //Safe block
-        blocks[k].type = SAFE;
-        blocks[k].xp = xp;
-        blocks[k].yp = yp;
-        blocks[k].wp = w;
-        blocks[k].hp = h;
-        blocks[k].rectset(xp, yp, w, h);
-
-        nblocks++;
+        block.type = SAFE;
+        block.xp = xp;
+        block.yp = yp;
+        block.wp = w;
+        block.hp = h;
+        block.rectset(xp, yp, w, h);
         break;
     case ACTIVITY: //Activity Zone
-        blocks[k].type = ACTIVITY;
-        blocks[k].x = xp;
-        blocks[k].y = yp;
-        blocks[k].wp = w;
-        blocks[k].hp = h;
-        blocks[k].rectset(xp, yp, w, h);
+        block.type = ACTIVITY;
+        block.x = xp;
+        block.y = yp;
+        block.wp = w;
+        block.hp = h;
+        block.rectset(xp, yp, w, h);
 
         //Ok, each and every activity zone in the game is initilised here. "Trig" in this case is a variable that
         //assigns all the details.
         switch(trig)
         {
         case 0: //testing zone
-            blocks[k].prompt = "Press ENTER to explode";
-            blocks[k].script = "intro";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to explode";
+            block.script = "intro";
+            block.setblockcolour("orange");
             trig=1;
             break;
         case 1:
-            blocks[k].prompt = "Press ENTER to talk to Violet";
-            blocks[k].script = "talkpurple";
-            blocks[k].setblockcolour("purple");
+            block.prompt = "Press ENTER to talk to Violet";
+            block.script = "talkpurple";
+            block.setblockcolour("purple");
             trig=0;
             break;
         case 2:
-            blocks[k].prompt = "Press ENTER to talk to Vitellary";
-            blocks[k].script = "talkyellow";
-            blocks[k].setblockcolour("yellow");
+            block.prompt = "Press ENTER to talk to Vitellary";
+            block.script = "talkyellow";
+            block.setblockcolour("yellow");
             trig=0;
             break;
         case 3:
-            blocks[k].prompt = "Press ENTER to talk to Vermilion";
-            blocks[k].script = "talkred";
-            blocks[k].setblockcolour("red");
+            block.prompt = "Press ENTER to talk to Vermilion";
+            block.script = "talkred";
+            block.setblockcolour("red");
             trig=0;
             break;
         case 4:
-            blocks[k].prompt = "Press ENTER to talk to Verdigris";
-            blocks[k].script = "talkgreen";
-            blocks[k].setblockcolour("green");
+            block.prompt = "Press ENTER to talk to Verdigris";
+            block.script = "talkgreen";
+            block.setblockcolour("green");
             trig=0;
             break;
         case 5:
-            blocks[k].prompt = "Press ENTER to talk to Victoria";
-            blocks[k].script = "talkblue";
-            blocks[k].setblockcolour("blue");
+            block.prompt = "Press ENTER to talk to Victoria";
+            block.script = "talkblue";
+            block.setblockcolour("blue");
             trig=0;
             break;
         case 6:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_station_1";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_station_1";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 7:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_outside_1";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_outside_1";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 8:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_outside_2";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_outside_2";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 9:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_outside_3";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_outside_3";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 10:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_outside_4";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_outside_4";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 11:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_outside_5";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_outside_5";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 12:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_outside_6";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_outside_6";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 13:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_finallevel";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_finallevel";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 14:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_station_2";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_station_2";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 15:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_station_3";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_station_3";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 16:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_station_4";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_station_4";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 17:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_warp_1";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_warp_1";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 18:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_warp_2";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_warp_2";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 19:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_lab_1";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_lab_1";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 20:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_lab_2";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_lab_2";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 21:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_secretlab";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_secretlab";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 22:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_shipcomputer";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_shipcomputer";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 23:
-            blocks[k].prompt = "Press ENTER to activate terminals";
-            blocks[k].script = "terminal_radio";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminals";
+            block.script = "terminal_radio";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 24:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "terminal_jukebox";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "terminal_jukebox";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 25:
-            blocks[k].prompt = "Passion for Exploring";
-            blocks[k].script = "terminal_juke1";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Passion for Exploring";
+            block.script = "terminal_juke1";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 26:
-            blocks[k].prompt = "Pushing Onwards";
-            blocks[k].script = "terminal_juke2";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Pushing Onwards";
+            block.script = "terminal_juke2";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 27:
-            blocks[k].prompt = "Positive Force";
-            blocks[k].script = "terminal_juke3";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Positive Force";
+            block.script = "terminal_juke3";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 28:
-            blocks[k].prompt = "Presenting VVVVVV";
-            blocks[k].script = "terminal_juke4";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Presenting VVVVVV";
+            block.script = "terminal_juke4";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 29:
-            blocks[k].prompt = "Potential for Anything";
-            blocks[k].script = "terminal_juke5";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Potential for Anything";
+            block.script = "terminal_juke5";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 30:
-            blocks[k].prompt = "Predestined Fate";
-            blocks[k].script = "terminal_juke6";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Predestined Fate";
+            block.script = "terminal_juke6";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 31:
-            blocks[k].prompt = "Pipe Dream";
-            blocks[k].script = "terminal_juke7";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Pipe Dream";
+            block.script = "terminal_juke7";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 32:
-            blocks[k].prompt = "Popular Potpourri";
-            blocks[k].script = "terminal_juke8";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Popular Potpourri";
+            block.script = "terminal_juke8";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 33:
-            blocks[k].prompt = "Pressure Cooker";
-            blocks[k].script = "terminal_juke9";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Pressure Cooker";
+            block.script = "terminal_juke9";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 34:
-            blocks[k].prompt = "ecroF evitisoP";
-            blocks[k].script = "terminal_juke10";
-            blocks[k].setblockcolour("orange");
+            block.prompt = "ecroF evitisoP";
+            block.script = "terminal_juke10";
+            block.setblockcolour("orange");
             trig=0;
             break;
         case 35:
-            blocks[k].prompt = "Press ENTER to activate terminal";
-            blocks[k].script = "custom_"+customscript;
-            blocks[k].setblockcolour("orange");
+            block.prompt = "Press ENTER to activate terminal";
+            block.script = "custom_"+customscript;
+            block.setblockcolour("orange");
             trig=0;
             break;
         }
-        nblocks++;
         break;
     }
+
+    blocks.push_back(block);
 }
 
 void entityclass::removeentity(int t)
@@ -1107,39 +1070,31 @@ void entityclass::removeentity(int t)
 
 void entityclass::removeallblocks()
 {
-    for(int i=0; i<nblocks; i++) blocks[i].clear();
-    nblocks=0;
+    blocks.clear();
 }
 
 void entityclass::removeblock( int t )
 {
-    blocks[t].clear();
-    int i = nblocks - 1;
-    while (i >= 0 && !(blocks[i].active))
-    {
-        nblocks--;
-        i--;
-    }
+    blocks.erase(blocks.begin() + t);
 }
 
 void entityclass::removeblockat( int x, int y )
 {
-    for (int i = 0; i < nblocks; i++)
+    for (size_t i = 0; i < blocks.size(); i++)
     {
-        if(blocks[i].xp == int(x) && blocks[i].yp == int(y)) removeblock(i);
+        if(blocks[i].xp == int(x) && blocks[i].yp == int(y)) removeblock_iter(i);
     }
 }
 
 void entityclass::removetrigger( int t )
 {
-    for(int i=0; i<nblocks; i++)
+    for(size_t i=0; i<blocks.size(); i++)
     {
         if(blocks[i].type == TRIGGER)
         {
             if (blocks[i].trigger == t)
             {
-                blocks[i].active = false;
-                removeblock(i);
+                removeblock_iter(i);
             }
         }
     }
@@ -3800,9 +3755,9 @@ bool entityclass::checkdamage()
             temph = entities[i].h;
             rectset(tempx, tempy, tempw, temph);
 
-            for (int j=0; j<nblocks; j++)
+            for (size_t j=0; j<blocks.size(); j++)
             {
-                if (blocks[j].type == DAMAGE && blocks[j].active)
+                if (blocks[j].type == DAMAGE)
                 {
                     if(help.intersects(blocks[j].rect, temprect))
                     {
@@ -3828,9 +3783,9 @@ bool entityclass::scmcheckdamage()
             temph = entities[i].h;
             rectset(tempx, tempy, tempw, temph);
 
-            for (int j=0; j<nblocks; j++)
+            for (size_t j=0; j<blocks.size(); j++)
             {
-                if (blocks[j].type == DAMAGE && blocks[j].active)
+                if (blocks[j].type == DAMAGE)
                 {
                     if(help.intersects(blocks[j].rect, temprect))
                     {
@@ -3866,9 +3821,9 @@ int entityclass::checktrigger()
             temph = entities[i].h;
             rectset(tempx, tempy, tempw, temph);
 
-            for (int j=0; j<nblocks; j++)
+            for (size_t j=0; j<blocks.size(); j++)
             {
-                if (blocks[j].type == TRIGGER && blocks[j].active)
+                if (blocks[j].type == TRIGGER)
                 {
                     if (help.intersects(blocks[j].rect, temprect))
                     {
@@ -3895,9 +3850,9 @@ int entityclass::checkactivity()
             temph = entities[i].h;
             rectset(tempx, tempy, tempw, temph);
 
-            for (int j=0; j<nblocks; j++)
+            for (size_t j=0; j<blocks.size(); j++)
             {
-                if (blocks[j].type == ACTIVITY && blocks[j].active)
+                if (blocks[j].type == ACTIVITY)
                 {
                     if (help.intersects(blocks[j].rect, temprect))
                     {
@@ -3930,9 +3885,9 @@ bool entityclass::cblocks( int t )
 bool entityclass::checkplatform()
 {
     //Return true if rectset intersects a moving platform, setups px & py to the platform x & y
-    for (int i = 0; i < nblocks; i++)
+    for (size_t i = 0; i < blocks.size(); i++)
     {
-        if (blocks[i].active)
+        if (true) //FIXME: remove this later (no more 'active')
         {
             if (blocks[i].type == BLOCK)
             {
@@ -3950,9 +3905,9 @@ bool entityclass::checkplatform()
 
 bool entityclass::checkblocks()
 {
-    for (int i = 0; i < nblocks; i++)
+    for (size_t i = 0; i < blocks.size(); i++)
     {
-        if (blocks[i].active)
+        if (true) //FIXME: remove this later (no more 'active')
         {
             if(!skipdirblocks)
             {

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1267,340 +1267,6 @@ int entityclass::crewcolour( int t )
     return 0;
 }
 
-void entityclass::setenemyroom( int t, int rx, int ry )
-{
-    //Simple function to initilise simple enemies
-    rx -= 100;
-    ry -= 100;
-    switch(rn(rx, ry))
-    {
-        //Space Station 1
-    case rn(12, 3):  //Security Drone
-        entities[t].tile = 36;
-        entities[t].colour = 8;
-        entities[t].animate = 1;
-        break;
-    case rn(13, 3):  //Wavelengths
-        entities[t].tile = 32;
-        entities[t].colour = 7;
-        entities[t].animate = 1;
-        entities[t].w = 32;
-        break;
-    case rn(15, 3):  //Traffic
-        entities[t].tile = 28;
-        entities[t].colour = 6;
-        entities[t].animate = 1;
-        entities[t].w = 22;
-        entities[t].h = 32;
-        break;
-    case rn(12, 5):  //The Yes Men
-        entities[t].tile = 40;
-        entities[t].colour = 9;
-        entities[t].animate = 1;
-        entities[t].w = 20;
-        entities[t].h = 20;
-        break;
-    case rn(13, 6):  //Hunchbacked Guards
-        entities[t].tile = 44;
-        entities[t].colour = 8;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 20;
-        break;
-    case rn(13, 4):  //Communication Station
-        entities[t].harmful = false;
-        if (entities[t].xp == 256)
-        {
-            //transmittor
-            entities[t].tile = 104;
-            entities[t].colour = 4;
-            entities[t].animate = 7;
-            entities[t].w = 16;
-            entities[t].h = 16;
-            entities[t].xp -= 24;
-            entities[t].yp -= 16;
-        }
-        else
-        {
-            //radar dish
-            entities[t].tile =124;
-            entities[t].colour = 4;
-            entities[t].animate = 6;
-            entities[t].w = 32;
-            entities[t].h = 32;
-            entities[t].cx = 4;
-            entities[t].size = 9;
-            entities[t].xp -= 4;
-            entities[t].yp -= 32;
-        }
-
-        break;
-        //The Lab
-    case rn(4, 0):
-        entities[t].tile = 78;
-        entities[t].colour = 7;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(2, 0):
-        entities[t].tile = 88;
-        entities[t].colour = 11;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-        //Space Station 2
-    case rn(14, 11):
-        entities[t].colour = 17;
-        break; //Lies
-    case rn(16, 11):
-        entities[t].colour = 8;
-        break; //Lies
-    case rn(13, 10):
-        entities[t].colour = 11;
-        break; //Factory
-    case rn(13, 9):
-        entities[t].colour = 9;
-        break; //Factory
-    case rn(13, 8):
-        entities[t].colour = 8;
-        break; //Factory
-    case rn(11, 13): //Truth
-        entities[t].tile = 64;
-        entities[t].colour = 7;
-        entities[t].animate = 100;
-        entities[t].w = 44;
-        entities[t].h = 10;
-        entities[t].size = 10;
-        break;
-    case rn(17, 7): //Brass sent us under the top
-        entities[t].tile =82;
-        entities[t].colour = 8;
-        entities[t].animate = 5;
-        entities[t].w = 28;
-        entities[t].h = 32;
-        entities[t].cx = 4;
-        break;
-    case rn(10, 7): // (deception)
-        entities[t].tile = 92;
-        entities[t].colour = 6;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(14, 13): // (chose poorly)
-        entities[t].tile = 56;
-        entities[t].colour = 6;
-        entities[t].animate = 1;
-        entities[t].w = 15;
-        entities[t].h = 24;
-        break;
-    case rn(13, 12): // (backsliders)
-        entities[t].tile = 164;
-        entities[t].colour = 7;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(14, 8): // (wheel of fortune room)
-        entities[t].tile = 116;
-        entities[t].colour = 12;
-        entities[t].animate = 1;
-        entities[t].w = 32;
-        entities[t].h = 32;
-        break;
-    case rn(16, 9): // (seeing dollar signs)
-        entities[t].tile = 68;
-        entities[t].colour = 7;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(16, 7): // (tomb of mad carew)
-        entities[t].tile = 106;
-        entities[t].colour = 7;
-        entities[t].animate = 2;
-        entities[t].w = 24;
-        entities[t].h = 25;
-        break;
-        //Warp Zone
-    case rn(15, 2): // (numbers)
-        entities[t].tile = 100;
-        entities[t].colour = 6;
-        entities[t].animate = 1;
-        entities[t].w = 32;
-        entities[t].h = 14;
-        entities[t].yp += 1;
-        break;
-    case rn(16, 2): // (Manequins)
-        entities[t].tile = 52;
-        entities[t].colour = 7;
-        entities[t].animate = 5;
-        entities[t].w = 16;
-        entities[t].h = 25;
-        entities[t].yp -= 4;
-        break;
-    case rn(18, 0): // (Obey)
-        entities[t].tile = 51;
-        entities[t].colour = 11;
-        entities[t].animate = 100;
-        entities[t].w = 30;
-        entities[t].h = 14;
-        break;
-    case rn(19, 1): // Ascending and Descending
-        entities[t].tile = 48;
-        entities[t].colour = 9;
-        entities[t].animate = 5;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(19, 2): // Shockwave Rider
-        entities[t].tile = 176;
-        entities[t].colour = 6;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(18, 3): // Mind the gap
-        entities[t].tile = 168;
-        entities[t].colour = 7;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(17, 3): // Edge Games
-        if (entities[t].yp ==96)
-        {
-            entities[t].tile = 160;
-            entities[t].colour = 8;
-            entities[t].animate = 1;
-            entities[t].w = 16;
-            entities[t].h = 16;
-        }
-        else
-        {
-            entities[t].tile = 156;
-            entities[t].colour = 8;
-            entities[t].animate = 1;
-            entities[t].w = 16;
-            entities[t].h = 16;
-        }
-        break;
-    case rn(16, 0): // I love you
-        entities[t].tile = 112;
-        entities[t].colour = 8;
-        entities[t].animate = 5;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(14, 2): // That's why I have to kill you
-        entities[t].tile = 114;
-        entities[t].colour = 6;
-        entities[t].animate = 5;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(18, 2): // Thinking with Portals
-        //depends on direction
-        if (entities[t].xp ==88)
-        {
-            entities[t].tile = 54+12;
-            entities[t].colour = 12;
-            entities[t].animate = 100;
-            entities[t].w = 60;
-            entities[t].h = 16;
-            entities[t].size = 10;
-        }
-        else
-        {
-            entities[t].tile = 54;
-            entities[t].colour = 12;
-            entities[t].animate = 100;
-            entities[t].w = 60;
-            entities[t].h = 16;
-            entities[t].size = 10;
-        }
-        break;
-        //Final level
-    case rn(50-100, 53-100):  //The Yes Men
-        entities[t].tile = 40;
-        entities[t].colour = 9;
-        entities[t].animate = 1;
-        entities[t].w = 20;
-        entities[t].h = 20;
-        break;
-    case rn(48-100, 51-100):  //Wavelengths
-        entities[t].tile = 32;
-        entities[t].colour = 7;
-        entities[t].animate = 1;
-        entities[t].w = 32;
-        break;
-    case rn(43-100,52-100): // Ascending and Descending
-        entities[t].tile = 48;
-        entities[t].colour = 9;
-        entities[t].animate = 5;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(46-100,51-100): //kids his age
-        entities[t].tile = 88;
-        entities[t].colour = 11;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(43-100,51-100): // Mind the gap
-        entities[t].tile = 168;
-        entities[t].colour = 7;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(44-100,51-100): // vertigo?
-        entities[t].tile = 172;
-        entities[t].colour = 7;
-        entities[t].animate = 100;
-        entities[t].w = 32;
-        entities[t].h = 32;
-        break;
-    case rn(44-100,52-100): // (backsliders)
-        entities[t].tile = 164;
-        entities[t].colour = 7;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(43-100, 56-100): //Intermission 1
-        entities[t].tile = 88;
-        entities[t].colour = 21;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-    case rn(45-100, 56-100): //Intermission 1
-        entities[t].tile = 88;
-        entities[t].colour = 21;
-        entities[t].animate = 1;
-        entities[t].w = 16;
-        entities[t].h = 16;
-        break;
-        //The elephant
-    case rn(11, 9):
-    case rn(12, 9):
-    case rn(11, 8):
-    case rn(12, 8):
-        entities[t].tile = 0;
-        entities[t].colour = 102;
-        entities[t].animate = 0;
-        entities[t].w = 464;
-        entities[t].h = 320;
-        entities[t].size = 11;
-        entities[t].harmful = false;
-        break;
-    }
-}
-
 void entityclass::settreadmillcolour( int t, int rx, int ry )
 {
     rx -= 100;
@@ -1781,12 +1447,12 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         if  (game.roomy == 111 && (game.roomx >= 113 && game.roomx <= 117))
         {
             entities[k].setenemy(0);
-            setenemyroom(k, game.roomx, game.roomy); //For colour
+            entities[k].setenemyroom(game.roomx, game.roomy); //For colour
         }
         else if  (game.roomx == 113 && (game.roomy <= 110 && game.roomy >= 108))
         {
             entities[k].setenemy(1);
-            setenemyroom(k, game.roomx, game.roomy); //For colour
+            entities[k].setenemyroom(game.roomx, game.roomy); //For colour
         }
         else if (game.roomx == 113 && game.roomy == 107)
         {
@@ -1800,7 +1466,7 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         }
         else
         {
-            setenemyroom(k, game.roomx, game.roomy);
+            entities[k].setenemyroom(game.roomx, game.roomy);
         }
 
         //}else{*/
@@ -2621,17 +2287,17 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         entities[k].harmful = true;
 
         switch(customenemy){
-          case 0: setenemyroom(k, 4+100, 0+100); break;
-          case 1: setenemyroom(k, 2+100, 0+100); break;
-          case 2: setenemyroom(k, 12+100, 3+100); break;
-          case 3: setenemyroom(k, 13+100, 12+100); break;
-          case 4: setenemyroom(k, 16+100, 9+100); break;
-          case 5: setenemyroom(k, 19+100, 1+100); break;
-          case 6: setenemyroom(k, 19+100, 2+100); break;
-          case 7: setenemyroom(k, 18+100, 3+100); break;
-          case 8: setenemyroom(k, 16+100, 0+100); break;
-          case 9: setenemyroom(k, 14+100, 2+100); break;
-          default: setenemyroom(k, 4+100, 0+100); break;
+          case 0: entities[k].setenemyroom(4+100, 0+100); break;
+          case 1: entities[k].setenemyroom(2+100, 0+100); break;
+          case 2: entities[k].setenemyroom(12+100, 3+100); break;
+          case 3: entities[k].setenemyroom(13+100, 12+100); break;
+          case 4: entities[k].setenemyroom(16+100, 9+100); break;
+          case 5: entities[k].setenemyroom(19+100, 1+100); break;
+          case 6: entities[k].setenemyroom(19+100, 2+100); break;
+          case 7: entities[k].setenemyroom(18+100, 3+100); break;
+          case 8: entities[k].setenemyroom(16+100, 0+100); break;
+          case 9: entities[k].setenemyroom(14+100, 2+100); break;
+          default: entities[k].setenemyroom(4+100, 0+100); break;
         }
 
         //Set colour based on room tile

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -3753,20 +3753,6 @@ void entityclass::animateentities( int _i )
     }
 }
 
-bool entityclass::gettype( int t )
-{
-    //Returns true is there is an entity of type t onscreen
-    for (size_t i = 0; i < entities.size(); i++)
-    {
-        if(entities[i].type==t)
-        {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 int entityclass::getcompanion()
 {
     //Returns the index of the companion with rule t

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -42,7 +42,6 @@ bool entityclass::checktowerspikes(int t)
 
 void entityclass::init()
 {
-    nentity = 0;
     nblocks = 0;
 
     skipblocks = false;
@@ -70,12 +69,8 @@ void entityclass::init()
 
     flags.resize(100);
     blocks.resize(500);
-    entities.resize(200);
-    linecrosskludge.resize(100);
     collect.resize(100);
     customcollect.resize(100);
-
-    nlinecrosskludge = 0;
 }
 
 void entityclass::resetallflags()
@@ -198,9 +193,9 @@ int entityclass::swncolour( int t )
 void entityclass::swnenemiescol( int t )
 {
     //change the colour of all SWN enemies to the current one
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
-        if (entities[i].active)
+        if (true) // FIXME: remove this later (no more 'active')
         {
             if (entities[i].type == 23)
             {
@@ -1175,7 +1170,7 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
 
 void entityclass::removeentity(int t)
 {
-    entities[t].active = false;
+    entities.erase(entities.begin() + t);
 }
 
 void entityclass::removeallblocks()
@@ -1221,14 +1216,7 @@ void entityclass::removetrigger( int t )
 void entityclass::copylinecross( int t )
 {
     //Copy entity t into the first free linecrosskludge entity
-    linecrosskludge[nlinecrosskludge].clear();
-    linecrosskludge[nlinecrosskludge].xp = entities[t].xp;
-    linecrosskludge[nlinecrosskludge].yp = entities[t].yp;
-    linecrosskludge[nlinecrosskludge].w = entities[t].w;
-    linecrosskludge[nlinecrosskludge].onentity = entities[t].onentity;
-    linecrosskludge[nlinecrosskludge].state = entities[t].state;
-    linecrosskludge[nlinecrosskludge].life = entities[t].life;
-    nlinecrosskludge++;
+    linecrosskludge.push_back(entities[t]);
 }
 
 void entityclass::revertlinecross( int t, int s )
@@ -1274,32 +1262,7 @@ int entityclass::crewcolour( int t )
 
 void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, float vy /*= 0*/, int p1 /*= 0*/, int p2 /*= 0*/, int p3 /*= 320*/, int p4 /*= 240 */ )
 {
-    //Find the first inactive case z that we can use to index the new entity
-    if (nentity == 0)
-    {
-        //If there are no active entities, Z=0;
-        k = 0;
-        nentity++;
-    }
-    else
-    {
-        int i = 0;
-        k = -1;
-        while (i < nentity)
-        {
-            if (!entities[i].active)
-            {
-                k = i;
-                i = nentity;
-            }
-            i++;
-        }
-        if (k == -1)
-        {
-            k = nentity;
-            nentity++;
-        }
-    }
+    k = entities.size();
 
     //Size 0 is a sprite
     //Size 1 is a tile
@@ -1316,124 +1279,123 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
     //Rule 4 is a horizontal line, 5 is vertical
     //Rule 6 is a crew member
 
-    entities[k].clear();
-    entities[k].active = true;
-    entities[k].type = t;
+    entclass entity;
+    entity.type = t;
     switch(t)
     {
     case 0: //Player
-        entities[k].rule = 0; //Playable character
-        entities[k].tile = 0;
-        entities[k].colour = 0;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cx = 6;
-        entities[k].cy = 2;
-        entities[k].w = 12;
-        entities[k].h = 21;
-        entities[k].dir = 1;
+        entity.rule = 0; //Playable character
+        entity.tile = 0;
+        entity.colour = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cx = 6;
+        entity.cy = 2;
+        entity.w = 12;
+        entity.h = 21;
+        entity.dir = 1;
 
-        if( (vx)==1) entities[k].invis = true;
+        if( (vx)==1) entity.invis = true;
 
-        entities[k].gravity = true;
+        entity.gravity = true;
         break;
     case 1: //Simple enemy, bouncing off the walls
-        entities[k].rule = 1;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].behave = vx;
-        entities[k].para = vy;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].cx = 0;
-        entities[k].cy = 0;
+        entity.rule = 1;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.behave = vx;
+        entity.para = vy;
+        entity.w = 16;
+        entity.h = 16;
+        entity.cx = 0;
+        entity.cy = 0;
 
-        entities[k].x1 = p1;
-        entities[k].y1 = p2;
-        entities[k].x2 = p3;
-        entities[k].y2 = p4;
+        entity.x1 = p1;
+        entity.y1 = p2;
+        entity.x2 = p3;
+        entity.y2 = p4;
 
-        entities[k].harmful = true;
+        entity.harmful = true;
         //Exact appearance depends entirely on location, assigned here:
         /*
         }else if (game.roomx == 50 && game.roomy == 52) {
-        entities[k].tile = 48; entities[k].colour = 6;
-        entities[k].w = 32;	entities[k].h = 27;
-        entities[k].animate = 1;
+        entity.tile = 48; entity.colour = 6;
+        entity.w = 32;	entity.h = 27;
+        entity.animate = 1;
         //ok, for space station 2
         */
-        entities[k].tile = 24;
-        entities[k].animate = 0;
-        entities[k].colour = 8;
+        entity.tile = 24;
+        entity.animate = 0;
+        entity.colour = 8;
 
         if  (game.roomy == 111 && (game.roomx >= 113 && game.roomx <= 117))
         {
-            entities[k].setenemy(0);
-            entities[k].setenemyroom(game.roomx, game.roomy); //For colour
+            entity.setenemy(0);
+            entity.setenemyroom(game.roomx, game.roomy); //For colour
         }
         else if  (game.roomx == 113 && (game.roomy <= 110 && game.roomy >= 108))
         {
-            entities[k].setenemy(1);
-            entities[k].setenemyroom(game.roomx, game.roomy); //For colour
+            entity.setenemy(1);
+            entity.setenemyroom(game.roomx, game.roomy); //For colour
         }
         else if (game.roomx == 113 && game.roomy == 107)
         {
             //MAVVERRRICK
-            entities[k].tile = 96;
-            entities[k].colour = 6;
-            entities[k].size = 9;
-            entities[k].w = 64;
-            entities[k].h = 44;
-            entities[k].animate = 4;
+            entity.tile = 96;
+            entity.colour = 6;
+            entity.size = 9;
+            entity.w = 64;
+            entity.h = 44;
+            entity.animate = 4;
         }
         else
         {
-            entities[k].setenemyroom(game.roomx, game.roomy);
+            entity.setenemyroom(game.roomx, game.roomy);
         }
 
         //}else{*/
         /*
-        entities[k].tile = 24;
-        entities[k].animate = 0;
-        entities[k].colour = 8;
+        entity.tile = 24;
+        entity.animate = 0;
+        entity.colour = 8;
         //for warpzone:
-        if (game.roomx == 51 && game.roomy == 51) entities[k].colour = 6;
-        if (game.roomx == 52 && game.roomy == 51) entities[k].colour = 7;
-        if (game.roomx == 54 && game.roomy == 49) entities[k].colour = 11;
-        if (game.roomx == 55 && game.roomy == 50) entities[k].colour = 9;
-        if (game.roomx == 55 && game.roomy == 51) entities[k].colour = 6;
-        if (game.roomx == 54 && game.roomy == 51) entities[k].colour = 12;
-        if (game.roomx == 54 && game.roomy == 52) entities[k].colour = 7;
-        if (game.roomx == 53 && game.roomy == 52) entities[k].colour = 8;
-        if (game.roomx == 51 && game.roomy == 52) entities[k].colour = 6;
-        if (game.roomx == 52 && game.roomy == 49) entities[k].colour = 8;
+        if (game.roomx == 51 && game.roomy == 51) entity.colour = 6;
+        if (game.roomx == 52 && game.roomy == 51) entity.colour = 7;
+        if (game.roomx == 54 && game.roomy == 49) entity.colour = 11;
+        if (game.roomx == 55 && game.roomy == 50) entity.colour = 9;
+        if (game.roomx == 55 && game.roomy == 51) entity.colour = 6;
+        if (game.roomx == 54 && game.roomy == 51) entity.colour = 12;
+        if (game.roomx == 54 && game.roomy == 52) entity.colour = 7;
+        if (game.roomx == 53 && game.roomy == 52) entity.colour = 8;
+        if (game.roomx == 51 && game.roomy == 52) entity.colour = 6;
+        if (game.roomx == 52 && game.roomy == 49) entity.colour = 8;
         //}
         */
         break;
     case 2: //A moving platform
-        entities[k].rule = 2;
-        entities[k].type = 1;
-        entities[k].size = 2;
-        entities[k].tile = 1;
+        entity.rule = 2;
+        entity.type = 1;
+        entity.size = 2;
+        entity.tile = 1;
 
         if (customplatformtile > 0){
-            entities[k].tile = customplatformtile;
+            entity.tile = customplatformtile;
         }else if (platformtile > 0) {
-            entities[k].tile = platformtile;
+            entity.tile = platformtile;
         }else{
           //appearance again depends on location
-          if (gridmatch(p1, p2, p3, p4, 100, 70, 320, 160)) entities[k].tile = 616;
-          if (gridmatch(p1, p2, p3, p4, 72, 0, 248, 240)) entities[k].tile = 610;
-          if (gridmatch(p1, p2, p3, p4, -20, 0, 320, 240)) entities[k].tile = 413;
+          if (gridmatch(p1, p2, p3, p4, 100, 70, 320, 160)) entity.tile = 616;
+          if (gridmatch(p1, p2, p3, p4, 72, 0, 248, 240)) entity.tile = 610;
+          if (gridmatch(p1, p2, p3, p4, -20, 0, 320, 240)) entity.tile = 413;
 
-          if (gridmatch(p1, p2, p3, p4, -96, -72, 400, 312)) entities[k].tile = 26;
-          if (gridmatch(p1, p2, p3, p4, -32, -40, 352, 264)) entities[k].tile = 27;
+          if (gridmatch(p1, p2, p3, p4, -96, -72, 400, 312)) entity.tile = 26;
+          if (gridmatch(p1, p2, p3, p4, -32, -40, 352, 264)) entity.tile = 27;
         }
 
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 32;
-        entities[k].h = 8;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 32;
+        entity.h = 8;
 
         if (int(vx) <= 1) vertplatforms = true;
         if (int(vx) >= 2  && int(vx) <= 5) horplatforms = true;
@@ -1443,437 +1405,437 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         if (int(vx) >= 10  && int(vx) <= 11)
         {
             //Double sized threadmills
-            entities[k].w = 64;
-            entities[k].h = 8;
+            entity.w = 64;
+            entity.h = 8;
             vx -= 2;
-            entities[k].size = 8;
+            entity.size = 8;
         }
 
-        entities[k].behave = vx;
-        entities[k].para = vy;
+        entity.behave = vx;
+        entity.para = vy;
 
         if (int(vx) >= 8  && int(vx) <= 9)
         {
             horplatforms = true; //threadmill!
-            entities[k].animate = 10;
+            entity.animate = 10;
             if(customplatformtile>0){
-              entities[k].tile = customplatformtile+4;
-              if (int(vx) == 8) entities[k].tile += 4;
-              if (int(vx) == 9) entities[k].animate = 11;
+              entity.tile = customplatformtile+4;
+              if (int(vx) == 8) entity.tile += 4;
+              if (int(vx) == 9) entity.animate = 11;
             }else{
-              entities[k].settreadmillcolour(game.roomx, game.roomy);
-              if (int(vx) == 8) entities[k].tile += 40;
-              if (int(vx) == 9) entities[k].animate = 11;
+              entity.settreadmillcolour(game.roomx, game.roomy);
+              if (int(vx) == 8) entity.tile += 40;
+              if (int(vx) == 9) entity.animate = 11;
             }
         }
         else
         {
-            entities[k].animate = 100;
+            entity.animate = 100;
         }
 
-        entities[k].x1 = p1;
-        entities[k].y1 = p2;
-        entities[k].x2 = p3;
-        entities[k].y2 = p4;
+        entity.x1 = p1;
+        entity.y1 = p2;
+        entity.x2 = p3;
+        entity.y2 = p4;
 
-        entities[k].isplatform = true;
+        entity.isplatform = true;
 
         createblock(0, xp, yp, 32, 8);
         break;
     case 3: //Disappearing platforms
-        entities[k].rule = 3;
-        entities[k].type = 2;
-        entities[k].size = 2;
-        entities[k].tile = 2;
+        entity.rule = 3;
+        entity.type = 2;
+        entity.size = 2;
+        entity.tile = 2;
         //appearance again depends on location
         if(customplatformtile>0)
         {
-          entities[k].tile=customplatformtile;
+          entity.tile=customplatformtile;
         }
         else if (vx > 0)
         {
-            entities[k].tile = int(vx);
+            entity.tile = int(vx);
         }
         else
         {
-            if(game.roomx==49 && game.roomy==52) entities[k].tile = 18;
-            if (game.roomx == 50 && game.roomy == 52) entities[k].tile = 22;
+            if(game.roomx==49 && game.roomy==52) entity.tile = 18;
+            if (game.roomx == 50 && game.roomy == 52) entity.tile = 22;
         }
 
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cy = -1;
-        entities[k].w = 32;
-        entities[k].h = 10;
-        entities[k].behave = vx;
-        entities[k].para = vy;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cy = -1;
+        entity.w = 32;
+        entity.h = 10;
+        entity.behave = vx;
+        entity.para = vy;
+        entity.onentity = 1;
+        entity.animate = 100;
 
         createblock(0, xp, yp, 32, 8);
         break;
     case 4: //Breakable blocks
-        entities[k].rule = 6;
-        entities[k].type = 3;
-        entities[k].size = 1;
-        entities[k].tile = 10;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cy = -1;
-        entities[k].w = 8;
-        entities[k].h = 10;
-        entities[k].behave = vx;
-        entities[k].para = vy;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
+        entity.rule = 6;
+        entity.type = 3;
+        entity.size = 1;
+        entity.tile = 10;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cy = -1;
+        entity.w = 8;
+        entity.h = 10;
+        entity.behave = vx;
+        entity.para = vy;
+        entity.onentity = 1;
+        entity.animate = 100;
 
         createblock(0, xp, yp, 8, 8);
         break;
     case 5: //Gravity Tokens
-        entities[k].rule = 3;
-        entities[k].type = 4;
-        entities[k].size = 0;
-        entities[k].tile = 11;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].behave = vx;
-        entities[k].para = vy;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
+        entity.rule = 3;
+        entity.type = 4;
+        entity.size = 0;
+        entity.tile = 11;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.behave = vx;
+        entity.para = vy;
+        entity.onentity = 1;
+        entity.animate = 100;
         break;
     case 6: //Decorative particles
-        entities[k].rule = 2;
-        entities[k].type = 5;  //Particles
-        entities[k].colour = 1;
-        entities[k].size = 3;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].vx = vx;
-        entities[k].vy = vy;
+        entity.rule = 2;
+        entity.type = 5;  //Particles
+        entity.colour = 1;
+        entity.size = 3;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.vx = vx;
+        entity.vy = vy;
 
-        entities[k].life = 12;
+        entity.life = 12;
         break;
     case 7: //Decorative particles
-        entities[k].rule = 2;
-        entities[k].type = 5;  //Particles
-        entities[k].colour = 2;
-        entities[k].size = 3;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].vx = vx;
-        entities[k].vy = vy;
+        entity.rule = 2;
+        entity.type = 5;  //Particles
+        entity.colour = 2;
+        entity.size = 3;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.vx = vx;
+        entity.vy = vy;
 
-        entities[k].life = 12;
+        entity.life = 12;
         break;
     case 8: //Small collectibles
-        entities[k].rule = 3;
-        entities[k].type = 6;
-        entities[k].size = 4;
-        entities[k].tile = 48;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 8;
-        entities[k].h = 8;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
+        entity.rule = 3;
+        entity.type = 6;
+        entity.size = 4;
+        entity.tile = 48;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 8;
+        entity.h = 8;
+        entity.onentity = 1;
+        entity.animate = 100;
 
         //Check if it's already been collected
-        entities[k].para = vx;
-        if (collect[vx] == 1) entities[k].active = false;
+        entity.para = vx;
+        if (collect[vx] == 1) return;
         break;
     case 9: //Something Shiny
-        entities[k].rule = 3;
-        entities[k].type = 7;
-        entities[k].size = 0;
-        entities[k].tile = 22;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].colour = 3;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
+        entity.rule = 3;
+        entity.type = 7;
+        entity.size = 0;
+        entity.tile = 22;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.colour = 3;
+        entity.onentity = 1;
+        entity.animate = 100;
 
         //Check if it's already been collected
-        entities[k].para = vx;
-        if (collect[vx] == 1) entities[k].active = false;
+        entity.para = vx;
+        if (collect[vx] == 1) return;
         break;
     case 10: //Savepoint
-        entities[k].rule = 3;
-        entities[k].type = 8;
-        entities[k].size = 0;
-        entities[k].tile = 20 + vx;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].colour = 4;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
-        entities[k].para = vy;
+        entity.rule = 3;
+        entity.type = 8;
+        entity.size = 0;
+        entity.tile = 20 + vx;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.colour = 4;
+        entity.onentity = 1;
+        entity.animate = 100;
+        entity.para = vy;
 
         if (game.savepoint ==  (vy))
         {
-            entities[k].colour = 5;
-            entities[k].onentity = 0;
+            entity.colour = 5;
+            entity.onentity = 0;
         }
 
         if (game.nodeathmode)
         {
-            entities[k].active = false;
+            return;
         }
         break;
     case 11: //Horizontal Gravity Line
-        entities[k].rule = 4;
-        entities[k].type = 9;
-        entities[k].size = 5;
-        entities[k].life = 0;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = vx;
-        entities[k].h = 1;
-        entities[k].onentity = 1;
+        entity.rule = 4;
+        entity.type = 9;
+        entity.size = 5;
+        entity.life = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = vx;
+        entity.h = 1;
+        entity.onentity = 1;
         break;
     case 12: //Vertical Gravity Line
-        entities[k].rule = 5;
-        entities[k].type = 10;
-        entities[k].size = 6;
-        entities[k].life = 0;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 1;
-        entities[k].h = vx;
-        //entities[k].colour = 0;
-        entities[k].onentity = 1;
+        entity.rule = 5;
+        entity.type = 10;
+        entity.size = 6;
+        entity.life = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 1;
+        entity.h = vx;
+        //entity.colour = 0;
+        entity.onentity = 1;
         break;
     case 13: //Warp token
-        entities[k].rule = 3;
-        entities[k].type = 11;
-        entities[k].size = 0;
-        entities[k].tile = 18;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].colour = 10;
-        entities[k].onentity = 1;
-        entities[k].animate = 2;
+        entity.rule = 3;
+        entity.type = 11;
+        entity.size = 0;
+        entity.tile = 18;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.colour = 10;
+        entity.onentity = 1;
+        entity.animate = 2;
         //Added in port, hope it doesn't break anything
-        entities[k].behave = vx;
-        entities[k].para = vy;
+        entity.behave = vx;
+        entity.para = vy;
         break;
     case 14: // Teleporter
-        entities[k].rule = 3;
-        entities[k].type = 100;
-        entities[k].size = 7;
-        entities[k].tile = 1; //inactive
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 96;
-        entities[k].h = 96;
-        entities[k].colour = 100;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
-        entities[k].para = vy;
+        entity.rule = 3;
+        entity.type = 100;
+        entity.size = 7;
+        entity.tile = 1; //inactive
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 96;
+        entity.h = 96;
+        entity.colour = 100;
+        entity.onentity = 1;
+        entity.animate = 100;
+        entity.para = vy;
 
         //we'll init it's activeness here later
         /*if (game.savepoint == vy) {
-        entities[k].colour = 5;
-        entities[k].onentity = 0;
+        entity.colour = 5;
+        entity.onentity = 0;
         }*/
         break;
     case 15: // Crew Member (warp zone)
-        entities[k].rule = 6;
-        entities[k].type = 12; //A special case!
-        entities[k].tile = 144;
-        entities[k].colour = 13; //144 for sad :(
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cx = 6;
-        entities[k].cy = 2;
-        entities[k].w = 12;
-        entities[k].h = 21;
-        entities[k].dir = 0;
+        entity.rule = 6;
+        entity.type = 12; //A special case!
+        entity.tile = 144;
+        entity.colour = 13; //144 for sad :(
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cx = 6;
+        entity.cy = 2;
+        entity.w = 12;
+        entity.h = 21;
+        entity.dir = 0;
 
-        entities[k].state = vx;
+        entity.state = vx;
 
-        entities[k].gravity = true;
+        entity.gravity = true;
         break;
     case 16: // Crew Member, upside down (space station)
-        entities[k].rule = 7;
-        entities[k].type = 12; //A special case!
-        entities[k].tile = 144+6;
-        entities[k].colour = 14; //144 for sad (upside down+12):(
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cx = 6;
-        entities[k].cy = 2;
-        entities[k].w = 12;
-        entities[k].h = 21;
-        entities[k].dir = 1;
+        entity.rule = 7;
+        entity.type = 12; //A special case!
+        entity.tile = 144+6;
+        entity.colour = 14; //144 for sad (upside down+12):(
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cx = 6;
+        entity.cy = 2;
+        entity.w = 12;
+        entity.h = 21;
+        entity.dir = 1;
 
-        entities[k].state = vx;
+        entity.state = vx;
 
-        entities[k].gravity = true;
+        entity.gravity = true;
         break;
     case 17: // Crew Member (Lab)
-        entities[k].rule = 6;
-        entities[k].type = 12; //A special case!
-        entities[k].tile = 144;
-        entities[k].colour = 16; //144 for sad :(
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cx = 6;
-        entities[k].cy = 2;
-        entities[k].w = 12;
-        entities[k].h = 21;
-        entities[k].dir = 1;
+        entity.rule = 6;
+        entity.type = 12; //A special case!
+        entity.tile = 144;
+        entity.colour = 16; //144 for sad :(
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cx = 6;
+        entity.cy = 2;
+        entity.w = 12;
+        entity.h = 21;
+        entity.dir = 1;
 
-        entities[k].state = vx;
+        entity.state = vx;
 
-        entities[k].gravity = true;
+        entity.gravity = true;
         break;
     case 18: // Crew Member (Ship)
         //This is the scriping crewmember
-        entities[k].rule = 6;
-        entities[k].type = 12; //A special case!
-        entities[k].colour = vx;
+        entity.rule = 6;
+        entity.type = 12; //A special case!
+        entity.colour = vx;
         if (int(vy) == 0)
         {
-            entities[k].tile = 0;
+            entity.tile = 0;
         }
         else
         {
-            entities[k].tile = 144;
+            entity.tile = 144;
         }
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cx = 6;
-        entities[k].cy = 2;
-        entities[k].w = 12;
-        entities[k].h = 21;
-        entities[k].dir = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cx = 6;
+        entity.cy = 2;
+        entity.w = 12;
+        entity.h = 21;
+        entity.dir = 0;
 
-        entities[k].state = p1;
-        entities[k].para = p2;
+        entity.state = p1;
+        entity.para = p2;
 
         if (p1 == 17)
         {
-            entities[k].dir = p2;
+            entity.dir = p2;
         }
 
-        entities[k].gravity = true;
+        entity.gravity = true;
         break;
     case 19: // Crew Member (Ship) More tests!
-        entities[k].rule = 6;
-        entities[k].type = 12; //A special case!
-        entities[k].tile = 0;
-        entities[k].colour = 6; //54 for sad :(
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cx = 6;
-        entities[k].cy = 2;
-        entities[k].w = 12;
-        entities[k].h = 21;
-        entities[k].dir = 1;
+        entity.rule = 6;
+        entity.type = 12; //A special case!
+        entity.tile = 0;
+        entity.colour = 6; //54 for sad :(
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cx = 6;
+        entity.cy = 2;
+        entity.w = 12;
+        entity.h = 21;
+        entity.dir = 1;
 
-        entities[k].state = vx;
+        entity.state = vx;
 
-        entities[k].gravity = true;
+        entity.gravity = true;
         break;
     case 20: //Terminal
-        entities[k].rule = 3;
-        entities[k].type = 13;
-        entities[k].size = 0;
-        entities[k].tile = 16 + vx;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].colour = 4;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
-        entities[k].para = vy;
+        entity.rule = 3;
+        entity.type = 13;
+        entity.size = 0;
+        entity.tile = 16 + vx;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.colour = 4;
+        entity.onentity = 1;
+        entity.animate = 100;
+        entity.para = vy;
 
         /*if (game.savepoint == vy) {
-        entities[k].colour = 5;
-        entities[k].onentity = 0;
+        entity.colour = 5;
+        entity.onentity = 0;
         }*/
         break;
     case 21: //as above, except doesn't highlight
-        entities[k].rule = 3;
-        entities[k].type = 13;
-        entities[k].size = 0;
-        entities[k].tile = 16 + vx;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].colour = 4;
-        entities[k].onentity = 0;
-        entities[k].animate = 100;
-        entities[k].para = vy;
+        entity.rule = 3;
+        entity.type = 13;
+        entity.size = 0;
+        entity.tile = 16 + vx;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.colour = 4;
+        entity.onentity = 0;
+        entity.animate = 100;
+        entity.para = vy;
 
         /*if (game.savepoint == vy) {
-        entities[k].colour = 5;
-        entities[k].onentity = 0;
+        entity.colour = 5;
+        entity.onentity = 0;
         }*/
         break;
     case 22: //Fake trinkets, only appear if you've collected them
-        entities[k].rule = 3;
-        entities[k].type = 7;
-        entities[k].size = 0;
-        entities[k].tile = 22;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].colour = 3;
-        entities[k].onentity = 0;
-        entities[k].animate = 100;
+        entity.rule = 3;
+        entity.type = 7;
+        entity.size = 0;
+        entity.tile = 22;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.colour = 3;
+        entity.onentity = 0;
+        entity.animate = 100;
 
         //Check if it's already been collected
-        entities[k].para = vx;
-        if (collect[ (vx)] == 0) entities[k].active = false;
+        entity.para = vx;
+        if (collect[ (vx)] == 0) return;
         break;
     case 23: //SWN Enemies
         //Given a different behavior, these enemies are especially for SWN mode and disappear outside the screen.
-        entities[k].rule = 1;
-        entities[k].type = 23;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].behave = vx;
-        entities[k].para = vy;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].cx = 0;
-        entities[k].cy = 0;
+        entity.rule = 1;
+        entity.type = 23;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.behave = vx;
+        entity.para = vy;
+        entity.w = 16;
+        entity.h = 16;
+        entity.cx = 0;
+        entity.cy = 0;
 
-        entities[k].x1 = -2000;
-        entities[k].y1 = -100;
-        entities[k].x2 = 5200;
-        entities[k].y2 = 340;
+        entity.x1 = -2000;
+        entity.y1 = -100;
+        entity.x2 = 5200;
+        entity.y2 = 340;
 
-        entities[k].harmful = true;
+        entity.harmful = true;
 
         //initilise tiles here based on behavior
-        entities[k].size = 12; //don't wrap around
-        entities[k].colour = 21;
-        entities[k].tile = 78; //default case
-        entities[k].animate = 1;
+        entity.size = 12; //don't wrap around
+        entity.colour = 21;
+        entity.tile = 78; //default case
+        entity.animate = 1;
         if (game.swngame == 1)
         {
             //set colour based on current state
-            entities[k].colour = swncolour(game.swncolstate);
+            entity.colour = swncolour(game.swncolstate);
         }
         break;
     case 24: // Super Crew Member
         //This special crewmember is way more advanced than the usual kind, and can interact with game objects
-        entities[k].rule = 6;
-        entities[k].type = 14; //A special case!
-        entities[k].colour = vx;
+        entity.rule = 6;
+        entity.type = 14; //A special case!
+        entity.colour = vx;
         if( (vx)==16)
         {
             //victoria is sad!
@@ -1885,110 +1847,110 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         }
         if (int(vy) == 0)
         {
-            entities[k].tile = 0;
+            entity.tile = 0;
         }
         else
         {
-            entities[k].tile = 144;
+            entity.tile = 144;
         }
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cx = 6;
-        entities[k].cy = 2;
-        entities[k].w = 12;
-        entities[k].h = 21;
-        entities[k].dir = 1;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cx = 6;
+        entity.cy = 2;
+        entity.w = 12;
+        entity.h = 21;
+        entity.dir = 1;
 
-        entities[k].x1 = -2000;
-        entities[k].y1 = -100;
-        entities[k].x2 = 5200;
-        entities[k].y2 = 340;
+        entity.x1 = -2000;
+        entity.y1 = -100;
+        entity.x2 = 5200;
+        entity.y2 = 340;
 
-        entities[k].state = p1;
-        entities[k].para = p2;
+        entity.state = p1;
+        entity.para = p2;
 
         if (p1 == 17)
         {
-            entities[k].dir = p2;
+            entity.dir = p2;
         }
 
-        entities[k].gravity = true;
+        entity.gravity = true;
         break;
     case 25: //Trophies
-        entities[k].rule = 3;
-        entities[k].type = 15;
-        entities[k].size = 0;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].colour = 4;
-        entities[k].onentity = 1;
-        entities[k].animate = 100;
-        entities[k].para = vy;
+        entity.rule = 3;
+        entity.type = 15;
+        entity.size = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 16;
+        entity.h = 16;
+        entity.colour = 4;
+        entity.onentity = 1;
+        entity.animate = 100;
+        entity.para = vy;
 
         //Decide tile here based on given achievement: both whether you have them and what they are
         //default is just a trophy base:
-        entities[k].tile = 180 + vx;
+        entity.tile = 180 + vx;
         switch(int(vy))
         {
         case 1:
             if(game.bestrank[0]>=3)
             {
-                entities[k].tile = 184 + vx;
-                entities[k].colour = 31;
+                entity.tile = 184 + vx;
+                entity.colour = 31;
             }
             break;
         case 2:
             if(game.bestrank[1]>=3)
             {
-                entities[k].tile = 186 + vx;
-                entities[k].colour = 35;
+                entity.tile = 186 + vx;
+                entity.colour = 35;
             }
             break;
         case 3:
             if(game.bestrank[2]>=3)
             {
-                entities[k].tile = 184 + vx;
-                entities[k].colour = 33;
+                entity.tile = 184 + vx;
+                entity.colour = 33;
             }
             break;
         case 4:
             if(game.bestrank[3]>=3)
             {
-                entities[k].tile = 184 + vx;
-                entities[k].colour = 32;
+                entity.tile = 184 + vx;
+                entity.colour = 32;
             }
             break;
         case 5:
             if(game.bestrank[4]>=3)
             {
-                entities[k].tile = 184 + vx;
-                entities[k].colour = 34;
+                entity.tile = 184 + vx;
+                entity.colour = 34;
             }
             break;
         case 6:
             if(game.bestrank[5]>=3)
             {
-                entities[k].tile = 184 + vx;
-                entities[k].colour = 30;
+                entity.tile = 184 + vx;
+                entity.colour = 30;
             }
             break;
 
         case 7:
             if(game.unlock[5])
             {
-                entities[k].tile = 188 + vx;
-                entities[k].colour = 37;
-                entities[k].h += 3;
+                entity.tile = 188 + vx;
+                entity.colour = 37;
+                entity.h += 3;
             }
             break;
         case 8:
             if(game.unlock[19])
             {
-                entities[k].tile = 188 + vx;
-                entities[k].colour = 37;
-                entities[k].h += 3;
+                entity.tile = 188 + vx;
+                entity.colour = 37;
+                entity.h += 3;
             }
             break;
 
@@ -1997,8 +1959,8 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
             {
                 if (game.bestgamedeaths <= 50)
                 {
-                    entities[k].tile = 182 + vx;
-                    entities[k].colour = 40;
+                    entity.tile = 182 + vx;
+                    entity.colour = 40;
                 }
             }
             break;
@@ -2007,8 +1969,8 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
             {
                 if (game.bestgamedeaths <= 100)
                 {
-                    entities[k].tile = 182 + vx;
-                    entities[k].colour = 36;
+                    entity.tile = 182 + vx;
+                    entity.colour = 36;
                 }
             }
             break;
@@ -2017,8 +1979,8 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
             {
                 if (game.bestgamedeaths <= 250)
                 {
-                    entities[k].tile = 182 + vx;
-                    entities[k].colour = 38;
+                    entity.tile = 182 + vx;
+                    entity.colour = 38;
                 }
             }
             break;
@@ -2027,8 +1989,8 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
             {
                 if (game.bestgamedeaths <= 500)
                 {
-                    entities[k].tile = 182 + vx;
-                    entities[k].colour = 39;
+                    entity.tile = 182 + vx;
+                    entity.colour = 39;
                 }
             }
             break;
@@ -2036,54 +1998,54 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         case 13:
             if(game.swnbestrank>=1)
             {
-                entities[k].tile = 182 + vx;
-                entities[k].colour = 39;
+                entity.tile = 182 + vx;
+                entity.colour = 39;
             }
             break;
         case 14:
             if(game.swnbestrank>=2)
             {
-                entities[k].tile =  (182 + vx);
-                entities[k].colour = 39;
+                entity.tile =  (182 + vx);
+                entity.colour = 39;
             }
             break;
         case 15:
             if(game.swnbestrank>=3)
             {
-                entities[k].tile =  (182 + vx);
-                entities[k].colour = 39;
+                entity.tile =  (182 + vx);
+                entity.colour = 39;
             }
             break;
         case 16:
             if(game.swnbestrank>=4)
             {
-                entities[k].tile =  (182 + vx);
-                entities[k].colour = 38;
+                entity.tile =  (182 + vx);
+                entity.colour = 38;
             }
             break;
         case 17:
             if(game.swnbestrank>=5)
             {
-                entities[k].tile =  (182 + vx);
-                entities[k].colour = 36;
+                entity.tile =  (182 + vx);
+                entity.colour = 36;
             }
             break;
         case 18:
             if(game.swnbestrank>=6)
             {
-                entities[k].tile =  (182 + vx);
-                entities[k].colour = 40;
+                entity.tile =  (182 + vx);
+                entity.colour = 40;
             }
             break;
 
         case 19:
             if(game.unlock[20])
             {
-                entities[k].tile = 3;
-                entities[k].colour = 102;
-                entities[k].size = 13;
-                entities[k].xp -= 64;
-                entities[k].yp -= 128;
+                entity.tile = 3;
+                entity.colour = 102;
+                entity.size = 13;
+                entity.xp -= 64;
+                entity.yp -= 128;
             }
             break;
 
@@ -2091,135 +2053,135 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
 
         break;
     case 26: //Epilogue super warp token
-        entities[k].rule = 3;
-        entities[k].type = 11;
-        entities[k].size = 0;
-        entities[k].tile = 18;
-        entities[k].xp =  (xp);
-        entities[k].yp =  (yp);
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].colour = 3;
-        entities[k].onentity = 0;
-        entities[k].animate = 100;
-        entities[k].para = vy;
-        entities[k].size = 13;
+        entity.rule = 3;
+        entity.type = 11;
+        entity.size = 0;
+        entity.tile = 18;
+        entity.xp =  (xp);
+        entity.yp =  (yp);
+        entity.w = 16;
+        entity.h = 16;
+        entity.colour = 3;
+        entity.onentity = 0;
+        entity.animate = 100;
+        entity.para = vy;
+        entity.size = 13;
         break;
 
     case 51: //Vertical Warp Line
-        entities[k].rule = 5;
-        entities[k].type = 51;
-        entities[k].size = 6;
-        entities[k].life = 0;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 1;
-        entities[k].h = vx;
-        //entities[k].colour = 0;
-        entities[k].onentity = 1;
-        entities[k].invis=true;
+        entity.rule = 5;
+        entity.type = 51;
+        entity.size = 6;
+        entity.life = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 1;
+        entity.h = vx;
+        //entity.colour = 0;
+        entity.onentity = 1;
+        entity.invis=true;
         if (map.custommode) customwarpmode = true;
         break;
       case 52: //Vertical Warp Line
-        entities[k].rule = 5;
-        entities[k].type = 52;
-        entities[k].size = 6;
-        entities[k].life = 0;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = 1;
-        entities[k].h = vx;
-        //entities[k].colour = 0;
-        entities[k].onentity = 1;
-        entities[k].invis=true;
+        entity.rule = 5;
+        entity.type = 52;
+        entity.size = 6;
+        entity.life = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = 1;
+        entity.h = vx;
+        //entity.colour = 0;
+        entity.onentity = 1;
+        entity.invis=true;
         if (map.custommode) customwarpmode = true;
         break;
       case 53: //Horizontal Warp Line
-        entities[k].rule = 7;
-        entities[k].type = 53;
-        entities[k].size = 5;
-        entities[k].life = 0;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = vx;
-        entities[k].h = 1;
-        entities[k].onentity = 1;
-        entities[k].invis=true;
+        entity.rule = 7;
+        entity.type = 53;
+        entity.size = 5;
+        entity.life = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = vx;
+        entity.h = 1;
+        entity.onentity = 1;
+        entity.invis=true;
         if (map.custommode) customwarpmode = true;
         break;
       case 54: //Horizontal Warp Line
-        entities[k].rule = 7;
-        entities[k].type = 54;
-        entities[k].size = 5;
-        entities[k].life = 0;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].w = vx;
-        entities[k].h = 1;
-        entities[k].onentity = 1;
-        entities[k].invis=true;
+        entity.rule = 7;
+        entity.type = 54;
+        entity.size = 5;
+        entity.life = 0;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.w = vx;
+        entity.h = 1;
+        entity.onentity = 1;
+        entity.invis=true;
         if (map.custommode) customwarpmode = true;
         break;
       case 55: // Crew Member (custom, collectable)
         //1 - position in array
         //2 - colour
-        entities[k].rule = 3;
-        entities[k].type = 55;
+        entity.rule = 3;
+        entity.type = 55;
         if(customcrewmoods[int(vy)]==1){
-          entities[k].tile = 144;
+          entity.tile = 144;
         }else{
-          entities[k].tile = 0;
+          entity.tile = 0;
         }
-        entities[k].colour = crewcolour(int(vy));
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].cx = 6;
-        entities[k].cy = 2;
-        entities[k].w = 12;
-        entities[k].h = 21;
-        entities[k].dir = 0;
+        entity.colour = crewcolour(int(vy));
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.cx = 6;
+        entity.cy = 2;
+        entity.w = 12;
+        entity.h = 21;
+        entity.dir = 0;
 
-        entities[k].state = 0;
-        entities[k].onentity = 1;
-        //entities[k].state = vx;
+        entity.state = 0;
+        entity.onentity = 1;
+        //entity.state = vx;
 
-        entities[k].gravity = true;
+        entity.gravity = true;
 
         //Check if it's already been collected
-        entities[k].para = vx;
-        if (customcollect[vx] == 1) entities[k].active = false;
+        entity.para = vx;
+        if (customcollect[vx] == 1) return;
         break;
       case 56: //Custom enemy
-        entities[k].rule = 1;
-        entities[k].type = 1;
-        entities[k].xp = xp;
-        entities[k].yp = yp;
-        entities[k].behave = vx;
-        entities[k].para = vy;
-        entities[k].w = 16;
-        entities[k].h = 16;
-        entities[k].cx = 0;
-        entities[k].cy = 0;
+        entity.rule = 1;
+        entity.type = 1;
+        entity.xp = xp;
+        entity.yp = yp;
+        entity.behave = vx;
+        entity.para = vy;
+        entity.w = 16;
+        entity.h = 16;
+        entity.cx = 0;
+        entity.cy = 0;
 
-        entities[k].x1 = p1;
-        entities[k].y1 = p2;
-        entities[k].x2 = p3;
-        entities[k].y2 = p4;
+        entity.x1 = p1;
+        entity.y1 = p2;
+        entity.x2 = p3;
+        entity.y2 = p4;
 
-        entities[k].harmful = true;
+        entity.harmful = true;
 
         switch(customenemy){
-          case 0: entities[k].setenemyroom(4+100, 0+100); break;
-          case 1: entities[k].setenemyroom(2+100, 0+100); break;
-          case 2: entities[k].setenemyroom(12+100, 3+100); break;
-          case 3: entities[k].setenemyroom(13+100, 12+100); break;
-          case 4: entities[k].setenemyroom(16+100, 9+100); break;
-          case 5: entities[k].setenemyroom(19+100, 1+100); break;
-          case 6: entities[k].setenemyroom(19+100, 2+100); break;
-          case 7: entities[k].setenemyroom(18+100, 3+100); break;
-          case 8: entities[k].setenemyroom(16+100, 0+100); break;
-          case 9: entities[k].setenemyroom(14+100, 2+100); break;
-          default: entities[k].setenemyroom(4+100, 0+100); break;
+          case 0: entity.setenemyroom(4+100, 0+100); break;
+          case 1: entity.setenemyroom(2+100, 0+100); break;
+          case 2: entity.setenemyroom(12+100, 3+100); break;
+          case 3: entity.setenemyroom(13+100, 12+100); break;
+          case 4: entity.setenemyroom(16+100, 9+100); break;
+          case 5: entity.setenemyroom(19+100, 1+100); break;
+          case 6: entity.setenemyroom(19+100, 2+100); break;
+          case 7: entity.setenemyroom(18+100, 3+100); break;
+          case 8: entity.setenemyroom(16+100, 0+100); break;
+          case 9: entity.setenemyroom(14+100, 2+100); break;
+          default: entity.setenemyroom(4+100, 0+100); break;
         }
 
         //Set colour based on room tile
@@ -2230,46 +2192,48 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
             //RED
             case 3: case 7: case 12: case 23: case 28:
             case 34: case 42: case 48: case 58:
-              entities[k].colour = 6; break;
+              entity.colour = 6; break;
             //GREEN
             case 5: case 9: case 22: case 25: case 29:
             case 31: case 38: case 46: case 52: case 53:
-              entities[k].colour = 7; break;
+              entity.colour = 7; break;
             //BLUE
             case 1: case 6: case 14: case 27: case 33:
             case 44: case 50: case 57:
-              entities[k].colour = 12; break;
+              entity.colour = 12; break;
             //YELLOW
             case 4: case 17: case 24: case 30: case 37:
             case 45: case 51: case 55:
-              entities[k].colour = 9; break;
+              entity.colour = 9; break;
             //PURPLE
             case 2: case 11: case 15: case 19: case 32:
             case 36: case 49:
-              entities[k].colour = 20; break;
+              entity.colour = 20; break;
             //CYAN
             case 8: case 10: case 13: case 18: case 26:
             case 35: case 41: case 47: case 54:
-              entities[k].colour = 11; break;
+              entity.colour = 11; break;
             //PINK
             case 16: case 20: case 39: case 43: case 56:
-              entities[k].colour = 8; break;
+              entity.colour = 8; break;
             //ORANGE
             case 21: case 40:
-              entities[k].colour = 17; break;
+              entity.colour = 17; break;
             default:
-              entities[k].colour = 6;
+              entity.colour = 6;
             break;
           }
         }
 
         break;
     }
+
+    entities.push_back(entity);
 }
 
 bool entityclass::updateentities( int i )
 {
-    if(entities[i].active)
+    if(true) // FIXME: remove this later (no more 'active')
     {
         if(entities[i].statedelay<=0)
         {
@@ -2452,10 +2416,10 @@ bool entityclass::updateentities( int i )
                     }
                     else if (entities[i].state == 1)
                     {
-                        if (entities[i].xp >= 335) entities[i].active = false;
+                        if (entities[i].xp >= 335) removeentity(i);
                         if (game.roomx == 117)
                         {
-                            if (entities[i].xp >= (33*8)-32) entities[i].active = false;
+                            if (entities[i].xp >= (33*8)-32) removeentity(i);
                             //collector for LIES
                         }
                     }
@@ -2481,10 +2445,10 @@ bool entityclass::updateentities( int i )
                     }
                     else if (entities[i].state == 1)
                     {
-                        if (entities[i].yp <= -60) entities[i].active = false;
+                        if (entities[i].yp <= -60) removeentity(i);
                         if (game.roomy == 108)
                         {
-                            if (entities[i].yp <= 60) entities[i].active = false;
+                            if (entities[i].yp <= 60) removeentity(i);
                             //collector for factory
                         }
                     }
@@ -2492,7 +2456,7 @@ bool entityclass::updateentities( int i )
                 case 14: //Very special hack: as two, but doesn't move in specific circumstances
                     if (entities[i].state == 0)   //Init
                     {
-                        for (int j = 0; j < nentity; j++)
+                        for (size_t j = 0; j < entities.size(); j++)
                         {
                             if (entities[j].type == 2 && entities[j].state== 3 && entities[j].xp == (entities[i].xp-32) )
                             {
@@ -2521,7 +2485,7 @@ bool entityclass::updateentities( int i )
                 case 15: //As above, but for 3!
                     if (entities[i].state == 0)   //Init
                     {
-                        for (int j = 0; j < nentity; j++)
+                        for (size_t j = 0; j < entities.size(); j++)
                         {
                             if (entities[j].type == 2 && entities[j].state==3 && entities[j].xp==entities[i].xp+32)
                             {
@@ -2682,7 +2646,7 @@ bool entityclass::updateentities( int i )
                     if (entities[i].life <= 0)
                     {
                         removeblockat(entities[i].xp, entities[i].yp);
-                        entities[i].active = false;
+                        removeentity(i);
                     }
                 }
                 break;
@@ -2690,7 +2654,7 @@ bool entityclass::updateentities( int i )
                 //wait for collision
                 if (entities[i].state == 1)
                 {
-                    entities[i].active = false;
+                    removeentity(i);
                     game.gravitycontrol = (game.gravitycontrol + 1) % 2;
 
                 }
@@ -2699,7 +2663,7 @@ bool entityclass::updateentities( int i )
                 if (entities[i].state == 0)
                 {
                     entities[i].life--;
-                    if (entities[i].life < 0) entities[i].active = false;
+                    if (entities[i].life < 0) removeentity(i);
                 }
                 break;
             case 6: //Small pickup
@@ -2710,7 +2674,7 @@ bool entityclass::updateentities( int i )
                     music.playef(4);
                     collect[entities[i].para] = 1;
 
-                    entities[i].active = false;
+                    removeentity(i);
                 }
                 break;
             case 7: //Found a trinket
@@ -2736,7 +2700,7 @@ bool entityclass::updateentities( int i )
                         }
                     }
 
-                    entities[i].active = false;
+                    removeentity(i);
                 }
                 break;
             case 8: //Savepoints
@@ -2744,9 +2708,9 @@ bool entityclass::updateentities( int i )
                 if (entities[i].state == 1)
                 {
                     //First, deactivate all other savepoints
-                    for (int j = 0; j < nentity; j++)
+                    for (size_t j = 0; j < entities.size(); j++)
                     {
-                        if (entities[j].type == 8 && entities[j].active)
+                        if (entities[j].type == 8)
                         {
                             entities[j].colour = 4;
                             entities[j].onentity = 1;
@@ -3232,7 +3196,7 @@ bool entityclass::updateentities( int i )
                     if (entities[i].xp >= 310)
                     {
                         game.scmprogress++;
-                        entities[i].active = false;
+                        removeentity(i);
                     }
                 }
                 break;
@@ -3255,14 +3219,14 @@ bool entityclass::updateentities( int i )
                     if (entities[i].state == 0)   //Init
                     {
                         entities[i].vx = 7;
-                        if (entities[i].xp > 320) entities[i].active = false;
+                        if (entities[i].xp > 320) removeentity(i);
                     }
                     break;
                 case 1:
                     if (entities[i].state == 0)   //Init
                     {
                         entities[i].vx = -7;
-                        if (entities[i].xp <-20) entities[i].active = false;
+                        if (entities[i].xp <-20) removeentity(i);
                     }
                     break;
                 }
@@ -3354,7 +3318,7 @@ bool entityclass::updateentities( int i )
                         customcollect[entities[i].para] = 1;
                     }
 
-                    entities[i].active = false;
+                    removeentity(i);
                 }
                 break;
             case 100: //The teleporter
@@ -3382,9 +3346,9 @@ bool entityclass::updateentities( int i )
 
                         //Alright, let's set this as our savepoint too
                         //First, deactivate all other savepoints
-                        for (int j = 0; j < nentity; j++)
+                        for (size_t j = 0; j < entities.size(); j++)
                         {
-                            if (entities[j].type == 8 && entities[j].active)
+                            if (entities[j].type == 8)
                             {
                                 entities[j].colour = 4;
                                 entities[j].onentity = 1;
@@ -3436,7 +3400,7 @@ bool entityclass::updateentities( int i )
 
 void entityclass::animateentities( int _i )
 {
-    if(entities[_i].active)
+    if(true) // FIXME: remove this later (no more 'active')
     {
         if(entities[_i].statedelay < 1)
         {
@@ -3801,7 +3765,7 @@ void entityclass::animateentities( int _i )
 bool entityclass::gettype( int t )
 {
     //Returns true is there is an entity of type t onscreen
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
         if(entities[i].type==t)
         {
@@ -3815,7 +3779,7 @@ bool entityclass::gettype( int t )
 int entityclass::getcompanion()
 {
     //Returns the index of the companion with rule t
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
         if(entities[i].rule==6 || entities[i].rule==7)
         {
@@ -3829,7 +3793,7 @@ int entityclass::getcompanion()
 int entityclass::getplayer()
 {
     //Returns the index of the first player entity
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
         if(entities[i].type==0)
         {
@@ -3843,7 +3807,7 @@ int entityclass::getplayer()
 int entityclass::getscm()
 {
     //Returns the supercrewmate
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
         if(entities[i].type==14)
         {
@@ -3857,7 +3821,7 @@ int entityclass::getscm()
 int entityclass::getlineat( int t )
 {
     //Get the entity which is a horizontal line at height t (for SWN game)
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
         if (entities[i].size == 5)
         {
@@ -3881,7 +3845,7 @@ int entityclass::getcrewman( int t )
     if (t == 4) t = 13;
     if (t == 5) t = 16;
 
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
         if ((entities[i].type == 12 || entities[i].type == 14)
         && (entities[i].rule == 6 || entities[i].rule == 7))
@@ -3906,7 +3870,7 @@ int entityclass::getcustomcrewman( int t )
     if (t == 4) t = 13;
     if (t == 5) t = 16;
 
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
         if (entities[i].type == 55)
         {
@@ -3922,9 +3886,9 @@ int entityclass::getcustomcrewman( int t )
 
 int entityclass::getteleporter()
 {
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
-        if(entities[i].type==100 && entities[i].active)
+        if(entities[i].type==100)
         {
             return i;
         }
@@ -3971,7 +3935,7 @@ bool entityclass::entitycollide( int a, int b )
 bool entityclass::checkdamage()
 {
     //Returns true if player entity (rule 0) collides with a damagepoint
-    for(int i=0; i < nentity; i++)
+    for(size_t i=0; i < entities.size(); i++)
     {
         if(entities[i].rule==0)
         {
@@ -3999,7 +3963,7 @@ bool entityclass::checkdamage()
 bool entityclass::scmcheckdamage()
 {
     //Returns true if supercrewmate collides with a damagepoint
-    for(int i=0; i < nentity; i++)
+    for(size_t i=0; i < entities.size(); i++)
     {
         if(entities[i].type==14)
         {
@@ -4037,7 +4001,7 @@ void entityclass::settemprect( int t )
 int entityclass::checktrigger()
 {
     //Returns an int player entity (rule 0) collides with a trigger
-    for(int i=0; i < nentity; i++)
+    for(size_t i=0; i < entities.size(); i++)
     {
         if(entities[i].rule==0)
         {
@@ -4066,7 +4030,7 @@ int entityclass::checktrigger()
 int entityclass::checkactivity()
 {
     //Returns an int player entity (rule 0) collides with an activity
-    for(int i=0; i < nentity; i++)
+    for(size_t i=0; i < entities.size(); i++)
     {
         if(entities[i].rule==0)
         {
@@ -4217,9 +4181,9 @@ bool entityclass::checkwall()
 float entityclass::hplatformat()
 {
     //Returns first entity of horizontal platform at (px, py), -1000 otherwise.
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
-        if (entities[i].active)
+        if (true) // FIXME: remove this later (no more 'active')
         {
             if (entities[i].rule == 2)
             {
@@ -4540,12 +4504,6 @@ void entityclass::applyfriction( int t, float xrate, float yrate )
 
 void entityclass::cleanup()
 {
-    int i = nentity - 1;
-    while (i >= 0 && !entities[i].active)
-    {
-        nentity--;
-        i--;
-    }
 }
 
 void entityclass::updateentitylogic( int t )
@@ -4699,10 +4657,10 @@ void entityclass::customwarplinecheck(int i) {
     //Turns on obj.customwarpmodevon and obj.customwarpmodehon if player collides
     //with warp lines
 
-    if (entities[i].active) {
+    if (true) { // FIXME: remove this later (no more 'active')
         //We test entity to entity
-        for (int j = 0; j < nentity; j++) {
-            if (entities[j].active && i != j) {//Active
+        for (int j = 0; j < (int) entities.size(); j++) {
+            if (i != j) {//Active
                 if (entities[i].rule == 0 && entities[j].rule == 5) { //Player vs vertical line!
                     if (entities[j].type == 51 || entities[j].type == 52) {
                         if (entitywarpvlinecollide(i, j)) {
@@ -4725,14 +4683,14 @@ void entityclass::customwarplinecheck(int i) {
 
 void entityclass::entitycollisioncheck()
 {
-    for (int i = 0; i < nentity; i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
-        if (entities[i].active)
+        if (true) // FIXME: remove this later (no more 'active')
         {
             //We test entity to entity
-            for (int j = 0; j < nentity; j++)
+            for (size_t j = 0; j < entities.size(); j++)
             {
-                if (entities[j].active && i!=j)  //Active
+                if (i!=j)  //Active
                 {
                     if (entities[i].rule == 0 && entities[j].rule == 1 && entities[j].harmful)
                     {

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -113,71 +113,6 @@ void entityclass::changeflag( int t, int s )
     flags[t] = s;
 }
 
-void entityclass::setblockcolour( int t, std::string col )
-{
-    if (col == "cyan")
-    {
-        blocks[t].r = 164;
-        blocks[t].g = 164;
-        blocks[t].b = 255;
-    }
-    else if (col == "red")
-    {
-        blocks[t].r = 255;
-        blocks[t].g = 60;
-        blocks[t].b = 60;
-    }
-    else if (col == "green")
-    {
-        blocks[t].r = 144;
-        blocks[t].g = 255;
-        blocks[t].b = 144;
-    }
-    else if (col == "yellow")
-    {
-        blocks[t].r = 255;
-        blocks[t].g = 255;
-        blocks[t].b = 134;
-    }
-    else if (col == "blue")
-    {
-        blocks[t].r = 95;
-        blocks[t].g = 95;
-        blocks[t].b = 255;
-    }
-    else if (col == "purple")
-    {
-        blocks[t].r = 255;
-        blocks[t].g = 134;
-        blocks[t].b = 255;
-    }
-    else if (col == "white")
-    {
-        blocks[t].r = 244;
-        blocks[t].g = 244;
-        blocks[t].b = 244;
-    }
-    else if (col == "gray")
-    {
-        blocks[t].r = 174;
-        blocks[t].g = 174;
-        blocks[t].b = 174;
-    }
-    else if (col == "orange")
-    {
-        blocks[t].r = 255;
-        blocks[t].g = 130;
-        blocks[t].b = 20;
-    }
-    else
-    {
-        //use a gray
-        blocks[t].r = 174;
-        blocks[t].g = 174;
-        blocks[t].b = 174;
-    }
-}
-
 int entityclass::swncolour( int t )
 {
     //given colour t, return colour in setcol
@@ -946,217 +881,217 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
         case 0: //testing zone
             blocks[k].prompt = "Press ENTER to explode";
             blocks[k].script = "intro";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=1;
             break;
         case 1:
             blocks[k].prompt = "Press ENTER to talk to Violet";
             blocks[k].script = "talkpurple";
-            setblockcolour(k, "purple");
+            blocks[k].setblockcolour("purple");
             trig=0;
             break;
         case 2:
             blocks[k].prompt = "Press ENTER to talk to Vitellary";
             blocks[k].script = "talkyellow";
-            setblockcolour(k, "yellow");
+            blocks[k].setblockcolour("yellow");
             trig=0;
             break;
         case 3:
             blocks[k].prompt = "Press ENTER to talk to Vermilion";
             blocks[k].script = "talkred";
-            setblockcolour(k, "red");
+            blocks[k].setblockcolour("red");
             trig=0;
             break;
         case 4:
             blocks[k].prompt = "Press ENTER to talk to Verdigris";
             blocks[k].script = "talkgreen";
-            setblockcolour(k, "green");
+            blocks[k].setblockcolour("green");
             trig=0;
             break;
         case 5:
             blocks[k].prompt = "Press ENTER to talk to Victoria";
             blocks[k].script = "talkblue";
-            setblockcolour(k, "blue");
+            blocks[k].setblockcolour("blue");
             trig=0;
             break;
         case 6:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_station_1";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 7:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_outside_1";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 8:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_outside_2";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 9:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_outside_3";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 10:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_outside_4";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 11:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_outside_5";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 12:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_outside_6";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 13:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_finallevel";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 14:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_station_2";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 15:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_station_3";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 16:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_station_4";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 17:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_warp_1";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 18:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_warp_2";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 19:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_lab_1";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 20:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_lab_2";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 21:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_secretlab";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 22:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_shipcomputer";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 23:
             blocks[k].prompt = "Press ENTER to activate terminals";
             blocks[k].script = "terminal_radio";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 24:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "terminal_jukebox";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 25:
             blocks[k].prompt = "Passion for Exploring";
             blocks[k].script = "terminal_juke1";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 26:
             blocks[k].prompt = "Pushing Onwards";
             blocks[k].script = "terminal_juke2";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 27:
             blocks[k].prompt = "Positive Force";
             blocks[k].script = "terminal_juke3";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 28:
             blocks[k].prompt = "Presenting VVVVVV";
             blocks[k].script = "terminal_juke4";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 29:
             blocks[k].prompt = "Potential for Anything";
             blocks[k].script = "terminal_juke5";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 30:
             blocks[k].prompt = "Predestined Fate";
             blocks[k].script = "terminal_juke6";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 31:
             blocks[k].prompt = "Pipe Dream";
             blocks[k].script = "terminal_juke7";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 32:
             blocks[k].prompt = "Popular Potpourri";
             blocks[k].script = "terminal_juke8";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 33:
             blocks[k].prompt = "Pressure Cooker";
             blocks[k].script = "terminal_juke9";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 34:
             blocks[k].prompt = "ecroF evitisoP";
             blocks[k].script = "terminal_juke10";
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         case 35:
             blocks[k].prompt = "Press ENTER to activate terminal";
             blocks[k].script = "custom_"+customscript;
-            setblockcolour(k, "orange");
+            blocks[k].setblockcolour("orange");
             trig=0;
             break;
         }

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1090,12 +1090,9 @@ void entityclass::removetrigger( int t )
 {
     for(size_t i=0; i<blocks.size(); i++)
     {
-        if(blocks[i].type == TRIGGER)
+        if(blocks[i].type == TRIGGER && blocks[i].trigger == t)
         {
-            if (blocks[i].trigger == t)
-            {
-                removeblock_iter(i);
-            }
+            removeblock_iter(i);
         }
     }
 }
@@ -3757,12 +3754,9 @@ bool entityclass::checkdamage()
 
             for (size_t j=0; j<blocks.size(); j++)
             {
-                if (blocks[j].type == DAMAGE)
+                if (blocks[j].type == DAMAGE && help.intersects(blocks[j].rect, temprect))
                 {
-                    if(help.intersects(blocks[j].rect, temprect))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
         }
@@ -3785,12 +3779,9 @@ bool entityclass::scmcheckdamage()
 
             for (size_t j=0; j<blocks.size(); j++)
             {
-                if (blocks[j].type == DAMAGE)
+                if (blocks[j].type == DAMAGE && help.intersects(blocks[j].rect, temprect))
                 {
-                    if(help.intersects(blocks[j].rect, temprect))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
         }
@@ -3823,13 +3814,10 @@ int entityclass::checktrigger()
 
             for (size_t j=0; j<blocks.size(); j++)
             {
-                if (blocks[j].type == TRIGGER)
+                if (blocks[j].type == TRIGGER && help.intersects(blocks[j].rect, temprect))
                 {
-                    if (help.intersects(blocks[j].rect, temprect))
-                    {
-                        activetrigger = blocks[j].trigger;
-                        return blocks[j].trigger;
-                    }
+                    activetrigger = blocks[j].trigger;
+                    return blocks[j].trigger;
                 }
             }
         }
@@ -3852,12 +3840,9 @@ int entityclass::checkactivity()
 
             for (size_t j=0; j<blocks.size(); j++)
             {
-                if (blocks[j].type == ACTIVITY)
+                if (blocks[j].type == ACTIVITY && help.intersects(blocks[j].rect, temprect))
                 {
-                    if (help.intersects(blocks[j].rect, temprect))
-                    {
-                        return j;
-                    }
+                    return j;
                 }
             }
         }
@@ -3887,17 +3872,11 @@ bool entityclass::checkplatform()
     //Return true if rectset intersects a moving platform, setups px & py to the platform x & y
     for (size_t i = 0; i < blocks.size(); i++)
     {
-        if (true) //FIXME: remove this later (no more 'active')
+        if (blocks[i].type == BLOCK && help.intersects(blocks[i].rect, temprect))
         {
-            if (blocks[i].type == BLOCK)
-            {
-                if (help.intersects(blocks[i].rect, temprect))
-                {
-                    px = blocks[i].xp;
-                    py = blocks[i].yp;
-                    return true;
-                }
-            }
+            px = blocks[i].xp;
+            py = blocks[i].yp;
+            return true;
         }
     }
     return false;
@@ -3907,35 +3886,20 @@ bool entityclass::checkblocks()
 {
     for (size_t i = 0; i < blocks.size(); i++)
     {
-        if (true) //FIXME: remove this later (no more 'active')
+        if(!skipdirblocks && blocks[i].type == DIRECTIONAL)
         {
-            if(!skipdirblocks)
-            {
-                if (blocks[i].type == DIRECTIONAL)
-                {
-                    if (dy > 0 && blocks[i].trigger == 0) if (help.intersects(blocks[i].rect, temprect)) return true;
-                    if (dy <= 0 && blocks[i].trigger == 1) if (help.intersects(blocks[i].rect, temprect)) return true;
-                    if (dx > 0 && blocks[i].trigger == 2) if (help.intersects(blocks[i].rect, temprect)) return true;
-                    if (dx <= 0 && blocks[i].trigger == 3) if (help.intersects(blocks[i].rect, temprect)) return true;
-                }
-            }
-            if (blocks[i].type == BLOCK)
-            {
-                if (help.intersects(blocks[i].rect, temprect))
-                {
-                    return true;
-                }
-            }
-            if (blocks[i].type == SAFE)
-            {
-                if( (dr)==1)
-                {
-                    if (help.intersects(blocks[i].rect, temprect))
-                    {
-                        return true;
-                    }
-                }
-            }
+            if (dy > 0 && blocks[i].trigger == 0) if (help.intersects(blocks[i].rect, temprect)) return true;
+            if (dy <= 0 && blocks[i].trigger == 1) if (help.intersects(blocks[i].rect, temprect)) return true;
+            if (dx > 0 && blocks[i].trigger == 2) if (help.intersects(blocks[i].rect, temprect)) return true;
+            if (dx <= 0 && blocks[i].trigger == 3) if (help.intersects(blocks[i].rect, temprect)) return true;
+        }
+        if (blocks[i].type == BLOCK && help.intersects(blocks[i].rect, temprect))
+        {
+            return true;
+        }
+        if (blocks[i].type == SAFE && (dr)==1 && help.intersects(blocks[i].rect, temprect))
+        {
+            return true;
         }
     }
     return false;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2228,7 +2228,7 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
     entities.push_back(entity);
 }
 
-bool entityclass::updateentities( int i )
+void entityclass::updateentities( int i )
 {
     if(entities[i].statedelay<=0)
     {
@@ -3388,8 +3388,6 @@ bool entityclass::updateentities( int i )
             entities[i].statedelay = 0;
         }
     }
-
-    return true;
 }
 
 void entityclass::animateentities( int _i )

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4106,25 +4106,20 @@ float entityclass::hplatformat()
     //Returns first entity of horizontal platform at (px, py), -1000 otherwise.
     for (size_t i = 0; i < entities.size(); i++)
     {
-        if (entities[i].rule == 2)
+        if (entities[i].rule == 2 && entities[i].behave >= 2
+        && entities[i].xp == px && entities[i].yp == py)
         {
-            if (entities[i].behave >= 2)
+            if (entities[i].behave == 8)   //threadmill!
             {
-                if (entities[i].xp == px && entities[i].yp == py)
-                {
-                    if (entities[i].behave == 8)   //threadmill!
-                    {
-                        return entities[i].para;
-                    }
-                    else if(entities[i].behave == 9)    //threadmill!
-                    {
-                        return -entities[i].para;
-                    }
-                    else
-                    {
-                        return entities[i].vx;
-                    }
-                }
+                return entities[i].para;
+            }
+            else if(entities[i].behave == 9)    //threadmill!
+            {
+                return -entities[i].para;
+            }
+            else
+            {
+                return entities[i].vx;
             }
         }
     }
@@ -4161,52 +4156,49 @@ bool entityclass::entityhlinecollide( int t, int l )
 bool entityclass::entityvlinecollide( int t, int l )
 {
     //Returns true is entity t collided with the vertical line l.
-    if(entities[t].yp + entities[t].cy+entities[t].h>=entities[l].yp)
+    if(entities[t].yp + entities[t].cy+entities[t].h>=entities[l].yp
+    && entities[t].yp + entities[t].cy<=entities[l].yp+entities[l].h)
     {
-        if(entities[t].yp + entities[t].cy<=entities[l].yp+entities[l].h)
-        {
-            linetemp = 0;
+        linetemp = 0;
 
-            linetemp += yline(entities[t].xp + entities[t].cx+1, entities[l].xp);
-            linetemp += yline(entities[t].xp + entities[t].cx+1 + entities[t].w, entities[l].xp);
-            linetemp += yline(entities[t].oldxp + entities[t].cx+1, entities[l].xp);
-            linetemp += yline(entities[t].oldxp + entities[t].cx+1 + entities[t].w, entities[l].xp);
+        linetemp += yline(entities[t].xp + entities[t].cx+1, entities[l].xp);
+        linetemp += yline(entities[t].xp + entities[t].cx+1 + entities[t].w, entities[l].xp);
+        linetemp += yline(entities[t].oldxp + entities[t].cx+1, entities[l].xp);
+        linetemp += yline(entities[t].oldxp + entities[t].cx+1 + entities[t].w, entities[l].xp);
 
-            if (linetemp > -4 && linetemp < 4) return true;
-            return false;
-        }
+        if (linetemp > -4 && linetemp < 4) return true;
+        return false;
     }
     return false;
 }
 
 bool entityclass::entitywarphlinecollide(int t, int l) {
     //Returns true is entity t collided with the horizontal line l.
-    if(entities[t].xp + entities[t].cx+entities[t].w>=entities[l].xp){
-        if(entities[t].xp + entities[t].cx<=entities[l].xp+entities[l].w){
-            linetemp = 0;
-            if (entities[l].yp < 120) {
-                //Top line
-                if (entities[t].vy < 0) {
-                    if (entities[t].yp < entities[l].yp + 10) linetemp++;
-                    if (entities[t].yp + entities[t].h < entities[l].yp + 10) linetemp++;
-                    if (entities[t].oldyp < entities[l].yp + 10) linetemp++;
-                    if (entities[t].oldyp + entities[t].h < entities[l].yp + 10) linetemp++;
-                }
-
-                if (linetemp > 0) return true;
-                return false;
-            }else {
-                //Bottom line
-                if (entities[t].vy > 0) {
-                    if (entities[t].yp > entities[l].yp - 10) linetemp++;
-                    if (entities[t].yp + entities[t].h > entities[l].yp - 10) linetemp++;
-                    if (entities[t].oldyp > entities[l].yp - 10) linetemp++;
-                    if (entities[t].oldyp + entities[t].h > entities[l].yp - 10) linetemp++;
-                }
-
-                if (linetemp > 0) return true;
-                return false;
+    if(entities[t].xp + entities[t].cx+entities[t].w>=entities[l].xp
+    &&entities[t].xp + entities[t].cx<=entities[l].xp+entities[l].w){
+        linetemp = 0;
+        if (entities[l].yp < 120) {
+            //Top line
+            if (entities[t].vy < 0) {
+                if (entities[t].yp < entities[l].yp + 10) linetemp++;
+                if (entities[t].yp + entities[t].h < entities[l].yp + 10) linetemp++;
+                if (entities[t].oldyp < entities[l].yp + 10) linetemp++;
+                if (entities[t].oldyp + entities[t].h < entities[l].yp + 10) linetemp++;
             }
+
+            if (linetemp > 0) return true;
+            return false;
+        }else {
+            //Bottom line
+            if (entities[t].vy > 0) {
+                if (entities[t].yp > entities[l].yp - 10) linetemp++;
+                if (entities[t].yp + entities[t].h > entities[l].yp - 10) linetemp++;
+                if (entities[t].oldyp > entities[l].yp - 10) linetemp++;
+                if (entities[t].oldyp + entities[t].h > entities[l].yp - 10) linetemp++;
+            }
+
+            if (linetemp > 0) return true;
+            return false;
         }
     }
     return false;
@@ -4214,28 +4206,27 @@ bool entityclass::entitywarphlinecollide(int t, int l) {
 
 bool entityclass::entitywarpvlinecollide(int t, int l) {
     //Returns true is entity t collided with the vertical warp line l.
-    if(entities[t].yp + entities[t].cy+entities[t].h>=entities[l].yp){
-        if (entities[t].yp + entities[t].cy <= entities[l].yp + entities[l].h) {
-            linetemp = 0;
-            if (entities[l].xp < 160) {
-                //Left hand line
-                if (entities[t].xp + entities[t].cx + 1 < entities[l].xp + 10) linetemp++;
-                if (entities[t].xp + entities[t].cx+1 + entities[t].w < entities[l].xp + 10) linetemp++;
-                if (entities[t].oldxp + entities[t].cx + 1 < entities[l].xp + 10) linetemp++;
-                if (entities[t].oldxp + entities[t].cx + 1 + entities[t].w < entities[l].xp + 10) linetemp++;
+    if(entities[t].yp + entities[t].cy+entities[t].h>=entities[l].yp
+    && entities[t].yp + entities[t].cy <= entities[l].yp + entities[l].h) {
+        linetemp = 0;
+        if (entities[l].xp < 160) {
+            //Left hand line
+            if (entities[t].xp + entities[t].cx + 1 < entities[l].xp + 10) linetemp++;
+            if (entities[t].xp + entities[t].cx+1 + entities[t].w < entities[l].xp + 10) linetemp++;
+            if (entities[t].oldxp + entities[t].cx + 1 < entities[l].xp + 10) linetemp++;
+            if (entities[t].oldxp + entities[t].cx + 1 + entities[t].w < entities[l].xp + 10) linetemp++;
 
-                if (linetemp > 0) return true;
-                return false;
-            }else {
-                //Right hand line
-                if (entities[t].xp + entities[t].cx + 1 > entities[l].xp - 10) linetemp++;
-                if (entities[t].xp + entities[t].cx+1 + entities[t].w > entities[l].xp - 10) linetemp++;
-                if (entities[t].oldxp + entities[t].cx + 1 > entities[l].xp - 10) linetemp++;
-                if (entities[t].oldxp + entities[t].cx + 1 + entities[t].w > entities[l].xp - 10) linetemp++;
+            if (linetemp > 0) return true;
+            return false;
+        }else {
+            //Right hand line
+            if (entities[t].xp + entities[t].cx + 1 > entities[l].xp - 10) linetemp++;
+            if (entities[t].xp + entities[t].cx+1 + entities[t].w > entities[l].xp - 10) linetemp++;
+            if (entities[t].oldxp + entities[t].cx + 1 > entities[l].xp - 10) linetemp++;
+            if (entities[t].oldxp + entities[t].cx + 1 + entities[t].w > entities[l].xp - 10) linetemp++;
 
-                if (linetemp > 0) return true;
-                return false;
-            }
+            if (linetemp > 0) return true;
+            return false;
         }
     }
     return false;
@@ -4566,20 +4557,16 @@ void entityclass::customwarplinecheck(int i) {
     //We test entity to entity
     for (int j = 0; j < (int) entities.size(); j++) {
         if (i != j) {//Active
-            if (entities[i].rule == 0 && entities[j].rule == 5) { //Player vs vertical line!
-                if (entities[j].type == 51 || entities[j].type == 52) {
-                    if (entitywarpvlinecollide(i, j)) {
-                        customwarpmodevon = true;
-                    }
-                }
+            if (entities[i].rule == 0 && entities[j].rule == 5 //Player vs vertical line!
+            && (entities[j].type == 51 || entities[j].type == 52)
+            && entitywarpvlinecollide(i, j)) {
+                customwarpmodevon = true;
             }
 
-            if (entities[i].rule == 0 && entities[j].rule == 7){   //Player vs horizontal WARP line
-                if (entities[j].type == 53 || entities[j].type == 54) {
-                    if (entitywarphlinecollide(i, j)) {
-                        customwarpmodehon = true;
-                    }
-                }
+            if (entities[i].rule == 0 && entities[j].rule == 7   //Player vs horizontal WARP line
+            && (entities[j].type == 53 || entities[j].type == 54)
+            && entitywarphlinecollide(i, j)) {
+                customwarpmodehon = true;
             }
         }
     }

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2192,9 +2192,6 @@ void entityclass::updateentities( int i )
         switch(entities[i].type)
         {
         case 0:  //Player
-            if (entities[i].state == 0)
-            {
-            }
             break;
         case 1:  //Movement behaviors
             //Enemies can have a number of different behaviors:

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1267,89 +1267,6 @@ int entityclass::crewcolour( int t )
     return 0;
 }
 
-void entityclass::settreadmillcolour( int t, int rx, int ry )
-{
-    rx -= 100;
-    ry -= 100;
-    rx += 50 - 12;
-    ry += 50 - 14;   //Space Station
-
-    entities[t].tile = 20; //default as blue
-    switch(rn(rx, ry))
-    {
-    case rn(52, 48):
-        entities[t].tile = 791;
-        break; //Cyan
-
-    case rn(49, 47):
-        entities[t].tile = 24;
-        break; //Yellow
-    case rn(56, 44):
-        entities[t].tile = 24;
-        break; //Yellow
-    case rn(54, 49):
-        entities[t].tile = 24;
-        break; //Yellow
-
-    case rn(49, 49):
-        entities[t].tile = 36;
-        break; //Green
-    case rn(55, 44):
-        entities[t].tile = 36;
-        break; //Green
-    case rn(54, 43):
-        entities[t].tile = 36;
-        break; //Green
-    case rn(53, 49):
-        entities[t].tile = 36;
-        break; //Green
-    case rn(54, 45):
-        entities[t].tile = 711;
-        break; //Green (special)
-    case rn(51, 48):
-        entities[t].tile = 711;
-        break; //Green (special)
-
-    case rn(50, 49):
-        entities[t].tile = 28;
-        break; //Purple
-    case rn(54, 44):
-        entities[t].tile = 28;
-        break; //Purple
-    case rn(49, 42):
-        entities[t].tile = 28;
-        break; //Purple
-    case rn(55, 43):
-        entities[t].tile = 28;
-        break; //Purple
-    case rn(54, 47):
-        entities[t].tile = 28;
-        break; //Purple
-    case rn(53, 48):
-        entities[t].tile = 28;
-        break; //Purple
-
-    case rn(51, 47):
-        entities[t].tile = 32;
-        break; //Red
-    case rn(52, 49):
-        entities[t].tile = 32;
-        break; //Red
-    case rn(48, 43):
-        entities[t].tile = 32;
-        break; //Red
-    case rn(55, 47):
-        entities[t].tile = 32;
-        break; //Red
-    case rn(54, 48):
-        entities[t].tile = 32;
-        break; //Red
-    default:
-        return;
-        break;
-    }
-}
-
 void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, float vy /*= 0*/, int p1 /*= 0*/, int p2 /*= 0*/, int p3 /*= 320*/, int p4 /*= 240 */ )
 {
     //Find the first inactive case z that we can use to index the new entity
@@ -1539,7 +1456,7 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
               if (int(vx) == 8) entities[k].tile += 4;
               if (int(vx) == 9) entities[k].animate = 11;
             }else{
-              settreadmillcolour(k, game.roomx, game.roomy);
+              entities[k].settreadmillcolour(game.roomx, game.roomy);
               if (int(vx) == 8) entities[k].tile += 40;
               if (int(vx) == 9) entities[k].animate = 11;
             }

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1601,91 +1601,6 @@ void entityclass::setenemyroom( int t, int rx, int ry )
     }
 }
 
-void entityclass::setenemy( int t, int r )
-{
-    switch(t)
-    {
-    case 0:
-        //lies emitter
-        if( (entities[r].para)==0)
-        {
-            entities[r].tile = 60;
-            entities[r].animate = 2;
-            entities[r].colour = 6;
-            entities[r].behave = 10;
-            entities[r].w = 32;
-            entities[r].h = 32;
-            entities[r].x1 = -200;
-        }
-        else if ( (entities[r].para) == 1)
-        {
-            entities[r].yp += 10;
-            entities[r].tile = 63;
-            entities[r].animate = 100; //LIES
-            entities[r].colour = 6;
-            entities[r].behave = 11;
-            entities[r].para = 9; //destroyed when outside
-            entities[r].x1 = -200;
-            entities[r].x2 = 400;
-            entities[r].w = 26;
-            entities[r].h = 10;
-            entities[r].cx = 1;
-            entities[r].cy = 1;
-        }
-        else if ( (entities[r].para) == 2)
-        {
-            entities[r].tile = 62;
-            entities[r].animate = 100;
-            entities[r].colour = 6;
-            entities[r].behave = -1;
-            entities[r].w = 32;
-            entities[r].h = 32;
-        }
-        break;
-    case 1:
-        //FACTORY emitter
-        if( (entities[r].para)==0)
-        {
-            entities[r].tile = 72;
-            entities[r].animate = 3;
-            entities[r].size = 9;
-            entities[r].colour = 6;
-            entities[r].behave = 12;
-            entities[r].w = 64;
-            entities[r].h = 40;
-            entities[r].cx = 0;
-            entities[r].cy = 24;
-        }
-        else if ( (entities[r].para) == 1)
-        {
-            entities[r].xp += 4;
-            entities[r].yp -= 4;
-            entities[r].tile = 76;
-            entities[r].animate = 100; // Clouds
-            entities[r].colour = 6;
-            entities[r].behave = 13;
-            entities[r].para = -6; //destroyed when outside
-            entities[r].x2 = 400;
-            entities[r].w = 32;
-            entities[r].h = 12;
-            entities[r].cx = 0;
-            entities[r].cy = 6;
-        }
-        else if ( (entities[r].para) == 2)
-        {
-            entities[r].tile = 77;
-            entities[r].animate = 100;
-            entities[r].colour = 6;
-            entities[r].behave = -1;
-            entities[r].w = 32;
-            entities[r].h = 16;
-        }
-        break;
-    default:
-        break;
-    }
-}
-
 void entityclass::settreadmillcolour( int t, int rx, int ry )
 {
     rx -= 100;
@@ -1865,12 +1780,12 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
 
         if  (game.roomy == 111 && (game.roomx >= 113 && game.roomx <= 117))
         {
-            setenemy(0, k);
+            entities[k].setenemy(0);
             setenemyroom(k, game.roomx, game.roomy); //For colour
         }
         else if  (game.roomx == 113 && (game.roomy <= 110 && game.roomy >= 108))
         {
-            setenemy(1, k);
+            entities[k].setenemy(1);
             setenemyroom(k, game.roomx, game.roomy); //For colour
         }
         else if (game.roomx == 113 && game.roomy == 107)

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -195,12 +195,9 @@ void entityclass::swnenemiescol( int t )
     //change the colour of all SWN enemies to the current one
     for (size_t i = 0; i < entities.size(); i++)
     {
-        if (true) // FIXME: remove this later (no more 'active')
+        if (entities[i].type == 23)
         {
-            if (entities[i].type == 23)
-            {
-                entities[i].colour = swncolour(t);
-            }
+            entities[i].colour = swncolour(t);
         }
     }
 }
@@ -2233,480 +2230,1116 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
 
 bool entityclass::updateentities( int i )
 {
-    if(true) // FIXME: remove this later (no more 'active')
+    if(entities[i].statedelay<=0)
     {
-        if(entities[i].statedelay<=0)
+        switch(entities[i].type)
         {
-            switch(entities[i].type)
+        case 0:  //Player
+            if (entities[i].state == 0)
             {
-            case 0:  //Player
-                if (entities[i].state == 0)
+            }
+            break;
+        case 1:  //Movement behaviors
+            //Enemies can have a number of different behaviors:
+            switch(entities[i].behave)
+            {
+            case 0: //Bounce, Start moving down
+                if (entities[i].state == 0)   //Init
                 {
+                    entities[i].state = 3;
+                    updateentities(i);
                 }
-                break;
-            case 1:  //Movement behaviors
-                //Enemies can have a number of different behaviors:
-                switch(entities[i].behave)
+                else if (entities[i].state == 1)
                 {
-                case 0: //Bounce, Start moving down
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].state = 3;
-                        updateentities(i);
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].outside()) entities[i].state = entities[i].onwall;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vy = -entities[i].para;
-                        entities[i].onwall = 3;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 3)
-                    {
-                        entities[i].vy = entities[i].para;
-                        entities[i].onwall = 2;
-                        entities[i].state = 1;
-                    }
-                    break;
-                case 1: //Bounce, Start moving up
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].state = 2;
-                        updateentities(i);
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].outside()) entities[i].state = entities[i].onwall;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vy = -entities[i].para;
-                        entities[i].onwall = 3;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 3)
-                    {
-                        entities[i].vy = entities[i].para;
-                        entities[i].onwall = 2;
-                        entities[i].state = 1;
-                    }
-                    break;
-                case 2: //Bounce, Start moving left
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].state = 3;
-                        updateentities(i);
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].outside()) entities[i].state = entities[i].onwall;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vx = entities[i].para;
-                        entities[i].onwall = 3;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 3)
-                    {
-                        entities[i].vx = -entities[i].para;
-                        entities[i].onwall = 2;
-                        entities[i].state = 1;
-                    }
-                    break;
-                case 3: //Bounce, Start moving right
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].state = 3;
-                        updateentities(i);
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].outside()) entities[i].state = entities[i].onwall;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vx = -entities[i].para;
-                        entities[i].onwall = 3;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 3)
-                    {
-                        entities[i].vx = entities[i].para;
-                        entities[i].onwall = 2;
-                        entities[i].state = 1;
-                    }
-                    break;
-                case 4: //Always move left
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].vx = entities[i].para;
-                    }
-                    break;
-                case 5: //Always move right
-                    if (entities[i].state == 0)
-                    {
-                        //Init
-                        entities[i].vx = static_cast<int>(entities[i].para);
-                        entities[i].state = 1;
-                        entities[i].onwall = 2;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vx = 0;
-                        entities[i].onwall = 0;
-                        entities[i].xp -=  static_cast<int>(entities[i].para);
-                        entities[i].statedelay=8;
-                        entities[i].state=0;
-                    }
-                    break;
-                case 6: //Always move up
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].vy = static_cast<int>(entities[i].para);
-                        entities[i].state = 1;
-                        entities[i].onwall = 2;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vy = static_cast<int>(-entities[i].para);
-                        entities[i].onwall = 0;
-                        entities[i].yp -=  (entities[i].para);
-                        entities[i].statedelay=8;
-                        entities[i].state=0;
-                    }
-                    break;
-                case 7: //Always move down
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].vx = static_cast<int>(entities[i].para);
-                    }
-                    break;
-                case 8:
-                case 9:
-                    //Threadmill: don't move, just impart velocity
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].vx = 0;
-                        entities[i].state = 1;
-                        entities[i].onwall = 0;
-                    }
-                    break;
-                case 10:
-                    //Emitter: shoot an enemy every so often
-                    if (entities[i].state == 0)
-                    {
-                        createentity(entities[i].xp+28, entities[i].yp, 1, 10, 1);
-                        entities[i].state = 1;
-                        entities[i].statedelay = 12;
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        entities[i].state = 0;
-                    }
-                    break;
-                case 11: //Always move right, destroy when outside screen
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].vx = entities[i].para;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].xp >= 335) removeentity(i);
-                        if (game.roomx == 117)
-                        {
-                            if (entities[i].xp >= (33*8)-32) removeentity(i);
-                            //collector for LIES
-                        }
-                    }
-                    break;
-                case 12:
-                    //Emitter: shoot an enemy every so often (up)
-                    if (entities[i].state == 0)
-                    {
-                        createentity(entities[i].xp, entities[i].yp, 1, 12, 1);
-                        entities[i].state = 1;
-                        entities[i].statedelay = 16;
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        entities[i].state = 0;
-                    }
-                    break;
-                case 13: //Always move up, destroy when outside screen
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].vy = entities[i].para;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].yp <= -60) removeentity(i);
-                        if (game.roomy == 108)
-                        {
-                            if (entities[i].yp <= 60) removeentity(i);
-                            //collector for factory
-                        }
-                    }
-                    break;
-                case 14: //Very special hack: as two, but doesn't move in specific circumstances
-                    if (entities[i].state == 0)   //Init
-                    {
-                        for (size_t j = 0; j < entities.size(); j++)
-                        {
-                            if (entities[j].type == 2 && entities[j].state== 3 && entities[j].xp == (entities[i].xp-32) )
-                            {
-                                entities[i].state = 3;
-                                updateentities(i);
-                            }
-                        }
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].outside()) entities[i].state = entities[i].onwall;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vx = entities[i].para;
-                        entities[i].onwall = 3;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 3)
-                    {
-                        entities[i].vx = -entities[i].para;
-                        entities[i].onwall = 2;
-                        entities[i].state = 1;
-                    }
-                    break;
-                case 15: //As above, but for 3!
-                    if (entities[i].state == 0)   //Init
-                    {
-                        for (size_t j = 0; j < entities.size(); j++)
-                        {
-                            if (entities[j].type == 2 && entities[j].state==3 && entities[j].xp==entities[i].xp+32)
-                            {
-                                entities[i].state = 3;
-                                updateentities(i);
-                            }
-                        }
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].outside()) entities[i].state = entities[i].onwall;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vx = -entities[i].para;
-                        entities[i].onwall = 3;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 3)
-                    {
-                        entities[i].vx = entities[i].para;
-                        entities[i].onwall = 2;
-                        entities[i].state = 1;
-                    }
-                    break;
-                case 16: //MAVERICK BUS FOLLOWS HIS OWN RULES
-                    if (entities[i].state == 0)   //Init
-                    {
-                        //first, y position
-                        if (entities[getplayer()].yp > 14 * 8)
-                        {
-                            entities[i].tile = 120;
-                            entities[i].yp = (28*8)-62;
-                        }
-                        else
-                        {
-                            entities[i].tile = 96;
-                            entities[i].yp = 24;
-                        }
-                        //now, x position
-                        if (entities[getplayer()].xp > 20 * 8)
-                        {
-                            //approach from the left
-                            entities[i].xp = -64;
-                            entities[i].state = 2;
-                            updateentities(i); //right
-                        }
-                        else
-                        {
-                            //approach from the left
-                            entities[i].xp = 320;
-                            entities[i].state = 3;
-                            updateentities(i); //left
-                        }
-
-                    }
-                    else if (entities[i].state == 1)
-                    {
-                        if (entities[i].outside()) entities[i].state = entities[i].onwall;
-                    }
-                    else if (entities[i].state == 2)
-                    {
-                        entities[i].vx = int(entities[i].para);
-                        entities[i].onwall = 3;
-                        entities[i].state = 1;
-                    }
-                    else if (entities[i].state == 3)
-                    {
-                        entities[i].vx = int(-entities[i].para);
-                        entities[i].onwall = 2;
-                        entities[i].state = 1;
-                    }
-                    break;
-                case 17: //Special for ASCII Snake (left)
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].statedelay = 6;
-                        entities[i].xp -=  int(entities[i].para);
-                    }
-                    break;
-                case 18: //Special for ASCII Snake (right)
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].statedelay = 6;
-                        entities[i].xp += int(entities[i].para);
-                    }
-                    break;
-                }
-                break;
-            case 2: //Disappearing platforms
-                //wait for collision
-                if (entities[i].state == 1)
-                {
-                    entities[i].life = 12;
-                    entities[i].state = 2;
-                    entities[i].onentity = 0;
-
-                    music.playef(7);
+                    if (entities[i].outside()) entities[i].state = entities[i].onwall;
                 }
                 else if (entities[i].state == 2)
                 {
-                    entities[i].life--;
-                    if (entities[i].life % 3 == 0) entities[i].tile++;
-                    if (entities[i].life <= 0)
-                    {
-                        removeblockat(entities[i].xp, entities[i].yp);
-                        entities[i].state = 3;// = false;
-                        entities[i].invis = true;
-                    }
+                    entities[i].vy = -entities[i].para;
+                    entities[i].onwall = 3;
+                    entities[i].state = 1;
                 }
                 else if (entities[i].state == 3)
                 {
-                    //wait until recharged!
-                }
-                else if (entities[i].state == 4)
-                {
-                    //restart!
-                    createblock(0, entities[i].xp, entities[i].yp, 32, 8);
-                    entities[i].state = 4;
-                    entities[i].invis = false;
-                    entities[i].tile--;
-                    entities[i].state++;
-                    entities[i].onentity = 1;
-                }
-                else if (entities[i].state == 5)
-                {
-                    entities[i].life+=3;
-                    if (entities[i].life % 3 == 0) entities[i].tile--;
-                    if (entities[i].life >= 12)
-                    {
-                        entities[i].life = 12;
-                        entities[i].state = 0;
-                        entities[i].tile++;
-                    }
+                    entities[i].vy = entities[i].para;
+                    entities[i].onwall = 2;
+                    entities[i].state = 1;
                 }
                 break;
-            case 3: //Breakable blocks
-                //Only counts if vy of player entity is non zero
-                if (entities[i].state == 1)
+            case 1: //Bounce, Start moving up
+                if (entities[i].state == 0)   //Init
                 {
-                    // int j = getplayer();
-                    //if (entities[j].vy > 0.5 && (entities[j].yp+entities[j].h<=entities[i].yp+6)) {
-                    entities[i].life = 4;
                     entities[i].state = 2;
-                    entities[i].onentity = 0;
-                    music.playef(6);
-                    /*}else if (entities[j].vy <= -0.5  && (entities[j].yp>=entities[i].yp+2)) {
-                    entities[i].life = 4;
-                    entities[i].state = 2; entities[i].onentity = 0;
-                    }else {
-                    entities[i].state = 0;
-                    }*/
+                    updateentities(i);
+                }
+                else if (entities[i].state == 1)
+                {
+                    if (entities[i].outside()) entities[i].state = entities[i].onwall;
                 }
                 else if (entities[i].state == 2)
                 {
-                    entities[i].life--;
-                    entities[i].tile++;
-                    if (entities[i].life <= 0)
+                    entities[i].vy = -entities[i].para;
+                    entities[i].onwall = 3;
+                    entities[i].state = 1;
+                }
+                else if (entities[i].state == 3)
+                {
+                    entities[i].vy = entities[i].para;
+                    entities[i].onwall = 2;
+                    entities[i].state = 1;
+                }
+                break;
+            case 2: //Bounce, Start moving left
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].state = 3;
+                    updateentities(i);
+                }
+                else if (entities[i].state == 1)
+                {
+                    if (entities[i].outside()) entities[i].state = entities[i].onwall;
+                }
+                else if (entities[i].state == 2)
+                {
+                    entities[i].vx = entities[i].para;
+                    entities[i].onwall = 3;
+                    entities[i].state = 1;
+                }
+                else if (entities[i].state == 3)
+                {
+                    entities[i].vx = -entities[i].para;
+                    entities[i].onwall = 2;
+                    entities[i].state = 1;
+                }
+                break;
+            case 3: //Bounce, Start moving right
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].state = 3;
+                    updateentities(i);
+                }
+                else if (entities[i].state == 1)
+                {
+                    if (entities[i].outside()) entities[i].state = entities[i].onwall;
+                }
+                else if (entities[i].state == 2)
+                {
+                    entities[i].vx = -entities[i].para;
+                    entities[i].onwall = 3;
+                    entities[i].state = 1;
+                }
+                else if (entities[i].state == 3)
+                {
+                    entities[i].vx = entities[i].para;
+                    entities[i].onwall = 2;
+                    entities[i].state = 1;
+                }
+                break;
+            case 4: //Always move left
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].vx = entities[i].para;
+                }
+                break;
+            case 5: //Always move right
+                if (entities[i].state == 0)
+                {
+                    //Init
+                    entities[i].vx = static_cast<int>(entities[i].para);
+                    entities[i].state = 1;
+                    entities[i].onwall = 2;
+                }
+                else if (entities[i].state == 2)
+                {
+                    entities[i].vx = 0;
+                    entities[i].onwall = 0;
+                    entities[i].xp -=  static_cast<int>(entities[i].para);
+                    entities[i].statedelay=8;
+                    entities[i].state=0;
+                }
+                break;
+            case 6: //Always move up
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].vy = static_cast<int>(entities[i].para);
+                    entities[i].state = 1;
+                    entities[i].onwall = 2;
+                }
+                else if (entities[i].state == 2)
+                {
+                    entities[i].vy = static_cast<int>(-entities[i].para);
+                    entities[i].onwall = 0;
+                    entities[i].yp -=  (entities[i].para);
+                    entities[i].statedelay=8;
+                    entities[i].state=0;
+                }
+                break;
+            case 7: //Always move down
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].vx = static_cast<int>(entities[i].para);
+                }
+                break;
+            case 8:
+            case 9:
+                //Threadmill: don't move, just impart velocity
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].vx = 0;
+                    entities[i].state = 1;
+                    entities[i].onwall = 0;
+                }
+                break;
+            case 10:
+                //Emitter: shoot an enemy every so often
+                if (entities[i].state == 0)
+                {
+                    createentity(entities[i].xp+28, entities[i].yp, 1, 10, 1);
+                    entities[i].state = 1;
+                    entities[i].statedelay = 12;
+                }
+                else if (entities[i].state == 1)
+                {
+                    entities[i].state = 0;
+                }
+                break;
+            case 11: //Always move right, destroy when outside screen
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].vx = entities[i].para;
+                    entities[i].state = 1;
+                }
+                else if (entities[i].state == 1)
+                {
+                    if (entities[i].xp >= 335) removeentity(i);
+                    if (game.roomx == 117)
                     {
-                        removeblockat(entities[i].xp, entities[i].yp);
-                        removeentity(i);
+                        if (entities[i].xp >= (33*8)-32) removeentity(i);
+                        //collector for LIES
                     }
                 }
                 break;
-            case 4: //Gravity token
-                //wait for collision
-                if (entities[i].state == 1)
-                {
-                    removeentity(i);
-                    game.gravitycontrol = (game.gravitycontrol + 1) % 2;
-
-                }
-                break;
-            case 5:  //Particle sprays
+            case 12:
+                //Emitter: shoot an enemy every so often (up)
                 if (entities[i].state == 0)
                 {
-                    entities[i].life--;
-                    if (entities[i].life < 0) removeentity(i);
+                    createentity(entities[i].xp, entities[i].yp, 1, 12, 1);
+                    entities[i].state = 1;
+                    entities[i].statedelay = 16;
+                }
+                else if (entities[i].state == 1)
+                {
+                    entities[i].state = 0;
                 }
                 break;
-            case 6: //Small pickup
-                //wait for collision
-                if (entities[i].state == 1)
+            case 13: //Always move up, destroy when outside screen
+                if (entities[i].state == 0)   //Init
                 {
-                    game.coins++;
-                    music.playef(4);
-                    collect[entities[i].para] = 1;
-
-                    removeentity(i);
+                    entities[i].vy = entities[i].para;
+                    entities[i].state = 1;
                 }
-                break;
-            case 7: //Found a trinket
-                //wait for collision
-                if (entities[i].state == 1)
+                else if (entities[i].state == 1)
                 {
-                    game.trinkets++;
-                    if (game.intimetrial)
+                    if (entities[i].yp <= -60) removeentity(i);
+                    if (game.roomy == 108)
                     {
-                        collect[entities[i].para] = 1;
-                        music.playef(25);
+                        if (entities[i].yp <= 60) removeentity(i);
+                        //collector for factory
+                    }
+                }
+                break;
+            case 14: //Very special hack: as two, but doesn't move in specific circumstances
+                if (entities[i].state == 0)   //Init
+                {
+                    for (size_t j = 0; j < entities.size(); j++)
+                    {
+                        if (entities[j].type == 2 && entities[j].state== 3 && entities[j].xp == (entities[i].xp-32) )
+                        {
+                            entities[i].state = 3;
+                            updateentities(i);
+                        }
+                    }
+                }
+                else if (entities[i].state == 1)
+                {
+                    if (entities[i].outside()) entities[i].state = entities[i].onwall;
+                }
+                else if (entities[i].state == 2)
+                {
+                    entities[i].vx = entities[i].para;
+                    entities[i].onwall = 3;
+                    entities[i].state = 1;
+                }
+                else if (entities[i].state == 3)
+                {
+                    entities[i].vx = -entities[i].para;
+                    entities[i].onwall = 2;
+                    entities[i].state = 1;
+                }
+                break;
+            case 15: //As above, but for 3!
+                if (entities[i].state == 0)   //Init
+                {
+                    for (size_t j = 0; j < entities.size(); j++)
+                    {
+                        if (entities[j].type == 2 && entities[j].state==3 && entities[j].xp==entities[i].xp+32)
+                        {
+                            entities[i].state = 3;
+                            updateentities(i);
+                        }
+                    }
+                }
+                else if (entities[i].state == 1)
+                {
+                    if (entities[i].outside()) entities[i].state = entities[i].onwall;
+                }
+                else if (entities[i].state == 2)
+                {
+                    entities[i].vx = -entities[i].para;
+                    entities[i].onwall = 3;
+                    entities[i].state = 1;
+                }
+                else if (entities[i].state == 3)
+                {
+                    entities[i].vx = entities[i].para;
+                    entities[i].onwall = 2;
+                    entities[i].state = 1;
+                }
+                break;
+            case 16: //MAVERICK BUS FOLLOWS HIS OWN RULES
+                if (entities[i].state == 0)   //Init
+                {
+                    //first, y position
+                    if (entities[getplayer()].yp > 14 * 8)
+                    {
+                        entities[i].tile = 120;
+                        entities[i].yp = (28*8)-62;
                     }
                     else
                     {
-                        game.state = 1000;
-                        //music.haltdasmusik();
-                        if(music.currentsong!=-1) music.silencedasmusik();
-                        music.playef(3);
-                        collect[entities[i].para] = 1;
-                        if (game.trinkets > game.stat_trinkets)
-                        {
-                            game.stat_trinkets = game.trinkets;
-                        }
+                        entities[i].tile = 96;
+                        entities[i].yp = 24;
+                    }
+                    //now, x position
+                    if (entities[getplayer()].xp > 20 * 8)
+                    {
+                        //approach from the left
+                        entities[i].xp = -64;
+                        entities[i].state = 2;
+                        updateentities(i); //right
+                    }
+                    else
+                    {
+                        //approach from the left
+                        entities[i].xp = 320;
+                        entities[i].state = 3;
+                        updateentities(i); //left
                     }
 
-                    removeentity(i);
+                }
+                else if (entities[i].state == 1)
+                {
+                    if (entities[i].outside()) entities[i].state = entities[i].onwall;
+                }
+                else if (entities[i].state == 2)
+                {
+                    entities[i].vx = int(entities[i].para);
+                    entities[i].onwall = 3;
+                    entities[i].state = 1;
+                }
+                else if (entities[i].state == 3)
+                {
+                    entities[i].vx = int(-entities[i].para);
+                    entities[i].onwall = 2;
+                    entities[i].state = 1;
                 }
                 break;
-            case 8: //Savepoints
-                //wait for collision
-                if (entities[i].state == 1)
+            case 17: //Special for ASCII Snake (left)
+                if (entities[i].state == 0)   //Init
                 {
+                    entities[i].statedelay = 6;
+                    entities[i].xp -=  int(entities[i].para);
+                }
+                break;
+            case 18: //Special for ASCII Snake (right)
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].statedelay = 6;
+                    entities[i].xp += int(entities[i].para);
+                }
+                break;
+            }
+            break;
+        case 2: //Disappearing platforms
+            //wait for collision
+            if (entities[i].state == 1)
+            {
+                entities[i].life = 12;
+                entities[i].state = 2;
+                entities[i].onentity = 0;
+
+                music.playef(7);
+            }
+            else if (entities[i].state == 2)
+            {
+                entities[i].life--;
+                if (entities[i].life % 3 == 0) entities[i].tile++;
+                if (entities[i].life <= 0)
+                {
+                    removeblockat(entities[i].xp, entities[i].yp);
+                    entities[i].state = 3;// = false;
+                    entities[i].invis = true;
+                }
+            }
+            else if (entities[i].state == 3)
+            {
+                //wait until recharged!
+            }
+            else if (entities[i].state == 4)
+            {
+                //restart!
+                createblock(0, entities[i].xp, entities[i].yp, 32, 8);
+                entities[i].state = 4;
+                entities[i].invis = false;
+                entities[i].tile--;
+                entities[i].state++;
+                entities[i].onentity = 1;
+            }
+            else if (entities[i].state == 5)
+            {
+                entities[i].life+=3;
+                if (entities[i].life % 3 == 0) entities[i].tile--;
+                if (entities[i].life >= 12)
+                {
+                    entities[i].life = 12;
+                    entities[i].state = 0;
+                    entities[i].tile++;
+                }
+            }
+            break;
+        case 3: //Breakable blocks
+            //Only counts if vy of player entity is non zero
+            if (entities[i].state == 1)
+            {
+                // int j = getplayer();
+                //if (entities[j].vy > 0.5 && (entities[j].yp+entities[j].h<=entities[i].yp+6)) {
+                entities[i].life = 4;
+                entities[i].state = 2;
+                entities[i].onentity = 0;
+                music.playef(6);
+                /*}else if (entities[j].vy <= -0.5  && (entities[j].yp>=entities[i].yp+2)) {
+                entities[i].life = 4;
+                entities[i].state = 2; entities[i].onentity = 0;
+                }else {
+                entities[i].state = 0;
+                }*/
+            }
+            else if (entities[i].state == 2)
+            {
+                entities[i].life--;
+                entities[i].tile++;
+                if (entities[i].life <= 0)
+                {
+                    removeblockat(entities[i].xp, entities[i].yp);
+                    removeentity(i);
+                }
+            }
+            break;
+        case 4: //Gravity token
+            //wait for collision
+            if (entities[i].state == 1)
+            {
+                removeentity(i);
+                game.gravitycontrol = (game.gravitycontrol + 1) % 2;
+
+            }
+            break;
+        case 5:  //Particle sprays
+            if (entities[i].state == 0)
+            {
+                entities[i].life--;
+                if (entities[i].life < 0) removeentity(i);
+            }
+            break;
+        case 6: //Small pickup
+            //wait for collision
+            if (entities[i].state == 1)
+            {
+                game.coins++;
+                music.playef(4);
+                collect[entities[i].para] = 1;
+
+                removeentity(i);
+            }
+            break;
+        case 7: //Found a trinket
+            //wait for collision
+            if (entities[i].state == 1)
+            {
+                game.trinkets++;
+                if (game.intimetrial)
+                {
+                    collect[entities[i].para] = 1;
+                    music.playef(25);
+                }
+                else
+                {
+                    game.state = 1000;
+                    //music.haltdasmusik();
+                    if(music.currentsong!=-1) music.silencedasmusik();
+                    music.playef(3);
+                    collect[entities[i].para] = 1;
+                    if (game.trinkets > game.stat_trinkets)
+                    {
+                        game.stat_trinkets = game.trinkets;
+                    }
+                }
+
+                removeentity(i);
+            }
+            break;
+        case 8: //Savepoints
+            //wait for collision
+            if (entities[i].state == 1)
+            {
+                //First, deactivate all other savepoints
+                for (size_t j = 0; j < entities.size(); j++)
+                {
+                    if (entities[j].type == 8)
+                    {
+                        entities[j].colour = 4;
+                        entities[j].onentity = 1;
+                    }
+                }
+                entities[i].colour = 5;
+                entities[i].onentity = 0;
+                game.savepoint = entities[i].para;
+                music.playef(5);
+
+                game.savex = entities[i].xp - 4;
+
+                if (entities[i].tile == 20)
+                {
+                    game.savey = entities[i].yp - 1;
+                    game.savegc = 1;
+                }
+                else if (entities[i].tile == 21)
+                {
+                    game.savey = entities[i].yp-8;
+                    game.savegc = 0;
+                }
+
+                game.saverx = game.roomx;
+                game.savery = game.roomy;
+                game.savedir = entities[getplayer()].dir;
+                entities[i].state = 0;
+            }
+            break;
+        case 9: //Gravity Lines
+            if (entities[i].state == 1)
+            {
+                entities[i].life--;
+                entities[i].onentity = 0;
+
+                if (entities[i].life <= 0)
+                {
+                    entities[i].state = 0;
+                    entities[i].onentity = 1;
+                }
+            }
+            break;
+        case 10: //Vertical gravity Lines
+            if (entities[i].state == 1)
+            {
+                entities[i].onentity = 3;
+                entities[i].state = 2;
+
+
+                music.playef(8);
+                game.gravitycontrol = (game.gravitycontrol + 1) % 2;
+                game.totalflips++;
+                temp = getplayer();
+                if (game.gravitycontrol == 0)
+                {
+                    if (entities[temp].vy < 3) entities[temp].vy = 3;
+                }
+                else
+                {
+                    if (entities[temp].vy > -3) entities[temp].vy = -3;
+                }
+            }
+            else if (entities[i].state == 2)
+            {
+                entities[i].life--;
+                if (entities[i].life <= 0)
+                {
+                    entities[i].state = 0;
+                    entities[i].onentity = 1;
+                }
+            }
+            else if (entities[i].state == 3)
+            {
+                entities[i].state = 2;
+                entities[i].life = 4;
+                entities[i].onentity = 3;
+            }
+            else if (entities[i].state == 4)
+            {
+                //Special case for room initilisations: As state one, except without the reversal
+                entities[i].onentity = 3;
+                entities[i].state = 2;
+            }
+            break;
+        case 11: //Warp point
+            //wait for collision
+            if (entities[i].state == 1)
+            {
+                //Depending on the room the warp point is in, teleport to a new location!
+                entities[i].onentity = 0;
+                //play a sound or somefink
+                music.playef(10);
+                game.teleport = true;
+
+                game.edteleportent = i;
+                //for the multiple room:
+                if (int(entities[i].xp) == 12*8) game.teleportxpos = 1;
+                if (int(entities[i].xp) == 5*8) game.teleportxpos = 2;
+                if (int(entities[i].xp) == 28*8) game.teleportxpos = 3;
+                if (int(entities[i].xp) == 21*8) game.teleportxpos = 4;
+            }
+            break;
+        case 12: //Crew member
+            //Somewhat complex AI: exactly what they do depends on room, location, state etc
+            //At state 0, do nothing at all.
+            if (entities[i].state == 1)
+            {
+                //happy!
+                if (entities[k].rule == 6)	entities[k].tile = 0;
+                if (entities[k].rule == 7)	entities[k].tile = 6;
+                //Stay close to the hero!
+                int j = getplayer();
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[j].xp > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[j].xp < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+
+                //Special rules:
+                if (game.roomx == 110 && game.roomy == 105)
+                {
+                    if (entities[i].xp < 155)
+                    {
+                        if (entities[i].ax < 0) entities[i].ax = 0;
+                    }
+                }
+            }
+            else if (entities[i].state == 2)
+            {
+                //Basic rules, don't change expression
+                int j = getplayer();
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[j].xp > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[j].xp < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+            }
+            else if (entities[i].state == 10)
+            {
+                //Everything from 10 on is for cutscenes
+                //Basic rules, don't change expression
+                int j = getplayer();
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[j].xp > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[j].xp < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+            }
+            else if (entities[i].state == 11)
+            {
+                //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
+                int j=getcrewman(1); //purple
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[j].xp > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[j].xp < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+            }
+            else if (entities[i].state == 12)
+            {
+                //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
+                int j=getcrewman(2); //yellow
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[j].xp > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[j].xp < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+            }
+            else if (entities[i].state == 13)
+            {
+                //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
+                int j=getcrewman(3); //red
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[j].xp > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[j].xp < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+            }
+            else if (entities[i].state == 14)
+            {
+                //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
+                int j=getcrewman(4); //green
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[j].xp > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[j].xp < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+            }
+            else if (entities[i].state == 15)
+            {
+                //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
+                int j=getcrewman(5); //blue
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[j].xp > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[j].xp < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+            }
+            else if (entities[i].state == 16)
+            {
+                //Follow a position: given an x coordinate, seek it out.
+                if (entities[i].para > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[i].para < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+
+                if (entities[i].para > entities[i].xp + 45)
+                {
+                    entities[i].ax = 3;
+                }
+                else if (entities[i].para < entities[i].xp - 45)
+                {
+                    entities[i].ax = -3;
+                }
+            }
+            else if (entities[i].state == 17)
+            {
+                //stand still
+            }
+            else if (entities[i].state == 18)
+            {
+                //Stand still and face the player
+                int j = getplayer();
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+            }
+            else if (entities[i].state == 19)
+            {
+                //Walk right off the screen after time t
+                if (entities[i].para <= 0)
+                {
+                    entities[i].dir = 1;
+                    entities[i].ax = 3;
+                }
+                else
+                {
+                    entities[i].para--;
+                }
+            }
+            else if (entities[i].state == 20)
+            {
+                //Panic! For briefing script
+                if (entities[i].life == 0)
+                {
+                    //walk left for a bit
+                    entities[i].ax = 0;
+                    if (40 > entities[i].xp + 5)
+                    {
+                        entities[i].dir = 1;
+                    }
+                    else if (40 < entities[i].xp - 5)
+                    {
+                        entities[i].dir = 0;
+                    }
+
+                    if (40 > entities[i].xp + 45)
+                    {
+                        entities[i].ax = 3;
+                    }
+                    else if (40 < entities[i].xp - 45)
+                    {
+                        entities[i].ax = -3;
+                    }
+                    if ( (entities[i].ax) == 0)
+                    {
+                        entities[i].life = 1;
+                        entities[i].para = 30;
+                    }
+                }
+                else	if (entities[i].life == 1)
+                {
+                    //Stand around for a bit
+                    entities[i].para--;
+                    if (entities[i].para <= 0)
+                    {
+                        entities[i].life++;
+                    }
+                }
+                else if (entities[i].life == 2)
+                {
+                    //walk right for a bit
+                    entities[i].ax = 0;
+                    if (280 > entities[i].xp + 5)
+                    {
+                        entities[i].dir = 1;
+                    }
+                    else if (280 < entities[i].xp - 5)
+                    {
+                        entities[i].dir = 0;
+                    }
+
+                    if (280 > entities[i].xp + 45)
+                    {
+                        entities[i].ax = 3;
+                    }
+                    else if (280 < entities[i].xp - 45)
+                    {
+                        entities[i].ax = -3;
+                    }
+                    if ( (entities[i].ax) == 0)
+                    {
+                        entities[i].life = 3;
+                        entities[i].para = 30;
+                    }
+                }
+                else	if (entities[i].life == 3)
+                {
+                    //Stand around for a bit
+                    entities[i].para--;
+                    if (entities[i].para <= 0)
+                    {
+                        entities[i].life=0;
+                    }
+                }
+            }
+            break;
+        case 13: //Terminals (very similar to savepoints)
+            //wait for collision
+            if (entities[i].state == 1)
+            {
+                entities[i].colour = 5;
+                entities[i].onentity = 0;
+                music.playef(17);
+
+                entities[i].state = 0;
+            }
+            break;
+        case 14: //Super Crew member
+            //Actually needs less complex AI than the scripting crewmember
+            if (entities[i].state == 0)
+            {
+                //follow player, but only if he's on the floor!
+                int j = getplayer();
+                if(entities[j].onground>0)
+                {
+                    if (entities[j].xp > entities[i].xp + 5)
+                    {
+                        entities[i].dir = 1;
+                    }
+                    else if (entities[j].xp>15 && entities[j].xp < entities[i].xp - 5)
+                    {
+                        entities[i].dir = 0;
+                    }
+
+                    if (entities[j].xp > entities[i].xp + 45)
+                    {
+                        entities[i].ax = 3;
+                    }
+                    else if (entities[j].xp < entities[i].xp - 45)
+                    {
+                        entities[i].ax = -3;
+                    }
+                    if (entities[i].ax < 0 && entities[i].xp < 60)
+                    {
+                        entities[i].ax = 0;
+                    }
+                }
+                else
+                {
+                    if (entities[j].xp > entities[i].xp + 5)
+                    {
+                        entities[i].dir = 1;
+                    }
+                    else if (entities[j].xp < entities[i].xp - 5)
+                    {
+                        entities[i].dir = 0;
+                    }
+
+                    entities[i].ax = 0;
+                }
+
+                if (entities[i].xp > 240)
+                {
+                    entities[i].ax = 3;
+                    entities[i].dir = 1;
+                }
+                if (entities[i].xp >= 310)
+                {
+                    game.scmprogress++;
+                    removeentity(i);
+                }
+            }
+            break;
+        case 15: //Trophy
+            //wait for collision
+            if (entities[i].state == 1)
+            {
+                trophytext+=2;
+                if (trophytext > 30) trophytext = 30;
+                trophytype = entities[i].para;
+
+                entities[i].state = 0;
+            }
+            break;
+        case 23:
+            //swn game!
+            switch(entities[i].behave)
+            {
+            case 0:
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].vx = 7;
+                    if (entities[i].xp > 320) removeentity(i);
+                }
+                break;
+            case 1:
+                if (entities[i].state == 0)   //Init
+                {
+                    entities[i].vx = -7;
+                    if (entities[i].xp <-20) removeentity(i);
+                }
+                break;
+            }
+            break;
+
+        case 51: //Vertical warp line
+            if (entities[i].state == 2){
+              int j=getplayer();
+              if(entities[j].xp<=307){
+                customwarpmodevon=false;
+                entities[i].state = 0;
+              }
+            }else if (entities[i].state == 1)
+            {
+              entities[i].state = 2;
+              entities[i].statedelay = 2;
+              entities[i].onentity = 1;
+              customwarpmodevon=true;
+            }
+            break;
+        case 52: //Vertical warp line
+            if (entities[i].state == 2){
+              int j=getplayer();
+              if(entities[j].xp<=307){
+                customwarpmodevon=false;
+                entities[i].state = 0;
+              }
+            }else if (entities[i].state == 1)
+            {
+              entities[i].state = 2;
+              entities[i].statedelay = 2;
+              entities[i].onentity = 1;
+              customwarpmodevon=true;
+            }
+            break;
+          case 53: //Warp lines Horizonal
+            if (entities[i].state == 2){
+              customwarpmodehon=false;
+              entities[i].state = 0;
+            }else if (entities[i].state == 1)
+            {
+              entities[i].state = 2;
+              entities[i].statedelay = 2;
+              entities[i].onentity = 1;
+              customwarpmodehon=true;
+            }
+            break;
+            case 54: //Warp lines Horizonal
+            if (entities[i].state == 2){
+              customwarpmodehon=false;
+              entities[i].state = 0;
+            }else if (entities[i].state == 1)
+            {
+               entities[i].state = 2;
+               entities[i].statedelay = 2;
+               entities[i].onentity = 1;
+               customwarpmodehon=true;
+            }
+            break;
+          case 55: //Collectable crewmate
+            //wait for collision
+            if (entities[i].state == 0)
+            {
+                //Basic rules, don't change expression
+                int j = getplayer();
+                if (entities[j].xp > entities[i].xp + 5)
+                {
+                    entities[i].dir = 1;
+                }
+                else if (entities[j].xp < entities[i].xp - 5)
+                {
+                    entities[i].dir = 0;
+                }
+            }
+            else if (entities[i].state == 1)
+            {
+                game.crewmates++;
+                if (game.intimetrial)
+                {
+                    customcollect[entities[i].para] = 1;
+                    music.playef(27);
+                }
+                else
+                {
+                    game.state = 1010;
+                    //music.haltdasmusik();
+                    if(music.currentsong!=-1) music.silencedasmusik();
+                    music.playef(27);
+                    customcollect[entities[i].para] = 1;
+                }
+
+                removeentity(i);
+            }
+            break;
+        case 100: //The teleporter
+            if (entities[i].state == 1)
+            {
+                //if inactive, activate!
+                if (entities[i].tile == 1)
+                {
+                    music.playef(18);
+                    entities[i].onentity = 0;
+                    entities[i].tile = 2;
+                    entities[i].colour = 101;
+                    if(!game.intimetrial && !game.nodeathmode)
+                    {
+                        game.state = 2000;
+                        game.statedelay = 0;
+                    }
+
+                    game.activetele = true;
+                    game.teleblock.x = entities[i].xp - 32;
+                    game.teleblock.y = entities[i].yp - 32;
+                    game.teleblock.w = 160;
+                    game.teleblock.h = 160;
+
+
+                    //Alright, let's set this as our savepoint too
                     //First, deactivate all other savepoints
                     for (size_t j = 0; j < entities.size(); j++)
                     {
@@ -2716,682 +3349,43 @@ bool entityclass::updateentities( int i )
                             entities[j].onentity = 1;
                         }
                     }
-                    entities[i].colour = 5;
-                    entities[i].onentity = 0;
-                    game.savepoint = entities[i].para;
-                    music.playef(5);
-
-                    game.savex = entities[i].xp - 4;
-
-                    if (entities[i].tile == 20)
-                    {
-                        game.savey = entities[i].yp - 1;
-                        game.savegc = 1;
-                    }
-                    else if (entities[i].tile == 21)
-                    {
-                        game.savey = entities[i].yp-8;
-                        game.savegc = 0;
-                    }
+                    game.savepoint = static_cast<int>(entities[i].para);
+                    game.savex = entities[i].xp + 44;
+                    game.savey = entities[i].yp + 44;
+                    game.savegc = 0;
 
                     game.saverx = game.roomx;
                     game.savery = game.roomy;
                     game.savedir = entities[getplayer()].dir;
                     entities[i].state = 0;
                 }
-                break;
-            case 9: //Gravity Lines
-                if (entities[i].state == 1)
-                {
-                    entities[i].life--;
-                    entities[i].onentity = 0;
 
-                    if (entities[i].life <= 0)
-                    {
-                        entities[i].state = 0;
-                        entities[i].onentity = 1;
-                    }
-                }
-                break;
-            case 10: //Vertical gravity Lines
-                if (entities[i].state == 1)
-                {
-                    entities[i].onentity = 3;
-                    entities[i].state = 2;
-
-
-                    music.playef(8);
-                    game.gravitycontrol = (game.gravitycontrol + 1) % 2;
-                    game.totalflips++;
-                    temp = getplayer();
-                    if (game.gravitycontrol == 0)
-                    {
-                        if (entities[temp].vy < 3) entities[temp].vy = 3;
-                    }
-                    else
-                    {
-                        if (entities[temp].vy > -3) entities[temp].vy = -3;
-                    }
-                }
-                else if (entities[i].state == 2)
-                {
-                    entities[i].life--;
-                    if (entities[i].life <= 0)
-                    {
-                        entities[i].state = 0;
-                        entities[i].onentity = 1;
-                    }
-                }
-                else if (entities[i].state == 3)
-                {
-                    entities[i].state = 2;
-                    entities[i].life = 4;
-                    entities[i].onentity = 3;
-                }
-                else if (entities[i].state == 4)
-                {
-                    //Special case for room initilisations: As state one, except without the reversal
-                    entities[i].onentity = 3;
-                    entities[i].state = 2;
-                }
-                break;
-            case 11: //Warp point
-                //wait for collision
-                if (entities[i].state == 1)
-                {
-                    //Depending on the room the warp point is in, teleport to a new location!
-                    entities[i].onentity = 0;
-                    //play a sound or somefink
-                    music.playef(10);
-                    game.teleport = true;
-
-                    game.edteleportent = i;
-                    //for the multiple room:
-                    if (int(entities[i].xp) == 12*8) game.teleportxpos = 1;
-                    if (int(entities[i].xp) == 5*8) game.teleportxpos = 2;
-                    if (int(entities[i].xp) == 28*8) game.teleportxpos = 3;
-                    if (int(entities[i].xp) == 21*8) game.teleportxpos = 4;
-                }
-                break;
-            case 12: //Crew member
-                //Somewhat complex AI: exactly what they do depends on room, location, state etc
-                //At state 0, do nothing at all.
-                if (entities[i].state == 1)
-                {
-                    //happy!
-                    if (entities[k].rule == 6)	entities[k].tile = 0;
-                    if (entities[k].rule == 7)	entities[k].tile = 6;
-                    //Stay close to the hero!
-                    int j = getplayer();
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[j].xp > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-
-                    //Special rules:
-                    if (game.roomx == 110 && game.roomy == 105)
-                    {
-                        if (entities[i].xp < 155)
-                        {
-                            if (entities[i].ax < 0) entities[i].ax = 0;
-                        }
-                    }
-                }
-                else if (entities[i].state == 2)
-                {
-                    //Basic rules, don't change expression
-                    int j = getplayer();
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[j].xp > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-                }
-                else if (entities[i].state == 10)
-                {
-                    //Everything from 10 on is for cutscenes
-                    //Basic rules, don't change expression
-                    int j = getplayer();
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[j].xp > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-                }
-                else if (entities[i].state == 11)
-                {
-                    //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                    int j=getcrewman(1); //purple
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[j].xp > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-                }
-                else if (entities[i].state == 12)
-                {
-                    //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                    int j=getcrewman(2); //yellow
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[j].xp > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-                }
-                else if (entities[i].state == 13)
-                {
-                    //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                    int j=getcrewman(3); //red
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[j].xp > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-                }
-                else if (entities[i].state == 14)
-                {
-                    //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                    int j=getcrewman(4); //green
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[j].xp > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-                }
-                else if (entities[i].state == 15)
-                {
-                    //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                    int j=getcrewman(5); //blue
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[j].xp > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-                }
-                else if (entities[i].state == 16)
-                {
-                    //Follow a position: given an x coordinate, seek it out.
-                    if (entities[i].para > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[i].para < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-
-                    if (entities[i].para > entities[i].xp + 45)
-                    {
-                        entities[i].ax = 3;
-                    }
-                    else if (entities[i].para < entities[i].xp - 45)
-                    {
-                        entities[i].ax = -3;
-                    }
-                }
-                else if (entities[i].state == 17)
-                {
-                    //stand still
-                }
-                else if (entities[i].state == 18)
-                {
-                    //Stand still and face the player
-                    int j = getplayer();
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-                }
-                else if (entities[i].state == 19)
-                {
-                    //Walk right off the screen after time t
-                    if (entities[i].para <= 0)
-                    {
-                        entities[i].dir = 1;
-                        entities[i].ax = 3;
-                    }
-                    else
-                    {
-                        entities[i].para--;
-                    }
-                }
-                else if (entities[i].state == 20)
-                {
-                    //Panic! For briefing script
-                    if (entities[i].life == 0)
-                    {
-                        //walk left for a bit
-                        entities[i].ax = 0;
-                        if (40 > entities[i].xp + 5)
-                        {
-                            entities[i].dir = 1;
-                        }
-                        else if (40 < entities[i].xp - 5)
-                        {
-                            entities[i].dir = 0;
-                        }
-
-                        if (40 > entities[i].xp + 45)
-                        {
-                            entities[i].ax = 3;
-                        }
-                        else if (40 < entities[i].xp - 45)
-                        {
-                            entities[i].ax = -3;
-                        }
-                        if ( (entities[i].ax) == 0)
-                        {
-                            entities[i].life = 1;
-                            entities[i].para = 30;
-                        }
-                    }
-                    else	if (entities[i].life == 1)
-                    {
-                        //Stand around for a bit
-                        entities[i].para--;
-                        if (entities[i].para <= 0)
-                        {
-                            entities[i].life++;
-                        }
-                    }
-                    else if (entities[i].life == 2)
-                    {
-                        //walk right for a bit
-                        entities[i].ax = 0;
-                        if (280 > entities[i].xp + 5)
-                        {
-                            entities[i].dir = 1;
-                        }
-                        else if (280 < entities[i].xp - 5)
-                        {
-                            entities[i].dir = 0;
-                        }
-
-                        if (280 > entities[i].xp + 45)
-                        {
-                            entities[i].ax = 3;
-                        }
-                        else if (280 < entities[i].xp - 45)
-                        {
-                            entities[i].ax = -3;
-                        }
-                        if ( (entities[i].ax) == 0)
-                        {
-                            entities[i].life = 3;
-                            entities[i].para = 30;
-                        }
-                    }
-                    else	if (entities[i].life == 3)
-                    {
-                        //Stand around for a bit
-                        entities[i].para--;
-                        if (entities[i].para <= 0)
-                        {
-                            entities[i].life=0;
-                        }
-                    }
-                }
-                break;
-            case 13: //Terminals (very similar to savepoints)
-                //wait for collision
-                if (entities[i].state == 1)
-                {
-                    entities[i].colour = 5;
-                    entities[i].onentity = 0;
-                    music.playef(17);
-
-                    entities[i].state = 0;
-                }
-                break;
-            case 14: //Super Crew member
-                //Actually needs less complex AI than the scripting crewmember
-                if (entities[i].state == 0)
-                {
-                    //follow player, but only if he's on the floor!
-                    int j = getplayer();
-                    if(entities[j].onground>0)
-                    {
-                        if (entities[j].xp > entities[i].xp + 5)
-                        {
-                            entities[i].dir = 1;
-                        }
-                        else if (entities[j].xp>15 && entities[j].xp < entities[i].xp - 5)
-                        {
-                            entities[i].dir = 0;
-                        }
-
-                        if (entities[j].xp > entities[i].xp + 45)
-                        {
-                            entities[i].ax = 3;
-                        }
-                        else if (entities[j].xp < entities[i].xp - 45)
-                        {
-                            entities[i].ax = -3;
-                        }
-                        if (entities[i].ax < 0 && entities[i].xp < 60)
-                        {
-                            entities[i].ax = 0;
-                        }
-                    }
-                    else
-                    {
-                        if (entities[j].xp > entities[i].xp + 5)
-                        {
-                            entities[i].dir = 1;
-                        }
-                        else if (entities[j].xp < entities[i].xp - 5)
-                        {
-                            entities[i].dir = 0;
-                        }
-
-                        entities[i].ax = 0;
-                    }
-
-                    if (entities[i].xp > 240)
-                    {
-                        entities[i].ax = 3;
-                        entities[i].dir = 1;
-                    }
-                    if (entities[i].xp >= 310)
-                    {
-                        game.scmprogress++;
-                        removeentity(i);
-                    }
-                }
-                break;
-            case 15: //Trophy
-                //wait for collision
-                if (entities[i].state == 1)
-                {
-                    trophytext+=2;
-                    if (trophytext > 30) trophytext = 30;
-                    trophytype = entities[i].para;
-
-                    entities[i].state = 0;
-                }
-                break;
-            case 23:
-                //swn game!
-                switch(entities[i].behave)
-                {
-                case 0:
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].vx = 7;
-                        if (entities[i].xp > 320) removeentity(i);
-                    }
-                    break;
-                case 1:
-                    if (entities[i].state == 0)   //Init
-                    {
-                        entities[i].vx = -7;
-                        if (entities[i].xp <-20) removeentity(i);
-                    }
-                    break;
-                }
-                break;
-
-            case 51: //Vertical warp line
-                if (entities[i].state == 2){
-                  int j=getplayer();
-                  if(entities[j].xp<=307){
-                    customwarpmodevon=false;
-                    entities[i].state = 0;
-                  }
-                }else if (entities[i].state == 1)
-                {
-                  entities[i].state = 2;
-                  entities[i].statedelay = 2;
-                  entities[i].onentity = 1;
-                  customwarpmodevon=true;
-                }
-                break;
-            case 52: //Vertical warp line
-                if (entities[i].state == 2){
-                  int j=getplayer();
-                  if(entities[j].xp<=307){
-                    customwarpmodevon=false;
-                    entities[i].state = 0;
-                  }
-                }else if (entities[i].state == 1)
-                {
-                  entities[i].state = 2;
-                  entities[i].statedelay = 2;
-                  entities[i].onentity = 1;
-                  customwarpmodevon=true;
-                }
-                break;
-              case 53: //Warp lines Horizonal
-                if (entities[i].state == 2){
-                  customwarpmodehon=false;
-                  entities[i].state = 0;
-                }else if (entities[i].state == 1)
-                {
-                  entities[i].state = 2;
-                  entities[i].statedelay = 2;
-                  entities[i].onentity = 1;
-                  customwarpmodehon=true;
-                }
-                break;
-                case 54: //Warp lines Horizonal
-                if (entities[i].state == 2){
-                  customwarpmodehon=false;
-                  entities[i].state = 0;
-                }else if (entities[i].state == 1)
-                {
-                   entities[i].state = 2;
-                   entities[i].statedelay = 2;
-                   entities[i].onentity = 1;
-                   customwarpmodehon=true;
-                }
-                break;
-              case 55: //Collectable crewmate
-                //wait for collision
-                if (entities[i].state == 0)
-                {
-                    //Basic rules, don't change expression
-                    int j = getplayer();
-                    if (entities[j].xp > entities[i].xp + 5)
-                    {
-                        entities[i].dir = 1;
-                    }
-                    else if (entities[j].xp < entities[i].xp - 5)
-                    {
-                        entities[i].dir = 0;
-                    }
-                }
-                else if (entities[i].state == 1)
-                {
-                    game.crewmates++;
-                    if (game.intimetrial)
-                    {
-                        customcollect[entities[i].para] = 1;
-                        music.playef(27);
-                    }
-                    else
-                    {
-                        game.state = 1010;
-                        //music.haltdasmusik();
-                        if(music.currentsong!=-1) music.silencedasmusik();
-                        music.playef(27);
-                        customcollect[entities[i].para] = 1;
-                    }
-
-                    removeentity(i);
-                }
-                break;
-            case 100: //The teleporter
-                if (entities[i].state == 1)
-                {
-                    //if inactive, activate!
-                    if (entities[i].tile == 1)
-                    {
-                        music.playef(18);
-                        entities[i].onentity = 0;
-                        entities[i].tile = 2;
-                        entities[i].colour = 101;
-                        if(!game.intimetrial && !game.nodeathmode)
-                        {
-                            game.state = 2000;
-                            game.statedelay = 0;
-                        }
-
-                        game.activetele = true;
-                        game.teleblock.x = entities[i].xp - 32;
-                        game.teleblock.y = entities[i].yp - 32;
-                        game.teleblock.w = 160;
-                        game.teleblock.h = 160;
-
-
-                        //Alright, let's set this as our savepoint too
-                        //First, deactivate all other savepoints
-                        for (size_t j = 0; j < entities.size(); j++)
-                        {
-                            if (entities[j].type == 8)
-                            {
-                                entities[j].colour = 4;
-                                entities[j].onentity = 1;
-                            }
-                        }
-                        game.savepoint = static_cast<int>(entities[i].para);
-                        game.savex = entities[i].xp + 44;
-                        game.savey = entities[i].yp + 44;
-                        game.savegc = 0;
-
-                        game.saverx = game.roomx;
-                        game.savery = game.roomy;
-                        game.savedir = entities[getplayer()].dir;
-                        entities[i].state = 0;
-                    }
-
-                    entities[i].state = 0;
-                }
-                else if (entities[i].state == 2)
-                {
-                    //Initilise the teleporter without changing the game state or playing sound
-                    entities[i].onentity = 0;
-                    entities[i].tile = 6;
-                    entities[i].colour = 102;
-
-                    game.activetele = true;
-                    game.teleblock.x = entities[i].xp - 32;
-                    game.teleblock.y = entities[i].yp - 32;
-                    game.teleblock.w = 160;
-                    game.teleblock.h = 160;
-
-                    entities[i].state = 0;
-                }
-                break;
+                entities[i].state = 0;
             }
-        }
-        else
-        {
-            entities[i].statedelay--;
-            if (entities[i].statedelay < 0)
+            else if (entities[i].state == 2)
             {
-                entities[i].statedelay = 0;
+                //Initilise the teleporter without changing the game state or playing sound
+                entities[i].onentity = 0;
+                entities[i].tile = 6;
+                entities[i].colour = 102;
+
+                game.activetele = true;
+                game.teleblock.x = entities[i].xp - 32;
+                game.teleblock.y = entities[i].yp - 32;
+                game.teleblock.w = 160;
+                game.teleblock.h = 160;
+
+                entities[i].state = 0;
             }
+            break;
+        }
+    }
+    else
+    {
+        entities[i].statedelay--;
+        if (entities[i].statedelay < 0)
+        {
+            entities[i].statedelay = 0;
         }
     }
 
@@ -3400,365 +3394,362 @@ bool entityclass::updateentities( int i )
 
 void entityclass::animateentities( int _i )
 {
-    if(true) // FIXME: remove this later (no more 'active')
+    if(entities[_i].statedelay < 1)
     {
-        if(entities[_i].statedelay < 1)
+        switch(entities[_i].type)
         {
-            switch(entities[_i].type)
+        case 0:
+            entities[_i].framedelay--;
+            if(entities[_i].dir==1)
+            {
+                entities[_i].drawframe=entities[_i].tile;
+            }
+            else
+            {
+                entities[_i].drawframe=entities[_i].tile+3;
+            }
+
+            if(entities[_i].onground>0 || entities[_i].onroof>0)
+            {
+                if(entities[_i].vx > 0.00f || entities[_i].vx < -0.00f)
+                {
+                    //Walking
+                    if(entities[_i].framedelay<=1)
+                    {
+                        entities[_i].framedelay=4;
+                        entities[_i].walkingframe++;
+                    }
+                    if (entities[_i].walkingframe >=2) entities[_i].walkingframe=0;
+                    entities[_i].drawframe += entities[_i].walkingframe + 1;
+                }
+
+                if (entities[_i].onroof > 0) entities[_i].drawframe += 6;
+            }
+            else
+            {
+                entities[_i].drawframe ++;
+                if (game.gravitycontrol == 1)
+                {
+                    entities[_i].drawframe += 6;
+                }
+            }
+
+            if (game.deathseq > -1)
+            {
+                entities[_i].drawframe=13;
+                if (entities[_i].dir == 1) entities[_i].drawframe = 12;
+                if (game.gravitycontrol == 1) entities[_i].drawframe += 2;
+            }
+            break;
+        case 1:
+        case 23:
+            //Variable animation
+            switch(entities[_i].animate)
             {
             case 0:
+                //Simple oscilation
                 entities[_i].framedelay--;
-                if(entities[_i].dir==1)
+                if(entities[_i].framedelay<=0)
                 {
-                    entities[_i].drawframe=entities[_i].tile;
-                }
-                else
-                {
-                    entities[_i].drawframe=entities[_i].tile+3;
-                }
-
-                if(entities[_i].onground>0 || entities[_i].onroof>0)
-                {
-                    if(entities[_i].vx > 0.00f || entities[_i].vx < -0.00f)
+                    entities[_i].framedelay = 8;
+                    if(entities[_i].actionframe==0)
                     {
-                        //Walking
-                        if(entities[_i].framedelay<=1)
-                        {
-                            entities[_i].framedelay=4;
-                            entities[_i].walkingframe++;
-                        }
-                        if (entities[_i].walkingframe >=2) entities[_i].walkingframe=0;
-                        entities[_i].drawframe += entities[_i].walkingframe + 1;
-                    }
-
-                    if (entities[_i].onroof > 0) entities[_i].drawframe += 6;
-                }
-                else
-                {
-                    entities[_i].drawframe ++;
-                    if (game.gravitycontrol == 1)
-                    {
-                        entities[_i].drawframe += 6;
-                    }
-                }
-
-                if (game.deathseq > -1)
-                {
-                    entities[_i].drawframe=13;
-                    if (entities[_i].dir == 1) entities[_i].drawframe = 12;
-                    if (game.gravitycontrol == 1) entities[_i].drawframe += 2;
-                }
-                break;
-            case 1:
-            case 23:
-                //Variable animation
-                switch(entities[_i].animate)
-                {
-                case 0:
-                    //Simple oscilation
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 8;
-                        if(entities[_i].actionframe==0)
-                        {
-                            entities[_i].walkingframe++;
-                            if (entities[_i].walkingframe == 4)
-                            {
-                                entities[_i].walkingframe = 2;
-                                entities[_i].actionframe = 1;
-                            }
-                        }
-                        else
-                        {
-                            entities[_i].walkingframe--;
-                            if (entities[_i].walkingframe == -1)
-                            {
-                                entities[_i].walkingframe = 1;
-                                entities[_i].actionframe = 0;
-                            }
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                    break;
-                case 1:
-                    //Simple Loop
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 8;
                         entities[_i].walkingframe++;
                         if (entities[_i].walkingframe == 4)
                         {
-                            entities[_i].walkingframe = 0;
+                            entities[_i].walkingframe = 2;
+                            entities[_i].actionframe = 1;
                         }
                     }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                    break;
-                case 2:
-                    //Simpler Loop (just two frames)
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
+                    else
                     {
-                        entities[_i].framedelay = 2;
-                        entities[_i].walkingframe++;
-                        if (entities[_i].walkingframe == 2)
-                        {
-                            entities[_i].walkingframe = 0;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                    break;
-                case 3:
-                    //Simpler Loop (just two frames, but double sized)
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 2;
-                        entities[_i].walkingframe++;
-                        if (entities[_i].walkingframe == 2)
-                        {
-                            entities[_i].walkingframe = 0;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += (entities[_i].walkingframe*2);
-                    break;
-                case 4:
-                    //Simpler Loop (just two frames, but double sized) (as above but slower)
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 6;
-                        entities[_i].walkingframe++;
-                        if (entities[_i].walkingframe == 2)
-                        {
-                            entities[_i].walkingframe = 0;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += (entities[_i].walkingframe*2);
-                    break;
-                case 5:
-                    //Simpler Loop (just two frames) (slower)
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 6;
-                        entities[_i].walkingframe++;
-                        if (entities[_i].walkingframe == 2)
-                        {
-                            entities[_i].walkingframe = 0;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                    break;
-                case 6:
-                    //Normal Loop (four frames, double sized)
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 4;
-                        entities[_i].walkingframe++;
-                        if (entities[_i].walkingframe == 4)
-                        {
-                            entities[_i].walkingframe = 0;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += (entities[_i].walkingframe*2);
-                    break;
-                case 7:
-                    //Simpler Loop (just two frames) (slower) (with directions!)
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 6;
-                        entities[_i].walkingframe++;
-                        if (entities[_i].walkingframe == 2)
-                        {
-                            entities[_i].walkingframe = 0;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-
-                    if (entities[_i].vx > 0.000f ) entities[_i].drawframe += 2;
-                    break;
-                case 10:
-                    //Threadmill left
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 3;//(6-entities[_i].para);
                         entities[_i].walkingframe--;
                         if (entities[_i].walkingframe == -1)
                         {
-                            entities[_i].walkingframe = 3;
+                            entities[_i].walkingframe = 1;
+                            entities[_i].actionframe = 0;
                         }
                     }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                    break;
-                case 11:
-                    //Threadmill right
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 3;//(6-entities[_i].para);
-                        entities[_i].walkingframe++;
-                        if (entities[_i].walkingframe == 4)
-                        {
-                            entities[_i].walkingframe = 0;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                    break;
-                case 100:
-                    //Simple case for no animation (platforms, etc)
-                    entities[_i].drawframe = entities[_i].tile;
-                    break;
-                default:
-                    entities[_i].drawframe = entities[_i].tile;
-                    break;
                 }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
+                break;
+            case 1:
+                //Simple Loop
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 8;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 4)
+                    {
+                        entities[_i].walkingframe = 0;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
+                break;
+            case 2:
+                //Simpler Loop (just two frames)
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 2;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 2)
+                    {
+                        entities[_i].walkingframe = 0;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
+                break;
+            case 3:
+                //Simpler Loop (just two frames, but double sized)
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 2;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 2)
+                    {
+                        entities[_i].walkingframe = 0;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += (entities[_i].walkingframe*2);
+                break;
+            case 4:
+                //Simpler Loop (just two frames, but double sized) (as above but slower)
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 6;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 2)
+                    {
+                        entities[_i].walkingframe = 0;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += (entities[_i].walkingframe*2);
+                break;
+            case 5:
+                //Simpler Loop (just two frames) (slower)
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 6;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 2)
+                    {
+                        entities[_i].walkingframe = 0;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
+                break;
+            case 6:
+                //Normal Loop (four frames, double sized)
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 4;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 4)
+                    {
+                        entities[_i].walkingframe = 0;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += (entities[_i].walkingframe*2);
+                break;
+            case 7:
+                //Simpler Loop (just two frames) (slower) (with directions!)
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 6;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 2)
+                    {
+                        entities[_i].walkingframe = 0;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
+
+                if (entities[_i].vx > 0.000f ) entities[_i].drawframe += 2;
+                break;
+            case 10:
+                //Threadmill left
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 3;//(6-entities[_i].para);
+                    entities[_i].walkingframe--;
+                    if (entities[_i].walkingframe == -1)
+                    {
+                        entities[_i].walkingframe = 3;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
                 break;
             case 11:
-                entities[_i].drawframe = entities[_i].tile;
-                if(entities[_i].animate==2)
-                {
-                    //Simpler Loop (just two frames)
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 10;
-                        entities[_i].walkingframe++;
-                        if (entities[_i].walkingframe == 2)
-                        {
-                            entities[_i].walkingframe = 0;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                }
-                break;
-            case 12:
-            case 55:
-            case 14: //Crew member! Very similar to hero
+                //Threadmill right
                 entities[_i].framedelay--;
-                if(entities[_i].dir==1)
+                if(entities[_i].framedelay<=0)
                 {
-                    entities[_i].drawframe=entities[_i].tile;
-                }
-                else
-                {
-                    entities[_i].drawframe=entities[_i].tile+3;
-                }
-
-                if(entities[_i].onground>0 || entities[_i].onroof>0)
-                {
-                    if(entities[_i].vx > 0.0000f || entities[_i].vx < -0.000f)
+                    entities[_i].framedelay = 3;//(6-entities[_i].para);
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 4)
                     {
-                        //Walking
-                        if(entities[_i].framedelay<=0)
-                        {
-                            entities[_i].framedelay=4;
-                            entities[_i].walkingframe++;
-                        }
-                        if (entities[_i].walkingframe >=2) entities[_i].walkingframe=0;
-                        entities[_i].drawframe += entities[_i].walkingframe + 1;
+                        entities[_i].walkingframe = 0;
                     }
-
-                    //if (entities[_i].onroof > 0) entities[_i].drawframe += 6;
-                }
-                else
-                {
-                    entities[_i].drawframe ++;
-                    //if (game.gravitycontrol == 1) {
-                    //	entities[_i].drawframe += 6;
-                    //}
                 }
 
-                if (game.deathseq > -1)
-                {
-                    entities[_i].drawframe=13;
-                    if (entities[_i].dir == 1) entities[_i].drawframe = 12;
-                    if (entities[_i].rule == 7) entities[_i].drawframe += 2;
-                    //if (game.gravitycontrol == 1) entities[_i].drawframe += 2;
-                }
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
                 break;
-            case 100: //the teleporter!
-                if (entities[_i].tile == 1)
-                {
-                    //it's inactive
-                    entities[_i].drawframe = entities[_i].tile;
-                }
-                else if (entities[_i].tile == 2)
-                {
-                    entities[_i].drawframe = entities[_i].tile;
-
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 1;
-                        entities[_i].walkingframe = int(fRandom() * 6);
-                        if (entities[_i].walkingframe >= 4)
-                        {
-                            entities[_i].walkingframe = -1;
-                            entities[_i].framedelay = 4;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                }
-                else if (entities[_i].tile == 6)
-                {
-                    //faster!
-                    entities[_i].drawframe = entities[_i].tile;
-
-                    entities[_i].framedelay--;
-                    if(entities[_i].framedelay<=0)
-                    {
-                        entities[_i].framedelay = 2;
-                        entities[_i].walkingframe = int(fRandom() * 6);
-                        if (entities[_i].walkingframe >= 4)
-                        {
-                            entities[_i].walkingframe = -5;
-                            entities[_i].framedelay = 4;
-                        }
-                    }
-
-                    entities[_i].drawframe = entities[_i].tile;
-                    entities[_i].drawframe += entities[_i].walkingframe;
-                }
+            case 100:
+                //Simple case for no animation (platforms, etc)
+                entities[_i].drawframe = entities[_i].tile;
                 break;
             default:
                 entities[_i].drawframe = entities[_i].tile;
                 break;
             }
+            break;
+        case 11:
+            entities[_i].drawframe = entities[_i].tile;
+            if(entities[_i].animate==2)
+            {
+                //Simpler Loop (just two frames)
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 10;
+                    entities[_i].walkingframe++;
+                    if (entities[_i].walkingframe == 2)
+                    {
+                        entities[_i].walkingframe = 0;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
+            }
+            break;
+        case 12:
+        case 55:
+        case 14: //Crew member! Very similar to hero
+            entities[_i].framedelay--;
+            if(entities[_i].dir==1)
+            {
+                entities[_i].drawframe=entities[_i].tile;
+            }
+            else
+            {
+                entities[_i].drawframe=entities[_i].tile+3;
+            }
+
+            if(entities[_i].onground>0 || entities[_i].onroof>0)
+            {
+                if(entities[_i].vx > 0.0000f || entities[_i].vx < -0.000f)
+                {
+                    //Walking
+                    if(entities[_i].framedelay<=0)
+                    {
+                        entities[_i].framedelay=4;
+                        entities[_i].walkingframe++;
+                    }
+                    if (entities[_i].walkingframe >=2) entities[_i].walkingframe=0;
+                    entities[_i].drawframe += entities[_i].walkingframe + 1;
+                }
+
+                //if (entities[_i].onroof > 0) entities[_i].drawframe += 6;
+            }
+            else
+            {
+                entities[_i].drawframe ++;
+                //if (game.gravitycontrol == 1) {
+                //	entities[_i].drawframe += 6;
+                //}
+            }
+
+            if (game.deathseq > -1)
+            {
+                entities[_i].drawframe=13;
+                if (entities[_i].dir == 1) entities[_i].drawframe = 12;
+                if (entities[_i].rule == 7) entities[_i].drawframe += 2;
+                //if (game.gravitycontrol == 1) entities[_i].drawframe += 2;
+            }
+            break;
+        case 100: //the teleporter!
+            if (entities[_i].tile == 1)
+            {
+                //it's inactive
+                entities[_i].drawframe = entities[_i].tile;
+            }
+            else if (entities[_i].tile == 2)
+            {
+                entities[_i].drawframe = entities[_i].tile;
+
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 1;
+                    entities[_i].walkingframe = int(fRandom() * 6);
+                    if (entities[_i].walkingframe >= 4)
+                    {
+                        entities[_i].walkingframe = -1;
+                        entities[_i].framedelay = 4;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
+            }
+            else if (entities[_i].tile == 6)
+            {
+                //faster!
+                entities[_i].drawframe = entities[_i].tile;
+
+                entities[_i].framedelay--;
+                if(entities[_i].framedelay<=0)
+                {
+                    entities[_i].framedelay = 2;
+                    entities[_i].walkingframe = int(fRandom() * 6);
+                    if (entities[_i].walkingframe >= 4)
+                    {
+                        entities[_i].walkingframe = -5;
+                        entities[_i].framedelay = 4;
+                    }
+                }
+
+                entities[_i].drawframe = entities[_i].tile;
+                entities[_i].drawframe += entities[_i].walkingframe;
+            }
+            break;
+        default:
+            entities[_i].drawframe = entities[_i].tile;
+            break;
         }
-        else
-        {
-            //entities[_i].statedelay--;
-            if (entities[_i].statedelay < 0) entities[_i].statedelay = 0;
-        }
+    }
+    else
+    {
+        //entities[_i].statedelay--;
+        if (entities[_i].statedelay < 0) entities[_i].statedelay = 0;
     }
 }
 
@@ -4183,26 +4174,23 @@ float entityclass::hplatformat()
     //Returns first entity of horizontal platform at (px, py), -1000 otherwise.
     for (size_t i = 0; i < entities.size(); i++)
     {
-        if (true) // FIXME: remove this later (no more 'active')
+        if (entities[i].rule == 2)
         {
-            if (entities[i].rule == 2)
+            if (entities[i].behave >= 2)
             {
-                if (entities[i].behave >= 2)
+                if (entities[i].xp == px && entities[i].yp == py)
                 {
-                    if (entities[i].xp == px && entities[i].yp == py)
+                    if (entities[i].behave == 8)   //threadmill!
                     {
-                        if (entities[i].behave == 8)   //threadmill!
-                        {
-                            return entities[i].para;
-                        }
-                        else if(entities[i].behave == 9)    //threadmill!
-                        {
-                            return -entities[i].para;
-                        }
-                        else
-                        {
-                            return entities[i].vx;
-                        }
+                        return entities[i].para;
+                    }
+                    else if(entities[i].behave == 9)    //threadmill!
+                    {
+                        return -entities[i].para;
+                    }
+                    else
+                    {
+                        return entities[i].vx;
                     }
                 }
             }
@@ -4657,23 +4645,21 @@ void entityclass::customwarplinecheck(int i) {
     //Turns on obj.customwarpmodevon and obj.customwarpmodehon if player collides
     //with warp lines
 
-    if (true) { // FIXME: remove this later (no more 'active')
-        //We test entity to entity
-        for (int j = 0; j < (int) entities.size(); j++) {
-            if (i != j) {//Active
-                if (entities[i].rule == 0 && entities[j].rule == 5) { //Player vs vertical line!
-                    if (entities[j].type == 51 || entities[j].type == 52) {
-                        if (entitywarpvlinecollide(i, j)) {
-                            customwarpmodevon = true;
-                        }
+    //We test entity to entity
+    for (int j = 0; j < (int) entities.size(); j++) {
+        if (i != j) {//Active
+            if (entities[i].rule == 0 && entities[j].rule == 5) { //Player vs vertical line!
+                if (entities[j].type == 51 || entities[j].type == 52) {
+                    if (entitywarpvlinecollide(i, j)) {
+                        customwarpmodevon = true;
                     }
                 }
+            }
 
-                if (entities[i].rule == 0 && entities[j].rule == 7){   //Player vs horizontal WARP line
-                    if (entities[j].type == 53 || entities[j].type == 54) {
-                        if (entitywarphlinecollide(i, j)) {
-                            customwarpmodehon = true;
-                        }
+            if (entities[i].rule == 0 && entities[j].rule == 7){   //Player vs horizontal WARP line
+                if (entities[j].type == 53 || entities[j].type == 54) {
+                    if (entitywarphlinecollide(i, j)) {
+                        customwarpmodehon = true;
                     }
                 }
             }
@@ -4685,192 +4671,189 @@ void entityclass::entitycollisioncheck()
 {
     for (size_t i = 0; i < entities.size(); i++)
     {
-        if (true) // FIXME: remove this later (no more 'active')
+        //We test entity to entity
+        for (size_t j = 0; j < entities.size(); j++)
         {
-            //We test entity to entity
-            for (size_t j = 0; j < entities.size(); j++)
+            if (i!=j)  //Active
             {
-                if (i!=j)  //Active
+                if (entities[i].rule == 0 && entities[j].rule == 1 && entities[j].harmful)
                 {
-                    if (entities[i].rule == 0 && entities[j].rule == 1 && entities[j].harmful)
+                    //player i hits enemy or enemy bullet j
+                    if (entitycollide(i, j) && !map.invincibility)
                     {
-                        //player i hits enemy or enemy bullet j
-                        if (entitycollide(i, j) && !map.invincibility)
+                        if (entities[i].size == 0 && (entities[j].size == 0 || entities[j].size == 12))
                         {
-                            if (entities[i].size == 0 && (entities[j].size == 0 || entities[j].size == 12))
+                            //They're both sprites, so do a per pixel collision
+                            colpoint1.x = entities[i].xp;
+                            colpoint1.y = entities[i].yp;
+                            colpoint2.x = entities[j].xp;
+                            colpoint2.y = entities[j].yp;
+                            if (graphics.flipmode)
                             {
-                                //They're both sprites, so do a per pixel collision
-                                colpoint1.x = entities[i].xp;
-                                colpoint1.y = entities[i].yp;
-                                colpoint2.x = entities[j].xp;
-                                colpoint2.y = entities[j].yp;
-                                if (graphics.flipmode)
+                                if (graphics.Hitest(graphics.flipsprites[entities[i].drawframe],
+                                                 colpoint1, graphics.flipsprites[entities[j].drawframe], colpoint2))
                                 {
-                                    if (graphics.Hitest(graphics.flipsprites[entities[i].drawframe],
-                                                     colpoint1, graphics.flipsprites[entities[j].drawframe], colpoint2))
-                                    {
-                                        //Do the collision stuff
-                                        game.deathseq = 30;
-                                    }
-                                }
-                                else
-                                {
-                                    if (graphics.Hitest(graphics.sprites[entities[i].drawframe],
-                                                     colpoint1, graphics.sprites[entities[j].drawframe], colpoint2) )
-                                    {
-                                        //Do the collision stuff
-                                        game.deathseq = 30;
-                                    }
+                                    //Do the collision stuff
+                                    game.deathseq = 30;
                                 }
                             }
                             else
                             {
-                                //Ok, then we just assume a normal bounding box collision
-                                game.deathseq = 30;
+                                if (graphics.Hitest(graphics.sprites[entities[i].drawframe],
+                                                 colpoint1, graphics.sprites[entities[j].drawframe], colpoint2) )
+                                {
+                                    //Do the collision stuff
+                                    game.deathseq = 30;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            //Ok, then we just assume a normal bounding box collision
+                            game.deathseq = 30;
+                        }
+                    }
+                }
+                if (entities[i].rule == 0 && entities[j].rule == 2)   //Moving platforms
+                {
+                    if (entitycollide(i, j)) removeblockat(entities[j].xp, entities[j].yp);
+                }
+                if (entities[i].rule == 0 && entities[j].rule == 3)   //Entity to entity
+                {
+                    if(entities[j].onentity>0)
+                    {
+                        if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
+                    }
+                }
+                if (entities[i].rule == 0 && entities[j].rule == 4)   //Player vs horizontal line!
+                {
+                    if(game.deathseq==-1)
+                    {
+                        //Here we compare the player's old position versus his new one versus the line.
+                        //All points either be above or below it. Otherwise, there was a collision this frame.
+                        if (entities[j].onentity > 0)
+                        {
+                            if (entityhlinecollide(i, j))
+                            {
+                                music.playef(8);
+                                game.gravitycontrol = (game.gravitycontrol + 1) % 2;
+                                game.totalflips++;
+                                if (game.gravitycontrol == 0)
+                                {
+                                    if (entities[i].vy < 1) entities[i].vy = 1;
+                                }
+                                else
+                                {
+                                    if (entities[i].vy > -1) entities[i].vy = -1;
+                                }
+
+                                entities[j].state = entities[j].onentity;
+                                entities[j].life = 6;
                             }
                         }
                     }
-                    if (entities[i].rule == 0 && entities[j].rule == 2)   //Moving platforms
-                    {
-                        if (entitycollide(i, j)) removeblockat(entities[j].xp, entities[j].yp);
-                    }
-                    if (entities[i].rule == 0 && entities[j].rule == 3)   //Entity to entity
+                }
+                if (entities[i].rule == 0 && entities[j].rule == 5)   //Player vs vertical line!
+                {
+                    if(game.deathseq==-1)
                     {
                         if(entities[j].onentity>0)
                         {
-                            if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
-                        }
-                    }
-                    if (entities[i].rule == 0 && entities[j].rule == 4)   //Player vs horizontal line!
-                    {
-                        if(game.deathseq==-1)
-                        {
-                            //Here we compare the player's old position versus his new one versus the line.
-                            //All points either be above or below it. Otherwise, there was a collision this frame.
-                            if (entities[j].onentity > 0)
+                            if (entityvlinecollide(i, j))
                             {
-                                if (entityhlinecollide(i, j))
-                                {
-                                    music.playef(8);
-                                    game.gravitycontrol = (game.gravitycontrol + 1) % 2;
-                                    game.totalflips++;
-                                    if (game.gravitycontrol == 0)
-                                    {
-                                        if (entities[i].vy < 1) entities[i].vy = 1;
-                                    }
-                                    else
-                                    {
-                                        if (entities[i].vy > -1) entities[i].vy = -1;
-                                    }
-
-                                    entities[j].state = entities[j].onentity;
-                                    entities[j].life = 6;
-                                }
+                                entities[j].state = entities[j].onentity;
+                                entities[j].life = 4;
                             }
                         }
                     }
-                    if (entities[i].rule == 0 && entities[j].rule == 5)   //Player vs vertical line!
+                }
+                if (entities[i].rule == 0 && entities[j].rule == 6)   //Player versus crumbly blocks! Special case
+                {
+                    if (entities[j].onentity > 0)
                     {
-                        if(game.deathseq==-1)
+                        //ok; only check the actual collision if they're in a close proximity
+                        temp = entities[i].yp - entities[j].yp;
+                        if (temp < 30 || temp > -30)
                         {
-                            if(entities[j].onentity>0)
-                            {
-                                if (entityvlinecollide(i, j))
-                                {
-                                    entities[j].state = entities[j].onentity;
-                                    entities[j].life = 4;
-                                }
-                            }
-                        }
-                    }
-                    if (entities[i].rule == 0 && entities[j].rule == 6)   //Player versus crumbly blocks! Special case
-                    {
-                        if (entities[j].onentity > 0)
-                        {
-                            //ok; only check the actual collision if they're in a close proximity
-                            temp = entities[i].yp - entities[j].yp;
+                            temp = entities[i].xp - entities[j].xp;
                             if (temp < 30 || temp > -30)
                             {
-                                temp = entities[i].xp - entities[j].xp;
-                                if (temp < 30 || temp > -30)
-                                {
-                                    if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
-                                }
+                                if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
                             }
                         }
                     }
-                    /*
-                    if (entities[i].rule == 0 && entities[j].rule == 7)   //Player vs horizontal WARP line
+                }
+                /*
+                if (entities[i].rule == 0 && entities[j].rule == 7)   //Player vs horizontal WARP line
+                {
+                    if(game.deathseq==-1)
                     {
-                        if(game.deathseq==-1)
+                        if(entities[j].onentity>0)
                         {
-                            if(entities[j].onentity>0)
+                            if (entityhlinecollide(i, j))
                             {
-                                if (entityhlinecollide(i, j))
-                                {
-                                    entities[j].state = entities[j].onentity;
-                                    entities[j].life = 4;
-                                }
+                                entities[j].state = entities[j].onentity;
+                                entities[j].life = 4;
                             }
                         }
                     }
-                    */
-                    if (game.supercrewmate)
+                }
+                */
+                if (game.supercrewmate)
+                {
+                    //some extra collisions
+                    if (entities[i].type == 14)   //i is the supercrewmate
                     {
-                        //some extra collisions
-                        if (entities[i].type == 14)   //i is the supercrewmate
+                        if (entities[j].rule == 1 && entities[j].harmful)  //j is a harmful enemy
                         {
-                            if (entities[j].rule == 1 && entities[j].harmful)  //j is a harmful enemy
+                            //player i hits enemy or enemy bullet j
+                            if (entitycollide(i, j) && !map.invincibility)
                             {
-                                //player i hits enemy or enemy bullet j
-                                if (entitycollide(i, j) && !map.invincibility)
+                                if (entities[i].size == 0 && entities[j].size == 0)
                                 {
-                                    if (entities[i].size == 0 && entities[j].size == 0)
+                                    //They're both sprites, so do a per pixel collision
+                                    colpoint1.x = entities[i].xp;
+                                    colpoint1.y = entities[i].yp;
+                                    colpoint2.x = entities[j].xp;
+                                    colpoint2.y = entities[j].yp;
+                                    if (graphics.flipmode)
                                     {
-                                        //They're both sprites, so do a per pixel collision
-                                        colpoint1.x = entities[i].xp;
-                                        colpoint1.y = entities[i].yp;
-                                        colpoint2.x = entities[j].xp;
-                                        colpoint2.y = entities[j].yp;
-                                        if (graphics.flipmode)
+                                        if (graphics.Hitest(graphics.flipsprites[entities[i].drawframe],
+                                                         colpoint1, graphics.flipsprites[entities[j].drawframe], colpoint2))
                                         {
-                                            if (graphics.Hitest(graphics.flipsprites[entities[i].drawframe],
-                                                             colpoint1, graphics.flipsprites[entities[j].drawframe], colpoint2))
-                                            {
-                                                //Do the collision stuff
-                                                game.deathseq = 30;
-                                                game.scmhurt = true;
-                                            }
-                                        }
-                                        else
-                                        {
-                                            if (graphics.Hitest(graphics.sprites[entities[i].drawframe],
-                                                             colpoint1, graphics.sprites[entities[j].drawframe], colpoint2))
-                                            {
-                                                //Do the collision stuff
-                                                game.deathseq = 30;
-                                                game.scmhurt = true;
-                                            }
+                                            //Do the collision stuff
+                                            game.deathseq = 30;
+                                            game.scmhurt = true;
                                         }
                                     }
                                     else
                                     {
-                                        //Ok, then we just assume a normal bounding box collision
-                                        game.deathseq = 30;
-                                        game.scmhurt = true;
+                                        if (graphics.Hitest(graphics.sprites[entities[i].drawframe],
+                                                         colpoint1, graphics.sprites[entities[j].drawframe], colpoint2))
+                                        {
+                                            //Do the collision stuff
+                                            game.deathseq = 30;
+                                            game.scmhurt = true;
+                                        }
                                     }
                                 }
-                            }
-                            if (entities[j].rule == 2)   //Moving platforms
-                            {
-                                if (entitycollide(i, j)) removeblockat(entities[j].xp, entities[j].yp);
-                            }
-                            if (entities[j].type == 8 && entities[j].rule == 3)   //Entity to entity (well, checkpoints anyway!)
-                            {
-                                if(entities[j].onentity>0)
+                                else
                                 {
-                                    if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
+                                    //Ok, then we just assume a normal bounding box collision
+                                    game.deathseq = 30;
+                                    game.scmhurt = true;
                                 }
+                            }
+                        }
+                        if (entities[j].rule == 2)   //Moving platforms
+                        {
+                            if (entitycollide(i, j)) removeblockat(entities[j].xp, entities[j].yp);
+                        }
+                        if (entities[j].type == 8 && entities[j].rule == 3)   //Entity to entity (well, checkpoints anyway!)
+                        {
+                            if(entities[j].onentity>0)
+                            {
+                                if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
                             }
                         }
                     }

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1313,14 +1313,6 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         entity.y2 = p4;
 
         entity.harmful = true;
-        //Exact appearance depends entirely on location, assigned here:
-        /*
-        }else if (game.roomx == 50 && game.roomy == 52) {
-        entity.tile = 48; entity.colour = 6;
-        entity.w = 32;	entity.h = 27;
-        entity.animate = 1;
-        //ok, for space station 2
-        */
         entity.tile = 24;
         entity.animate = 0;
         entity.colour = 8;
@@ -1349,25 +1341,6 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         {
             entity.setenemyroom(game.roomx, game.roomy);
         }
-
-        //}else{*/
-        /*
-        entity.tile = 24;
-        entity.animate = 0;
-        entity.colour = 8;
-        //for warpzone:
-        if (game.roomx == 51 && game.roomy == 51) entity.colour = 6;
-        if (game.roomx == 52 && game.roomy == 51) entity.colour = 7;
-        if (game.roomx == 54 && game.roomy == 49) entity.colour = 11;
-        if (game.roomx == 55 && game.roomy == 50) entity.colour = 9;
-        if (game.roomx == 55 && game.roomy == 51) entity.colour = 6;
-        if (game.roomx == 54 && game.roomy == 51) entity.colour = 12;
-        if (game.roomx == 54 && game.roomy == 52) entity.colour = 7;
-        if (game.roomx == 53 && game.roomy == 52) entity.colour = 8;
-        if (game.roomx == 51 && game.roomy == 52) entity.colour = 6;
-        if (game.roomx == 52 && game.roomy == 49) entity.colour = 8;
-        //}
-        */
         break;
     case 2: //A moving platform
         entity.rule = 2;
@@ -1636,12 +1609,6 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         entity.onentity = 1;
         entity.animate = 100;
         entity.para = vy;
-
-        //we'll init it's activeness here later
-        /*if (game.savepoint == vy) {
-        entity.colour = 5;
-        entity.onentity = 0;
-        }*/
         break;
     case 15: // Crew Member (warp zone)
         entity.rule = 6;
@@ -1755,11 +1722,6 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         entity.onentity = 1;
         entity.animate = 100;
         entity.para = vy;
-
-        /*if (game.savepoint == vy) {
-        entity.colour = 5;
-        entity.onentity = 0;
-        }*/
         break;
     case 21: //as above, except doesn't highlight
         entity.rule = 3;
@@ -1774,11 +1736,6 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         entity.onentity = 0;
         entity.animate = 100;
         entity.para = vy;
-
-        /*if (game.savepoint == vy) {
-        entity.colour = 5;
-        entity.onentity = 0;
-        }*/
         break;
     case 22: //Fake trinkets, only appear if you've collected them
         entity.rule = 3;
@@ -2621,18 +2578,10 @@ void entityclass::updateentities( int i )
             //Only counts if vy of player entity is non zero
             if (entities[i].state == 1)
             {
-                // int j = getplayer();
-                //if (entities[j].vy > 0.5 && (entities[j].yp+entities[j].h<=entities[i].yp+6)) {
                 entities[i].life = 4;
                 entities[i].state = 2;
                 entities[i].onentity = 0;
                 music.playef(6);
-                /*}else if (entities[j].vy <= -0.5  && (entities[j].yp>=entities[i].yp+2)) {
-                entities[i].life = 4;
-                entities[i].state = 2; entities[i].onentity = 0;
-                }else {
-                entities[i].state = 0;
-                }*/
             }
             else if (entities[i].state == 2)
             {
@@ -2685,7 +2634,6 @@ void entityclass::updateentities( int i )
                 else
                 {
                     game.state = 1000;
-                    //music.haltdasmusik();
                     if(music.currentsong!=-1) music.silencedasmusik();
                     music.playef(3);
                     collect[entities[i].para] = 1;
@@ -4589,13 +4537,11 @@ void entityclass::scmmovingplatformfix( int t )
                 {
                     entities[j].yp = entities[t].yp + entities[t].h;
                     entities[j].vy = 0;
-                    //entities[j].onroof = true;
                 }
                 else
                 {
                     entities[j].yp = entities[t].yp - entities[j].h-entities[j].cy;
                     entities[j].vy = 0;
-                    //entities[j].onground = true;
                 }
             }
             else
@@ -4611,14 +4557,6 @@ void entityclass::hormovingplatformfix( int t )
     //If this intersects the player, then we move the player along it
     //for horizontal platforms, this is simplier
     createblock(0, entities[t].xp, entities[t].yp, entities[t].w, entities[t].h);
-    /*j = getplayer();
-    if (entitycollide(t, j)) {
-    //ok, bollox, let's make sure
-    entities[j].yp = entities[j].yp + entities[j].vy;
-    if (entitycollide(t, j)) {
-    //entities[t].state = entities[t].onwall;
-    }
-    }*/
 }
 
 void entityclass::customwarplinecheck(int i) {
@@ -4763,22 +4701,6 @@ void entityclass::entitycollisioncheck()
                         }
                     }
                 }
-                /*
-                if (entities[i].rule == 0 && entities[j].rule == 7)   //Player vs horizontal WARP line
-                {
-                    if(game.deathseq==-1)
-                    {
-                        if(entities[j].onentity>0)
-                        {
-                            if (entityhlinecollide(i, j))
-                            {
-                                entities[j].state = entities[j].onentity;
-                                entities[j].life = 4;
-                            }
-                        }
-                    }
-                }
-                */
                 if (game.supercrewmate)
                 {
                     //some extra collisions

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4556,7 +4556,7 @@ void entityclass::customwarplinecheck(int i) {
 
     //We test entity to entity
     for (int j = 0; j < (int) entities.size(); j++) {
-        if (i != j) {//Active
+        if (i != j) {
             if (entities[i].rule == 0 && entities[j].rule == 5 //Player vs vertical line!
             && (entities[j].type == 51 || entities[j].type == 52)
             && entitywarpvlinecollide(i, j)) {
@@ -4579,7 +4579,7 @@ void entityclass::entitycollisioncheck()
         //We test entity to entity
         for (size_t j = 0; j < entities.size(); j++)
         {
-            if (i!=j)  //Active
+            if (i!=j)
             {
                 if (entities[i].rule == 0 && entities[j].rule == 1 && entities[j].harmful)
                 {

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4490,10 +4490,6 @@ void entityclass::applyfriction( int t, float xrate, float yrate )
     if (std::abs(entities[t].vy) < yrate) entities[t].vy = 0.0f;
 }
 
-void entityclass::cleanup()
-{
-}
-
 void entityclass::updateentitylogic( int t )
 {
     entities[t].oldxp = entities[t].xp;

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -64,6 +64,8 @@ public:
 
     void createblock(int t, int xp, int yp, int w, int h, int trig = 0);
 
+    void removeentity(int t);
+
     void removeallblocks();
 
     void removeblock(int t);

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -8,6 +8,8 @@
 #include <vector>
 #include <string>
 
+#define removeentity_iter(index) { obj.removeentity(index); index--; }
+
 enum
 {
     BLOCK = 0,

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -87,7 +87,7 @@ public:
     void createentity(float xp, float yp, int t, float vx = 0, float vy = 0,
                       int p1 = 0, int p2 = 0, int p3 = 320, int p4 = 240 );
 
-    bool updateentities(int i);
+    void updateentities(int i);
 
     void animateentities(int i);
 

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -8,8 +8,6 @@
 #include <vector>
 #include <string>
 
-#define		rn( rx,  ry) ((rx) + ((ry) * 100))
-
 enum
 {
     BLOCK = 0,
@@ -81,8 +79,6 @@ public:
     bool gridmatch(int p1, int p2, int p3, int p4, int p11, int p21, int p31, int p41);
 
     int crewcolour(int t);
-
-    void setenemyroom(int t, int rx, int ry);
 
     void settreadmillcolour(int t, int rx, int ry);
 

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -84,8 +84,6 @@ public:
 
     void setenemyroom(int t, int rx, int ry);
 
-    void setenemy(int t, int r);
-
     void settreadmillcolour(int t, int rx, int ry);
 
     void createentity(float xp, float yp, int t, float vx = 0, float vy = 0,

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -181,10 +181,7 @@ public:
 
     std::vector<entclass> entities;
 
-    int nentity;
-
     std::vector<entclass> linecrosskludge;
-    int nlinecrosskludge;
 
     point colpoint1, colpoint2;
 

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -198,7 +198,6 @@ public:
     std::vector<int> collect;
     std::vector<int> customcollect;
 
-    int nblocks;
     bool skipblocks, skipdirblocks;
 
     int platformtile;

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -91,8 +91,6 @@ public:
 
     void animateentities(int i);
 
-    bool gettype(int t);
-
     int getcompanion();
 
     int getplayer();

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -54,8 +54,6 @@ public:
         createblock(DAMAGE, 312, -8, 16, 260);
     }
 
-    void setblockcolour(int t, std::string col);
-
     int swncolour(int t );
 
     void swnenemiescol(int t);

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -163,8 +163,6 @@ public:
 
     void applyfriction(int t, float xrate, float yrate);
 
-    void cleanup();
-
     void updateentitylogic(int t);
 
 

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #define removeentity_iter(index) { obj.removeentity(index); index--; }
+#define removeblock_iter(index) { obj.removeblock(index); index--; }
 
 enum
 {

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -80,8 +80,6 @@ public:
 
     int crewcolour(int t);
 
-    void settreadmillcolour(int t, int rx, int ry);
-
     void createentity(float xp, float yp, int t, float vx = 0, float vy = 0,
                       int p1 = 0, int p2 = 0, int p3 = 320, int p4 = 240 );
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -2296,7 +2296,7 @@ void Game::updatestate()
             i = obj.getcompanion();
             if(i>-1)
             {
-                obj.entities[i].active = false;
+                obj.removeentity(i);
             }
 
             i = obj.getteleporter();

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1417,9 +1417,9 @@ void Graphics::drawentities()
 
     trinketcolset = false;
 
-    for (int i = obj.nentity - 1; i >= 0; i--)
+    for (int i = obj.entities.size() - 1; i >= 0; i--)
     {
-        if (!obj.entities[i].invis && obj.entities[i].active)
+        if (!obj.entities[i].invis)
         {
             if (obj.entities[i].size == 0)
             {
@@ -2429,9 +2429,9 @@ void Graphics::drawtowerentities()
     point tpoint;
     SDL_Rect trect;
 
-    for (int i = obj.nentity - 1; i >= 0; i--)
+    for (int i = obj.entities.size() - 1; i >= 0; i--)
     {
-        if (!obj.entities[i].invis && obj.entities[i].active)
+        if (!obj.entities[i].invis)
         {
             if (obj.entities[i].size == 0)        // Sprites
             {

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -580,145 +580,142 @@ void Graphics::drawgui()
     {
         //This routine also updates the textboxs
         textbox[i].update();
-        if (true) //FIXME: remove this later (no more 'active')
+        if (textbox[i].tm == 2 && textbox[i].tl <= 0.5)
         {
-            if (textbox[i].tm == 2 && textbox[i].tl <= 0.5)
-            {
-                textbox.erase(textbox.begin() + i);
-                i--;
-                continue;
-            }
+            textbox.erase(textbox.begin() + i);
+            i--;
+            continue;
+        }
 
-            if (textbox[i].r == 0 && textbox[i].g == 0 && textbox[i].b == 0)
+        if (textbox[i].r == 0 && textbox[i].g == 0 && textbox[i].b == 0)
+        {
+            if(flipmode)
             {
-                if(flipmode)
+                for (j = 0; j < textbox[i].numlines; j++)
                 {
-                    for (j = 0; j < textbox[i].numlines; j++)
-                    {
-                        Print(textbox[i].xp + 8, textbox[i].yp + (textbox[i].numlines*8) - (j * 8), textbox[i].line[j], 196, 196, 255 - help.glow);
-                    }
-                }
-                else
-                {
-                    for (j = 0; j < textbox[i].numlines; j++)
-                    {
-                        Print(textbox[i].xp + 8, textbox[i].yp + 8 + (j * 8), textbox[i].line[j], 196, 196, 255 - help.glow);
-                    }
+                    Print(textbox[i].xp + 8, textbox[i].yp + (textbox[i].numlines*8) - (j * 8), textbox[i].line[j], 196, 196, 255 - help.glow);
                 }
             }
             else
             {
-
-                FillRect(backBuffer,textbox[i].textrect, textbox[i].r/6, textbox[i].g/6, textbox[i].b / 6 );
-
-                drawcoloredtile(textbox[i].xp, textbox[i].yp, 40, textbox[i].r, textbox[i].g, textbox[i].b);
-                drawcoloredtile(textbox[i].xp+textbox[i].w-8, textbox[i].yp, 42, textbox[i].r, textbox[i].g, textbox[i].b);
-                drawcoloredtile(textbox[i].xp, textbox[i].yp+textbox[i].h-8, 45, textbox[i].r, textbox[i].g, textbox[i].b);
-                drawcoloredtile(textbox[i].xp+textbox[i].w-8, textbox[i].yp+textbox[i].h-8, 47, textbox[i].r, textbox[i].g, textbox[i].b);
-                for (int k = 0; k < textbox[i].lw; k++)
+                for (j = 0; j < textbox[i].numlines; j++)
                 {
-                    drawcoloredtile(textbox[i].xp + 8 + (k * 8), textbox[i].yp, 41, textbox[i].r, textbox[i].g, textbox[i].b);
-                    drawcoloredtile(textbox[i].xp + 8 + (k * 8), textbox[i].yp+textbox[i].h-8, 46, textbox[i].r, textbox[i].g, textbox[i].b);
-                }
-                for (int k = 0; k < textbox[i].numlines; k++)
-                {
-                    drawcoloredtile(textbox[i].xp, textbox[i].yp + 8 + (k * 8), 43, textbox[i].r, textbox[i].g, textbox[i].b);
-                    drawcoloredtile(textbox[i].xp + textbox[i].w-8, textbox[i].yp + 8 + (k * 8), 44, textbox[i].r, textbox[i].g, textbox[i].b);
-                }
-
-                if(flipmode)
-                {
-                    for (j = 0; j < textbox[i].numlines; j++)
-                    {
-                        Print(textbox[i].xp + 8, textbox[i].yp  + (textbox[i].numlines*8) - (j * 8), textbox[i].line[j], textbox[i].r, textbox[i].g, textbox[i].b);
-                    }
-                }
-                else
-                {
-                    for (j = 0; j < textbox[i].numlines; j++)
-                    {
-                        Print(textbox[i].xp + 8, textbox[i].yp +8 + (j * 8), textbox[i].line[j], textbox[i].r, textbox[i].g, textbox[i].b);
-                    }
+                    Print(textbox[i].xp + 8, textbox[i].yp + 8 + (j * 8), textbox[i].line[j], 196, 196, 255 - help.glow);
                 }
             }
+        }
+        else
+        {
 
-            if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].r == 165)
+            FillRect(backBuffer,textbox[i].textrect, textbox[i].r/6, textbox[i].g/6, textbox[i].b / 6 );
+
+            drawcoloredtile(textbox[i].xp, textbox[i].yp, 40, textbox[i].r, textbox[i].g, textbox[i].b);
+            drawcoloredtile(textbox[i].xp+textbox[i].w-8, textbox[i].yp, 42, textbox[i].r, textbox[i].g, textbox[i].b);
+            drawcoloredtile(textbox[i].xp, textbox[i].yp+textbox[i].h-8, 45, textbox[i].r, textbox[i].g, textbox[i].b);
+            drawcoloredtile(textbox[i].xp+textbox[i].w-8, textbox[i].yp+textbox[i].h-8, 47, textbox[i].r, textbox[i].g, textbox[i].b);
+            for (int k = 0; k < textbox[i].lw; k++)
             {
-                if (flipmode)
-                {
-                    drawimage(5, 0, 180, true);
-                }
-                else
-                {
-                    drawimage(0, 0, 12, true);
-                }
+                drawcoloredtile(textbox[i].xp + 8 + (k * 8), textbox[i].yp, 41, textbox[i].r, textbox[i].g, textbox[i].b);
+                drawcoloredtile(textbox[i].xp + 8 + (k * 8), textbox[i].yp+textbox[i].h-8, 46, textbox[i].r, textbox[i].g, textbox[i].b);
             }
-            else if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].g == 165)
+            for (int k = 0; k < textbox[i].numlines; k++)
             {
-                if (flipmode)
+                drawcoloredtile(textbox[i].xp, textbox[i].yp + 8 + (k * 8), 43, textbox[i].r, textbox[i].g, textbox[i].b);
+                drawcoloredtile(textbox[i].xp + textbox[i].w-8, textbox[i].yp + 8 + (k * 8), 44, textbox[i].r, textbox[i].g, textbox[i].b);
+            }
+
+            if(flipmode)
+            {
+                for (j = 0; j < textbox[i].numlines; j++)
                 {
-                    drawimage(6, 0, 180, true);
-                }
-                else
-                {
-                    drawimage(4, 0, 12, true);
+                    Print(textbox[i].xp + 8, textbox[i].yp  + (textbox[i].numlines*8) - (j * 8), textbox[i].line[j], textbox[i].r, textbox[i].g, textbox[i].b);
                 }
             }
+            else
+            {
+                for (j = 0; j < textbox[i].numlines; j++)
+                {
+                    Print(textbox[i].xp + 8, textbox[i].yp +8 + (j * 8), textbox[i].line[j], textbox[i].r, textbox[i].g, textbox[i].b);
+                }
+            }
+        }
+
+        if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].r == 165)
+        {
             if (flipmode)
             {
-                if (textbox[i].r == 175 && textbox[i].g == 175)
-                {
-                    //purple guy
-                    drawsprite(80 - 6, 64 + 48 + 4, 6, 220- help.glow/4 - int(fRandom()*20), 120- help.glow/4, 210 - help.glow/4);
-                }
-                else if (textbox[i].r == 175 && textbox[i].b == 175)
-                {
-                    //red guy
-                    drawsprite(80 - 6, 64 + 48+ 4, 6, 255 - help.glow/8, 70 - help.glow/4, 70 - help.glow / 4);
-                }
-                else if (textbox[i].r == 175)
-                {
-                    //green guy
-                    drawsprite(80 - 6, 64 + 48 + 4, 6, 120 - help.glow / 4 - int(fRandom() * 20), 220 - help.glow / 4, 120 - help.glow / 4);
-                }
-                else if (textbox[i].g == 175)
-                {
-                    //yellow guy
-                    drawsprite(80 - 6, 64 + 48+ 4, 6, 220- help.glow/4 - int(fRandom()*20), 210 - help.glow/4, 120- help.glow/4);
-                }
-                else if (textbox[i].b == 175)
-                {
-                    //blue guy
-                    drawsprite(80 - 6, 64 + 48+ 4, 6, 75, 75, 255- help.glow/4 - int(fRandom()*20));
-                }
+                drawimage(5, 0, 180, true);
             }
             else
             {
-                if (textbox[i].r == 175 && textbox[i].g == 175)
-                {
-                    //purple guy
-                    drawsprite(80 - 6, 64 + 32 + 4, 0, 220- help.glow/4 - int(fRandom()*20), 120- help.glow/4, 210 - help.glow/4);
-                }
-                else if (textbox[i].r == 175 && textbox[i].b == 175)
-                {
-                    //red guy
-                    drawsprite(80 - 6, 64 + 32 + 4, 0, 255 - help.glow/8, 70 - help.glow/4, 70 - help.glow / 4);
-                }
-                else if (textbox[i].r == 175)
-                {
-                    //green guy
-                    drawsprite(80 - 6, 64 + 32 + 4, 0, 120 - help.glow / 4 - int(fRandom() * 20), 220 - help.glow / 4, 120 - help.glow / 4);
-                }
-                else if (textbox[i].g == 175)
-                {
-                    //yellow guy
-                    drawsprite(80 - 6, 64 + 32 + 4, 0, 220- help.glow/4 - int(fRandom()*20), 210 - help.glow/4, 120- help.glow/4);
-                }
-                else if (textbox[i].b == 175)
-                {
-                    //blue guy
-                    drawsprite(80 - 6, 64 + 32 + 4, 0, 75, 75, 255- help.glow/4 - int(fRandom()*20));
-                }
+                drawimage(0, 0, 12, true);
+            }
+        }
+        else if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].g == 165)
+        {
+            if (flipmode)
+            {
+                drawimage(6, 0, 180, true);
+            }
+            else
+            {
+                drawimage(4, 0, 12, true);
+            }
+        }
+        if (flipmode)
+        {
+            if (textbox[i].r == 175 && textbox[i].g == 175)
+            {
+                //purple guy
+                drawsprite(80 - 6, 64 + 48 + 4, 6, 220- help.glow/4 - int(fRandom()*20), 120- help.glow/4, 210 - help.glow/4);
+            }
+            else if (textbox[i].r == 175 && textbox[i].b == 175)
+            {
+                //red guy
+                drawsprite(80 - 6, 64 + 48+ 4, 6, 255 - help.glow/8, 70 - help.glow/4, 70 - help.glow / 4);
+            }
+            else if (textbox[i].r == 175)
+            {
+                //green guy
+                drawsprite(80 - 6, 64 + 48 + 4, 6, 120 - help.glow / 4 - int(fRandom() * 20), 220 - help.glow / 4, 120 - help.glow / 4);
+            }
+            else if (textbox[i].g == 175)
+            {
+                //yellow guy
+                drawsprite(80 - 6, 64 + 48+ 4, 6, 220- help.glow/4 - int(fRandom()*20), 210 - help.glow/4, 120- help.glow/4);
+            }
+            else if (textbox[i].b == 175)
+            {
+                //blue guy
+                drawsprite(80 - 6, 64 + 48+ 4, 6, 75, 75, 255- help.glow/4 - int(fRandom()*20));
+            }
+        }
+        else
+        {
+            if (textbox[i].r == 175 && textbox[i].g == 175)
+            {
+                //purple guy
+                drawsprite(80 - 6, 64 + 32 + 4, 0, 220- help.glow/4 - int(fRandom()*20), 120- help.glow/4, 210 - help.glow/4);
+            }
+            else if (textbox[i].r == 175 && textbox[i].b == 175)
+            {
+                //red guy
+                drawsprite(80 - 6, 64 + 32 + 4, 0, 255 - help.glow/8, 70 - help.glow/4, 70 - help.glow / 4);
+            }
+            else if (textbox[i].r == 175)
+            {
+                //green guy
+                drawsprite(80 - 6, 64 + 32 + 4, 0, 120 - help.glow / 4 - int(fRandom() * 20), 220 - help.glow / 4, 120 - help.glow / 4);
+            }
+            else if (textbox[i].g == 175)
+            {
+                //yellow guy
+                drawsprite(80 - 6, 64 + 32 + 4, 0, 220- help.glow/4 - int(fRandom()*20), 210 - help.glow/4, 120- help.glow/4);
+            }
+            else if (textbox[i].b == 175)
+            {
+                //blue guy
+                drawsprite(80 - 6, 64 + 32 + 4, 0, 75, 75, 255- help.glow/4 - int(fRandom()*20));
             }
         }
     }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -591,14 +591,14 @@ void Graphics::drawgui()
         {
             if(flipmode)
             {
-                for (j = 0; j < textbox[i].numlines; j++)
+                for (j = 0; j < (int) textbox[i].line.size(); j++)
                 {
-                    Print(textbox[i].xp + 8, textbox[i].yp + (textbox[i].numlines*8) - (j * 8), textbox[i].line[j], 196, 196, 255 - help.glow);
+                    Print(textbox[i].xp + 8, textbox[i].yp + (textbox[i].line.size()*8) - (j * 8), textbox[i].line[j], 196, 196, 255 - help.glow);
                 }
             }
             else
             {
-                for (j = 0; j < textbox[i].numlines; j++)
+                for (j = 0; j < (int) textbox[i].line.size(); j++)
                 {
                     Print(textbox[i].xp + 8, textbox[i].yp + 8 + (j * 8), textbox[i].line[j], 196, 196, 255 - help.glow);
                 }
@@ -618,7 +618,7 @@ void Graphics::drawgui()
                 drawcoloredtile(textbox[i].xp + 8 + (k * 8), textbox[i].yp, 41, textbox[i].r, textbox[i].g, textbox[i].b);
                 drawcoloredtile(textbox[i].xp + 8 + (k * 8), textbox[i].yp+textbox[i].h-8, 46, textbox[i].r, textbox[i].g, textbox[i].b);
             }
-            for (int k = 0; k < textbox[i].numlines; k++)
+            for (size_t k = 0; k < textbox[i].line.size(); k++)
             {
                 drawcoloredtile(textbox[i].xp, textbox[i].yp + 8 + (k * 8), 43, textbox[i].r, textbox[i].g, textbox[i].b);
                 drawcoloredtile(textbox[i].xp + textbox[i].w-8, textbox[i].yp + 8 + (k * 8), 44, textbox[i].r, textbox[i].g, textbox[i].b);
@@ -626,14 +626,14 @@ void Graphics::drawgui()
 
             if(flipmode)
             {
-                for (j = 0; j < textbox[i].numlines; j++)
+                for (j = 0; j < (int) textbox[i].line.size(); j++)
                 {
-                    Print(textbox[i].xp + 8, textbox[i].yp  + (textbox[i].numlines*8) - (j * 8), textbox[i].line[j], textbox[i].r, textbox[i].g, textbox[i].b);
+                    Print(textbox[i].xp + 8, textbox[i].yp  + (textbox[i].line.size()*8) - (j * 8), textbox[i].line[j], textbox[i].r, textbox[i].g, textbox[i].b);
                 }
             }
             else
             {
-                for (j = 0; j < textbox[i].numlines; j++)
+                for (j = 0; j < (int) textbox[i].line.size(); j++)
                 {
                     Print(textbox[i].xp + 8, textbox[i].yp +8 + (j * 8), textbox[i].line[j], textbox[i].r, textbox[i].g, textbox[i].b);
                 }
@@ -1008,8 +1008,7 @@ void Graphics::createtextbox( std::string t, int xp, int yp, int r/*= 255*/, int
     if(m<20)
     {
         textboxclass text;
-        text.clear();
-        text.line[0] = t;
+        text.line.push_back(t);
         text.xp = xp;
         int length = utf8::unchecked::distance(t.begin(), t.end());
         if (xp == -1) text.xp = 160 - (((length / 2) + 1) * 8);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -85,10 +85,6 @@ void Graphics::init()
     menuoffset = 0;
     resumegamemode = false;
 
-    //Textboxes!
-    textbox.resize(30);
-    ntextbox = 0;
-
     //Fading stuff
     fadebars.resize(15);
 
@@ -580,15 +576,17 @@ void Graphics::drawgui()
 {
     textboxcleanup();
     //Draw all the textboxes to the screen
-    for (int i = 0; i<ntextbox; i++)
+    for (size_t i = 0; i<textbox.size(); i++)
     {
         //This routine also updates the textboxs
         textbox[i].update();
-        if (textbox[i].active)
+        if (true) //FIXME: remove this later (no more 'active')
         {
             if (textbox[i].tm == 2 && textbox[i].tl <= 0.5)
             {
-                textbox[i].active = false;
+                textbox.erase(textbox.begin() + i);
+                i--;
+                continue;
             }
 
             if (textbox[i].r == 0 && textbox[i].g == 0 && textbox[i].b == 0)
@@ -966,7 +964,7 @@ void Graphics::drawtextbox( int x, int y, int w, int h, int r, int g, int b )
 void Graphics::textboxactive()
 {
     //Remove all but the most recent textbox
-    for (int i = 0; i < ntextbox; i++)
+    for (int i = 0; i < (int) textbox.size(); i++)
     {
         if (m != i) textbox[i].remove();
     }
@@ -975,7 +973,7 @@ void Graphics::textboxactive()
 void Graphics::textboxremovefast()
 {
     //Remove all textboxes
-    for (int i = 0; i < ntextbox; i++)
+    for (size_t i = 0; i < textbox.size(); i++)
     {
         textbox[i].removefast();
     }
@@ -984,7 +982,7 @@ void Graphics::textboxremovefast()
 void Graphics::textboxremove()
 {
     //Remove all textboxes
-    for (int i = 0; i < ntextbox; i++)
+    for (size_t i = 0; i < textbox.size(); i++)
     {
         textbox[i].remove();
     }
@@ -1008,36 +1006,20 @@ void Graphics::textboxadjust()
 
 void Graphics::createtextbox( std::string t, int xp, int yp, int r/*= 255*/, int g/*= 255*/, int b /*= 255*/ )
 {
-
-    if(ntextbox == 0)
-    {
-        //If there are no active textboxes, Z=0;
-        m = 0;
-        ntextbox++;
-    }
-    else
-    {
-        /*i = 0; m = -1;
-        while (i < ntextbox) {
-        if (!textbox[i].active) {	m = i; i = ntextbox;}
-        i++;
-        }
-        if (m == -1) {m = ntextbox; ntextbox++;}
-        */
-        m = ntextbox;
-        ntextbox++;
-    }
+    m = textbox.size();
 
     if(m<20)
     {
-        textbox[m].clear();
-        textbox[m].line[0] = t;
-        textbox[m].xp = xp;
+        textboxclass text;
+        text.clear();
+        text.line[0] = t;
+        text.xp = xp;
         int length = utf8::unchecked::distance(t.begin(), t.end());
-        if (xp == -1) textbox[m].xp = 160 - (((length / 2) + 1) * 8);
-        textbox[m].yp = yp;
-        textbox[m].initcol(r, g, b);
-        textbox[m].resize();
+        if (xp == -1) text.xp = 160 - (((length / 2) + 1) * 8);
+        text.yp = yp;
+        text.initcol(r, g, b);
+        text.resize();
+        textbox.push_back(text);
     }
 }
 
@@ -2891,12 +2873,6 @@ void Graphics::setwarprect( int a, int b, int c, int d )
 
 	void Graphics::textboxcleanup()
 	{
-		int i = ntextbox - 1;
-		while (i >= 0 && !textbox[i].active)
-		{
-			ntextbox--;
-			i--;
-		}
 	}
 
 void Graphics::textboxcenter()

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -586,6 +586,11 @@ void Graphics::drawgui()
         textbox[i].update();
         if (textbox[i].active)
         {
+            if (textbox[i].tm == 2 && textbox[i].tl <= 0.5)
+            {
+                textbox[i].active = false;
+            }
+
             if (textbox[i].r == 0 && textbox[i].g == 0 && textbox[i].b == 0)
             {
                 if(flipmode)

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -265,7 +265,6 @@ public:
 	int trinketr, trinketg, trinketb;
 
 	std::vector <textboxclass> textbox;
-	int ntextbox;
 
 	bool showcutscenebars;
 	int cutscenebarspos;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1717,6 +1717,7 @@ void gameinput()
             {
                 script.load(obj.blocks[game.activeactivity].script);
                 obj.removeblock(game.activeactivity);
+                game.activeactivity = -1;
             }
         }else{
           game.gamestate = EDITORMODE;
@@ -1823,6 +1824,7 @@ void gameinput()
                         {
                             script.load(obj.blocks[game.activeactivity].script);
                             obj.removeblock(game.activeactivity);
+                            game.activeactivity = -1;
                         }
                     }
                     else if (game.swnmode == 1 && game.swngame == 1)
@@ -2058,6 +2060,7 @@ void mapinput()
         FillRect(graphics.menubuffer, 0x000000);
         graphics.resumegamemode = true;
         obj.removeallblocks();
+        game.activeactivity = -1;
         game.menukludge = false;
         if (game.menupage >= 20)
         {

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1709,38 +1709,38 @@ void gameinput()
     //Returning to editor mode must always be possible
 #if !defined(NO_CUSTOM_LEVELS)
     if(map.custommode && !map.custommodeforreal){
-      if ((game.press_map || key.isDown(27)) && !game.mapheld){
-        game.mapheld = true;
-        //Return to level editor
-        if (game.activeactivity > -1 && game.press_map){
-           if((int(std::abs(obj.entities[obj.getplayer()].vx))<=1) && (int(obj.entities[obj.getplayer()].vy) == 0) )
-            {
-                script.load(obj.blocks[game.activeactivity].script);
-                obj.removeblock(game.activeactivity);
-                game.activeactivity = -1;
-            }
-        }else{
-          game.gamestate = EDITORMODE;
+        if ((game.press_map || key.isDown(27)) && !game.mapheld){
+            game.mapheld = true;
+            //Return to level editor
+            if (game.activeactivity > -1 && game.press_map){
+               if((int(std::abs(obj.entities[obj.getplayer()].vx))<=1) && (int(obj.entities[obj.getplayer()].vy) == 0) )
+               {
+                   script.load(obj.blocks[game.activeactivity].script);
+                   obj.removeblock(game.activeactivity);
+                   game.activeactivity = -1;
+               }
+            }else{
+                game.gamestate = EDITORMODE;
 
-          graphics.textboxremove();
-          game.hascontrol = true;
-          game.advancetext = false;
-          game.completestop = false;
-          game.state = 0;
-          graphics.showcutscenebars = false;
+                graphics.textboxremove();
+                game.hascontrol = true;
+                game.advancetext = false;
+                game.completestop = false;
+                game.state = 0;
+                graphics.showcutscenebars = false;
 
-          graphics.backgrounddrawn=false;
-          music.fadeout();
-          //If warpdir() is used during playtesting, we need to set it back after!
-          for (int j = 0; j < ed.maxheight; j++)
-          {
-            for (int i = 0; i < ed.maxwidth; i++)
-            {
-              ed.level[i+(j*ed.maxwidth)].warpdir=ed.kludgewarpdir[i+(j*ed.maxwidth)];
+                graphics.backgrounddrawn=false;
+                music.fadeout();
+                //If warpdir() is used during playtesting, we need to set it back after!
+                for (int j = 0; j < ed.maxheight; j++)
+                {
+                    for (int i = 0; i < ed.maxwidth; i++)
+                    {
+                       ed.level[i+(j*ed.maxwidth)].warpdir=ed.kludgewarpdir[i+(j*ed.maxwidth)];
+                    }
+                }
             }
-          }
         }
-      }
     }
 #endif
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1744,7 +1744,7 @@ void gameinput()
 #endif
 
     //Entity type 0 is player controled
-    for (int ie = 0; ie < obj.nentity; ++ie)
+    for (size_t ie = 0; ie < obj.entities.size(); ++ie)
     {
         if (obj.entities[ie].rule == 0)
         {

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -498,8 +498,6 @@ void towerlogic()
 
 
         }
-        //now! let's clean up removed entities
-        obj.cleanup();
 
         //Looping around, room change conditions!
     }
@@ -1013,9 +1011,6 @@ void gamelogic()
 
             obj.entitycollisioncheck();         // Check ent v ent collisions, update states
         }
-
-        //now! let's clean up removed entities
-        obj.cleanup();
 
         //Using warplines?
         if (obj.customwarpmode) {

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -347,7 +347,7 @@ void towerlogic()
 
         if(!game.completestop)
         {
-            for (int i = obj.nentity - 1; i >= 0;  i--)
+            for (int i = obj.entities.size() - 1; i >= 0;  i--)
             {
                 obj.updateentities(i);                // Behavioral logic
                 obj.updateentitylogic(i);             // Basic Physics
@@ -411,7 +411,7 @@ void towerlogic()
                 //Always wrap except for the very top and very bottom of the tower
                 if(map.ypos>=500 && map.ypos <=5000)
                 {
-                    for (int i = 0; i < obj.nentity;  i++)
+                    for (size_t i = 0; i < obj.entities.size();  i++)
                     {
                         if (obj.entities[i].xp <= -10)
                         {
@@ -557,7 +557,7 @@ void gamelogic()
 
     if (game.deathseq != -1)
     {
-        for (int i = 0; i < obj.nentity; i++)
+        for (size_t i = 0; i < obj.entities.size(); i++)
         {
             if (game.roomx == 111 && game.roomy == 107 && !map.custommode)
             {
@@ -848,7 +848,7 @@ void gamelogic()
                 obj.entities[obj.getlineat(148 + 32)].xp += 24;
                 if (obj.entities[obj.getlineat(148 + 32)].xp > 320)
                 {
-                    obj.entities[obj.getlineat(148 + 32)].active = false;
+                    obj.removeentity(obj.getlineat(148 + 32));
                     game.swnmode = false;
                     game.swngame = 6;
                 }
@@ -937,7 +937,7 @@ void gamelogic()
         {
             if(obj.vertplatforms)
             {
-                for (int i = obj.nentity - 1; i >= 0;  i--)
+                for (int i = obj.entities.size() - 1; i >= 0;  i--)
                 {
                     if (obj.entities[i].isplatform)
                     {
@@ -966,7 +966,7 @@ void gamelogic()
 
             if(obj.horplatforms)
             {
-                for (int ie = obj.nentity - 1; ie >= 0;  ie--)
+                for (int ie = obj.entities.size() - 1; ie >= 0;  ie--)
                 {
                     if (obj.entities[ie].isplatform)
                     {
@@ -1001,7 +1001,7 @@ void gamelogic()
                 }
             }
 
-            for (int ie = obj.nentity - 1; ie >= 0;  ie--)
+            for (int ie = obj.entities.size() - 1; ie >= 0;  ie--)
             {
                 if (!obj.entities[ie].isplatform)
                 {
@@ -1040,7 +1040,7 @@ void gamelogic()
         //Finally: Are we changing room?
         if (map.warpx && map.warpy)
         {
-            for (int i = 0; i < obj.nentity;  i++)
+            for (size_t i = 0; i < obj.entities.size();  i++)
             {
                 if(obj.entities[i].type<50){ //Don't warp warp lines
                   if (obj.entities[i].size < 12)   //Don't wrap SWN enemies
@@ -1060,7 +1060,7 @@ void gamelogic()
                 }
             }
 
-            for (int i = 0; i < obj.nentity;  i++)
+            for (size_t i = 0; i < obj.entities.size();  i++)
             {
 
                 if(obj.entities[i].type<50){ //Don't warp warp lines
@@ -1083,7 +1083,7 @@ void gamelogic()
         }
         else if (map.warpx)
         {
-            for (int i = 0; i < obj.nentity;  i++)
+            for (size_t i = 0; i < obj.entities.size();  i++)
             {
                 if(obj.entities[i].type<50){ //Don't warp warp lines
                   if (obj.entities[i].size < 12)   //Don't wrap SWN enemies
@@ -1135,7 +1135,7 @@ void gamelogic()
         }
         else if (map.warpy)
         {
-            for (int i = 0; i < obj.nentity;  i++)
+            for (size_t i = 0; i < obj.entities.size();  i++)
             {
                 if(obj.entities[i].type<50){ //Don't warp warp lines
                   if (obj.entities[i].yp <= -12)
@@ -1152,7 +1152,7 @@ void gamelogic()
                 }
             }
 
-            for (int i = 0; i < obj.nentity;  i++)
+            for (size_t i = 0; i < obj.entities.size();  i++)
             {
 
                 if(obj.entities[i].type<50){ //Don't warp warp lines

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -515,7 +515,7 @@ void mapclass::changefinalcol(int t)
 	final_mapcol = t;
 	temp = 6 - t;
 	//Next, entities
-	for (int i = 0; i < obj.nentity; i++)
+	for (size_t i = 0; i < obj.entities.size(); i++)
 	{
 		if (obj.entities[i].type == 1) //something with a movement behavior
 		{
@@ -886,10 +886,10 @@ void mapclass::gotoroom(int rx, int ry)
 	game.readytotele = 0;
 
 	//Ok, let's save the position of all lines on the screen
-	obj.nlinecrosskludge = 0;
-	for (int i = 0; i < obj.nentity; i++)
+	obj.linecrosskludge.clear();
+	for (size_t i = 0; i < obj.entities.size(); i++)
 	{
-		if (obj.entities[i].type == 9 && obj.entities[i].active)
+		if (obj.entities[i].type == 9)
 		{
 			//It's a horizontal line
 			if (obj.entities[i].xp <= 0 || (obj.entities[i].xp + obj.entities[i].w) >= 312)
@@ -901,11 +901,12 @@ void mapclass::gotoroom(int rx, int ry)
 	}
 
 	int theplayer = obj.getplayer();
-	for (int i = 0; i < obj.nentity; i++)
+	for (int i = 0; i < (int) obj.entities.size(); i++)
 	{
 		if (i != theplayer)
 		{
-			obj.entities[i].active = false;
+			removeentity_iter(i);
+			theplayer--; //just in case indice of player is not 0
 		}
 	}
 	obj.cleanup();
@@ -1084,15 +1085,15 @@ void mapclass::gotoroom(int rx, int ry)
 		obj.entities[temp].oldyp = obj.entities[temp].yp;
 	}
 
-	for (int i = 0; i < obj.nentity; i++)
+	for (size_t i = 0; i < obj.entities.size(); i++)
 	{
-		if (obj.entities[i].type == 9 && obj.entities[i].active)
+		if (obj.entities[i].type == 9)
 		{
 			//It's a horizontal line
 			if (obj.entities[i].xp <= 0 || obj.entities[i].xp + obj.entities[i].w >= 312)
 			{
 				//it's on a screen edge
-				for (j = 0; j < obj.nlinecrosskludge; j++)
+				for (j = 0; j < (int) obj.linecrosskludge.size(); j++)
 				{
 					if (obj.entities[i].yp == obj.linecrosskludge[j].yp)
 					{
@@ -1823,9 +1824,9 @@ void mapclass::loadlevel(int rx, int ry)
 			}
 		}
 
-		for (int i = 0; i < obj.nentity; i++)
+		for (size_t i = 0; i < obj.entities.size(); i++)
 		{
-			if (obj.entities[i].active)
+			if (true) //FIXME: remove this later (no more 'active')
 			{
 				if (obj.entities[i].type == 1 && obj.entities[i].behave >= 8 && obj.entities[i].behave < 10)
 				{
@@ -1965,7 +1966,7 @@ void mapclass::loadlevel(int rx, int ry)
 	}
 
 	//Make sure our crewmates are facing the player if appliciable
-	for (int i = 0; i < obj.nentity; i++)
+	for (size_t i = 0; i < obj.entities.size(); i++)
 	{
 		if (obj.entities[i].rule == 6 || obj.entities[i].rule == 7)
 		{

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1826,24 +1826,21 @@ void mapclass::loadlevel(int rx, int ry)
 
 		for (size_t i = 0; i < obj.entities.size(); i++)
 		{
-			if (true) //FIXME: remove this later (no more 'active')
+			if (obj.entities[i].type == 1 && obj.entities[i].behave >= 8 && obj.entities[i].behave < 10)
 			{
-				if (obj.entities[i].type == 1 && obj.entities[i].behave >= 8 && obj.entities[i].behave < 10)
+				//put a block underneath
+				temp = obj.entities[i].xp / 8.0f;
+				temp2 = obj.entities[i].yp / 8.0f;
+				settile(temp, temp2, 1);
+				settile(temp+1, temp2, 1);
+				settile(temp+2, temp2, 1);
+				settile(temp+3, temp2, 1);
+				if (obj.entities[i].w == 64)
 				{
-					//put a block underneath
-					temp = obj.entities[i].xp / 8.0f;
-					temp2 = obj.entities[i].yp / 8.0f;
-					settile(temp, temp2, 1);
-					settile(temp+1, temp2, 1);
-					settile(temp+2, temp2, 1);
-					settile(temp+3, temp2, 1);
-					if (obj.entities[i].w == 64)
-					{
-						settile(temp+4, temp2, 1);
-						settile(temp+5, temp2, 1);
-						settile(temp+6, temp2, 1);
-						settile(temp+7, temp2, 1);
-					}
+					settile(temp+4, temp2, 1);
+					settile(temp+5, temp2, 1);
+					settile(temp+6, temp2, 1);
+					settile(temp+7, temp2, 1);
 				}
 			}
 		}

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -909,7 +909,6 @@ void mapclass::gotoroom(int rx, int ry)
 			theplayer--; //just in case indice of player is not 0
 		}
 	}
-	obj.cleanup();
 
 	game.door_up = rx + ((ry - 1) * 100);
 	game.door_down = rx + ((ry + 1) * 100);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -12,7 +12,6 @@ scriptclass::scriptclass()
 
 	//Init
 	words.resize(40);
-	txt.resize(40);
 
 	position = 0;
 	scriptdelay = 0;
@@ -28,7 +27,6 @@ scriptclass::scriptclass()
 	r = 0;
 	textx = 0;
 	texty = 0;
-	txtnumlines = 0;
 }
 
 void scriptclass::clearcustom(){
@@ -374,11 +372,11 @@ void scriptclass::run()
 				texty = ss_toi(words[3]);
 
 				//Number of lines for the textbox!
-				txtnumlines = ss_toi(words[4]);
-				for (int i = 0; i < txtnumlines; i++)
+				txt.clear();
+				for (int i = 0; i < ss_toi(words[4]); i++)
 				{
 					position++;
-					txt[i] = commands[position];
+					txt.push_back(commands[position]);
 				}
 			}
 			else if (words[0] == "position")
@@ -448,12 +446,12 @@ void scriptclass::run()
 					if (j == 1)    //left
 					{
 						textx = obj.entities[i].xp -10000; //tells the box to be oriented correctly later
-						texty = obj.entities[i].yp - 16 - (txtnumlines*8);
+						texty = obj.entities[i].yp - 16 - (txt.size()*8);
 					}
 					else if (j == 0)     //Right
 					{
 						textx = obj.entities[i].xp - 16;
-						texty = obj.entities[i].yp - 18 - (txtnumlines * 8);
+						texty = obj.entities[i].yp - 18 - (txt.size() * 8);
 					}
 				}
 				else
@@ -545,12 +543,12 @@ void scriptclass::run()
 					if (j == 1)    //left
 					{
 						textx = obj.entities[i].xp -10000; //tells the box to be oriented correctly later
-						texty = obj.entities[i].yp - 16 - (txtnumlines*8);
+						texty = obj.entities[i].yp - 16 - (txt.size()*8);
 					}
 					else if (j == 0)     //Right
 					{
 						textx = obj.entities[i].xp - 16;
-						texty = obj.entities[i].yp - 18 - (txtnumlines * 8);
+						texty = obj.entities[i].yp - 18 - (txt.size() * 8);
 					}
 				}
 				else
@@ -573,15 +571,15 @@ void scriptclass::run()
 			}
 			else if (words[0] == "flipme")
 			{
-				if(graphics.flipmode) texty += 2*(120 - texty) - 8*(txtnumlines+2);
+				if(graphics.flipmode) texty += 2*(120 - texty) - 8*(txt.size()+2);
 			}
 			else if (words[0] == "speak_active")
 			{
 				//Ok, actually display the textbox we've initilised now!
 				graphics.createtextbox(txt[0], textx, texty, r, g, b);
-				if (txtnumlines > 1)
+				if ((int) txt.size() > 1)
 				{
-					for (i = 1; i < txtnumlines; i++)
+					for (i = 1; i < (int) txt.size(); i++)
 					{
 						graphics.addline(txt[i]);
 					}
@@ -624,9 +622,9 @@ void scriptclass::run()
 			{
 				//Exactly as above, except don't make the textbox active (so we can use multiple textboxes)
 				graphics.createtextbox(txt[0], textx, texty, r, g, b);
-				if (txtnumlines > 1)
+				if ((int) txt.size() > 1)
 				{
-					for (i = 1; i < txtnumlines; i++)
+					for (i = 1; i < (int) txt.size(); i++)
 					{
 						graphics.addline(txt[i]);
 					}
@@ -2020,12 +2018,12 @@ void scriptclass::run()
 				switch(ss_toi(words[1]))
 				{
 				case 1:
-					txtnumlines = 1;
+					txt.resize(1);
 
 					txt[0] = "I'm worried about " + game.unrescued() + ", Doctor!";
 					break;
 				case 2:
-					txtnumlines = 3;
+					txt.resize(3);
 
 					if (game.crewrescued() < 5)
 					{
@@ -2034,7 +2032,7 @@ void scriptclass::run()
 					}
 					else
 					{
-						txtnumlines = 2;
+						txt.resize(2);
 						txt[1] = "to helping you find " + game.unrescued() + "!";
 					}
 					break;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -141,17 +141,17 @@ void scriptclass::run()
 			if (words[0] == "destroy")
 			{
 				if(words[1]=="gravitylines"){
-					for(int edi=0; edi<obj.nentity; edi++){
-						if(obj.entities[edi].type==9) obj.entities[edi].active=false;
-						if(obj.entities[edi].type==10) obj.entities[edi].active=false;
+					for(size_t edi=0; edi<obj.entities.size(); edi++){
+						if(obj.entities[edi].type==9) removeentity_iter(edi);
+						if(obj.entities[edi].type==10) removeentity_iter(edi);
 					}
 				}else if(words[1]=="warptokens"){
-					for(int edi=0; edi<obj.nentity; edi++){
-						if(obj.entities[edi].type==11) obj.entities[edi].active=false;
+					for(size_t edi=0; edi<obj.entities.size(); edi++){
+						if(obj.entities[edi].type==11) removeentity_iter(edi);
 					}
 				}else if(words[1]=="platforms"){
-					for(int edi=0; edi<obj.nentity; edi++){
-						if(obj.entities[edi].rule==2 && obj.entities[edi].animate==100) obj.entities[edi].active=false;
+					for(size_t edi=0; edi<obj.entities.size(); edi++){
+						if(obj.entities[edi].rule==2 && obj.entities[edi].animate==100) removeentity_iter(edi);
 					}
 				}
 			}
@@ -1652,9 +1652,9 @@ void scriptclass::run()
 			}
 			else if (words[0] == "jukebox")
 			{
-				for (j = 0; j < obj.nentity; j++)
+				for (j = 0; j < (int) obj.entities.size(); j++)
 				{
-					if (obj.entities[j].type == 13 && obj.entities[j].active)
+					if (obj.entities[j].type == 13)
 					{
 						obj.entities[j].colour = 4;
 					}
@@ -1662,7 +1662,7 @@ void scriptclass::run()
 				if (ss_toi(words[1]) == 1)
 				{
 					obj.createblock(5, 88 - 4, 80, 20, 16, 25);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 88 && obj.entities[j].yp==80)
 						{
@@ -1673,7 +1673,7 @@ void scriptclass::run()
 				else if (ss_toi(words[1]) == 2)
 				{
 					obj.createblock(5, 128 - 4, 80, 20, 16, 26);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 128 && obj.entities[j].yp==80)
 						{
@@ -1684,7 +1684,7 @@ void scriptclass::run()
 				else if (ss_toi(words[1]) == 3)
 				{
 					obj.createblock(5, 176 - 4, 80, 20, 16, 27);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 176 && obj.entities[j].yp==80)
 						{
@@ -1695,7 +1695,7 @@ void scriptclass::run()
 				else if (ss_toi(words[1]) == 4)
 				{
 					obj.createblock(5, 216 - 4, 80, 20, 16, 28);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 216 && obj.entities[j].yp==80)
 						{
@@ -1706,7 +1706,7 @@ void scriptclass::run()
 				else if (ss_toi(words[1]) == 5)
 				{
 					obj.createblock(5, 88 - 4, 128, 20, 16, 29);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 88 && obj.entities[j].yp==128)
 						{
@@ -1717,7 +1717,7 @@ void scriptclass::run()
 				else if (ss_toi(words[1]) == 6)
 				{
 					obj.createblock(5, 176 - 4, 128, 20, 16, 30);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 176 && obj.entities[j].yp==128)
 						{
@@ -1728,7 +1728,7 @@ void scriptclass::run()
 				else if (ss_toi(words[1]) == 7)
 				{
 					obj.createblock(5, 40 - 4, 40, 20, 16, 31);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 40 && obj.entities[j].yp==40)
 						{
@@ -1739,7 +1739,7 @@ void scriptclass::run()
 				else if (ss_toi(words[1]) == 8)
 				{
 					obj.createblock(5, 216 - 4, 128, 20, 16, 32);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 216 && obj.entities[j].yp==128)
 						{
@@ -1750,7 +1750,7 @@ void scriptclass::run()
 				else if (ss_toi(words[1]) == 9)
 				{
 					obj.createblock(5, 128 - 4, 128, 20, 16, 33);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 128 && obj.entities[j].yp==128)
 						{
@@ -1761,7 +1761,7 @@ void scriptclass::run()
 				else if (ss_toi(words[1]) == 10)
 				{
 					obj.createblock(5, 264 - 4, 40, 20, 16, 34);
-					for (j = 0; j < obj.nentity; j++)
+					for (j = 0; j < (int) obj.entities.size(); j++)
 					{
 						if (obj.entities[j].xp == 264 && obj.entities[j].yp==40)
 						{
@@ -1959,7 +1959,7 @@ void scriptclass::run()
 			}
 			else if (words[0] == "everybodysad")
 			{
-				for (i = 0; i < obj.nentity; i++)
+				for (i = 0; i < (int) obj.entities.size(); i++)
 				{
 					if (obj.entities[i].rule == 6 || obj.entities[i].rule == 0)
 					{
@@ -2535,7 +2535,7 @@ void scriptclass::resetgametomenu()
 {
 	game.gamestate = TITLEMODE;
 	graphics.flipmode = false;
-	obj.nentity = 0;
+	obj.entities.clear();
 	graphics.fademode = 4;
 	game.createmenu("gameover");
 }
@@ -2555,7 +2555,7 @@ void scriptclass::startgamemode( int t )
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
 
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2578,7 +2578,7 @@ void scriptclass::startgamemode( int t )
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
 
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2600,7 +2600,7 @@ void scriptclass::startgamemode( int t )
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
 
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2639,7 +2639,7 @@ void scriptclass::startgamemode( int t )
 		game.jumpheld = true;
 
 		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2667,7 +2667,7 @@ void scriptclass::startgamemode( int t )
 		game.jumpheld = true;
 
 		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2695,7 +2695,7 @@ void scriptclass::startgamemode( int t )
 		game.jumpheld = true;
 
 		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2723,7 +2723,7 @@ void scriptclass::startgamemode( int t )
 		game.jumpheld = true;
 
 		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2751,7 +2751,7 @@ void scriptclass::startgamemode( int t )
 		game.jumpheld = true;
 
 		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2785,7 +2785,7 @@ void scriptclass::startgamemode( int t )
 		game.jumpheld = true;
 
 		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2808,7 +2808,7 @@ void scriptclass::startgamemode( int t )
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
 
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2835,7 +2835,7 @@ void scriptclass::startgamemode( int t )
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
 
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2871,7 +2871,7 @@ void scriptclass::startgamemode( int t )
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
 
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2906,7 +2906,7 @@ void scriptclass::startgamemode( int t )
 
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2941,7 +2941,7 @@ void scriptclass::startgamemode( int t )
 
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -2976,7 +2976,7 @@ void scriptclass::startgamemode( int t )
 
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3011,7 +3011,7 @@ void scriptclass::startgamemode( int t )
 
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3043,7 +3043,7 @@ void scriptclass::startgamemode( int t )
 
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3075,7 +3075,7 @@ void scriptclass::startgamemode( int t )
 
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3107,7 +3107,7 @@ void scriptclass::startgamemode( int t )
 
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3139,7 +3139,7 @@ void scriptclass::startgamemode( int t )
 
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3162,7 +3162,7 @@ void scriptclass::startgamemode( int t )
 		game.jumpheld = true;
 
 		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3196,7 +3196,7 @@ void scriptclass::startgamemode( int t )
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
 
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3233,7 +3233,7 @@ void scriptclass::startgamemode( int t )
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
 
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}
@@ -3278,7 +3278,7 @@ void scriptclass::startgamemode( int t )
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
 
-		if(obj.nentity==0)
+		if(obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -54,7 +54,6 @@ public:
     int textx;
     int texty;
     int r,g,b;
-    int txtnumlines;
 
     //Misc
     int i, j, k;

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -105,7 +105,7 @@ void textboxclass::update()
         if (tl <= 0.5)
         {
             tl = 0.5;
-            active = false;
+            //this textbox will be removed by drawgui() later
         }
         setcol(int(tr * tl), int(tg * tl), int(tb * tl));
     }

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -23,7 +23,6 @@ void textboxclass::firstcreate()
     lw = 0;
     tl = 0;
     tm = 0;
-    active = false;
     timer = 0;
 }
 
@@ -42,7 +41,6 @@ void textboxclass::clear()
     lw = 0;
     tl = 0;
     tm = 0;
-    active = true;
     timer = 0;
 }
 

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -3,28 +3,8 @@
 
 textboxclass::textboxclass()
 {
-    firstcreate();
-}
-
-void textboxclass::firstcreate()
-{
-    //Like clear, only it creates the actual arrays, etc
     x = 0;
     y = 0;
-    w = 0;
-    h = 0;
-    lw = 0;
-    tl = 0;
-    tm = 0;
-    timer = 0;
-}
-
-void textboxclass::clear()
-{
-    //Set all values to a default, required for creating a new entity
-    line.resize(1);
-    xp = 0;
-    yp = 0;
     w = 0;
     h = 0;
     lw = 0;

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -9,17 +9,10 @@ textboxclass::textboxclass()
 void textboxclass::firstcreate()
 {
     //Like clear, only it creates the actual arrays, etc
-    for (int iter = 0; iter < 10; iter++)
-    {
-        std::string t;
-        t = "";
-        line.push_back(t);
-    }
     x = 0;
     y = 0;
     w = 0;
     h = 0;
-    numlines = 0;
     lw = 0;
     tl = 0;
     tm = 0;
@@ -29,15 +22,11 @@ void textboxclass::firstcreate()
 void textboxclass::clear()
 {
     //Set all values to a default, required for creating a new entity
-    for (size_t iter = 0; iter < line.size(); iter++)
-    {
-        line[iter]="";
-    }
+    line.resize(1);
     xp = 0;
     yp = 0;
     w = 0;
     h = 0;
-    numlines = 1;
     lw = 0;
     tl = 0;
     tm = 0;
@@ -130,7 +119,7 @@ void textboxclass::resize()
 {
     //Set the width and height to the correct sizes
     max = 0;
-    for (int iter = 0; iter < numlines; iter++)
+    for (size_t iter = 0; iter < line.size(); iter++)
     {
         unsigned int len = utf8::unchecked::distance(line[iter].begin(), line[iter].end());
         if (len > (unsigned int)max) max = len;
@@ -138,7 +127,7 @@ void textboxclass::resize()
 
     lw = max;
     w = (max +2) * 8;
-    h = (numlines + 2) * 8;
+    h = (line.size() + 2) * 8;
     textrect.x = xp;
     textrect.y = yp;
     textrect.w = w;
@@ -147,8 +136,7 @@ void textboxclass::resize()
 
 void textboxclass::addline(std::string t)
 {
-    line[numlines] = t;
-    numlines++;
+    line.push_back(t);
     resize();
-    if (numlines >= 12) numlines = 0;
+    if ((int) line.size() >= 12) line.clear();
 }

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -36,7 +36,7 @@ public:
 public:
     //Fundamentals
     std::vector<std::string> line;
-    int xp, yp, lw, w, h, numlines;
+    int xp, yp, lw, w, h;
     int x,y;
     int r,g,b;
     int tr,tg,tb;

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -10,10 +10,6 @@ class textboxclass
 public:
     textboxclass();
 
-    void firstcreate();
-
-    void clear();
-
     void centerx();
 
     void centery();

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -41,7 +41,6 @@ public:
     int r,g,b;
     int tr,tg,tb;
     SDL_Rect textrect;
-    bool active;
     int timer;
 
     float tl;

--- a/desktop_version/src/WarpClass.cpp
+++ b/desktop_version/src/WarpClass.cpp
@@ -931,10 +931,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry)
 		warpy = true;
 		rcol = 5;
 
-		obj.entities[obj.nentity].active = true;
-		obj.nentity++;
 		obj.createentity(14 * 8, (8 * 8) + 4, 14); //Teleporter!
-		obj.entities[obj.nentity - 2].active = false;
 
 		if(game.intimetrial)
 		{

--- a/desktop_version/src/titlerender.cpp
+++ b/desktop_version/src/titlerender.cpp
@@ -1423,7 +1423,7 @@ void gamerender()
 
         if(!game.completestop)
         {
-            for (int i = 0; i < obj.nentity; i++)
+            for (size_t i = 0; i < obj.entities.size(); i++)
             {
                 //Is this entity on the ground? (needed for jumping)
                 if (obj.entitycollidefloor(i))
@@ -2606,7 +2606,7 @@ void towerrender()
 
     if(!game.completestop)
     {
-        for (int i = 0; i < obj.nentity; i++)
+        for (size_t i = 0; i < obj.entities.size(); i++)
         {
             //Is this entity on the ground? (needed for jumping)
             if (obj.entitycollidefloor(i))


### PR DESCRIPTION
## Changes:

### Summary

This is a re-do of #174 but instead of everything being in one commit, it has been split into 28.

This PR removes the variables `obj.nentity`, `obj.nblocks`, `obj.nlinecrosskludge`, `graphics.ntextbox`, `script.txtnumlines`, and `textboxclass::numlines`, in favor of using `obj.entities.size()`, `obj.blocks.size()`, `obj.linecrosskludge.size()`, `graphics.textbox.size()`, `script.txt.size()`, and `textboxclass::line::size()`, respectively. Furthermore, all entclass, blockclass, and textboxclass objects no longer have an `active` attribute, meaning that they are guaranteed to be real and you don't have to check their `active` attribute before doing any operations with them.

See #174 for more information, I don't feel like re-typing or re-copy-pasting everything here.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
