### PR TITLE
Prevent spawning crewmates/activity zones in custommode

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1842,7 +1842,7 @@ void mapclass::loadlevel(int rx, int ry)
 	}
 
 	//Special scripting: Create objects and triggers based on what crewmembers are rescued.
-	if (!finalmode)
+	if (!finalmode && !custommode)
 	{
 		//First up: the extra bits:
 		//Vermilion's quest:


### PR DESCRIPTION
## Changes:

Looks like there wasn't a `custommode` check for the spawning of crewmates based on which crewmates were rescued, but now there is.

This has gone undiscovered for a long time, mostly because people don't use the `rescued()` internal command.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
