### PR TITLE
Render screen effects in maprender()

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2495,7 +2495,7 @@ void maprender()
     }
     else
     {
-        graphics.render();
+        graphics.renderwithscreeneffects();
     }
 }
 


### PR DESCRIPTION
## Changes:

I had forgotten that the game flashed and did screen-shaking when you pressed ACTION to quicksave.

While testing for my over-30-FPS patch I stumbled across this.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
