### PR TITLE
Rename titlerender.cpp to Render.cpp and titlerender.h to Render.h

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -82,6 +82,7 @@ SET(VVV_SRC
 	src/Music.cpp
 	src/Otherlevel.cpp
 	src/preloader.cpp
+	src/Render.cpp
 	src/Screen.cpp
 	src/Script.cpp
 	src/Scripts.cpp
@@ -89,7 +90,6 @@ SET(VVV_SRC
 	src/Spacestation2.cpp
 	src/TerminalScripts.cpp
 	src/Textbox.cpp
-	src/titlerender.cpp
 	src/Tower.cpp
 	src/UtilityClass.cpp
 	src/WarpClass.cpp

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1,4 +1,4 @@
-#include "titlerender.h"
+#include "Render.h"
 
 #include "Graphics.h"
 #include "UtilityClass.h"

--- a/desktop_version/src/Render.h
+++ b/desktop_version/src/Render.h
@@ -1,5 +1,5 @@
-#ifndef TITLERENDERER_H
-#define TITLERENDERER_H
+#ifndef RENDER_H
+#define RENDER_H
 
 #include "Graphics.h"
 #include "UtilityClass.h"
@@ -22,4 +22,4 @@ void gamecompleterender();
 
 void gamecompleterender2();
 
-#endif /* TITLERENDERER_H */
+#endif /* RENDER_H */

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -5,7 +5,7 @@
 #include "Game.h"
 #include "Graphics.h"
 #include "KeyPoll.h"
-#include "titlerender.h"
+#include "Render.h"
 
 #include "Tower.h"
 #include "WarpClass.h"


### PR DESCRIPTION
## Changes:

* **Rename `titlerender.cpp` to `Render.cpp` and `titlerender.h` to `Render.h`**

  All references to `titlerender.cpp` and `titlerender.h` have been updated accordingly.

  Looks like `titlerender.cpp` was a misnomer, maybe in development someone started only with the `titlerender()` function in that file, but it soon included every other render function, too.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
