### PR TITLE
Make the game (visually) run at framerates above ~30 FPS

### DIFF
--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -53,6 +53,8 @@ entclass::entclass()
 	walkingframe = 0;
 	dir = 0;
 	actionframe = 0;
+
+	realcol = 0;
 }
 
 bool entclass::outside()
@@ -583,6 +585,53 @@ void entclass::settreadmillcolour( int rx, int ry )
 		break; //Red
 	default:
 		return;
+		break;
+	}
+}
+
+void entclass::updatecolour()
+{
+	switch (size)
+	{
+	case 0: // Sprites
+	case 7: // Teleporter
+	case 9: // Really Big Sprite! (2x2)
+	case 10: // 2x1 Sprite
+	case 13: // Special for epilogue: huge hero!
+		graphics.setcol(colour);
+		realcol = graphics.ct.colour;
+		break;
+	case 3: // Big chunky pixels!
+		realcol = graphics.bigchunkygetcol(colour);
+		break;
+	case 4: // Small pickups
+		graphics.huetilesetcol(colour);
+		realcol = graphics.ct.colour;
+		break;
+	case 11: // The fucking elephant
+		if (game.noflashingmode)
+		{
+			graphics.setcol(22);
+		}
+		else
+		{
+			graphics.setcol(colour);
+		}
+		realcol = graphics.ct.colour;
+		break;
+	case 12: // Regular sprites that don't wrap
+		// if we're outside the screen, we need to draw indicators
+		if ((xp < -20 && vx > 0) || (xp > 340 && vx < 0))
+		{
+			graphics.setcol(23);
+		}
+		else
+		{
+			graphics.setcol(colour);
+		}
+		realcol = graphics.ct.colour;
+		break;
+	default:
 		break;
 	}
 }

--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -223,7 +223,9 @@ void entclass::setenemyroom( int rx, int ry )
 			w = 16;
 			h = 16;
 			xp -= 24;
+			oldxp -= 24;
 			yp -= 16;
+			oldyp -= 16;
 		}
 		else
 		{
@@ -236,7 +238,9 @@ void entclass::setenemyroom( int rx, int ry )
 			cx = 4;
 			size = 9;
 			xp -= 4;
+			oldxp -= 4;
 			yp -= 32;
+			oldyp -= 32;
 		}
 
 		break;
@@ -337,6 +341,7 @@ void entclass::setenemyroom( int rx, int ry )
 		w = 32;
 		h = 14;
 		yp += 1;
+		oldyp += 1;
 		break;
 	case rn(16, 2): // (Manequins)
 		tile = 52;
@@ -345,6 +350,7 @@ void entclass::setenemyroom( int rx, int ry )
 		w = 16;
 		h = 25;
 		yp -= 4;
+		oldyp -= 4;
 		break;
 	case rn(18, 0): // (Obey)
 		tile = 51;

--- a/desktop_version/src/Ent.h
+++ b/desktop_version/src/Ent.h
@@ -1,6 +1,8 @@
 #ifndef ENT_H
 #define ENT_H
 
+#include "Graphics.h"
+
 #define		rn( rx,  ry) ((rx) + ((ry) * 100))
 
 class entclass
@@ -15,6 +17,8 @@ public:
     void setenemyroom(int rx, int ry);
 
     void settreadmillcolour(int rx, int ry);
+
+    void updatecolour();
 
 public:
     //Fundamentals
@@ -45,6 +49,8 @@ public:
     //Animation
     int framedelay, drawframe, walkingframe, dir, actionframe;
     int yp;int xp;
+
+    Uint32 realcol;
 };
 
 #endif /* ENT_H */

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2008,6 +2008,10 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
     }
 
     entity.drawframe = entity.tile;
+    if (!entity.invis)
+    {
+        entity.updatecolour();
+    }
 
     entities.push_back(entity);
 }

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -62,6 +62,7 @@ void entityclass::init()
     customenemy=0;
     customwarpmode=false; customwarpmodevon=false; customwarpmodehon=false;
     trophytext = 0 ;
+    oldtrophytext = 0;
     trophytype = 0;
     altstates = 0;
 

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2376,6 +2376,7 @@ bool entityclass::updateentities( int i )
                 {
                     entities[i].statedelay = 6;
                     entities[i].xp -=  int(entities[i].para);
+                    entities[i].oldxp -=  int(entities[i].para);
                 }
                 break;
             case 18: //Special for ASCII Snake (right)
@@ -2383,6 +2384,7 @@ bool entityclass::updateentities( int i )
                 {
                     entities[i].statedelay = 6;
                     entities[i].xp += int(entities[i].para);
+                    entities[i].oldxp += int(entities[i].para);
                 }
                 break;
             }

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2012,6 +2012,32 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
     {
         entity.updatecolour();
     }
+    if (entity.type == 1)
+    {
+        switch (entity.animate)
+        {
+        case 0: // Simple Loop
+        case 1: // Simple Loop
+        case 2: // Simpler Loop (just two frames)
+        case 3: // Simpler Loop (just two frames, but double sized)
+        case 4: // Simpler Loop (just two frames, but double sized) (as above, but slower)
+        case 5: // Simpler Loop (just two frames) (slower)
+        case 6: // Normal Loop (four frames, double sized)
+        case 7: // Simpler Loop (just two frames) (slower) (with directions!)
+        case 11: // Conveyor right
+            entity.drawframe++;
+            break;
+        case 10: // Conveyor left
+            entity.drawframe += 3;
+            break;
+        default:
+            break;
+        }
+    }
+    else if (entity.type == 2 && entity.animate == 2)
+    {
+        entity.drawframe++;
+    }
 
     entities.push_back(entity);
 }

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -197,6 +197,7 @@ public:
 
     //Trophy Text
     int trophytext, trophytype;
+    int oldtrophytext;
 
     //Secret lab scripts
     int altstates;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -162,6 +162,7 @@ void Game::init(void)
     creditposx = 0;
     creditposy = 0;
     creditposdelay = 0;
+    oldcreditposx = 0;
 
     useteleporter = false;
     teleport_to_teleporter = 0;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -387,6 +387,8 @@ void Game::init(void)
     shouldreturntoeditor = false;
 #endif
 
+    over30mode = false;
+
     /* Terry's Patrons... */
     const char* superpatrons_arr[] = {
     "Anders Ekermo",
@@ -4746,6 +4748,11 @@ void Game::loadstats()
             skipfakeload = atoi(pText);
         }
 
+        if (pKey == "over30mode")
+        {
+            over30mode = atoi(pText);
+        }
+
         if (pKey == "notextoutline")
         {
             graphics.notextoutline = atoi(pText);
@@ -4989,6 +4996,10 @@ void Game::savestats()
 
     msg = doc.NewElement("showmousecursor");
     msg->LinkEndChild(doc.NewText(help.String((int)graphics.showmousecursor).c_str()));
+    dataNode->LinkEndChild(msg);
+
+    msg = doc.NewElement("over30mode");
+    msg->LinkEndChild(doc.NewText(help.String((int) over30mode).c_str()));
     dataNode->LinkEndChild(msg);
 
     for (size_t i = 0; i < controllerButton_flip.size(); i += 1)
@@ -7063,6 +7074,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("toggle filter");
         option("toggle analogue");
         option("toggle mouse");
+        option("toggle fps");
         option("return");
         menuxoff = -50;
         menuyoff = 8;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -174,6 +174,7 @@ void Game::init(void)
     activity_g = 0;
     activity_b = 0;
     creditposition = 0;
+    oldcreditposition = 0;
     bestgamedeaths = -1;
 
     fullScreenEffect_badSignal = false;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -168,6 +168,7 @@ void Game::init(void)
 
     activetele = false;
     readytotele = 0;
+    oldreadytotele = 0;
     activity_lastprompt = "";
     activity_r = 0;
     activity_g = 0;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -2398,11 +2398,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 180, 165, 165, 255);
+                graphics.createtextbox("", -1, 180, 165, 165, 255, true);
             }
             else
             {
-                graphics.createtextbox("", -1, 12, 165, 165, 255);
+                graphics.createtextbox("", -1, 12, 165, 165, 255, true);
             }
             //graphics.addline("      Level Complete!      ");
             graphics.addline("                                   ");
@@ -2422,11 +2422,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 104, 175,174,174);
+                graphics.createtextbox("", -1, 104, 175,174,174, true);
             }
             else
             {
-                graphics.createtextbox("", -1, 64+8+16, 175,174,174);
+                graphics.createtextbox("", -1, 64+8+16, 175,174,174, true);
             }
             graphics.addline("     You have rescued  ");
             graphics.addline("      a crew member!   ");
@@ -2515,11 +2515,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 180, 165, 165, 255);
+                graphics.createtextbox("", -1, 180, 165, 165, 255, true);
             }
             else
             {
-                graphics.createtextbox("", -1, 12, 165, 165, 255);
+                graphics.createtextbox("", -1, 12, 165, 165, 255, true);
             }
             //graphics.addline("      Level Complete!      ");
             graphics.addline("                                   ");
@@ -2539,11 +2539,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 104, 174,175,174);
+                graphics.createtextbox("", -1, 104, 174,175,174, true);
             }
             else
             {
-                graphics.createtextbox("", -1, 64+8+16, 174,175,174);
+                graphics.createtextbox("", -1, 64+8+16, 174,175,174, true);
             }
             graphics.addline("     You have rescued  ");
             graphics.addline("      a crew member!   ");
@@ -2631,11 +2631,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 180, 165, 165, 255);
+                graphics.createtextbox("", -1, 180, 165, 165, 255, true);
             }
             else
             {
-                graphics.createtextbox("", -1, 12, 165, 165, 255);
+                graphics.createtextbox("", -1, 12, 165, 165, 255, true);
             }
             //graphics.addline("      Level Complete!      ");
             graphics.addline("                                   ");
@@ -2655,11 +2655,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 104, 174,174,175);
+                graphics.createtextbox("", -1, 104, 174,174,175, true);
             }
             else
             {
-                graphics.createtextbox("", -1, 64+8+16, 174,174,175);
+                graphics.createtextbox("", -1, 64+8+16, 174,174,175, true);
             }
             graphics.addline("     You have rescued  ");
             graphics.addline("      a crew member!   ");
@@ -2748,11 +2748,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 180, 165, 165, 255);
+                graphics.createtextbox("", -1, 180, 165, 165, 255, true);
             }
             else
             {
-                graphics.createtextbox("", -1, 12, 165, 165, 255);
+                graphics.createtextbox("", -1, 12, 165, 165, 255, true);
             }
             //graphics.addline("      Level Complete!      ");
             graphics.addline("                                   ");
@@ -2772,11 +2772,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 104, 175,175,174);
+                graphics.createtextbox("", -1, 104, 175,175,174, true);
             }
             else
             {
-                graphics.createtextbox("", -1, 64+8+16, 175,175,174);
+                graphics.createtextbox("", -1, 64+8+16, 175,175,174, true);
             }
             graphics.addline("     You have rescued  ");
             graphics.addline("      a crew member!   ");
@@ -2883,11 +2883,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 180, 165, 165, 255);
+                graphics.createtextbox("", -1, 180, 165, 165, 255, true);
             }
             else
             {
-                graphics.createtextbox("", -1, 12, 165, 165, 255);
+                graphics.createtextbox("", -1, 12, 165, 165, 255, true);
             }
             //graphics.addline("      Level Complete!      ");
             graphics.addline("                                   ");
@@ -2907,11 +2907,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 104, 175,174,175);
+                graphics.createtextbox("", -1, 104, 175,174,175, true);
             }
             else
             {
-                graphics.createtextbox("", -1, 64+8+16, 175,174,175);
+                graphics.createtextbox("", -1, 64+8+16, 175,174,175, true);
             }
             graphics.addline("     You have rescued  ");
             graphics.addline("      a crew member!   ");
@@ -3179,11 +3179,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 180, 164, 165, 255);
+                graphics.createtextbox("", -1, 180, 164, 165, 255, true);
             }
             else
             {
-                graphics.createtextbox("", -1, 12, 164, 165, 255);
+                graphics.createtextbox("", -1, 12, 164, 165, 255, true);
             }
             graphics.addline("                                   ");
             graphics.addline("");

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4753,6 +4753,11 @@ void Game::loadstats()
             over30mode = atoi(pText);
         }
 
+        if (pKey == "vsync")
+        {
+            graphics.vsync = atoi(pText);
+        }
+
         if (pKey == "notextoutline")
         {
             graphics.notextoutline = atoi(pText);
@@ -5000,6 +5005,10 @@ void Game::savestats()
 
     msg = doc.NewElement("over30mode");
     msg->LinkEndChild(doc.NewText(help.String((int) over30mode).c_str()));
+    dataNode->LinkEndChild(msg);
+
+    msg = doc.NewElement("vsync");
+    msg->LinkEndChild(doc.NewText(help.String((int) graphics.vsync).c_str()));
     dataNode->LinkEndChild(msg);
 
     for (size_t i = 0; i < controllerButton_flip.size(); i += 1)
@@ -7075,9 +7084,10 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("toggle analogue");
         option("toggle mouse");
         option("toggle fps");
+        option("toggle vsync");
         option("return");
-        menuxoff = -50;
-        menuyoff = 8;
+        menuxoff = -85;
+        menuyoff = 0;
         break;
     case Menu::ed_settings:
         option("change description");

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -318,6 +318,7 @@ public:
     SDL_Rect teleblock;
     bool activetele;
     int readytotele;
+    int oldreadytotele;
     int activity_r, activity_g, activity_b;
     std::string activity_lastprompt;
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -260,6 +260,7 @@ public:
     int timetrialpar, timetrialresulttime, timetrialrank;
 
     int creditposition;
+    int oldcreditposition;
     int creditmaxposition;
     std::vector<const char*> superpatrons;
     std::vector<const char*> patrons;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -232,6 +232,7 @@ public:
     enum Menu::MenuName menudest;
 
     int creditposx, creditposy, creditposdelay;
+    int oldcreditposx;
 
 
     //Sine Wave Ninja Minigame

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -401,6 +401,8 @@ public:
     {
         return inintermission || insecretlab || intimetrial || nodeathmode;
     }
+
+    bool over30mode;
 };
 
 extern Game game;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -139,6 +139,8 @@ void Graphics::init()
     col_tb = 0;
 
     kludgeswnlinewidth = false;
+
+    vsync = false;
 }
 
 int Graphics::font_idx(uint32_t ch) {
@@ -3099,4 +3101,9 @@ Uint32 Graphics::crewcolourreal(int t)
 		return col_crewblue;
 	}
 	return col_crewcyan;
+}
+
+void Graphics::processVsync()
+{
+	SDL_SetHintWithPriority(SDL_HINT_RENDER_VSYNC, vsync ? "1" : "0", SDL_HINT_OVERRIDE);
 }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -137,6 +137,8 @@ void Graphics::init()
     col_tr = 0;
     col_tg = 0;
     col_tb = 0;
