### PR TITLE
Fix the menu that you land on when you complete game or custom level

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -2105,6 +2105,7 @@ void Game::updatestate()
                 if(!muted && ed.levmusic>0) music.fadeMusicVolumeIn(3000);
             }
             graphics.showcutscenebars = false;
+            returntomenu(Menu::levellist);
             break;
 #endif
         case 1014:

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -109,6 +109,7 @@ void gamecompletelogic2()
         game.gamestate = TITLEMODE;
         graphics.fademode = 4;
         music.playef(18);
+        game.returntomenu(Menu::play);
         game.createmenu(Menu::gamecompletecontinue);
         map.nexttowercolour();
     }


### PR DESCRIPTION
## Changes:

When you complete the game, you're now redirected to the play menu. This is because your quicksave will have been deleted so you can't go back to the summary menu.

When you complete a custom level, you'll go back to the levels list, in case you started the level from a quicksave.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
