### PR TITLE
Don't update game.stat_trinkets in custom levels

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2521,7 +2521,7 @@ void entityclass::updateentities( int i )
                     if(music.currentsong!=-1) music.silencedasmusik();
                     music.playef(3);
                     collect[entities[i].para] = 1;
-                    if (game.trinkets > game.stat_trinkets)
+                    if (game.trinkets > game.stat_trinkets && !map.custommode)
                     {
                         game.stat_trinkets = game.trinkets;
                     }


### PR DESCRIPTION
## Changes:

* **Prevent `game.stat_trinkets` from being changed in in custom levels**

  Whenever you collect a trinket, `game.stat_trinkets` gets updated (if applicable) to signify the greatest amount of trinkets you have ever collected in the game. However, custom levels shouldn't be able to affect this, as their trinkets are not the same trinkets as the main game.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
