### PR TITLE
Merge towerrender/towerlogic into gamerender/gamelogic

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1408,6 +1408,16 @@ void Graphics::drawentities()
         tilesvec = &tiles;
     }
 
+    std::vector<SDL_Surface*> *spritesvec;
+    if (flipmode)
+    {
+        spritesvec = &flipsprites;
+    }
+    else
+    {
+        spritesvec = &sprites;
+    }
+
     trinketcolset = false;
 
     for (int i = obj.entities.size() - 1; i >= 0; i--)
@@ -1417,57 +1427,7 @@ void Graphics::drawentities()
             if (obj.entities[i].size == 0)
             {
                 // Sprites
-                if (flipmode)
-                {
-                    tpoint.x = obj.entities[i].xp;
-                    tpoint.y = obj.entities[i].yp;
-                    setcol(obj.entities[i].colour);
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                    if (map.warpx)
-                    {
-                        //screenwrapping!
-                        if (tpoint.x < 0)
-                        {
-                            tpoint.x += 320;
-                            drawRect = sprites_rect;
-                            drawRect.x += tpoint.x;
-                            drawRect.y += tpoint.y;
-                            BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                        }
-                        if (tpoint.x > 300)
-                        {
-                            tpoint.x -= 320;
-                            drawRect = sprites_rect;
-                            drawRect.x += tpoint.x;
-                            drawRect.y += tpoint.y;
-                            BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                        }
-                    }
-                    else if (map.warpy)
-                    {
-                        if (tpoint.y < 0)
-                        {
-                            tpoint.y += 230;
-                            drawRect = sprites_rect;
-                            drawRect.x += tpoint.x;
-                            drawRect.y += tpoint.y;
-                            BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                        }
-                        if (tpoint.y > 210)
-                        {
-                            tpoint.y -= 230;
-                            drawRect = sprites_rect;
-                            drawRect.x += tpoint.x;
-                            drawRect.y += tpoint.y;
-                            BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                        }
-                    }
-                }
-                else
-                {
+                // FIXME: Remove temporary indent here
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
                     setcol(obj.entities[i].colour);
@@ -1475,7 +1435,7 @@ void Graphics::drawentities()
                     drawRect = sprites_rect;
                     drawRect.x += tpoint.x;
                     drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(sprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                     if (map.warpx)
                     {
                         //screenwrapping!
@@ -1485,7 +1445,7 @@ void Graphics::drawentities()
                             drawRect = sprites_rect;
                             drawRect.x += tpoint.x;
                             drawRect.y += tpoint.y;
-                            BlitSurfaceColoured(sprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                         }
                         if (tpoint.x > 300)
                         {
@@ -1493,7 +1453,7 @@ void Graphics::drawentities()
                             drawRect = sprites_rect;
                             drawRect.x += tpoint.x;
                             drawRect.y += tpoint.y;
-                            BlitSurfaceColoured(sprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                         }
                     }
                     else if (map.warpy)
@@ -1504,7 +1464,7 @@ void Graphics::drawentities()
                             drawRect = sprites_rect;
                             drawRect.x += tpoint.x;
                             drawRect.y += tpoint.y;
-                            BlitSurfaceColoured(sprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                         }
                         if (tpoint.y > 210)
                         {
@@ -1512,10 +1472,9 @@ void Graphics::drawentities()
                             drawRect = sprites_rect;
                             drawRect.x += tpoint.x;
                             drawRect.y += tpoint.y;
-                            BlitSurfaceColoured(sprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                         }
                     }
-                }
             }
             else if (obj.entities[i].size == 1)
             {
@@ -1590,44 +1549,7 @@ void Graphics::drawentities()
             }
             else if (obj.entities[i].size == 9)         // Really Big Sprite! (2x2)
             {
-                if (flipmode)
-                {
-                    setcol(obj.entities[i].colour);
-
-                    tpoint.x = obj.entities[i].xp;
-                    tpoint.y = obj.entities[i].yp;
-                    //
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-
-                    tpoint.x = obj.entities[i].xp+32;
-                    tpoint.y = obj.entities[i].yp;
-                    //
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe +1],NULL, backBuffer, &drawRect, ct);
-
-                    tpoint.x = obj.entities[i].xp;
-                    tpoint.y = obj.entities[i].yp+32;
-                    //
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe+ 12],NULL, backBuffer, &drawRect, ct);
-
-                    tpoint.x = obj.entities[i].xp+32;
-                    tpoint.y = obj.entities[i].yp+32;
-                    //
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe+ 13],NULL, backBuffer, &drawRect, ct);
-                }
-                else
-                {
+                // FIXME: Remove temporary indent here
                     setcol(obj.entities[i].colour);
 
                     tpoint.x = obj.entities[i].xp;
@@ -1636,7 +1558,7 @@ void Graphics::drawentities()
                     drawRect = sprites_rect;
                     drawRect.x += tpoint.x;
                     drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(sprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
 
                     tpoint.x = obj.entities[i].xp+32;
                     tpoint.y = obj.entities[i].yp;
@@ -1644,7 +1566,7 @@ void Graphics::drawentities()
                     drawRect = sprites_rect;
                     drawRect.x += tpoint.x;
                     drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(sprites[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
+                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
 
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp+32;
@@ -1652,7 +1574,7 @@ void Graphics::drawentities()
                     drawRect = sprites_rect;
                     drawRect.x += tpoint.x;
                     drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(sprites[obj.entities[i].drawframe+12],NULL, backBuffer, &drawRect, ct);
+                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+12],NULL, backBuffer, &drawRect, ct);
 
                     tpoint.x = obj.entities[i].xp+32;
                     tpoint.y = obj.entities[i].yp+32;
@@ -1660,13 +1582,11 @@ void Graphics::drawentities()
                     drawRect = sprites_rect;
                     drawRect.x += tpoint.x;
                     drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(sprites[obj.entities[i].drawframe + 13],NULL, backBuffer, &drawRect, ct);
-                }
+                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe + 13],NULL, backBuffer, &drawRect, ct);
             }
             else if (obj.entities[i].size == 10)         // 2x1 Sprite
             {
-                if (flipmode)
-                {
+                // FIXME: Remove temporary indent here
                     setcol(obj.entities[i].colour);
 
                     tpoint.x = obj.entities[i].xp;
@@ -1675,7 +1595,7 @@ void Graphics::drawentities()
                     drawRect = sprites_rect;
                     drawRect.x += tpoint.x;
                     drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
 
                     tpoint.x = obj.entities[i].xp+32;
                     tpoint.y = obj.entities[i].yp;
@@ -1683,28 +1603,7 @@ void Graphics::drawentities()
                     drawRect = sprites_rect;
                     drawRect.x += tpoint.x;
                     drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
-                }
-                else
-                {
-                    setcol(obj.entities[i].colour);
-
-                    tpoint.x = obj.entities[i].xp;
-                    tpoint.y = obj.entities[i].yp;
-                    //
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(sprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-
-                    tpoint.x = obj.entities[i].xp+32;
-                    tpoint.y = obj.entities[i].yp;
-                    //
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(sprites[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
-                }
+                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
             }
             else if (obj.entities[i].size == 11)    //The fucking elephant
             {
@@ -1713,62 +1612,7 @@ void Graphics::drawentities()
             }
             else if (obj.entities[i].size == 12)         // Regular sprites that don't wrap
             {
-                if (flipmode)
-                {
-                    //forget this for a minute;
-                    tpoint.x = obj.entities[i].xp;
-                    tpoint.y = obj.entities[i].yp;
-                    setcol(obj.entities[i].colour);
-
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(flipsprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-
-                    //if we're outside the screen, we need to draw indicators
-                    if (obj.entities[i].xp < -20 && obj.entities[i].vx > 0)
-                    {
-                        if (obj.entities[i].xp < -100)
-                        {
-                            tpoint.x = -5 + (int(( -obj.entities[i].xp) / 10));
-                        }
-                        else
-                        {
-                            tpoint.x = 5;
-                        }
-
-                        tpoint.y = tpoint.y+4;
-                        setcol(23);
-
-                        drawRect = tiles_rect;
-                        drawRect.x += tpoint.x;
-                        drawRect.y += tpoint.y;
-                        BlitSurfaceColoured(tiles[1167],NULL, backBuffer, &drawRect, ct);
-
-                    }
-                    else if (obj.entities[i].xp > 340 && obj.entities[i].vx < 0)
-                    {
-                        if (obj.entities[i].xp > 420)
-                        {
-                            tpoint.x = 320 - (int(( obj.entities[i].xp-320) / 10));
-                        }
-                        else
-                        {
-                            tpoint.x = 310;
-                        }
-
-                        tpoint.y = tpoint.y+4;
-                        setcol(23);
-                        //
-
-                        drawRect = tiles_rect;
-                        drawRect.x += tpoint.x;
-                        drawRect.y += tpoint.y;
-                        BlitSurfaceColoured(tiles[1166],NULL, backBuffer, &drawRect, ct);
-                    }
-                }
-                else
-                {
+                // FIXME: Remove temporary indent here
                     tpoint.x = obj.entities[i].xp;
                     tpoint.y = obj.entities[i].yp;
                     setcol(obj.entities[i].colour);
@@ -1776,7 +1620,7 @@ void Graphics::drawentities()
                     drawRect = sprites_rect;
                     drawRect.x += tpoint.x;
                     drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(sprites[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
 
 
                     //if we're outside the screen, we need to draw indicators
@@ -1822,34 +1666,18 @@ void Graphics::drawentities()
                         drawRect.y += tpoint.y;
                         BlitSurfaceColoured(tiles[1166],NULL, backBuffer, &drawRect, ct);
                     }
-                }
             }
             else if (obj.entities[i].size == 13)
             {
                  //Special for epilogue: huge hero!
 
-                if (flipmode) {
-
-
-
-                    FillRect(tempBuffer, 0x000000);
-
-                    tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
-                    setcol(obj.entities[i].colour);
-                    SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), sprites_rect.x, sprites_rect.y   };
-                    SDL_Surface* TempSurface = ScaleSurface( flipsprites[obj.entities[i].drawframe], 6* sprites_rect.w,6* sprites_rect.w );
-                    BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
-                    SDL_FreeSurface(TempSurface);
-                }
-                else
-                {
+                // FIXME: Remove temporary indent here
                     tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
                     setcol(obj.entities[i].colour);
                     SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
-                    SDL_Surface* TempSurface = ScaleSurface( flipsprites[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
+                    SDL_Surface* TempSurface = ScaleSurface( (*spritesvec)[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
                     BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
                     SDL_FreeSurface(TempSurface);
-                }
 
 
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1427,54 +1427,53 @@ void Graphics::drawentities()
             if (obj.entities[i].size == 0)
             {
                 // Sprites
-                // FIXME: Remove temporary indent here
-                    tpoint.x = obj.entities[i].xp;
-                    tpoint.y = obj.entities[i].yp;
-                    setcol(obj.entities[i].colour);
+                tpoint.x = obj.entities[i].xp;
+                tpoint.y = obj.entities[i].yp;
+                setcol(obj.entities[i].colour);
 
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                    if (map.warpx)
+                drawRect = sprites_rect;
+                drawRect.x += tpoint.x;
+                drawRect.y += tpoint.y;
+                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                if (map.warpx)
+                {
+                    //screenwrapping!
+                    if (tpoint.x < 0)
                     {
-                        //screenwrapping!
-                        if (tpoint.x < 0)
-                        {
-                            tpoint.x += 320;
-                            drawRect = sprites_rect;
-                            drawRect.x += tpoint.x;
-                            drawRect.y += tpoint.y;
-                            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                        }
-                        if (tpoint.x > 300)
-                        {
-                            tpoint.x -= 320;
-                            drawRect = sprites_rect;
-                            drawRect.x += tpoint.x;
-                            drawRect.y += tpoint.y;
-                            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                        }
+                        tpoint.x += 320;
+                        drawRect = sprites_rect;
+                        drawRect.x += tpoint.x;
+                        drawRect.y += tpoint.y;
+                        BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                     }
-                    else if (map.warpy)
+                    if (tpoint.x > 300)
                     {
-                        if (tpoint.y < 0)
-                        {
-                            tpoint.y += 230;
-                            drawRect = sprites_rect;
-                            drawRect.x += tpoint.x;
-                            drawRect.y += tpoint.y;
-                            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                        }
-                        if (tpoint.y > 210)
-                        {
-                            tpoint.y -= 230;
-                            drawRect = sprites_rect;
-                            drawRect.x += tpoint.x;
-                            drawRect.y += tpoint.y;
-                            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                        }
+                        tpoint.x -= 320;
+                        drawRect = sprites_rect;
+                        drawRect.x += tpoint.x;
+                        drawRect.y += tpoint.y;
+                        BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                     }
+                }
+                else if (map.warpy)
+                {
+                    if (tpoint.y < 0)
+                    {
+                        tpoint.y += 230;
+                        drawRect = sprites_rect;
+                        drawRect.x += tpoint.x;
+                        drawRect.y += tpoint.y;
+                        BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                    }
+                    if (tpoint.y > 210)
+                    {
+                        tpoint.y -= 230;
+                        drawRect = sprites_rect;
+                        drawRect.x += tpoint.x;
+                        drawRect.y += tpoint.y;
+                        BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                    }
+                }
             }
             else if (obj.entities[i].size == 1)
             {
@@ -1549,61 +1548,59 @@ void Graphics::drawentities()
             }
             else if (obj.entities[i].size == 9)         // Really Big Sprite! (2x2)
             {
-                // FIXME: Remove temporary indent here
-                    setcol(obj.entities[i].colour);
+                setcol(obj.entities[i].colour);
 
-                    tpoint.x = obj.entities[i].xp;
-                    tpoint.y = obj.entities[i].yp;
+                tpoint.x = obj.entities[i].xp;
+                tpoint.y = obj.entities[i].yp;
 
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                drawRect = sprites_rect;
+                drawRect.x += tpoint.x;
+                drawRect.y += tpoint.y;
+                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
 
-                    tpoint.x = obj.entities[i].xp+32;
-                    tpoint.y = obj.entities[i].yp;
-                    //
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
+                tpoint.x = obj.entities[i].xp+32;
+                tpoint.y = obj.entities[i].yp;
+                //
+                drawRect = sprites_rect;
+                drawRect.x += tpoint.x;
+                drawRect.y += tpoint.y;
+                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
 
-                    tpoint.x = obj.entities[i].xp;
-                    tpoint.y = obj.entities[i].yp+32;
-                    //
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+12],NULL, backBuffer, &drawRect, ct);
+                tpoint.x = obj.entities[i].xp;
+                tpoint.y = obj.entities[i].yp+32;
+                //
+                drawRect = sprites_rect;
+                drawRect.x += tpoint.x;
+                drawRect.y += tpoint.y;
+                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+12],NULL, backBuffer, &drawRect, ct);
 
-                    tpoint.x = obj.entities[i].xp+32;
-                    tpoint.y = obj.entities[i].yp+32;
-                    //
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe + 13],NULL, backBuffer, &drawRect, ct);
+                tpoint.x = obj.entities[i].xp+32;
+                tpoint.y = obj.entities[i].yp+32;
+                //
+                drawRect = sprites_rect;
+                drawRect.x += tpoint.x;
+                drawRect.y += tpoint.y;
+                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe + 13],NULL, backBuffer, &drawRect, ct);
             }
             else if (obj.entities[i].size == 10)         // 2x1 Sprite
             {
-                // FIXME: Remove temporary indent here
-                    setcol(obj.entities[i].colour);
+                setcol(obj.entities[i].colour);
 
-                    tpoint.x = obj.entities[i].xp;
-                    tpoint.y = obj.entities[i].yp;
-                    //
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                tpoint.x = obj.entities[i].xp;
+                tpoint.y = obj.entities[i].yp;
+                //
+                drawRect = sprites_rect;
+                drawRect.x += tpoint.x;
+                drawRect.y += tpoint.y;
+                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
 
-                    tpoint.x = obj.entities[i].xp+32;
-                    tpoint.y = obj.entities[i].yp;
-                    //
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
+                tpoint.x = obj.entities[i].xp+32;
+                tpoint.y = obj.entities[i].yp;
+                //
+                drawRect = sprites_rect;
+                drawRect.x += tpoint.x;
+                drawRect.y += tpoint.y;
+                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
             }
             else if (obj.entities[i].size == 11)    //The fucking elephant
             {
@@ -1612,72 +1609,70 @@ void Graphics::drawentities()
             }
             else if (obj.entities[i].size == 12)         // Regular sprites that don't wrap
             {
-                // FIXME: Remove temporary indent here
-                    tpoint.x = obj.entities[i].xp;
-                    tpoint.y = obj.entities[i].yp;
-                    setcol(obj.entities[i].colour);
-                    //
-                    drawRect = sprites_rect;
+                tpoint.x = obj.entities[i].xp;
+                tpoint.y = obj.entities[i].yp;
+                setcol(obj.entities[i].colour);
+                //
+                drawRect = sprites_rect;
+                drawRect.x += tpoint.x;
+                drawRect.y += tpoint.y;
+                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+
+
+                //if we're outside the screen, we need to draw indicators
+
+                if (obj.entities[i].xp < -20 && obj.entities[i].vx > 0)
+                {
+                    if (obj.entities[i].xp < -100)
+                    {
+                        tpoint.x = -5 + (int(( -obj.entities[i].xp) / 10));
+                    }
+                    else
+                    {
+                        tpoint.x = 5;
+                    }
+
+                    tpoint.y = tpoint.y+4;
+                    setcol(23);
+
+
+                    drawRect = tiles_rect;
                     drawRect.x += tpoint.x;
                     drawRect.y += tpoint.y;
-                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                    BlitSurfaceColoured(tiles[1167],NULL, backBuffer, &drawRect, ct);
 
-
-                    //if we're outside the screen, we need to draw indicators
-
-                    if (obj.entities[i].xp < -20 && obj.entities[i].vx > 0)
+                }
+                else if (obj.entities[i].xp > 340 && obj.entities[i].vx < 0)
+                {
+                    if (obj.entities[i].xp > 420)
                     {
-                        if (obj.entities[i].xp < -100)
-                        {
-                            tpoint.x = -5 + (int(( -obj.entities[i].xp) / 10));
-                        }
-                        else
-                        {
-                            tpoint.x = 5;
-                        }
-
-                        tpoint.y = tpoint.y+4;
-                        setcol(23);
-
-
-                        drawRect = tiles_rect;
-                        drawRect.x += tpoint.x;
-                        drawRect.y += tpoint.y;
-                        BlitSurfaceColoured(tiles[1167],NULL, backBuffer, &drawRect, ct);
-
+                        tpoint.x = 320 - (int(( obj.entities[i].xp-320) / 10));
                     }
-                    else if (obj.entities[i].xp > 340 && obj.entities[i].vx < 0)
+                    else
                     {
-                        if (obj.entities[i].xp > 420)
-                        {
-                            tpoint.x = 320 - (int(( obj.entities[i].xp-320) / 10));
-                        }
-                        else
-                        {
-                            tpoint.x = 310;
-                        }
-
-                        tpoint.y = tpoint.y+4;
-                        setcol(23);
-                        //
-
-                        drawRect = tiles_rect;
-                        drawRect.x += tpoint.x;
-                        drawRect.y += tpoint.y;
-                        BlitSurfaceColoured(tiles[1166],NULL, backBuffer, &drawRect, ct);
+                        tpoint.x = 310;
                     }
+
+                    tpoint.y = tpoint.y+4;
+                    setcol(23);
+                    //
+
+                    drawRect = tiles_rect;
+                    drawRect.x += tpoint.x;
+                    drawRect.y += tpoint.y;
+                    BlitSurfaceColoured(tiles[1166],NULL, backBuffer, &drawRect, ct);
+                }
             }
             else if (obj.entities[i].size == 13)
             {
-                 //Special for epilogue: huge hero!
+                //Special for epilogue: huge hero!
 
-                // FIXME: Remove temporary indent here
-                    tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
-                    setcol(obj.entities[i].colour);
-                    SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
-                    SDL_Surface* TempSurface = ScaleSurface( (*spritesvec)[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
-                    BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
-                    SDL_FreeSurface(TempSurface);
+                tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
+                setcol(obj.entities[i].colour);
+                SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
+                SDL_Surface* TempSurface = ScaleSurface( (*spritesvec)[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
+                BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
+                SDL_FreeSurface(TempSurface);
 
 
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1449,7 +1449,7 @@ void Graphics::drawentities()
                     drawRect.y += tpoint.y;
                     BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                 }
-                if (tpoint.x > 300)
+                else if (tpoint.x > 300)
                 {
                     tpoint.x -= 320;
                     drawRect = sprites_rect;
@@ -1468,7 +1468,7 @@ void Graphics::drawentities()
                     drawRect.y += tpoint.y;
                     BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                 }
-                if (tpoint.y > 210)
+                else if (tpoint.y > 210)
                 {
                     tpoint.y -= 230;
                     drawRect = sprites_rect;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2839,6 +2839,7 @@ void Graphics::drawtele(int x, int y, int t, int c)
 	if (t > 9) t = 8;
 	if (t < 0) t = 0;
 
+	setRect(telerect, x , y, tele_rect.w, tele_rect.h );
 	BlitSurfaceColoured(tele[t], NULL, backBuffer, &telerect, ct);
 }
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1427,8 +1427,9 @@ void Graphics::drawentities()
             continue;
         }
 
-        if (obj.entities[i].size == 0)
+        switch (obj.entities[i].size)
         {
+        case 0:
             // Sprites
             tpoint.x = obj.entities[i].xp;
             tpoint.y = obj.entities[i].yp;
@@ -1477,9 +1478,8 @@ void Graphics::drawentities()
                     BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                 }
             }
-        }
-        else if (obj.entities[i].size == 1)
-        {
+            break;
+        case 1:
             // Tiles
             tpoint.x = obj.entities[i].xp;
             tpoint.y = obj.entities[i].yp;
@@ -1487,8 +1487,9 @@ void Graphics::drawentities()
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
             BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-        }
-        else if (obj.entities[i].size == 2 || obj.entities[i].size == 8)
+            break;
+        case 2:
+        case 8:
         {
             // Special: Moving platform, 4 tiles or 8 tiles
             tpoint.x = obj.entities[i].xp;
@@ -1506,9 +1507,9 @@ void Graphics::drawentities()
                 drawRect.x += 8 * ii;
                 BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
             }
+            break;
         }
