### PR TITLE
Fix seam when entering a new room with a horizontal or vertical warp background

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2122,10 +2122,10 @@ void Graphics::drawbackground( int t )
                 for (int i = 0; i < 21; i++)
                 {
                     temp = 680 + (rcol * 3);
-                    drawtowertile((i * 16) - backoffset, (j * 16), temp+40);
-                    drawtowertile((i * 16) - backoffset + 8, (j * 16), temp + 41);
-                    drawtowertile((i * 16) - backoffset, (j * 16) + 8, temp + 80);
-                    drawtowertile((i * 16) - backoffset + 8, (j * 16) + 8, temp + 81);
+                    drawtowertile((i * 16) - backoffset - 3, (j * 16), temp+40);
+                    drawtowertile((i * 16) - backoffset + 8 - 3, (j * 16), temp + 41);
+                    drawtowertile((i * 16) - backoffset - 3, (j * 16) + 8, temp + 80);
+                    drawtowertile((i * 16) - backoffset + 8 - 3, (j * 16) + 8, temp + 81);
                 }
             }
             backgrounddrawn = true;
@@ -2158,10 +2158,10 @@ void Graphics::drawbackground( int t )
                 for (int i = 0; i < 21; i++)
                 {
                     temp = 760 + (rcol * 3);
-                    drawtowertile((i * 16), (j * 16)- backoffset, temp+40);
-                    drawtowertile((i * 16)+ 8, (j * 16)- backoffset, temp + 41);
-                    drawtowertile((i * 16), (j * 16)- backoffset + 8, temp + 80);
-                    drawtowertile((i * 16)+ 8, (j * 16)- backoffset + 8, temp + 81);
+                    drawtowertile((i * 16), (j * 16)- backoffset - 3, temp+40);
+                    drawtowertile((i * 16)+ 8, (j * 16)- backoffset - 3, temp + 41);
+                    drawtowertile((i * 16), (j * 16)- backoffset + 8 - 3, temp + 80);
+                    drawtowertile((i * 16)+ 8, (j * 16)- backoffset + 8 - 3, temp + 81);
                 }
             }
             backgrounddrawn = true;


### PR DESCRIPTION
## Changes:

There's a noticeable seam in the horizontal and warp backgrounds whenever you enter a new room. Entering a new room triggers the game to re-draw the entire warp background instead of simply scrolling what it already has. This seam is the result of the initial background draw being misaligned with the rest of the scrolling.

![Top 10 images you'll never unsee (until I fix this bug)](https://user-images.githubusercontent.com/59748578/80288267-ccd26b00-86eb-11ea-83f1-56413444b52c.png)

If you get out your measuring tools, you'll see that it's misaligned by exactly 3 pixels (this applies to both horizontal and vertical warping). If you look at the part of the code where the game draws fresh warping textures after scrolling the existing ones offscreen, you'll see it starts with an offset of 317, which is exactly 320 minus 3. And for vertical, it uses 237, which is exactly 240 minus 3.

This is where the misalignment comes from. Since the incoming textures are drawn 3 pixels to the left, but the initial draw isn't, this results in a misalignment and causes the seam.

To fix this, draw the initial draw of the horizontal and vertical warp backgrounds 3 pixels to the left.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
