### PR TITLE
Fix editor menu being drawn on top of editor with BGs disabled

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3008,7 +3008,14 @@ void editorrender()
     }
     else if(ed.settingsmod)
     {
-        if(!game.colourblindmode) graphics.drawtowerbackgroundsolo();
+        if(!game.colourblindmode)
+        {
+            graphics.drawtowerbackgroundsolo();
+        }
+        else
+        {
+            FillRect(graphics.backBuffer, 0, 0, 320, 240, 0x00000000);
+        }
 
         int tr = map.r - (help.glow / 4) - int(fRandom() * 4);
         int tg = map.g - (help.glow / 4) - int(fRandom() * 4);


### PR DESCRIPTION
## Changes:

Previously, if you had backgrounds disabled in accessibility options, and went to the editor and opened up the editor menu, it would be drawn straight on top of what was already there in the editor instead of being drawn on top of black. So now it's drawn on top of black.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