-        else if (obj.entities[i].size == 3)    // Big chunky pixels!
-        {
+        case 3:    // Big chunky pixels!
             prect.x = obj.entities[i].xp;
             prect.y = obj.entities[i].yp;
             //A seperate index of colours, for simplicity
@@ -1520,37 +1521,31 @@ void Graphics::drawentities()
             {
                 FillRect(backBuffer,prect, int(160- help.glow/2 - (fRandom()*20)),  200- help.glow/2, 220 - help.glow);
             }
-        }
-        else if (obj.entities[i].size == 4)    // Small pickups
-        {
+            break;
+        case 4:    // Small pickups
             drawhuetile(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].tile, obj.entities[i].colour);
-        }
-        else if (obj.entities[i].size == 5)    //Horizontal Line
-        {
+            break;
+        case 5:    //Horizontal Line
             line_rect.x = obj.entities[i].xp;
             line_rect.y = obj.entities[i].yp;
             line_rect.w = obj.entities[i].w;
             line_rect.h = 1;
             drawgravityline(i);
-        }
-        else if (obj.entities[i].size == 6)    //Vertical Line
-        {
+            break;
+        case 6:    //Vertical Line
             line_rect.x = obj.entities[i].xp;
             line_rect.y = obj.entities[i].yp;
             line_rect.w = 1;
             line_rect.h = obj.entities[i].h;
             drawgravityline(i);
-        }
-        else if (obj.entities[i].size == 7)    //Teleporter
-        {
+            break;
+        case 7:    //Teleporter
             drawtele(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].drawframe, obj.entities[i].colour);