+
+    kludgeswnlinewidth = false;
 }
 
 int Graphics::font_idx(uint32_t ch) {
@@ -1649,7 +1651,7 @@ void Graphics::drawentities()
         case 5:    //Horizontal Line
         {
             int oldw = obj.entities[i].w;
-            if (game.swngame == 3 && obj.getlineat(84 - 32) == i)
+            if ((game.swngame == 3 || kludgeswnlinewidth) && obj.getlineat(84 - 32) == i)
             {
                 oldw -= 24;
             }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2007,7 +2007,7 @@ void Graphics::drawbackground( int t )
 
         for (int i = 10 ; i >= 0; i--)
         {
-            temp = (i << 4) + backoffset;
+            temp = (i << 4) + lerp(backoffset - 1, backoffset);
             setwarprect(160 - temp, 120 - temp, temp * 2, temp * 2);
             if (i % 2 == warpskip)
             {

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -124,6 +124,19 @@ void Graphics::init()
 
     screenshake_x = 0;
     screenshake_y = 0;
+
+    col_crewred = 0x00000000;
+    col_crewyellow = 0x00000000;
+    col_crewgreen = 0x00000000;
+    col_crewcyan = 0x00000000;
+    col_crewblue = 0x00000000;
+    col_crewpurple = 0x00000000;
+    col_crewinactive = 0x00000000;
+    col_clock = 0x00000000;
+    col_trinket = 0x00000000;
+    col_tr = 0;
+    col_tg = 0;
+    col_tb = 0;
 }
 
 int Graphics::font_idx(uint32_t ch) {
@@ -158,6 +171,29 @@ void Graphics::drawspritesetcol(int x, int y, int t, int c)
     setcol(c);
 
     BlitSurfaceColoured(sprites[t],NULL,backBuffer, &rect, ct);
+}
+
+void Graphics::updatetitlecolours()
+{
+    setcol(15);
+    col_crewred = ct.colour;
+    setcol(14);
+    col_crewyellow = ct.colour;
+    setcol(13);
+    col_crewgreen = ct.colour;
+    setcol(0);
+    col_crewcyan = ct.colour;
+    setcol(16);
+    col_crewblue = ct.colour;
+    setcol(20);
+    col_crewpurple = ct.colour;
+    setcol(19);
+    col_crewinactive = ct.colour;
+
+    setcol(18);
+    col_clock = ct.colour;
+    setcol(18);
+    col_trinket = ct.colour;
 }
 
 void Graphics::Makebfont()
@@ -540,6 +576,13 @@ void Graphics::drawsprite( int x, int y, int t, int r, int g,  int b )
     BlitSurfaceColoured(sprites[t], NULL, backBuffer, &rect, ct);
 }
 
+void Graphics::drawsprite(int x, int y, int t, Uint32 c)
+{
+    SDL_Rect rect = { Sint16(x), Sint16(y), sprites_rect.w, sprites_rect.h };
+    setcolreal(c);
+    BlitSurfaceColoured(sprites[t], NULL, backBuffer, &rect, ct);
+}
+
 void Graphics::drawtile( int x, int y, int t )
 {
     if (!INBOUNDS(t, tiles))
@@ -890,22 +933,22 @@ void Graphics::drawcrewman( int x, int y, int t, bool act, bool noshift /*=false
         {
             if (flipmode)
             {
-                drawspritesetcol(x, y, 14, 19);
+                drawsprite(x, y, 14, col_crewinactive);
             }
             else
             {
-                drawspritesetcol(x, y, 12, 19);
+                drawsprite(x, y, 12, col_crewinactive);
             }
         }
         else
         {
             if (flipmode)
             {
-                drawspritesetcol(x - 8, y, 14, 19);
+                drawsprite(x - 8, y, 14, col_crewinactive);
             }
             else
             {
-                drawspritesetcol(x - 8, y, 12, 19);
+                drawsprite(x - 8, y, 12, col_crewinactive);
             }
         }
     }
@@ -916,22 +959,22 @@ void Graphics::drawcrewman( int x, int y, int t, bool act, bool noshift /*=false
         switch(t)
         {
         case 0:
-            drawspritesetcol(x, y, crewframe, 0);
+            drawsprite(x, y, crewframe, col_crewcyan);
             break;
         case 1:
-            drawspritesetcol(x, y, crewframe, 20);
+            drawsprite(x, y, crewframe, col_crewpurple);
             break;
         case 2:
-            drawspritesetcol(x, y, crewframe, 14);
+            drawsprite(x, y, crewframe, col_crewyellow);
             break;
         case 3:
-            drawspritesetcol(x, y, crewframe, 15);
+            drawsprite(x, y, crewframe, col_crewred);
             break;
         case 4:
-            drawspritesetcol(x, y, crewframe, 13);
+            drawsprite(x, y, crewframe, col_crewgreen);
             break;
         case 5:
-            drawspritesetcol(x, y, crewframe, 16);
+            drawsprite(x, y, crewframe, col_crewblue);
             break;
         }
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2174,6 +2174,8 @@ void Graphics::updatebackground(int t)
         }
         break;
     case 3: //Warp zone (horizontal)
+    {
+        int temp = 680 + (rcol * 3);
         backoffset+=3;
         if (backoffset >= 16) backoffset -= 16;
 
@@ -2182,11 +2184,13 @@ void Graphics::updatebackground(int t)
             ScrollSurface(towerbuffer, -3, 0 );
             for (int j = 0; j < 15; j++)
             {
-                int temp = 680 + (rcol * 3);
-                drawtowertile(317 - backoffset, (j * 16), temp+40);  //20*16 = 320
-                drawtowertile(317 - backoffset + 8, (j * 16), temp + 41);
-                drawtowertile(317 - backoffset, (j * 16) + 8, temp + 80);
-                drawtowertile(317 - backoffset + 8, (j * 16) + 8, temp + 81);
+                for (int i = 0; i < 2; i++)
+                {
+                    drawtowertile(317 - backoffset + (i * 16), (j * 16), temp+40);  //20*16 = 320
+                    drawtowertile(317 - backoffset + (i * 16) + 8, (j * 16), temp + 41);
+                    drawtowertile(317 - backoffset + (i * 16), (j * 16) + 8, temp + 80);
+                    drawtowertile(317 - backoffset + (i * 16) + 8, (j * 16) + 8, temp + 81);
+                }
             }
         }
         else
@@ -2198,7 +2202,6 @@ void Graphics::updatebackground(int t)
             {
                 for (int i = 0; i < 21; i++)
                 {
-                    int temp = 680 + (rcol * 3);
                     drawtowertile((i * 16) - backoffset - 3, (j * 16), temp+40);
                     drawtowertile((i * 16) - backoffset + 8 - 3, (j * 16), temp + 41);
                     drawtowertile((i * 16) - backoffset - 3, (j * 16) + 8, temp + 80);
@@ -2208,20 +2211,25 @@ void Graphics::updatebackground(int t)
             backgrounddrawn = true;
         }
         break;
+    }
     case 4: //Warp zone (vertical)
+    {
+        int temp = 760 + (rcol * 3);
         backoffset+=3;
         if (backoffset >= 16) backoffset -= 16;
 
         if (backgrounddrawn)
         {
             ScrollSurface(towerbuffer,0,-3);
-            for (int i = 0; i < 21; i++)
+            for (int j = 0; j < 2; j++)
             {
-                int temp = 760 + (rcol * 3);
-                drawtowertile((i * 16), 237 - backoffset, temp + 40); //14*17=240 - 3
-                drawtowertile((i * 16) + 8, 237 - backoffset, temp + 41);
-                drawtowertile((i * 16), 237 - backoffset + 8, temp + 80);
-                drawtowertile((i * 16) + 8, 237 - backoffset + 8, temp + 81);
+                for (int i = 0; i < 21; i++)
+                {
+                    drawtowertile((i * 16), 237 - backoffset + (j * 16), temp + 40); //14*17=240 - 3
+                    drawtowertile((i * 16) + 8, 237 - backoffset + (j * 16), temp + 41);
+                    drawtowertile((i * 16), 237 - backoffset + (j * 16) + 8, temp + 80);
+                    drawtowertile((i * 16) + 8, 237 - backoffset + (j * 16) + 8, temp + 81);
+                }
             }
         }
         else
@@ -2229,11 +2237,10 @@ void Graphics::updatebackground(int t)
             //draw the whole thing for the first time!
             backoffset = 0;
             FillRect(towerbuffer,0x000000 );
-            for (int j = 0; j < 15; j++)
+            for (int j = 0; j < 16; j++)
             {
                 for (int i = 0; i < 21; i++)
                 {
-                    int temp = 760 + (rcol * 3);
                     drawtowertile((i * 16), (j * 16)- backoffset - 3, temp+40);
                     drawtowertile((i * 16)+ 8, (j * 16)- backoffset - 3, temp + 41);
                     drawtowertile((i * 16), (j * 16)- backoffset + 8 - 3, temp + 80);
@@ -2243,6 +2250,7 @@ void Graphics::updatebackground(int t)
             backgrounddrawn = true;
         }
         break;
+    }
     case 5:
         //Warp zone, central
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -667,7 +667,7 @@ void Graphics::drawgui()
             }
         }
 
-        if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].r == 165)
+        if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].r == 165 && textbox[i].allowspecial)
         {
             if (flipmode)
             {
@@ -678,7 +678,7 @@ void Graphics::drawgui()
                 drawimage(0, 0, 12, true);
             }
         }
-        else if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].g == 165)
+        else if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].g == 165 && textbox[i].allowspecial)
         {
             if (flipmode)
             {
@@ -691,27 +691,27 @@ void Graphics::drawgui()
         }
         if (flipmode)
         {
-            if (textbox[i].r == 175 && textbox[i].g == 175)
+            if (textbox[i].r == 175 && textbox[i].g == 175 && textbox[i].allowspecial)
             {
                 //purple guy
                 drawsprite(80 - 6, 64 + 48 + 4, 6, 220- help.glow/4 - int(fRandom()*20), 120- help.glow/4, 210 - help.glow/4);
             }
-            else if (textbox[i].r == 175 && textbox[i].b == 175)
+            else if (textbox[i].r == 175 && textbox[i].b == 175 && textbox[i].allowspecial)
             {
                 //red guy
                 drawsprite(80 - 6, 64 + 48+ 4, 6, 255 - help.glow/8, 70 - help.glow/4, 70 - help.glow / 4);
             }
-            else if (textbox[i].r == 175)
+            else if (textbox[i].r == 175 && textbox[i].allowspecial)
             {
                 //green guy
                 drawsprite(80 - 6, 64 + 48 + 4, 6, 120 - help.glow / 4 - int(fRandom() * 20), 220 - help.glow / 4, 120 - help.glow / 4);
             }
-            else if (textbox[i].g == 175)
+            else if (textbox[i].g == 175 && textbox[i].allowspecial)
             {
                 //yellow guy
                 drawsprite(80 - 6, 64 + 48+ 4, 6, 220- help.glow/4 - int(fRandom()*20), 210 - help.glow/4, 120- help.glow/4);
             }
-            else if (textbox[i].b == 175)
+            else if (textbox[i].b == 175 && textbox[i].allowspecial)
             {
                 //blue guy
                 drawsprite(80 - 6, 64 + 48+ 4, 6, 75, 75, 255- help.glow/4 - int(fRandom()*20));
@@ -719,27 +719,27 @@ void Graphics::drawgui()
         }
         else
         {
-            if (textbox[i].r == 175 && textbox[i].g == 175)
+            if (textbox[i].r == 175 && textbox[i].g == 175 && textbox[i].allowspecial)
             {
                 //purple guy
                 drawsprite(80 - 6, 64 + 32 + 4, 0, 220- help.glow/4 - int(fRandom()*20), 120- help.glow/4, 210 - help.glow/4);
             }
-            else if (textbox[i].r == 175 && textbox[i].b == 175)
+            else if (textbox[i].r == 175 && textbox[i].b == 175 && textbox[i].allowspecial)
             {
                 //red guy
                 drawsprite(80 - 6, 64 + 32 + 4, 0, 255 - help.glow/8, 70 - help.glow/4, 70 - help.glow / 4);
             }
-            else if (textbox[i].r == 175)
+            else if (textbox[i].r == 175 && textbox[i].allowspecial)
             {
                 //green guy
                 drawsprite(80 - 6, 64 + 32 + 4, 0, 120 - help.glow / 4 - int(fRandom() * 20), 220 - help.glow / 4, 120 - help.glow / 4);
             }
-            else if (textbox[i].g == 175)
+            else if (textbox[i].g == 175 && textbox[i].allowspecial)
             {
                 //yellow guy
                 drawsprite(80 - 6, 64 + 32 + 4, 0, 220- help.glow/4 - int(fRandom()*20), 210 - help.glow/4, 120- help.glow/4);
             }
-            else if (textbox[i].b == 175)
+            else if (textbox[i].b == 175 && textbox[i].allowspecial)
             {
                 //blue guy
                 drawsprite(80 - 6, 64 + 32 + 4, 0, 75, 75, 255- help.glow/4 - int(fRandom()*20));
@@ -1065,7 +1065,7 @@ void Graphics::textboxadjust()
 }
 
 
-void Graphics::createtextbox( std::string t, int xp, int yp, int r/*= 255*/, int g/*= 255*/, int b /*= 255*/ )
+void Graphics::createtextbox( std::string t, int xp, int yp, int r/*= 255*/, int g/*= 255*/, int b /*= 255*/, bool allowspecial/*= false*/ )
 {
     m = textbox.size();
 
@@ -1079,6 +1079,7 @@ void Graphics::createtextbox( std::string t, int xp, int yp, int r/*= 255*/, int
         text.yp = yp;
         text.initcol(r, g, b);
         text.resize();
+        text.allowspecial = allowspecial;
         textbox.push_back(text);
     }
 }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1610,7 +1610,8 @@ void Graphics::drawentities()
             }
             break;
         case 4:    // Small pickups
-            drawhuetile(xp, yp - yoff, obj.entities[i].tile, obj.entities[i].colour);
+            huetilesetcol(obj.entities[i].colour);
+            drawhuetile(xp, yp - yoff, obj.entities[i].tile);
             break;
         case 5:    //Horizontal Line
             line_rect.x = xp;
@@ -2640,7 +2641,7 @@ void Graphics::menuoffrender()
 	FillRect(backBuffer, 0x000000);
 }
 
-void Graphics::drawhuetile( int x, int y, int t, int c )
+void Graphics::drawhuetile( int x, int y, int t )
 {
 	if (!INBOUNDS(t, tiles))
 	{
@@ -2649,7 +2650,16 @@ void Graphics::drawhuetile( int x, int y, int t, int c )
 	point tpoint;
 	tpoint.x = x;
 	tpoint.y = y;
-	switch(c)
+
+
+	SDL_Rect rect;
+	setRect(rect,tpoint.x,tpoint.y,tiles_rect.w, tiles_rect.h);
+	BlitSurfaceColoured(tiles[t],NULL,backBuffer, &rect, ct);
+}
+
+void Graphics::huetilesetcol(int t)
+{
+	switch (t)
 	{
 	case 0:
 		setcolreal(getRGB(250-int(fRandom()*32), 250-int(fRandom()*32), 10));
@@ -2661,11 +2671,6 @@ void Graphics::drawhuetile( int x, int y, int t, int c )
 		setcolreal(getRGB(250-int(fRandom()*32), 250-int(fRandom()*32),  10));
 		break;
 	}
-
-
-	SDL_Rect rect;
-	setRect(rect,tpoint.x,tpoint.y,tiles_rect.w, tiles_rect.h);
-	BlitSurfaceColoured(tiles[t],NULL,backBuffer, &rect, ct);
 }
 
 void Graphics::setwarprect( int a, int b, int c, int d )

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1481,7 +1481,7 @@ void Graphics::drawentities()
     int yoff;
     if (map.towermode)
     {
-        yoff = map.ypos;
+        yoff = lerp(map.oldypos, map.ypos);
     }
     else
     {
@@ -2320,12 +2320,13 @@ void Graphics::drawfinalmap()
 void Graphics::drawtowermap()
 {
     int temp;
+    int yoff = lerp(map.oldypos, map.ypos);
     for (int j = 0; j < 31; j++)
     {
         for (int i = 0; i < 40; i++)
         {
-            temp = map.tower.at(i, j, map.ypos);
-            if (temp > 0) drawtile3(i * 8, (j * 8) - ((int)map.ypos % 8), temp, map.colstate);
+            temp = map.tower.at(i, j, yoff);
+            if (temp > 0) drawtile3(i * 8, (j * 8) - (yoff % 8), temp, map.colstate);
         }
     }
 }
@@ -2333,12 +2334,13 @@ void Graphics::drawtowermap()
 void Graphics::drawtowermap_nobackground()
 {
     int temp;
+    int yoff = lerp(map.oldypos, map.ypos);
     for (int j = 0; j < 31; j++)
     {
         for (int i = 0; i < 40; i++)
         {
-            temp = map.tower.at(i, j, map.ypos);
-            if (temp > 0 && temp<28) drawtile3(i * 8, (j * 8) - ((int)map.ypos % 8), temp, map.colstate);
+            temp = map.tower.at(i, j, yoff);
+            if (temp > 0 && temp<28) drawtile3(i * 8, (j * 8) - (yoff % 8), temp, map.colstate);
         }
     }
 }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1994,11 +1994,13 @@ void Graphics::drawbackground( int t )
         }
         break;
     case 3: //Warp zone (horizontal)
+        FillRect(backBuffer, 0x000000);
         BlitSurfaceStandard(towerbuffer, NULL, towerbuffer_lerp, NULL);
         ScrollSurface(towerbuffer_lerp, lerp(0, -3), 0);
         BlitSurfaceStandard(towerbuffer_lerp, NULL, backBuffer, NULL);
         break;
     case 4: //Warp zone (vertical)
+        FillRect(backBuffer, 0x000000);
         SDL_BlitSurface(towerbuffer, NULL, towerbuffer_lerp, NULL);
         ScrollSurface(towerbuffer_lerp, 0, lerp(0, -3));
         SDL_BlitSurface(towerbuffer_lerp,NULL, backBuffer,NULL);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1369,9 +1369,10 @@ void Graphics::drawtrophytext()
 
     if (obj.trophytext < 15)
     {
-        temp = (196 * obj.trophytext) / 15;
-        temp2 = (196 * obj.trophytext) / 15;
-        temp3 = ((255 - help.glow) * obj.trophytext) / 15;
+        int usethismult = lerp(obj.oldtrophytext, obj.trophytext);
+        temp = (196 * usethismult) / 15;
+        temp2 = (196 * usethismult) / 15;
+        temp3 = ((255 - help.glow) * usethismult) / 15;
     }
     else
     {

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3080,3 +3080,23 @@ void Graphics::reloadresources() {
 
 	music.init();
 }
+
+Uint32 Graphics::crewcolourreal(int t)
+{
+	switch (t)
+	{
+	case 0:
+		return col_crewcyan;
+	case 1:
+		return col_crewpurple;
+	case 2:
+		return col_crewyellow;
+	case 3:
+		return col_crewred;
+	case 4:
+		return col_crewgreen;
+	case 5:
+		return col_crewblue;
+	}
+	return col_crewcyan;
+}

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1647,12 +1647,19 @@ void Graphics::drawentities()
             drawhuetile(xp, yp - yoff, obj.entities[i].tile);
             break;
         case 5:    //Horizontal Line
+        {
+            int oldw = obj.entities[i].w;
+            if (game.swngame == 3 && obj.getlineat(84 - 32) == i)
+            {
+                oldw -= 24;
+            }
             line_rect.x = xp;
             line_rect.y = yp - yoff;
-            line_rect.w = obj.entities[i].w;
+            line_rect.w = lerp(oldw, obj.entities[i].w);
             line_rect.h = 1;
             drawgravityline(i);
             break;
+        }
         case 6:    //Vertical Line
             line_rect.x = xp;
             line_rect.y = yp - yoff;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1488,8 +1488,6 @@ void Graphics::drawentities()
         yoff = 0;
     }
 
-    trinketcolset = false;
-
     for (int i = obj.entities.size() - 1; i >= 0; i--)
     {
         if (obj.entities[i].invis)
@@ -1510,7 +1508,7 @@ void Graphics::drawentities()
             }
             tpoint.x = xp;
             tpoint.y = yp - yoff;
-            setcol(obj.entities[i].colour);
+            setcolreal(obj.entities[i].realcol);
 
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
@@ -1599,10 +1597,10 @@ void Graphics::drawentities()
         case 3:    // Big chunky pixels!
             prect.x = xp;
             prect.y = yp - yoff;
-            FillRect(backBuffer, prect, bigchunkygetcol(obj.entities[i].colour));
+            FillRect(backBuffer, prect, obj.entities[i].realcol);
             break;
         case 4:    // Small pickups
-            huetilesetcol(obj.entities[i].colour);
+            setcol(obj.entities[i].realcol);
             drawhuetile(xp, yp - yoff, obj.entities[i].tile);
             break;
         case 5:    //Horizontal Line
@@ -1620,7 +1618,7 @@ void Graphics::drawentities()
             drawgravityline(i);
             break;
         case 7:    //Teleporter
-            drawtele(xp, yp - yoff, obj.entities[i].drawframe, obj.entities[i].colour);
+            drawtele(xp, yp - yoff, obj.entities[i].drawframe, obj.entities[i].realcol);
             break;
         //case 8:    // Special: Moving platform, 8 tiles
             // Note: This code is in the 4-tile code
@@ -1630,7 +1628,7 @@ void Graphics::drawentities()
             {
                 continue;
             }
-            setcol(obj.entities[i].colour);
+            setcolreal(obj.entities[i].realcol);
 
             tpoint.x = xp;
             tpoint.y = yp - yoff;
@@ -1669,7 +1667,7 @@ void Graphics::drawentities()
             {
                 continue;
             }
-            setcol(obj.entities[i].colour);
+            setcolreal(obj.entities[i].realcol);
 
             tpoint.x = xp;
             tpoint.y = yp - yoff;
@@ -1688,14 +1686,7 @@ void Graphics::drawentities()
             BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
             break;
         case 11:    //The fucking elephant
-            if (game.noflashingmode)
-            {
-                setcol(22);
-            }
-            else
-            {
-                setcol(obj.entities[i].colour);
-            }
+            setcolreal(obj.entities[i].realcol);
             drawimagecol(3, xp, yp - yoff);
             break;
         case 12:         // Regular sprites that don't wrap
@@ -1705,7 +1696,7 @@ void Graphics::drawentities()
             }
             tpoint.x = xp;
             tpoint.y = yp - yoff;
-            setcol(obj.entities[i].colour);
+            setcolreal(obj.entities[i].realcol);
             //
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
@@ -1727,7 +1718,6 @@ void Graphics::drawentities()
                 }
 
                 tpoint.y = tpoint.y+4;
-                setcol(23);
 
 
                 drawRect = tiles_rect;
@@ -1748,7 +1738,6 @@ void Graphics::drawentities()
                 }
 
                 tpoint.y = tpoint.y+4;
-                setcol(23);
                 //
 
                 drawRect = tiles_rect;
@@ -1766,7 +1755,7 @@ void Graphics::drawentities()
             }
 
             tpoint.x = xp; tpoint.y = yp - yoff;
-            setcol(obj.entities[i].colour);
+            setcolreal(obj.entities[i].realcol);
             SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp - yoff), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
             SDL_Surface* TempSurface = ScaleSurface( (*spritesvec)[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
             BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
@@ -2867,7 +2856,7 @@ void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool
 	}
 }
 
-void Graphics::drawtele(int x, int y, int t, int c)
+void Graphics::drawtele(int x, int y, int t, Uint32 c)
 {
 	setcolreal(getRGB(16,16,16));
 
@@ -2878,7 +2867,7 @@ void Graphics::drawtele(int x, int y, int t, int c)
 		BlitSurfaceColoured(tele[0], NULL, backBuffer, &telerect, ct);
 	}
 
-	setcol(c);
+	setcolreal(c);
 	if (t > 9) t = 8;
 	if (t < 0) t = 0;
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2332,10 +2332,12 @@ void Graphics::drawtowermap_nobackground()
 
 void Graphics::drawtowerspikes()
 {
+    int spikeleveltop = lerp(map.oldspikeleveltop, map.spikeleveltop);
+    int spikelevelbottom = lerp(map.oldspikelevelbottom, map.spikelevelbottom);
     for (int i = 0; i < 40; i++)
     {
-        drawtile3(i * 8, -8+map.spikeleveltop, 9, map.colstate);
-        drawtile3(i * 8, 230-map.spikelevelbottom, 8, map.colstate);
+        drawtile3(i * 8, -8+spikeleveltop, 9, map.colstate);
+        drawtile3(i * 8, 230-spikelevelbottom, 8, map.colstate);
     }
 }
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2403,7 +2403,7 @@ void Graphics::updatetowerbackground()
     {
         int off = map.scrolldir == 0 ? 0 : map.bscroll;
         //Draw the whole thing; needed for every colour cycle!
-        for (int j = 0; j < 31; j++)
+        for (int j = 0; j < 32; j++)
         {
             for (int i = 0; i < 40; i++)
             {
@@ -2436,6 +2436,8 @@ void Graphics::updatetowerbackground()
                 drawtowertile3(i * 8, 30*8 - (map.bypos % 8) - map.bscroll, temp, map.colstate);
                 temp = map.tower.backat(i, 31, map.bypos);
                 drawtowertile3(i * 8, 31*8 - (map.bypos % 8) - map.bscroll, temp, map.colstate);
+                temp = map.tower.backat(i, 32, map.bypos);
+                drawtowertile3(i * 8, 32*8 - (map.bypos % 8) - map.bscroll, temp, map.colstate);
             }
         }
     }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1599,15 +1599,7 @@ void Graphics::drawentities()
         case 3:    // Big chunky pixels!
             prect.x = xp;
             prect.y = yp - yoff;
-            //A seperate index of colours, for simplicity
-            if(obj.entities[i].colour==1)
-            {
-                FillRect(backBuffer, prect, (fRandom() * 64), 10, 10);
-            }
-            else if (obj.entities[i].colour == 2)
-            {
-                FillRect(backBuffer,prect, int(160- help.glow/2 - (fRandom()*20)),  200- help.glow/2, 220 - help.glow);
-            }
+            FillRect(backBuffer, prect, bigchunkygetcol(obj.entities[i].colour));
             break;
         case 4:    // Small pickups
             huetilesetcol(obj.entities[i].colour);
@@ -2671,6 +2663,19 @@ void Graphics::huetilesetcol(int t)
 		setcolreal(getRGB(250-int(fRandom()*32), 250-int(fRandom()*32),  10));
 		break;
 	}
