### PR TITLE
Don't use separate variables for tracking number of trinkets and crewmates

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -94,11 +94,6 @@ void entityclass::confirmflags()
     }
 }
 
-void entityclass::changecustomcollect( int t, int s )
-{
-    collect[t] = s;
-}
-
 int entityclass::swncolour( int t )
 {
     //given colour t, return colour in setcol

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2498,7 +2498,6 @@ void entityclass::updateentities( int i )
             //wait for collision
             if (entities[i].state == 1)
             {
-                game.coins++;
                 music.playef(4);
                 collect[entities[i].para] = 1;
 

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -94,12 +94,6 @@ void entityclass::confirmflags()
     }
 }
 
-void entityclass::changecollect( int t, int s )
-{
-    collect[t] = s;
-}
-
-
 void entityclass::changecustomcollect( int t, int s )
 {
     collect[t] = s;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -3129,7 +3129,6 @@ void entityclass::updateentities( int i )
             }
             else if (entities[i].state == 1)
             {
-                game.crewmates++;
                 if (game.intimetrial)
                 {
                     customcollect[entities[i].para] = 1;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2509,7 +2509,6 @@ void entityclass::updateentities( int i )
             //wait for collision
             if (entities[i].state == 1)
             {
-                game.trinkets++;
                 if (game.intimetrial)
                 {
                     collect[entities[i].para] = 1;
@@ -2521,9 +2520,9 @@ void entityclass::updateentities( int i )
                     if(music.currentsong!=-1) music.silencedasmusik();
                     music.playef(3);
                     collect[entities[i].para] = 1;
-                    if (game.trinkets > game.stat_trinkets && !map.custommode)
+                    if (game.trinkets() > game.stat_trinkets && !map.custommode)
                     {
-                        game.stat_trinkets = game.trinkets;
+                        game.stat_trinkets = game.trinkets();
                     }
                 }
 

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1958,7 +1958,7 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
 
         //Check if it's already been collected
         entity.para = vx;
-        if (customcollect[vx] == 1) return;
+        if (customcollect[vx]) return;
         break;
       case 56: //Custom enemy
         entity.rule = 1;
@@ -3098,7 +3098,7 @@ void entityclass::updateentities( int i )
             {
                 if (game.intimetrial)
                 {
-                    customcollect[entities[i].para] = 1;
+                    customcollect[entities[i].para] = true;
                     music.playef(27);
                 }
                 else
@@ -3107,7 +3107,7 @@ void entityclass::updateentities( int i )
                     //music.haltdasmusik();
                     if(music.currentsong!=-1) music.silencedasmusik();
                     music.playef(27);
-                    customcollect[entities[i].para] = 1;
+                    customcollect[entities[i].para] = true;
                 }
 
                 removeentity(i);

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -78,14 +78,6 @@ void entityclass::resetallflags()
     }
 }
 
-void entityclass::confirmflags()
-{
-    for (int i = 0; i < 100; i++)
-    {
-        if (flags[i] == 2) flags[i] = 1;
-    }
-}
-
 int entityclass::swncolour( int t )
 {
     //given colour t, return colour in setcol

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -78,14 +78,6 @@ void entityclass::resetallflags()
     }
 }
 
-void entityclass::resetflags()
-{
-    for (int i = 0; i < 100; i++)
-    {
-        if (flags[i] == 2) flags[i] = 0;
-    }
-}
-
 void entityclass::confirmflags()
 {
     for (int i = 0; i < 100; i++)

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -105,11 +105,6 @@ void entityclass::changecustomcollect( int t, int s )
     collect[t] = s;
 }
 
-void entityclass::changeflag( int t, bool s )
-{
-    flags[t] = s;
-}
-
 int entityclass::swncolour( int t )
 {
     //given colour t, return colour in setcol

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -74,7 +74,7 @@ void entityclass::resetallflags()
 {
     for (int i = 0; i < 100; i++)
     {
-        flags[i] = 0;
+        flags[i] = false;
     }
 }
 
@@ -105,7 +105,7 @@ void entityclass::changecustomcollect( int t, int s )
     collect[t] = s;
 }
 
-void entityclass::changeflag( int t, int s )
+void entityclass::changeflag( int t, bool s )
 {
     flags[t] = s;
 }

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1368,7 +1368,7 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
 
         //Check if it's already been collected
         entity.para = vx;
-        if (collect[vx] == 1) return;
+        if (collect[vx]) return;
         break;
     case 9: //Something Shiny
         entity.rule = 3;
@@ -1385,7 +1385,7 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
 
         //Check if it's already been collected
         entity.para = vx;
-        if (collect[vx] == 1) return;
+        if (collect[vx]) return;
         break;
     case 10: //Savepoint
         entity.rule = 3;
@@ -1607,7 +1607,7 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
 
         //Check if it's already been collected
         entity.para = vx;
-        if (collect[ (vx)] == 0) return;
+        if (!collect[ (vx)]) return;
         break;
     case 23: //SWN Enemies
         //Given a different behavior, these enemies are especially for SWN mode and disappear outside the screen.
@@ -2467,7 +2467,7 @@ void entityclass::updateentities( int i )
             if (entities[i].state == 1)
             {
                 music.playef(4);
-                collect[entities[i].para] = 1;
+                collect[entities[i].para] = true;
 
                 removeentity(i);
             }