-        }
-        else if (obj.entities[i].size == 8)    // Special: Moving platform, 8 tiles
-        {
+            break;
+        //case 8:    // Special: Moving platform, 8 tiles
             // Note: This code is in the 4-tile code
-        }
-        else if (obj.entities[i].size == 9)         // Really Big Sprite! (2x2)
-        {
+            break;
+        case 9:         // Really Big Sprite! (2x2)
             setcol(obj.entities[i].colour);
 
             tpoint.x = obj.entities[i].xp;
@@ -1584,9 +1579,8 @@ void Graphics::drawentities()
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
             BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe + 13],NULL, backBuffer, &drawRect, ct);
-        }
-        else if (obj.entities[i].size == 10)         // 2x1 Sprite
-        {
+            break;
+        case 10:         // 2x1 Sprite
             setcol(obj.entities[i].colour);
 
             tpoint.x = obj.entities[i].xp;
@@ -1604,14 +1598,12 @@ void Graphics::drawentities()
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
             BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
-        }
-        else if (obj.entities[i].size == 11)    //The fucking elephant
-        {
+            break;
+        case 11:    //The fucking elephant
             setcol(obj.entities[i].colour);
             drawimagecol(3, obj.entities[i].xp, obj.entities[i].yp);
-        }
-        else if (obj.entities[i].size == 12)         // Regular sprites that don't wrap
-        {
+            break;
+        case 12:         // Regular sprites that don't wrap
             tpoint.x = obj.entities[i].xp;
             tpoint.y = obj.entities[i].yp;
             setcol(obj.entities[i].colour);
@@ -1665,8 +1657,8 @@ void Graphics::drawentities()
                 drawRect.y += tpoint.y;
                 BlitSurfaceColoured(tiles[1166],NULL, backBuffer, &drawRect, ct);
             }
