### PR TITLE
Fix menuing when having no saves but having something unlocked, fix deleting saves

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -510,3 +510,8 @@ bool FILESYSTEM_openDirectory(const char *dname)
 	return false;
 }
 #endif
+
+bool FILESYSTEM_delete(const char *name)
+{
+    return PHYSFS_delete(name) != 0;
+}

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -23,4 +23,6 @@ std::vector<std::string> FILESYSTEM_getLevelDirFileNames();
 bool FILESYSTEM_openDirectoryEnabled();
 bool FILESYSTEM_openDirectory(const char *dname);
 
+bool FILESYSTEM_delete(const char *name);
+
 #endif /* FILESYSTEMUTILS_H */

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7313,3 +7313,20 @@ int Game::crewmates()
     }
     return temp;
 }
+
+bool Game::anything_unlocked()
+{
+    for (size_t i = 0; i < unlock.size(); i++)
+    {
+        if (unlock[i] &&
+        (i == 8 // Secret Lab
+        || i >= 9 || i <= 14 // any Time Trial
+        || i == 16 // Intermission replays
+        || i == 17 // No Death Mode
+        || i == 18)) // Flip Mode
+        {
+            return true;
+        }
+    }
+    return false;
+}

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4215,21 +4215,27 @@ void Game::gethardestroom()
 
 void Game::deletestats()
 {
-    for (int i = 0; i < 25; i++)
+    if (!FILESYSTEM_delete("saves/unlock.vvv"))
     {
-        unlock[i] = false;
-        unlocknotify[i] = false;
+        puts("Error deleting saves/unlock.vvv");
     }
-    for (int i = 0; i < 6; i++)
+    else
     {
-        besttimes[i] = -1;
-        besttrinkets[i] = -1;
-        bestlives[i] = -1;
-        bestrank[i] = -1;
+        for (int i = 0; i < 25; i++)
+        {
+            unlock[i] = false;
+            unlocknotify[i] = false;
+        }
+        for (int i = 0; i < 6; i++)
+        {
+            besttimes[i] = -1;
+            besttrinkets[i] = -1;
+            bestlives[i] = -1;
+            bestrank[i] = -1;
+        }
+        graphics.setflipmode = false;
+        stat_trinkets = 0;
     }
-    graphics.setflipmode = false;
-    stat_trinkets = 0;
-    savestats();
 }
 
 void Game::unlocknum( int t )

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1357,7 +1357,7 @@ void Game::updatestate()
             {
                 returntomenu(Menu::levellist);
             }
-            else if (game.telesummary != "" || game.quicksummary != "")
+            else if (game.telesummary != "" || game.quicksummary != "" || anything_unlocked())
             {
                 returntomenu(Menu::play);
             }
