### PR TITLE
Improve and de-duplicate screen effects handling

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2667,6 +2667,23 @@ void Graphics::render()
 	}
 }
 
+void Graphics::renderwithscreeneffects()
+{
+	if (game.flashlight > 0 && !game.noflashingmode)
+	{
+		graphics.flashlight();
+	}
+
+	if (game.screenshake > 0 && !game.noflashingmode)
+	{
+		graphics.screenshake();
+	}
+	else
+	{
+		graphics.render();
+	}
+}
+
 void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool cen, float sc)
 {
 	if (r < 0) r = 0;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -131,6 +131,7 @@ public:
 	void screenshake();
 
 	void render();
+	void renderwithscreeneffects();
 
 	bool Hitest(SDL_Surface* surface1, point p1, SDL_Surface* surface2, point p2);
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1126,13 +1126,11 @@ void titlerender()
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
-        game.flashlight--;
         graphics.flashlight();
     }
 
     if (game.screenshake > 0  && !game.noflashingmode)
     {
-        game.screenshake--;
         graphics.screenshake();
     }
     else
@@ -1291,13 +1289,11 @@ void gamecompleterender()
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
-        game.flashlight--;
         graphics.flashlight();
     }
 
     if (game.screenshake > 0 && !game.noflashingmode)
     {
-        game.screenshake--;
         graphics.screenshake();
     }
     else
@@ -1335,13 +1331,11 @@ void gamecompleterender2()
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
-        game.flashlight--;
         graphics.flashlight();
     }
 
     if (game.screenshake > 0 && !game.noflashingmode)
     {
-        game.screenshake--;
         graphics.screenshake();
     }
     else
@@ -1705,13 +1699,11 @@ void gamerender()
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
-        game.flashlight--;
         graphics.flashlight();
     }
 
     if (game.screenshake > 0 && !game.noflashingmode)
     {
-        game.screenshake--;
         graphics.screenshake();
     }
     else
@@ -2520,7 +2512,6 @@ void maprender()
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
-        game.flashlight--;
         graphics.flashlight();
     }
 
@@ -2559,7 +2550,6 @@ void maprender()
     {
         if (game.screenshake > 0 && !game.noflashingmode)
         {
-            game.screenshake--;
             graphics.screenshake();
         }
         else
@@ -2697,7 +2687,6 @@ void teleporterrender()
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
-        game.flashlight--;
         graphics.flashlight();
     }
 
@@ -2736,7 +2725,6 @@ void teleporterrender()
     {
         if (game.screenshake > 0 && !game.noflashingmode)
         {
-            game.screenshake--;
             graphics.screenshake();
         }
         else

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1275,7 +1275,7 @@ void gamecompleterender()
 
     graphics.drawfade();
 
-    graphics.renderwithscreeneffects();
+    graphics.render();
 }
 
 void gamecompleterender2()
@@ -1305,7 +1305,7 @@ void gamecompleterender2()
 
     graphics.drawfade();
 
-    graphics.renderwithscreeneffects();
+    graphics.render();
 }
 
 void gamerender()
@@ -2495,7 +2495,7 @@ void maprender()
     }
     else
     {
-        graphics.renderwithscreeneffects();
+        graphics.render();
     }
 }
 
@@ -2658,6 +2658,6 @@ void teleporterrender()
     }
     else
     {
-        graphics.renderwithscreeneffects();
+        graphics.render();
     }
 }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1124,19 +1124,7 @@ void titlerender()
 
     graphics.drawfade();
 
-    if (game.flashlight > 0 && !game.noflashingmode)
-    {
-        graphics.flashlight();
-    }
-
-    if (game.screenshake > 0  && !game.noflashingmode)
-    {
-        graphics.screenshake();
-    }
-    else
-    {
-        graphics.render();
-    }
+    graphics.renderwithscreeneffects();
 }
 
 void gamecompleterender()
@@ -1287,19 +1275,7 @@ void gamecompleterender()
 
     graphics.drawfade();
 
-    if (game.flashlight > 0 && !game.noflashingmode)
-    {
-        graphics.flashlight();
-    }
-
-    if (game.screenshake > 0 && !game.noflashingmode)
-    {
-        graphics.screenshake();
-    }
-    else
-    {
-        graphics.render();
-    }
+    graphics.renderwithscreeneffects();
 }
 
 void gamecompleterender2()
@@ -1329,19 +1305,7 @@ void gamecompleterender2()
 
     graphics.drawfade();
 
-    if (game.flashlight > 0 && !game.noflashingmode)
-    {
-        graphics.flashlight();
-    }
-
-    if (game.screenshake > 0 && !game.noflashingmode)
-    {
-        graphics.screenshake();
-    }
-    else
-    {
-        graphics.render();
-    }
+    graphics.renderwithscreeneffects();
 }
 
 void gamerender()
@@ -1697,19 +1661,7 @@ void gamerender()
     }
 
 