-        }
-        else if (obj.entities[i].size == 13)
+            break;
+        case 13:
         {
             //Special for epilogue: huge hero!
 
@@ -1679,6 +1671,8 @@ void Graphics::drawentities()
 
 
 
+            break;
+        }
         }
     }
 }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1418,6 +1418,16 @@ void Graphics::drawentities()
         spritesvec = &sprites;
     }
 
+    int yoff;
+    if (map.towermode)
+    {
+        yoff = map.ypos;
+    }
+    else
+    {
+        yoff = 0;
+    }
+
     trinketcolset = false;
 
     for (int i = obj.entities.size() - 1; i >= 0; i--)
@@ -1432,16 +1442,18 @@ void Graphics::drawentities()
         case 0:
             // Sprites
             tpoint.x = obj.entities[i].xp;
-            tpoint.y = obj.entities[i].yp;
+            tpoint.y = obj.entities[i].yp - yoff;
             setcol(obj.entities[i].colour);
 
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
             BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-            if (map.warpx)
+            //screenwrapping!
+            if (map.warpx ||
+            (map.towermode && !map.minitowermode
+            && map.ypos >= 500 && map.ypos <= 5000))   //The "wrapping" area of the tower
             {
-                //screenwrapping!
                 if (tpoint.x < 0)
                 {
                     tpoint.x += 320;
@@ -1482,7 +1494,7 @@ void Graphics::drawentities()
         case 1:
             // Tiles
             tpoint.x = obj.entities[i].xp;
-            tpoint.y = obj.entities[i].yp;
+            tpoint.y = obj.entities[i].yp - yoff;
             drawRect = tiles_rect;
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
@@ -1493,7 +1505,7 @@ void Graphics::drawentities()
         {
             // Special: Moving platform, 4 tiles or 8 tiles
             tpoint.x = obj.entities[i].xp;
-            tpoint.y = obj.entities[i].yp;
+            tpoint.y = obj.entities[i].yp - yoff;
             int thiswidth = 4;
             if (obj.entities[i].size == 8)
             {
@@ -1511,7 +1523,7 @@ void Graphics::drawentities()
         }
         case 3:    // Big chunky pixels!
             prect.x = obj.entities[i].xp;
-            prect.y = obj.entities[i].yp;
+            prect.y = obj.entities[i].yp - yoff;
             //A seperate index of colours, for simplicity
             if(obj.entities[i].colour==1)
             {
@@ -1523,24 +1535,24 @@ void Graphics::drawentities()
             }
             break;
         case 4:    // Small pickups
-            drawhuetile(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].tile, obj.entities[i].colour);
+            drawhuetile(obj.entities[i].xp, obj.entities[i].yp - yoff, obj.entities[i].tile, obj.entities[i].colour);
             break;
         case 5:    //Horizontal Line
             line_rect.x = obj.entities[i].xp;
-            line_rect.y = obj.entities[i].yp;
+            line_rect.y = obj.entities[i].yp - yoff;
             line_rect.w = obj.entities[i].w;
             line_rect.h = 1;
             drawgravityline(i);
             break;
         case 6:    //Vertical Line
             line_rect.x = obj.entities[i].xp;
-            line_rect.y = obj.entities[i].yp;
+            line_rect.y = obj.entities[i].yp - yoff;
             line_rect.w = 1;
             line_rect.h = obj.entities[i].h;
             drawgravityline(i);
             break;
         case 7:    //Teleporter
-            drawtele(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].drawframe, obj.entities[i].colour);
+            drawtele(obj.entities[i].xp, obj.entities[i].yp - yoff, obj.entities[i].drawframe, obj.entities[i].colour);
             break;
         //case 8:    // Special: Moving platform, 8 tiles
             // Note: This code is in the 4-tile code
@@ -1549,7 +1561,7 @@ void Graphics::drawentities()
             setcol(obj.entities[i].colour);
 
             tpoint.x = obj.entities[i].xp;
-            tpoint.y = obj.entities[i].yp;
+            tpoint.y = obj.entities[i].yp - yoff;
 
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
@@ -1557,7 +1569,7 @@ void Graphics::drawentities()
             BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
 
             tpoint.x = obj.entities[i].xp+32;
-            tpoint.y = obj.entities[i].yp;
+            tpoint.y = obj.entities[i].yp - yoff;
             //
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
@@ -1565,7 +1577,7 @@ void Graphics::drawentities()
             BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
 
             tpoint.x = obj.entities[i].xp;
-            tpoint.y = obj.entities[i].yp+32;
+            tpoint.y = obj.entities[i].yp+32 - yoff;
             //
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
@@ -1573,7 +1585,7 @@ void Graphics::drawentities()
             BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+12],NULL, backBuffer, &drawRect, ct);
 
             tpoint.x = obj.entities[i].xp+32;
-            tpoint.y = obj.entities[i].yp+32;
+            tpoint.y = obj.entities[i].yp+32 - yoff;
             //
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
@@ -1584,7 +1596,7 @@ void Graphics::drawentities()
             setcol(obj.entities[i].colour);
 
             tpoint.x = obj.entities[i].xp;
-            tpoint.y = obj.entities[i].yp;
+            tpoint.y = obj.entities[i].yp - yoff;
             //
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
@@ -1592,7 +1604,7 @@ void Graphics::drawentities()
             BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
 
             tpoint.x = obj.entities[i].xp+32;
