### PR TITLE
Optimize loading the levels list

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -189,7 +189,11 @@ void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem,
 	{
 		*mem = (unsigned char*) malloc(length);
 	}
-	PHYSFS_readBytes(handle, *mem, length);
+	int success = PHYSFS_readBytes(handle, *mem, length);
+	if (success == -1)
+	{
+		FILESYSTEM_freeMemory(mem);
+	}
 	PHYSFS_close(handle);
 }
 

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -207,3 +207,15 @@ void UtilityClass::updateglow()
 		if (glow < 2) glowdir = 0;
 	}
 }
+
+bool is_positive_num(const std::string& str)
+{
+	for (size_t i = 0; i < str.length(); i++)
+	{
+		if (!std::isdigit(str[i]))
+		{
+			return false;
+		}
+	}
+	return true;
+}

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -11,6 +11,8 @@ std::vector<std::string> split(const std::string &s, char delim, std::vector<std
 
 std::vector<std::string> split(const std::string &s, char delim);
 
+bool is_positive_num(const std::string& str);
+
 
 //helperClass
 class UtilityClass

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -202,100 +202,32 @@ void editorclass::getDirectoryData()
 }
 bool editorclass::getLevelMetaData(std::string& _path, LevelMetaData& _data )
 {
-    TiXmlDocument doc;
-    if (!FILESYSTEM_loadTiXmlDocument(_path.c_str(), &doc))
+    unsigned char *uMem = NULL;
+    FILESYSTEM_loadFileToMemory(_path.c_str(), &uMem, NULL, true);
+
+    if (uMem == NULL)
     {
         printf("Level %s not found :(\n", _path.c_str());
         return false;
     }
 
-    TiXmlHandle hDoc(&doc);
-    TiXmlElement* pElem;
-    TiXmlHandle hRoot(0);
+    std::string buf((char*) uMem);
 
-
+    if (find_metadata(buf) == "")
     {
-        pElem=hDoc.FirstChildElement().Element();
-        // should always have a valid root but handle gracefully if it does
-        if (!pElem)
-        {
-            printf("No valid root! Corrupt level file?\n");
-        }
-
-        // save this for later
-        hRoot=TiXmlHandle(pElem);
+        printf("Couldn't load metadata for %s\n", _path.c_str());
+        return false;
     }
 
-    for( pElem = hRoot.FirstChild( "Data" ).FirstChild().Element(); pElem; pElem=pElem->NextSiblingElement())
-    {
-        std::string pKey(pElem->Value());
-        const char* pText = pElem->GetText() ;
-        if(pText == NULL)
-        {
-            pText = "";
-        }
+    _data.creator = find_creator(buf);
+    _data.title = find_title(buf);
+    _data.Desc1 = find_desc1(buf);
+    _data.Desc2 = find_desc2(buf);
+    _data.Desc3 = find_desc3(buf);
+    _data.website = find_desc3(buf);
 
-        if (pKey == "MetaData")
-        {
-
-            for( TiXmlElement* subElem = pElem->FirstChildElement(); subElem; subElem= subElem->NextSiblingElement())
-            {
-                std::string pKey(subElem->Value());
-                const char* pText = subElem->GetText() ;
-                if(pText == NULL)
-                {
-                    pText = "";
-                }
-                _data.filename = _path;
-
-                if(pKey == "Created")
-                {
-                    _data.timeCreated = pText;
-                }
-
-                if(pKey == "Creator")
-                {
-                    _data.creator = pText;
-                }
-
-                if(pKey == "Title")
-                {
-                    _data.title = pText;
-                }
-
-                if(pKey == "Modified")
-                {
-                    _data.timeModified = pText;
-                }
-
-                if(pKey == "Modifiers")
-                {
-                    _data.modifier = pText;
-                }
-
-                if(pKey == "Desc1")
-                {
-                    _data.Desc1 = pText;
-                }
-
-                if(pKey == "Desc2")
-                {
-                    _data.Desc2 = pText;
-                }
-
-                if(pKey == "Desc3")
-                {
-                    _data.Desc3 = pText;
-                }
-
-                if(pKey == "website")
-                {
-                    _data.website = pText;
-                }
-            }
-        }
-    }
-    return (_data.filename != "");
+    _data.filename = _path;
+    return true;
 }
 
 void editorclass::reset()

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -86,6 +86,22 @@ bool compare_nocase (std::string first, std::string second)
         return false;
 }
 
+void replace_all(std::string& str, const std::string& from, const std::string& to)
+{
+    if (from.empty())
+    {
+        return;
+    }
+
+    size_t start_pos = 0;
+
+    while ((start_pos = str.find(from, start_pos)) != std::string::npos)
+    {
+        str.replace(start_pos, from.length(), to);
+        start_pos += to.length(); //In case `to` contains `from`, like replacing 'x' with 'yx'
+    }
+}
+
 void editorclass::getDirectoryData()
 {
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -153,6 +153,23 @@ std::string find_tag(const std::string& buf, const std::string& start, const std
     return value;
 }
 
+#define TAG_FINDER(NAME, TAG) \
+std::string NAME(const std::string& buf) \
+{ \
+    return find_tag(buf, "<" TAG ">", "</" TAG ">"); \
+}
+
+TAG_FINDER(find_metadata, "MetaData"); //only for checking that it exists
+
+TAG_FINDER(find_creator, "Creator");
+TAG_FINDER(find_title, "Title");
+TAG_FINDER(find_desc1, "Desc1");
+TAG_FINDER(find_desc2, "Desc2");
+TAG_FINDER(find_desc3, "Desc3");
+TAG_FINDER(find_website, "website");
+
+#undef TAG_FINDER
+
 void editorclass::getDirectoryData()
 {
 


### PR DESCRIPTION
## Changes:

This PR optimizes loading the levels list when selecting "play a level" in the playerworlds menu.

Previously, it was *extremely* slow, because we kept parsing the *entire* XML document for every single level file, which gets pretty slow very quickly. In extreme cases, someone could have a cursed level file, like I did once, with 2<sup>18</sup> edentities inside it (don't ask<sup>note 1</sup>), making loading the levels list completely *choke* on it and temporarily take up a gigabyte of RAM. But if we no longer parse the entire XML document, bombs like these are avoided.

Instead, all we have to do is look for the metadata tags themselves, and what's contained between them. This is the same thing that Ved (an external VVVVVV level editor) does.

This optimization was added to VCE but hasn't been upstreamed until now, probably because Leo has a strange habit of using weird magic like exceptions and C++17 stuff for no good reason.

<sup>note 1</sup>: Ok, it was the result of a particularly nasty VCE bug that kept exponentially increasing the amount of edentities in a level, due to me screwing up when merging changes from upstream. The level file is 75 megabytes in size.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
