### PR TITLE
Add an "open level folder" menu option to the "play levels" menu

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -484,7 +484,7 @@ bool FILESYSTEM_openDirectory(const char *dname)
 #elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__HAIKU__)
 bool FILESYSTEM_openDirectoryEnabled()
 {
-	return true;
+	return std::getenv("SteamTenfoot") == NULL;
 }
  #ifdef __linux__
 const char* open_cmd = "xdg-open";

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -20,4 +20,7 @@ bool FILESYSTEM_loadTiXmlDocument(const char *name, TiXmlDocument *doc);
 
 std::vector<std::string> FILESYSTEM_getLevelDirFileNames();
 
+bool FILESYSTEM_openDirectoryEnabled();
+bool FILESYSTEM_openDirectory(const char *dname);
+
 #endif /* FILESYSTEMUTILS_H */

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6636,7 +6636,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
  #if !defined(NO_EDITOR)
         option("level editor");
  #endif
-        //option("open level folder");
+        option("open level folder", FILESYSTEM_openDirectoryEnabled());
         option("back to menu");
         menuxoff = -30;
         menuyoff = -40;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -285,17 +285,19 @@ void menuactionpress()
             ed.filename="";
             break;
  #endif
-        /*case OFFSET+2:
-            music.playef(11);
-            //"OPENFOLDERHOOK"
-            //When the player selects the "open level folder" menu option,
-            //this is where it should run the appropriate code.
-            //This code should:
-            // - Minimise the game
-            // - Open the levels folder for whatever operating system we're on
-            SDL_assert(0 && "Remove open level dir");
-            break;*/
         case OFFSET+2:
+            //"OPENFOLDERHOOK"
+            if (FILESYSTEM_openDirectory(FILESYSTEM_getUserLevelDirectory()))
+            {
+                music.playef(11);
+                SDL_MinimizeWindow(graphics.screenbuffer->m_window);
+            }
+            else
+            {
+                music.playef(2);
+            }
+            break;
+        case OFFSET+3:
             //back
             music.playef(11);
             game.returnmenu();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -287,7 +287,8 @@ void menuactionpress()
  #endif
         case OFFSET+2:
             //"OPENFOLDERHOOK"
-            if (FILESYSTEM_openDirectory(FILESYSTEM_getUserLevelDirectory()))
+            if (FILESYSTEM_openDirectoryEnabled()
+            && FILESYSTEM_openDirectory(FILESYSTEM_getUserLevelDirectory()))
             {
                 music.playef(11);
                 SDL_MinimizeWindow(graphics.screenbuffer->m_window);


### PR DESCRIPTION
## Changes:

This simply adds an "open level folder" option to the "play levels" menu, which was commented out and left unimplemented. If you press ACTION on it, it will open the level folder for you and minimize the game window. If it can't open the level folder (or the option is grayed out), it will play the sad sound effect.

Most of this code I stole from leo60228, and I kept that `#include <sys/types.h>` even though it seems to compile just fine without it because it sounds important or something.

This is yet another feature added to VCE that hasn't been upstreamed until now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
