### PR TITLE
Add pressing N to mute music only, and pausing audio upon lost focus

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -121,7 +121,6 @@ void Game::init(void)
     muted = false;
     musicmuted = false;
     musicmutebutton = 0;
-    globalsound = 128;
 
     glitchrunkludge = false;
     hascontrol = true;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -122,7 +122,6 @@ void Game::init(void)
     musicmuted = false;
     musicmutebutton = 0;
     globalsound = 128;
-    m_globalVol = 1.0f;
 
     glitchrunkludge = false;
     hascontrol = true;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -119,6 +119,8 @@ void Game::init(void)
     infocus = true;
     paused = false;
     muted = false;
+    musicmuted = false;
+    musicmutebutton = 0;
     globalsound = 128;
     m_globalVol = 1.0f;
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -84,16 +84,6 @@ public:
     ~Game(void);
 
 
-    void setGlobalSoundVol(const float _vol)
-    {
-        m_globalVol = _vol;
-    }
-    float getGlobalSoundVol()
-    {
-        return m_globalVol;
-    }
-
-
     int crewrescued();
 
     std::string unrescued();
@@ -194,10 +184,6 @@ public:
     int mutebutton;
     bool musicmuted;
     int musicmutebutton;
-private:
-    float m_globalVol;
-
-public:
 
     int tapleft, tapright;
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -192,6 +192,8 @@ public:
     bool infocus;
     bool muted;
     int mutebutton;
+    bool musicmuted;
+    int musicmutebutton;
 private:
     float m_globalVol;
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -350,7 +350,6 @@ public:
     bool quickrestartkludge;
 
     bool paused;
-    int globalsound;
 
     //Custom stuff
     std::string customscript[50];

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -21,6 +21,7 @@ enum Kybrd
 	KEYBOARD_a = SDLK_a,
 	KEYBOARD_d = SDLK_d,
 	KEYBOARD_m = SDLK_m,
+	KEYBOARD_n = SDLK_n,
 
 	KEYBOARD_v = SDLK_v,
 	KEYBOARD_z = SDLK_z,

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -440,51 +440,51 @@ int main(int argc, char *argv[])
                     gameinput();
                     gamerender();
                     gamelogic();
+                }
 
-
-                    break;
-                case MAPMODE:
-                    maprender();
-                    mapinput();
-                    maplogic();
-                    break;
-                case TELEPORTERMODE:
-                    teleporterrender();
-                    if(game.useteleporter)
-                    {
-                        teleporterinput();
-                    }
-                    else
-                    {
-                        if (script.running)
-                        {
-                            script.run();
-                        }
-                        gameinput();
-                    }
-                    maplogic();
-                    break;
-                case GAMECOMPLETE:
-                    gamecompleterender();
-                    //Input
-                    gamecompleteinput();
-                    //Logic
-                    gamecompletelogic();
-                    break;
-                case GAMECOMPLETE2:
-                    gamecompleterender2();
-                    //Input
-                    gamecompleteinput2();
-                    //Logic
-                    gamecompletelogic2();
-                    break;
-                case CLICKTOSTART:
-                    help.updateglow();
-                    break;
-                default:
 
                 break;
+            case MAPMODE:
+                maprender();
+                mapinput();
+                maplogic();
+                break;
+            case TELEPORTERMODE:
+                teleporterrender();
+                if(game.useteleporter)
+                {
+                    teleporterinput();
                 }