+}
+
+Uint32 Graphics::bigchunkygetcol(int t)
+{
+	//A seperate index of colours, for simplicity
+	switch (t)
+	{
+	case 1:
+		return getRGB((fRandom() * 64), 10, 10);
+	case 2:
+		return getRGB(int(160- help.glow/2 - (fRandom()*20)),  200- help.glow/2, 220 - help.glow);
+	}
+	return 0x00000000;
 }
 
 void Graphics::setwarprect( int a, int b, int c, int d )

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2279,21 +2279,6 @@ void Graphics::drawmap()
 
 void Graphics::drawfinalmap()
 {
-    //Update colour cycling for final level
-    if (map.final_colormode) {
-        map.final_aniframedelay--;
-        if(map.final_aniframedelay==0)
-        {
-            foregrounddrawn=false;
-        }
-        if (map.final_aniframedelay <= 0) {
-            map.final_aniframedelay = 2;
-            map.final_aniframe++;
-            if (map.final_aniframe >= 4)
-                map.final_aniframe = 0;
-        }
-    }
-
     if (!foregrounddrawn) {
         FillRect(foregroundBuffer, 0x00000000);
         if(map.tileset==0){

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2379,6 +2379,7 @@ void Graphics::drawtowerspikes()
 
 void Graphics::drawtowerbackground()
 {
+    FillRect(backBuffer, 0x000000);
     SDL_BlitSurface(towerbuffer, NULL, towerbuffer_lerp, NULL);
     ScrollSurface(towerbuffer_lerp, 0, lerp(0, -map.bscroll));
     SDL_BlitSurface(towerbuffer_lerp,NULL, backBuffer,NULL);

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -320,6 +320,8 @@ public:
 	int col_tg;
 	int col_tb;
 	void updatetitlecolours();
+
+	bool kludgeswnlinewidth;
 };
 
 extern Graphics graphics;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -53,7 +53,7 @@ public:
 
 	void setwarprect(int a, int b, int c, int d);
 
-	void createtextbox(std::string t, int xp, int yp, int r= 255, int g= 255, int b = 255);
+	void createtextbox(std::string t, int xp, int yp, int r= 255, int g= 255, int b = 255, bool allowspecial = false);
 
 	void textboxcenter();
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -32,7 +32,8 @@ public:
 
 	void Makebfont();
 
-	void drawhuetile(int x, int y, int t, int c);
+	void drawhuetile(int x, int y, int t);
+	void huetilesetcol(int t);
 
 	void drawgravityline(int t);
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -322,6 +322,8 @@ public:
 	void updatetitlecolours();
 
 	bool kludgeswnlinewidth;
+
+	Uint32 crewcolourreal(int t);
 };
 
 extern Graphics graphics;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -103,6 +103,7 @@ public:
 	void drawgui();
 
 	void drawsprite(int x, int y, int t, int r, int g, int b);
+	void drawsprite(int x, int y, int t, Uint32 c);
 
 	void printcrewname(int x, int y, int t);
 
@@ -305,6 +306,20 @@ public:
 		return v0 + alpha * (v1 - v0);
 	}
 	float alpha;
+
+	Uint32 col_crewred;
+	Uint32 col_crewyellow;
+	Uint32 col_crewgreen;
+	Uint32 col_crewcyan;
+	Uint32 col_crewblue;
+	Uint32 col_crewpurple; //actually pink
+	Uint32 col_crewinactive;
+	Uint32 col_clock;
+	Uint32 col_trinket;
+	int col_tr;
+	int col_tg;
+	int col_tb;
+	void updatetitlecolours();
 };
 
 extern Graphics graphics;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -34,6 +34,7 @@ public:
 
 	void drawhuetile(int x, int y, int t);
 	void huetilesetcol(int t);
+	Uint32 bigchunkygetcol(int t);
 
 	void drawgravityline(int t);
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -324,6 +324,9 @@ public:
 	bool kludgeswnlinewidth;
 
 	Uint32 crewcolourreal(int t);
+
+	bool vsync;
+	void processVsync();
 };
 
 extern Graphics graphics;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -148,7 +148,7 @@ public:
 	void bigrprint(int x, int y, std::string& t, int r, int g, int b, bool cen = false, float sc = 2);
 
 
-	void drawtele(int x, int y, int t, int c);
+	void drawtele(int x, int y, int t, Uint32 c);
 
 	Uint32 getRGBA(Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -315,11 +315,9 @@ void BlitSurfaceColoured(
 
 int scrollamount = 0;
 bool isscrolling = 0;
-SDL_Surface* ApplyFilter( SDL_Surface* _src )
-{
-    SDL_Surface* _ret = SDL_CreateRGBSurface(_src->flags, _src->w, _src->h, 32,
-        _src->format->Rmask, _src->format->Gmask, _src->format->Bmask, _src->format->Amask);
 
+void UpdateFilter()
+{
     if (rand() % 4000 < 8)
     {
         isscrolling = true;
@@ -334,6 +332,12 @@ SDL_Surface* ApplyFilter( SDL_Surface* _src )
             isscrolling = false;
         }
     }
+}
+
+SDL_Surface* ApplyFilter( SDL_Surface* _src )
+{
+    SDL_Surface* _ret = SDL_CreateRGBSurface(_src->flags, _src->w, _src->h, 32,
+        _src->format->Rmask, _src->format->Gmask, _src->format->Bmask, _src->format->Amask);
 
     int redOffset = rand() % 4;
 

--- a/desktop_version/src/GraphicsUtil.h
+++ b/desktop_version/src/GraphicsUtil.h
@@ -46,6 +46,7 @@ void ScrollSurface(SDL_Surface* _src, int pX, int py);
 SDL_Surface * FlipSurfaceHorizontal(SDL_Surface* _src);
 SDL_Surface * FlipSurfaceVerticle(SDL_Surface* _src);
 SDL_Surface * ScaleSurfaceSlow( SDL_Surface *_surface, int Width, int Height );
+void UpdateFilter();
 SDL_Surface* ApplyFilter( SDL_Surface* _src );
 
 #endif /* GRAPHICSUTIL_H */

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2171,8 +2171,9 @@ void gamecompleteinput()
     game.press_action = false;
     game.press_map = false;
 
-    //Do this here because input comes first
+    //Do these here because input comes first
     map.bypos += map.bscroll;
+    game.oldcreditposition = game.creditposition;
 
     if (key.isDown(KEYBOARD_z) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v) || key.isDown(game.controllerButton_flip))
     {

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2171,6 +2171,12 @@ void gamecompleteinput()
     game.press_action = false;
     game.press_map = false;
 
+    //Do this before we update map.bypos
+    if (!game.colourblindmode)
+    {
+        graphics.updatetowerbackground();
+    }
+
     //Do these here because input comes first
     map.bypos += map.bscroll;
     game.oldcreditposition = game.creditposition;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -358,6 +358,12 @@ void menuactionpress()
                 graphics.showmousecursor = true;
             }
             break;
+        case 5:
+            //toggle 30+ fps
+            music.playef(11);
+            game.over30mode = !game.over30mode;
+            game.savestats();
+            break;
         default:
             //back
             music.playef(11);

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -364,6 +364,13 @@ void menuactionpress()
             game.over30mode = !game.over30mode;
             game.savestats();
             break;
+        case 6:
+            //toggle vsync
+            music.playef(11);
+            graphics.vsync = !graphics.vsync;
+            graphics.processVsync();
+            game.savestats();
+            break;
         default:
             //back
             music.playef(11);

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2220,10 +2220,13 @@ void gamecompleteinput2()
     game.press_action = false;
     game.press_map = false;
 
+    //Do this here because input comes first
+    game.oldcreditposx = game.creditposx;
 
     if (key.isDown(KEYBOARD_z) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v) || key.isDown(game.controllerButton_flip))
     {
         game.creditposx++;
+        game.oldcreditposx++;
         if (game.creditposy >= 30)
         {
             if(graphics.fademode==0)

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2039,7 +2039,7 @@ void mapinput()
             music.fadeout();
             map.nexttowercolour();
             game.fadetomenu = true;
-            game.fadetomenudelay = 15;
+            game.fadetomenudelay = 16;
         }
 
         if (game.menupage == 20 && game.press_action)
@@ -2054,7 +2054,7 @@ void mapinput()
             graphics.fademode = 2;
             music.fadeout();
             game.fadetolab = true;
-            game.fadetolabdelay = 15;
+            game.fadetolabdelay = 16;
         }
 
         if (game.menupage < 0) game.menupage = 3;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1490,6 +1490,7 @@ void gamelogic()
 
     game.activeactivity = obj.checkactivity();
 
+    game.oldreadytotele = game.readytotele;
     if (game.activetele)
     {
         int i = obj.getplayer();

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1022,11 +1022,13 @@ void gamelogic()
                         {
                             if (obj.entities[i].isplatform) obj.removeblockat(obj.entities[i].xp, obj.entities[i].yp);
                             obj.entities[i].xp += 400;
+                            obj.entities[i].oldxp += 400;
                         }
                         else if (obj.entities[i].xp > 320)
                         {
                             if (obj.entities[i].isplatform) obj.removeblockat(obj.entities[i].xp, obj.entities[i].yp);
                             obj.entities[i].xp -= 400;
+                            obj.entities[i].oldxp -= 400;
                         }
                     }
                     else

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1608,4 +1608,15 @@ void gamelogic()
             graphics.linedelay--;
         }
     }
+
+    graphics.trinketcolset = false;
+    for (int i = obj.entities.size() - 1; i >= 0; i--)
+    {
+        if (obj.entities[i].invis)
+        {
+            continue;
+        }
+
+        obj.entities[i].updatecolour();
+    }
 }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -247,6 +247,8 @@ void gamelogic()
         obj.upset = 0;
     }
 
+    obj.oldtrophytext = obj.trophytext;
+
     if (map.towermode)
     {
         if(!game.completestop)

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -17,6 +17,13 @@ void titlelogic()
         graphics.updatetowerbackground();
     }
 
+    graphics.crewframedelay--;
+    if (graphics.crewframedelay <= 0)
+    {
+        graphics.crewframedelay = 8;
+        graphics.crewframe = (graphics.crewframe + 1) % 2;
+    }
+
     if (game.menucountdown > 0)
     {
         game.menucountdown--;
@@ -44,6 +51,13 @@ void maplogic()
     //Misc
     help.updateglow();
     graphics.updatetextboxes();
+
+    graphics.crewframedelay--;
+    if (graphics.crewframedelay <= 0)
+    {
+        graphics.crewframedelay = 8;
+        graphics.crewframe = (graphics.crewframe + 1) % 2;
+    }
 
     graphics.oldmenuoffset = graphics.menuoffset;
     if (graphics.resumegamemode)

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1689,6 +1689,7 @@ void gamelogic()
                     ghost.x = obj.entities[i].xp;
                     ghost.y = obj.entities[i].yp;
                     ghost.col = obj.entities[i].colour;
+                    ghost.realcol = obj.entities[i].realcol;
                     ghost.frame = obj.entities[i].drawframe;
                 }
                 ed.ghosts.push_back(ghost);

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1666,6 +1666,7 @@ void gamelogic()
     }
 
 #if !defined(NO_CUSTOM_LEVELS)
+    ed.oldreturneditoralpha = ed.returneditoralpha;
     if (map.custommode && !map.custommodeforreal && ed.returneditoralpha > 0)
     {
         ed.returneditoralpha -= 15;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1595,7 +1595,6 @@ void gamelogic()
 #if !defined(NO_CUSTOM_LEVELS)
     if (game.shouldreturntoeditor)
     {
-        game.shouldreturntoeditor = false;
         game.returntoeditor();
     }
 #endif

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -115,6 +115,11 @@ void maplogic()
     }else if (map.cursorstate == 2){
         map.cursordelay++;
     }
+
+    if (map.finalmode)
+    {
+        map.glitchname = map.getglitchname(game.roomx, game.roomy);
+    }
 }
 
 
@@ -1653,5 +1658,10 @@ void gamelogic()
         }
 
         obj.entities[i].updatecolour();
+    }
+
+    if (map.finalmode)
+    {
+        map.glitchname = map.getglitchname(game.roomx, game.roomy);
     }
 }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -17,6 +17,27 @@ void titlelogic()
         graphics.updatetowerbackground();
     }
 
+    if (!game.menustart)
+    {
+        graphics.col_tr = (int)(164 - (help.glow / 2) - int(fRandom() * 4));
+        graphics.col_tg = 164 - (help.glow / 2) - int(fRandom() * 4);
+        graphics.col_tb = 164 - (help.glow / 2) - int(fRandom() * 4);
+    }
+    else
+    {
+        graphics.col_tr = map.r - (help.glow / 4) - int(fRandom() * 4);
+        graphics.col_tg = map.g - (help.glow / 4) - int(fRandom() * 4);
+        graphics.col_tb = map.b - (help.glow / 4) - int(fRandom() * 4);
+        if (graphics.col_tr < 0) graphics.col_tr = 0;
+        if(graphics.col_tr>255) graphics.col_tr=255;
+        if (graphics.col_tg < 0) graphics.col_tg = 0;
+        if(graphics.col_tg>255) graphics.col_tg=255;
+        if (graphics.col_tb < 0) graphics.col_tb = 0;
+        if(graphics.col_tb>255) graphics.col_tb=255;
+
+        graphics.updatetitlecolours();
+    }
+
     graphics.crewframedelay--;
     if (graphics.crewframedelay <= 0)
     {
@@ -51,6 +72,7 @@ void maplogic()
     //Misc
     help.updateglow();
     graphics.updatetextboxes();
+    graphics.updatetitlecolours();
 
     graphics.crewframedelay--;
     if (graphics.crewframedelay <= 0)
@@ -103,6 +125,17 @@ void gamecompletelogic()
     help.updateglow();
     graphics.crewframe = 0;
     map.scrolldir = 1;
+    graphics.updatetitlecolours();
+
+    graphics.col_tr = map.r - (help.glow / 4) - fRandom() * 4;
+    graphics.col_tg = map.g - (help.glow / 4) - fRandom() * 4;
+    graphics.col_tb = map.b - (help.glow / 4) - fRandom() * 4;
+    if (graphics.col_tr < 0) graphics.col_tr = 0;
+    if(graphics.col_tr>255) graphics.col_tr=255;
+    if (graphics.col_tg < 0) graphics.col_tg = 0;
+    if(graphics.col_tg>255) graphics.col_tg=255;
+    if (graphics.col_tb < 0) graphics.col_tb = 0;
+    if(graphics.col_tb>255) graphics.col_tb=255;
 
     game.creditposition--;
     if (game.creditposition <= -game.creditmaxposition)

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -260,6 +260,7 @@ void gamelogic()
 
     if (map.towermode)
     {
+        map.oldypos = map.ypos;
         if(!game.completestop)
         {
             if (map.cameramode == 0)

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -115,11 +115,6 @@ void gamecompletelogic()
         map.bscroll = +1;
     }
 
-    if (!game.colourblindmode)
-    {
-        graphics.updatetowerbackground();
-    }
-
     if (graphics.fademode == 1)
     {
         //Fix some graphical things

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -261,6 +261,8 @@ void gamelogic()
     if (map.towermode)
     {
         map.oldypos = map.ypos;
+        map.oldspikeleveltop = map.spikeleveltop;
+        map.oldspikelevelbottom = map.spikelevelbottom;
         if(!game.completestop)
         {
             if (map.cameramode == 0)

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1672,5 +1672,32 @@ void gamelogic()
     {
         ed.returneditoralpha -= 15;
     }
+
+    // Editor ghosts!
+    if (game.ghostsenabled)
+    {
+        if (map.custommode && !map.custommodeforreal)
+        {
+            if (game.gametimer % 3 == 0)
+            {
+                int i = obj.getplayer();
+                GhostInfo ghost;
+                ghost.rx = game.roomx-100;
+                ghost.ry = game.roomy-100;
+                if (i > -1)
+                {
+                    ghost.x = obj.entities[i].xp;
+                    ghost.y = obj.entities[i].yp;
+                    ghost.col = obj.entities[i].colour;
+                    ghost.frame = obj.entities[i].drawframe;
+                }
+                ed.ghosts.push_back(ghost);
+            }
+            if (ed.ghosts.size() > 100)
+            {
+                ed.ghosts.erase(ed.ghosts.begin());
+            }
+        }
+    }
 #endif
 }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1664,4 +1664,11 @@ void gamelogic()
     {
         map.glitchname = map.getglitchname(game.roomx, game.roomy);
     }
+
+#if !defined(NO_CUSTOM_LEVELS)
+    if (map.custommode && !map.custommodeforreal && ed.returneditoralpha > 0)
+    {
+        ed.returneditoralpha -= 15;
+    }
+#endif
 }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -442,6 +442,7 @@ void gamelogic()
         game.lifesequence();
     }
 
+    graphics.kludgeswnlinewidth = false;
 
     if (game.deathseq != -1)
     {
@@ -747,6 +748,7 @@ void gamelogic()
                 {
                     obj.entities[obj.getlineat(84 - 32)].w = 332;
                     game.swngame = 2;
+                    graphics.kludgeswnlinewidth = true;
                 }
             }
             else if (game.swngame == 4)    //create top line

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1306,6 +1306,23 @@ void gamelogic()
             }
         }
     }
+
+    //Update colour cycling for final level
+    if (map.finalmode && map.final_colormode)
+    {
+        map.final_aniframedelay--;
+        if(map.final_aniframedelay==0)
+        {
+            graphics.foregrounddrawn=false;
+        }
+        if (map.final_aniframedelay <= 0) {
+            map.final_aniframedelay = 2;
+            map.final_aniframe++;
+            if (map.final_aniframe >= 4)
+                map.final_aniframe = 0;
+        }
+    }
+
     int j;
     if (game.roomchange)
     {

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1150,6 +1150,8 @@ void mapclass::loadlevel(int rx, int ry)
 	ypos = 0;
 	oldypos = 0;
 	extrarow = 0;
+	spikeleveltop = 0;
+	spikelevelbottom = 0;
 
 	//Custom stuff for warplines
 	obj.customwarpmode=false;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1942,6 +1942,10 @@ void mapclass::loadlevel(int rx, int ry)
 	{
 		if (obj.entities[i].rule == 6 || obj.entities[i].rule == 7)
 		{
+			if (obj.entities[i].tile == 144 || obj.entities[i].tile == 144+6)
+			{
+				obj.entities[i].drawframe = 144;
+			}
 			if (obj.entities[i].state == 18)
 			{
 				//face the player

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -799,6 +799,7 @@ void mapclass::resetplayer()
 			{
 				ypos = 0;
 			}
+			oldypos = ypos;
 			bypos = ypos / 2;
 		}
 	}
@@ -1147,6 +1148,7 @@ void mapclass::loadlevel(int rx, int ry)
 
 	towermode = false;
 	ypos = 0;
+	oldypos = 0;
 	extrarow = 0;
 
 	//Custom stuff for warplines
@@ -1202,6 +1204,7 @@ void mapclass::loadlevel(int rx, int ry)
 				}
 
 				ypos = (700-29) * 8;
+				oldypos = ypos;
 				bypos = ypos / 2;
 				cameramode = 0;
 				colstate = 0;
@@ -1211,6 +1214,7 @@ void mapclass::loadlevel(int rx, int ry)
 			{
 				//you've entered from the top floor
 				ypos = 0;
+				oldypos = ypos;
 				bypos = 0;
 				cameramode = 0;
 				colstate = 0;
@@ -1379,6 +1383,7 @@ void mapclass::loadlevel(int rx, int ry)
 		tower.loadminitower1();
 
 		ypos = 0;
+		oldypos = 0;
 		bypos = 0;
 		cameramode = 0;
 		colstate = 0;
@@ -1408,6 +1413,7 @@ void mapclass::loadlevel(int rx, int ry)
 		finaly--;
 
 		ypos = (100-29) * 8;
+		oldypos = ypos;
 		bypos = ypos/2;
 		cameramode = 0;
 		colstate = 0;
@@ -1452,6 +1458,7 @@ void mapclass::loadlevel(int rx, int ry)
 		finaly--;
 
 		ypos = (100-29) * 8;
+		oldypos = ypos;
 		bypos = ypos/2;
 		cameramode = 0;
 		colstate = 0;
@@ -1490,6 +1497,7 @@ void mapclass::loadlevel(int rx, int ry)
 		obj.createentity(72, 156, 11, 200); // (horizontal gravity line)
 
 		ypos = 0;
+		oldypos = 0;
 		bypos = 0;
 		cameramode = 0;
 		colstate = 0;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1144,6 +1144,7 @@ void mapclass::loadlevel(int rx, int ry)
 	obj.vertplatforms = false;
 	obj.horplatforms = false;
 	roomname = "";
+	hiddenname = "";
 	background = 1;
 	warpx = false;
 	warpy = false;
@@ -1282,6 +1283,15 @@ void mapclass::loadlevel(int rx, int ry)
 		{
 			roomtexton = true;
 			roomtext = std::vector<Roomtext>(otherlevel.roomtext);
+		}
+
+		if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111)
+		{
+			hiddenname = "The Ship";
+		}
+		else
+		{
+			hiddenname = "Dimension VVVVVV";
 		}
 		break;
 	case 2: //The Lab

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -91,6 +91,10 @@ mapclass::mapclass()
 	2,2,2,2,2,0,0,2,0,3,0,0,0,0,0,0,0,0,0,0,
 	};
 	areamap.insert(areamap.end(), tmap, tmap+400);
+
+	ypos = 0;
+	oldypos = 0;
+	bypos = 0;
 }
 
 int mapclass::RGB(int red,int green,int blue)

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1909,6 +1909,7 @@ void mapclass::loadlevel(int rx, int ry)
 	}
 
 	//Make sure our crewmates are facing the player if appliciable
+	//Also make sure they're flipped if they're flipped
 	for (size_t i = 0; i < obj.entities.size(); i++)
 	{
 		if (obj.entities[i].rule == 6 || obj.entities[i].rule == 7)
@@ -1924,8 +1925,13 @@ void mapclass::loadlevel(int rx, int ry)
 				else if (j > -1 && obj.entities[j].xp < obj.entities[i].xp - 5)
 				{
 					obj.entities[i].dir = 0;
+					obj.entities[i].drawframe += 3;
 				}
 			}
+		}
+		if (obj.entities[i].rule == 7)
+		{
+			obj.entities[i].drawframe += 6;
 		}
 	}
 }

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -13,6 +13,8 @@ mapclass::mapclass()
 	colsuperstate = 0;
 	spikeleveltop = 0;
 	spikelevelbottom = 0;
+	oldspikeleveltop = 0;
+	oldspikelevelbottom = 0;
 	warpx = false;
 	warpy = false;
 	extrarow = 0;
@@ -1152,6 +1154,8 @@ void mapclass::loadlevel(int rx, int ry)
 	extrarow = 0;
 	spikeleveltop = 0;
 	spikelevelbottom = 0;
+	oldspikeleveltop = 0;
+	oldspikelevelbottom = 0;
 
 	//Custom stuff for warplines
 	obj.customwarpmode=false;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1383,6 +1383,14 @@ void mapclass::loadlevel(int rx, int ry)
 
 		graphics.rcol = 6;
 		changefinalcol(final_mapcol);
