### PR TITLE
Fix exiting No Death Mode being one menu too far back

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -233,6 +233,8 @@ void Game::init(void)
     createmenu(Menu::mainmenu);
 
     wasintimetrial = false;
+    wasinintermission = false;
+    wasinnodeathmode = false;
     wasincustommode = false;
 
     deathcounts = 0;
@@ -1353,6 +1355,10 @@ void Game::updatestate()
             {
                 returntomenu(Menu::intermissionmenu);
             }
+            else if (wasinnodeathmode)
+            {
+                returntomenu(Menu::playmodes);
+            }
             else if (wasincustommode)
             {
                 returntomenu(Menu::levellist);
@@ -1367,6 +1373,7 @@ void Game::updatestate()
             }
             wasintimetrial = false;
             wasinintermission = false;
+            wasinnodeathmode = false;
             wasincustommode = false;
             state = 0;
             break;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -237,6 +237,7 @@ public:
     //Menu kludge...
     bool wasintimetrial;
     bool wasinintermission;
+    bool wasinnodeathmode;
     bool wasincustommode;
 
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1233,7 +1233,7 @@ void menuactionpress()
         //back
         music.playef(11);
         music.play(6);
-        game.returnmenu();
+        game.returntomenu(Menu::playmodes);
         map.nexttowercolour();
         break;
     case Menu::unlocktimetrials:
@@ -1970,6 +1970,7 @@ void mapinput()
                 if (game.intimetrial || game.insecretlab || game.nodeathmode) game.menukludge = true;
                 game.wasintimetrial = game.intimetrial;
                 game.wasinintermission = game.inintermission;
+                game.wasinnodeathmode = game.nodeathmode;
                 game.wasincustommode = map.custommode;
                 script.hardreset();
                 if(graphics.setflipmode) graphics.flipmode = true;


### PR DESCRIPTION
## Changes:

I want exiting No Death Mode to go back to the "play modes" menu, not to the "start game" menu, because it's too far back. Also do the same if you either die or complete No Death Mode.

Also I initialized `Game::wasinintermission`, probably a good thing to initialize variables.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