+                else
+                {
+                    if (script.running)
+                    {
+                        script.run();
+                    }
+                    gameinput();
+                }
+                maplogic();
+                break;
+            case GAMECOMPLETE:
+                gamecompleterender();
+                //Input
+                gamecompleteinput();
+                //Logic
+                gamecompletelogic();
+                break;
+            case GAMECOMPLETE2:
+                gamecompleterender2();
+                //Input
+                gamecompleteinput2();
+                //Logic
+                gamecompletelogic2();
+                break;
+            case CLICKTOSTART:
+                help.updateglow();
+                break;
+            default:
+
+                break;
 
             }
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -379,6 +379,9 @@ int main(int argc, char *argv[])
         game.infocus = key.isActive;
         if(!game.infocus)
         {
+            Mix_Pause(-1);
+            Mix_PauseMusic();
+
             FillRect(graphics.backBuffer, 0x00000000);
             graphics.bprint(5, 110, "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
             graphics.bprint(5, 120, "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
@@ -390,6 +393,9 @@ int main(int argc, char *argv[])
         }
         else
         {
+            Mix_Resume(-1);
+            Mix_ResumeMusic();
+
             switch(game.gamestate)
             {
             case PRELOADER:

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -531,8 +531,7 @@ int main(int argc, char *argv[])
             Mix_VolumeMusic(0) ;
             Mix_Volume(-1,0);
         }
-
-        if (!game.muted)
+        else
         {
             Mix_Volume(-1,MIX_MAX_VOLUME);
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -519,6 +519,16 @@ int main(int argc, char *argv[])
             game.mutebutton--;
         }
 
+        if (key.isDown(KEYBOARD_n) && game.musicmutebutton <= 0 && !inEditor)
+        {
+            game.musicmutebutton = 8;
+            game.musicmuted = !game.musicmuted;
+        }
+        if (game.musicmutebutton > 0)
+        {
+            game.musicmutebutton--;
+        }
+
         if (game.muted)
         {
             game.globalsound = 0;
@@ -529,8 +539,16 @@ int main(int argc, char *argv[])
         if (!game.muted && game.globalsound == 0)
         {
             game.globalsound = 1;
-            Mix_VolumeMusic(MIX_MAX_VOLUME) ;
             Mix_Volume(-1,MIX_MAX_VOLUME);
+
+            if (game.musicmuted)
+            {
+                Mix_VolumeMusic(0);
+            }
+            else
+            {
+                Mix_VolumeMusic(MIX_MAX_VOLUME);
+            }
         }
 
         if (key.resetWindow)

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -528,14 +528,12 @@ int main(int argc, char *argv[])
 
         if (game.muted)
         {
-            game.globalsound = 0;
             Mix_VolumeMusic(0) ;
             Mix_Volume(-1,0);
         }
 
-        if (!game.muted && game.globalsound == 0)
+        if (!game.muted)
         {
-            game.globalsound = 1;
             Mix_Volume(-1,MIX_MAX_VOLUME);
 
             if (game.musicmuted)

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -379,10 +379,6 @@ int main(int argc, char *argv[])
         game.infocus = key.isActive;
         if(!game.infocus)
         {
-            if(game.getGlobalSoundVol()> 0)
-            {
-                game.setGlobalSoundVol(0);
-            }
             FillRect(graphics.backBuffer, 0x00000000);
             graphics.bprint(5, 110, "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
             graphics.bprint(5, 120, "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -386,7 +386,8 @@ int main(int argc, char *argv[])
             FillRect(graphics.backBuffer, 0x00000000);
             graphics.bprint(5, 110, "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
             graphics.bprint(5, 120, "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
-            graphics.bprint(5, 230, "Press M to mute in game", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+            graphics.bprint(5, 220, "Press M to mute in game", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+            graphics.bprint(5, 230, "Press N to mute music only", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
             graphics.render();
             //We are minimised, so lets put a bit of a delay to save CPU
             SDL_Delay(100);


### PR DESCRIPTION
## Changes:

This PR adds being able to press N to mute music only, and automatically pausing the audio of the game when it's unfocused and resuming when it regains focus.

Both of these are already in VCE, however they did music-only muting a bit worse (it's an option in "game options" instead of being a simple keybind, which is annoying).

Some players (myself included) would like to have their own soundtrack playing in the background when playing the game, but don't want to mute sound effects as well.

Also, some custom levels have custom music that they sync to their scripted cutscenes. However, it's always been a problem that the music would desync if players unfocused the game, leading to having to do things like put indicators that say "don't unfocus the game" during cutscenes. If the audio of the game automatically paused when unfocusing, this problem would go away, without having to remove automatic pausing of the game.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file for all of said releases, but
  will NOT be compensated for these changes