-            tpoint.y = obj.entities[i].yp;
+            tpoint.y = obj.entities[i].yp - yoff;
             //
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
@@ -1601,11 +1613,11 @@ void Graphics::drawentities()
             break;
         case 11:    //The fucking elephant
             setcol(obj.entities[i].colour);
-            drawimagecol(3, obj.entities[i].xp, obj.entities[i].yp);
+            drawimagecol(3, obj.entities[i].xp, obj.entities[i].yp - yoff);
             break;
         case 12:         // Regular sprites that don't wrap
             tpoint.x = obj.entities[i].xp;
-            tpoint.y = obj.entities[i].yp;
+            tpoint.y = obj.entities[i].yp - yoff;
             setcol(obj.entities[i].colour);
             //
             drawRect = sprites_rect;
@@ -1662,9 +1674,9 @@ void Graphics::drawentities()
         {
             //Special for epilogue: huge hero!
 
-            tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
+            tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp - yoff;
             setcol(obj.entities[i].colour);
-            SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
+            SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp - yoff), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
             SDL_Surface* TempSurface = ScaleSurface( (*spritesvec)[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
             BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
             SDL_FreeSurface(TempSurface);
@@ -2176,118 +2188,6 @@ void Graphics::drawtowermap_nobackground()
         {
             temp = map.tower.at(i, j, map.ypos);
             if (temp > 0 && temp<28) drawtile3(i * 8, (j * 8) - ((int)map.ypos % 8), temp, map.colstate);
-        }
-    }
-}
-
-void Graphics::drawtowerentities()
-{
-    //Update line colours!
-    if (linedelay <= 0)
-    {
-        linestate++;
-        if (linestate >= 10) linestate = 0;
-        linedelay = 2;
-    }
-    else
-    {
-        linedelay--;
-    }
-    point tpoint;
-    SDL_Rect trect;
-
-    for (int i = obj.entities.size() - 1; i >= 0; i--)
-    {
-        if (!obj.entities[i].invis)
-        {
-            if (obj.entities[i].size == 0)        // Sprites
-            {
-                trinketcolset = false;
-                tpoint.x = obj.entities[i].xp;
-                tpoint.y = obj.entities[i].yp-map.ypos;
-                setcol(obj.entities[i].colour);
-                setRect(trect, tpoint.x, tpoint.y, sprites_rect.w, sprites_rect.h);
-                BlitSurfaceColoured(sprites[obj.entities[i].drawframe], NULL, backBuffer, &trect, ct);
-                //screenwrapping!
-                if (!map.minitowermode)
-                {
-                    if ( map.ypos >= 500 && map.ypos <= 5000)   //The "wrapping" area of the tower
-                    {
-                        if (tpoint.x < 0)
-                        {
-                            tpoint.x += 320;
-                            setRect(trect, tpoint.x, tpoint.y, sprites_rect.w, sprites_rect.h);
-                            BlitSurfaceColoured(sprites[obj.entities[i].drawframe], NULL, backBuffer, &trect, ct);
-                        }
-                        if (tpoint.x > 300)
-                        {
-                            tpoint.x -= 320;
-                            setRect(trect,  tpoint.x, tpoint.y, sprites_rect.w, sprites_rect.h);
-                            BlitSurfaceColoured(sprites[obj.entities[i].drawframe], NULL, backBuffer, &trect, ct);
-                        }
-                    }
-                }
-            }
-            else if (obj.entities[i].size == 1)
-            {
-                // Tiles
-                tpoint.x = obj.entities[i].xp;
-                tpoint.y = obj.entities[i].yp-map.ypos;
-                setRect(trect,tiles_rect.w, tiles_rect.h, tpoint.x, tpoint.y);
-                BlitSurfaceColoured(tiles[obj.entities[i].drawframe], NULL, backBuffer, &trect, ct);
-            }
-            else if (obj.entities[i].size == 2)
-            {
-                // Special: Moving platform, 4 tiles
-                tpoint.x = obj.entities[i].xp;
-                tpoint.y = obj.entities[i].yp-map.ypos;
-                setRect(trect,tiles_rect.w, tiles_rect.h, tpoint.x, tpoint.y);
-                BlitSurfaceColoured(tiles[obj.entities[i].drawframe], NULL, backBuffer, &trect, ct);
-                tpoint.x += 8;
-                setRect(trect,sprites_rect.w, sprites_rect.h, tpoint.x, tpoint.y);
-                BlitSurfaceColoured(tiles[obj.entities[i].drawframe], NULL, backBuffer, &trect, ct);
-                tpoint.x += 8;
-                setRect(trect,sprites_rect.w, sprites_rect.h, tpoint.x, tpoint.y);
-                BlitSurfaceColoured(tiles[obj.entities[i].drawframe], NULL, backBuffer, &trect, ct);
-                tpoint.x += 8;
-                setRect(trect,sprites_rect.w, sprites_rect.h, tpoint.x, tpoint.y);
-                BlitSurfaceColoured(tiles[obj.entities[i].drawframe], NULL, backBuffer, &trect, ct);
-
-            }
-            else if (obj.entities[i].size == 3)    // Big chunky pixels!
-            {
-                prect.x = obj.entities[i].xp;
-                prect.y = obj.entities[i].yp-map.ypos;
-                //A seperate index of colours, for simplicity
-                if(obj.entities[i].colour==1)
-                {
-                    FillRect(backBuffer, prect, getRGB(196 - (fRandom() * 64), 10, 10));
-                }
-                else if (obj.entities[i].colour == 2)
-                {
-                    FillRect(backBuffer, prect, getRGB(160- help.glow/2 - (fRandom()*20), 200- help.glow/2, 220 - help.glow));
-                }
-            }
-            else if (obj.entities[i].size == 4)    // Small pickups
-            {
-                drawhuetile(obj.entities[i].xp, obj.entities[i].yp-map.ypos, obj.entities[i].tile, obj.entities[i].colour);
-            }
-            else if (obj.entities[i].size == 5)    //Horizontal Line
-            {
-                line_rect.x = obj.entities[i].xp;
-                line_rect.y = obj.entities[i].yp-map.ypos;
-                line_rect.w = obj.entities[i].w;
-                line_rect.h = 1;
-                drawgravityline(i);
-            }
-            else if (obj.entities[i].size == 6)    //Vertical Line
-            {
-                line_rect.x = obj.entities[i].xp;
-                line_rect.y = obj.entities[i].yp-map.ypos;
-                line_rect.w = 1;
-                line_rect.h = obj.entities[i].h;
-                drawgravityline(i);
-            }
         }
     }
 }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1422,261 +1422,263 @@ void Graphics::drawentities()
 
     for (int i = obj.entities.size() - 1; i >= 0; i--)
     {
-        if (!obj.entities[i].invis)
+        if (obj.entities[i].invis)
         {
-            if (obj.entities[i].size == 0)
-            {
-                // Sprites
-                tpoint.x = obj.entities[i].xp;
-                tpoint.y = obj.entities[i].yp;
-                setcol(obj.entities[i].colour);
+            continue;
+        }
 
-                drawRect = sprites_rect;
-                drawRect.x += tpoint.x;
-                drawRect.y += tpoint.y;
-                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                if (map.warpx)
+        if (obj.entities[i].size == 0)
+        {
+            // Sprites
+            tpoint.x = obj.entities[i].xp;
+            tpoint.y = obj.entities[i].yp;
+            setcol(obj.entities[i].colour);
+
+            drawRect = sprites_rect;
+            drawRect.x += tpoint.x;
+            drawRect.y += tpoint.y;
+            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+            if (map.warpx)
+            {
+                //screenwrapping!
+                if (tpoint.x < 0)
                 {
-                    //screenwrapping!
-                    if (tpoint.x < 0)
-                    {
-                        tpoint.x += 320;
-                        drawRect = sprites_rect;
-                        drawRect.x += tpoint.x;
-                        drawRect.y += tpoint.y;
-                        BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                    }
-                    if (tpoint.x > 300)
-                    {
-                        tpoint.x -= 320;
-                        drawRect = sprites_rect;
-                        drawRect.x += tpoint.x;
-                        drawRect.y += tpoint.y;
-                        BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                    }
+                    tpoint.x += 320;
+                    drawRect = sprites_rect;
+                    drawRect.x += tpoint.x;
+                    drawRect.y += tpoint.y;
+                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                 }
-                else if (map.warpy)
+                if (tpoint.x > 300)
                 {
-                    if (tpoint.y < 0)
-                    {
-                        tpoint.y += 230;
-                        drawRect = sprites_rect;
-                        drawRect.x += tpoint.x;
-                        drawRect.y += tpoint.y;
-                        BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                    }
-                    if (tpoint.y > 210)
-                    {
-                        tpoint.y -= 230;
-                        drawRect = sprites_rect;
-                        drawRect.x += tpoint.x;
-                        drawRect.y += tpoint.y;
-                        BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                    }
+                    tpoint.x -= 320;
+                    drawRect = sprites_rect;
+                    drawRect.x += tpoint.x;
+                    drawRect.y += tpoint.y;
+                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                 }
             }
-            else if (obj.entities[i].size == 1)
+            else if (map.warpy)
             {
-                // Tiles
-                tpoint.x = obj.entities[i].xp;
-                tpoint.y = obj.entities[i].yp;
+                if (tpoint.y < 0)
+                {
+                    tpoint.y += 230;
+                    drawRect = sprites_rect;
+                    drawRect.x += tpoint.x;
+                    drawRect.y += tpoint.y;
+                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                }
+                if (tpoint.y > 210)
+                {
+                    tpoint.y -= 230;
+                    drawRect = sprites_rect;
+                    drawRect.x += tpoint.x;
+                    drawRect.y += tpoint.y;
+                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                }
+            }
+        }
+        else if (obj.entities[i].size == 1)
+        {
+            // Tiles
+            tpoint.x = obj.entities[i].xp;
+            tpoint.y = obj.entities[i].yp;
+            drawRect = tiles_rect;
+            drawRect.x += tpoint.x;
+            drawRect.y += tpoint.y;
+            BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+        }
+        else if (obj.entities[i].size == 2 || obj.entities[i].size == 8)
+        {
+            // Special: Moving platform, 4 tiles or 8 tiles
+            tpoint.x = obj.entities[i].xp;
+            tpoint.y = obj.entities[i].yp;
+            int thiswidth = 4;
+            if (obj.entities[i].size == 8)
+            {
+                thiswidth = 8;
+            }
+            for (int ii = 0; ii < thiswidth; ii++)
+            {
                 drawRect = tiles_rect;
                 drawRect.x += tpoint.x;
                 drawRect.y += tpoint.y;
-                BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                drawRect.x += 8 * ii;
+                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
             }
-            else if (obj.entities[i].size == 2 || obj.entities[i].size == 8)
+        }
+        else if (obj.entities[i].size == 3)    // Big chunky pixels!
+        {
+            prect.x = obj.entities[i].xp;
+            prect.y = obj.entities[i].yp;
+            //A seperate index of colours, for simplicity
+            if(obj.entities[i].colour==1)
             {
-                // Special: Moving platform, 4 tiles or 8 tiles
-                tpoint.x = obj.entities[i].xp;
-                tpoint.y = obj.entities[i].yp;
-                int thiswidth = 4;
-                if (obj.entities[i].size == 8)
+                FillRect(backBuffer, prect, (fRandom() * 64), 10, 10);
+            }
+            else if (obj.entities[i].colour == 2)
+            {
+                FillRect(backBuffer,prect, int(160- help.glow/2 - (fRandom()*20)),  200- help.glow/2, 220 - help.glow);
+            }
+        }
+        else if (obj.entities[i].size == 4)    // Small pickups
+        {
+            drawhuetile(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].tile, obj.entities[i].colour);
+        }
+        else if (obj.entities[i].size == 5)    //Horizontal Line
+        {
+            line_rect.x = obj.entities[i].xp;
+            line_rect.y = obj.entities[i].yp;
+            line_rect.w = obj.entities[i].w;
+            line_rect.h = 1;
+            drawgravityline(i);
+        }
+        else if (obj.entities[i].size == 6)    //Vertical Line
+        {
+            line_rect.x = obj.entities[i].xp;
+            line_rect.y = obj.entities[i].yp;
+            line_rect.w = 1;
+            line_rect.h = obj.entities[i].h;
+            drawgravityline(i);
+        }
+        else if (obj.entities[i].size == 7)    //Teleporter
+        {
+            drawtele(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].drawframe, obj.entities[i].colour);
+        }
+        else if (obj.entities[i].size == 8)    // Special: Moving platform, 8 tiles
+        {
+            // Note: This code is in the 4-tile code
+        }
+        else if (obj.entities[i].size == 9)         // Really Big Sprite! (2x2)
+        {
+            setcol(obj.entities[i].colour);
+
+            tpoint.x = obj.entities[i].xp;
+            tpoint.y = obj.entities[i].yp;
+
+            drawRect = sprites_rect;
+            drawRect.x += tpoint.x;
+            drawRect.y += tpoint.y;
+            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+
+            tpoint.x = obj.entities[i].xp+32;
+            tpoint.y = obj.entities[i].yp;
+            //
+            drawRect = sprites_rect;
+            drawRect.x += tpoint.x;
+            drawRect.y += tpoint.y;
+            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
+
+            tpoint.x = obj.entities[i].xp;
+            tpoint.y = obj.entities[i].yp+32;
+            //
+            drawRect = sprites_rect;
+            drawRect.x += tpoint.x;
+            drawRect.y += tpoint.y;
+            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+12],NULL, backBuffer, &drawRect, ct);
+
+            tpoint.x = obj.entities[i].xp+32;
+            tpoint.y = obj.entities[i].yp+32;
+            //
+            drawRect = sprites_rect;
+            drawRect.x += tpoint.x;
+            drawRect.y += tpoint.y;
+            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe + 13],NULL, backBuffer, &drawRect, ct);
+        }
+        else if (obj.entities[i].size == 10)         // 2x1 Sprite
+        {
+            setcol(obj.entities[i].colour);
+
+            tpoint.x = obj.entities[i].xp;
+            tpoint.y = obj.entities[i].yp;
+            //
+            drawRect = sprites_rect;
+            drawRect.x += tpoint.x;
+            drawRect.y += tpoint.y;
+            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+
+            tpoint.x = obj.entities[i].xp+32;
+            tpoint.y = obj.entities[i].yp;
+            //
+            drawRect = sprites_rect;
+            drawRect.x += tpoint.x;
+            drawRect.y += tpoint.y;
+            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
+        }
+        else if (obj.entities[i].size == 11)    //The fucking elephant
+        {
+            setcol(obj.entities[i].colour);
+            drawimagecol(3, obj.entities[i].xp, obj.entities[i].yp);
+        }
+        else if (obj.entities[i].size == 12)         // Regular sprites that don't wrap
+        {
+            tpoint.x = obj.entities[i].xp;
+            tpoint.y = obj.entities[i].yp;
+            setcol(obj.entities[i].colour);
+            //
+            drawRect = sprites_rect;
+            drawRect.x += tpoint.x;
+            drawRect.y += tpoint.y;
+            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+
+
+            //if we're outside the screen, we need to draw indicators
+
+            if (obj.entities[i].xp < -20 && obj.entities[i].vx > 0)
+            {
+                if (obj.entities[i].xp < -100)
                 {
-                    thiswidth = 8;
+                    tpoint.x = -5 + (int(( -obj.entities[i].xp) / 10));
                 }
-                for (int ii = 0; ii < thiswidth; ii++)
+                else
                 {
-                    drawRect = tiles_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    drawRect.x += 8 * ii;
-                    BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                    tpoint.x = 5;
                 }
+
+                tpoint.y = tpoint.y+4;
+                setcol(23);
+
+
+                drawRect = tiles_rect;
+                drawRect.x += tpoint.x;
+                drawRect.y += tpoint.y;
+                BlitSurfaceColoured(tiles[1167],NULL, backBuffer, &drawRect, ct);
+
             }
-            else if (obj.entities[i].size == 3)    // Big chunky pixels!
+            else if (obj.entities[i].xp > 340 && obj.entities[i].vx < 0)
             {
-                prect.x = obj.entities[i].xp;
-                prect.y = obj.entities[i].yp;
-                //A seperate index of colours, for simplicity
-                if(obj.entities[i].colour==1)
+                if (obj.entities[i].xp > 420)
                 {
-                    FillRect(backBuffer, prect, (fRandom() * 64), 10, 10);
+                    tpoint.x = 320 - (int(( obj.entities[i].xp-320) / 10));
                 }
-                else if (obj.entities[i].colour == 2)
+                else
                 {
-                    FillRect(backBuffer,prect, int(160- help.glow/2 - (fRandom()*20)),  200- help.glow/2, 220 - help.glow);
+                    tpoint.x = 310;
                 }
-            }
-            else if (obj.entities[i].size == 4)    // Small pickups
-            {
-                drawhuetile(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].tile, obj.entities[i].colour);
-            }
-            else if (obj.entities[i].size == 5)    //Horizontal Line
-            {
-                line_rect.x = obj.entities[i].xp;
-                line_rect.y = obj.entities[i].yp;
-                line_rect.w = obj.entities[i].w;
-                line_rect.h = 1;
-                drawgravityline(i);
-            }
-            else if (obj.entities[i].size == 6)    //Vertical Line
-            {
-                line_rect.x = obj.entities[i].xp;
-                line_rect.y = obj.entities[i].yp;
-                line_rect.w = 1;
-                line_rect.h = obj.entities[i].h;
-                drawgravityline(i);
-            }
-            else if (obj.entities[i].size == 7)    //Teleporter
-            {
-                drawtele(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].drawframe, obj.entities[i].colour);
-            }
-            else if (obj.entities[i].size == 8)    // Special: Moving platform, 8 tiles
-            {
-                // Note: This code is in the 4-tile code
-            }
-            else if (obj.entities[i].size == 9)         // Really Big Sprite! (2x2)
-            {
-                setcol(obj.entities[i].colour);
 
-                tpoint.x = obj.entities[i].xp;
-                tpoint.y = obj.entities[i].yp;
-
-                drawRect = sprites_rect;
-                drawRect.x += tpoint.x;
-                drawRect.y += tpoint.y;
-                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-
-                tpoint.x = obj.entities[i].xp+32;
-                tpoint.y = obj.entities[i].yp;
+                tpoint.y = tpoint.y+4;
+                setcol(23);
                 //
-                drawRect = sprites_rect;
-                drawRect.x += tpoint.x;
-                drawRect.y += tpoint.y;
-                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
 
-                tpoint.x = obj.entities[i].xp;
-                tpoint.y = obj.entities[i].yp+32;
-                //
-                drawRect = sprites_rect;
+                drawRect = tiles_rect;
                 drawRect.x += tpoint.x;
                 drawRect.y += tpoint.y;
-                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+12],NULL, backBuffer, &drawRect, ct);
-
-                tpoint.x = obj.entities[i].xp+32;
-                tpoint.y = obj.entities[i].yp+32;
-                //
-                drawRect = sprites_rect;
-                drawRect.x += tpoint.x;
-                drawRect.y += tpoint.y;
-                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe + 13],NULL, backBuffer, &drawRect, ct);
+                BlitSurfaceColoured(tiles[1166],NULL, backBuffer, &drawRect, ct);
             }
