### PR TITLE
Fix copy-paste bug in command-line playtesting code

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5196,7 +5196,7 @@ void Game::customloadquick(std::string savfile)
 {
     if (cliplaytest) {
         savex = playx;
-        savey = savey;
+        savey = playy;
         saverx = playrx;
         savery = playry;
         savegc = playgc;


### PR DESCRIPTION
## Changes:

Found this because when I compiled with Clang, -Wself-assign-field was
enabled.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
