### PR TITLE
Fix some menu oversights that I made

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6588,6 +6588,32 @@ void Game::returnmenu()
     }
 }
 
+void Game::returntomenu(enum Menu::MenuName t)
+{
+    if (currentmenuname == t)
+    {
+        //Why are you calling this function then?
+        return;
+    }
+
+    //Unwind the menu stack until we reach our desired menu
+    int i = menustack.size() - 1;
+    while (i >= 0)
+    {
+        //If we pop it off we can't reference it anymore, so check for it now
+        bool is_the_menu_we_want = menustack[i].name == t;
+
+        returnmenu();
+
+        if (is_the_menu_we_want)
+        {
+            break;
+        }
+
+        i--;
+    }
+}
+
 void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
 {
     if (t == Menu::mainmenu)

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1345,11 +1345,28 @@ void Game::updatestate()
             //or "who do you want to play the level with?"
             //or "do you want cutscenes?"
             //or the confirm-load-quicksave menu
-            if ((!wasintimetrial && !wasincustommode) || currentmenuname == Menu::quickloadlevel)
+            if (wasintimetrial)
             {
-                returnmenu();
+                returntomenu(Menu::timetrials);
+            }
+            else if (wasinintermission)
+            {
+                returntomenu(Menu::intermissionmenu);
+            }
+            else if (wasincustommode)
+            {
+                returntomenu(Menu::levellist);
+            }
+            else if (game.telesummary != "" || game.quicksummary != "")
+            {
+                returntomenu(Menu::play);
+            }
+            else
+            {
+                createmenu(Menu::mainmenu);
             }
             wasintimetrial = false;
+            wasinintermission = false;
             wasincustommode = false;
             state = 0;
             break;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -236,6 +236,7 @@ public:
 
     //Menu kludge...
     bool wasintimetrial;
+    bool wasinintermission;
     bool wasincustommode;
 
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -106,6 +106,7 @@ public:
     std::string timetstring(int t);
 
     void returnmenu();
+    void returntomenu(enum Menu::MenuName t);
     void  createmenu(enum Menu::MenuName t, bool samemenu = false);
 
     void lifesequence();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1961,6 +1961,7 @@ void mapinput()
                 FillRect(graphics.tempBuffer, 0x000000);
                 if (game.intimetrial || game.insecretlab || game.nodeathmode) game.menukludge = true;
                 game.wasintimetrial = game.intimetrial;
+                game.wasinintermission = game.inintermission;
                 game.wasincustommode = map.custommode;
                 script.hardreset();
                 if(graphics.setflipmode) graphics.flipmode = true;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3471,10 +3471,7 @@ void editorlogic()
         map.nexttowercolour();
         ed.settingsmod=false;
         graphics.backgrounddrawn=false;
-        //Do returnmenu twice because we have two menus:
-        //the main editor menu and the confirm save&quit menu
-        game.returnmenu();
-        game.returnmenu();
+        game.returntomenu(Menu::playerworlds);
     }
 }
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3509,7 +3509,7 @@ void editormenuactionpress()
             break;
         case 4:
             music.playef(11);
-            game.createmenu(Menu::ed_settings);
+            game.returnmenu();
             map.nexttowercolour();
             break;
         }
@@ -3600,7 +3600,7 @@ void editormenuactionpress()
         case 1:
             music.playef(11);
             music.fadeout();
-            game.createmenu(Menu::ed_settings);
+            game.returnmenu();
             map.nexttowercolour();
             break;
         }
@@ -3633,7 +3633,7 @@ void editormenuactionpress()
         case 2:
             //Go back to editor
             music.playef(11);
-            game.createmenu(Menu::ed_settings);
+            game.returnmenu();
             map.nexttowercolour();
             break;
         }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3719,8 +3719,27 @@ void editorinput()
             ed.settingsmod=!ed.settingsmod;
             graphics.backgrounddrawn=false;
 
-            game.createmenu(Menu::ed_settings);
-            map.nexttowercolour();
+            if (ed.settingsmod)
+            {
+                bool edsettings_in_stack = false;
+                for (size_t i = 0; i < game.menustack.size(); i++)
+                {
+                    if (game.menustack[i].name == Menu::ed_settings)
+                    {
+                        edsettings_in_stack = true;
+                        break;
+                    }
+                }
+                if (edsettings_in_stack)
+                {
+                    game.returntomenu(Menu::ed_settings);
+                }
+                else
+                {
+                    game.createmenu(Menu::ed_settings);
+                }
+                map.nexttowercolour();
+            }
         }
     }
 


### PR DESCRIPTION
## Changes:

In #201 I forgot a couple of things.

Most notably, I forgot to use `game.returnmenu()` for the editor menus. As well, I've improved the code for quitting and going back to the main menu, which now uses a new function called `game.returntomenu()`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