-            else if (obj.entities[i].size == 10)         // 2x1 Sprite
-            {
-                setcol(obj.entities[i].colour);
+        }
+        else if (obj.entities[i].size == 13)
+        {
+            //Special for epilogue: huge hero!
 
-                tpoint.x = obj.entities[i].xp;
-                tpoint.y = obj.entities[i].yp;
-                //
-                drawRect = sprites_rect;
-                drawRect.x += tpoint.x;
-                drawRect.y += tpoint.y;
-                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-
-                tpoint.x = obj.entities[i].xp+32;
-                tpoint.y = obj.entities[i].yp;
-                //
-                drawRect = sprites_rect;
-                drawRect.x += tpoint.x;
-                drawRect.y += tpoint.y;
-                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
-            }
-            else if (obj.entities[i].size == 11)    //The fucking elephant
-            {
-                setcol(obj.entities[i].colour);
-                drawimagecol(3, obj.entities[i].xp, obj.entities[i].yp);
-            }
-            else if (obj.entities[i].size == 12)         // Regular sprites that don't wrap
-            {
-                tpoint.x = obj.entities[i].xp;
-                tpoint.y = obj.entities[i].yp;
-                setcol(obj.entities[i].colour);
-                //
-                drawRect = sprites_rect;
-                drawRect.x += tpoint.x;
-                drawRect.y += tpoint.y;
-                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-
-
-                //if we're outside the screen, we need to draw indicators
-
-                if (obj.entities[i].xp < -20 && obj.entities[i].vx > 0)
-                {
-                    if (obj.entities[i].xp < -100)
-                    {
-                        tpoint.x = -5 + (int(( -obj.entities[i].xp) / 10));
-                    }
-                    else
-                    {
-                        tpoint.x = 5;
-                    }
-
-                    tpoint.y = tpoint.y+4;
-                    setcol(23);
-
-
-                    drawRect = tiles_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(tiles[1167],NULL, backBuffer, &drawRect, ct);
-
-                }
-                else if (obj.entities[i].xp > 340 && obj.entities[i].vx < 0)
-                {
-                    if (obj.entities[i].xp > 420)
-                    {
-                        tpoint.x = 320 - (int(( obj.entities[i].xp-320) / 10));
-                    }
-                    else
-                    {
-                        tpoint.x = 310;
-                    }
-
-                    tpoint.y = tpoint.y+4;
-                    setcol(23);
-                    //
-
-                    drawRect = tiles_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured(tiles[1166],NULL, backBuffer, &drawRect, ct);
-                }
-            }
-            else if (obj.entities[i].size == 13)
-            {
-                //Special for epilogue: huge hero!
-
-                tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
-                setcol(obj.entities[i].colour);
-                SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
-                SDL_Surface* TempSurface = ScaleSurface( (*spritesvec)[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
-                BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
-                SDL_FreeSurface(TempSurface);
+            tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp;
+            setcol(obj.entities[i].colour);
+            SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
+            SDL_Surface* TempSurface = ScaleSurface( (*spritesvec)[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
+            BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
+            SDL_FreeSurface(TempSurface);
 
 
 
-            }
         }
     }
 }

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -182,8 +182,6 @@ public:
 
 	void drawtowerspikes();
 
-	void drawtowerentities();
-
 	bool onscreen(int t);
 
 	void drawtowerbackgroundsolo();

--- a/desktop_version/src/Logic.h
+++ b/desktop_version/src/Logic.h
@@ -16,8 +16,6 @@ void gamecompletelogic();
 
 void gamecompletelogic2();
 
-void towerlogic();
-
 void gamelogic();
 
 #endif /* LOGIC_H */

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2592,7 +2592,7 @@ void towerrender()
         }
     }
 