@@ -7025,14 +7025,24 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
             }
             else
             {
-                option("continue");
+                if (telesummary != "" || quicksummary != "")
+                {
+                    option("continue");
+                }
+                else
+                {
+                    option("start");
+                }
                 //ok, secret lab! no notification, but test:
                 if (unlock[8])
                 {
                     option("secret lab", !map.invincibility && game.slowdown == 30);
                 }
                 option("play modes");
-                option("new game");
+                if (telesummary != "" || quicksummary != "")
+                {
+                    option("new game");
+                }
                 option("return");
                 if (unlock[8])
                 {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7188,16 +7188,16 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
 
 void Game::deletequick()
 {
-    if( remove( "qsave.vvv" ) != 0 )
-        puts("Error deleting qsave.vvv");
+    if( !FILESYSTEM_delete( "saves/qsave.vvv" ) )
+        puts("Error deleting saves/qsave.vvv");
     else
         quicksummary = "";
 }
 
 void Game::deletetele()
 {
-    if( remove( "tsave.vvv" ) != 0 )
-        puts("Error deleting tsave.vvv");
+    if( !FILESYSTEM_delete( "saves/tsave.vvv" ) )
+        puts("Error deleting saves/tsave.vvv");
     else
         telesummary = "";
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7189,7 +7189,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
 void Game::deletequick()
 {
     if( remove( "qsave.vvv" ) != 0 )
-        printf("Error deleting file\n");
+        puts("Error deleting qsave.vvv");
     else
         quicksummary = "";
 }
@@ -7197,7 +7197,7 @@ void Game::deletequick()
 void Game::deletetele()
 {
     if( remove( "tsave.vvv" ) != 0 )
-        printf("Error deleting file\n");
+        puts("Error deleting tsave.vvv");
     else
         telesummary = "";
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1357,7 +1357,7 @@ void Game::updatestate()
             {
                 returntomenu(Menu::levellist);
             }
-            else if (game.telesummary != "" || game.quicksummary != "" || anything_unlocked())
+            else if (telesummary != "" || quicksummary != "" || anything_unlocked())
             {
                 returntomenu(Menu::play);
             }
@@ -7036,7 +7036,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
                 //ok, secret lab! no notification, but test:
                 if (unlock[8])
                 {
-                    option("secret lab", !map.invincibility && game.slowdown == 30);
+                    option("secret lab", !map.invincibility && slowdown == 30);
                 }
                 option("play modes");
                 if (telesummary != "" || quicksummary != "")
@@ -7074,9 +7074,9 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         menuyoff = 64;
         break;
     case Menu::playmodes:
-        option("time trials", !map.invincibility && game.slowdown == 30);
+        option("time trials", !map.invincibility && slowdown == 30);
         option("intermissions", unlock[16]);
-        option("no death mode", unlock[17] && !map.invincibility && game.slowdown == 30);
+        option("no death mode", unlock[17] && !map.invincibility && slowdown == 30);
         option("flip mode", unlock[18]);
         option("return to play menu");
         menuxoff = -70;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1357,7 +1357,7 @@ void Game::updatestate()
             {
                 returntomenu(Menu::levellist);
             }
-            else if (telesummary != "" || quicksummary != "" || anything_unlocked())
+            else if (save_exists() || anything_unlocked())
             {
                 returntomenu(Menu::play);
             }
@@ -7031,7 +7031,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
             }
             else
             {
-                if (telesummary != "" || quicksummary != "")
+                if (save_exists())
                 {
                     option("continue");
                 }
@@ -7045,7 +7045,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
                     option("secret lab", !map.invincibility && slowdown == 30);
                 }
                 option("play modes");
-                if (telesummary != "" || quicksummary != "")
+                if (save_exists())
                 {
                     option("new game");
                 }
@@ -7345,4 +7345,9 @@ bool Game::anything_unlocked()
         }
     }
     return false;
+}
+
+bool Game::save_exists()
+{
+    return telesummary != "" || quicksummary != "";
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7190,16 +7190,16 @@ void Game::deletequick()
 {
     if( remove( "qsave.vvv" ) != 0 )
         printf("Error deleting file\n");
-
-    quicksummary = "";
+    else
+        quicksummary = "";
 }
 
 void Game::deletetele()
 {
     if( remove( "tsave.vvv" ) != 0 )
         printf("Error deleting file\n");
-
-    telesummary = "";
+    else
+        telesummary = "";
 }
 
 void Game::swnpenalty()

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -328,6 +328,7 @@ public:
     std::string activity_lastprompt;
 
     std::string telesummary, quicksummary, customquicksummary;
+    bool save_exists();
 
     bool backgroundtext;
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -286,6 +286,7 @@ public:
 
     std::vector<int> unlock;
     std::vector<int> unlocknotify;
+    bool anything_unlocked();
     int stat_trinkets;
     bool fullscreen;
     int bestgamedeaths;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -134,7 +134,7 @@ void menuactionpress()
 #if !defined(MAKEANDPLAY)
         case 0:
             //Play
-            if (game.telesummary == "" && game.quicksummary == "" && !game.anything_unlocked())
+            if (!game.save_exists() && !game.anything_unlocked())
             {
                 //No saves exist, just start a new game
                 game.mainmenu = 0;
@@ -950,12 +950,12 @@ void menuactionpress()
         //Do we have the Secret Lab option?
         int sloffset = game.unlock[8] ? 0 : -1;
         //Do we have a telesave or quicksave?
-        int ngoffset = game.telesummary != "" || game.quicksummary != "" ? 0 : -1;
+        int ngoffset = game.save_exists() ? 0 : -1;
         if (game.currentmenuoption == 0)
         {
             //continue
             //right, this depends on what saves you've got
-            if (game.telesummary == "" && game.quicksummary == "")
+            if (!game.save_exists())
             {
                 //You have no saves but have something unlocked, or you couldn't have gotten here
                 game.mainmenu = 0;
@@ -998,7 +998,7 @@ void menuactionpress()
             game.createmenu(Menu::playmodes);
             map.nexttowercolour();
         }
-        else if (game.currentmenuoption == sloffset+3 && (game.telesummary != "" || game.quicksummary != ""))
+        else if (game.currentmenuoption == sloffset+3 && game.save_exists())
         {
             //newgame
             music.playef(11);

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -134,7 +134,7 @@ void menuactionpress()
 #if !defined(MAKEANDPLAY)
         case 0:
             //Play
-            if (game.telesummary == "" && game.quicksummary == "")
+            if (game.telesummary == "" && game.quicksummary == "" && !game.anything_unlocked())
             {
                 //No saves exist, just start a new game
                 game.mainmenu = 0;
@@ -948,12 +948,20 @@ void menuactionpress()
     case Menu::play:
     {
         //Do we have the Secret Lab option?
-        int offset = game.unlock[8] ? 0 : -1;
+        int sloffset = game.unlock[8] ? 0 : -1;
+        //Do we have a telesave or quicksave?
+        int ngoffset = game.telesummary != "" || game.quicksummary != "" ? 0 : -1;
         if (game.currentmenuoption == 0)
         {
             //continue
             //right, this depends on what saves you've got
-            if (game.telesummary == "")
+            if (game.telesummary == "" && game.quicksummary == "")
+            {
+                //You have no saves but have something unlocked, or you couldn't have gotten here
+                game.mainmenu = 0;
+                graphics.fademode = 2;
+            }
+            else if (game.telesummary == "")
             {
                 //You at least have a quicksave, or you couldn't have gotten here
                 game.mainmenu = 2;
@@ -983,21 +991,21 @@ void menuactionpress()
                 music.playef(2);
             }
         }
-        else if (game.currentmenuoption == offset+2)
+        else if (game.currentmenuoption == sloffset+2)
         {
             //play modes
             music.playef(11);
             game.createmenu(Menu::playmodes);
             map.nexttowercolour();
         }
-        else if (game.currentmenuoption == offset+3)
+        else if (game.currentmenuoption == sloffset+3 && (game.telesummary != "" || game.quicksummary != ""))
         {
             //newgame
             music.playef(11);
             game.createmenu(Menu::newgamewarning);
             map.nexttowercolour();
         }
-        else if (game.currentmenuoption == offset+4)
+        else if (game.currentmenuoption == sloffset+ngoffset+4)
         {
             //back
             music.playef(11);


### PR DESCRIPTION
## Changes:

* **Fix annoying menu flow if you have no saves but have something unlocked**

  It's slightly annoying that "start game" takes you to a new game instead of the play menu just because you have no quicksave or telesave, even though you have something unlocked like Time Trials or the Secret Lab.

  Now, if you have no saves but have something unlocked, "start game" will take you to the play menu. In the play menu, "continue" will be replaced with "start", and "new game" will be missing.

  Speedrunners will especially notice this because they start new runs (and thus delete their saves) all the time. And speaking of deleting saves...

* **Fix deleting `saves/tsave.vvv`, `saves/qsave.vvv`, and `saves/unlock.vvv`**

  Looks like deleting the telesave and quicksave has never actually properly worked, because the game tries to delete `tsave.vvv` and `qsave.vvv` *in the current run path* instead of `saves/tsave.vvv` and `saves/qsave.vvv`! It only doesn't cause any problems (until you relaunch) because the game doesn't care about the successful deletion of those files anyway, and instead internally thinks they're deleted.

  Also, `saves/unlock.vvv` isn't actually properly deleted. Instead it's simply blanked out, which gets the job done but is very hacky.

  To fix these, we need to use PhysFS stuff, because that's what it was made for.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
