### PR TITLE
Rename "start" option to "new game"

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7045,7 +7045,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
                 }
                 else
                 {
-                    option("start");
+                    option("new game");
                 }
                 //ok, secret lab! no notification, but test:
                 if (unlock[8])


### PR DESCRIPTION
By popular request.

![rename_start_to_new_game_aizu_dms](https://user-images.githubusercontent.com/59748578/81220959-07af8b00-8f97-11ea-9f75-731bd79e4daf.png)

![rename_start_to_new_game_space-station-1](https://user-images.githubusercontent.com/59748578/81220973-0b431200-8f97-11ea-9e6d-1da2631c4190.png)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