-    graphics.drawtowerentities();
+    graphics.drawentities();
 
     graphics.drawtowerspikes();
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1358,21 +1358,37 @@ void gamerender()
     if(!game.blackout)
     {
 
-        if(!game.colourblindmode)
+        if (map.towermode)
         {
-            graphics.drawbackground(map.background);
+            if (!game.colourblindmode)
+            {
+                graphics.drawtowerbackground();
+                graphics.drawtowermap();
+            }
+            else
+            {
+                FillRect(graphics.backBuffer,0x00000);
+                graphics.drawtowermap_nobackground();
+            }
         }
         else
         {
-            FillRect(graphics.backBuffer,0x00000);
-        }
-        if (map.final_colormode)
-        {
-            graphics.drawfinalmap();
-        }
-        else
-        {
-            graphics.drawmap();
+            if(!game.colourblindmode)
+            {
+                graphics.drawbackground(map.background);
+            }
+            else
+            {
+                FillRect(graphics.backBuffer,0x00000);
+            }
+            if (map.final_colormode)
+            {
+                graphics.drawfinalmap();
+            }
+            else
+            {
+                graphics.drawmap();
+            }
         }
 
 
@@ -1405,6 +1421,10 @@ void gamerender()
         }
 
         graphics.drawentities();
+        if (map.towermode)
+        {
+            graphics.drawtowerspikes();
+        }
     }
 
     if(map.extrarow==0 || (map.custommode && map.roomname!=""))
