### PR TITLE
Don't boot user back to main menu after toggling using MMMMMM

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -751,8 +751,6 @@ void titleinput()
                             music.playef(11);
                             music.play(6);
                             game.savestats();
-                            game.createmenu("mainmenu");
-                            map.nexttowercolour();
                         }
                         if (game.currentmenuoption == 4)
                         {
@@ -814,8 +812,6 @@ void titleinput()
                             music.playef(11);
                             music.play(6);
                             game.savestats();
-                            game.createmenu("mainmenu");
-                            map.nexttowercolour();
                         }
                         if (game.currentmenuoption == 5)
                         {


### PR DESCRIPTION
## Changes:

* **Keep user in "game options" menu after toggling MMMMMM**

  It's a bit rude to put the user back at the main menu after toggling something. Maybe they also wanted to do something else in the menu while they're toggling MMMMMM, there's no reason to immediately put them back there.

  This is a patch that was added to VCE but not yet upstreamed, so I'm upstreaming it now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
