### PR TITLE
Re-draw tower background when dying in No Death Mode

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2534,6 +2534,7 @@ void scriptclass::resetgametomenu()
 	graphics.flipmode = false;
 	obj.entities.clear();
 	graphics.fademode = 4;
+	map.tdrawback = true;
 	game.createmenu(Menu::gameover);
 }
 


### PR DESCRIPTION
## Changes:

Otherwise, if you died after entering a room with a horizontal or vertical warp background (but not the all-sides warp background), the warp background would be the first thing you see when going to the Game Over screen, and would then start scrolling downwards with the proper tower background coming in from the top.

This oversight seems to have always been in the game.

Was No Death Mode actually tested? Like, did anyone ever play through the entire game without dying in the Warp Zone, or even *after* completing the Warp Zone, like, ever? Seems like if someone ever did do that, this oversight would've been fixed already.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