@@ -2546,166 +2566,6 @@ void maprender()
         {
             graphics.render();
         }
-    }
-}
-
-void towerrender()
-{
-
-    FillRect(graphics.backBuffer, 0x000000);
-
-    if (!game.colourblindmode)
-    {
-        graphics.drawtowerbackground();
-        graphics.drawtowermap();
-    }
-    else
-    {
-        graphics.drawtowermap_nobackground();
-    }
-
-    if(!game.completestop)
-    {
-        for (size_t i = 0; i < obj.entities.size(); i++)
-        {
-            //Is this entity on the ground? (needed for jumping)
-            if (obj.entitycollidefloor(i))
-            {
-                obj.entities[i].onground = 2;
-            }
-            else
-            {
-                obj.entities[i].onground--;
-            }
-
-            if (obj.entitycollideroof(i))
-            {
-                obj.entities[i].onroof = 2;
-            }
-            else
-            {
-                obj.entities[i].onroof--;
-            }
-
-            //Animate the entities
-            obj.animateentities(i);
-        }
-    }
-
-    graphics.drawentities();
-
-    graphics.drawtowerspikes();
-
-
-    graphics.cutscenebars();
-    BlitSurfaceStandard(graphics.backBuffer, NULL, graphics.tempBuffer, NULL);
-
-    graphics.drawgui();
-    if (graphics.flipmode)
-    {
-        if (game.advancetext) graphics.bprint(5, 228, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
-    }
-    else
-    {
-        if (game.advancetext) graphics.bprint(5, 5, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
-    }
-
-
-    graphics.footerrect.y = 230;
-    if (graphics.translucentroomname)
-    {
-        SDL_BlitSurface(graphics.footerbuffer, NULL, graphics.backBuffer, &graphics.footerrect);
-    }
-    else
-    {
-        FillRect(graphics.backBuffer, graphics.footerrect, 0);
-    }
-    graphics.bprint(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
-
-    if (game.intimetrial && graphics.fademode==0)
-    {
-        //Draw countdown!
-        if (game.timetrialcountdown > 0)
-        {
-            if (game.timetrialcountdown < 30)
-            {
-                game.resetgameclock();
-                if (int(game.timetrialcountdown / 4) % 2 == 0) graphics.bigprint( -1, 100, "Go!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
-            }
-            else if (game.timetrialcountdown < 60)
-            {
-                graphics.bigprint( -1, 100, "1", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
-            }
-            else if (game.timetrialcountdown < 90)
-            {
-                graphics.bigprint( -1, 100, "2", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
-            }
-            else if (game.timetrialcountdown < 120)
-            {
-                graphics.bigprint( -1, 100, "3", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
-            }
-        }
-        else
-        {
-            //Draw OSD stuff
-            graphics.bprint(6, 18, "TIME :",  255,255,255);
-            graphics.bprint(6, 30, "DEATH:",  255, 255, 255);
-            graphics.bprint(6, 42, "SHINY:",  255,255,255);
-
-            if(game.timetrialparlost)
-            {
-                graphics.bprint(56, 18, game.timestring(),  196, 80, 80);
-            }
-            else
-            {
-                graphics.bprint(56, 18, game.timestring(),  196, 196, 196);
-            }
-            if(game.deathcounts>0)
-            {
-                graphics.bprint(56, 30,help.String(game.deathcounts),  196, 80, 80);
-            }
-            else
-            {
-                graphics.bprint(56, 30,help.String(game.deathcounts),  196, 196, 196);
-            }
-            if(game.trinkets()<game.timetrialshinytarget)
-            {
-                graphics.bprint(56, 42,help.String(game.trinkets()) + " of " +help.String(game.timetrialshinytarget),  196, 80, 80);
-            }
-            else
-            {
-                graphics.bprint(56, 42,help.String(game.trinkets()) + " of " +help.String(game.timetrialshinytarget),  196, 196, 196);
-            }
-
-            if(game.timetrialparlost)
-            {
-                graphics.bprint(195, 214, "PAR TIME:",  80, 80, 80);
-                graphics.bprint(275, 214, game.partimestring(),  80, 80, 80);
-            }
-            else
-            {
-                graphics.bprint(195, 214, "PAR TIME:",  255, 255, 255);
-                graphics.bprint(275, 214, game.partimestring(),  196, 196, 196);
-            }
-        }
-    }
-
-    graphics.drawfade();
-
-    if (game.flashlight > 0 && !game.noflashingmode)
-    {
-        game.flashlight--;
-        graphics.flashlight();
-    }
-
-    if (game.screenshake > 0 && !game.noflashingmode)
-    {
-        game.screenshake--;
-        graphics.screenshake();
-    }
-    else
-    {
-        graphics.render();
     }
 }
 

--- a/desktop_version/src/Render.h
+++ b/desktop_version/src/Render.h
@@ -10,8 +10,6 @@
 
 void titlerender();
 
-void towerrender();
-
 void gamerender();
 
 void maprender();

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -541,7 +541,7 @@ int main(int argc, char *argv[])
         {
             Mix_Volume(-1,MIX_MAX_VOLUME);
 
-            if (game.musicmuted)
+            if (game.musicmuted || game.completestop)
             {
                 Mix_VolumeMusic(0);
             }

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -422,25 +422,14 @@ int main(int argc, char *argv[])
                 titlelogic();
                 break;
             case GAMEMODE:
-                if (map.towermode)
+                if (script.running)
                 {
-                    gameinput();
-                    gamerender();
-                    gamelogic();
-
+                    script.run();
                 }
-                else
-                {
 
-                    if (script.running)
-                    {
-                        script.run();
-                    }
-
-                    gameinput();
-                    gamerender();
-                    gamelogic();
-                }
+                gameinput();
+                gamerender();
+                gamelogic();
 
 
                 break;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -426,7 +426,7 @@ int main(int argc, char *argv[])
                 {
                     gameinput();
                     towerrender();
-                    towerlogic();
+                    gamelogic();
 
                 }
                 else

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -425,7 +425,7 @@ int main(int argc, char *argv[])
                 if (map.towermode)
                 {
                     gameinput();
-                    towerrender();
+                    gamerender();
                     gamelogic();
 
                 }


### PR DESCRIPTION
## Changes:

This is a refactor that removes the copy-pasted code in tower functions. More specifically, `towerlogic()` has been merged into `gamelogic()`, `Graphics::drawtowerentities()` has been merged into `Graphics::drawentities()`, and `towerrender()` has been merged into `gamerender()`.

This is one of several refactors that will make it easier for me to eventually make an over-30-FPS patch of this game. (I plan to keep the timestep but interpolate animations, which will require me fiddling with mostly render functions, and it's a bit annoying if I have to deal with lots of copy-pasted code...)

Also there's a bugfix for a bug I encountered during testing of this PR.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