+		for (size_t i = 0; i < obj.entities.size(); i++)
+		{
+			if (obj.entities[i].type == 1 || obj.entities[i].type == 2)
+			{
+				//Fix 1-frame glitch
+				obj.entities[i].drawframe = obj.entities[i].tile;
+			}
+		}
 		break;
 	case 7: //Final Level, Tower 1
 		tdrawback = true;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1040,8 +1040,8 @@ void mapclass::gotoroom(int rx, int ry)
 	temp = obj.getplayer();
 	if(temp>-1)
 	{
-		obj.entities[temp].oldxp = obj.entities[temp].xp;
-		obj.entities[temp].oldyp = obj.entities[temp].yp;
+		obj.entities[temp].oldxp = obj.entities[temp].xp - int(obj.entities[temp].vx);
+		obj.entities[temp].oldyp = obj.entities[temp].yp - int(obj.entities[temp].vy);
 	}
 
 	for (size_t i = 0; i < obj.entities.size(); i++)

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -94,6 +94,7 @@ public:
 
 
     std::string roomname;
+    std::string hiddenname;
 
     //Special tower stuff
     bool towermode;

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -113,6 +113,7 @@ public:
     int colstate, colstatedelay;
     int colsuperstate;
     int spikeleveltop, spikelevelbottom;
+    int oldspikeleveltop, oldspikelevelbottom;
     bool tdrawback;
     int bscroll;
     //final level navigation

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -98,6 +98,7 @@ public:
     //Special tower stuff
     bool towermode;
     float ypos;
+    float oldypos;
     int bypos;
     int cameramode;
     int cameraseek, cameraseekframe;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -504,12 +504,6 @@ void menurender()
         graphics.Print( -1, 75, "Are you sure you want to quit?", tr, tg, tb, true);
         break;
     case Menu::continuemenu:
-        graphics.crewframedelay--;
-        if (graphics.crewframedelay <= 0)
-        {
-            graphics.crewframedelay = 8;
-            graphics.crewframe = (graphics.crewframe + 1) % 2;
-        }
         switch (game.currentmenuoption)
         {
         case 0:
@@ -551,12 +545,6 @@ void menurender()
     {
         graphics.bigprint( -1, 25, "GAME OVER", tr, tg, tb, true, 3);
 
-        graphics.crewframedelay--;
-        if (graphics.crewframedelay <= 0)
-        {
-            graphics.crewframedelay = 8;
-            graphics.crewframe = (graphics.crewframe + 1) % 2;
-        }
         for (int i = 0; i < 6; i++)
         {
             graphics.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], true);
@@ -602,12 +590,6 @@ void menurender()
     {
         graphics.bigprint( -1, 8, "WOW", tr, tg, tb, true, 4);
 
-        graphics.crewframedelay--;
-        if (graphics.crewframedelay <= 0)
-        {
-            graphics.crewframedelay = 8;
-            graphics.crewframe = (graphics.crewframe + 1) % 2;
-        }
         for (int i = 0; i < 6; i++)
         {
             graphics.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], true);
@@ -1683,13 +1665,6 @@ void maprender()
 
     //Background color
     FillRect(graphics.backBuffer,0, 12, 320, 240, 10, 24, 26 );
-
-    graphics.crewframedelay--;
-    if (graphics.crewframedelay <= 0)
-    {
-        graphics.crewframedelay = 8;
-        graphics.crewframe = (graphics.crewframe + 1) % 2;
-    }
 
 
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -176,6 +176,18 @@ void menurender()
                 graphics.Print(-1, 95, "Current mode: Over 30 FPS", tr, tg, tb, true);
             }
             break;
+        case 6:
+            graphics.bigprint(-1, 30, "Toggle VSync", tr, tg, tb, true);
+            graphics.Print(-1, 65, "Turn VSync on or off.", tr, tg, tb, true);
+
+            if (!graphics.vsync)
+            {
+                graphics.Print(-1, 95, "Current mode: VSYNC OFF", tr/2, tg/2, tb/2, true);
+            }
+            else
+            {
+                graphics.Print(-1, 95, "Current mode: VSYNC ON", tr, tg, tb, true);
+            }
         }
         break;
     case Menu::credits:

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -519,8 +519,8 @@ void menurender()
             graphics.Print(160 - 84, 132-20, game.tele_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
             graphics.Print(160 + 40, 132-20, help.number(game.tele_trinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-            graphics.drawspritesetcol(50, 126-20, 50, 18);
-            graphics.drawspritesetcol(175, 126-20, 22, 18);
+            graphics.drawsprite(50, 126-20, 50, graphics.col_clock);
+            graphics.drawsprite(175, 126-20, 22, graphics.col_trinket);
             break;
         case 1:
             //Show quick save info
@@ -535,8 +535,8 @@ void menurender()
             graphics.Print(160 - 84, 132-20, game.quick_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
             graphics.Print(160 + 40, 132-20, help.number(game.quick_trinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-            graphics.drawspritesetcol(50, 126-20, 50, 18);
-            graphics.drawspritesetcol(175, 126-20, 22, 18);
+            graphics.drawsprite(50, 126-20, 50, graphics.col_clock);
+            graphics.drawsprite(175, 126-20, 22, graphics.col_trinket);
             break;
         }
         break;
@@ -1029,9 +1029,9 @@ void titlerender()
 
     if (!game.menustart)
     {
-        tr = (int)(164 - (help.glow / 2) - int(fRandom() * 4));
-        tg = 164 - (help.glow / 2) - int(fRandom() * 4);
-        tb = 164 - (help.glow / 2) - int(fRandom() * 4);
+        tr = graphics.col_tr;
+        tg = graphics.col_tg;
+        tb = graphics.col_tb;
 
         int temp = 50;
         graphics.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
@@ -1051,15 +1051,9 @@ void titlerender()
     {
         if(!game.colourblindmode) graphics.drawtowerbackground();
 
-        tr = map.r - (help.glow / 4) - int(fRandom() * 4);
-        tg = map.g - (help.glow / 4) - int(fRandom() * 4);
-        tb = map.b - (help.glow / 4) - int(fRandom() * 4);
-        if (tr < 0) tr = 0;
-        if(tr>255) tr=255;
-        if (tg < 0) tg = 0;
-        if(tg>255) tg=255;
-        if (tb < 0) tb = 0;
-        if(tb>255) tb=255;
+        tr = graphics.col_tr;
+        tg = graphics.col_tg;
+        tb = graphics.col_tb;
 
         menurender();
 
@@ -1113,15 +1107,9 @@ void gamecompleterender()
 
     if(!game.colourblindmode) graphics.drawtowerbackground();
 
-    tr = map.r - (help.glow / 4) - fRandom() * 4;
-    tg = map.g - (help.glow / 4) - fRandom() * 4;
-    tb = map.b - (help.glow / 4) - fRandom() * 4;
-    if (tr < 0) tr = 0;
-    if(tr>255) tr=255;
-    if (tg < 0) tg = 0;
-    if(tg>255) tg=255;
-    if (tb < 0) tb = 0;
-    if(tb>255) tb=255;
+    tr = graphics.col_tr;
+    tg = graphics.col_tg;
+    tb = graphics.col_tb;
 
 
     //rendering starts... here!
@@ -2193,8 +2181,8 @@ void maprender()
                     graphics.Print(160 - 84, 78, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
                     graphics.Print(160 + 40, 78, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    graphics.drawspritesetcol(50, 74, 50, 18);
-                    graphics.drawspritesetcol(175, 74, 22, 18);
+                    graphics.drawsprite(50, 74, 50, graphics.col_clock);
+                    graphics.drawsprite(175, 74, 22, graphics.col_trinket);
                 }
                 else
                 {
@@ -2202,8 +2190,8 @@ void maprender()
                     graphics.Print(160 - 84, 132, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
                     graphics.Print(160 + 40, 132, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    graphics.drawspritesetcol(50, 126, 50, 18);
-                    graphics.drawspritesetcol(175, 126, 22, 18);
+                    graphics.drawsprite(50, 126, 50, graphics.col_clock);
+                    graphics.drawsprite(175, 126, 22, graphics.col_trinket);
                 }
             }
             else
@@ -2240,8 +2228,8 @@ void maprender()
                     graphics.Print(160 - 84, 78, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
                     graphics.Print(160 + 40, 78, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    graphics.drawspritesetcol(50, 74, 50, 18);
-                    graphics.drawspritesetcol(175, 74, 22, 18);
+                    graphics.drawsprite(50, 74, 50, graphics.col_clock);
+                    graphics.drawsprite(175, 74, 22, graphics.col_trinket);
                 }
                 else
                 {
@@ -2253,8 +2241,8 @@ void maprender()
                     graphics.Print(160 - 84, 132, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
                     graphics.Print(160 + 40, 132, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    graphics.drawspritesetcol(50, 126, 50, 18);
-                    graphics.drawspritesetcol(175, 126, 22, 18);
+                    graphics.drawsprite(50, 126, 50, graphics.col_clock);
+                    graphics.drawsprite(175, 126, 22, graphics.col_trinket);
                 }
             }
             else

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1410,7 +1410,7 @@ void gamerender()
         if (game.advancetext) graphics.bprint(5, 5, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
 
-    if (game.readytotele > 100 && !game.advancetext && game.hascontrol && !script.running && !game.intimetrial)
+    if ((game.readytotele > 100 || game.oldreadytotele > 100) && !game.advancetext && game.hascontrol && !script.running && !game.intimetrial)
     {
         int alpha = graphics.lerp(game.oldreadytotele, game.readytotele);
         if(graphics.flipmode)

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1631,17 +1631,9 @@ void maprender()
 
     //draw screen alliteration
     //Roomname:
-    int temp = map.area(game.roomx, game.roomy);
-    if (temp < 2 && !map.custommode && graphics.fademode==0)
+    if (map.hiddenname != "")
     {
-        if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111)
-        {
-            graphics.Print(5, 2, "The Ship", 196, 196, 255 - help.glow, true);
-        }
-        else
-        {
-            graphics.Print(5, 2, "Dimension VVVVVV", 196, 196, 255 - help.glow, true);
-        }
+        graphics.Print(5, 2, map.hiddenname, 196, 196, 255 - help.glow, true);
     }
     else
     {
@@ -2402,14 +2394,7 @@ void teleporterrender()
     int temp = map.area(game.roomx, game.roomy);
     if (temp < 2 && !map.custommode && graphics.fademode==0)
     {
-        if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111)
-        {
-            graphics.Print(5, 2, "The Ship", 196, 196, 255 - help.glow, true);
-        }
-        else
-        {
-            graphics.Print(5, 2, "Dimension VVVVVV", 196, 196, 255 - help.glow, true);
-        }
+        graphics.Print(5, 2, map.hiddenname, 196, 196, 255 - help.glow, true);
     }
     else
     {

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1441,13 +1441,14 @@ void gamerender()
 
     if (game.readytotele > 100 && !game.advancetext && game.hascontrol && !script.running && !game.intimetrial)
     {
+        int alpha = graphics.lerp(game.oldreadytotele, game.readytotele);
         if(graphics.flipmode)
         {
-            graphics.bprint(5, 20, "- Press ENTER to Teleport -", game.readytotele - 20 - (help.glow / 2), game.readytotele - 20 - (help.glow / 2), game.readytotele, true);
+            graphics.bprint(5, 20, "- Press ENTER to Teleport -", alpha - 20 - (help.glow / 2), alpha - 20 - (help.glow / 2), alpha, true);
         }
         else
         {
-            graphics.bprint(5, 210, "- Press ENTER to Teleport -", game.readytotele - 20 - (help.glow / 2), game.readytotele - 20 - (help.glow / 2), game.readytotele, true);
+            graphics.bprint(5, 210, "- Press ENTER to Teleport -", alpha - 20 - (help.glow / 2), alpha - 20 - (help.glow / 2), alpha, true);
         }
     }
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1371,7 +1371,6 @@ void gamerender()
 
         if (map.finalmode)
         {
-            map.glitchname = map.getglitchname(game.roomx, game.roomy);
             graphics.bprint(5, 231, map.glitchname, 196, 196, 255 - help.glow, true);
         }else{
             graphics.bprint(5, 231, map.roomname, 196, 196, 255 - help.glow, true);
@@ -1647,7 +1646,6 @@ void maprender()
     else
     {
       if (map.finalmode){
-        map.glitchname = map.getglitchname(game.roomx, game.roomy);
         graphics.Print(5, 2, map.glitchname, 196, 196, 255 - help.glow, true);
       }else{
         graphics.Print(5, 2, map.roomname, 196, 196, 255 - help.glow, true);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2382,7 +2382,7 @@ void maprender()
         graphics.drawfade();
     }
 
-    if (graphics.resumegamemode || graphics.menuoffset > 0)
+    if (graphics.resumegamemode || graphics.menuoffset > 0 || graphics.oldmenuoffset > 0)
     {
         graphics.menuoffrender();
     }
@@ -2518,7 +2518,7 @@ void teleporterrender()
     }
 
 
-    if (graphics.resumegamemode || graphics.menuoffset > 0)
+    if (graphics.resumegamemode || graphics.menuoffset > 0 || graphics.oldmenuoffset > 0)
     {
         graphics.menuoffrender();
     }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1627,6 +1627,8 @@ void gamerender()
 
 void maprender()
 {
+    FillRect(graphics.backBuffer, 0x000000);
+
     //draw screen alliteration
     //Roomname:
     int temp = map.area(game.roomx, game.roomy);
@@ -2392,6 +2394,7 @@ void maprender()
 
 void teleporterrender()
 {
+    FillRect(graphics.backBuffer, 0x000000);
     int tempx;
     int tempy;
     //draw screen alliteration

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1352,35 +1352,6 @@ void gamerender()
         {
             graphics.drawtowerspikes();
         }
-
-#if !defined(NO_CUSTOM_LEVELS)
-        // Editor ghosts!
-        if (game.ghostsenabled)
-        {
-            if (map.custommode && !map.custommodeforreal)
-            {
-                if (game.gametimer % 3 == 0)
-                {
-                    int i = obj.getplayer();
-                    GhostInfo ghost;
-                    ghost.rx = game.roomx-100;
-                    ghost.ry = game.roomy-100;
-                    if (i > -1)
-                    {
-                        ghost.x = obj.entities[i].xp;
-                        ghost.y = obj.entities[i].yp;
-                        ghost.col = obj.entities[i].colour;
-                        ghost.frame = obj.entities[i].drawframe;
-                    }
-                    ed.ghosts.push_back(ghost);
-                }
-                if (ed.ghosts.size() > 100)
-                {
-                    ed.ghosts.erase(ed.ghosts.begin());
-                }
-            }
-        }
-#endif
     }
 
     if(map.extrarow==0 || (map.custommode && map.roomname!=""))

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1617,7 +1617,7 @@ void gamerender()
         graphics.Print(5, 12, game.activity_lastprompt, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha, true);
     }
 
-    if (obj.trophytext > 0)
+    if (obj.trophytext > 0 || obj.oldtrophytext > 0)
     {
         graphics.drawtrophytext();
     }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -162,6 +162,20 @@ void menurender()
                 graphics.Print(-1, 85, "Current mode: HIDE", tr/2, tg/2, tb/2, true);
             }
             break;
+        case 5:
+            graphics.bigprint(-1, 30, "Toggle 30+ FPS", tr, tg, tb, true);
+            graphics.Print(-1, 65, "Change whether the game", tr, tg, tb, true);
+            graphics.Print(-1, 75, "runs at 30 or over 30 FPS.", tr, tg, tb, true);
+
+            if (!game.over30mode)
+            {
+                graphics.Print(-1, 95, "Current mode: 30 FPS", tr/2, tg/2, tb/2, true);
+            }
+            else
+            {
+                graphics.Print(-1, 95, "Current mode: Over 30 FPS", tr, tg, tb, true);
+            }
+            break;
         }
         break;
     case Menu::credits:

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1611,7 +1611,7 @@ void gamerender()
         graphics.drawtextbox(16, 4, 36, 3, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha);
         graphics.Print(5, 12, game.activity_lastprompt, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha, true);
     }
-    else if(game.act_fade>5)
+    else if(game.act_fade>5 || game.prev_act_fade>5)
     {
         graphics.drawtextbox(16, 4, 36, 3, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha);
         graphics.Print(5, 12, game.activity_lastprompt, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha, true);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1389,7 +1389,8 @@ void gamerender()
 #if !defined(NO_CUSTOM_LEVELS)
      if(map.custommode && !map.custommodeforreal && !game.advancetext){
         //Return to level editor
-        graphics.bprintalpha(5, 5, "[Press ENTER to return to editor]", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), ed.returneditoralpha, false);
+        int alpha = graphics.lerp(ed.oldreturneditoralpha, ed.returneditoralpha);
+        graphics.bprintalpha(5, 5, "[Press ENTER to return to editor]", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), alpha, false);
       }
 #endif
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1390,9 +1390,6 @@ void gamerender()
      if(map.custommode && !map.custommodeforreal && !game.advancetext){
         //Return to level editor
         graphics.bprintalpha(5, 5, "[Press ENTER to return to editor]", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), ed.returneditoralpha, false);
-        if (ed.returneditoralpha > 0) {
-            ed.returneditoralpha -= 15;
-        }
       }
 #endif
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1272,6 +1272,8 @@ void gamecompleterender2()
         }
     }
 
+    FillRect(graphics.backBuffer, graphics.lerp(game.oldcreditposx * 8, game.creditposx * 8) + 8, game.creditposy * 8, 8, 8, 0, 0, 0);
+
     graphics.drawfade();
 
     graphics.render();

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1126,9 +1126,10 @@ void gamecompleterender()
 
     //rendering starts... here!
 
-    if (graphics.onscreen(220 + game.creditposition))
+    int position = graphics.lerp(game.oldcreditposition, game.creditposition);
+    if (graphics.onscreen(220 + position))
     {
-        int temp = 220 + game.creditposition;
+        int temp = 220 + position;
         graphics.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
         graphics.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
         graphics.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
@@ -1137,121 +1138,121 @@ void gamecompleterender()
         graphics.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
     }
 
-    if (graphics.onscreen(290 + game.creditposition)) graphics.bigprint( -1, 290 + game.creditposition, "Starring", tr, tg, tb, true, 2);
+    if (graphics.onscreen(290 + position)) graphics.bigprint( -1, 290 + position, "Starring", tr, tg, tb, true, 2);
 
-    if (graphics.onscreen(320 + game.creditposition))
+    if (graphics.onscreen(320 + position))
     {
-        graphics.drawcrewman(70, 320 + game.creditposition, 0, true);
-        graphics.Print(100, 330 + game.creditposition, "Captain Viridian", tr, tg, tb);
+        graphics.drawcrewman(70, 320 + position, 0, true);
+        graphics.Print(100, 330 + position, "Captain Viridian", tr, tg, tb);
     }
-    if (graphics.onscreen(350 + game.creditposition))
+    if (graphics.onscreen(350 + position))
     {
-        graphics.drawcrewman(70, 350 + game.creditposition, 1, true);
-        graphics.Print(100, 360 + game.creditposition, "Doctor Violet", tr, tg, tb);
+        graphics.drawcrewman(70, 350 + position, 1, true);
+        graphics.Print(100, 360 + position, "Doctor Violet", tr, tg, tb);
     }
-    if (graphics.onscreen(380 + game.creditposition))
+    if (graphics.onscreen(380 + position))
     {
-        graphics.drawcrewman(70, 380 + game.creditposition, 2, true);
-        graphics.Print(100, 390 + game.creditposition, "Professor Vitellary", tr, tg, tb);
+        graphics.drawcrewman(70, 380 + position, 2, true);
+        graphics.Print(100, 390 + position, "Professor Vitellary", tr, tg, tb);
     }
-    if (graphics.onscreen(410 + game.creditposition))
+    if (graphics.onscreen(410 + position))
     {
-        graphics.drawcrewman(70, 410 + game.creditposition, 3, true);
-        graphics.Print(100, 420 + game.creditposition, "Officer Vermilion", tr, tg, tb);
+        graphics.drawcrewman(70, 410 + position, 3, true);
+        graphics.Print(100, 420 + position, "Officer Vermilion", tr, tg, tb);
     }
-    if (graphics.onscreen(440 + game.creditposition))
+    if (graphics.onscreen(440 + position))
     {
-        graphics.drawcrewman(70, 440 + game.creditposition, 4, true);
-        graphics.Print(100, 450 + game.creditposition, "Chief Verdigris", tr, tg, tb);
+        graphics.drawcrewman(70, 440 + position, 4, true);
+        graphics.Print(100, 450 + position, "Chief Verdigris", tr, tg, tb);
     }
-    if (graphics.onscreen(470 + game.creditposition))
+    if (graphics.onscreen(470 + position))
     {
-        graphics.drawcrewman(70, 470 + game.creditposition, 5, true);
-        graphics.Print(100, 480 + game.creditposition, "Doctor Victoria", tr, tg, tb);
-    }
-
-    if (graphics.onscreen(520 + game.creditposition)) graphics.bigprint( -1, 520 + game.creditposition, "Credits", tr, tg, tb, true, 3);
-
-    if (graphics.onscreen(560 + game.creditposition))
-    {
-        graphics.Print(40, 560 + game.creditposition, "Created by", tr, tg, tb);
-        graphics.bigprint(60, 570 + game.creditposition, "Terry Cavanagh", tr, tg, tb);
+        graphics.drawcrewman(70, 470 + position, 5, true);
+        graphics.Print(100, 480 + position, "Doctor Victoria", tr, tg, tb);
     }
 
-    if (graphics.onscreen(600 + game.creditposition))
+    if (graphics.onscreen(520 + position)) graphics.bigprint( -1, 520 + position, "Credits", tr, tg, tb, true, 3);
+
+    if (graphics.onscreen(560 + position))
     {
-        graphics.Print(40, 600 + game.creditposition, "With Music by", tr, tg, tb);
-        graphics.bigprint(60, 610 + game.creditposition, "Magnus P~lsson", tr, tg, tb);
+        graphics.Print(40, 560 + position, "Created by", tr, tg, tb);
+        graphics.bigprint(60, 570 + position, "Terry Cavanagh", tr, tg, tb);
     }
 
-    if (graphics.onscreen(640 + game.creditposition))
+    if (graphics.onscreen(600 + position))
     {
-        graphics.Print(40, 640 + game.creditposition, "Rooms Named by", tr, tg, tb);
-        graphics.bigprint(60, 650 + game.creditposition, "Bennett Foddy", tr, tg, tb);
+        graphics.Print(40, 600 + position, "With Music by", tr, tg, tb);
+        graphics.bigprint(60, 610 + position, "Magnus P~lsson", tr, tg, tb);
     }
 
-    if (graphics.onscreen(680 + game.creditposition))
+    if (graphics.onscreen(640 + position))
     {
-        graphics.Print(40, 680 + game.creditposition, "C++ Port by", tr, tg, tb);
-        graphics.bigprint(60, 690 + game.creditposition, "Simon Roth", tr, tg, tb);
-        graphics.bigprint(60, 710 + game.creditposition, "Ethan Lee", tr, tg, tb);
+        graphics.Print(40, 640 + position, "Rooms Named by", tr, tg, tb);
+        graphics.bigprint(60, 650 + position, "Bennett Foddy", tr, tg, tb);
+    }
+
+    if (graphics.onscreen(680 + position))
+    {
+        graphics.Print(40, 680 + position, "C++ Port by", tr, tg, tb);
+        graphics.bigprint(60, 690 + position, "Simon Roth", tr, tg, tb);
+        graphics.bigprint(60, 710 + position, "Ethan Lee", tr, tg, tb);
     }
 
 
-    if (graphics.onscreen(740 + game.creditposition))
+    if (graphics.onscreen(740 + position))
     {
-        graphics.Print(40, 740 + game.creditposition, "Beta Testing by", tr, tg, tb);
-        graphics.bigprint(60, 750 + game.creditposition, "Sam Kaplan", tr, tg, tb);
-        graphics.bigprint(60, 770 + game.creditposition, "Pauli Kohberger", tr, tg, tb);
+        graphics.Print(40, 740 + position, "Beta Testing by", tr, tg, tb);
+        graphics.bigprint(60, 750 + position, "Sam Kaplan", tr, tg, tb);
+        graphics.bigprint(60, 770 + position, "Pauli Kohberger", tr, tg, tb);
     }
 
-    if (graphics.onscreen(800 + game.creditposition))
+    if (graphics.onscreen(800 + position))
     {
-        graphics.Print(40, 800 + game.creditposition, "Ending Picture by", tr, tg, tb);
-        graphics.bigprint(60, 810 + game.creditposition, "Pauli Kohberger", tr, tg, tb);
+        graphics.Print(40, 800 + position, "Ending Picture by", tr, tg, tb);
+        graphics.bigprint(60, 810 + position, "Pauli Kohberger", tr, tg, tb);
     }
 
-    if (graphics.onscreen(890 + game.creditposition)) graphics.bigprint( -1, 870 + game.creditposition, "Patrons", tr, tg, tb, true, 3);
+    if (graphics.onscreen(890 + position)) graphics.bigprint( -1, 870 + position, "Patrons", tr, tg, tb, true, 3);
 
     int creditOffset = 930;
 
     for (size_t i = 0; i < game.superpatrons.size(); i += 1)
     {
-        if (graphics.onscreen(creditOffset + game.creditposition))
+        if (graphics.onscreen(creditOffset + position))
         {
-            graphics.Print(-1, creditOffset + game.creditposition, game.superpatrons[i], tr, tg, tb, true);
+            graphics.Print(-1, creditOffset + position, game.superpatrons[i], tr, tg, tb, true);
         }
         creditOffset += 10;
     }
 
     creditOffset += 10;
-    if (graphics.onscreen(creditOffset + game.creditposition)) graphics.Print( -1, creditOffset + game.creditposition, "and", tr, tg, tb, true);
+    if (graphics.onscreen(creditOffset + position)) graphics.Print( -1, creditOffset + position, "and", tr, tg, tb, true);
     creditOffset += 20;
 
     for (size_t i = 0; i < game.patrons.size(); i += 1)
     {
-        if (graphics.onscreen(creditOffset + game.creditposition))
+        if (graphics.onscreen(creditOffset + position))
         {
-            graphics.Print(-1, creditOffset + game.creditposition, game.patrons[i], tr, tg, tb, true);
+            graphics.Print(-1, creditOffset + position, game.patrons[i], tr, tg, tb, true);
         }
         creditOffset += 10;
     }
 
     creditOffset += 20;
-    if (graphics.onscreen(creditOffset + game.creditposition)) graphics.bigprint(40, creditOffset + game.creditposition, "GitHub Contributors", tr, tg, tb, true);
+    if (graphics.onscreen(creditOffset + position)) graphics.bigprint(40, creditOffset + position, "GitHub Contributors", tr, tg, tb, true);
     creditOffset += 30;
 
     for (size_t i = 0; i < game.githubfriends.size(); i += 1)
     {
-        if (graphics.onscreen(creditOffset + game.creditposition))
+        if (graphics.onscreen(creditOffset + position))
         {
-            graphics.Print(-1, creditOffset + game.creditposition, game.githubfriends[i], tr, tg, tb, true);
+            graphics.Print(-1, creditOffset + position, game.githubfriends[i], tr, tg, tb, true);
         }
         creditOffset += 10;
     }
 
     creditOffset += 140;
-    if (graphics.onscreen(creditOffset + game.creditposition)) graphics.bigprint( -1, creditOffset + game.creditposition, "Thanks for playing!", tr, tg, tb, true, 2);
+    if (graphics.onscreen(creditOffset + position)) graphics.bigprint( -1, creditOffset + position, "Thanks for playing!", tr, tg, tb, true, 2);
 
     graphics.drawfade();
 

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -12,6 +12,7 @@ textboxclass::textboxclass()
     prev_tl = 0;
     tm = 0;
     timer = 0;
+    allowspecial = false;
 }
 
 void textboxclass::centerx()

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -45,6 +45,8 @@ public:
 
     int max;
 
+    bool allowspecial;
+
 };
 
 #endif /* TEXTBOX_H */

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -305,6 +305,7 @@ void editorclass::reset()
     saveandquit=false;
     note="";
     notedelay=0;
+    oldnotedelay=0;
     roomnamemod=false;
     textentry=false;
     savemod=false;
@@ -3574,11 +3575,12 @@ void editorrender()
         }
     }
 
-    if(ed.notedelay>0)
+    if(ed.notedelay>0 || ed.oldnotedelay>0)
     {
+        float alpha = graphics.lerp(ed.oldnotedelay, ed.notedelay);
         FillRect(graphics.backBuffer, 0,115,320,18, graphics.getRGB(92,92,92));
         FillRect(graphics.backBuffer, 0,116,320,16, graphics.getRGB(0,0,0));
-        graphics.Print(0,121, ed.note,196-((45-ed.notedelay)*4), 196-((45-ed.notedelay)*4), 196-((45-ed.notedelay)*4), true);
+        graphics.Print(0,121, ed.note,196-((45.0f-alpha)*4), 196-((45.0f-alpha)*4), 196-((45.0f-alpha)*4), true);
     }
 
     graphics.drawfade();
@@ -3601,6 +3603,7 @@ void editorlogic()
         ed.entframedelay=8;
     }
 
+    ed.oldnotedelay = ed.notedelay;
     if(ed.notedelay>0)
     {
         ed.notedelay--;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2564,8 +2564,6 @@ void editorrender()
     }
 
     //Draw entities
-    game.customcol=ed.getlevelcol(ed.levx+(ed.levy*ed.maxwidth))+1;
-    ed.entcol=ed.getenemycol(game.customcol);
     obj.customplatformtile=game.customcol*12;
 
     ed.temp=edentat(ed.tilex+ (ed.levx*40),ed.tiley+ (ed.levy*30));
@@ -2585,7 +2583,7 @@ void editorrender()
             switch(edentity[i].t)
             {
             case 1: //Entities
-                graphics.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),ed.getenemyframe(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype),ed.entcol);
+                graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),ed.getenemyframe(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype),ed.entcolreal);
                 if(edentity[i].p1==0) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "V", 255, 255, 255 - help.glow, false);
                 if(edentity[i].p1==1) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "^", 255, 255, 255 - help.glow, false);
                 if(edentity[i].p1==2) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "<", 255, 255, 255 - help.glow, false);
