### PR TITLE
Refactor map data handling a little bit

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -3821,17 +3821,6 @@ int entityclass::getgridpoint( int t )
     return t;
 }
 
-bool entityclass::cblocks( int t )
-{
-    tempx = entities[t].xp + entities[t].cx;
-    tempy = entities[t].yp + entities[t].cy;
-    tempw = entities[t].w;
-    temph = entities[t].h;
-    rectset(tempx, tempy, tempw, temph);
-
-    return checkblocks();
-}
-
 bool entityclass::checkplatform()
 {
     //Return true if rectset intersects a moving platform, setups px & py to the platform x & y

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -111,8 +111,6 @@ public:
 
     int getgridpoint(int t);
 
-    bool cblocks(int t);
-
     bool checkplatform();
 
     bool checkblocks();

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5593,7 +5593,7 @@ void Game::initteleportermode()
     //Set the teleporter variable to the right position!
     teleport_to_teleporter = 0;
 
-    for (int i = 0; i < map.numteleporters; i++)
+    for (size_t i = 0; i < map.teleporters.size(); i++)
     {
         if (roomx == map.teleporters[i].x + 100 && roomy == map.teleporters[i].y + 100)
         {

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2224,13 +2224,13 @@ void teleporterinput()
         if (game.press_left)
         {
             game.teleport_to_teleporter--;
-            if (game.teleport_to_teleporter < 0) game.teleport_to_teleporter = map.numteleporters - 1;
+            if (game.teleport_to_teleporter < 0) game.teleport_to_teleporter = map.teleporters.size() - 1;
             tempx = map.teleporters[game.teleport_to_teleporter].x;
             tempy = map.teleporters[game.teleport_to_teleporter].y;
             while (map.explored[tempx + (20 * tempy)] == 0)
             {
                 game.teleport_to_teleporter--;
-                if (game.teleport_to_teleporter < 0) game.teleport_to_teleporter = map.numteleporters - 1;
+                if (game.teleport_to_teleporter < 0) game.teleport_to_teleporter = map.teleporters.size() - 1;
                 tempx = map.teleporters[game.teleport_to_teleporter].x;
                 tempy = map.teleporters[game.teleport_to_teleporter].y;
             }
@@ -2238,13 +2238,13 @@ void teleporterinput()
         else if (game.press_right)
         {
             game.teleport_to_teleporter++;
-            if (game.teleport_to_teleporter >= map.numteleporters) game.teleport_to_teleporter = 0;
+            if (game.teleport_to_teleporter >= (int) map.teleporters.size()) game.teleport_to_teleporter = 0;
             tempx = map.teleporters[game.teleport_to_teleporter].x;
             tempy = map.teleporters[game.teleport_to_teleporter].y;
             while (map.explored[tempx + (20 * tempy)] == 0)
             {
                 game.teleport_to_teleporter++;
-                if (game.teleport_to_teleporter >= map.numteleporters) game.teleport_to_teleporter = 0;
+                if (game.teleport_to_teleporter >= (int) map.teleporters.size()) game.teleport_to_teleporter = 0;
                 tempx = map.teleporters[game.teleport_to_teleporter].x;
                 tempy = map.teleporters[game.teleport_to_teleporter].y;
             }

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -411,7 +411,6 @@ std::string mapclass::getglitchname(int x, int y)
 void mapclass::initmapdata()
 {
 	//Set up static map information like teleporters and shiny trinkets.
-	numteleporters = 17;
 	setteleporter(0, 0);
 	setteleporter(0, 16);
 	setteleporter(2, 4);

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -57,7 +57,6 @@ mapclass::mapclass()
 	for (int i = 0; i < 30; i++)
 	{
 		vmult.push_back(int(i * 40));
-		shinytrinkets.push_back(point());
 	}
 	//We create a blank map
 	for (int j = 0; j < 30; j++)
@@ -133,8 +132,10 @@ void mapclass::setteleporter(int x, int y)
 
 void mapclass::settrinket(int t, int x, int y)
 {
-	shinytrinkets[t].x = x;
-	shinytrinkets[t].y = y;
+	point temp;
+	temp.x = x;
+	temp.y = y;
+	shinytrinkets.push_back(temp);
 }
 
 void mapclass::resetmap()

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -57,7 +57,6 @@ mapclass::mapclass()
 	for (int i = 0; i < 30; i++)
 	{
 		vmult.push_back(int(i * 40));
-		teleporters.push_back(point());
 		shinytrinkets.push_back(point());
 	}
 	//We create a blank map
@@ -126,8 +125,10 @@ int mapclass::intpol(int a, int b, float c)
 
 void mapclass::setteleporter(int t, int x, int y)
 {
-	teleporters[t].x = x;
-	teleporters[t].y = y;
+	point temp;
+	temp.x = x;
+	temp.y = y;
+	teleporters.push_back(temp);
 }
 
 void mapclass::settrinket(int t, int x, int y)

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -130,7 +130,7 @@ void mapclass::setteleporter(int x, int y)
 	teleporters.push_back(temp);
 }
 
-void mapclass::settrinket(int t, int x, int y)
+void mapclass::settrinket(int x, int y)
 {
 	point temp;
 	temp.x = x;
@@ -431,24 +431,24 @@ void mapclass::initmapdata()
 	setteleporter(18, 7);
 
 	numshinytrinkets = 18;
-	settrinket(0, 14, 4);
-	settrinket(1, 13, 6);
-	settrinket(2, 11, 12);
-	settrinket(3, 15, 12);
-	settrinket(4, 14, 11);
-	settrinket(5, 18, 14);
-	settrinket(6, 11, 7);
-	settrinket(7, 9, 2);
-	settrinket(8, 9, 16);
-	settrinket(9, 2, 18);
-	settrinket(10, 7, 18);
-	settrinket(11, 6, 1);
-	settrinket(12, 17, 3);
-	settrinket(13, 10, 19);
-	settrinket(14, 5, 15);
-	settrinket(15, 1, 10);
-	settrinket(16, 3, 2);
-	settrinket(17, 10, 8);
+	settrinket(14, 4);
+	settrinket(13, 6);
+	settrinket(11, 12);
+	settrinket(15, 12);
+	settrinket(14, 11);
+	settrinket(18, 14);
+	settrinket(11, 7);
+	settrinket(9, 2);
+	settrinket(9, 16);
+	settrinket(2, 18);
+	settrinket(7, 18);
+	settrinket(6, 1);
+	settrinket(17, 3);
+	settrinket(10, 19);
+	settrinket(5, 15);
+	settrinket(1, 10);
+	settrinket(3, 2);
+	settrinket(10, 8);
 }
 
 int mapclass::finalat(int x, int y)

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -123,7 +123,7 @@ int mapclass::intpol(int a, int b, float c)
 	return static_cast<int>(a + ((b - a) * c));
 }
 
-void mapclass::setteleporter(int t, int x, int y)
+void mapclass::setteleporter(int x, int y)
 {
 	point temp;
 	temp.x = x;
@@ -412,23 +412,23 @@ void mapclass::initmapdata()
 {
 	//Set up static map information like teleporters and shiny trinkets.
 	numteleporters = 17;
-	setteleporter(0, 0, 0);
-	setteleporter(1, 0, 16);
-	setteleporter(2, 2, 4);
-	setteleporter(3, 2, 11);
-	setteleporter(4, 7, 9);
-	setteleporter(5, 7, 15);
-	setteleporter(6, 8, 11);
-	setteleporter(7, 10, 5);
-	setteleporter(8, 11, 4);
-	setteleporter(9, 13, 2);
-	setteleporter(10, 13, 8);
-	setteleporter(11, 14, 19);
-	setteleporter(12, 15, 0);
-	setteleporter(13, 17, 12);
-	setteleporter(14, 17, 17);
-	setteleporter(15, 18, 1);
-	setteleporter(16, 18, 7);
+	setteleporter(0, 0);
+	setteleporter(0, 16);
+	setteleporter(2, 4);
+	setteleporter(2, 11);
+	setteleporter(7, 9);
+	setteleporter(7, 15);
+	setteleporter(8, 11);
+	setteleporter(10, 5);
+	setteleporter(11, 4);
+	setteleporter(13, 2);
+	setteleporter(13, 8);
+	setteleporter(14, 19);
+	setteleporter(15, 0);
+	setteleporter(17, 12);
+	setteleporter(17, 17);
+	setteleporter(18, 1);
+	setteleporter(18, 7);
 
 	numshinytrinkets = 18;
 	settrinket(0, 14, 4);

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -430,7 +430,6 @@ void mapclass::initmapdata()
 	setteleporter(18, 1);
 	setteleporter(18, 7);
 
-	numshinytrinkets = 18;
 	settrinket(14, 4);
 	settrinket(13, 6);
 	settrinket(11, 12);

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -154,7 +154,7 @@ public:
     std::vector<point> teleporters;
     std::vector<point> shinytrinkets;
 
-    int numteleporters, numshinytrinkets;
+    int numshinytrinkets;
     bool showteleporters, showtargets, showtrinkets;
 
     //Roomtext

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -28,7 +28,7 @@ public:
 
     void setteleporter(int x, int y);
 
-    void settrinket(int t, int x, int y);
+    void settrinket(int x, int y);
 
     void resetmap();
 

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -154,7 +154,6 @@ public:
     std::vector<point> teleporters;
     std::vector<point> shinytrinkets;
 
-    int numshinytrinkets;
     bool showteleporters, showtargets, showtrinkets;
 
     //Roomtext

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -26,7 +26,7 @@ public:
 
     int intpol(int a, int b, float c);
 
-    void setteleporter(int t, int x, int y);
+    void setteleporter(int x, int y);
 
     void settrinket(int t, int x, int y);
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2026,7 +2026,7 @@ void maprender()
 
             if (map.showtrinkets)
             {
-                for (int i = 0; i < map.numshinytrinkets; i++)
+                for (size_t i = 0; i < map.shinytrinkets.size(); i++)
                 {
                     if (!obj.collect[i])
                     {
@@ -2837,7 +2837,7 @@ void teleporterrender()
 
     if (map.showtrinkets)
     {
-        for (int i = 0; i < map.numshinytrinkets; i++)
+        for (size_t i = 0; i < map.shinytrinkets.size(); i++)
         {
             if (!obj.collect[i])
             {

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2008,7 +2008,7 @@ void maprender()
             }
 
             //draw legend details
-            for (int i = 0; i < map.numteleporters; i++)
+            for (size_t i = 0; i < map.teleporters.size(); i++)
             {
                 if (map.showteleporters && map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)] > 0)
                 {
@@ -2819,7 +2819,7 @@ void teleporterrender()
     }
 
     //draw legend details
-    for (int i = 0; i < map.numteleporters; i++)
+    for (size_t i = 0; i < map.teleporters.size(); i++)
     {
         if (map.showteleporters && map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)] > 0)
         {


### PR DESCRIPTION
## Changes:

### Summary

This removes the variables `map.numteleporters` and `map.numshinytrinkets`, and removes having to give an indice when setting teleporters/trinkets (now we just `push_back` them automatically).

Also I removed `entityclass::cblocks()` because it was unused.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
