### PR TITLE
Add towermode checks to minitowermode screen transitions

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -256,7 +256,7 @@ void gamelogic()
             map.bypos = 0;
             map.bscroll = 0;
         }
-        if (map.minitowermode)
+        if (map.towermode && map.minitowermode)
         {
             if (map.ypos >= 568)
             {
@@ -963,7 +963,7 @@ void gamelogic()
         }
 
         //Right so! Screenwraping for tower:
-        if (map.minitowermode)
+        if (map.towermode && map.minitowermode)
         {
             if (map.scrolldir == 1)
             {


### PR DESCRIPTION
## Changes:

Apparently, the game just leaves minitowermode on, which can cause issues if you're in a horizontal warping room (and not any other room type, due to how frame ordering works). This would manifest itself as a wrong warp to (20,20) because the game is trying to apply the hardcoded minitower screen transitions when it shouldn't be, and the map wrapping would just put you back at (20,20).

Closes #226.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
