### PR TITLE
Fix the second, third, and fourth segments of moving platforms rendering offset from the first segment if they touch the top or left side of the screen

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1532,9 +1532,6 @@ void Graphics::drawentities()
                 // Special: Moving platform, 4 tiles or 8 tiles
                 tpoint.x = obj.entities[i].xp;
                 tpoint.y = obj.entities[i].yp;
-                drawRect = tiles_rect;
-                drawRect.x += tpoint.x;
-                drawRect.y += tpoint.y;
                 int thiswidth = 4;
                 if (obj.entities[i].size == 8)
                 {
@@ -1542,8 +1539,11 @@ void Graphics::drawentities()
                 }
                 for (int ii = 0; ii < thiswidth; ii++)
                 {
+                    drawRect = tiles_rect;
+                    drawRect.x += tpoint.x;
+                    drawRect.y += tpoint.y;
+                    drawRect.x += 8 * ii;
                     BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                    drawRect.x += 8;
                 }
             }
             else if (obj.entities[i].size == 3)    // Big chunky pixels!

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1535,13 +1535,11 @@ void Graphics::drawentities()
                 drawRect = tiles_rect;
                 drawRect.x += tpoint.x;
                 drawRect.y += tpoint.y;
-                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                drawRect.x += 8;
-                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                drawRect.x += 8;
-                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                drawRect.x += 8;
-                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                for (int ii = 0; ii < 4; ii++)
+                {
+                    BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                    drawRect.x += 8;
+                }
             }
             else if (obj.entities[i].size == 3)    // Big chunky pixels!
             {
@@ -1589,21 +1587,11 @@ void Graphics::drawentities()
                 drawRect.x += tpoint.x;
                 drawRect.y += tpoint.y;
 
-                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                drawRect.x += 8;
-                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                drawRect.x += 8;
-                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                drawRect.x += 8;
-                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                drawRect.x += 8;
-                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                drawRect.x += 8;
-                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                drawRect.x += 8;
-                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                drawRect.x += 8;
-                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                for (int ii = 0; ii < 8; ii++)
+                {
+                    BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                    drawRect.x += 8;
+                }
             }
             else if (obj.entities[i].size == 9)         // Really Big Sprite! (2x2)
             {

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1527,15 +1527,20 @@ void Graphics::drawentities()
                 drawRect.y += tpoint.y;
                 BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
             }
-            else if (obj.entities[i].size == 2)
+            else if (obj.entities[i].size == 2 || obj.entities[i].size == 8)
             {
-                // Special: Moving platform, 4 tiles
+                // Special: Moving platform, 4 tiles or 8 tiles
                 tpoint.x = obj.entities[i].xp;
                 tpoint.y = obj.entities[i].yp;
                 drawRect = tiles_rect;
                 drawRect.x += tpoint.x;
                 drawRect.y += tpoint.y;
-                for (int ii = 0; ii < 4; ii++)
+                int thiswidth = 4;
+                if (obj.entities[i].size == 8)
+                {
+                    thiswidth = 8;
+                }
+                for (int ii = 0; ii < thiswidth; ii++)
                 {
                     BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
                     drawRect.x += 8;
@@ -1581,17 +1586,7 @@ void Graphics::drawentities()
             }
             else if (obj.entities[i].size == 8)    // Special: Moving platform, 8 tiles
             {
-                tpoint.x = obj.entities[i].xp;
-                tpoint.y = obj.entities[i].yp;
-                drawRect = sprites_rect;
-                drawRect.x += tpoint.x;
-                drawRect.y += tpoint.y;
-
-                for (int ii = 0; ii < 8; ii++)
-                {
-                    BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                    drawRect.x += 8;
-                }
+                // Note: This code is in the 4-tile code
             }
             else if (obj.entities[i].size == 9)         // Really Big Sprite! (2x2)
             {

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1398,6 +1398,16 @@ void Graphics::drawentities()
 
     SDL_Rect drawRect;
 
+    std::vector<SDL_Surface*> *tilesvec;
+    if (map.custommode)
+    {
+        tilesvec = &entcolours;
+    }
+    else
+    {
+        tilesvec = &tiles;
+    }
+
     trinketcolset = false;
 
     for (int i = obj.entities.size() - 1; i >= 0; i--)
@@ -1525,23 +1535,13 @@ void Graphics::drawentities()
                 drawRect = tiles_rect;
                 drawRect.x += tpoint.x;
                 drawRect.y += tpoint.y;
-                if(map.custommode){
-                  BlitSurfaceStandard(entcolours[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(entcolours[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(entcolours[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(entcolours[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                }else{
-                  BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                }
+                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                drawRect.x += 8;
+                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                drawRect.x += 8;
+                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                drawRect.x += 8;
+                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
             }
             else if (obj.entities[i].size == 3)    // Big chunky pixels!
             {
@@ -1589,39 +1589,21 @@ void Graphics::drawentities()
                 drawRect.x += tpoint.x;
                 drawRect.y += tpoint.y;
 
-                 if(map.custommode){
-                  BlitSurfaceStandard(entcolours[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(entcolours[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(entcolours[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(entcolours[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(entcolours[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(entcolours[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(entcolours[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(entcolours[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                }else{
-                  BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                  drawRect.x += 8;
-                  BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                }
+                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                drawRect.x += 8;
+                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                drawRect.x += 8;
+                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                drawRect.x += 8;
+                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                drawRect.x += 8;
+                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                drawRect.x += 8;
+                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                drawRect.x += 8;
+                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                drawRect.x += 8;
+                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
             }
             else if (obj.entities[i].size == 9)         // Really Big Sprite! (2x2)
             {


### PR DESCRIPTION
## Changes:

Moving platforms are made up of four 8x8 segment tiles.

There's a bug where if a moving platform touches the left side or top side of the screen, the first segment will be drawn correctly, but the second to fourth segments will not be. (Naïvely it looks like the first segment is the odd one out, but that's not the case and it's the other way around - the other ones are the odd ones out, not the first one.)

![These platforms are flat-out broke.](https://user-images.githubusercontent.com/59748578/80291935-c2719a80-8706-11ea-8eec-961f3004f092.png)

This happens because each segment re-uses the `SDL_Rect` from the previous segment, but after each `SDL_BlitSurface()`, negative coordinates get set to 0 (due to `SDL_BlitSurface()`'s... "clipping"? Idk, it says [here](https://wiki.libsdl.org/SDL_BlitSurface) that "negative `dstrect` coordinates will be clipped properly", don't know what that means other than that it causes this bug).

To fix this, set the draw rectangle every time we draw a segment.

Also some refactors to de-duplicate moving platform drawing code.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
