### PR TITLE
Fix memory leak when the game warps moving platforms

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1037,8 +1037,66 @@ void gamelogic()
         {
             for (size_t i = 0; i < obj.entities.size();  i++)
             {
-                if(obj.entities[i].type<50){ //Don't warp warp lines
-                    if (obj.entities[i].size < 12)   //Don't wrap SWN enemies
+                if(obj.entities[i].type<50 //Don't warp warp lines
+                && obj.entities[i].size < 12)   //Don't wrap SWN enemies
+                {
+                    if (obj.entities[i].xp <= -10)
+                    {
+                        obj.entities[i].xp += 320;
+                    }
+                    else
+                    {
+                        if (obj.entities[i].xp > 310)
+                        {
+                            obj.entities[i].xp -= 320;
+                        }
+                    }
+                }
+            }
+
+            for (size_t i = 0; i < obj.entities.size();  i++)
+            {
+
+                if(obj.entities[i].type<50 //Don't warp warp lines
+                && obj.entities[i].size < 12)   //Don't wrap SWN enemies
+                {
+                    if (obj.entities[i].yp <= -12)
+                    {
+                        obj.entities[i].yp += 232;
+                    }
+                    else
+                    {
+                        if (obj.entities[i].yp > 226)
+                        {
+                            obj.entities[i].yp -= 232;
+                        }
+                    }
+                }
+            }
+        }
+        else if (map.warpx)
+        {
+            for (size_t i = 0; i < obj.entities.size();  i++)
+            {
+                if(obj.entities[i].type<50 //Don't warp warp lines
+                && obj.entities[i].size < 12)   //Don't wrap SWN enemies
+                {
+                    if (game.roomx == 118 && game.roomy == 102 && obj.entities[i].rule==1 && !map.custommode)
+                    {
+                        //ascii snakes
+                        if (obj.entities[i].xp <= -80)
+                        {
+                            obj.entities[i].xp += 400;
+                        }
+                        else
+                        {
+                            if (obj.entities[i].xp > 320)
+                            {
+                                obj.entities[i].xp -= 400;
+                            }
+                        }
+                    }
+                    else
                     {
                         if (obj.entities[i].xp <= -10)
                         {
@@ -1049,67 +1107,6 @@ void gamelogic()
                             if (obj.entities[i].xp > 310)
                             {
                                 obj.entities[i].xp -= 320;
-                            }
-                        }
-                    }
-                }
-            }
-
-            for (size_t i = 0; i < obj.entities.size();  i++)
-            {
-
-                if(obj.entities[i].type<50){ //Don't warp warp lines
-                    if (obj.entities[i].size < 12)   //Don't wrap SWN enemies
-                    {
-                        if (obj.entities[i].yp <= -12)
-                        {
-                            obj.entities[i].yp += 232;
-                        }
-                        else
-                        {
-                            if (obj.entities[i].yp > 226)
-                            {
-                                obj.entities[i].yp -= 232;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        else if (map.warpx)
-        {
-            for (size_t i = 0; i < obj.entities.size();  i++)
-            {
-                if(obj.entities[i].type<50){ //Don't warp warp lines
-                    if (obj.entities[i].size < 12)   //Don't wrap SWN enemies
-                    {
-                        if (game.roomx == 118 && game.roomy == 102 && obj.entities[i].rule==1 && !map.custommode)
-                        {
-                            //ascii snakes
-                            if (obj.entities[i].xp <= -80)
-                            {
-                                obj.entities[i].xp += 400;
-                            }
-                            else
-                            {
-                                if (obj.entities[i].xp > 320)
-                                {
-                                    obj.entities[i].xp -= 400;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            if (obj.entities[i].xp <= -10)
-                            {
-                                obj.entities[i].xp += 320;
-                            }
-                            else
-                            {
-                                if (obj.entities[i].xp > 310)
-                                {
-                                    obj.entities[i].xp -= 320;
-                                }
                             }
                         }
                     }
@@ -1150,19 +1147,18 @@ void gamelogic()
             for (size_t i = 0; i < obj.entities.size();  i++)
             {
 
-                if(obj.entities[i].type<50){ //Don't warp warp lines
-                    if(obj.entities[i].rule!=0)
+                if(obj.entities[i].type<50 //Don't warp warp lines
+                &&obj.entities[i].rule!=0)
+                {
+                    if (obj.entities[i].xp <= -30)
                     {
-                        if (obj.entities[i].xp <= -30)
+                        obj.entities[i].xp += 350;
+                    }
+                    else
+                    {
+                        if (obj.entities[i].xp > 320)
                         {
-                            obj.entities[i].xp += 350;
-                        }
-                        else
-                        {
-                            if (obj.entities[i].xp > 320)
-                            {
-                                obj.entities[i].xp -= 350;
-                            }
+                            obj.entities[i].xp -= 350;
                         }
                     }
                 }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1038,20 +1038,20 @@ void gamelogic()
             for (size_t i = 0; i < obj.entities.size();  i++)
             {
                 if(obj.entities[i].type<50){ //Don't warp warp lines
-                  if (obj.entities[i].size < 12)   //Don't wrap SWN enemies
-                  {
-                      if (obj.entities[i].xp <= -10)
-                      {
-                          obj.entities[i].xp += 320;
-                      }
-                      else
-                      {
-                          if (obj.entities[i].xp > 310)
-                          {
-                              obj.entities[i].xp -= 320;
-                          }
-                      }
-                  }
+                    if (obj.entities[i].size < 12)   //Don't wrap SWN enemies
+                    {
+                        if (obj.entities[i].xp <= -10)
+                        {
+                            obj.entities[i].xp += 320;
+                        }
+                        else
+                        {
+                            if (obj.entities[i].xp > 310)
+                            {
+                                obj.entities[i].xp -= 320;
+                            }
+                        }
+                    }
                 }
             }
 
@@ -1059,20 +1059,20 @@ void gamelogic()
             {
 
                 if(obj.entities[i].type<50){ //Don't warp warp lines
-                  if (obj.entities[i].size < 12)   //Don't wrap SWN enemies
-                  {
-                      if (obj.entities[i].yp <= -12)
-                      {
-                          obj.entities[i].yp += 232;
-                      }
-                      else
-                      {
-                          if (obj.entities[i].yp > 226)
-                          {
-                              obj.entities[i].yp -= 232;
-                          }
-                      }
-                  }
+                    if (obj.entities[i].size < 12)   //Don't wrap SWN enemies
+                    {
+                        if (obj.entities[i].yp <= -12)
+                        {
+                            obj.entities[i].yp += 232;
+                        }
+                        else
+                        {
+                            if (obj.entities[i].yp > 226)
+                            {
+                                obj.entities[i].yp -= 232;
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -1081,38 +1081,38 @@ void gamelogic()
             for (size_t i = 0; i < obj.entities.size();  i++)
             {
                 if(obj.entities[i].type<50){ //Don't warp warp lines
-                  if (obj.entities[i].size < 12)   //Don't wrap SWN enemies
-                  {
-                      if (game.roomx == 118 && game.roomy == 102 && obj.entities[i].rule==1 && !map.custommode)
-                      {
-                          //ascii snakes
-                          if (obj.entities[i].xp <= -80)
-                          {
-                              obj.entities[i].xp += 400;
-                          }
-                          else
-                          {
-                              if (obj.entities[i].xp > 320)
-                              {
-                                  obj.entities[i].xp -= 400;
-                              }
-                          }
-                      }
-                      else
-                      {
-                          if (obj.entities[i].xp <= -10)
-                          {
-                              obj.entities[i].xp += 320;
-                          }
-                          else
-                          {
-                              if (obj.entities[i].xp > 310)
-                              {
-                                  obj.entities[i].xp -= 320;
-                              }
-                          }
-                      }
-                  }
+                    if (obj.entities[i].size < 12)   //Don't wrap SWN enemies
+                    {
+                        if (game.roomx == 118 && game.roomy == 102 && obj.entities[i].rule==1 && !map.custommode)
+                        {
+                            //ascii snakes
+                            if (obj.entities[i].xp <= -80)
+                            {
+                                obj.entities[i].xp += 400;
+                            }
+                            else
+                            {
+                                if (obj.entities[i].xp > 320)
+                                {
+                                    obj.entities[i].xp -= 400;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (obj.entities[i].xp <= -10)
+                            {
+                                obj.entities[i].xp += 320;
+                            }
+                            else
+                            {
+                                if (obj.entities[i].xp > 310)
+                                {
+                                    obj.entities[i].xp -= 320;
+                                }
+                            }
+                        }
+                    }
                 }
             }
 
@@ -1133,17 +1133,17 @@ void gamelogic()
             for (size_t i = 0; i < obj.entities.size();  i++)
             {
                 if(obj.entities[i].type<50){ //Don't warp warp lines
-                  if (obj.entities[i].yp <= -12)
-                  {
-                      obj.entities[i].yp += 232;
-                  }
-                  else
-                  {
-                      if (obj.entities[i].yp > 226)
-                      {
-                          obj.entities[i].yp -= 232;
-                      }
-                  }
+                    if (obj.entities[i].yp <= -12)
+                    {
+                        obj.entities[i].yp += 232;
+                    }
+                    else
+                    {
+                        if (obj.entities[i].yp > 226)
+                        {
+                            obj.entities[i].yp -= 232;
+                        }
+                    }
                 }
             }
 
@@ -1151,20 +1151,20 @@ void gamelogic()
             {
 
                 if(obj.entities[i].type<50){ //Don't warp warp lines
-                  if(obj.entities[i].rule!=0)
-                  {
-                      if (obj.entities[i].xp <= -30)
-                      {
-                          obj.entities[i].xp += 350;
-                      }
-                      else
-                      {
-                          if (obj.entities[i].xp > 320)
-                          {
-                              obj.entities[i].xp -= 350;
-                          }
-                      }
-                  }
+                    if(obj.entities[i].rule!=0)
+                    {
+                        if (obj.entities[i].xp <= -30)
+                        {
+                            obj.entities[i].xp += 350;
+                        }
+                        else
+                        {
+                            if (obj.entities[i].xp > 320)
+                            {
+                                obj.entities[i].xp -= 350;
+                            }
+                        }
+                    }
                 }
             }
 
@@ -1208,119 +1208,119 @@ void gamelogic()
 
         //Warp tokens
         if (map.custommode){
-          if (game.teleport)
-          {
-              int edi=obj.entities[game.edteleportent].behave;
-              int edj=obj.entities[game.edteleportent].para;
-              int edi2, edj2;
-              edi2 = (edi-(edi%40))/40;
-              edj2 = (edj-(edj%30))/30;
+            if (game.teleport)
+            {
+                int edi=obj.entities[game.edteleportent].behave;
+                int edj=obj.entities[game.edteleportent].para;
+                int edi2, edj2;
+                edi2 = (edi-(edi%40))/40;
+                edj2 = (edj-(edj%30))/30;
 
-              map.warpto(100+edi2, 100+edj2, obj.getplayer(), edi%40, (edj%30)+2);
-              game.teleport = false;
+                map.warpto(100+edi2, 100+edj2, obj.getplayer(), edi%40, (edj%30)+2);
+                game.teleport = false;
 
-              if (game.teleport == false)
-              {
-                  game.flashlight = 6;
-                  game.screenshake = 25;
-              }
-          }
+                if (game.teleport == false)
+                {
+                    game.flashlight = 6;
+                    game.screenshake = 25;
+                }
+            }
         }else{
-          if (game.teleport)
-          {
-              if (game.roomx == 117 && game.roomy == 102)
-              {
-                  int i = obj.getplayer();
-                  obj.entities[i].yp = 225;
-                  map.gotoroom(119, 100);
-                  game.teleport = false;
-              }
-              else if (game.roomx == 119 && game.roomy == 100)
-              {
-                  int i = obj.getplayer();
-                  obj.entities[i].yp = 225;
-                  map.gotoroom(119, 103);
-                  game.teleport = false;
-              }
-              else if (game.roomx == 119 && game.roomy == 103)
-              {
-                  int i = obj.getplayer();
-                  obj.entities[i].xp = 0;
-                  map.gotoroom(116, 103);
-                  game.teleport = false;
-              }
-              else if (game.roomx == 116 && game.roomy == 103)
-              {
-                  int i = obj.getplayer();
-                  obj.entities[i].yp = 225;
-                  map.gotoroom(116, 100);
-                  game.teleport = false;
-              }
-              else if (game.roomx == 116 && game.roomy == 100)
-              {
-                  int i = obj.getplayer();
-                  obj.entities[i].xp = 0;
-                  map.gotoroom(114, 102);
-                  game.teleport = false;
-              }
-              else if (game.roomx == 114 && game.roomy == 102)
-              {
-                  int i = obj.getplayer();
-                  obj.entities[i].yp = 225;
-                  map.gotoroom(113, 100);
-                  game.teleport = false;
-              }
-              else if (game.roomx == 116 && game.roomy == 104)
-              {
-                  //pre warp zone here
-                  map.warpto(107, 101, obj.getplayer(), 14, 16);
-              }
-              else if (game.roomx == 107 && game.roomy == 101)
-              {
-                  map.warpto(105, 119, obj.getplayer(), 5, 26);
-              }
-              else if (game.roomx == 105 && game.roomy == 118)
-              {
-                  map.warpto(101, 111, obj.getplayer(), 34, 6);
-              }
-              else if (game.roomx == 101 && game.roomy == 111)
-              {
-                  //There are lots of warp tokens in this room, so we have to distinguish!
-                  switch(game.teleportxpos)
-                  {
-                  case 1:
-                      map.warpto(108, 108, obj.getplayer(), 4, 27);
-                      break;
-                  case 2:
-                      map.warpto(101, 111, obj.getplayer(), 12, 27);
-                      break;
-                  case 3:
-                      map.warpto(119, 111, obj.getplayer(), 31, 7);
-                      break;
-                  case 4:
-                      map.warpto(114, 117, obj.getplayer(), 19, 16);
-                      break;
-                  }
-              }
-              else if (game.roomx == 108 && game.roomy == 106)
-              {
-                  map.warpto(119, 111, obj.getplayer(), 4, 27);
-              }
-              else if (game.roomx == 100 && game.roomy == 111)
-              {
-                  map.warpto(101, 111, obj.getplayer(), 24, 6);
-              }
-              else if (game.roomx == 119 && game.roomy == 107)
-              {
-                  //Secret lab, to super gravitron
-                  map.warpto(119, 108, obj.getplayer(), 19, 10);
-              }
-              if (game.teleport == false)
-              {
-                  game.flashlight = 6;
-                  game.screenshake = 25;
-              }
-          }
+            if (game.teleport)
+            {
+                if (game.roomx == 117 && game.roomy == 102)
+                {
+                    int i = obj.getplayer();
+                    obj.entities[i].yp = 225;
+                    map.gotoroom(119, 100);
+                    game.teleport = false;
+                }
+                else if (game.roomx == 119 && game.roomy == 100)
+                {
+                    int i = obj.getplayer();
+                    obj.entities[i].yp = 225;
+                    map.gotoroom(119, 103);
+                    game.teleport = false;
+                }
+                else if (game.roomx == 119 && game.roomy == 103)
+                {
+                    int i = obj.getplayer();
+                    obj.entities[i].xp = 0;
+                    map.gotoroom(116, 103);
+                    game.teleport = false;
+                }
+                else if (game.roomx == 116 && game.roomy == 103)
+                {
+                    int i = obj.getplayer();
+                    obj.entities[i].yp = 225;
+                    map.gotoroom(116, 100);
+                    game.teleport = false;
+                }
+                else if (game.roomx == 116 && game.roomy == 100)
+                {
+                    int i = obj.getplayer();
+                    obj.entities[i].xp = 0;
+                    map.gotoroom(114, 102);
+                    game.teleport = false;
+                }
+                else if (game.roomx == 114 && game.roomy == 102)
+                {
+                    int i = obj.getplayer();
+                    obj.entities[i].yp = 225;
+                    map.gotoroom(113, 100);
+                    game.teleport = false;
+                }
+                else if (game.roomx == 116 && game.roomy == 104)
+                {
+                    //pre warp zone here
+                    map.warpto(107, 101, obj.getplayer(), 14, 16);
+                }
+                else if (game.roomx == 107 && game.roomy == 101)
+                {
+                    map.warpto(105, 119, obj.getplayer(), 5, 26);
+                }
+                else if (game.roomx == 105 && game.roomy == 118)
+                {
+                    map.warpto(101, 111, obj.getplayer(), 34, 6);
+                }
+                else if (game.roomx == 101 && game.roomy == 111)
+                {
+                    //There are lots of warp tokens in this room, so we have to distinguish!
+                    switch(game.teleportxpos)
+                    {
+                    case 1:
+                        map.warpto(108, 108, obj.getplayer(), 4, 27);
+                        break;
+                    case 2:
+                        map.warpto(101, 111, obj.getplayer(), 12, 27);
+                        break;
+                    case 3:
+                        map.warpto(119, 111, obj.getplayer(), 31, 7);
+                        break;
+                    case 4:
+                        map.warpto(114, 117, obj.getplayer(), 19, 16);
+                        break;
+                    }
+                }
+                else if (game.roomx == 108 && game.roomy == 106)
+                {
+                    map.warpto(119, 111, obj.getplayer(), 4, 27);
+                }
+                else if (game.roomx == 100 && game.roomy == 111)
+                {
+                    map.warpto(101, 111, obj.getplayer(), 24, 6);
+                }
+                else if (game.roomx == 119 && game.roomy == 107)
+                {
+                    //Secret lab, to super gravitron
+                    map.warpto(119, 108, obj.getplayer(), 19, 10);
+                }
+                if (game.teleport == false)
+                {
+                    game.flashlight = 6;
+                    game.screenshake = 25;
+                }
+            }
         }
     }
     int j;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1044,12 +1044,9 @@ void gamelogic()
                     {
                         obj.entities[i].xp += 320;
                     }
-                    else
+                    else if (obj.entities[i].xp > 310)
                     {
-                        if (obj.entities[i].xp > 310)
-                        {
-                            obj.entities[i].xp -= 320;
-                        }
+                        obj.entities[i].xp -= 320;
                     }
                 }
             }
@@ -1064,12 +1061,9 @@ void gamelogic()
                     {
                         obj.entities[i].yp += 232;
                     }
-                    else
+                    else if (obj.entities[i].yp > 226)
                     {
-                        if (obj.entities[i].yp > 226)
-                        {
-                            obj.entities[i].yp -= 232;
-                        }
+                        obj.entities[i].yp -= 232;
                     }
                 }
             }
@@ -1088,12 +1082,9 @@ void gamelogic()
                         {
                             obj.entities[i].xp += 400;
                         }
-                        else
+                        else if (obj.entities[i].xp > 320)
                         {
-                            if (obj.entities[i].xp > 320)
-                            {
-                                obj.entities[i].xp -= 400;
-                            }
+                            obj.entities[i].xp -= 400;
                         }
                     }
                     else
@@ -1102,12 +1093,9 @@ void gamelogic()
                         {
                             obj.entities[i].xp += 320;
                         }
-                        else
+                        else if (obj.entities[i].xp > 310)
                         {
-                            if (obj.entities[i].xp > 310)
-                            {
-                                obj.entities[i].xp -= 320;
-                            }
+                            obj.entities[i].xp -= 320;
                         }
                     }
                 }
@@ -1134,12 +1122,9 @@ void gamelogic()
                     {
                         obj.entities[i].yp += 232;
                     }
-                    else
+                    else if (obj.entities[i].yp > 226)
                     {
-                        if (obj.entities[i].yp > 226)
-                        {
-                            obj.entities[i].yp -= 232;
-                        }
+                        obj.entities[i].yp -= 232;
                     }
                 }
             }
@@ -1154,12 +1139,9 @@ void gamelogic()
                     {
                         obj.entities[i].xp += 350;
                     }
-                    else
+                    else if (obj.entities[i].xp > 320)
                     {
-                        if (obj.entities[i].xp > 320)
-                        {
-                            obj.entities[i].xp -= 350;
-                        }
+                        obj.entities[i].xp -= 350;
                     }
                 }
             }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1045,10 +1045,12 @@ void gamelogic()
                         //ascii snakes
                         if (obj.entities[i].xp <= -80)
                         {
+                            if (obj.entities[i].isplatform) obj.removeblockat(obj.entities[i].xp, obj.entities[i].yp);
                             obj.entities[i].xp += 400;
                         }
                         else if (obj.entities[i].xp > 320)
                         {
+                            if (obj.entities[i].isplatform) obj.removeblockat(obj.entities[i].xp, obj.entities[i].yp);
                             obj.entities[i].xp -= 400;
                         }
                     }
@@ -1056,10 +1058,12 @@ void gamelogic()
                     {
                         if (obj.entities[i].xp <= -10)
                         {
+                            if (obj.entities[i].isplatform) obj.removeblockat(obj.entities[i].xp, obj.entities[i].yp);
                             obj.entities[i].xp += 320;
                         }
                         else if (obj.entities[i].xp > 310)
                         {
+                            if (obj.entities[i].isplatform) obj.removeblockat(obj.entities[i].xp, obj.entities[i].yp);
                             obj.entities[i].xp -= 320;
                         }
                     }
@@ -1074,10 +1078,12 @@ void gamelogic()
                 if(obj.entities[i].type<50){ //Don't warp warp lines
                     if (obj.entities[i].yp <= -12)
                     {
+                        if (obj.entities[i].isplatform) obj.removeblockat(obj.entities[i].xp, obj.entities[i].yp);
                         obj.entities[i].yp += 232;
                     }
                     else if (obj.entities[i].yp > 226)
                     {
+                        if (obj.entities[i].isplatform) obj.removeblockat(obj.entities[i].xp, obj.entities[i].yp);
                         obj.entities[i].yp -= 232;
                     }
                 }
@@ -1094,10 +1100,12 @@ void gamelogic()
                 {
                     if (obj.entities[i].xp <= -30)
                     {
+                        if (obj.entities[i].isplatform) obj.removeblockat(obj.entities[i].xp, obj.entities[i].yp);
                         obj.entities[i].xp += 350;
                     }
                     else if (obj.entities[i].xp > 320)
                     {
+                        if (obj.entities[i].isplatform) obj.removeblockat(obj.entities[i].xp, obj.entities[i].yp);
                         obj.entities[i].xp -= 350;
                     }
                 }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1033,42 +1033,7 @@ void gamelogic()
         }
 
         //Finally: Are we changing room?
-        if (map.warpx && map.warpy)
-        {
-            for (size_t i = 0; i < obj.entities.size();  i++)
-            {
-                if(obj.entities[i].type<50 //Don't warp warp lines
-                && obj.entities[i].size < 12)   //Don't wrap SWN enemies
-                {
-                    if (obj.entities[i].xp <= -10)
-                    {
-                        obj.entities[i].xp += 320;
-                    }
-                    else if (obj.entities[i].xp > 310)
-                    {
-                        obj.entities[i].xp -= 320;
-                    }
-                }
-            }
-
-            for (size_t i = 0; i < obj.entities.size();  i++)
-            {
-
-                if(obj.entities[i].type<50 //Don't warp warp lines
-                && obj.entities[i].size < 12)   //Don't wrap SWN enemies
-                {
-                    if (obj.entities[i].yp <= -12)
-                    {
-                        obj.entities[i].yp += 232;
-                    }
-                    else if (obj.entities[i].yp > 226)
-                    {
-                        obj.entities[i].yp -= 232;
-                    }
-                }
-            }
-        }
-        else if (map.warpx)
+        if (map.warpx)
         {
             for (size_t i = 0; i < obj.entities.size();  i++)
             {
@@ -1100,20 +1065,9 @@ void gamelogic()
                     }
                 }
             }
-
-            int player = obj.getplayer();
-            if (game.door_down > -2 && obj.entities[player].yp >= 238)
-            {
-                obj.entities[player].yp -= 240;
-                map.gotoroom(game.roomx, game.roomy + 1);
-            }
-            if (game.door_up > -2 && obj.entities[player].yp < -2)
-            {
-                obj.entities[player].yp += 240;
-                map.gotoroom(game.roomx, game.roomy - 1);
-            }
         }
-        else if (map.warpy)
+
+        if (map.warpy)
         {
             for (size_t i = 0; i < obj.entities.size();  i++)
             {
@@ -1128,7 +1082,10 @@ void gamelogic()
                     }
                 }
             }
+        }
 
+        if (map.warpy && !map.warpx)
+        {
             for (size_t i = 0; i < obj.entities.size();  i++)
             {
 
@@ -1145,20 +1102,9 @@ void gamelogic()
                     }
                 }
             }
-
-            int player = obj.getplayer();
-            if (game.door_left > -2 && obj.entities[player].xp < -14)
-            {
-                obj.entities[player].xp += 320;
-                map.gotoroom(game.roomx - 1, game.roomy);
-            }
-            if (game.door_right > -2 && obj.entities[player].xp >= 308)
-            {
-                obj.entities[player].xp -= 320;
-                map.gotoroom(game.roomx + 1, game.roomy);
-            }
         }
-        else
+
+        if (!map.warpy)
         {
             //Normal! Just change room
             int player = obj.getplayer();
@@ -1172,6 +1118,12 @@ void gamelogic()
                 obj.entities[player].yp += 240;
                 map.gotoroom(game.roomx, game.roomy - 1);
             }
+        }
+
+        if (!map.warpx)
+        {
+            //Normal! Just change room
+            int player = obj.getplayer();
             if (game.door_left > -2 && obj.entities[player].xp < -14)
             {
                 obj.entities[player].xp += 320;


### PR DESCRIPTION
## Changes:

* **Fix memory leak from warping moving platforms**

  When the game warps a moving platform, it doesn't remove the moving platform's old block from the position where it warped. That means that block is abandoned and will never be removed. Over time this can pile up, causing a huge memory leak.

  This would cause a crash on 2.2 and below, but in 2.3 it will simply cause the game to take up as much RAM as possible.

  In extreme cases, you can cause a massive memory leak that takes up a gig by strategically placing moving platforms, like in this example level:

  * [fast_platform_warping_crash.zip](https://github.com/TerryCavanagh/VVVVVV/files/4432326/fast_platform_warping_crash.zip)

* **Clean up some `gamelogic()` code**

  I de-duplicated some code, condensed if-statements and "else if"-statements, and fixed some indentation.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