@@ -2478,7 +2478,7 @@ void entityclass::updateentities( int i )
             {
                 if (game.intimetrial)
                 {
-                    collect[entities[i].para] = 1;
+                    collect[entities[i].para] = true;
                     music.playef(25);
                 }
                 else
@@ -2486,7 +2486,7 @@ void entityclass::updateentities( int i )
                     game.state = 1000;
                     if(music.currentsong!=-1) music.silencedasmusik();
                     music.playef(3);
-                    collect[entities[i].para] = 1;
+                    collect[entities[i].para] = true;
                     if (game.trinkets() > game.stat_trinkets && !map.custommode)
                     {
                         game.stat_trinkets = game.trinkets();

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -36,7 +36,7 @@ public:
 
     void changecustomcollect(int t, int s);
 
-    void changeflag(int t, int s);
+    void changeflag(int t, bool s);
 
     void fatal_top()
     {
@@ -194,7 +194,7 @@ public:
 
 
     std::vector<blockclass> blocks;
-    std::vector<int> flags;
+    std::vector<bool> flags;
     std::vector<int> collect;
     std::vector<int> customcollect;
 

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -32,8 +32,6 @@ public:
 
     void confirmflags();
 
-    void changecustomcollect(int t, int s);
-
     void fatal_top()
     {
         createblock(DAMAGE, -8, -8, 384, 16);

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -36,8 +36,6 @@ public:
 
     void changecustomcollect(int t, int s);
 
-    void changeflag(int t, bool s);
-
     void fatal_top()
     {
         createblock(DAMAGE, -8, -8, 384, 16);

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -185,7 +185,7 @@ public:
 
     std::vector<blockclass> blocks;
     std::vector<bool> flags;
-    std::vector<int> collect;
+    std::vector<bool> collect;
     std::vector<int> customcollect;
 
     bool skipblocks, skipdirblocks;

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -28,8 +28,6 @@ public:
 
     void resetallflags();
 
-    void resetflags();
-
     void confirmflags();
 
     void fatal_top()

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -32,8 +32,6 @@ public:
 
     void confirmflags();
 
-    void changecollect(int t, int s);
-
     void changecustomcollect(int t, int s);
 
     void fatal_top()

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -186,7 +186,7 @@ public:
     std::vector<blockclass> blocks;
     std::vector<bool> flags;
     std::vector<bool> collect;
-    std::vector<int> customcollect;
+    std::vector<bool> customcollect;
 
     bool skipblocks, skipdirblocks;
 

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -28,8 +28,6 @@ public:
 
     void resetallflags();
 
-    void confirmflags();
-
     void fatal_top()
     {
         createblock(DAMAGE, -8, -8, 384, 16);

--- a/desktop_version/src/Finalclass.cpp
+++ b/desktop_version/src/Finalclass.cpp
@@ -533,7 +533,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry)
 		obj.createentity(264, 168, 10, 1, 52410);  // (savepoint)
 		obj.createentity(152, 112, 20, 1);  // (terminal)
 
-		if(obj.flags[72] == 0)
+		if(!obj.flags[72])
 		{
 			if (game.intimetrial || game.nocutscenes)
 			{
@@ -1313,7 +1313,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry)
 
 		obj.createentity(264, 32, 10, 0, 54480);  // (savepoint)
 
-		/*if(!game.nocutscenes && obj.flags[71]==0){
+		/*if(!game.nocutscenes && !obj.flags[71]){
 		obj.createblock(1, 72, 0, 320, 240, 49);
 		}*/
 
@@ -1434,7 +1434,7 @@ std::vector<std::string> finalclass::loadlevel(int rx, int ry)
 
 		if(!game.intimetrial)
 		{
-			if(game.companion==0 && obj.flags[8]==0 && !game.crewstats[3])   //also need to check if he's rescued in a previous game
+			if(game.companion==0 && !obj.flags[8] && !game.crewstats[3])   //also need to check if he's rescued in a previous game
 			{
 				obj.createentity(264, 185, 18, 15, 1, 17, 0);
 				obj.createblock(1, 26*8, 0, 32, 240, 36);

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -2004,17 +2004,17 @@ void Game::updatestate()
                 graphics.addline("You have found a lost crewmate!");
                 graphics.textboxcenterx();
 
-                if(ed.numcrewmates-crewmates()==0)
+                if(ed.numcrewmates()-crewmates()==0)
                 {
                     graphics.createtextbox("     All crewmates rescued!    ", 50, 65, 174, 174, 174);
                 }
-                else if(ed.numcrewmates-crewmates()==1)
+                else if(ed.numcrewmates()-crewmates()==1)
                 {
-                    graphics.createtextbox("    " + help.number(ed.numcrewmates-crewmates())+ " remains    ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox("    " + help.number(ed.numcrewmates()-crewmates())+ " remains    ", 50, 65, 174, 174, 174);
                 }
                 else
                 {
-                    graphics.createtextbox("     " + help.number(ed.numcrewmates-crewmates())+ " remain    ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox("     " + help.number(ed.numcrewmates()-crewmates())+ " remain    ", 50, 65, 174, 174, 174);
                 }
                 graphics.textboxcenterx();
 
@@ -2026,17 +2026,17 @@ void Game::updatestate()
                 graphics.addline("You have found a lost crewmate!");
                 graphics.textboxcenterx();
 
-                if(ed.numcrewmates-crewmates()==0)
+                if(ed.numcrewmates()-crewmates()==0)
                 {
                     graphics.createtextbox("     All crewmates rescued!    ", 50, 135, 174, 174, 174);
                 }
-                else if(ed.numcrewmates-crewmates()==1)
+                else if(ed.numcrewmates()-crewmates()==1)
                 {
-                    graphics.createtextbox("    " + help.number(ed.numcrewmates-crewmates())+ " remains    ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox("    " + help.number(ed.numcrewmates()-crewmates())+ " remains    ", 50, 135, 174, 174, 174);
                 }
                 else
                 {
-                    graphics.createtextbox("     " + help.number(ed.numcrewmates-crewmates())+ " remain    ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox("     " + help.number(ed.numcrewmates()-crewmates())+ " remain    ", 50, 135, 174, 174, 174);
                 }
                 graphics.textboxcenterx();
             }
@@ -2048,7 +2048,7 @@ void Game::updatestate()
             completestop = false;
             state = 0;
 
-            if(ed.numcrewmates-crewmates()==0)
+            if(ed.numcrewmates()-crewmates()==0)
             {
                 if(map.custommodeforreal)
                 {
@@ -2085,7 +2085,7 @@ void Game::updatestate()
             map.tdrawback = true;
 #if !defined(NO_CUSTOM_LEVELS)
             //Update level stats
-            if(ed.numcrewmates-crewmates()==0)
+            if(ed.numcrewmates()-crewmates()==0)
             {
                 //Finished level
                 if(ed.numtrinkets()-trinkets()==0)

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7625,7 +7625,15 @@ void Game::resetgameclock()
 
 int Game::trinkets()
 {
-    return std::count(obj.collect.begin(), obj.collect.end(), true);
+    int temp = 0;
+    for (size_t i = 0; i < obj.collect.size(); i++)
+    {
+        if (obj.collect[i])
+        {
+            temp++;
+        }
+    }
+    return temp;
 }
 
 int Game::crewmates()

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4598,115 +4598,113 @@ void Game::savestats()
     msg->LinkEndChild( new TiXmlText( s_bestrank.c_str() ));
     dataNode->LinkEndChild( msg );
 
-    //for itoa ops
-    UtilityClass tu;
     msg = new TiXmlElement( "bestgamedeaths" );
-    msg->LinkEndChild( new TiXmlText( tu.String(bestgamedeaths).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(bestgamedeaths).c_str() ));
     dataNode->LinkEndChild( msg );
     msg = new TiXmlElement( "stat_trinkets" );
-    msg->LinkEndChild( new TiXmlText( tu.String(stat_trinkets).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(stat_trinkets).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "fullscreen" );
-    msg->LinkEndChild( new TiXmlText( tu.String(fullscreen).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(fullscreen).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "stretch" );
-    msg->LinkEndChild( new TiXmlText( tu.String(stretchMode).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(stretchMode).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "useLinearFilter" );
-    msg->LinkEndChild( new TiXmlText( tu.String(useLinearFilter).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(useLinearFilter).c_str()));
     dataNode->LinkEndChild( msg );
 
     int width, height;
     graphics.screenbuffer->GetWindowSize(&width, &height);
     msg = new TiXmlElement( "window_width" );
-    msg->LinkEndChild( new TiXmlText( tu.String(width).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(width).c_str()));
     dataNode->LinkEndChild( msg );
     msg = new TiXmlElement( "window_height" );
-    msg->LinkEndChild( new TiXmlText( tu.String(height).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(height).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "noflashingmode" );
-    msg->LinkEndChild( new TiXmlText( tu.String(noflashingmode).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(noflashingmode).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "colourblindmode" );
-    msg->LinkEndChild( new TiXmlText( tu.String(colourblindmode).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(colourblindmode).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "setflipmode" );
-    msg->LinkEndChild( new TiXmlText( tu.String(graphics.setflipmode).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(graphics.setflipmode).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "invincibility" );
-    msg->LinkEndChild( new TiXmlText( tu.String(map.invincibility).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(map.invincibility).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "slowdown" );
-    msg->LinkEndChild( new TiXmlText( tu.String(slowdown).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(slowdown).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "swnbestrank" );
-    msg->LinkEndChild( new TiXmlText( tu.String(swnbestrank).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(swnbestrank).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "swnrecord" );
-    msg->LinkEndChild( new TiXmlText( tu.String(swnrecord).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(swnrecord).c_str()));
     dataNode->LinkEndChild( msg );
 
 
     msg = new TiXmlElement( "advanced_mode" );
-    msg->LinkEndChild( new TiXmlText( tu.String(advanced_mode).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(advanced_mode).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement( "advanced_smoothing" );
-    msg->LinkEndChild( new TiXmlText( tu.String(fullScreenEffect_badSignal).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(fullScreenEffect_badSignal).c_str()));
     dataNode->LinkEndChild( msg );
 
 
     msg = new TiXmlElement( "usingmmmmmm" );
-    msg->LinkEndChild( new TiXmlText( tu.String(usingmmmmmm).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(usingmmmmmm).c_str()));
     dataNode->LinkEndChild( msg );
 
     msg = new TiXmlElement("skipfakeload");
-    msg->LinkEndChild(new TiXmlText(tu.String((int) skipfakeload).c_str()));
+    msg->LinkEndChild(new TiXmlText(help.String((int) skipfakeload).c_str()));
     dataNode->LinkEndChild(msg);
 
     msg = new TiXmlElement("notextoutline");
-    msg->LinkEndChild(new TiXmlText(tu.String((int) graphics.notextoutline).c_str()));
+    msg->LinkEndChild(new TiXmlText(help.String((int) graphics.notextoutline).c_str()));
     dataNode->LinkEndChild(msg);
 
     msg = new TiXmlElement("translucentroomname");
-    msg->LinkEndChild(new TiXmlText(tu.String((int) graphics.translucentroomname).c_str()));
+    msg->LinkEndChild(new TiXmlText(help.String((int) graphics.translucentroomname).c_str()));
     dataNode->LinkEndChild(msg);
 
     msg = new TiXmlElement("showmousecursor");
-    msg->LinkEndChild(new TiXmlText(tu.String((int)graphics.showmousecursor).c_str()));
+    msg->LinkEndChild(new TiXmlText(help.String((int)graphics.showmousecursor).c_str()));
     dataNode->LinkEndChild(msg);
 
     for (size_t i = 0; i < controllerButton_flip.size(); i += 1)
     {
         msg = new TiXmlElement("flipButton");
-        msg->LinkEndChild(new TiXmlText(tu.String((int) controllerButton_flip[i]).c_str()));
+        msg->LinkEndChild(new TiXmlText(help.String((int) controllerButton_flip[i]).c_str()));
         dataNode->LinkEndChild(msg);
     }
     for (size_t i = 0; i < controllerButton_map.size(); i += 1)
     {
         msg = new TiXmlElement("enterButton");
-        msg->LinkEndChild(new TiXmlText(tu.String((int) controllerButton_map[i]).c_str()));
+        msg->LinkEndChild(new TiXmlText(help.String((int) controllerButton_map[i]).c_str()));
         dataNode->LinkEndChild(msg);
     }
     for (size_t i = 0; i < controllerButton_esc.size(); i += 1)
     {
         msg = new TiXmlElement("escButton");
-        msg->LinkEndChild(new TiXmlText(tu.String((int) controllerButton_esc[i]).c_str()));
+        msg->LinkEndChild(new TiXmlText(help.String((int) controllerButton_esc[i]).c_str()));
         dataNode->LinkEndChild(msg);
     }
 
     msg = new TiXmlElement( "controllerSensitivity" );
-    msg->LinkEndChild( new TiXmlText( tu.String(controllerSensitivity).c_str()));
+    msg->LinkEndChild( new TiXmlText( help.String(controllerSensitivity).c_str()));
     dataNode->LinkEndChild( msg );
 
     FILESYSTEM_saveTiXmlDocument("saves/unlock.vvv", &doc);

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7604,7 +7604,15 @@ void Game::swnpenalty()
 
 int Game::crewrescued()
 {
-    return std::count(crewstats.begin(), crewstats.end(), true);
+    int temp = 0;
+    for (size_t i = 0; i < crewstats.size(); i++)
+    {
+        if (crewstats[i])
+        {
+            temp++;
+        }
+    }
+    return temp;
 }
 
 void Game::resetgameclock()

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -730,7 +730,7 @@ void Game::updatestate()
             obj.removetrigger(8);
             if (!obj.flags[13])
             {
-                obj.changeflag(13, true);
+                obj.flags[13] = true;
                 graphics.createtextbox("  Press ENTER to view map  ", -1, 155, 174, 174, 174);
                 graphics.addline("      and quicksave");
                 graphics.textboxtimer(60);
@@ -832,7 +832,7 @@ void Game::updatestate()
             obj.removetrigger(12);
             if (!obj.flags[61])
             {
-                obj.changeflag(61, true);
+                obj.flags[61] = true;
                 graphics.textboxremovefast();
                 graphics.createtextbox("  You can't continue to the next   ", -1, 8, 174, 174, 174);
                 if (lastsaved == 5)
@@ -911,7 +911,7 @@ void Game::updatestate()
         case 20:
             if (!obj.flags[1])
             {
-                obj.changeflag(1, true);
+                obj.flags[1] = true;
                 state = 0;
                 graphics.textboxremove();
             }
@@ -920,7 +920,7 @@ void Game::updatestate()
         case 21:
             if (!obj.flags[2])
             {
-                obj.changeflag(2, true);
+                obj.flags[2] = true;
                 state = 0;
                 graphics.textboxremove();
             }
@@ -930,7 +930,7 @@ void Game::updatestate()
             if (!obj.flags[3])
             {
                 graphics.textboxremovefast();
-                obj.changeflag(3, true);
+                obj.flags[3] = true;
                 state = 0;
                 graphics.createtextbox("  Press ACTION to flip  ", -1, 25, 174, 174, 174);
                 graphics.textboxtimer(60);
@@ -942,7 +942,7 @@ void Game::updatestate()
             //Generic "run script"
             if (!obj.flags[4])
             {
-                obj.changeflag(4, true);
+                obj.flags[4] = true;
                 startscript = true;
                 newscript="firststeps";
                 state = 0;
@@ -956,9 +956,9 @@ void Game::updatestate()
             statedelay = 0;
             if (!obj.flags[6])
             {
-                obj.changeflag(6, true);
+                obj.flags[6] = true;
 
-                obj.changeflag(5, true);
+                obj.flags[5] = true;
                 startscript = true;
                 newscript="communicationstation";
                 state = 0;
@@ -970,7 +970,7 @@ void Game::updatestate()
             //Generic "run script"
             if (!obj.flags[7])
             {
-                obj.changeflag(7, true);
+                obj.flags[7] = true;
                 startscript = true;
                 newscript="teleporterback";
                 state = 0;
@@ -982,7 +982,7 @@ void Game::updatestate()
             //Generic "run script"
             if (!obj.flags[9])
             {
-                obj.changeflag(9, true);
+                obj.flags[9] = true;
                 startscript = true;
                 newscript="rescueblue";
                 state = 0;
@@ -994,7 +994,7 @@ void Game::updatestate()
             //Generic "run script"
             if (!obj.flags[10])
             {
-                obj.changeflag(10, true);
+                obj.flags[10] = true;
                 startscript = true;
                 newscript="rescueyellow";
                 state = 0;
@@ -1006,7 +1006,7 @@ void Game::updatestate()
             //Generic "run script"
             if (!obj.flags[11])
             {
-                obj.changeflag(11, true);
+                obj.flags[11] = true;
                 startscript = true;
                 newscript="rescuegreen";
                 state = 0;
@@ -1018,7 +1018,7 @@ void Game::updatestate()
             //Generic "run script"
             if (!obj.flags[8])
             {
-                obj.changeflag(8, true);
+                obj.flags[8] = true;
                 startscript = true;
                 newscript="rescuered";
                 state = 0;
@@ -1076,7 +1076,7 @@ void Game::updatestate()
             //Generic "run script"
             if (!obj.flags[60])
             {
-                obj.changeflag(60, true);
+                obj.flags[60] = true;
                 startscript = true;
                 if (lastsaved == 2)
                 {
@@ -1103,7 +1103,7 @@ void Game::updatestate()
             //Generic "run script"
             if (!obj.flags[62])
             {
-                obj.changeflag(62, true);
+                obj.flags[62] = true;
                 startscript = true;
                 if (lastsaved == 2)
                 {
@@ -1130,7 +1130,7 @@ void Game::updatestate()
             //Generic "run script"
             if (!obj.flags[63])
             {
-                obj.changeflag(63, true);
+                obj.flags[63] = true;
                 startscript = true;
                 if (lastsaved == 2)
                 {
@@ -1157,7 +1157,7 @@ void Game::updatestate()
             //Generic "run script"
             if (!obj.flags[64])
             {
-                obj.changeflag(64, true);
+                obj.flags[64] = true;
                 startscript = true;
                 if (lastsaved == 2)
                 {
@@ -1184,7 +1184,7 @@ void Game::updatestate()
             //Generic "run script"
             if (!obj.flags[65])
             {
-                obj.changeflag(65, true);
+                obj.flags[65] = true;
                 startscript = true;
                 if (lastsaved == 2)
                 {
@@ -1211,7 +1211,7 @@ void Game::updatestate()
             //Generic "run script"
             if (!obj.flags[66])
             {
-                obj.changeflag(66, true);
+                obj.flags[66] = true;
                 startscript = true;
                 if (lastsaved == 2)
                 {
@@ -1239,7 +1239,7 @@ void Game::updatestate()
             //Generic "run script"
             if (!obj.flags[69])
             {
-                obj.changeflag(69, true);
+                obj.flags[69] = true;
                 startscript = true;
                 newscript="trenchwarfare";
                 state = 0;
@@ -1251,7 +1251,7 @@ void Game::updatestate()
             //Generic "run script"
             if (!obj.flags[70])
             {
-                obj.changeflag(70, true);
+                obj.flags[70] = true;
                 startscript = true;
                 newscript="trinketcollector";
                 state = 0;
@@ -1263,7 +1263,7 @@ void Game::updatestate()
             //Start final level music
             if (!obj.flags[71])
             {
-                obj.changeflag(71, true);
+                obj.flags[71] = true;
                 music.niceplay(15);  //Final level remix
                 state = 0;
             }
@@ -1482,7 +1482,7 @@ void Game::updatestate()
             obj.removetrigger(100);
             if (!obj.flags[4])
             {
-                obj.changeflag(4, true);
+                obj.flags[4] = true;
                 state++;
             }
             break;
@@ -1601,7 +1601,7 @@ void Game::updatestate()
             obj.removetrigger(120);
             if (!obj.flags[5])
             {
-                obj.changeflag(5, true);
+                obj.flags[5] = true;
                 state++;
             }
             break;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1992,6 +1992,7 @@ void Game::updatestate()
             state++;
             statedelay = 15;
             break;
+#if !defined(NO_CUSTOM_LEVELS)
         case 1011:
             //Found a crewmate!
             advancetext = true;
@@ -2003,17 +2004,17 @@ void Game::updatestate()
                 graphics.addline("You have found a lost crewmate!");
                 graphics.textboxcenterx();
 
-                if(int(map.customcrewmates-crewmates())==0)
+                if(int(ed.numcrewmates-crewmates())==0)
                 {
                     graphics.createtextbox("     All crewmates rescued!    ", 50, 65, 174, 174, 174);
                 }
-                else if(map.customcrewmates-crewmates()==1)
+                else if(ed.numcrewmates-crewmates()==1)
                 {
-                    graphics.createtextbox("    " + help.number(int(map.customcrewmates-crewmates()))+ " remains    ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox("    " + help.number(int(ed.numcrewmates-crewmates()))+ " remains    ", 50, 65, 174, 174, 174);
                 }
                 else
                 {
-                    graphics.createtextbox("     " + help.number(int(map.customcrewmates-crewmates()))+ " remain    ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox("     " + help.number(int(ed.numcrewmates-crewmates()))+ " remain    ", 50, 65, 174, 174, 174);
                 }
                 graphics.textboxcenterx();
 
@@ -2025,22 +2026,21 @@ void Game::updatestate()
                 graphics.addline("You have found a lost crewmate!");
                 graphics.textboxcenterx();
 
-                if(int(map.customcrewmates-crewmates())==0)
+                if(int(ed.numcrewmates-crewmates())==0)
                 {
                     graphics.createtextbox("     All crewmates rescued!    ", 50, 135, 174, 174, 174);
                 }
-                else if(map.customcrewmates-crewmates()==1)
+                else if(ed.numcrewmates-crewmates()==1)
                 {
-                    graphics.createtextbox("    " + help.number(int(map.customcrewmates-crewmates()))+ " remains    ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox("    " + help.number(int(ed.numcrewmates-crewmates()))+ " remains    ", 50, 135, 174, 174, 174);
                 }
                 else
                 {
-                    graphics.createtextbox("     " + help.number(int(map.customcrewmates-crewmates()))+ " remain    ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox("     " + help.number(int(ed.numcrewmates-crewmates()))+ " remain    ", 50, 135, 174, 174, 174);
                 }
                 graphics.textboxcenterx();
             }
             break;
-#if !defined(NO_CUSTOM_LEVELS)
         case 1013:
             graphics.textboxremove();
             hascontrol = true;
@@ -2048,7 +2048,7 @@ void Game::updatestate()
             completestop = false;
             state = 0;
 
-            if(map.customcrewmates-crewmates()==0)
+            if(ed.numcrewmates-crewmates()==0)
             {
                 if(map.custommodeforreal)
                 {
@@ -2083,10 +2083,10 @@ void Game::updatestate()
             music.play(6);
             graphics.backgrounddrawn = true;
             map.tdrawback = true;
-            //Update level stats
-            if(map.customcrewmates-crewmates()==0)
-            {
 #if !defined(NO_CUSTOM_LEVELS)
+            //Update level stats
+            if(ed.numcrewmates-crewmates()==0)
+            {
                 //Finished level
                 if(ed.numtrinkets-trinkets()==0)
                 {
@@ -2094,11 +2094,11 @@ void Game::updatestate()
                     updatecustomlevelstats(customlevelfilename, 3);
                 }
                 else
-#endif
                 {
                     updatecustomlevelstats(customlevelfilename, 1);
                 }
             }
+#endif
             createmenu("levellist");
             state = 0;
             break;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -728,9 +728,9 @@ void Game::updatestate()
         case 8:
             //Enter dialogue
             obj.removetrigger(8);
-            if (obj.flags[13] == 0)
+            if (!obj.flags[13])
             {
-                obj.changeflag(13, 1);
+                obj.changeflag(13, true);
                 graphics.createtextbox("  Press ENTER to view map  ", -1, 155, 174, 174, 174);
                 graphics.addline("      and quicksave");
                 graphics.textboxtimer(60);
@@ -830,9 +830,9 @@ void Game::updatestate()
         case 12:
             //Intermission 1 instructional textbox, depends on last saved
             obj.removetrigger(12);
-            if (obj.flags[61] == 0)
+            if (!obj.flags[61])
             {
-                obj.changeflag(61, 1);
+                obj.changeflag(61, true);
                 graphics.textboxremovefast();
                 graphics.createtextbox("  You can't continue to the next   ", -1, 8, 174, 174, 174);
                 if (lastsaved == 5)
@@ -909,28 +909,28 @@ void Game::updatestate()
             break;
 
         case 20:
-            if (obj.flags[1] == 0)
+            if (!obj.flags[1])
             {
-                obj.changeflag(1, 1);
+                obj.changeflag(1, true);
                 state = 0;
                 graphics.textboxremove();
             }
             obj.removetrigger(20);
             break;
         case 21:
-            if (obj.flags[2] == 0)
+            if (!obj.flags[2])
             {
-                obj.changeflag(2, 1);
+                obj.changeflag(2, true);
                 state = 0;
                 graphics.textboxremove();
             }
             obj.removetrigger(21);
             break;
         case 22:
-            if (obj.flags[3] == 0)
+            if (!obj.flags[3])
             {
                 graphics.textboxremovefast();
-                obj.changeflag(3, 1);
+                obj.changeflag(3, true);
                 state = 0;
                 graphics.createtextbox("  Press ACTION to flip  ", -1, 25, 174, 174, 174);
                 graphics.textboxtimer(60);
@@ -940,9 +940,9 @@ void Game::updatestate()
 
         case 30:
             //Generic "run script"
-            if (obj.flags[4] == 0)
+            if (!obj.flags[4])
             {
-                obj.changeflag(4, 1);
+                obj.changeflag(4, true);
                 startscript = true;
                 newscript="firststeps";
                 state = 0;
@@ -954,11 +954,11 @@ void Game::updatestate()
             //state = 55;  statedelay = 50;
             state = 0;
             statedelay = 0;
-            if (obj.flags[6] == 0)
+            if (!obj.flags[6])
             {
-                obj.changeflag(6, 1);
+                obj.changeflag(6, true);
 
-                obj.changeflag(5, 1);
+                obj.changeflag(5, true);
                 startscript = true;
                 newscript="communicationstation";
                 state = 0;
@@ -968,9 +968,9 @@ void Game::updatestate()
             break;
         case 32:
             //Generic "run script"
-            if (obj.flags[7] == 0)
+            if (!obj.flags[7])
             {
-                obj.changeflag(7, 1);
+                obj.changeflag(7, true);
                 startscript = true;
                 newscript="teleporterback";
                 state = 0;
@@ -980,9 +980,9 @@ void Game::updatestate()
             break;
         case 33:
             //Generic "run script"
-            if (obj.flags[9] == 0)
+            if (!obj.flags[9])
             {
-                obj.changeflag(9, 1);
+                obj.changeflag(9, true);
                 startscript = true;
                 newscript="rescueblue";
                 state = 0;
@@ -992,9 +992,9 @@ void Game::updatestate()
             break;
         case 34:
             //Generic "run script"
-            if (obj.flags[10] == 0)
+            if (!obj.flags[10])
             {
-                obj.changeflag(10, 1);
+                obj.changeflag(10, true);
                 startscript = true;
                 newscript="rescueyellow";
                 state = 0;
@@ -1004,9 +1004,9 @@ void Game::updatestate()
             break;
         case 35:
             //Generic "run script"
-            if (obj.flags[11] == 0)
+            if (!obj.flags[11])
             {
-                obj.changeflag(11, 1);
+                obj.changeflag(11, true);
                 startscript = true;
                 newscript="rescuegreen";
                 state = 0;
@@ -1016,9 +1016,9 @@ void Game::updatestate()
             break;
         case 36:
             //Generic "run script"
-            if (obj.flags[8] == 0)
+            if (!obj.flags[8])
             {
-                obj.changeflag(8, 1);
+                obj.changeflag(8, true);
                 startscript = true;
                 newscript="rescuered";
                 state = 0;
@@ -1074,9 +1074,9 @@ void Game::updatestate()
 
         case 41:
             //Generic "run script"
-            if (obj.flags[60] == 0)
+            if (!obj.flags[60])
             {
-                obj.changeflag(60, 1);
+                obj.changeflag(60, true);
                 startscript = true;
                 if (lastsaved == 2)
                 {
@@ -1101,9 +1101,9 @@ void Game::updatestate()
             break;
         case 42:
             //Generic "run script"
-            if (obj.flags[62] == 0)
+            if (!obj.flags[62])
             {
-                obj.changeflag(62, 1);
+                obj.changeflag(62, true);
                 startscript = true;
                 if (lastsaved == 2)
                 {
@@ -1128,9 +1128,9 @@ void Game::updatestate()
             break;
         case 43:
             //Generic "run script"
-            if (obj.flags[63] == 0)
+            if (!obj.flags[63])
             {
-                obj.changeflag(63, 1);
+                obj.changeflag(63, true);
                 startscript = true;
                 if (lastsaved == 2)
                 {
@@ -1155,9 +1155,9 @@ void Game::updatestate()
             break;
         case 44:
             //Generic "run script"
-            if (obj.flags[64] == 0)
+            if (!obj.flags[64])
             {
-                obj.changeflag(64, 1);
+                obj.changeflag(64, true);
                 startscript = true;
                 if (lastsaved == 2)
                 {
@@ -1182,9 +1182,9 @@ void Game::updatestate()
             break;
         case 45:
             //Generic "run script"
-            if (obj.flags[65] == 0)
+            if (!obj.flags[65])
             {
-                obj.changeflag(65, 1);
+                obj.changeflag(65, true);
                 startscript = true;
                 if (lastsaved == 2)
                 {
@@ -1209,9 +1209,9 @@ void Game::updatestate()
             break;
         case 46:
             //Generic "run script"
-            if (obj.flags[66] == 0)
+            if (!obj.flags[66])
             {
-                obj.changeflag(66, 1);
+                obj.changeflag(66, true);
                 startscript = true;
                 if (lastsaved == 2)
                 {
@@ -1237,9 +1237,9 @@ void Game::updatestate()
 
         case 47:
             //Generic "run script"
-            if (obj.flags[69] == 0)
+            if (!obj.flags[69])
             {
-                obj.changeflag(69, 1);
+                obj.changeflag(69, true);
                 startscript = true;
                 newscript="trenchwarfare";
                 state = 0;
@@ -1249,9 +1249,9 @@ void Game::updatestate()
             break;
         case 48:
             //Generic "run script"
-            if (obj.flags[70] == 0)
+            if (!obj.flags[70])
             {
-                obj.changeflag(70, 1);
+                obj.changeflag(70, true);
                 startscript = true;
                 newscript="trinketcollector";
                 state = 0;
@@ -1261,9 +1261,9 @@ void Game::updatestate()
             break;
         case 49:
             //Start final level music
-            if (obj.flags[71] == 0)
+            if (!obj.flags[71])
             {
-                obj.changeflag(71, 1);
+                obj.changeflag(71, true);
                 music.niceplay(15);  //Final level remix
                 state = 0;
             }
@@ -1404,7 +1404,7 @@ void Game::updatestate()
             state++;
             music.playef(9);
             music.play(2);
-            obj.flags[72] = 1;
+            obj.flags[72] = true;
 
             screenshake = 10;
             flashlight = 5;
@@ -1480,9 +1480,9 @@ void Game::updatestate()
             //                       Meeting crewmate in the warpzone
             //
             obj.removetrigger(100);
-            if (obj.flags[4] == 0)
+            if (!obj.flags[4])
             {
-                obj.changeflag(4, 1);
+                obj.changeflag(4, true);
                 state++;
             }
             break;
@@ -1599,9 +1599,9 @@ void Game::updatestate()
             //                       Meeting crewmate in the space station
             //
             obj.removetrigger(120);
-            if (obj.flags[5] == 0)
+            if (!obj.flags[5])
             {
-                obj.changeflag(5, 1);
+                obj.changeflag(5, true);
                 state++;
             }
             break;
@@ -1679,7 +1679,7 @@ void Game::updatestate()
             state++;
             music.playef(9);
             //music.play(2);
-            obj.flags[72] = 1;
+            obj.flags[72] = true;
 
             screenshake = 10;
             flashlight = 5;
@@ -2912,27 +2912,27 @@ void Game::updatestate()
             //change depending on when they get back to the ship.
             if (lastsaved == 2)
             {
-                if (crewstats[3]) obj.flags[25] = 1;
-                if (crewstats[4]) obj.flags[26] = 1;
-                if (crewstats[5]) obj.flags[24] = 1;
+                if (crewstats[3]) obj.flags[25] = true;
+                if (crewstats[4]) obj.flags[26] = true;
+                if (crewstats[5]) obj.flags[24] = true;
             }
             else if (lastsaved == 3)
             {
-                if (crewstats[2]) obj.flags[50] = 1;
-                if (crewstats[4]) obj.flags[49] = 1;
-                if (crewstats[5]) obj.flags[48] = 1;
+                if (crewstats[2]) obj.flags[50] = true;
+                if (crewstats[4]) obj.flags[49] = true;
+                if (crewstats[5]) obj.flags[48] = true;
             }
             else if (lastsaved == 4)
             {
-                if (crewstats[2]) obj.flags[54] = 1;
-                if (crewstats[3]) obj.flags[55] = 1;
-                if (crewstats[5]) obj.flags[56] = 1;
+                if (crewstats[2]) obj.flags[54] = true;
+                if (crewstats[3]) obj.flags[55] = true;
+                if (crewstats[5]) obj.flags[56] = true;
             }
             else if (lastsaved == 5)
             {
-                if (crewstats[2]) obj.flags[37] = 1;
-                if (crewstats[3]) obj.flags[38] = 1;
-                if (crewstats[4]) obj.flags[39] = 1;
+                if (crewstats[2]) obj.flags[37] = true;
+                if (crewstats[3]) obj.flags[38] = true;
+                if (crewstats[4]) obj.flags[39] = true;
             }
             //We're pitch black now, make a decision
             companion = 0;
@@ -2950,22 +2950,22 @@ void Game::updatestate()
 
                 startscript = true;
                 newscript = "intermission_1";
-                obj.flags[19] = 1;
-                if (lastsaved == 2) obj.flags[32] = 1;
-                if (lastsaved == 3) obj.flags[35] = 1;
-                if (lastsaved == 4) obj.flags[34] = 1;
-                if (lastsaved == 5) obj.flags[33] = 1;
+                obj.flags[19] = true;
+                if (lastsaved == 2) obj.flags[32] = true;
+                if (lastsaved == 3) obj.flags[35] = true;
+                if (lastsaved == 4) obj.flags[34] = true;
+                if (lastsaved == 5) obj.flags[33] = true;
                 state = 0;
             }
             else if (crewrescued() == 5)
             {
                 startscript = true;
                 newscript = "intermission_2";
-                obj.flags[20] = 1;
-                if (lastsaved == 2) obj.flags[32] = 1;
-                if (lastsaved == 3) obj.flags[35] = 1;
-                if (lastsaved == 4) obj.flags[34] = 1;
-                if (lastsaved == 5) obj.flags[33] = 1;
+                obj.flags[20] = true;
+                if (lastsaved == 2) obj.flags[32] = true;
+                if (lastsaved == 3) obj.flags[35] = true;
+                if (lastsaved == 4) obj.flags[34] = true;
+                if (lastsaved == 5) obj.flags[33] = true;
                 state = 0;
             }
             else
@@ -3222,7 +3222,7 @@ void Game::updatestate()
             break;
         case 3510:
             //Save stats and stuff here
-            if (obj.flags[73] == 0)
+            if (!obj.flags[73])
             {
                 //flip mode complete
                 NETWORK_unlockAchievement("vvvvvvgamecompleteflip");
@@ -3276,7 +3276,7 @@ void Game::updatestate()
             i = obj.getplayer();
             obj.entities[i].colour = 102;
 
-            obj.flags[67] = 1;
+            obj.flags[67] = true;
 
             state++;
             statedelay = 30;
@@ -4975,7 +4975,7 @@ void Game::loadquick()
                 obj.flags.clear();
                 for(size_t i = 0; i < values.size(); i++)
                 {
-                    obj.flags.push_back(atoi(values[i].c_str()));
+                    obj.flags.push_back((bool) atoi(values[i].c_str()));
                 }
             }
         }
@@ -5132,8 +5132,8 @@ void Game::loadquick()
     }
 
     map.showteleporters = true;
-    if(obj.flags[12]==1) map.showtargets = true;
-    if (obj.flags[42] == 1) map.showtrinkets = true;
+    if(obj.flags[12]) map.showtargets = true;
+    if (obj.flags[42]) map.showtrinkets = true;
 
 
 }
@@ -5193,7 +5193,7 @@ void Game::customloadquick(std::string savfile)
                 obj.flags.clear();
                 for(size_t i = 0; i < values.size(); i++)
                 {
-                    obj.flags.push_back(atoi(values[i].c_str()));
+                    obj.flags.push_back((bool) atoi(values[i].c_str()));
                 }
             }
         }
@@ -5382,8 +5382,8 @@ void Game::customloadquick(std::string savfile)
     }
 
     map.showteleporters = true;
-    if(obj.flags[12]==1) map.showtargets = true;
-    if (obj.flags[42] == 1) map.showtrinkets = true;
+    if(obj.flags[12]) map.showtargets = true;
+    if (obj.flags[42]) map.showtrinkets = true;
 
 }
 
@@ -5626,7 +5626,7 @@ void Game::savetele()
     std::string flags;
     for(size_t i = 0; i < obj.flags.size(); i++ )
     {
-        flags += help.String(obj.flags[i]) + ",";
+        flags += help.String((int) obj.flags[i]) + ",";
     }
     msg = new TiXmlElement( "flags" );
     msg->LinkEndChild( new TiXmlText( flags.c_str() ));
@@ -5823,7 +5823,7 @@ void Game::savequick()
     std::string flags;
     for(size_t i = 0; i < obj.flags.size(); i++ )
     {
-        flags += help.String(obj.flags[i]) + ",";
+        flags += help.String((int) obj.flags[i]) + ",";
     }
     msg = new TiXmlElement( "flags" );
     msg->LinkEndChild( new TiXmlText( flags.c_str() ));
@@ -6013,7 +6013,7 @@ void Game::customsavequick(std::string savfile)
     std::string flags;
     for(size_t i = 0; i < obj.flags.size(); i++ )
     {
-        flags += help.String(obj.flags[i]) + ",";
+        flags += help.String((int) obj.flags[i]) + ",";
     }
     msg = new TiXmlElement( "flags" );
     msg->LinkEndChild( new TiXmlText( flags.c_str() ));
@@ -6246,7 +6246,7 @@ void Game::loadtele()
                 obj.flags.clear();
                 for(size_t i = 0; i < values.size(); i++)
                 {
-                    obj.flags.push_back(atoi(values[i].c_str()));
+                    obj.flags.push_back((bool) atoi(values[i].c_str()));
                 }
             }
         }
@@ -6404,8 +6404,8 @@ void Game::loadtele()
     }
 
     map.showteleporters = true;
-    if(obj.flags[12]==1) map.showtargets = true;
-    if (obj.flags[42] == 1) map.showtrinkets = true;
+    if(obj.flags[12]) map.showtargets = true;
+    if (obj.flags[42]) map.showtrinkets = true;
 }
 
 std::string Game::unrescued()

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1943,7 +1943,7 @@ void Game::updatestate()
 #if !defined(NO_CUSTOM_LEVELS)
                 if(map.custommode)
                 {
-                    graphics.createtextbox(" " + help.number(trinkets()) + " out of " + help.number(ed.numtrinkets)+ " ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox(" " + help.number(trinkets()) + " out of " + help.number(ed.numtrinkets())+ " ", 50, 65, 174, 174, 174);
                     graphics.textboxcenterx();
                 }
                 else
@@ -1963,7 +1963,7 @@ void Game::updatestate()
 #if !defined(NO_CUSTOM_LEVELS)
                 if(map.custommode)
                 {
-                    graphics.createtextbox(" " + help.number(trinkets()) + " out of " + help.number(ed.numtrinkets)+ " ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox(" " + help.number(trinkets()) + " out of " + help.number(ed.numtrinkets())+ " ", 50, 135, 174, 174, 174);
                     graphics.textboxcenterx();
                 }
                 else
@@ -2088,7 +2088,7 @@ void Game::updatestate()
             if(ed.numcrewmates-crewmates()==0)
             {
                 //Finished level
-                if(ed.numtrinkets-trinkets()==0)
+                if(ed.numtrinkets()-trinkets()==0)
                 {
                     //and got all the trinkets!
                     updatecustomlevelstats(customlevelfilename, 3);

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4729,8 +4729,6 @@ void Game::customstart()
     savepoint = 0;
     gravitycontrol = savegc;
 
-    coins = 0;
-
     //state = 2; deathseq = -1; lifeseq = 10; //Not dead, in game initilisation state
     state = 0;
     deathseq = -1;
@@ -4754,8 +4752,6 @@ void Game::start()
     //savex = 6 * 8; savey = 15 * 8; saverx = 46; savery = 54; savegc = 0; savedir = 1; //Final Level Current
     savepoint = 0;
     gravitycontrol = savegc;
-
-    coins = 0;
 
     //state = 2; deathseq = -1; lifeseq = 10; //Not dead, in game initilisation state
     state = 0;
@@ -4852,7 +4848,6 @@ void Game::startspecial( int t )
 
     savepoint = 0;
     gravitycontrol = savegc;
-    coins = 0;
     state = 0;
     deathseq = -1;
     lifeseq = 0;
@@ -4923,8 +4918,6 @@ void Game::starttrial( int t )
 
     savepoint = 0;
     gravitycontrol = savegc;
-
-    coins = 0;
 
     //state = 2; deathseq = -1; lifeseq = 10; //Not dead, in game initilisation state
     state = 0;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1350,16 +1350,16 @@ void Game::updatestate()
             timetrialresulttime = seconds + (minutes * 60);
             timetrialrank = 0;
             if (timetrialresulttime <= timetrialpar) timetrialrank++;
-            if (trinkets >= timetrialshinytarget) timetrialrank++;
+            if (trinkets() >= timetrialshinytarget) timetrialrank++;
             if (deathcounts == 0) timetrialrank++;
 
             if (timetrialresulttime < besttimes[timetriallevel] || besttimes[timetriallevel]==-1)
             {
                 besttimes[timetriallevel] = timetrialresulttime;
             }
-            if (trinkets > besttrinkets[timetriallevel] || besttrinkets[timetriallevel]==-1)
+            if (trinkets() > besttrinkets[timetriallevel] || besttrinkets[timetriallevel]==-1)
             {
-                besttrinkets[timetriallevel] = trinkets;
+                besttrinkets[timetriallevel] = trinkets();
             }
             if (deathcounts < bestlives[timetriallevel] || bestlives[timetriallevel]==-1)
             {
@@ -1942,12 +1942,12 @@ void Game::updatestate()
 
                 if(map.custommode)
                 {
-                    graphics.createtextbox(" " + help.number(trinkets) + " out of " + help.number(map.customtrinkets)+ " ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox(" " + help.number(trinkets()) + " out of " + help.number(map.customtrinkets)+ " ", 50, 65, 174, 174, 174);
                     graphics.textboxcenterx();
                 }
                 else
                 {
-                    graphics.createtextbox(" " + help.number(trinkets) + " out of Twenty ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox(" " + help.number(trinkets()) + " out of Twenty ", 50, 65, 174, 174, 174);
                     graphics.textboxcenterx();
                 }
             }
@@ -1960,12 +1960,12 @@ void Game::updatestate()
 
                 if(map.custommode)
                 {
-                    graphics.createtextbox(" " + help.number(trinkets) + " out of " + help.number(map.customtrinkets)+ " ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox(" " + help.number(trinkets()) + " out of " + help.number(map.customtrinkets)+ " ", 50, 135, 174, 174, 174);
                     graphics.textboxcenterx();
                 }
                 else
                 {
-                    graphics.createtextbox(" " + help.number(trinkets) + " out of Twenty ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox(" " + help.number(trinkets()) + " out of Twenty ", 50, 135, 174, 174, 174);
                     graphics.textboxcenterx();
                 }
             }
@@ -2083,7 +2083,7 @@ void Game::updatestate()
             if(map.customcrewmates-crewmates==0)
             {
                 //Finished level
-                if(map.customtrinkets-trinkets==0)
+                if(map.customtrinkets-trinkets()==0)
                 {
                     //and got all the trinkets!
                     updatecustomlevelstats(customlevelfilename, 3);
@@ -3114,7 +3114,7 @@ void Game::updatestate()
             state++;
             statedelay = 45;
 
-            std::string tempstring = help.number(trinkets);
+            std::string tempstring = help.number(trinkets());
             if (graphics.flipmode)
             {
                 graphics.createtextbox("Trinkets Found:", 48, 155-24, 0,0,0);
@@ -4724,7 +4724,6 @@ void Game::customstart()
     gravitycontrol = savegc;
 
     coins = 0;
-    trinkets = 0;
 
     //state = 2; deathseq = -1; lifeseq = 10; //Not dead, in game initilisation state
     state = 0;
@@ -4751,7 +4750,6 @@ void Game::start()
     gravitycontrol = savegc;
 
     coins = 0;
-    trinkets = 0;
 
     //state = 2; deathseq = -1; lifeseq = 10; //Not dead, in game initilisation state
     state = 0;
@@ -4849,7 +4847,6 @@ void Game::startspecial( int t )
     savepoint = 0;
     gravitycontrol = savegc;
     coins = 0;
-    trinkets = 0;
     state = 0;
     deathseq = -1;
     lifeseq = 0;
@@ -4922,7 +4919,6 @@ void Game::starttrial( int t )
     gravitycontrol = savegc;
 
     coins = 0;
-    trinkets = 0;
     crewmates = 0;
 
     //state = 2; deathseq = -1; lifeseq = 10; //Not dead, in game initilisation state
@@ -5062,10 +5058,6 @@ void Game::loadquick()
         else if (pKey == "savepoint")
         {
             savepoint = atoi(pText);
-        }
-        else if (pKey == "trinkets")
-        {
-            trinkets = atoi(pText);
         }
         else if (pKey == "companion")
         {
@@ -5326,10 +5318,6 @@ void Game::customloadquick(std::string savfile)
         else if (pKey == "savepoint")
         {
             savepoint = atoi(pText);
-        }
-        else if (pKey == "trinkets")
-        {
-            trinkets = atoi(pText);
         }
         else if (pKey == "crewmates")
         {
@@ -5711,7 +5699,7 @@ void Game::savetele()
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "trinkets" );
-    msg->LinkEndChild( new TiXmlText( help.String(trinkets).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(trinkets()).c_str() ));
     msgs->LinkEndChild( msg );
 
 
@@ -5908,7 +5896,7 @@ void Game::savequick()
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "trinkets" );
-    msg->LinkEndChild( new TiXmlText( help.String(trinkets).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(trinkets()).c_str() ));
     msgs->LinkEndChild( msg );
 
 
@@ -6116,7 +6104,7 @@ void Game::customsavequick(std::string savfile)
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "trinkets" );
-    msg->LinkEndChild( new TiXmlText( help.String(trinkets).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(trinkets()).c_str() ));
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "crewmates" );
@@ -6360,10 +6348,6 @@ void Game::loadtele()
         else if (pKey == "savepoint")
         {
             savepoint = atoi(pText);
-        }
-        else if (pKey == "trinkets")
-        {
-            trinkets = atoi(pText);
         }
         else if (pKey == "companion")
         {
@@ -7653,4 +7637,9 @@ void Game::resetgameclock()
     minutes = 0;
     hours = 0;
     timerStartTime = SDL_GetTicks();
+}
+
+int Game::trinkets()
+{
+    return std::count(obj.collect.begin(), obj.collect.end(), 1);
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1940,12 +1940,14 @@ void Game::updatestate()
                 graphics.addline("You have found a shiny trinket!");
                 graphics.textboxcenterx();
 
+#if !defined(NO_CUSTOM_LEVELS)
                 if(map.custommode)
                 {
-                    graphics.createtextbox(" " + help.number(trinkets()) + " out of " + help.number(map.customtrinkets)+ " ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox(" " + help.number(trinkets()) + " out of " + help.number(ed.numtrinkets)+ " ", 50, 65, 174, 174, 174);
                     graphics.textboxcenterx();
                 }
                 else
+#endif
                 {
                     graphics.createtextbox(" " + help.number(trinkets()) + " out of Twenty ", 50, 65, 174, 174, 174);
                     graphics.textboxcenterx();
@@ -1958,12 +1960,14 @@ void Game::updatestate()
                 graphics.addline("You have found a shiny trinket!");
                 graphics.textboxcenterx();
 
+#if !defined(NO_CUSTOM_LEVELS)
                 if(map.custommode)
                 {
-                    graphics.createtextbox(" " + help.number(trinkets()) + " out of " + help.number(map.customtrinkets)+ " ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox(" " + help.number(trinkets()) + " out of " + help.number(ed.numtrinkets)+ " ", 50, 135, 174, 174, 174);
                     graphics.textboxcenterx();
                 }
                 else
+#endif
                 {
                     graphics.createtextbox(" " + help.number(trinkets()) + " out of Twenty ", 50, 135, 174, 174, 174);
                     graphics.textboxcenterx();
@@ -2082,13 +2086,15 @@ void Game::updatestate()
             //Update level stats
             if(map.customcrewmates-crewmates()==0)
             {
+#if !defined(NO_CUSTOM_LEVELS)
                 //Finished level
-                if(map.customtrinkets-trinkets()==0)
+                if(ed.numtrinkets-trinkets()==0)
                 {
                     //and got all the trinkets!
                     updatecustomlevelstats(customlevelfilename, 3);
                 }
                 else
+#endif
                 {
                     updatecustomlevelstats(customlevelfilename, 1);
                 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -2004,17 +2004,17 @@ void Game::updatestate()
                 graphics.addline("You have found a lost crewmate!");
                 graphics.textboxcenterx();
 
-                if(int(ed.numcrewmates-crewmates())==0)
+                if(ed.numcrewmates-crewmates()==0)
                 {
                     graphics.createtextbox("     All crewmates rescued!    ", 50, 65, 174, 174, 174);
                 }
                 else if(ed.numcrewmates-crewmates()==1)
                 {
-                    graphics.createtextbox("    " + help.number(int(ed.numcrewmates-crewmates()))+ " remains    ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox("    " + help.number(ed.numcrewmates-crewmates())+ " remains    ", 50, 65, 174, 174, 174);
                 }
                 else
                 {
-                    graphics.createtextbox("     " + help.number(int(ed.numcrewmates-crewmates()))+ " remain    ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox("     " + help.number(ed.numcrewmates-crewmates())+ " remain    ", 50, 65, 174, 174, 174);
                 }
                 graphics.textboxcenterx();
 
@@ -2026,17 +2026,17 @@ void Game::updatestate()
                 graphics.addline("You have found a lost crewmate!");
                 graphics.textboxcenterx();
 
-                if(int(ed.numcrewmates-crewmates())==0)
+                if(ed.numcrewmates-crewmates()==0)
                 {
                     graphics.createtextbox("     All crewmates rescued!    ", 50, 135, 174, 174, 174);
                 }
                 else if(ed.numcrewmates-crewmates()==1)
                 {
-                    graphics.createtextbox("    " + help.number(int(ed.numcrewmates-crewmates()))+ " remains    ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox("    " + help.number(ed.numcrewmates-crewmates())+ " remains    ", 50, 135, 174, 174, 174);
                 }
                 else
                 {
-                    graphics.createtextbox("     " + help.number(int(ed.numcrewmates-crewmates()))+ " remain    ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox("     " + help.number(ed.numcrewmates-crewmates())+ " remain    ", 50, 135, 174, 174, 174);
                 }
                 graphics.textboxcenterx();
             }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -122,8 +122,6 @@ void Game::init(void)
     globalsound = 128;
     m_globalVol = 1.0f;
 
-    timerStartTime= SDL_GetTicks();
-
     glitchrunkludge = false;
     hascontrol = true;
     jumpheld = false;
@@ -7630,7 +7628,6 @@ void Game::resetgameclock()
     seconds = 0;
     minutes = 0;
     hours = 0;
-    timerStartTime = SDL_GetTicks();
 }
 
 int Game::trinkets()

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5248,7 +5248,7 @@ void Game::customloadquick(std::string savfile)
                 obj.customcollect.clear();
                 for(size_t i = 0; i < values.size(); i++)
                 {
-                    obj.customcollect.push_back(atoi(values[i].c_str()));
+                    obj.customcollect.push_back((bool) atoi(values[i].c_str()));
                 }
             }
         }
@@ -6049,7 +6049,7 @@ void Game::customsavequick(std::string savfile)
     std::string customcollect;
     for(size_t i = 0; i < obj.customcollect.size(); i++ )
     {
-        customcollect += help.String(obj.customcollect[i]) + ",";
+        customcollect += help.String((int) obj.customcollect[i]) + ",";
     }
     msg = new TiXmlElement( "customcollect" );
     msg->LinkEndChild( new TiXmlText( customcollect.c_str() ));
@@ -7622,5 +7622,5 @@ int Game::trinkets()
 
 int Game::crewmates()
 {
-    return std::count(obj.customcollect.begin(), obj.customcollect.end(), 1);
+    return std::count(obj.customcollect.begin(), obj.customcollect.end(), true);
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7638,5 +7638,13 @@ int Game::trinkets()
 
 int Game::crewmates()
 {
-    return std::count(obj.customcollect.begin(), obj.customcollect.end(), true);
+    int temp = 0;
+    for (size_t i = 0; i < obj.customcollect.size(); i++)
+    {
+        if (obj.customcollect[i])
+        {
+            temp++;
+        }
+    }
+    return temp;
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5003,7 +5003,7 @@ void Game::loadquick()
                 obj.collect.clear();
                 for(size_t i = 0; i < values.size(); i++)
                 {
-                    obj.collect.push_back(atoi(values[i].c_str()));
+                    obj.collect.push_back((bool) atoi(values[i].c_str()));
                 }
             }
         }
@@ -5234,7 +5234,7 @@ void Game::customloadquick(std::string savfile)
                 obj.collect.clear();
                 for(size_t i = 0; i < values.size(); i++)
                 {
-                    obj.collect.push_back(atoi(values[i].c_str()));
+                    obj.collect.push_back((bool) atoi(values[i].c_str()));
                 }
             }
         }
@@ -5644,7 +5644,7 @@ void Game::savetele()
     std::string collect;
     for(size_t i = 0; i < obj.collect.size(); i++ )
     {
-        collect += help.String(obj.collect[i]) + ",";
+        collect += help.String((int) obj.collect[i]) + ",";
     }
     msg = new TiXmlElement( "collect" );
     msg->LinkEndChild( new TiXmlText( collect.c_str() ));
@@ -5841,7 +5841,7 @@ void Game::savequick()
     std::string collect;
     for(size_t i = 0; i < obj.collect.size(); i++ )
     {
-        collect += help.String(obj.collect[i]) + ",";
+        collect += help.String((int) obj.collect[i]) + ",";
     }
     msg = new TiXmlElement( "collect" );
     msg->LinkEndChild( new TiXmlText( collect.c_str() ));
@@ -6040,7 +6040,7 @@ void Game::customsavequick(std::string savfile)
     std::string collect;
     for(size_t i = 0; i < obj.collect.size(); i++ )
     {
-        collect += help.String(obj.collect[i]) + ",";
+        collect += help.String((int) obj.collect[i]) + ",";
     }
     msg = new TiXmlElement( "collect" );
     msg->LinkEndChild( new TiXmlText( collect.c_str() ));
@@ -6274,7 +6274,7 @@ void Game::loadtele()
                 obj.collect.clear();
                 for(size_t i = 0; i < values.size(); i++)
                 {
-                    obj.collect.push_back(atoi(values[i].c_str()));
+                    obj.collect.push_back((bool) atoi(values[i].c_str()));
                 }
             }
         }
@@ -7617,7 +7617,7 @@ void Game::resetgameclock()
 
 int Game::trinkets()
 {
-    return std::count(obj.collect.begin(), obj.collect.end(), 1);
+    return std::count(obj.collect.begin(), obj.collect.end(), true);
 }
 
 int Game::crewmates()

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1999,17 +1999,17 @@ void Game::updatestate()
                 graphics.addline("You have found a lost crewmate!");
                 graphics.textboxcenterx();
 
-                if(int(map.customcrewmates-crewmates)==0)
+                if(int(map.customcrewmates-crewmates())==0)
                 {
                     graphics.createtextbox("     All crewmates rescued!    ", 50, 65, 174, 174, 174);
                 }
-                else if(map.customcrewmates-crewmates==1)
+                else if(map.customcrewmates-crewmates()==1)
                 {
-                    graphics.createtextbox("    " + help.number(int(map.customcrewmates-crewmates))+ " remains    ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox("    " + help.number(int(map.customcrewmates-crewmates()))+ " remains    ", 50, 65, 174, 174, 174);
                 }
                 else
                 {
-                    graphics.createtextbox("     " + help.number(int(map.customcrewmates-crewmates))+ " remain    ", 50, 65, 174, 174, 174);
+                    graphics.createtextbox("     " + help.number(int(map.customcrewmates-crewmates()))+ " remain    ", 50, 65, 174, 174, 174);
                 }
                 graphics.textboxcenterx();
 
@@ -2021,17 +2021,17 @@ void Game::updatestate()
                 graphics.addline("You have found a lost crewmate!");
                 graphics.textboxcenterx();
 
-                if(int(map.customcrewmates-crewmates)==0)
+                if(int(map.customcrewmates-crewmates())==0)
                 {
                     graphics.createtextbox("     All crewmates rescued!    ", 50, 135, 174, 174, 174);
                 }
-                else if(map.customcrewmates-crewmates==1)
+                else if(map.customcrewmates-crewmates()==1)
                 {
-                    graphics.createtextbox("    " + help.number(int(map.customcrewmates-crewmates))+ " remains    ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox("    " + help.number(int(map.customcrewmates-crewmates()))+ " remains    ", 50, 135, 174, 174, 174);
                 }
                 else
                 {
-                    graphics.createtextbox("     " + help.number(int(map.customcrewmates-crewmates))+ " remain    ", 50, 135, 174, 174, 174);
+                    graphics.createtextbox("     " + help.number(int(map.customcrewmates-crewmates()))+ " remain    ", 50, 135, 174, 174, 174);
                 }
                 graphics.textboxcenterx();
             }
@@ -2044,7 +2044,7 @@ void Game::updatestate()
             completestop = false;
             state = 0;
 
-            if(map.customcrewmates-crewmates==0)
+            if(map.customcrewmates-crewmates()==0)
             {
                 if(map.custommodeforreal)
                 {
@@ -2080,7 +2080,7 @@ void Game::updatestate()
             graphics.backgrounddrawn = true;
             map.tdrawback = true;
             //Update level stats
-            if(map.customcrewmates-crewmates==0)
+            if(map.customcrewmates-crewmates()==0)
             {
                 //Finished level
                 if(map.customtrinkets-trinkets()==0)
@@ -4919,7 +4919,6 @@ void Game::starttrial( int t )
     gravitycontrol = savegc;
 
     coins = 0;
-    crewmates = 0;
 
     //state = 2; deathseq = -1; lifeseq = 10; //Not dead, in game initilisation state
     state = 0;
@@ -5318,10 +5317,6 @@ void Game::customloadquick(std::string savfile)
         else if (pKey == "savepoint")
         {
             savepoint = atoi(pText);
-        }
-        else if (pKey == "crewmates")
-        {
-            crewmates = atoi(pText);
         }
         else if (pKey == "companion")
         {
@@ -6108,7 +6103,7 @@ void Game::customsavequick(std::string savfile)
     msgs->LinkEndChild( msg );
 
     msg = new TiXmlElement( "crewmates" );
-    msg->LinkEndChild( new TiXmlText( help.String(crewmates).c_str() ));
+    msg->LinkEndChild( new TiXmlText( help.String(crewmates()).c_str() ));
     msgs->LinkEndChild( msg );
 
 
@@ -7642,4 +7637,9 @@ void Game::resetgameclock()
 int Game::trinkets()
 {
     return std::count(obj.collect.begin(), obj.collect.end(), 1);
+}
+
+int Game::crewmates()
+{
+    return std::count(obj.customcollect.begin(), obj.customcollect.end(), 1);
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7606,20 +7606,7 @@ void Game::swnpenalty()
 
 int Game::crewrescued()
 {
-    int temp = 0;
-    if (crewstats[0])
-        temp++;
-    if (crewstats[1])
-        temp++;
-    if (crewstats[2])
-        temp++;
-    if (crewstats[3])
-        temp++;
-    if (crewstats[4])
-        temp++;
-    if (crewstats[5])
-        temp++;
-    return temp;
+    return std::count(crewstats.begin(), crewstats.end(), true);
 }
 
 void Game::resetgameclock()

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -240,7 +240,8 @@ public:
     int deathseq, lifeseq;
 
     int trinkets(), crewmates();
-    int savepoint, teleport, teleportxpos;
+    int savepoint, teleportxpos;
+    bool teleport;
     int edteleportent;
     bool completestop;
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -247,7 +247,7 @@ public:
 
     int deathseq, lifeseq;
 
-    int coins, trinkets(), crewmates, trinkencollect;
+    int coins, trinkets(), crewmates(), trinkencollect;
     int savepoint, teleport, teleportxpos;
     int edteleportent;
     bool completestop;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -247,7 +247,7 @@ public:
 
     int deathseq, lifeseq;
 
-    int coins, trinkets(), crewmates();
+    int trinkets(), crewmates();
     int savepoint, teleport, teleportxpos;
     int edteleportent;
     bool completestop;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -247,7 +247,7 @@ public:
 
     int deathseq, lifeseq;
 
-    int coins, trinkets, crewmates, trinkencollect;
+    int coins, trinkets(), crewmates, trinkencollect;
     int savepoint, teleport, teleportxpos;
     int edteleportent;
     bool completestop;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -222,12 +222,6 @@ public:
     bool fullscreen;
     int bestgamedeaths;
 
-    bool stat_screenshakes;
-    bool stat_backgrounds;
-    bool stat_flipmode;
-    bool stat_invincibility;
-    int stat_slowdown;
-
 
     std::vector<int>besttimes;
     std::vector<int>besttrinkets;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -238,7 +238,8 @@ public:
 
     int deathseq, lifeseq;
 
-    int trinkets(), crewmates();
+    int trinkets();
+    int crewmates();
     int savepoint, teleportxpos;
     bool teleport;
     int edteleportent;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -216,8 +216,6 @@ public:
 
     std::vector<int> unlock;
     std::vector<int> unlocknotify;
-    std::vector<int> temp_unlock;
-    std::vector<int> temp_unlocknotify;
     int stat_trinkets;
     bool fullscreen;
     int bestgamedeaths;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -247,7 +247,7 @@ public:
 
     int deathseq, lifeseq;
 
-    int coins, trinkets(), crewmates(), trinkencollect;
+    int coins, trinkets(), crewmates();
     int savepoint, teleport, teleportxpos;
     int edteleportent;
     bool completestop;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -136,7 +136,6 @@ public:
     //public var crewstats:Array = new Array();
     int lastsaved;
     int deathcounts;
-    int timerStartTime;
 
     int frames, seconds, minutes, hours;
     bool gamesaved;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2117,7 +2117,7 @@ void mapinput()
 
             game.savetime = game.timestring();
             game.savearea = map.currentarea(map.area(game.roomx, game.roomy));
-            game.savetrinkets = game.trinkets;
+            game.savetrinkets = game.trinkets();
 
             if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111) game.savearea = "The Ship";
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1755,7 +1755,7 @@ void gameinput()
                     {
                         if(!graphics.flipmode)
                         {
-                            obj.flags[73] = 1; //Flip mode test
+                            obj.flags[73] = true; //Flip mode test
                         }
                         if(int(std::abs(obj.entities[ie].vx))<=1 && int(obj.entities[ie].vy)==0)
                         {
@@ -2086,7 +2086,7 @@ void mapinput()
             game.menupage++;
         }
 
-        if (game.menupage == 1 && obj.flags[67] == 1 && game.press_action && !game.insecretlab && !map.custommode)
+        if (game.menupage == 1 && obj.flags[67] && game.press_action && !game.insecretlab && !map.custommode)
         {
             //Warp back to the ship
             graphics.resumegamemode = true;

--- a/desktop_version/src/Labclass.cpp
+++ b/desktop_version/src/Labclass.cpp
@@ -1766,7 +1766,7 @@ std::vector<std::string> labclass::loadlevel(int rx, int ry)
 
 		if(!game.intimetrial)
 		{
-			if(game.companion==0 && obj.flags[9]==0 &&  !game.crewstats[5])   //also need to check if he's rescued in a previous game
+			if(game.companion==0 && !obj.flags[9] &&  !game.crewstats[5])   //also need to check if he's rescued in a previous game
 			{
 				obj.createentity(32, 177, 18, 16, 1, 17, 1);
 				obj.createblock(1, 24*8, 0, 32, 240, 33);

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1333,7 +1333,7 @@ void gamelogic()
                 //intermission 2, choose colour based on lastsaved
                 if (game.roomy == 51)
                 {
-                    if (obj.flags[59] == 0)
+                    if (!obj.flags[59])
                     {
                         obj.createentity(225.0f, 169.0f, 18, graphics.crewcolour(game.lastsaved), 0, 10);
                         j = obj.getcompanion();
@@ -1343,7 +1343,7 @@ void gamelogic()
                 }
                 else	if (game.roomy >= 52)
                 {
-                    if (obj.flags[59] == 1)
+                    if (obj.flags[59])
                     {
                         obj.createentity(160.0f, 177.0f, 18, graphics.crewcolour(game.lastsaved), 0, 18, 1);
                         j = obj.getcompanion();
@@ -1352,7 +1352,7 @@ void gamelogic()
                     }
                     else
                     {
-                        obj.flags[59] = 1;
+                        obj.flags[59] = true;
                         obj.createentity(obj.entities[i].xp, -20.0f, 18.0f, graphics.crewcolour(game.lastsaved), 0, 10, 0);
                         j = obj.getcompanion();
                         obj.entities[j].vx = obj.entities[i].vx;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -42,7 +42,6 @@ mapclass::mapclass()
 
 	custommode=false;
 	custommodeforreal=false;
-	customtrinkets=0;
 	customx=0; customy=0;
 	customwidth=20; customheight=20;
 	custommmxoff=0; custommmyoff=0; custommmxsize=0; custommmysize=0;
@@ -1732,7 +1731,6 @@ void mapclass::loadlevel(int rx, int ry)
 			}
 			}
 
-		customtrinkets=ed.numtrinkets;
 		customcrewmates=ed.numcrewmates;
 
 		//do the appear/remove roomname here

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1731,8 +1731,6 @@ void mapclass::loadlevel(int rx, int ry)
 			}
 			}
 
-		customcrewmates=ed.numcrewmates;
-
 		//do the appear/remove roomname here
 		break;
 #endif

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1060,7 +1060,7 @@ void mapclass::gotoroom(int rx, int ry)
 	//textbox thingy. if tag five is not set when changing room, reset the game state. (tag 5 is set when you get back to the ship)
 	if(!game.intimetrial && !custommode)
 	{
-		if (obj.flags[5] == 0 && !finalmode)
+		if (!obj.flags[5] && !finalmode)
 		{
 			game.state = 0;
 			if (game.roomx == 113 && game.roomy == 104)

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -134,7 +134,6 @@ public:
     bool custommodeforreal;
     int customx, customy;
     int customwidth, customheight;
-    int customcrewmates;
     int custommmxoff, custommmyoff, custommmxsize, custommmysize;
     int customzoom;
     bool customshowmm;

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -134,7 +134,6 @@ public:
     bool custommodeforreal;
     int customx, customy;
     int customwidth, customheight;
-    int customtrinkets;
     int customcrewmates;
     int custommmxoff, custommmyoff, custommmxsize, custommmysize;
     int customzoom;

--- a/desktop_version/src/Otherlevel.cpp
+++ b/desktop_version/src/Otherlevel.cpp
@@ -1415,7 +1415,7 @@ std::vector<std::string> otherlevelclass::loadlevel(int rx, int ry)
 			obj.createentity(136, 80, 22, 18);  // (shiny trinket)
 			obj.createentity(136, 32, 22, 19);  // (shiny trinket)
 
-			if(!game.nocutscenes && obj.flags[70]==0)
+			if(!game.nocutscenes && !obj.flags[70])
 			{
 				obj.createblock(1, 304, 0, 16, 240, 48);
 			}

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2245,11 +2245,13 @@ void maprender()
         graphics.Print(185-12, 220, "[STATS]", 196, 196, 255 - help.glow);
         graphics.Print(258, 220, "SAVE", 64, 64, 64);
 
-        if(map.custommode){
+#if !defined(NO_CUSTOM_LEVELS)
+        if(map.custommode)
+        {
           if (graphics.flipmode)
           {
               graphics.Print(0, 164, "[Trinkets found]", 196, 196, 255 - help.glow, true);
-              graphics.Print(0, 152, help.number(game.trinkets()) + " out of " + help.number(map.customtrinkets), 96,96,96, true);
+              graphics.Print(0, 152, help.number(game.trinkets()) + " out of " + help.number(ed.numtrinkets), 96,96,96, true);
 
               graphics.Print(0, 114, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
               graphics.Print(0, 102,help.String(game.deathcounts),  96,96,96, true);
@@ -2260,7 +2262,7 @@ void maprender()
           else
           {
               graphics.Print(0, 52, "[Trinkets found]", 196, 196, 255 - help.glow, true);
-              graphics.Print(0, 64, help.number(game.trinkets()) + " out of "+help.number(map.customtrinkets), 96,96,96, true);
+              graphics.Print(0, 64, help.number(game.trinkets()) + " out of "+help.number(ed.numtrinkets), 96,96,96, true);
 
               graphics.Print(0, 102, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
               graphics.Print(0, 114,help.String(game.deathcounts),  96,96,96, true);
@@ -2268,7 +2270,10 @@ void maprender()
               graphics.Print(0, 152, "[Time Taken]", 196, 196, 255 - help.glow, true);
               graphics.Print(0, 164, game.timestring(),  96, 96, 96, true);
           }
-        }else{
+        }
+        else
+#endif
+        {
           if (graphics.flipmode)
           {
               graphics.Print(0, 164, "[Trinkets found]", 196, 196, 255 - help.glow, true);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2028,7 +2028,7 @@ void maprender()
             {
                 for (int i = 0; i < map.numshinytrinkets; i++)
                 {
-                    if (obj.collect[i] == 0)
+                    if (!obj.collect[i])
                     {
                         int temp = 1086;
                         if (graphics.flipmode) temp += 3;
@@ -2839,7 +2839,7 @@ void teleporterrender()
     {
         for (int i = 0; i < map.numshinytrinkets; i++)
         {
-            if (obj.collect[i] == 0)
+            if (!obj.collect[i])
             {
                 temp = 1086;
                 if (graphics.flipmode) temp += 3;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -649,7 +649,7 @@ void titlerender()
             tempstring = "You rescued " + help.number(game.crewrescued()) + " crewmates";
             graphics.Print(0, 100, tempstring, tr, tg, tb, true);
 
-            tempstring = "and found " + help.number(game.trinkets) + " trinkets.";
+            tempstring = "and found " + help.number(game.trinkets()) + " trinkets.";
             graphics.Print(0, 110, tempstring, tr, tg, tb, true);
 
             tempstring = "You managed to reach:";
@@ -700,7 +700,7 @@ void titlerender()
             std::string tempstring = "You rescued all the crewmates!";
             graphics.Print(0, 100, tempstring, tr, tg, tb, true);
 
-            tempstring = "And you found " + help.number(game.trinkets) + " trinkets.";
+            tempstring = "And you found " + help.number(game.trinkets()) + " trinkets.";
             graphics.Print(0, 110, tempstring, tr, tg, tb, true);
 
             graphics.Print(0, 160, "A new trophy has been awarded and", tr, tg, tb, true);
@@ -731,11 +731,11 @@ void titlerender()
                 graphics.Print(220, 85+20, "+1 Rank!", 255, 255, 255);
             }
 
-            tempstring = help.String(game.trinkets) + " of " + help.String(game.timetrialshinytarget);
+            tempstring = help.String(game.trinkets()) + " of " + help.String(game.timetrialshinytarget);
             graphics.drawspritesetcol(30, 80+55, 22, 22);
             graphics.Print(65, 80+55, "SHINY TRINKETS:", 255, 255, 255);
             graphics.Print(65, 90+55, tempstring, tr, tg, tb);
-            if (game.trinkets >= game.timetrialshinytarget)
+            if (game.trinkets() >= game.timetrialshinytarget)
             {
                 graphics.Print(220, 85+55, "+1 Rank!", 255, 255, 255);
             }
@@ -1675,13 +1675,13 @@ void gamerender()
             {
                 graphics.bprint(56, 30,help.String(game.deathcounts),  196, 196, 196);
             }
-            if(game.trinkets<game.timetrialshinytarget)
+            if(game.trinkets()<game.timetrialshinytarget)
             {
-                graphics.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 80, 80);
+                graphics.bprint(56, 42,help.String(game.trinkets()) + " of " +help.String(game.timetrialshinytarget),  196, 80, 80);
             }
             else
             {
-                graphics.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 196, 196);
+                graphics.bprint(56, 42,help.String(game.trinkets()) + " of " +help.String(game.timetrialshinytarget),  196, 196, 196);
             }
 
             if(game.timetrialparlost)
@@ -2249,7 +2249,7 @@ void maprender()
           if (graphics.flipmode)
           {
               graphics.Print(0, 164, "[Trinkets found]", 196, 196, 255 - help.glow, true);
-              graphics.Print(0, 152, help.number(game.trinkets) + " out of " + help.number(map.customtrinkets), 96,96,96, true);
+              graphics.Print(0, 152, help.number(game.trinkets()) + " out of " + help.number(map.customtrinkets), 96,96,96, true);
 
               graphics.Print(0, 114, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
               graphics.Print(0, 102,help.String(game.deathcounts),  96,96,96, true);
@@ -2260,7 +2260,7 @@ void maprender()
           else
           {
               graphics.Print(0, 52, "[Trinkets found]", 196, 196, 255 - help.glow, true);
-              graphics.Print(0, 64, help.number(game.trinkets) + " out of "+help.number(map.customtrinkets), 96,96,96, true);
+              graphics.Print(0, 64, help.number(game.trinkets()) + " out of "+help.number(map.customtrinkets), 96,96,96, true);
 
               graphics.Print(0, 102, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
               graphics.Print(0, 114,help.String(game.deathcounts),  96,96,96, true);
@@ -2272,7 +2272,7 @@ void maprender()
           if (graphics.flipmode)
           {
               graphics.Print(0, 164, "[Trinkets found]", 196, 196, 255 - help.glow, true);
-              graphics.Print(0, 152, help.number(game.trinkets) + " out of Twenty", 96,96,96, true);
+              graphics.Print(0, 152, help.number(game.trinkets()) + " out of Twenty", 96,96,96, true);
 
               graphics.Print(0, 114, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
               graphics.Print(0, 102,help.String(game.deathcounts),  96,96,96, true);
@@ -2283,7 +2283,7 @@ void maprender()
           else
           {
               graphics.Print(0, 52, "[Trinkets found]", 196, 196, 255 - help.glow, true);
-              graphics.Print(0, 64, help.number(game.trinkets) + " out of Twenty", 96,96,96, true);
+              graphics.Print(0, 64, help.number(game.trinkets()) + " out of Twenty", 96,96,96, true);
 
               graphics.Print(0, 102, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
               graphics.Print(0, 114,help.String(game.deathcounts),  96,96,96, true);
@@ -2708,13 +2708,13 @@ void towerrender()
             {
                 graphics.bprint(56, 30,help.String(game.deathcounts),  196, 196, 196);
             }
-            if(game.trinkets<game.timetrialshinytarget)
+            if(game.trinkets()<game.timetrialshinytarget)
             {
-                graphics.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 80, 80);
+                graphics.bprint(56, 42,help.String(game.trinkets()) + " of " +help.String(game.timetrialshinytarget),  196, 80, 80);
             }
             else
             {
-                graphics.bprint(56, 42,help.String(game.trinkets) + " of " +help.String(game.timetrialshinytarget),  196, 196, 196);
+                graphics.bprint(56, 42,help.String(game.trinkets()) + " of " +help.String(game.timetrialshinytarget),  196, 196, 196);
             }
 
             if(game.timetrialparlost)

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1795,7 +1795,7 @@ void maprender()
         {
             graphics.Print(103, 220, "GRAV", 64, 64, 64);
         }
-        else if (obj.flags[67] == 1 && !map.custommode)
+        else if (obj.flags[67] && !map.custommode)
         {
             graphics.Print(103, 220, "SHIP", 64,64,64);
         }
@@ -2113,7 +2113,7 @@ void maprender()
                 }
             }
         }
-        else if (obj.flags[67] == 1 && !map.custommode)
+        else if (obj.flags[67] && !map.custommode)
         {
             graphics.Print(30, 220, "MAP", 64,64,64);
             graphics.Print(103-8, 220, "[SHIP]", 196, 196, 255 - help.glow);
@@ -2234,7 +2234,7 @@ void maprender()
         {
             graphics.Print(103, 220, "GRAV", 64, 64, 64);
         }
-        else if (obj.flags[67] == 1 && !map.custommode)
+        else if (obj.flags[67] && !map.custommode)
         {
             graphics.Print(103, 220, "SHIP", 64,64,64);
         }
@@ -2304,7 +2304,7 @@ void maprender()
         {
             graphics.Print(103, 220, "GRAV", 64, 64, 64);
         }
-        else if (obj.flags[67] == 1 && !map.custommode)
+        else if (obj.flags[67] && !map.custommode)
         {
             graphics.Print(103, 220, "SHIP", 64,64,64);
         }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2138,10 +2138,10 @@ void maprender()
                 graphics.Print( -1, 220-110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
                 graphics.Print( -1, 220-120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
 
-                if(map.customcrewmates-game.crewmates==1){
-                    graphics.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmate remains", 196, 196, 255 - help.glow, true);
-                }else if(map.customcrewmates-game.crewmates>0){
-                    graphics.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmates remain", 196, 196, 255 - help.glow, true);
+                if(map.customcrewmates-game.crewmates()==1){
+                    graphics.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates()))+ " crewmate remains", 196, 196, 255 - help.glow, true);
+                }else if(map.customcrewmates-game.crewmates()>0){
+                    graphics.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates()))+ " crewmates remain", 196, 196, 255 - help.glow, true);
                 }
             }
             else
@@ -2153,10 +2153,10 @@ void maprender()
                 graphics.Print( -1, 110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
                 graphics.Print( -1, 120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
 
-                if(map.customcrewmates-game.crewmates==1){
-                    graphics.Print(1,165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmate remains", 196, 196, 255 - help.glow, true);
-                }else if(map.customcrewmates-game.crewmates>0){
-                    graphics.Print(1,165, help.number(int(map.customcrewmates-game.crewmates))+ " crewmates remain", 196, 196, 255 - help.glow, true);
+                if(map.customcrewmates-game.crewmates()==1){
+                    graphics.Print(1,165, help.number(int(map.customcrewmates-game.crewmates()))+ " crewmate remains", 196, 196, 255 - help.glow, true);
+                }else if(map.customcrewmates-game.crewmates()>0){
+                    graphics.Print(1,165, help.number(int(map.customcrewmates-game.crewmates()))+ " crewmates remain", 196, 196, 255 - help.glow, true);
                 }
             }
         }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2138,10 +2138,10 @@ void maprender()
                 graphics.Print( -1, 220-110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
                 graphics.Print( -1, 220-120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
 
-                if(map.customcrewmates-game.crewmates()==1){
-                    graphics.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates()))+ " crewmate remains", 196, 196, 255 - help.glow, true);
-                }else if(map.customcrewmates-game.crewmates()>0){
-                    graphics.Print(1,220-165, help.number(int(map.customcrewmates-game.crewmates()))+ " crewmates remain", 196, 196, 255 - help.glow, true);
+                if(ed.numcrewmates-game.crewmates()==1){
+                    graphics.Print(1,220-165, help.number(int(ed.numcrewmates-game.crewmates()))+ " crewmate remains", 196, 196, 255 - help.glow, true);
+                }else if(ed.numcrewmates-game.crewmates()>0){
+                    graphics.Print(1,220-165, help.number(int(ed.numcrewmates-game.crewmates()))+ " crewmates remain", 196, 196, 255 - help.glow, true);
                 }
             }
             else
@@ -2153,10 +2153,10 @@ void maprender()
                 graphics.Print( -1, 110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
                 graphics.Print( -1, 120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
 
-                if(map.customcrewmates-game.crewmates()==1){
-                    graphics.Print(1,165, help.number(int(map.customcrewmates-game.crewmates()))+ " crewmate remains", 196, 196, 255 - help.glow, true);
-                }else if(map.customcrewmates-game.crewmates()>0){
-                    graphics.Print(1,165, help.number(int(map.customcrewmates-game.crewmates()))+ " crewmates remain", 196, 196, 255 - help.glow, true);
+                if(ed.numcrewmates-game.crewmates()==1){
+                    graphics.Print(1,165, help.number(int(ed.numcrewmates-game.crewmates()))+ " crewmate remains", 196, 196, 255 - help.glow, true);
+                }else if(ed.numcrewmates-game.crewmates()>0){
+                    graphics.Print(1,165, help.number(int(ed.numcrewmates-game.crewmates()))+ " crewmates remain", 196, 196, 255 - help.glow, true);
                 }
             }
         }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2251,7 +2251,7 @@ void maprender()
           if (graphics.flipmode)
           {
               graphics.Print(0, 164, "[Trinkets found]", 196, 196, 255 - help.glow, true);
-              graphics.Print(0, 152, help.number(game.trinkets()) + " out of " + help.number(ed.numtrinkets), 96,96,96, true);
+              graphics.Print(0, 152, help.number(game.trinkets()) + " out of " + help.number(ed.numtrinkets()), 96,96,96, true);
 
               graphics.Print(0, 114, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
               graphics.Print(0, 102,help.String(game.deathcounts),  96,96,96, true);
@@ -2262,7 +2262,7 @@ void maprender()
           else
           {
               graphics.Print(0, 52, "[Trinkets found]", 196, 196, 255 - help.glow, true);
-              graphics.Print(0, 64, help.number(game.trinkets()) + " out of "+help.number(ed.numtrinkets), 96,96,96, true);
+              graphics.Print(0, 64, help.number(game.trinkets()) + " out of "+help.number(ed.numtrinkets()), 96,96,96, true);
 
               graphics.Print(0, 102, "[Number of Deaths]", 196, 196, 255 - help.glow, true);
               graphics.Print(0, 114,help.String(game.deathcounts),  96,96,96, true);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2139,9 +2139,9 @@ void maprender()
                 graphics.Print( -1, 220-120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
 
                 if(ed.numcrewmates-game.crewmates()==1){
-                    graphics.Print(1,220-165, help.number(int(ed.numcrewmates-game.crewmates()))+ " crewmate remains", 196, 196, 255 - help.glow, true);
+                    graphics.Print(1,220-165, help.number(ed.numcrewmates-game.crewmates())+ " crewmate remains", 196, 196, 255 - help.glow, true);
                 }else if(ed.numcrewmates-game.crewmates()>0){
-                    graphics.Print(1,220-165, help.number(int(ed.numcrewmates-game.crewmates()))+ " crewmates remain", 196, 196, 255 - help.glow, true);
+                    graphics.Print(1,220-165, help.number(ed.numcrewmates-game.crewmates())+ " crewmates remain", 196, 196, 255 - help.glow, true);
                 }
             }
             else
@@ -2154,9 +2154,9 @@ void maprender()
                 graphics.Print( -1, 120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
 
                 if(ed.numcrewmates-game.crewmates()==1){
-                    graphics.Print(1,165, help.number(int(ed.numcrewmates-game.crewmates()))+ " crewmate remains", 196, 196, 255 - help.glow, true);
+                    graphics.Print(1,165, help.number(ed.numcrewmates-game.crewmates())+ " crewmate remains", 196, 196, 255 - help.glow, true);
                 }else if(ed.numcrewmates-game.crewmates()>0){
-                    graphics.Print(1,165, help.number(int(ed.numcrewmates-game.crewmates()))+ " crewmates remain", 196, 196, 255 - help.glow, true);
+                    graphics.Print(1,165, help.number(ed.numcrewmates-game.crewmates())+ " crewmates remain", 196, 196, 255 - help.glow, true);
                 }
             }
         }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2138,10 +2138,10 @@ void maprender()
                 graphics.Print( -1, 220-110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
                 graphics.Print( -1, 220-120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
 
-                if(ed.numcrewmates-game.crewmates()==1){
-                    graphics.Print(1,220-165, help.number(ed.numcrewmates-game.crewmates())+ " crewmate remains", 196, 196, 255 - help.glow, true);
-                }else if(ed.numcrewmates-game.crewmates()>0){
-                    graphics.Print(1,220-165, help.number(ed.numcrewmates-game.crewmates())+ " crewmates remain", 196, 196, 255 - help.glow, true);
+                if(ed.numcrewmates()-game.crewmates()==1){
+                    graphics.Print(1,220-165, help.number(ed.numcrewmates()-game.crewmates())+ " crewmate remains", 196, 196, 255 - help.glow, true);
+                }else if(ed.numcrewmates()-game.crewmates()>0){
+                    graphics.Print(1,220-165, help.number(ed.numcrewmates()-game.crewmates())+ " crewmates remain", 196, 196, 255 - help.glow, true);
                 }
             }
             else
@@ -2153,10 +2153,10 @@ void maprender()
                 graphics.Print( -1, 110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
                 graphics.Print( -1, 120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
 
-                if(ed.numcrewmates-game.crewmates()==1){
-                    graphics.Print(1,165, help.number(ed.numcrewmates-game.crewmates())+ " crewmate remains", 196, 196, 255 - help.glow, true);
-                }else if(ed.numcrewmates-game.crewmates()>0){
-                    graphics.Print(1,165, help.number(ed.numcrewmates-game.crewmates())+ " crewmates remain", 196, 196, 255 - help.glow, true);
+                if(ed.numcrewmates()-game.crewmates()==1){
+                    graphics.Print(1,165, help.number(ed.numcrewmates()-game.crewmates())+ " crewmate remains", 196, 196, 255 - help.glow, true);
+                }else if(ed.numcrewmates()-game.crewmates()>0){
+                    graphics.Print(1,165, help.number(ed.numcrewmates()-game.crewmates())+ " crewmates remain", 196, 196, 255 - help.glow, true);
                 }
             }
         }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -194,9 +194,9 @@ void scriptclass::run()
 			{
 				if(ss_toi(words[1])>=0 && ss_toi(words[1])<100){
 					if(words[2]=="on"){
-						obj.changeflag(ss_toi(words[1]),true);
+						obj.flags[ss_toi(words[1])] = true;
 					}else if(words[2]=="off"){
-						obj.changeflag(ss_toi(words[1]),false);
+						obj.flags[ss_toi(words[1])] = false;
 					}
 				}
 			}

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -155,7 +155,7 @@ void scriptclass::run()
 			}
 			if (words[0] == "customiftrinkets")
 			{
-				if (game.trinkets >= ss_toi(words[1]))
+				if (game.trinkets() >= ss_toi(words[1]))
 				{
 					load("custom_"+words[2]);
 					position--;
@@ -163,7 +163,7 @@ void scriptclass::run()
 			}
 			if (words[0] == "customiftrinketsless")
 			{
-				if (game.trinkets < ss_toi(words[1]))
+				if (game.trinkets() < ss_toi(words[1]))
 				{
 					load("custom_"+words[2]);
 					position--;
@@ -1321,7 +1321,7 @@ void scriptclass::run()
 			}
 			else if (words[0] == "iftrinkets")
 			{
-				if (game.trinkets >= ss_toi(words[1]))
+				if (game.trinkets() >= ss_toi(words[1]))
 				{
 					load(words[2]);
 					position--;
@@ -1466,7 +1466,6 @@ void scriptclass::run()
 				i = obj.getplayer();
 				obj.entities[i].tile = 0;
 
-				game.trinkets = 0;
 				game.crewmates=0;
 				for (i = 0; i < 100; i++)
 				{
@@ -1879,7 +1878,6 @@ void scriptclass::run()
 				music.haltdasmusik();
 				music.playef(3);
 
-				game.trinkets++;
 				obj.collect[ss_toi(words[1])] = 1;
 
 				graphics.textboxremovefast();
@@ -1898,7 +1896,7 @@ void scriptclass::run()
 				{
 					usethisnum = "Twenty";
 				}
-				graphics.createtextbox(" " + help.number(game.trinkets) + " out of " + usethisnum + " ", 50, 135, 174, 174, 174);
+				graphics.createtextbox(" " + help.number(game.trinkets()) + " out of " + usethisnum + " ", 50, 135, 174, 174, 174);
 				graphics.textboxcenterx();
 
 				if (!game.backgroundtext)
@@ -2040,12 +2038,12 @@ void scriptclass::run()
 			}
 			else if (words[0] == "trinketbluecontrol")
 			{
-				if (game.trinkets == 20 && obj.flags[67] == 1)
+				if (game.trinkets() == 20 && obj.flags[67] == 1)
 				{
 					load("talkblue_trinket6");
 					position--;
 				}
-				else if (game.trinkets >= 19 && obj.flags[67] == 0)
+				else if (game.trinkets() >= 19 && obj.flags[67] == 0)
 				{
 					load("talkblue_trinket5");
 					position--;
@@ -2058,7 +2056,7 @@ void scriptclass::run()
 			}
 			else if (words[0] == "trinketyellowcontrol")
 			{
-				if (game.trinkets >= 19)
+				if (game.trinkets() >= 19)
 				{
 					load("talkyellow_trinket3");
 					position--;
@@ -2257,7 +2255,7 @@ void scriptclass::run()
 					else
 					{
 						//Ok, we've already dealt with the trinket thing; so either you have them all, or you don't. If you do:
-						if (game.trinkets >= 20)
+						if (game.trinkets() >= 20)
 						{
 							load("startepilogue");
 							position--;
@@ -2862,7 +2860,6 @@ void scriptclass::startgamemode( int t )
 				map.explored[i + (j * 20)] = 1;
 			}
 		}
-		game.trinkets = 20;
 		game.insecretlab = true;
 		map.showteleporters = true;
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -171,7 +171,7 @@ void scriptclass::run()
 			}
 			else if (words[0] == "customifflag")
 			{
-				if (obj.flags[ss_toi(words[1])]==1)
+				if (obj.flags[ss_toi(words[1])])
 				{
 					load("custom_"+words[2]);
 					position--;
@@ -194,9 +194,9 @@ void scriptclass::run()
 			{
 				if(ss_toi(words[1])>=0 && ss_toi(words[1])<100){
 					if(words[2]=="on"){
-						obj.changeflag(ss_toi(words[1]),1);
+						obj.changeflag(ss_toi(words[1]),true);
 					}else if(words[2]=="off"){
-						obj.changeflag(ss_toi(words[1]),0);
+						obj.changeflag(ss_toi(words[1]),false);
 					}
 				}
 			}
@@ -1305,7 +1305,7 @@ void scriptclass::run()
 			}
 			else if (words[0] == "ifflag")
 			{
-				if (obj.flags[ss_toi(words[1])]==1)
+				if (obj.flags[ss_toi(words[1])])
 				{
 					load(words[2]);
 					position--;
@@ -2039,12 +2039,12 @@ void scriptclass::run()
 			}
 			else if (words[0] == "trinketbluecontrol")
 			{
-				if (game.trinkets() == 20 && obj.flags[67] == 1)
+				if (game.trinkets() == 20 && obj.flags[67])
 				{
 					load("talkblue_trinket6");
 					position--;
 				}
-				else if (game.trinkets() >= 19 && obj.flags[67] == 0)
+				else if (game.trinkets() >= 19 && !obj.flags[67])
 				{
 					load("talkblue_trinket5");
 					position--;
@@ -2093,70 +2093,70 @@ void scriptclass::run()
 						position--;
 					}
 				}
-				else if (obj.flags[67] == 1)
+				else if (obj.flags[67])
 				{
 					//game complete
 					load("talkred_13");
 					position--;
 				}
-				else if (obj.flags[35] == 1 && obj.flags[52] == 0)
+				else if (obj.flags[35] && !obj.flags[52])
 				{
 					//Intermission level
-					obj.flags[52] = 1;
+					obj.flags[52] = true;
 					load("talkred_9");
 					position--;
 				}
-				else if (obj.flags[51] == 0)
+				else if (!obj.flags[51])
 				{
 					//We're back home!
-					obj.flags[51] = 1;
+					obj.flags[51] = true;
 					load("talkred_5");
 					position--;
 				}
-				else if (obj.flags[48] == 0 && game.crewstats[5])
+				else if (!obj.flags[48] && game.crewstats[5])
 				{
 					//Victoria's back
-					obj.flags[48] = 1;
+					obj.flags[48] = true;
 					load("talkred_6");
 					position--;
 				}
-				else if (obj.flags[49] == 0 && game.crewstats[4])
+				else if (!obj.flags[49] && game.crewstats[4])
 				{
 					//Verdigris' back
-					obj.flags[49] = 1;
+					obj.flags[49] = true;
 					load("talkred_7");
 					position--;
 				}
-				else if (obj.flags[50] == 0 && game.crewstats[2])
+				else if (!obj.flags[50] && game.crewstats[2])
 				{
 					//Vitellary's back
-					obj.flags[50] = 1;
+					obj.flags[50] = true;
 					load("talkred_8");
 					position--;
 				}
-				else if (obj.flags[45] == 0 && !game.crewstats[5])
+				else if (!obj.flags[45] && !game.crewstats[5])
 				{
-					obj.flags[45] = 1;
+					obj.flags[45] = true;
 					load("talkred_2");
 					position--;
 				}
-				else if (obj.flags[46] == 0 && !game.crewstats[4])
+				else if (!obj.flags[46] && !game.crewstats[4])
 				{
-					obj.flags[46] = 1;
+					obj.flags[46] = true;
 					load("talkred_3");
 					position--;
 				}
-				else if (obj.flags[47] == 0 && !game.crewstats[2])
+				else if (!obj.flags[47] && !game.crewstats[2])
 				{
-					obj.flags[47] = 1;
+					obj.flags[47] = true;
 					load("talkred_4");
 					position--;
 				}
 				else
 				{
-					obj.flags[45] = 0;
-					obj.flags[46] = 0;
-					obj.flags[47] = 0;
+					obj.flags[45] = false;
+					obj.flags[46] = false;
+					obj.flags[47] = false;
 					load("talkred_1");
 					position--;
 				}
@@ -2179,47 +2179,47 @@ void scriptclass::run()
 					load("talkgreen_9");
 					position--;
 				}
-				else if (obj.flags[67] == 1)
+				else if (obj.flags[67])
 				{
 					//game complete
 					load("talkgreen_10");
 					position--;
 				}
-				else if (obj.flags[34] == 1 && obj.flags[57] == 0)
+				else if (obj.flags[34] && !obj.flags[57])
 				{
 					//Intermission level
-					obj.flags[57] = 1;
+					obj.flags[57] = true;
 					load("talkgreen_7");
 					position--;
 				}
-				else if (obj.flags[53] == 0)
+				else if (!obj.flags[53])
 				{
 					//Home!
-					obj.flags[53] = 1;
+					obj.flags[53] = true;
 					load("talkgreen_6");
 					position--;
 				}
-				else if (obj.flags[54] == 0 && game.crewstats[2])
+				else if (!obj.flags[54] && game.crewstats[2])
 				{
-					obj.flags[54] = 1;
+					obj.flags[54] = true;
 					load("talkgreen_5");
 					position--;
 				}
-				else if (obj.flags[55] == 0 && game.crewstats[3])
+				else if (!obj.flags[55] && game.crewstats[3])
 				{
-					obj.flags[55] = 1;
+					obj.flags[55] = true;
 					load("talkgreen_4");
 					position--;
 				}
-				else if (obj.flags[56] == 0 && game.crewstats[5])
+				else if (!obj.flags[56] && game.crewstats[5])
 				{
-					obj.flags[56] = 1;
+					obj.flags[56] = true;
 					load("talkgreen_3");
 					position--;
 				}
-				else if (obj.flags[58] == 0)
+				else if (!obj.flags[58])
 				{
-					obj.flags[58] = 1;
+					obj.flags[58] = true;
 					load("talkgreen_2");
 					position--;
 				}
@@ -2236,20 +2236,20 @@ void scriptclass::run()
 					load("talkblue_9");
 					position--;
 				}
-				else	if (obj.flags[67] == 1)
+				else	if (obj.flags[67])
 				{
 					//game complete, everything changes for victoria
-					if (obj.flags[41] == 1 && obj.flags[42] == 0)
+					if (obj.flags[41] && !obj.flags[42])
 					{
 						//second trinket conversation
-						obj.flags[42] = 1;
+						obj.flags[42] = true;
 						load("talkblue_trinket2");
 						position--;
 					}
-					else if (obj.flags[41] == 0 && obj.flags[42] == 0)
+					else if (!obj.flags[41] && !obj.flags[42])
 					{
 						//Third trinket conversation
-						obj.flags[42] = 1;
+						obj.flags[42] = true;
 						load("talkblue_trinket3");
 						position--;
 					}
@@ -2268,56 +2268,56 @@ void scriptclass::run()
 						}
 					}
 				}
-				else if (obj.flags[33] == 1 && obj.flags[40] == 0)
+				else if (obj.flags[33] && !obj.flags[40])
 				{
 					//Intermission level
-					obj.flags[40] = 1;
+					obj.flags[40] = true;
 					load("talkblue_7");
 					position--;
 				}
-				else if (obj.flags[36] == 0 && game.crewstats[5])
+				else if (!obj.flags[36] && game.crewstats[5])
 				{
 					//Back on the ship!
-					obj.flags[36] = 1;
+					obj.flags[36] = true;
 					load("talkblue_3");
 					position--;
 				}
-				else if (obj.flags[41] == 0 && game.crewrescued() <= 4)
+				else if (!obj.flags[41] && game.crewrescued() <= 4)
 				{
 					//First trinket conversation
-					obj.flags[41] = 1;
+					obj.flags[41] = true;
 					load("talkblue_trinket1");
 					position--;
 				}
-				else if (obj.flags[41] == 1 && obj.flags[42] == 0 && game.crewrescued() == 5)
+				else if (obj.flags[41] && !obj.flags[42] && game.crewrescued() == 5)
 				{
 					//second trinket conversation
-					obj.flags[42] = 1;
+					obj.flags[42] = true;
 					load("talkblue_trinket2");
 					position--;
 				}
-				else if (obj.flags[41] == 0 && obj.flags[42] == 0 && game.crewrescued() == 5)
+				else if (!obj.flags[41] && !obj.flags[42] && game.crewrescued() == 5)
 				{
 					//Third trinket conversation
-					obj.flags[42] = 1;
+					obj.flags[42] = true;
 					load("talkblue_trinket3");
 					position--;
 				}
-				else if (obj.flags[37] == 0 && game.crewstats[2])
+				else if (!obj.flags[37] && game.crewstats[2])
 				{
-					obj.flags[37] = 1;
+					obj.flags[37] = true;
 					load("talkblue_4");
 					position--;
 				}
-				else if (obj.flags[38] == 0 && game.crewstats[3])
+				else if (!obj.flags[38] && game.crewstats[3])
 				{
-					obj.flags[38] = 1;
+					obj.flags[38] = true;
 					load("talkblue_5");
 					position--;
 				}
-				else if (obj.flags[39] == 0 && game.crewstats[4])
+				else if (!obj.flags[39] && game.crewstats[4])
 				{
-					obj.flags[39] = 1;
+					obj.flags[39] = true;
 					load("talkblue_6");
 					position--;
 				}
@@ -2344,75 +2344,75 @@ void scriptclass::run()
 					load("talkyellow_12");
 					position--;
 				}
-				else	if (obj.flags[67] == 1)
+				else	if (obj.flags[67])
 				{
 					//game complete
 					load("talkyellow_11");
 					position--;
 				}
-				else if (obj.flags[32] == 1 && obj.flags[31] == 0)
+				else if (obj.flags[32] && !obj.flags[31])
 				{
 					//Intermission level
-					obj.flags[31] = 1;
+					obj.flags[31] = true;
 					load("talkyellow_6");
 					position--;
 				}
-				else if (obj.flags[27] == 0 && game.crewstats[2])
+				else if (!obj.flags[27] && game.crewstats[2])
 				{
 					//Back on the ship!
-					obj.flags[27] = 1;
+					obj.flags[27] = true;
 					load("talkyellow_10");
 					position--;
 				}
-				else if (obj.flags[43] == 0 && game.crewrescued() == 5 && !game.crewstats[5])
+				else if (!obj.flags[43] && game.crewrescued() == 5 && !game.crewstats[5])
 				{
 					//If by chance we've rescued everyone except Victoria by the end, Vitellary provides you with
 					//the trinket information instead.
-					obj.flags[43] = 1;
-					obj.flags[42] = 1;
-					obj.flags[41] = 1;
+					obj.flags[43] = true;
+					obj.flags[42] = true;
+					obj.flags[41] = true;
 					load("talkyellow_trinket1");
 					position--;
 				}
-				else if (obj.flags[24] == 0 && game.crewstats[5])
+				else if (!obj.flags[24] && game.crewstats[5])
 				{
-					obj.flags[24] = 1;
+					obj.flags[24] = true;
 					load("talkyellow_8");
 					position--;
 				}
-				else if (obj.flags[26] == 0 && game.crewstats[4])
+				else if (!obj.flags[26] && game.crewstats[4])
 				{
-					obj.flags[26] = 1;
+					obj.flags[26] = true;
 					load("talkyellow_7");
 					position--;
 				}
-				else if (obj.flags[25] == 0 && game.crewstats[3])
+				else if (!obj.flags[25] && game.crewstats[3])
 				{
-					obj.flags[25] = 1;
+					obj.flags[25] = true;
 					load("talkyellow_9");
 					position--;
 				}
-				else if (obj.flags[28] == 0)
+				else if (!obj.flags[28])
 				{
-					obj.flags[28] = 1;
+					obj.flags[28] = true;
 					load("talkyellow_3");
 					position--;
 				}
-				else if (obj.flags[29] == 0)
+				else if (!obj.flags[29])
 				{
-					obj.flags[29] = 1;
+					obj.flags[29] = true;
 					load("talkyellow_4");
 					position--;
 				}
-				else if (obj.flags[30] == 0)
+				else if (!obj.flags[30])
 				{
-					obj.flags[30] = 1;
+					obj.flags[30] = true;
 					load("talkyellow_5");
 					position--;
 				}
-				else if (obj.flags[23] == 0)
+				else if (!obj.flags[23])
 				{
-					obj.flags[23] = 1;
+					obj.flags[23] = true;
 					load("talkyellow_2");
 					position--;
 				}
@@ -2420,7 +2420,7 @@ void scriptclass::run()
 				{
 					load("talkyellow_1");
 					position--;
-					obj.flags[23] = 0;
+					obj.flags[23] = false;
 				}
 			}
 			else if (words[0] == "purplecontrol")
@@ -2432,68 +2432,68 @@ void scriptclass::run()
 					load("talkpurple_9");
 					position--;
 				}
-				else	if (obj.flags[67] == 1)
+				else	if (obj.flags[67])
 				{
 					//game complete
 					load("talkpurple_8");
 					position--;
 				}
-				else if (obj.flags[17] == 0 && game.crewstats[4])
+				else if (!obj.flags[17] && game.crewstats[4])
 				{
-					obj.flags[17] = 1;
+					obj.flags[17] = true;
 					load("talkpurple_6");
 					position--;
 				}
-				else if (obj.flags[15] == 0 && game.crewstats[5])
+				else if (!obj.flags[15] && game.crewstats[5])
 				{
-					obj.flags[15] = 1;
+					obj.flags[15] = true;
 					load("talkpurple_4");
 					position--;
 				}
-				else if (obj.flags[16] == 0 && game.crewstats[3])
+				else if (!obj.flags[16] && game.crewstats[3])
 				{
-					obj.flags[16] = 1;
+					obj.flags[16] = true;
 					load("talkpurple_5");
 					position--;
 				}
-				else if (obj.flags[18] == 0 && game.crewstats[2])
+				else if (!obj.flags[18] && game.crewstats[2])
 				{
-					obj.flags[18] = 1;
+					obj.flags[18] = true;
 					load("talkpurple_7");
 					position--;
 				}
-				else if (obj.flags[19] == 1 && obj.flags[20] == 0 && obj.flags[21] == 0)
+				else if (obj.flags[19] && !obj.flags[20] && !obj.flags[21])
 				{
 					//intermission one: if played one / not had first conversation / not played two [conversation one]
-					obj.flags[21] = 1;
+					obj.flags[21] = true;
 					load("talkpurple_intermission1");
 					position--;
 				}
-				else if (obj.flags[20] == 1 && obj.flags[21] == 1 && obj.flags[22] == 0)
+				else if (obj.flags[20] && obj.flags[21] && !obj.flags[22])
 				{
 					//intermission two: if played two / had first conversation / not had second conversation [conversation two]
-					obj.flags[22] = 1;
+					obj.flags[22] = true;
 					load("talkpurple_intermission2");
 					position--;
 				}
-				else if (obj.flags[20] == 1 && obj.flags[21] == 0 && obj.flags[22] == 0)
+				else if (obj.flags[20] && !obj.flags[21] && !obj.flags[22])
 				{
 					//intermission two: if played two / not had first conversation / not had second conversation [conversation three]
-					obj.flags[22] = 1;
+					obj.flags[22] = true;
 					load("talkpurple_intermission3");
 					position--;
 				}
-				else if (obj.flags[12] == 0)
+				else if (!obj.flags[12])
 				{
 					//Intro conversation
-					obj.flags[12] = 1;
+					obj.flags[12] = true;
 					load("talkpurple_intro");
 					position--;
 				}
-				else if (obj.flags[14] == 0)
+				else if (!obj.flags[14])
 				{
 					//Shorter intro conversation
-					obj.flags[14] = 1;
+					obj.flags[14] = true;
 					load("talkpurple_3");
 					position--;
 				}

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1890,7 +1890,7 @@ void scriptclass::run()
 #if !defined(NO_CUSTOM_LEVELS)
 				if (map.custommode)
 				{
-					usethisnum = help.number(ed.numtrinkets);
+					usethisnum = help.number(ed.numtrinkets());
 				}
 				else
 #endif

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1469,7 +1469,7 @@ void scriptclass::run()
 				for (i = 0; i < 100; i++)
 				{
 					obj.collect[i] = false;
-					obj.customcollect[i] = 0;
+					obj.customcollect[i] = false;
 				}
 				game.deathcounts = 0;
 				game.advancetext = false;
@@ -3561,7 +3561,7 @@ void scriptclass::hardreset()
 	for (i = 0; i < 100; i++)
 	{
 		obj.collect[i] = false;
-		obj.customcollect[i] = 0;
+		obj.customcollect[i] = false;
 	}
 
 	if (obj.getplayer() > -1){

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1466,7 +1466,6 @@ void scriptclass::run()
 				i = obj.getplayer();
 				obj.entities[i].tile = 0;
 
-				game.crewmates=0;
 				for (i = 0; i < 100; i++)
 				{
 					obj.collect[i] = 0;
@@ -3489,8 +3488,6 @@ void scriptclass::hardreset()
 
 	game.inintermission = false;
 	game.insecretlab = false;
-
-	game.crewmates=0;
 
 	game.state = 0;
 	game.statedelay = 0;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1468,7 +1468,7 @@ void scriptclass::run()
 
 				for (i = 0; i < 100; i++)
 				{
-					obj.collect[i] = 0;
+					obj.collect[i] = false;
 					obj.customcollect[i] = 0;
 				}
 				game.deathcounts = 0;
@@ -1877,7 +1877,7 @@ void scriptclass::run()
 				music.haltdasmusik();
 				music.playef(3);
 
-				obj.collect[ss_toi(words[1])] = 1;
+				obj.collect[ss_toi(words[1])] = true;
 
 				graphics.textboxremovefast();
 
@@ -3560,7 +3560,7 @@ void scriptclass::hardreset()
 
 	for (i = 0; i < 100; i++)
 	{
-		obj.collect[i] = 0;
+		obj.collect[i] = false;
 		obj.customcollect[i] = 0;
 	}
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1887,11 +1887,13 @@ void scriptclass::run()
 				graphics.textboxcenterx();
 
 				std::string usethisnum;
+#if !defined(NO_CUSTOM_LEVELS)
 				if (map.custommode)
 				{
-					usethisnum = help.number(map.customtrinkets);
+					usethisnum = help.number(ed.numtrinkets);
 				}
 				else
+#endif
 				{
 					usethisnum = "Twenty";
 				}

--- a/desktop_version/src/Spacestation2.cpp
+++ b/desktop_version/src/Spacestation2.cpp
@@ -1977,11 +1977,11 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry)
 		}
 		else
 		{
-			if(obj.flags[7] == 0)
+			if(!obj.flags[7])
 			{
 				if (game.nocutscenes)
 				{
-					obj.changeflag(7, 1);
+					obj.changeflag(7, true);
 					game.teleportscript = "levelonecomplete";
 				}
 				else
@@ -2419,7 +2419,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry)
 
 		if(!game.intimetrial)
 		{
-			if(game.companion==0 && obj.flags[10]==0 &&  !game.crewstats[2])   //also need to check if he's rescued in a previous game
+			if(game.companion==0 && !obj.flags[10] &&  !game.crewstats[2])   //also need to check if he's rescued in a previous game
 			{
 				obj.createentity(42, 86, 16, 0);
 				obj.createblock(1, 0, 0, 140, 240, 34);
@@ -2560,10 +2560,10 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry)
 
 		if(!game.nocutscenes)
 		{
-			if(obj.flags[68]==0)
+			if(!obj.flags[68])
 			{
 				obj.createblock(1, 32, 0, 320, 240, 17);
-				obj.flags[68] = 1;
+				obj.flags[68] = true;
 			}
 		}
 		roomname = "Quicksand";

--- a/desktop_version/src/Spacestation2.cpp
+++ b/desktop_version/src/Spacestation2.cpp
@@ -1981,7 +1981,7 @@ std::vector<std::string> spacestation2class::loadlevel(int rx, int ry)
 			{
 				if (game.nocutscenes)
 				{
-					obj.changeflag(7, true);
+					obj.flags[7] = true;
 					game.teleportscript = "levelonecomplete";
 				}
 				else

--- a/desktop_version/src/WarpClass.cpp
+++ b/desktop_version/src/WarpClass.cpp
@@ -977,7 +977,7 @@ std::vector<std::string> warpclass::loadlevel(int rx, int ry)
 
 		if(!game.intimetrial)
 		{
-			if(game.companion==0 && obj.flags[11]==0 && !game.crewstats[4])   //also need to check if he's rescued in a previous game
+			if(game.companion==0 && !obj.flags[11] && !game.crewstats[4])   //also need to check if he's rescued in a previous game
 			{
 				obj.createentity(255, 121, 15, 0);
 				obj.createblock(1, 215, 0, 160, 240, 35);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1618,10 +1618,6 @@ int editorclass::findwarptoken(int t)
     return 0;
 }
 
-void editorclass::countstuff()
-{
-}
-
 void editorclass::load(std::string& _path)
 {
     reset();
@@ -1846,7 +1842,6 @@ void editorclass::load(std::string& _path)
     }
 
     gethooks();
-    countstuff();
     version=2;
 }
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -285,7 +285,6 @@ void editorclass::reset()
     entframe=0;
     entframedelay=0;
 
-    numcrewmates=0;
     edentity.clear();
     levmusic=0;
 
@@ -1621,11 +1620,6 @@ int editorclass::findwarptoken(int t)
 
 void editorclass::countstuff()
 {
-    numcrewmates=0;
-    for(size_t i=0; i<edentity.size(); i++)
-    {
-        if(edentity[i].t==15) numcrewmates++;
-    }
 }
 
 void editorclass::load(std::string& _path)
@@ -4920,11 +4914,10 @@ void editorinput()
                             }
                             else if(ed.drawmode==15)  //Crewmate
                             {
-                                if(ed.numcrewmates<100)
+                                if(ed.numcrewmates()<100)
                                 {
                                     addedentity(ed.tilex+ (ed.levx*40),ed.tiley+ (ed.levy*30),15,1 + int(fRandom() * 5));
                                     ed.lclickdelay=1;
-                                    ed.numcrewmates++;
                                 }
                                 else
                                 {
@@ -5047,7 +5040,6 @@ void editorinput()
                     {
                         if(edentity[i].x==ed.tilex + (ed.levx*40)&& edentity[i].y==ed.tiley+ (ed.levy*30))
                         {
-                            if(edentity[i].t==15) ed.numcrewmates--;
                             removeedentity(i);
                         }
                     }
@@ -5207,6 +5199,19 @@ int editorclass::numtrinkets()
     for (size_t i = 0; i < edentity.size(); i++)
     {
         if (edentity[i].t == 9)
+        {
+            temp++;
+        }
+    }
+    return temp;
+}
+
+int editorclass::numcrewmates()
+{
+    int temp = 0;
+    for (size_t i = 0; i < edentity.size(); i++)
+    {
+        if (edentity[i].t == 15)
         {
             temp++;
         }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -285,7 +285,6 @@ void editorclass::reset()
     entframe=0;
     entframedelay=0;
 
-    numtrinkets=0;
     numcrewmates=0;
     edentity.clear();
     levmusic=0;
@@ -1622,11 +1621,9 @@ int editorclass::findwarptoken(int t)
 
 void editorclass::countstuff()
 {
-    numtrinkets=0;
     numcrewmates=0;
     for(size_t i=0; i<edentity.size(); i++)
     {
-        if(edentity[i].t==9) numtrinkets++;
         if(edentity[i].t==15) numcrewmates++;
     }
 }
@@ -4828,11 +4825,10 @@ void editorinput()
                         {
                             if(ed.drawmode==3)
                             {
-                                if(ed.numtrinkets<100)
+                                if(ed.numtrinkets()<100)
                                 {
                                     addedentity(ed.tilex+ (ed.levx*40),ed.tiley+ (ed.levy*30),9);
                                     ed.lclickdelay=1;
-                                    ed.numtrinkets++;
                                 }
                                 else
                                 {
@@ -5051,7 +5047,6 @@ void editorinput()
                     {
                         if(edentity[i].x==ed.tilex + (ed.levx*40)&& edentity[i].y==ed.tiley+ (ed.levy*30))
                         {
-                            if(edentity[i].t==9) ed.numtrinkets--;
                             if(edentity[i].t==15) ed.numcrewmates--;
                             removeedentity(i);
                         }
@@ -5204,6 +5199,19 @@ void editorinput()
             break;
         }
     }
+}
+
+int editorclass::numtrinkets()
+{
+    int temp = 0;
+    for (size_t i = 0; i < edentity.size(); i++)
+    {
+        if (edentity[i].t == 9)
+        {
+            temp++;
+        }
+    }
+    return temp;
 }
 
 #endif /* NO_CUSTOM_LEVELS */

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -138,7 +138,6 @@ class editorclass{
   int findtrinket(int t);
   int findcrewmate(int t);
   int findwarptoken(int t);
-  void countstuff();
   void findstartpoint();
   int getlevelcol(int t);
   int getenemycol(int t);

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -152,7 +152,7 @@ class editorclass{
   std::vector <int> contents;
   std::vector <int> vmult;
   int numtrinkets();
-  int numcrewmates;
+  int numcrewmates();
   edlevelclass level[400]; //Maxwidth*maxheight
   int kludgewarpdir[400]; //Also maxwidth*maxheight
 

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -151,7 +151,7 @@ class editorclass{
   std::vector <int> swapmap;
   std::vector <int> contents;
   std::vector <int> vmult;
-  int numtrinkets;
+  int numtrinkets();
   int numcrewmates;
   edlevelclass level[400]; //Maxwidth*maxheight
   int kludgewarpdir[400]; //Also maxwidth*maxheight


### PR DESCRIPTION
## Changes:

### Summary

This changes the variables `game.trinkets` and `game.crewmates` to be functions which count the number of collected trinkets and crewmates automatically, so we don't have to keep track of the amount of collected trinkets and crewmates separately. It also does the same for `ed.numtrinkets` and `ed.numcrewmates` to keep track of how many trinkets and crewmates there are in the level overall. `map.customtrinkets` and `map.customcrewmates` have been removed due to simply being duplicates of `ed.numtrinkets` and `ed.numcrewmates`.

Also, I cleaned up unused or useless variables.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
