### PR TITLE
Optimize descending tower background drawing

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2201,43 +2201,6 @@ void Graphics::drawtowerspikes()
     }
 }
 
-void Graphics::drawtowerbackgroundsolo()
-{
-    if (map.bypos < 0)
-    {
-        map.bypos += 120 * 8;
-    }
-
-    int temp = 0;
-
-    if (map.tdrawback)
-    {
-        //Draw the whole thing; needed for every colour cycle!
-        for (int j = 0; j < 31; j++)
-        {
-            for (int  i = 0; i < 40; i++)
-            {
-                temp = map.tower.backat(i, j, map.bypos);
-                drawtowertile3(i * 8, (j * 8) - (map.bypos % 8), temp, map.colstate);
-            }
-        }
-        SDL_BlitSurface(towerbuffer,NULL, backBuffer,NULL);
-        map.tdrawback = false;
-    }
-    else
-    {
-        //just update the bottom
-        ScrollSurface(towerbuffer,0, -map.bscroll);
-        for (int i = 0; i < 40; i++)
-        {
-            temp = map.tower.backat(i, 0, map.bypos);
-            drawtowertile3(i * 8, -(map.bypos % 8), temp, map.colstate);
-        }
-
-        SDL_BlitSurface(towerbuffer, NULL, backBuffer,NULL);
-    }
-}
-
 void Graphics::drawtowerbackground()
 {
     int temp;
@@ -2248,7 +2211,7 @@ void Graphics::drawtowerbackground()
     {
         int off = map.scrolldir == 0 ? 0 : map.bscroll;
         //Draw the whole thing; needed for every colour cycle!
-        for (j = 0; j < 30; j++)
+        for (int j = 0; j < 31; j++)
         {
             for (int i = 0; i < 40; i++)
             {
@@ -2265,14 +2228,17 @@ void Graphics::drawtowerbackground()
     {
         //just update the bottom
         ScrollSurface(towerbuffer, 0, -map.bscroll);
-        for (int i = 0; i < 40; i++)
+        if (map.scrolldir == 0)
         {
-            if (map.scrolldir == 0)
+            for (int i = 0; i < 40; i++)
             {
                 temp = map.tower.backat(i, 0, map.bypos);
                 drawtowertile3(i * 8, -(map.bypos % 8), temp, map.colstate);
             }
-            else
+        }
+        else
+        {
+            for (int i = 0; i < 40; i++)
             {
                 temp = map.tower.backat(i, 29, map.bypos);
                 drawtowertile3(i * 8, 29*8 - (map.bypos % 8) - map.bscroll, temp, map.colstate);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2244,8 +2244,6 @@ void Graphics::drawtowerbackground()
 
     if (map.bypos < 0) map.bypos += 120 * 8;
 
-    if (map.scrolldir == 1) map.tdrawback = true;
-
     if (map.tdrawback)
     {
         //Draw the whole thing; needed for every colour cycle!
@@ -2268,8 +2266,18 @@ void Graphics::drawtowerbackground()
         ScrollSurface(towerbuffer, 0, -map.bscroll);
         for (int i = 0; i < 40; i++)
         {
-            temp = map.tower.backat(i, 0, map.bypos);
-            drawtowertile3(i * 8, -(map.bypos % 8), temp, map.colstate);
+            if (map.scrolldir == 0)
+            {
+                temp = map.tower.backat(i, 0, map.bypos);
+                drawtowertile3(i * 8, -(map.bypos % 8), temp, map.colstate);
+            }
+            else
+            {
+                temp = map.tower.backat(i, 29, map.bypos);
+                drawtowertile3(i * 8, 29*8 - (map.bypos % 8) - map.bscroll, temp, map.colstate);
+                temp = map.tower.backat(i, 30, map.bypos);
+                drawtowertile3(i * 8, 30*8 - (map.bypos % 8) - map.bscroll, temp, map.colstate);
+            }
         }
 
         SDL_BlitSurface(towerbuffer,NULL, backBuffer,NULL);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2246,13 +2246,14 @@ void Graphics::drawtowerbackground()
 
     if (map.tdrawback)
     {
+        int off = map.scrolldir == 0 ? 0 : map.bscroll;
         //Draw the whole thing; needed for every colour cycle!
         for (j = 0; j < 30; j++)
         {
             for (int i = 0; i < 40; i++)
             {
                 temp = map.tower.backat(i, j, map.bypos);
-                drawtowertile3(i * 8, (j * 8) - (map.bypos % 8), temp, map.colstate);
+                drawtowertile3(i * 8, (j * 8) - (map.bypos % 8) - off, temp, map.colstate);
             }
         }
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -185,8 +185,6 @@ public:
 
 	bool onscreen(int t);
 
-	void drawtowerbackgroundsolo();
-
 
 	void menuoffrender();
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1556,6 +1556,7 @@ void gameinput()
                        ed.level[i+(j*ed.maxwidth)].warpdir=ed.kludgewarpdir[i+(j*ed.maxwidth)];
                     }
                 }
+                map.scrolldir = 0;
             }
         }
     }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1069,7 +1069,7 @@ void titlerender()
     }
     else
     {
-        if(!game.colourblindmode) graphics.drawtowerbackgroundsolo();
+        if(!game.colourblindmode) graphics.drawtowerbackground();
 
         tr = map.r - (help.glow / 4) - int(fRandom() * 4);
         tg = map.g - (help.glow / 4) - int(fRandom() * 4);
@@ -1131,7 +1131,7 @@ void gamecompleterender()
 {
     FillRect(graphics.backBuffer, 0x000000);
 
-    if(!game.colourblindmode) graphics.drawtowerbackgroundsolo();
+    if(!game.colourblindmode) graphics.drawtowerbackground();
 
     tr = map.r - (help.glow / 4) - fRandom() * 4;
     tg = map.g - (help.glow / 4) - fRandom() * 4;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3532,6 +3532,7 @@ void scriptclass::hardreset()
 	map.towermode=false;
 	map.cameraseekframe = 0;
 	map.resumedelay = 0;
+	map.scrolldir = 0;
 	map.customshowmm=true;
 
 	for (j = 0; j < 20; j++)

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3010,7 +3010,7 @@ void editorrender()
     {
         if(!game.colourblindmode)
         {
-            graphics.drawtowerbackgroundsolo();
+            graphics.drawtowerbackground();
         }
         else
         {


### PR DESCRIPTION
## Changes:

When working on my over-30-FPS patch, I noticed that the descending tower background kept getting re-drawn every frame, which is kind of inefficient. Also, it'd be better for my over-30-FPS patch if the background scrolled whatever it had (at least until the color change), because that way would be much easier to interpolate than having to redraw the background every frame.

And since the background is now scrolling instead of being redrawn, when the background *does* need to be redrawn anyway, it needs to account for `map.bscroll` to be aligned with the incoming new textures. But only for the descending background.

Also, I merged `Graphics::drawtowerbackgroundsolo()` into `Graphics::drawtowerbackground()` because it'll mean I have to copy-paste less for my over-30-FPS patch.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