@@ -2728,17 +2726,17 @@ void editorrender()
                 }
                 break;
             case 15: //Crewmates
-                graphics.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),144,obj.crewcolour(edentity[i].p1));
+                graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),144,graphics.crewcolourreal(edentity[i].p1));
                 fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,24,graphics.getRGB(164,164,164));
                 break;
             case 16: //Start
                 if(edentity[i].p1==0)  //Left
                 {
-                    graphics.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),0,obj.crewcolour(0));
+                    graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),0,graphics.col_crewcyan);
                 }
                 else if(edentity[i].p1==1)
                 {
-                    graphics.drawspritesetcol((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),3,obj.crewcolour(0));
+                    graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8)-4,(edentity[i].y*8)- (ed.levy*30*8),3,graphics.col_crewcyan);
                 }
                 fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,24,graphics.getRGB(164,255,255));
                 if(ed.entframe<2)
@@ -3365,10 +3363,10 @@ void editorrender()
                 FillRect(graphics.backBuffer, tx+6,ty+2,4,12,graphics.getRGB(255,255,255));
                 //15:
                 tx+=tg;
-                graphics.drawsprite(tx,ty,186,75, 75, 255- help.glow/4 - (fRandom()*20));
+                graphics.drawsprite(tx,ty,186,graphics.col_crewblue);
                 //16:
                 tx+=tg;
-                graphics.drawsprite(tx,ty,184,160- help.glow/2 - (fRandom()*20), 200- help.glow/2, 220 - help.glow);
+                graphics.drawsprite(tx,ty,184,graphics.col_crewcyan);
 
                 if(ed.drawmode==10)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"R",255,255,255,false);
                 if(ed.drawmode==11)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"T",255,255,255,false);
@@ -3593,6 +3591,13 @@ void editorlogic()
 {
     //Misc
     help.updateglow();
+    graphics.updatetitlecolours();
+
+    game.customcol=ed.getlevelcol(ed.levx+(ed.levy*ed.maxwidth))+1;
+    ed.entcol=ed.getenemycol(game.customcol);
+
+    graphics.setcol(ed.entcol);
+    ed.entcolreal = graphics.ct.colour;
 
     map.bypos -= 2;
     map.bscroll = -2;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2889,7 +2889,7 @@ void editorrender()
                 point tpoint;
                 tpoint.x = ed.ghosts[i].x;
                 tpoint.y = ed.ghosts[i].y;
-                graphics.setcol(ed.ghosts[i].col);
+                graphics.setcolreal(ed.ghosts[i].realcol);
                 Uint32 alpha = graphics.ct.colour & graphics.backBuffer->format->Amask;
                 Uint32 therest = graphics.ct.colour & 0x00FFFFFF;
                 alpha = (3 * (alpha >> 24) / 4) << 24;
@@ -3621,6 +3621,19 @@ void editorlogic()
 
     if (game.ghostsenabled)
     {
+        for (size_t i = 0; i < ed.ghosts.size(); i++)
+        {
+            GhostInfo& ghost = ed.ghosts[i];
+
+            if ((int) i > ed.currentghosts || ghost.rx != ed.levx || ghost.ry != ed.levy)
+            {
+                continue;
+            }
+
+            graphics.setcol(ghost.col);
+            ghost.realcol = graphics.ct.colour;
+        }
+
         if (ed.currentghosts + 1 < (int)ed.ghosts.size()) {
             ed.currentghosts++;
             if (ed.zmod) ed.currentghosts++;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2900,12 +2900,6 @@ void editorrender()
                 BlitSurfaceColoured(graphics.sprites[ed.ghosts[i].frame],NULL, graphics.ghostbuffer, &drawRect, graphics.ct);
             }
         }
-        if (ed.currentghosts + 1 < (int)ed.ghosts.size()) {
-            ed.currentghosts++;
-            if (ed.zmod) ed.currentghosts++;
-        } else {
-            ed.currentghosts = (int)ed.ghosts.size() - 1;
-        }
         SDL_BlitSurface(graphics.ghostbuffer, NULL, graphics.backBuffer, &graphics.bg_rect);
     }
 
@@ -3623,6 +3617,16 @@ void editorlogic()
     if(ed.notedelay>0)
     {
         ed.notedelay--;
+    }
+
+    if (game.ghostsenabled)
+    {
+        if (ed.currentghosts + 1 < (int)ed.ghosts.size()) {
+            ed.currentghosts++;
+            if (ed.zmod) ed.currentghosts++;
+        } else {
+            ed.currentghosts = (int)ed.ghosts.size() - 1;
+        }
     }
 
     if (!ed.settingsmod)

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -407,6 +407,7 @@ void editorclass::reset()
     script.customscripts.clear();
 
     returneditoralpha = 0;
+    oldreturneditoralpha = 0;
 
     ghosts.clear();
     currentghosts = 0;
@@ -4636,6 +4637,7 @@ void editorinput()
                         music.haltdasmusik();
                         graphics.backgrounddrawn=false;
                         ed.returneditoralpha = 1000; // Let's start it higher than 255 since it gets clamped
+                        ed.oldreturneditoralpha = 1000;
                         script.startgamemode(21);
                     }
                 }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2463,6 +2463,11 @@ void editormenurender(int tr, int tg, int tb)
 
 void editorrender()
 {
+    if (game.shouldreturntoeditor)
+    {
+        graphics.backgrounddrawn = false;
+    }
+
     //Draw grid
 
     FillRect(graphics.backBuffer, 0, 0, 320,240, graphics.getRGB(0,0,0));
@@ -3598,6 +3603,11 @@ void editorlogic()
 
     graphics.setcol(ed.entcol);
     ed.entcolreal = graphics.ct.colour;
+
+    if (game.shouldreturntoeditor)
+    {
+        game.shouldreturntoeditor = false;
+    }
 
     map.bypos -= 2;
     map.bscroll = -2;

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -82,6 +82,7 @@ struct GhostInfo {
     int x; // .xp
     int y; // .yp
     int col; // .colour
+    Uint32 realcol;
     int frame; // .drawframe
 };
 

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <string>
 #include "Script.h"
+#include "Graphics.h"
 
 class edentities{
 public:
@@ -150,6 +151,7 @@ class editorclass{
   int getlevelcol(int t);
   int getenemycol(int t);
   int entcol;
+  Uint32 entcolreal;
 
   //Colouring stuff
   int getwarpbackground(int rx, int ry);

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -164,6 +164,7 @@ class editorclass{
 
   int temp;
   int notedelay;
+  int oldnotedelay;
   std::string note;
   std::string keybuffer;
   std::string filename;

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -237,6 +237,7 @@ class editorclass{
   int dmtileeditor;
 
   int returneditoralpha;
+  int oldreturneditoralpha;
 
   std::vector<GhostInfo> ghosts;
   int currentghosts;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -400,6 +400,7 @@ int main(int argc, char *argv[])
                 switch(game.gamestate)
                 {
                 case PRELOADER:
+                    preloaderlogic();
                     break;
 #if !defined(NO_CUSTOM_LEVELS)
                 case EDITORMODE:

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -64,6 +64,7 @@ volatile Uint32 f_timePrev = 0;
 volatile Uint32 f_accumulator = 0;
 
 void gameloop();
+void deltaloop();
 
 int main(int argc, char *argv[])
 {
@@ -353,6 +354,12 @@ void gameloop()
         timePrev = time_;
         time_ = SDL_GetTicks();
 
+        deltaloop();
+    }
+}
+
+void deltaloop()
+{
         game.infocus = key.isActive;
 
         // Update network per frame.
@@ -639,5 +646,4 @@ void gameloop()
             }
             gameScreen.FlipScreen();
         }
-    }
 }

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -395,10 +395,12 @@ void deltaloop()
         case PRELOADER:
             preloaderrender();
             break;
+#if !defined(NO_CUSTOM_LEVELS)
         case EDITORMODE:
             graphics.flipmode = false;
             editorrender();
             break;
+#endif
         case TITLEMODE:
             titlerender();
             break;
@@ -494,7 +496,6 @@ void fixedloop()
             break;
 #if !defined(NO_CUSTOM_LEVELS)
         case EDITORMODE:
-            graphics.flipmode = false;
             //Input
             editorinput();
             ////Logic

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -103,9 +103,6 @@ int main(int argc, char *argv[])
                 return 1;
             }
         }
-        if (std::string(argv[i]) == "-renderer") {
-            SDL_SetHintWithPriority(SDL_HINT_RENDER_DRIVER, argv[2], SDL_HINT_OVERRIDE);
-        }
     }
 
     SDL_SetHintWithPriority(SDL_HINT_RENDER_VSYNC, "1", SDL_HINT_OVERRIDE);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -191,9 +191,9 @@ int main(int argc, char *argv[])
     graphics.menubuffer = SDL_CreateRGBSurface(SDL_SWSURFACE ,320 ,240 ,fmt->BitsPerPixel,fmt->Rmask,fmt->Gmask,fmt->Bmask,fmt->Amask );
     SDL_SetSurfaceBlendMode(graphics.menubuffer, SDL_BLENDMODE_NONE);
 
-    graphics.towerbuffer =  SDL_CreateRGBSurface(SDL_SWSURFACE ,320 ,240 ,fmt->BitsPerPixel,fmt->Rmask,fmt->Gmask,fmt->Bmask,fmt->Amask  );
+    graphics.towerbuffer =  SDL_CreateRGBSurface(SDL_SWSURFACE ,320+16 ,240+16 ,fmt->BitsPerPixel,fmt->Rmask,fmt->Gmask,fmt->Bmask,fmt->Amask  );
     SDL_SetSurfaceBlendMode(graphics.towerbuffer, SDL_BLENDMODE_NONE);
-    graphics.towerbuffer_lerp = SDL_CreateRGBSurface(SDL_SWSURFACE, 320, 240, fmt->BitsPerPixel, fmt->Rmask, fmt->Gmask, fmt->Bmask, fmt->Amask);
+    graphics.towerbuffer_lerp = SDL_CreateRGBSurface(SDL_SWSURFACE, 320+16, 240+16, fmt->BitsPerPixel, fmt->Rmask, fmt->Gmask, fmt->Bmask, fmt->Amask);
     SDL_SetSurfaceBlendMode(graphics.towerbuffer, SDL_BLENDMODE_NONE);
 
     graphics.tempBuffer = SDL_CreateRGBSurface(SDL_SWSURFACE ,320 ,240 ,fmt->BitsPerPixel,fmt->Rmask,fmt->Gmask,fmt->Bmask,fmt->Amask  );

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -585,7 +585,7 @@ int main(int argc, char *argv[])
                 graphics.processfade();
                 game.gameclock();
             }
-            const float alpha = static_cast<float>(accumulator) / timesteplimit;
+            const float alpha = game.over30mode ? static_cast<float>(accumulator) / timesteplimit : 1.0f;
             graphics.alpha = alpha;
 
             if (game.infocus)

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -330,9 +330,13 @@ int main(int argc, char *argv[])
         {
             timesteplimit = 24;
         }