-    if (game.flashlight > 0 && !game.noflashingmode)
-    {
-        graphics.flashlight();
-    }
-
-    if (game.screenshake > 0 && !game.noflashingmode)
-    {
-        graphics.screenshake();
-    }
-    else
-    {
-        graphics.render();
-    }
+    graphics.renderwithscreeneffects();
 }
 
 void maprender()
@@ -2510,11 +2462,6 @@ void maprender()
 
     graphics.drawfade();
 
-    if (game.flashlight > 0 && !game.noflashingmode)
-    {
-        graphics.flashlight();
-    }
-
     if (graphics.resumegamemode)
     {
         graphics.menuoffset += 25;
@@ -2548,14 +2495,7 @@ void maprender()
     }
     else
     {
-        if (game.screenshake > 0 && !game.noflashingmode)
-        {
-            graphics.screenshake();
-        }
-        else
-        {
-            graphics.render();
-        }
+        graphics.renderwithscreeneffects();
     }
 }
 
@@ -2685,11 +2625,6 @@ void teleporterrender()
     }
 
 
-    if (game.flashlight > 0 && !game.noflashingmode)
-    {
-        graphics.flashlight();
-    }
-
     if (graphics.resumegamemode)
     {
         graphics.menuoffset += 25;
@@ -2723,13 +2658,6 @@ void teleporterrender()
     }
     else
     {
-        if (game.screenshake > 0 && !game.noflashingmode)
-        {
-            graphics.screenshake();
-        }
-        else
-        {
-            graphics.render();
-        }
+        graphics.renderwithscreeneffects();
     }
 }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3499,6 +3499,9 @@ void scriptclass::hardreset()
 
 	game.pausescript = false;
 
+	game.flashlight = 0;
+	game.screenshake = 0;
+
 	//dwgraphicsclass
 	graphics.backgrounddrawn = false;
 	graphics.textboxremovefast();

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3422,19 +3422,7 @@ void editorrender()
 
     graphics.drawfade();
 
-    if (game.flashlight > 0 && !game.noflashingmode)
-    {
-        graphics.flashlight();
-    }
-
-    if (game.screenshake > 0  && !game.noflashingmode)
-    {
-        graphics.screenshake();
-    }
-    else
-    {
-        graphics.render();
-    }
+    graphics.renderwithscreeneffects();
 }
 
 void editorlogic()

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3451,6 +3451,7 @@ void editorlogic()
         map.nexttowercolour();
         map.colstate = 10;
         game.gamestate = TITLEMODE;
+        script.hardreset();
         graphics.fademode = 4;
         music.haltdasmusik();
         music.play(6);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3424,13 +3424,11 @@ void editorrender()
 
     if (game.flashlight > 0 && !game.noflashingmode)
     {
-        game.flashlight--;
         graphics.flashlight();
     }
 
     if (game.screenshake > 0  && !game.noflashingmode)
     {
-        game.screenshake--;
         graphics.screenshake();
     }
     else

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3422,7 +3422,7 @@ void editorrender()
 
     graphics.drawfade();
 
-    graphics.renderwithscreeneffects();
+    graphics.render();
 }
 
 void editorlogic()

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -479,6 +479,16 @@ int main(int argc, char *argv[])
 
         }
 
+        //Screen effects timers
+        if (game.infocus && game.flashlight > 0)
+        {
+            game.flashlight--;
+        }
+        if (game.infocus && game.screenshake > 0)
+        {
+            game.screenshake--;
+        }
+
         //We did editorinput, now it's safe to turn this off
         key.linealreadyemptykludge = false;
 

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -95,17 +95,5 @@ void preloaderrender()
 
   graphics.drawfade();
 
-  if (game.flashlight > 0 && !game.noflashingmode)
-  {
-    graphics.flashlight();
-  }
-
-  if (game.screenshake > 0  && !game.noflashingmode)
-  {
-    graphics.screenshake();
-  }
-  else
-  {
-    graphics.render();
-  }
+  graphics.renderwithscreeneffects();
 }

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -95,5 +95,5 @@ void preloaderrender()
 
   graphics.drawfade();
 
-  graphics.renderwithscreeneffects();
+  graphics.render();
 }

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -97,13 +97,11 @@ void preloaderrender()
 
   if (game.flashlight > 0 && !game.noflashingmode)
   {
-    game.flashlight--;
     graphics.flashlight();
   }
 
   if (game.screenshake > 0  && !game.noflashingmode)
   {
-    game.screenshake--;
     graphics.screenshake();
   }
   else


### PR DESCRIPTION
## Changes:

The timers of screen effects, which are simply the flash and shake effects, are now handled outside the render functions, in the framerate loop in `main.cpp`. Furthermore, the rendering code to handle flashing and shaking if the flash or shake timer is active has been de-duplicated. Additionally, these timers are now reset in `scriptclass::hardreset()`, still tick down even if screen effects are disabled, and these screen effects only apply in `TITLEMODE` and `GAMEMODE`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
