### PR TITLE
Add analogue movement support using controller joystick

### DIFF
--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -21,6 +21,8 @@ entclass::entclass()
 	ay = 0;
 	vx = 0;
 	vy = 0;
+	mx = 1;
+	my = 1;
 	w = 16;
 	h = 16;
 	cx = 0;

--- a/desktop_version/src/Ent.h
+++ b/desktop_version/src/Ent.h
@@ -28,6 +28,7 @@ public:
     //Position and velocity
     int oldxp, oldyp;
     float ax, ay, vx, vy;
+    float mx, my;
     int cx, cy, w, h;
     float newxp, newyp;
     bool isplatform;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4251,8 +4251,10 @@ void entityclass::updateentitylogic( int t )
         applyfriction(t, game.inertia, 0.25f);
     }
 
-    entities[t].newxp = entities[t].xp + entities[t].vx;
-    entities[t].newyp = entities[t].yp + entities[t].vy;
+    entities[t].mx = clamp(entities[t].mx, -1, 1);
+    entities[t].my = clamp(entities[t].my, -1, 1);
+    entities[t].newxp = entities[t].xp + entities[t].vx*entities[t].mx;
+    entities[t].newyp = entities[t].yp + entities[t].vy*entities[t].my;
 }
 
 void entityclass::entitymapcollision( int t )

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1737,6 +1737,18 @@ void gameinput()
                     obj.entities[ie].dir = 1;
                 }
 
+                if (game.press_left || game.press_right)
+                {
+                    if (key.xMagnitude != 0.0f)
+                    {
+                        obj.entities[ie].mx = key.xMagnitude;
+                    }
+                    else
+                    {
+                        obj.entities[ie].mx = 1;
+                    }
+                }
+
                 if (!game.press_action)
                 {
                     game.jumppressed = 0;

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -53,6 +53,8 @@ KeyPoll::KeyPoll()
 	}
 
 	linealreadyemptykludge = false;
+
+	xMagnitude = 0.0f;
 }
 
 void KeyPoll::enabletextentry()
@@ -194,10 +196,12 @@ void KeyPoll::Poll()
 					evt.caxis.value < sensitivity	)
 				{
 					xVel = 0;
+					xMagnitude = 0;
 				}
 				else
 				{
 					xVel = (evt.caxis.value > 0) ? 1 : -1;
+					xMagnitude = (std::abs(evt.caxis.value) - sensitivity) / (32768.0f - sensitivity);
 				}
 			}
 			if (evt.caxis.axis == SDL_CONTROLLER_AXIS_LEFTY)

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -73,6 +73,8 @@ public:
 
 	bool linealreadyemptykludge;
 
+	float xMagnitude;
+
 private:
 	std::map<SDL_JoystickID, SDL_GameController*> controllers;
 	std::map<SDL_GameControllerButton, bool> buttonmap;


### PR DESCRIPTION
## Changes:

This PR lets you use your gamepad joystick to move Viridian as much as you want them to move, instead of either doing "full speed ahead" or "no movement at all". This makes it easier and more fluid to use the joystick if you have a controller.

I verified with libTAS that this does not change any keyboard-only input, meaning it should be the same as before unless you use a controller.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