-        else
+        else if (game.gamestate == GAMEMODE || game.gamestate == MAPMODE || game.gamestate == TELEPORTERMODE)
         {
             timesteplimit = game.gameframerate;
+        }
+        else
+        {
+            timesteplimit = 34;
         }
 
         while (accumulator >= timesteplimit)

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -361,11 +361,6 @@ void gameloop()
 
 void deltaloop()
 {
-    game.infocus = key.isActive;
-
-    // Update network per frame.
-    NETWORK_update();
-
     //timestep limit to 30
     const float rawdeltatime = static_cast<float>(time_ - timePrev);
     accumulator += rawdeltatime;
@@ -432,6 +427,11 @@ void deltaloop()
 
 void fixedloop()
 {
+    game.infocus = key.isActive;
+
+    // Update network per frame.
+    NETWORK_update();
+
     key.Poll();
     if(key.toggleFullscreen)
     {

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -63,9 +63,9 @@ volatile Uint32 f_time = 0;
 volatile Uint32 f_timePrev = 0;
 volatile Uint32 f_accumulator = 0;
 
-void gameloop();
-void deltaloop();
-void fixedloop();
+void inline gameloop();
+void inline deltaloop();
+void inline fixedloop();
 
 int main(int argc, char *argv[])
 {
@@ -339,7 +339,7 @@ int main(int argc, char *argv[])
     return 0;
 }
 
-void gameloop()
+void inline gameloop()
 {
     while ((game.over30mode || f_accumulator >= 34) && !key.quitProgram)
     {
@@ -359,7 +359,7 @@ void gameloop()
     }
 }
 
-void deltaloop()
+void inline deltaloop()
 {
     //timestep limit to 30
     const float rawdeltatime = static_cast<float>(time_ - timePrev);
@@ -427,7 +427,7 @@ void deltaloop()
     }
 }
 
-void fixedloop()
+void inline fixedloop()
 {
     game.infocus = key.isActive;
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -432,224 +432,224 @@ void deltaloop()
 
 void fixedloop()
 {
-        key.Poll();
-        if(key.toggleFullscreen)
+    key.Poll();
+    if(key.toggleFullscreen)
+    {
+        if(!gameScreen.isWindowed)
         {
-            if(!gameScreen.isWindowed)
-            {
-                SDL_ShowCursor(SDL_DISABLE);
-                SDL_ShowCursor(SDL_ENABLE);
-            }
-            else
-            {
-                SDL_ShowCursor(SDL_ENABLE);
-            }
-
-
-            if(game.gamestate == EDITORMODE)
-            {
-                SDL_ShowCursor(SDL_ENABLE);
-            }
-
-            gameScreen.toggleFullScreen();
-            game.fullscreen = !game.fullscreen;
-            key.toggleFullscreen = false;
-
-            key.keymap.clear(); //we lost the input due to a new window.
-            game.press_left = false;
-            game.press_right = false;
-            game.press_action = true;
-            game.press_map = false;
-        }
-
-        if(!game.infocus)
-        {
-            Mix_Pause(-1);
-            Mix_PauseMusic();
-
-            if (!game.blackout)
-            {
-                FillRect(graphics.backBuffer, 0x00000000);
-                graphics.bprint(5, 110, "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
-                graphics.bprint(5, 120, "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
-                graphics.bprint(5, 220, "Press M to mute in game", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
-                graphics.bprint(5, 230, "Press N to mute music only", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
-            }
-            graphics.render();
-            gameScreen.FlipScreen();
-            //We are minimised, so lets put a bit of a delay to save CPU
-            SDL_Delay(100);
+            SDL_ShowCursor(SDL_DISABLE);
+            SDL_ShowCursor(SDL_ENABLE);
         }
         else
         {
-            Mix_Resume(-1);
-            Mix_ResumeMusic();
-            game.gametimer++;
-            graphics.cutscenebarstimer();
+            SDL_ShowCursor(SDL_ENABLE);
+        }
 
-            switch(game.gamestate)
-            {
-            case PRELOADER:
-                preloaderlogic();
-                break;
+
+        if(game.gamestate == EDITORMODE)
+        {
+            SDL_ShowCursor(SDL_ENABLE);
+        }
+
+        gameScreen.toggleFullScreen();
+        game.fullscreen = !game.fullscreen;
+        key.toggleFullscreen = false;
+
+        key.keymap.clear(); //we lost the input due to a new window.
+        game.press_left = false;
+        game.press_right = false;
+        game.press_action = true;
+        game.press_map = false;
+    }
+
+    if(!game.infocus)
+    {
+        Mix_Pause(-1);
+        Mix_PauseMusic();
+
+        if (!game.blackout)
+        {
+            FillRect(graphics.backBuffer, 0x00000000);
+            graphics.bprint(5, 110, "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
+            graphics.bprint(5, 120, "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
+            graphics.bprint(5, 220, "Press M to mute in game", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+            graphics.bprint(5, 230, "Press N to mute music only", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+        }
+        graphics.render();
+        gameScreen.FlipScreen();
+        //We are minimised, so lets put a bit of a delay to save CPU
+        SDL_Delay(100);
+    }
+    else
+    {
+        Mix_Resume(-1);
+        Mix_ResumeMusic();
+        game.gametimer++;
+        graphics.cutscenebarstimer();
+
+        switch(game.gamestate)
+        {
+        case PRELOADER:
+            preloaderlogic();
+            break;
 #if !defined(NO_CUSTOM_LEVELS)
-            case EDITORMODE:
-                graphics.flipmode = false;
-                //Input
-                editorinput();
-                ////Logic
-                editorlogic();
-                break;
+        case EDITORMODE:
+            graphics.flipmode = false;
+            //Input
+            editorinput();
+            ////Logic
+            editorlogic();
+            break;
 #endif
-            case TITLEMODE:
-                //Input
-                titleinput();
-                ////Logic
-                titlelogic();
-                break;
-            case GAMEMODE:
+        case TITLEMODE:
+            //Input
+            titleinput();
+            ////Logic
+            titlelogic();
+            break;
+        case GAMEMODE:
+            if (script.running)
+            {
+                script.run();
+            }
+
+            //Update old positions of entities - has to be done BEFORE gameinput!
+            for (size_t i = 0; i < obj.entities.size(); i++)
+            {
+                obj.entities[i].oldxp = obj.entities[i].xp;
+                obj.entities[i].oldyp = obj.entities[i].yp;
+            }
+
+            gameinput();
+            gamelogic();
+
+
+            break;
+        case MAPMODE:
+            mapinput();
+            maplogic();
+            break;
+        case TELEPORTERMODE:
+            if(game.useteleporter)
+            {
+                teleporterinput();
+            }
+            else
+            {
                 if (script.running)
                 {
                     script.run();
                 }
-
-                //Update old positions of entities - has to be done BEFORE gameinput!
-                for (size_t i = 0; i < obj.entities.size(); i++)
-                {
-                    obj.entities[i].oldxp = obj.entities[i].xp;
-                    obj.entities[i].oldyp = obj.entities[i].yp;
-                }
-
                 gameinput();
-                gamelogic();
-
-
-                break;
-            case MAPMODE:
-                mapinput();
-                maplogic();
-                break;
-            case TELEPORTERMODE:
-                if(game.useteleporter)
-                {
-                    teleporterinput();
-                }
-                else
-                {
-                    if (script.running)
-                    {
-                        script.run();
-                    }
-                    gameinput();
-                }
-                maplogic();
-                break;
-            case GAMECOMPLETE:
-                //Input
-                gamecompleteinput();
-                //Logic
-                gamecompletelogic();
-                break;
-            case GAMECOMPLETE2:
-                //Input
-                gamecompleteinput2();
-                //Logic
-                gamecompletelogic2();
-                break;
-            case CLICKTOSTART:
-                break;
-            default:
-
-                break;
-
             }
+            maplogic();
+            break;
+        case GAMECOMPLETE:
+            //Input
+            gamecompleteinput();
+            //Logic
+            gamecompletelogic();
+            break;
+        case GAMECOMPLETE2:
+            //Input
+            gamecompleteinput2();
+            //Logic
+            gamecompletelogic2();
+            break;
+        case CLICKTOSTART:
+            break;
+        default:
+
+            break;
 
         }
 
-        //Screen effects timers
-        if (game.infocus && game.flashlight > 0)
-        {
-            game.flashlight--;
-        }
-        if (game.infocus && game.screenshake > 0)
-        {
-            game.screenshake--;
-            graphics.updatescreenshake();
-        }
+    }
 
-        if (graphics.screenbuffer->badSignalEffect)
-        {
-            UpdateFilter();
-        }
+    //Screen effects timers
+    if (game.infocus && game.flashlight > 0)
+    {
+        game.flashlight--;
+    }
+    if (game.infocus && game.screenshake > 0)
+    {
+        game.screenshake--;
+        graphics.updatescreenshake();
+    }
 
-        //We did editorinput, now it's safe to turn this off
-        key.linealreadyemptykludge = false;
+    if (graphics.screenbuffer->badSignalEffect)
+    {
+        UpdateFilter();
+    }
 
-        if (game.savemystats)
-        {
-            game.savemystats = false;
-            game.savestats();
-        }
+    //We did editorinput, now it's safe to turn this off
+    key.linealreadyemptykludge = false;
 
-        //Mute button
+    if (game.savemystats)
+    {
+        game.savemystats = false;
+        game.savestats();
+    }
+
+    //Mute button
 #if !defined(NO_CUSTOM_LEVELS)
-        bool inEditor = ed.textentry || ed.scripthelppage == 1;
+    bool inEditor = ed.textentry || ed.scripthelppage == 1;
 #else
-        bool inEditor = false;
+    bool inEditor = false;
 #endif
-        if (key.isDown(KEYBOARD_m) && game.mutebutton<=0 && !inEditor)
-        {
-            game.mutebutton = 8;
-            if (game.muted)
-            {
-                game.muted = false;
-            }
-            else
-            {
-                game.muted = true;
-            }
-        }
-        if(game.mutebutton>0)
-        {
-            game.mutebutton--;
-        }
-
-        if (key.isDown(KEYBOARD_n) && game.musicmutebutton <= 0 && !inEditor)
-        {
-            game.musicmutebutton = 8;
-            game.musicmuted = !game.musicmuted;
-        }
-        if (game.musicmutebutton > 0)
-        {
-            game.musicmutebutton--;
-        }
-
+    if (key.isDown(KEYBOARD_m) && game.mutebutton<=0 && !inEditor)
+    {
+        game.mutebutton = 8;
         if (game.muted)
         {
-            Mix_VolumeMusic(0) ;
-            Mix_Volume(-1,0);
+            game.muted = false;
         }
         else
         {
-            Mix_Volume(-1,MIX_MAX_VOLUME);
-
-            if (game.musicmuted || game.completestop)
-            {
-                Mix_VolumeMusic(0);
-            }
-            else
-            {
-                Mix_VolumeMusic(MIX_MAX_VOLUME);
-            }
+            game.muted = true;
         }
+    }
+    if(game.mutebutton>0)
+    {
+        game.mutebutton--;
+    }
 
-        if (key.resetWindow)
+    if (key.isDown(KEYBOARD_n) && game.musicmutebutton <= 0 && !inEditor)
+    {
+        game.musicmutebutton = 8;
+        game.musicmuted = !game.musicmuted;
+    }
+    if (game.musicmutebutton > 0)
+    {
+        game.musicmutebutton--;
+    }
+
+    if (game.muted)
+    {
+        Mix_VolumeMusic(0) ;
+        Mix_Volume(-1,0);
+    }
+    else
+    {
+        Mix_Volume(-1,MIX_MAX_VOLUME);
+
+        if (game.musicmuted || game.completestop)
         {
-            key.resetWindow = false;
-            gameScreen.ResizeScreen(-1, -1);
+            Mix_VolumeMusic(0);
         }
+        else
+        {
+            Mix_VolumeMusic(MIX_MAX_VOLUME);
+        }
+    }
 
-        music.processmusic();
-        graphics.processfade();
-        game.gameclock();
+    if (key.resetWindow)
+    {
+        key.resetWindow = false;
+        gameScreen.ResizeScreen(-1, -1);
+    }
+
+    music.processmusic();
+    graphics.processfade();
+    game.gameclock();
 }

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -108,6 +108,8 @@ int main(int argc, char *argv[])
         }
     }
 
+    SDL_SetHintWithPriority(SDL_HINT_RENDER_VSYNC, "1", SDL_HINT_OVERRIDE);
+
     if(!FILESYSTEM_init(argv[0], baseDir, assetsPath))
     {
         return 1;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -65,6 +65,7 @@ volatile Uint32 f_accumulator = 0;
 
 void gameloop();
 void deltaloop();
+void fixedloop();
 
 int main(int argc, char *argv[])
 {
@@ -387,6 +388,50 @@ void deltaloop()
     {
         accumulator = fmodf(accumulator, timesteplimit);
 
+        fixedloop();
+    }
+    const float alpha = game.over30mode ? static_cast<float>(accumulator) / timesteplimit : 1.0f;
+    graphics.alpha = alpha;
+
+    if (game.infocus)
+    {
+        switch (game.gamestate)
+        {
+        case PRELOADER:
+            preloaderrender();
+            break;
+        case EDITORMODE:
+            graphics.flipmode = false;
+            editorrender();
+            break;
+        case TITLEMODE:
+            titlerender();
+            break;
+        case GAMEMODE:
+            gamerender();
+            break;
+        case MAPMODE:
+            maprender();
+            break;
+        case TELEPORTERMODE:
+            teleporterrender();
+            break;
+        case GAMECOMPLETE:
+            gamecompleterender();
+            break;
+        case GAMECOMPLETE2:
+            gamecompleterender2();
+            break;
+        case CLICKTOSTART:
+            help.updateglow();
+            break;
+        }
+        gameScreen.FlipScreen();
+    }
+}
+
+void fixedloop()
+{
         key.Poll();
         if(key.toggleFullscreen)
         {
@@ -607,43 +652,4 @@ void deltaloop()
         music.processmusic();
         graphics.processfade();
         game.gameclock();
-    }
-    const float alpha = game.over30mode ? static_cast<float>(accumulator) / timesteplimit : 1.0f;
-    graphics.alpha = alpha;
-
-    if (game.infocus)
-    {
-        switch (game.gamestate)
-        {
-        case PRELOADER:
-            preloaderrender();
-            break;
-        case EDITORMODE:
-            graphics.flipmode = false;
-            editorrender();
-            break;
-        case TITLEMODE:
-            titlerender();
-            break;
-        case GAMEMODE:
-            gamerender();
-            break;
-        case MAPMODE:
-            maprender();
-            break;
-        case TELEPORTERMODE:
-            teleporterrender();
-            break;
-        case GAMECOMPLETE:
-            gamecompleterender();
-            break;
-        case GAMECOMPLETE2:
-            gamecompleterender2();
-            break;
-        case CLICKTOSTART:
-            help.updateglow();
-            break;
-        }
-        gameScreen.FlipScreen();
-    }
 }

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -360,290 +360,290 @@ void gameloop()
 
 void deltaloop()
 {
-        game.infocus = key.isActive;
+    game.infocus = key.isActive;
 
-        // Update network per frame.
-        NETWORK_update();
+    // Update network per frame.
+    NETWORK_update();
 
-        //timestep limit to 30
-        const float rawdeltatime = static_cast<float>(time_ - timePrev);
-        accumulator += rawdeltatime;
+    //timestep limit to 30
+    const float rawdeltatime = static_cast<float>(time_ - timePrev);
+    accumulator += rawdeltatime;
 
-        Uint32 timesteplimit;
-        if (game.gamestate == EDITORMODE)
+    Uint32 timesteplimit;
+    if (game.gamestate == EDITORMODE)
+    {
+        timesteplimit = 24;
+    }
+    else if (game.gamestate == GAMEMODE || game.gamestate == MAPMODE || game.gamestate == TELEPORTERMODE)
+    {
+        timesteplimit = game.gameframerate;
+    }
+    else
+    {
+        timesteplimit = 34;
+    }
+
+    while (accumulator >= timesteplimit)
+    {
+        accumulator = fmodf(accumulator, timesteplimit);
+
+        key.Poll();
+        if(key.toggleFullscreen)
         {
-            timesteplimit = 24;
-        }
-        else if (game.gamestate == GAMEMODE || game.gamestate == MAPMODE || game.gamestate == TELEPORTERMODE)
-        {
-            timesteplimit = game.gameframerate;
-        }
-        else
-        {
-            timesteplimit = 34;
-        }
-
-        while (accumulator >= timesteplimit)
-        {
-            accumulator = fmodf(accumulator, timesteplimit);
-
-            key.Poll();
-            if(key.toggleFullscreen)
+            if(!gameScreen.isWindowed)
             {
-                if(!gameScreen.isWindowed)
-                {
-                    SDL_ShowCursor(SDL_DISABLE);
-                    SDL_ShowCursor(SDL_ENABLE);
-                }
-                else
-                {
-                    SDL_ShowCursor(SDL_ENABLE);
-                }
-
-
-                if(game.gamestate == EDITORMODE)
-                {
-                    SDL_ShowCursor(SDL_ENABLE);
-                }
-
-                gameScreen.toggleFullScreen();
-                game.fullscreen = !game.fullscreen;
-                key.toggleFullscreen = false;
-
-                key.keymap.clear(); //we lost the input due to a new window.
-                game.press_left = false;
-                game.press_right = false;
-                game.press_action = true;
-                game.press_map = false;
-            }
-
-            if(!game.infocus)
-            {
-                Mix_Pause(-1);
-                Mix_PauseMusic();
-
-                if (!game.blackout)
-                {
-                    FillRect(graphics.backBuffer, 0x00000000);
-                    graphics.bprint(5, 110, "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
-                    graphics.bprint(5, 120, "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
-                    graphics.bprint(5, 220, "Press M to mute in game", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
-                    graphics.bprint(5, 230, "Press N to mute music only", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
-                }
-                graphics.render();
-                gameScreen.FlipScreen();
-                //We are minimised, so lets put a bit of a delay to save CPU
-                SDL_Delay(100);
+                SDL_ShowCursor(SDL_DISABLE);
+                SDL_ShowCursor(SDL_ENABLE);
             }
             else
             {
-                Mix_Resume(-1);
-                Mix_ResumeMusic();
-                game.gametimer++;
-                graphics.cutscenebarstimer();
+                SDL_ShowCursor(SDL_ENABLE);
+            }
 
-                switch(game.gamestate)
-                {
-                case PRELOADER:
-                    preloaderlogic();
-                    break;
+
+            if(game.gamestate == EDITORMODE)
+            {
+                SDL_ShowCursor(SDL_ENABLE);
+            }
+
+            gameScreen.toggleFullScreen();
+            game.fullscreen = !game.fullscreen;
+            key.toggleFullscreen = false;
+
+            key.keymap.clear(); //we lost the input due to a new window.
+            game.press_left = false;
+            game.press_right = false;
+            game.press_action = true;
+            game.press_map = false;
+        }
+
+        if(!game.infocus)
+        {
+            Mix_Pause(-1);
+            Mix_PauseMusic();
+
+            if (!game.blackout)
+            {
+                FillRect(graphics.backBuffer, 0x00000000);
+                graphics.bprint(5, 110, "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
+                graphics.bprint(5, 120, "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
+                graphics.bprint(5, 220, "Press M to mute in game", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+                graphics.bprint(5, 230, "Press N to mute music only", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+            }
+            graphics.render();
+            gameScreen.FlipScreen();
+            //We are minimised, so lets put a bit of a delay to save CPU
+            SDL_Delay(100);
+        }
+        else
+        {
+            Mix_Resume(-1);
+            Mix_ResumeMusic();
+            game.gametimer++;
+            graphics.cutscenebarstimer();
+
+            switch(game.gamestate)
+            {
+            case PRELOADER:
+                preloaderlogic();
+                break;
 #if !defined(NO_CUSTOM_LEVELS)
-                case EDITORMODE:
-                    graphics.flipmode = false;
-                    //Input
-                    editorinput();
-                    ////Logic
-                    editorlogic();
-                    break;
+            case EDITORMODE:
+                graphics.flipmode = false;
+                //Input
+                editorinput();
+                ////Logic
+                editorlogic();
+                break;
 #endif
-                case TITLEMODE:
-                    //Input
-                    titleinput();
-                    ////Logic
-                    titlelogic();
-                    break;
-                case GAMEMODE:
+            case TITLEMODE:
+                //Input
+                titleinput();
+                ////Logic
+                titlelogic();
+                break;
+            case GAMEMODE:
+                if (script.running)
+                {
+                    script.run();
+                }
+
+                //Update old positions of entities - has to be done BEFORE gameinput!
+                for (size_t i = 0; i < obj.entities.size(); i++)
+                {
+                    obj.entities[i].oldxp = obj.entities[i].xp;
+                    obj.entities[i].oldyp = obj.entities[i].yp;
+                }
+
+                gameinput();
+                gamelogic();
+
+
+                break;
+            case MAPMODE:
+                mapinput();
+                maplogic();
+                break;
+            case TELEPORTERMODE:
+                if(game.useteleporter)
+                {
+                    teleporterinput();
+                }
+                else
+                {
                     if (script.running)
                     {
                         script.run();
                     }
-
-                    //Update old positions of entities - has to be done BEFORE gameinput!
-                    for (size_t i = 0; i < obj.entities.size(); i++)
-                    {
-                        obj.entities[i].oldxp = obj.entities[i].xp;
-                        obj.entities[i].oldyp = obj.entities[i].yp;
-                    }
-
                     gameinput();
-                    gamelogic();
-
-
-                    break;
-                case MAPMODE:
-                    mapinput();
-                    maplogic();
-                    break;
-                case TELEPORTERMODE:
-                    if(game.useteleporter)
-                    {
-                        teleporterinput();
-                    }
-                    else
-                    {
-                        if (script.running)
-                        {
-                            script.run();
-                        }
-                        gameinput();
-                    }
-                    maplogic();
-                    break;
-                case GAMECOMPLETE:
-                    //Input
-                    gamecompleteinput();
-                    //Logic
-                    gamecompletelogic();
-                    break;
-                case GAMECOMPLETE2:
-                    //Input
-                    gamecompleteinput2();
-                    //Logic
-                    gamecompletelogic2();
-                    break;
-                case CLICKTOSTART:
-                    break;
-                default:
-
-                    break;
-
                 }
+                maplogic();
+                break;
+            case GAMECOMPLETE:
+                //Input
+                gamecompleteinput();
+                //Logic
+                gamecompletelogic();
+                break;
+            case GAMECOMPLETE2:
+                //Input
+                gamecompleteinput2();
+                //Logic
+                gamecompletelogic2();
+                break;
+            case CLICKTOSTART:
+                break;
+            default:
+
+                break;
 
             }
 
-            //Screen effects timers
-            if (game.infocus && game.flashlight > 0)
-            {
-                game.flashlight--;
-            }
-            if (game.infocus && game.screenshake > 0)
-            {
-                game.screenshake--;
-                graphics.updatescreenshake();
-            }
+        }
 
-            if (graphics.screenbuffer->badSignalEffect)
-            {
-                UpdateFilter();
-            }
+        //Screen effects timers
+        if (game.infocus && game.flashlight > 0)
+        {
+            game.flashlight--;
+        }
+        if (game.infocus && game.screenshake > 0)
+        {
+            game.screenshake--;
+            graphics.updatescreenshake();
+        }
 
-            //We did editorinput, now it's safe to turn this off
-            key.linealreadyemptykludge = false;
+        if (graphics.screenbuffer->badSignalEffect)
+        {
+            UpdateFilter();
+        }
 
-            if (game.savemystats)
-            {
-                game.savemystats = false;
-                game.savestats();
-            }
+        //We did editorinput, now it's safe to turn this off
+        key.linealreadyemptykludge = false;
 
-            //Mute button
+        if (game.savemystats)
+        {
+            game.savemystats = false;
+            game.savestats();
+        }
+
+        //Mute button
 #if !defined(NO_CUSTOM_LEVELS)
-            bool inEditor = ed.textentry || ed.scripthelppage == 1;
+        bool inEditor = ed.textentry || ed.scripthelppage == 1;
 #else
-            bool inEditor = false;
+        bool inEditor = false;
 #endif
-            if (key.isDown(KEYBOARD_m) && game.mutebutton<=0 && !inEditor)
-            {
-                game.mutebutton = 8;
-                if (game.muted)
-                {
-                    game.muted = false;
-                }
-                else
-                {
-                    game.muted = true;
-                }
-            }
-            if(game.mutebutton>0)
-            {
-                game.mutebutton--;
-            }
-
-            if (key.isDown(KEYBOARD_n) && game.musicmutebutton <= 0 && !inEditor)
-            {
-                game.musicmutebutton = 8;
-                game.musicmuted = !game.musicmuted;
-            }
-            if (game.musicmutebutton > 0)
-            {
-                game.musicmutebutton--;
-            }
-
+        if (key.isDown(KEYBOARD_m) && game.mutebutton<=0 && !inEditor)
+        {
+            game.mutebutton = 8;
             if (game.muted)
             {
-                Mix_VolumeMusic(0) ;
-                Mix_Volume(-1,0);
+                game.muted = false;
             }
             else
             {
-                Mix_Volume(-1,MIX_MAX_VOLUME);
-
-                if (game.musicmuted || game.completestop)
-                {
-                    Mix_VolumeMusic(0);
-                }
-                else
-                {
-                    Mix_VolumeMusic(MIX_MAX_VOLUME);
-                }
+                game.muted = true;
             }
-
-            if (key.resetWindow)
-            {
-                key.resetWindow = false;
-                gameScreen.ResizeScreen(-1, -1);
-            }
-
-            music.processmusic();
-            graphics.processfade();
-            game.gameclock();
         }
-        const float alpha = game.over30mode ? static_cast<float>(accumulator) / timesteplimit : 1.0f;
-        graphics.alpha = alpha;
-
-        if (game.infocus)
+        if(game.mutebutton>0)
         {
-            switch (game.gamestate)
-            {
-            case PRELOADER:
-                preloaderrender();
-                break;
-            case EDITORMODE:
-                graphics.flipmode = false;
-                editorrender();
-                break;
-            case TITLEMODE:
-                titlerender();
-                break;
-            case GAMEMODE:
-                gamerender();
-                break;
-            case MAPMODE:
-                maprender();
-                break;
-            case TELEPORTERMODE:
-                teleporterrender();
-                break;
-            case GAMECOMPLETE:
-                gamecompleterender();
-                break;
-            case GAMECOMPLETE2:
-                gamecompleterender2();
-                break;
-            case CLICKTOSTART:
-                help.updateglow();
-                break;
-            }
-            gameScreen.FlipScreen();
+            game.mutebutton--;
         }
+
+        if (key.isDown(KEYBOARD_n) && game.musicmutebutton <= 0 && !inEditor)
+        {
+            game.musicmutebutton = 8;
+            game.musicmuted = !game.musicmuted;
+        }
+        if (game.musicmutebutton > 0)
+        {
+            game.musicmutebutton--;
+        }
+
+        if (game.muted)
+        {
+            Mix_VolumeMusic(0) ;
+            Mix_Volume(-1,0);
+        }
+        else
+        {
+            Mix_Volume(-1,MIX_MAX_VOLUME);
+
+            if (game.musicmuted || game.completestop)
+            {
+                Mix_VolumeMusic(0);
+            }
+            else
+            {
+                Mix_VolumeMusic(MIX_MAX_VOLUME);
+            }
+        }
+
+        if (key.resetWindow)
+        {
+            key.resetWindow = false;
+            gameScreen.ResizeScreen(-1, -1);
+        }
+
+        music.processmusic();
+        graphics.processfade();
+        game.gameclock();
+    }
+    const float alpha = game.over30mode ? static_cast<float>(accumulator) / timesteplimit : 1.0f;
+    graphics.alpha = alpha;
+
+    if (game.infocus)
+    {
+        switch (game.gamestate)
+        {
+        case PRELOADER:
+            preloaderrender();
+            break;
+        case EDITORMODE:
+            graphics.flipmode = false;
+            editorrender();
+            break;
+        case TITLEMODE:
+            titlerender();
+            break;
+        case GAMEMODE:
+            gamerender();
+            break;
+        case MAPMODE:
+            maprender();
+            break;
+        case TELEPORTERMODE:
+            teleporterrender();
+            break;
+        case GAMECOMPLETE:
+            gamecompleterender();
+            break;
+        case GAMECOMPLETE2:
+            gamecompleterender2();
+            break;
+        case CLICKTOSTART:
+            help.updateglow();
+            break;
+        }
+        gameScreen.FlipScreen();
+    }
 }

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -486,6 +486,11 @@ int main(int argc, char *argv[])
                 graphics.updatescreenshake();
             }
 
+            if (graphics.screenbuffer->badSignalEffect)
+            {
+                UpdateFilter();
+            }
+
             //We did editorinput, now it's safe to turn this off
             key.linealreadyemptykludge = false;
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -56,6 +56,15 @@ int savemusic = 0;
 
 std::string playtestname;
 
+volatile Uint32 time_ = 0;
+volatile Uint32 timePrev = 0;
+volatile Uint32 accumulator = 0;
+volatile Uint32 f_time = 0;
+volatile Uint32 f_timePrev = 0;
+volatile Uint32 f_accumulator = 0;
+
+void gameloop();
+
 int main(int argc, char *argv[])
 {
     char* baseDir = NULL;
@@ -303,12 +312,6 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    volatile Uint32 time_ = 0;
-    volatile Uint32 timePrev = 0;
-    volatile Uint32 accumulator = 0;
-    volatile Uint32 f_time = 0;
-    volatile Uint32 f_timePrev = 0;
-    volatile Uint32 f_accumulator = 0;
     game.infocus = true;
     key.isActive = true;
     game.gametimer = 0;
@@ -323,6 +326,19 @@ int main(int argc, char *argv[])
             f_accumulator += f_rawdeltatime;
         }
 
+        gameloop();
+    }
+
+    game.savestats();
+    NETWORK_shutdown();
+    SDL_Quit();
+    FILESYSTEM_deinit();
+
+    return 0;
+}
+
+void gameloop()
+{
         while ((game.over30mode || f_accumulator >= 34) && !key.quitProgram)
         {
             if (game.over30mode)
@@ -624,12 +640,4 @@ int main(int argc, char *argv[])
                 gameScreen.FlipScreen();
             }
         }
-    }
-
-    game.savestats();
-    NETWORK_shutdown();
-    SDL_Quit();
-    FILESYSTEM_deinit();
-
-    return 0;
 }

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -306,12 +306,34 @@ int main(int argc, char *argv[])
     volatile Uint32 time = 0;
     volatile Uint32 timePrev = 0;
     volatile Uint32 accumulator = 0;
+    volatile Uint32 f_time = 0;
+    volatile Uint32 f_timePrev = 0;
+    volatile Uint32 f_accumulator = 0;
     game.infocus = true;
     key.isActive = true;
     game.gametimer = 0;
 
     while(!key.quitProgram)
     {
+        f_timePrev = f_time;
+        f_time = SDL_GetTicks();
+        const float f_rawdeltatime = static_cast<float>(f_time - f_timePrev);
+        if (!game.over30mode)
+        {
+            f_accumulator += f_rawdeltatime;
+        }
+
+        while ((game.over30mode || f_accumulator >= 34) && !key.quitProgram)
+        {
+            if (game.over30mode)
+            {
+                f_accumulator = 0;
+            }
+            else
+            {
+                f_accumulator = fmodf(f_accumulator, 34);
+            }
+
         timePrev = time;
         time = SDL_GetTicks();
 
@@ -600,6 +622,7 @@ int main(int argc, char *argv[])
                 break;
             }
             gameScreen.FlipScreen();
+        }
         }
     }
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -334,295 +334,295 @@ int main(int argc, char *argv[])
                 f_accumulator = fmodf(f_accumulator, 34);
             }
 
-        timePrev = time;
-        time = SDL_GetTicks();
+            timePrev = time;
+            time = SDL_GetTicks();
 
-        game.infocus = key.isActive;
+            game.infocus = key.isActive;
 
-        // Update network per frame.
-        NETWORK_update();
+            // Update network per frame.
+            NETWORK_update();
 
-        //timestep limit to 30
-        const float rawdeltatime = static_cast<float>(time - timePrev);
-        accumulator += rawdeltatime;
+            //timestep limit to 30
+            const float rawdeltatime = static_cast<float>(time - timePrev);
+            accumulator += rawdeltatime;
 
-        Uint32 timesteplimit;
-        if (game.gamestate == EDITORMODE)
-        {
-            timesteplimit = 24;
-        }
-        else if (game.gamestate == GAMEMODE || game.gamestate == MAPMODE || game.gamestate == TELEPORTERMODE)
-        {
-            timesteplimit = game.gameframerate;
-        }
-        else
-        {
-            timesteplimit = 34;
-        }
-
-        while (accumulator >= timesteplimit)
-        {
-            accumulator = fmodf(accumulator, timesteplimit);
-
-            key.Poll();
-            if(key.toggleFullscreen)
+            Uint32 timesteplimit;
+            if (game.gamestate == EDITORMODE)
             {
-                if(!gameScreen.isWindowed)
-                {
-                    SDL_ShowCursor(SDL_DISABLE);
-                    SDL_ShowCursor(SDL_ENABLE);
-                }
-                else
-                {
-                    SDL_ShowCursor(SDL_ENABLE);
-                }
-
-
-                if(game.gamestate == EDITORMODE)
-                {
-                    SDL_ShowCursor(SDL_ENABLE);
-                }
-
-                gameScreen.toggleFullScreen();
-                game.fullscreen = !game.fullscreen;
-                key.toggleFullscreen = false;
-
-                key.keymap.clear(); //we lost the input due to a new window.
-                game.press_left = false;
-                game.press_right = false;
-                game.press_action = true;
-                game.press_map = false;
+                timesteplimit = 24;
             }
-
-            if(!game.infocus)
+            else if (game.gamestate == GAMEMODE || game.gamestate == MAPMODE || game.gamestate == TELEPORTERMODE)
             {
-                Mix_Pause(-1);
-                Mix_PauseMusic();
-
-                if (!game.blackout)
-                {
-                    FillRect(graphics.backBuffer, 0x00000000);
-                    graphics.bprint(5, 110, "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
-                    graphics.bprint(5, 120, "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
-                    graphics.bprint(5, 220, "Press M to mute in game", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
-                    graphics.bprint(5, 230, "Press N to mute music only", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
-                }
-                graphics.render();
-                gameScreen.FlipScreen();
-                //We are minimised, so lets put a bit of a delay to save CPU
-                SDL_Delay(100);
+                timesteplimit = game.gameframerate;
             }
             else
             {
-                Mix_Resume(-1);
-                Mix_ResumeMusic();
-                game.gametimer++;
-                graphics.cutscenebarstimer();
+                timesteplimit = 34;
+            }
 
-                switch(game.gamestate)
+            while (accumulator >= timesteplimit)
+            {
+                accumulator = fmodf(accumulator, timesteplimit);
+
+                key.Poll();
+                if(key.toggleFullscreen)
                 {
-                case PRELOADER:
-                    preloaderlogic();
-                    break;
-#if !defined(NO_CUSTOM_LEVELS)
-                case EDITORMODE:
-                    graphics.flipmode = false;
-                    //Input
-                    editorinput();
-                    ////Logic
-                    editorlogic();
-                    break;
-#endif
-                case TITLEMODE:
-                    //Input
-                    titleinput();
-                    ////Logic
-                    titlelogic();
-                    break;
-                case GAMEMODE:
-                    if (script.running)
+                    if(!gameScreen.isWindowed)
                     {
-                        script.run();
-                    }
-
-                    //Update old positions of entities - has to be done BEFORE gameinput!
-                    for (size_t i = 0; i < obj.entities.size(); i++)
-                    {
-                        obj.entities[i].oldxp = obj.entities[i].xp;
-                        obj.entities[i].oldyp = obj.entities[i].yp;
-                    }
-
-                    gameinput();
-                    gamelogic();
-
-
-                    break;
-                case MAPMODE:
-                    mapinput();
-                    maplogic();
-                    break;
-                case TELEPORTERMODE:
-                    if(game.useteleporter)
-                    {
-                        teleporterinput();
+                        SDL_ShowCursor(SDL_DISABLE);
+                        SDL_ShowCursor(SDL_ENABLE);
                     }
                     else
                     {
+                        SDL_ShowCursor(SDL_ENABLE);
+                    }
+
+
+                    if(game.gamestate == EDITORMODE)
+                    {
+                        SDL_ShowCursor(SDL_ENABLE);
+                    }
+
+                    gameScreen.toggleFullScreen();
+                    game.fullscreen = !game.fullscreen;
+                    key.toggleFullscreen = false;
+
+                    key.keymap.clear(); //we lost the input due to a new window.
+                    game.press_left = false;
+                    game.press_right = false;
+                    game.press_action = true;
+                    game.press_map = false;
+                }
+
+                if(!game.infocus)
+                {
+                    Mix_Pause(-1);
+                    Mix_PauseMusic();
+
+                    if (!game.blackout)
+                    {
+                        FillRect(graphics.backBuffer, 0x00000000);
+                        graphics.bprint(5, 110, "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
+                        graphics.bprint(5, 120, "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
+                        graphics.bprint(5, 220, "Press M to mute in game", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+                        graphics.bprint(5, 230, "Press N to mute music only", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+                    }
+                    graphics.render();
+                    gameScreen.FlipScreen();
+                    //We are minimised, so lets put a bit of a delay to save CPU
+                    SDL_Delay(100);
+                }
+                else
+                {
+                    Mix_Resume(-1);
+                    Mix_ResumeMusic();
+                    game.gametimer++;
+                    graphics.cutscenebarstimer();
+
+                    switch(game.gamestate)
+                    {
+                    case PRELOADER:
+                        preloaderlogic();
+                        break;
+#if !defined(NO_CUSTOM_LEVELS)
+                    case EDITORMODE:
+                        graphics.flipmode = false;
+                        //Input
+                        editorinput();
+                        ////Logic
+                        editorlogic();
+                        break;
+#endif
+                    case TITLEMODE:
+                        //Input
+                        titleinput();
+                        ////Logic
+                        titlelogic();
+                        break;
+                    case GAMEMODE:
                         if (script.running)
                         {
                             script.run();
                         }
-                        gameinput();
-                    }
-                    maplogic();
-                    break;
-                case GAMECOMPLETE:
-                    //Input
-                    gamecompleteinput();
-                    //Logic
-                    gamecompletelogic();
-                    break;
-                case GAMECOMPLETE2:
-                    //Input
-                    gamecompleteinput2();
-                    //Logic
-                    gamecompletelogic2();
-                    break;
-                case CLICKTOSTART:
-                    break;
-                default:
 
-                    break;
+                        //Update old positions of entities - has to be done BEFORE gameinput!
+                        for (size_t i = 0; i < obj.entities.size(); i++)
+                        {
+                            obj.entities[i].oldxp = obj.entities[i].xp;
+                            obj.entities[i].oldyp = obj.entities[i].yp;
+                        }
+
+                        gameinput();
+                        gamelogic();
+
+
+                        break;
+                    case MAPMODE:
+                        mapinput();
+                        maplogic();
+                        break;
+                    case TELEPORTERMODE:
+                        if(game.useteleporter)
+                        {
+                            teleporterinput();
+                        }
+                        else
+                        {
+                            if (script.running)
+                            {
+                                script.run();
+                            }
+                            gameinput();
+                        }
+                        maplogic();
+                        break;
+                    case GAMECOMPLETE:
+                        //Input
+                        gamecompleteinput();
+                        //Logic
+                        gamecompletelogic();
+                        break;
+                    case GAMECOMPLETE2:
+                        //Input
+                        gamecompleteinput2();
+                        //Logic
+                        gamecompletelogic2();
+                        break;
+                    case CLICKTOSTART:
+                        break;
+                    default:
+
+                        break;
+
+                    }
 
                 }
 
-            }
+                //Screen effects timers
+                if (game.infocus && game.flashlight > 0)
+                {
+                    game.flashlight--;
+                }
+                if (game.infocus && game.screenshake > 0)
+                {
+                    game.screenshake--;
+                    graphics.updatescreenshake();
+                }
 
-            //Screen effects timers
-            if (game.infocus && game.flashlight > 0)
-            {
-                game.flashlight--;
-            }
-            if (game.infocus && game.screenshake > 0)
-            {
-                game.screenshake--;
-                graphics.updatescreenshake();
-            }
+                if (graphics.screenbuffer->badSignalEffect)
+                {
+                    UpdateFilter();
+                }
 
-            if (graphics.screenbuffer->badSignalEffect)
-            {
-                UpdateFilter();
-            }
+                //We did editorinput, now it's safe to turn this off
+                key.linealreadyemptykludge = false;
 
-            //We did editorinput, now it's safe to turn this off
-            key.linealreadyemptykludge = false;
+                if (game.savemystats)
+                {
+                    game.savemystats = false;
+                    game.savestats();
+                }
 
-            if (game.savemystats)
-            {
-                game.savemystats = false;
-                game.savestats();
-            }
-
-            //Mute button
+                //Mute button
 #if !defined(NO_CUSTOM_LEVELS)
-            bool inEditor = ed.textentry || ed.scripthelppage == 1;
+                bool inEditor = ed.textentry || ed.scripthelppage == 1;
 #else
-            bool inEditor = false;
+                bool inEditor = false;
 #endif
-            if (key.isDown(KEYBOARD_m) && game.mutebutton<=0 && !inEditor)
-            {
-                game.mutebutton = 8;
+                if (key.isDown(KEYBOARD_m) && game.mutebutton<=0 && !inEditor)
+                {
+                    game.mutebutton = 8;
+                    if (game.muted)
+                    {
+                        game.muted = false;
+                    }
+                    else
+                    {
+                        game.muted = true;
+                    }
+                }
+                if(game.mutebutton>0)
+                {
+                    game.mutebutton--;
+                }
+
+                if (key.isDown(KEYBOARD_n) && game.musicmutebutton <= 0 && !inEditor)
+                {
+                    game.musicmutebutton = 8;
+                    game.musicmuted = !game.musicmuted;
+                }
+                if (game.musicmutebutton > 0)
+                {
+                    game.musicmutebutton--;
+                }
+
                 if (game.muted)
                 {
-                    game.muted = false;
+                    Mix_VolumeMusic(0) ;
+                    Mix_Volume(-1,0);
                 }
                 else
                 {
-                    game.muted = true;
+                    Mix_Volume(-1,MIX_MAX_VOLUME);
+
+                    if (game.musicmuted || game.completestop)
+                    {
+                        Mix_VolumeMusic(0);
+                    }
+                    else
+                    {
+                        Mix_VolumeMusic(MIX_MAX_VOLUME);
+                    }
                 }
-            }
-            if(game.mutebutton>0)
-            {
-                game.mutebutton--;
-            }
 
-            if (key.isDown(KEYBOARD_n) && game.musicmutebutton <= 0 && !inEditor)
-            {
-                game.musicmutebutton = 8;
-                game.musicmuted = !game.musicmuted;
-            }
-            if (game.musicmutebutton > 0)
-            {
-                game.musicmutebutton--;
-            }
-
-            if (game.muted)
-            {
-                Mix_VolumeMusic(0) ;
-                Mix_Volume(-1,0);
-            }
-            else
-            {
-                Mix_Volume(-1,MIX_MAX_VOLUME);
-
-                if (game.musicmuted || game.completestop)
+                if (key.resetWindow)
                 {
-                    Mix_VolumeMusic(0);
+                    key.resetWindow = false;
+                    gameScreen.ResizeScreen(-1, -1);
                 }
-                else
+
+                music.processmusic();
+                graphics.processfade();
+                game.gameclock();
+            }
+            const float alpha = static_cast<float>(accumulator) / timesteplimit;
+            graphics.alpha = alpha;
+
+            if (game.infocus)
+            {
+                switch (game.gamestate)
                 {
-                    Mix_VolumeMusic(MIX_MAX_VOLUME);
+                case PRELOADER:
+                    preloaderrender();
+                    break;
+                case EDITORMODE:
+                    graphics.flipmode = false;
+                    editorrender();
+                    break;
+                case TITLEMODE:
+                    titlerender();
+                    break;
+                case GAMEMODE:
+                    gamerender();
+                    break;
+                case MAPMODE:
+                    maprender();
+                    break;
+                case TELEPORTERMODE:
+                    teleporterrender();
+                    break;
+                case GAMECOMPLETE:
+                    gamecompleterender();
+                    break;
+                case GAMECOMPLETE2:
+                    gamecompleterender2();
+                    break;
+                case CLICKTOSTART:
+                    help.updateglow();
+                    break;
                 }
+                gameScreen.FlipScreen();
             }
-
-            if (key.resetWindow)
-            {
-                key.resetWindow = false;
-                gameScreen.ResizeScreen(-1, -1);
-            }
-
-            music.processmusic();
-            graphics.processfade();
-            game.gameclock();
-        }
-        const float alpha = static_cast<float>(accumulator) / timesteplimit;
-        graphics.alpha = alpha;
-
-        if (game.infocus)
-        {
-            switch (game.gamestate)
-            {
-            case PRELOADER:
-                preloaderrender();
-                break;
-            case EDITORMODE:
-                graphics.flipmode = false;
-                editorrender();
-                break;
-            case TITLEMODE:
-                titlerender();
-                break;
-            case GAMEMODE:
-                gamerender();
-                break;
-            case MAPMODE:
-                maprender();
-                break;
-            case TELEPORTERMODE:
-                teleporterrender();
-                break;
-            case GAMECOMPLETE:
-                gamecompleterender();
-                break;
-            case GAMECOMPLETE2:
-                gamecompleterender2();
-                break;
-            case CLICKTOSTART:
-                help.updateglow();
-                break;
-            }
-            gameScreen.FlipScreen();
-        }
         }
     }
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -105,8 +105,6 @@ int main(int argc, char *argv[])
         }
     }
 
-    SDL_SetHintWithPriority(SDL_HINT_RENDER_VSYNC, "1", SDL_HINT_OVERRIDE);
-
     if(!FILESYSTEM_init(argv[0], baseDir, assetsPath))
     {
         return 1;
@@ -208,6 +206,8 @@ int main(int argc, char *argv[])
 
     //Moved screensetting init here from main menu V2.1
     game.loadstats();
+    graphics.processVsync();
+
     if (game.skipfakeload)
         game.gamestate = TITLEMODE;
     if(game.usingmmmmmm==0) music.usingmmmmmm=false;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -303,7 +303,7 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    volatile Uint32 time = 0;
+    volatile Uint32 time_ = 0;
     volatile Uint32 timePrev = 0;
     volatile Uint32 accumulator = 0;
     volatile Uint32 f_time = 0;
@@ -334,8 +334,8 @@ int main(int argc, char *argv[])
                 f_accumulator = fmodf(f_accumulator, 34);
             }
 
-            timePrev = time;
-            time = SDL_GetTicks();
+            timePrev = time_;
+            time_ = SDL_GetTicks();
 
             game.infocus = key.isActive;
 
@@ -343,7 +343,7 @@ int main(int argc, char *argv[])
             NETWORK_update();
 
             //timestep limit to 30
-            const float rawdeltatime = static_cast<float>(time - timePrev);
+            const float rawdeltatime = static_cast<float>(time_ - timePrev);
             accumulator += rawdeltatime;
 
             Uint32 timesteplimit;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -339,305 +339,305 @@ int main(int argc, char *argv[])
 
 void gameloop()
 {
-        while ((game.over30mode || f_accumulator >= 34) && !key.quitProgram)
+    while ((game.over30mode || f_accumulator >= 34) && !key.quitProgram)
+    {
+        if (game.over30mode)
         {
-            if (game.over30mode)
+            f_accumulator = 0;
+        }
+        else
+        {
+            f_accumulator = fmodf(f_accumulator, 34);
+        }
+
+        timePrev = time_;
+        time_ = SDL_GetTicks();
+
+        game.infocus = key.isActive;
+
+        // Update network per frame.
+        NETWORK_update();
+
+        //timestep limit to 30
+        const float rawdeltatime = static_cast<float>(time_ - timePrev);
+        accumulator += rawdeltatime;
+
+        Uint32 timesteplimit;
+        if (game.gamestate == EDITORMODE)
+        {
+            timesteplimit = 24;
+        }
+        else if (game.gamestate == GAMEMODE || game.gamestate == MAPMODE || game.gamestate == TELEPORTERMODE)
+        {
+            timesteplimit = game.gameframerate;
+        }
+        else
+        {
+            timesteplimit = 34;
+        }
+
+        while (accumulator >= timesteplimit)
+        {
+            accumulator = fmodf(accumulator, timesteplimit);
+
+            key.Poll();
+            if(key.toggleFullscreen)
             {
-                f_accumulator = 0;
-            }
-            else
-            {
-                f_accumulator = fmodf(f_accumulator, 34);
-            }
-
-            timePrev = time_;
-            time_ = SDL_GetTicks();
-
-            game.infocus = key.isActive;
-
-            // Update network per frame.
-            NETWORK_update();
-
-            //timestep limit to 30
-            const float rawdeltatime = static_cast<float>(time_ - timePrev);
-            accumulator += rawdeltatime;
-
-            Uint32 timesteplimit;
-            if (game.gamestate == EDITORMODE)
-            {
-                timesteplimit = 24;
-            }
-            else if (game.gamestate == GAMEMODE || game.gamestate == MAPMODE || game.gamestate == TELEPORTERMODE)
-            {
-                timesteplimit = game.gameframerate;
-            }
-            else
-            {
-                timesteplimit = 34;
-            }
-
-            while (accumulator >= timesteplimit)
-            {
-                accumulator = fmodf(accumulator, timesteplimit);
-
-                key.Poll();
-                if(key.toggleFullscreen)
+                if(!gameScreen.isWindowed)
                 {
-                    if(!gameScreen.isWindowed)
-                    {
-                        SDL_ShowCursor(SDL_DISABLE);
-                        SDL_ShowCursor(SDL_ENABLE);
-                    }
-                    else
-                    {
-                        SDL_ShowCursor(SDL_ENABLE);
-                    }
-
-
-                    if(game.gamestate == EDITORMODE)
-                    {
-                        SDL_ShowCursor(SDL_ENABLE);
-                    }
-
-                    gameScreen.toggleFullScreen();
-                    game.fullscreen = !game.fullscreen;
-                    key.toggleFullscreen = false;
-
-                    key.keymap.clear(); //we lost the input due to a new window.
-                    game.press_left = false;
-                    game.press_right = false;
-                    game.press_action = true;
-                    game.press_map = false;
-                }
-
-                if(!game.infocus)
-                {
-                    Mix_Pause(-1);
-                    Mix_PauseMusic();
-
-                    if (!game.blackout)
-                    {
-                        FillRect(graphics.backBuffer, 0x00000000);
-                        graphics.bprint(5, 110, "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
-                        graphics.bprint(5, 120, "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
-                        graphics.bprint(5, 220, "Press M to mute in game", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
-                        graphics.bprint(5, 230, "Press N to mute music only", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
-                    }
-                    graphics.render();
-                    gameScreen.FlipScreen();
-                    //We are minimised, so lets put a bit of a delay to save CPU
-                    SDL_Delay(100);
+                    SDL_ShowCursor(SDL_DISABLE);
+                    SDL_ShowCursor(SDL_ENABLE);
                 }
                 else
                 {
-                    Mix_Resume(-1);
-                    Mix_ResumeMusic();
-                    game.gametimer++;
-                    graphics.cutscenebarstimer();
+                    SDL_ShowCursor(SDL_ENABLE);
+                }
 
-                    switch(game.gamestate)
-                    {
-                    case PRELOADER:
-                        preloaderlogic();
-                        break;
+
+                if(game.gamestate == EDITORMODE)
+                {
+                    SDL_ShowCursor(SDL_ENABLE);
+                }
+
+                gameScreen.toggleFullScreen();
+                game.fullscreen = !game.fullscreen;
+                key.toggleFullscreen = false;
+
+                key.keymap.clear(); //we lost the input due to a new window.
+                game.press_left = false;
+                game.press_right = false;
+                game.press_action = true;
+                game.press_map = false;
+            }
+
+            if(!game.infocus)
+            {
+                Mix_Pause(-1);
+                Mix_PauseMusic();
+
+                if (!game.blackout)
+                {
+                    FillRect(graphics.backBuffer, 0x00000000);
+                    graphics.bprint(5, 110, "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
+                    graphics.bprint(5, 120, "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
+                    graphics.bprint(5, 220, "Press M to mute in game", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+                    graphics.bprint(5, 230, "Press N to mute music only", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+                }
+                graphics.render();
+                gameScreen.FlipScreen();
+                //We are minimised, so lets put a bit of a delay to save CPU
+                SDL_Delay(100);
+            }
+            else
+            {
+                Mix_Resume(-1);
+                Mix_ResumeMusic();
+                game.gametimer++;
+                graphics.cutscenebarstimer();
+
+                switch(game.gamestate)
+                {
+                case PRELOADER:
+                    preloaderlogic();
+                    break;
 #if !defined(NO_CUSTOM_LEVELS)
-                    case EDITORMODE:
-                        graphics.flipmode = false;
-                        //Input
-                        editorinput();
-                        ////Logic
-                        editorlogic();
-                        break;
+                case EDITORMODE:
+                    graphics.flipmode = false;
+                    //Input
+                    editorinput();
+                    ////Logic
+                    editorlogic();
+                    break;
 #endif
-                    case TITLEMODE:
-                        //Input
-                        titleinput();
-                        ////Logic
-                        titlelogic();
-                        break;
-                    case GAMEMODE:
+                case TITLEMODE:
+                    //Input
+                    titleinput();
+                    ////Logic
+                    titlelogic();
+                    break;
+                case GAMEMODE:
+                    if (script.running)
+                    {
+                        script.run();
+                    }
+
+                    //Update old positions of entities - has to be done BEFORE gameinput!
+                    for (size_t i = 0; i < obj.entities.size(); i++)
+                    {
+                        obj.entities[i].oldxp = obj.entities[i].xp;
+                        obj.entities[i].oldyp = obj.entities[i].yp;
+                    }
+
+                    gameinput();
+                    gamelogic();
+
+
+                    break;
+                case MAPMODE:
+                    mapinput();
+                    maplogic();
+                    break;
+                case TELEPORTERMODE:
+                    if(game.useteleporter)
+                    {
+                        teleporterinput();
+                    }
+                    else
+                    {
                         if (script.running)
                         {
                             script.run();
                         }
-
-                        //Update old positions of entities - has to be done BEFORE gameinput!
-                        for (size_t i = 0; i < obj.entities.size(); i++)
-                        {
-                            obj.entities[i].oldxp = obj.entities[i].xp;
-                            obj.entities[i].oldyp = obj.entities[i].yp;
-                        }
-
                         gameinput();
-                        gamelogic();
-
-
-                        break;
-                    case MAPMODE:
-                        mapinput();
-                        maplogic();
-                        break;
-                    case TELEPORTERMODE:
-                        if(game.useteleporter)
-                        {
-                            teleporterinput();
-                        }
-                        else
-                        {
-                            if (script.running)
-                            {
-                                script.run();
-                            }
-                            gameinput();
-                        }
-                        maplogic();
-                        break;
-                    case GAMECOMPLETE:
-                        //Input
-                        gamecompleteinput();
-                        //Logic
-                        gamecompletelogic();
-                        break;
-                    case GAMECOMPLETE2:
-                        //Input
-                        gamecompleteinput2();
-                        //Logic
-                        gamecompletelogic2();
-                        break;
-                    case CLICKTOSTART:
-                        break;
-                    default:
-
-                        break;
-
                     }
+                    maplogic();
+                    break;
+                case GAMECOMPLETE:
+                    //Input
+                    gamecompleteinput();
+                    //Logic
+                    gamecompletelogic();
+                    break;
+                case GAMECOMPLETE2:
+                    //Input
+                    gamecompleteinput2();
+                    //Logic
+                    gamecompletelogic2();
+                    break;
+                case CLICKTOSTART:
+                    break;
+                default:
+
+                    break;
 
                 }
 
-                //Screen effects timers
-                if (game.infocus && game.flashlight > 0)
-                {
-                    game.flashlight--;
-                }
-                if (game.infocus && game.screenshake > 0)
-                {
-                    game.screenshake--;
-                    graphics.updatescreenshake();
-                }
+            }
 
-                if (graphics.screenbuffer->badSignalEffect)
-                {
-                    UpdateFilter();
-                }
+            //Screen effects timers
+            if (game.infocus && game.flashlight > 0)
+            {
+                game.flashlight--;
+            }
+            if (game.infocus && game.screenshake > 0)
+            {
+                game.screenshake--;
+                graphics.updatescreenshake();
+            }
 
-                //We did editorinput, now it's safe to turn this off
-                key.linealreadyemptykludge = false;
+            if (graphics.screenbuffer->badSignalEffect)
+            {
+                UpdateFilter();
+            }
 
-                if (game.savemystats)
-                {
-                    game.savemystats = false;
-                    game.savestats();
-                }
+            //We did editorinput, now it's safe to turn this off
+            key.linealreadyemptykludge = false;
 
-                //Mute button
+            if (game.savemystats)
+            {
+                game.savemystats = false;
+                game.savestats();
+            }
+
+            //Mute button
 #if !defined(NO_CUSTOM_LEVELS)
-                bool inEditor = ed.textentry || ed.scripthelppage == 1;
+            bool inEditor = ed.textentry || ed.scripthelppage == 1;
 #else
-                bool inEditor = false;
+            bool inEditor = false;
 #endif
-                if (key.isDown(KEYBOARD_m) && game.mutebutton<=0 && !inEditor)
-                {
-                    game.mutebutton = 8;
-                    if (game.muted)
-                    {
-                        game.muted = false;
-                    }
-                    else
-                    {
-                        game.muted = true;
-                    }
-                }
-                if(game.mutebutton>0)
-                {
-                    game.mutebutton--;
-                }
-
-                if (key.isDown(KEYBOARD_n) && game.musicmutebutton <= 0 && !inEditor)
-                {
-                    game.musicmutebutton = 8;
-                    game.musicmuted = !game.musicmuted;
-                }
-                if (game.musicmutebutton > 0)
-                {
-                    game.musicmutebutton--;
-                }
-
+            if (key.isDown(KEYBOARD_m) && game.mutebutton<=0 && !inEditor)
+            {
+                game.mutebutton = 8;
                 if (game.muted)
                 {
-                    Mix_VolumeMusic(0) ;
-                    Mix_Volume(-1,0);
+                    game.muted = false;
                 }
                 else
                 {
-                    Mix_Volume(-1,MIX_MAX_VOLUME);
-
-                    if (game.musicmuted || game.completestop)
-                    {
-                        Mix_VolumeMusic(0);
-                    }
-                    else
-                    {
-                        Mix_VolumeMusic(MIX_MAX_VOLUME);
-                    }
+                    game.muted = true;
                 }
-
-                if (key.resetWindow)
-                {
-                    key.resetWindow = false;
-                    gameScreen.ResizeScreen(-1, -1);
-                }
-
-                music.processmusic();
-                graphics.processfade();
-                game.gameclock();
             }
-            const float alpha = game.over30mode ? static_cast<float>(accumulator) / timesteplimit : 1.0f;
-            graphics.alpha = alpha;
-
-            if (game.infocus)
+            if(game.mutebutton>0)
             {
-                switch (game.gamestate)
-                {
-                case PRELOADER:
-                    preloaderrender();
-                    break;
-                case EDITORMODE:
-                    graphics.flipmode = false;
-                    editorrender();
-                    break;
-                case TITLEMODE:
-                    titlerender();
-                    break;
-                case GAMEMODE:
-                    gamerender();
-                    break;
-                case MAPMODE:
-                    maprender();
-                    break;
-                case TELEPORTERMODE:
-                    teleporterrender();
-                    break;
-                case GAMECOMPLETE:
-                    gamecompleterender();
-                    break;
-                case GAMECOMPLETE2:
-                    gamecompleterender2();
-                    break;
-                case CLICKTOSTART:
-                    help.updateglow();
-                    break;
-                }
-                gameScreen.FlipScreen();
+                game.mutebutton--;
             }
+
+            if (key.isDown(KEYBOARD_n) && game.musicmutebutton <= 0 && !inEditor)
+            {
+                game.musicmutebutton = 8;
+                game.musicmuted = !game.musicmuted;
+            }
+            if (game.musicmutebutton > 0)
+            {
+                game.musicmutebutton--;
+            }
+
+            if (game.muted)
+            {
+                Mix_VolumeMusic(0) ;
+                Mix_Volume(-1,0);
+            }
+            else
+            {
+                Mix_Volume(-1,MIX_MAX_VOLUME);
+
+                if (game.musicmuted || game.completestop)
+                {
+                    Mix_VolumeMusic(0);
+                }
+                else
+                {
+                    Mix_VolumeMusic(MIX_MAX_VOLUME);
+                }
+            }
+
+            if (key.resetWindow)
+            {
+                key.resetWindow = false;
+                gameScreen.ResizeScreen(-1, -1);
+            }
+
+            music.processmusic();
+            graphics.processfade();
+            game.gameclock();
         }
+        const float alpha = game.over30mode ? static_cast<float>(accumulator) / timesteplimit : 1.0f;
+        graphics.alpha = alpha;
+
+        if (game.infocus)
+        {
+            switch (game.gamestate)
+            {
+            case PRELOADER:
+                preloaderrender();
+                break;
+            case EDITORMODE:
+                graphics.flipmode = false;
+                editorrender();
+                break;
+            case TITLEMODE:
+                titlerender();
+                break;
+            case GAMEMODE:
+                gamerender();
+                break;
+            case MAPMODE:
+                maprender();
+                break;
+            case TELEPORTERMODE:
+                teleporterrender();
+                break;
+            case GAMECOMPLETE:
+                gamecompleterender();
+                break;
+            case GAMECOMPLETE2:
+                gamecompleterender2();
+                break;
+            case CLICKTOSTART:
+                help.updateglow();
+                break;
+            }
+            gameScreen.FlipScreen();
+        }
+    }
 }

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -9,7 +9,7 @@ int pre_darkcol=0, pre_lightcol=0, pre_curcol=0, pre_coltimer=0, pre_offset=0;
 int pre_frontrectx=30, pre_frontrecty=20, pre_frontrectw=260, pre_frontrecth=200;
 int pre_temprectx=0, pre_temprecty=0, pre_temprectw=320, pre_temprecth=240;
 
-void preloaderrender()
+void preloaderlogic()
 {
   if (pre_transition < 30) pre_transition--;
   if(pre_transition>=30){
@@ -25,6 +25,12 @@ void preloaderrender()
       pre_curcol = (pre_curcol + int(fRandom() * 5.0f)) % 6;
       pre_coltimer = 8;
     }
+  }
+}
+
+void preloaderrender()
+{
+  if(pre_transition>=30){
     switch(pre_curcol) {
     case 0:
       pre_lightcol = graphics.RGBflip(0xBF,0x59,0x6F);

--- a/desktop_version/src/preloader.h
+++ b/desktop_version/src/preloader.h
@@ -7,4 +7,6 @@
 
 void preloaderrender();
 
+void preloaderlogic();
+
 #endif /* PRELOADER_H */


### PR DESCRIPTION
## Changes:

VVVVVV is a game that runs at 1000/34 frames per second, which is approximately 29.4 frames a second, which is close to, but not quite, 30 frames a second. This odd number comes from the fact that the amount of times it takes for each frame is coded to be 34 milliseconds, and not 33.333333333... milliseconds.

This pull request unlocks VVVVVV's framecap of 1000/34 FPS. It does this in such a way that the underlying engine still runs at an actual framerate of 1000/34 FPS (which we should be calling tickrate now), and in between each actual frame we just draw what the frames in between each frame *should* be, using something called "linear interpolation". So now the game will visually run at the same rate as your monitor (my monitor is 60hz, I'm not a true gamer :( &#x200b; &#x200b; &#x200b; &#x200b; ).

What's linear interpolation, you might ask? Well it's basically like drawing a straight line between two points on a graph. But it's more akin to averaging something. All the rendering does is go like, "Ok so on this frame, we have 2, and on the next frame, we have 4. What's the average of 2 and 4? Why, it's 3! So we should draw a frame using 3."

This approach means that the underlying physics isn't changed, which is a very good thing because if I changed the physics around to update at, say, twice the speed but with half the values, that would run the risk of breaking custom levels. Also, it's easier to do it this way because it requires changing less values, although it does require disentangling all pieces of update code from render code so as to make sure things don't update as quickly as possible. And regardless of those concerns, this approach is the cleanest imo, since the physics don't subtly change depending on your refresh rate (unlike games like Super Meat Boy, which apparently [desyncs TASes depending on if your refresh rate is 59hz or 60hz](/clementgallet/libTAS/issues/220), oh and also different resolutions have different refresh rates, good luck).

Oh, and by the way, the Switch version (made by some weird company named Nicalis) actually does the screw-up-the-physics approach instead of what I'm doing. They've apparently had to change some custom levels because the way they did it broke things like edge-flipping. Maddening.

Most of the work I took was from [Colon-D's fork of VVVVVV attempting to run it at over 30 FPS](/Colon-D/VVVVVV-over-30-FPS). However, his mod is incomplete (for example, the title screen still runs at 1000/34 FPS) and also does some things inefficiently (like re-drawing warp backgrounds every single frame, instead of scrolling a surface + incoming textures after drawing an initial background). Also it hasn't been updated in months.

This patch also seems to improve the 100 milliseconds of `SDL_Delay` the unfocus-pause gives, in that it actually seems to have an effect now and be noticeable when you re-focus (possibly because before we were using `SDL_Delay` as the frame limiter, too, and I guess one of them kind of canceled the other out?).

To enable this, you need to go into "graphic options" and turn on the "toggle fps" option. You can turn on "toggle vsync" as well if you feel like it, too.

Honestly, after playing the game at 60 FPS, it feels really strange to play the game at normal 30 FPS.

#99 is already closed, but seems relevant to mention in this PR.

(Current base commit ID for this PR: 62441edbc9b279d4e37ea6a640f376288ffc8417)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
