### PR TITLE
Fix being able to interrupt the exiting-to-menu fadeout and remove pressing Esc when the screen is fully black taking you to the main menu no matter what

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1336,44 +1336,7 @@ void Game::updatestate()
             if(graphics.fademode == 1)	state++;
             break;
         case 81:
-            gamestate = TITLEMODE;
-            graphics.fademode = 4;
-            music.play(6);
-            graphics.backgrounddrawn = false;
-            map.tdrawback = true;
-            graphics.flipmode = false;
-            //Don't be stuck on the summary screen,
-            //or "who do you want to play the level with?"
-            //or "do you want cutscenes?"
-            //or the confirm-load-quicksave menu
-            if (wasintimetrial)
-            {
-                returntomenu(Menu::timetrials);
-            }
-            else if (wasinintermission)
-            {
-                returntomenu(Menu::intermissionmenu);
-            }
-            else if (wasinnodeathmode)
-            {
-                returntomenu(Menu::playmodes);
-            }
-            else if (wasincustommode)
-            {
-                returntomenu(Menu::levellist);
-            }
-            else if (save_exists() || anything_unlocked())
-            {
-                returntomenu(Menu::play);
-            }
-            else
-            {
-                createmenu(Menu::mainmenu);
-            }
-            wasintimetrial = false;
-            wasinintermission = false;
-            wasinnodeathmode = false;
-            wasincustommode = false;
+            quittomenu();
             state = 0;
             break;
 
@@ -7357,4 +7320,46 @@ bool Game::anything_unlocked()
 bool Game::save_exists()
 {
     return telesummary != "" || quicksummary != "";
+}
+
+void Game::quittomenu()
+{
+    gamestate = TITLEMODE;
+    graphics.fademode = 4;
+    music.play(6);
+    graphics.backgrounddrawn = false;
+    map.tdrawback = true;
+    graphics.flipmode = false;
+    //Don't be stuck on the summary screen,
+    //or "who do you want to play the level with?"
+    //or "do you want cutscenes?"
+    //or the confirm-load-quicksave menu
+    if (wasintimetrial)
+    {
+        returntomenu(Menu::timetrials);
+    }
+    else if (wasinintermission)
+    {
+        returntomenu(Menu::intermissionmenu);
+    }
+    else if (wasinnodeathmode)
+    {
+        returntomenu(Menu::playmodes);
+    }
+    else if (wasincustommode)
+    {
+        returntomenu(Menu::levellist);
+    }
+    else if (save_exists() || anything_unlocked())
+    {
+        returntomenu(Menu::play);
+    }
+    else
+    {
+        createmenu(Menu::mainmenu);
+    }
+    wasintimetrial = false;
+    wasinintermission = false;
+    wasinnodeathmode = false;
+    wasincustommode = false;
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -372,6 +372,8 @@ void Game::init(void)
 
     fadetomenu = false;
     fadetomenudelay = 0;
+    fadetolab = false;
+    fadetolabdelay = 0;
 
     /* Terry's Patrons... */
     superpatrons.push_back("Anders Ekermo");

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -135,7 +135,6 @@ void Game::init(void)
 
     teleportscript = "";
     savemystats = false;
-    menukludge = false;
     quickrestartkludge = false;
 
     tapleft = 0;
@@ -230,11 +229,6 @@ void Game::init(void)
     playcustomlevel=0;
     customleveltitle="";
     createmenu(Menu::mainmenu);
-
-    wasintimetrial = false;
-    wasinintermission = false;
-    wasinnodeathmode = false;
-    wasincustommode = false;
 
     deathcounts = 0;
     gameoverdelay = 0;
@@ -7334,19 +7328,19 @@ void Game::quittomenu()
     //or "who do you want to play the level with?"
     //or "do you want cutscenes?"
     //or the confirm-load-quicksave menu
-    if (wasintimetrial)
+    if (intimetrial)
     {
         returntomenu(Menu::timetrials);
     }
-    else if (wasinintermission)
+    else if (inintermission)
     {
         returntomenu(Menu::intermissionmenu);
     }
-    else if (wasinnodeathmode)
+    else if (nodeathmode)
     {
         returntomenu(Menu::playmodes);
     }
-    else if (wasincustommode)
+    else if (map.custommode)
     {
         returntomenu(Menu::levellist);
     }
@@ -7358,8 +7352,5 @@ void Game::quittomenu()
     {
         createmenu(Menu::mainmenu);
     }
-    wasintimetrial = false;
-    wasinintermission = false;
-    wasinnodeathmode = false;
-    wasincustommode = false;
+    script.hardreset();
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1461,10 +1461,7 @@ void Game::updatestate()
             if(graphics.fademode == 1)	state++;
             break;
         case 97:
-            gamestate = GAMEMODE;
-            graphics.fademode = 4;
-            startscript = true;
-            newscript="returntolab";
+            returntolab();
             state = 0;
             break;
 
@@ -7353,4 +7350,12 @@ void Game::quittomenu()
         createmenu(Menu::mainmenu);
     }
     script.hardreset();
+}
+
+void Game::returntolab()
+{
+    gamestate = GAMEMODE;
+    graphics.fademode = 4;
+    startscript = true;
+    newscript="returntolab";
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7361,6 +7361,25 @@ void Game::returntolab()
 {
     gamestate = GAMEMODE;
     graphics.fademode = 4;
-    startscript = true;
-    newscript="returntolab";
+    map.gotoroom(119, 107);
+    int player = obj.getplayer();
+    if (player > -1)
+    {
+        obj.entities[player].xp = 132;
+        obj.entities[player].yp = 137;
+    }
+    gravitycontrol = 0;
+
+    savepoint = 0;
+    saverx = 119;
+    savery = 107;
+    savex = 132;
+    savey = 137;
+    savegc = 0;
+    if (player > -1)
+    {
+        savedir = obj.entities[player].dir;
+    }
+
+    music.play(11);
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -117,7 +117,6 @@ void Game::init(void)
 {
     mutebutton = 0;
     infocus = true;
-    paused = false;
     muted = false;
     musicmuted = false;
     musicmutebutton = 0;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -370,6 +370,9 @@ void Game::init(void)
     playry = 0;
     playgc = 0;
 
+    fadetomenu = false;
+    fadetomenudelay = 0;
+
     /* Terry's Patrons... */
     superpatrons.push_back("Anders Ekermo");
     superpatrons.push_back("Andreas K|mper");

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -381,6 +381,8 @@ public:
 
     void quittomenu();
     void returntolab();
+    bool fadetomenu;
+    int fadetomenudelay;
 };
 
 extern Game game;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -354,8 +354,6 @@ public:
     bool menukludge;
     bool quickrestartkludge;
 
-    bool paused;
-
     //Custom stuff
     std::string customscript[50];
     int customcol;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -383,6 +383,8 @@ public:
     void returntolab();
     bool fadetomenu;
     int fadetomenudelay;
+    bool fadetolab;
+    int fadetolabdelay;
 };
 
 extern Game game;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -234,12 +234,6 @@ public:
 
     int creditposx, creditposy, creditposdelay;
 
-    //Menu kludge...
-    bool wasintimetrial;
-    bool wasinintermission;
-    bool wasinnodeathmode;
-    bool wasincustommode;
-
 
     //Sine Wave Ninja Minigame
     bool swnmode;
@@ -351,7 +345,6 @@ public:
     int stretchMode;
     int controllerSensitivity;
 
-    bool menukludge;
     bool quickrestartkludge;
 
     //Custom stuff

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -380,6 +380,7 @@ public:
     int playgc;
 
     void quittomenu();
+    void returntolab();
 };
 
 extern Game game;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -385,6 +385,8 @@ public:
     int playrx;
     int playry;
     int playgc;
+
+    void quittomenu();
 };
 
 extern Game game;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1971,8 +1971,7 @@ void mapinput()
         if (game.menupage == 11 && game.press_action)
         {
             //quit to menu
-            if (graphics.fademode == 0)
-            {
+
                 //Kill contents of offset render buffer, since we do that for some reason.
                 //This fixes an apparent frame flicker.
                 FillRect(graphics.tempBuffer, 0x000000);
@@ -1981,7 +1980,6 @@ void mapinput()
                 map.nexttowercolour();
                 game.fadetomenu = true;
                 game.fadetomenudelay = 15;
-            }
         }
 
         if (game.menupage == 20 && game.press_action)
@@ -1992,14 +1990,11 @@ void mapinput()
         if (game.menupage == 21 && game.press_action)
         {
             //quit to menu
-            if (graphics.fademode == 0)
-            {
                 game.swnmode = false;
                 graphics.fademode = 2;
                 music.fadeout();
                 game.fadetolab = true;
                 game.fadetolabdelay = 15;
-            }
         }
 
         if (game.menupage < 0) game.menupage = 3;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1545,6 +1545,7 @@ void gameinput()
                 game.completestop = false;
                 game.state = 0;
                 graphics.showcutscenebars = false;
+                graphics.fademode = 0;
 
                 graphics.backgrounddrawn=false;
                 music.fadeout();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1879,7 +1879,6 @@ void mapinput()
         graphics.resumegamemode = true;
         obj.removeallblocks();
         game.activeactivity = -1;
-        game.menukludge = false;
         if (game.menupage >= 20)
         {
             game.state = 96;
@@ -1968,13 +1967,6 @@ void mapinput()
                 //Kill contents of offset render buffer, since we do that for some reason.
                 //This fixes an apparent frame flicker.
                 FillRect(graphics.tempBuffer, 0x000000);
-                if (game.intimetrial || game.insecretlab || game.nodeathmode) game.menukludge = true;
-                game.wasintimetrial = game.intimetrial;
-                game.wasinintermission = game.inintermission;
-                game.wasinnodeathmode = game.nodeathmode;
-                game.wasincustommode = map.custommode;
-                script.hardreset();
-                if(graphics.setflipmode) graphics.flipmode = true;
                 graphics.fademode = 2;
                 music.fadeout();
                 map.nexttowercolour();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1972,14 +1972,14 @@ void mapinput()
         {
             //quit to menu
 
-                //Kill contents of offset render buffer, since we do that for some reason.
-                //This fixes an apparent frame flicker.
-                FillRect(graphics.tempBuffer, 0x000000);
-                graphics.fademode = 2;
-                music.fadeout();
-                map.nexttowercolour();
-                game.fadetomenu = true;
-                game.fadetomenudelay = 15;
+            //Kill contents of offset render buffer, since we do that for some reason.
+            //This fixes an apparent frame flicker.
+            FillRect(graphics.tempBuffer, 0x000000);
+            graphics.fademode = 2;
+            music.fadeout();
+            map.nexttowercolour();
+            game.fadetomenu = true;
+            game.fadetomenudelay = 15;
         }
 
         if (game.menupage == 20 && game.press_action)
@@ -1990,11 +1990,11 @@ void mapinput()
         if (game.menupage == 21 && game.press_action)
         {
             //quit to menu
-                game.swnmode = false;
-                graphics.fademode = 2;
-                music.fadeout();
-                game.fadetolab = true;
-                game.fadetolabdelay = 15;
+            game.swnmode = false;
+            graphics.fademode = 2;
+            music.fadeout();
+            game.fadetolab = true;
+            game.fadetolabdelay = 15;
         }
 
         if (game.menupage < 0) game.menupage = 3;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1812,6 +1812,19 @@ void mapinput()
     game.press_action = false;
     game.press_map = false;
 
+    if (game.fadetomenu)
+    {
+        if (game.fadetomenudelay > 0)
+        {
+            game.fadetomenudelay--;
+        }
+        else
+        {
+            game.quittomenu();
+            game.fadetomenu = false;
+        }
+    }
+
     if(graphics.menuoffset==0)
     {
         if (graphics.flipmode)
@@ -1970,6 +1983,8 @@ void mapinput()
                 graphics.fademode = 2;
                 music.fadeout();
                 map.nexttowercolour();
+                game.fadetomenu = true;
+                game.fadetomenudelay = 15;
             }
         }
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1825,6 +1825,19 @@ void mapinput()
         }
     }
 
+    if (game.fadetolab)
+    {
+        if (game.fadetolabdelay > 0)
+        {
+            game.fadetolabdelay--;
+        }
+        else
+        {
+            game.returntolab();
+            game.fadetolab = false;
+        }
+    }
+
     if(graphics.menuoffset==0)
     {
         if (graphics.flipmode)
@@ -2001,6 +2014,8 @@ void mapinput()
                 game.swnmode = false;
                 graphics.fademode = 2;
                 music.fadeout();
+                game.fadetolab = true;
+                game.fadetolabdelay = 15;
             }
         }
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1900,24 +1900,6 @@ void mapinput()
         }
     }
 
-    if (graphics.fademode == 1)
-    {
-        FillRect(graphics.menubuffer, 0x000000);
-        graphics.resumegamemode = true;
-        obj.removeallblocks();
-        game.activeactivity = -1;
-        if (game.menupage >= 20)
-        {
-            game.state = 96;
-            game.statedelay = 0;
-        }
-        else
-        {
-            game.state = 80;
-            game.statedelay = 0;
-        }
-    }
-
     if (!game.jumpheld)
     {
         if (game.press_action || game.press_left || game.press_right || game.press_map)

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2460,7 +2460,10 @@ void maprender()
 
 
 
-    graphics.drawfade();
+    if (graphics.fademode == 3 || graphics.fademode == 5)
+    {
+        graphics.drawfade();
+    }
 
     if (graphics.resumegamemode)
     {

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2353,7 +2353,7 @@ void maprender()
 
         if (graphics.flipmode)
         {
-            if (game.intimetrial || game.insecretlab || game.nodeathmode || game.menukludge)
+            if (game.intimetrial || game.insecretlab || game.nodeathmode)
             {
                 graphics.Print(0, 135, "Return to main menu?", 196, 196, 255 - help.glow, true);
             }
@@ -2369,7 +2369,7 @@ void maprender()
         else
         {
 
-            if (game.intimetrial || game.insecretlab || game.nodeathmode || game.menukludge)
+            if (game.intimetrial || game.insecretlab || game.nodeathmode)
             {
                 graphics.Print(0, 80, "Return to main menu?", 196, 196, 255 - help.glow, true);
             }
@@ -2389,7 +2389,7 @@ void maprender()
 
         if (graphics.flipmode)
         {
-            if (game.intimetrial || game.insecretlab || game.nodeathmode || game.menukludge)
+            if (game.intimetrial || game.insecretlab || game.nodeathmode)
             {
                 graphics.Print(0, 135, "Return to main menu?", 196, 196, 255 - help.glow, true);
             }
@@ -2404,7 +2404,7 @@ void maprender()
         }
         else
         {
-            if (game.intimetrial || game.insecretlab || game.nodeathmode || game.menukludge)
+            if (game.intimetrial || game.insecretlab || game.nodeathmode)
             {
                 graphics.Print(0, 80, "Return to main menu?", 196, 196, 255 - help.glow, true);
             }


### PR DESCRIPTION
Currently, quitting to the menu is kind of a kludge-filled mess. There are numerous issues with it:

1. You can sometimes interrupt the exit-to-menu fadeout. This seems to happen most often in towers, and it does so without you having to do any crazy hijinks or anything. It just always gets interrupted in towers for whatever reason.

2. As a hacky workaround, if the fadeout has been interrupted and you're on a black screen, you can press Esc to manually resume the fadeout and get back to the title screen. This "fix" seems to have been made somewhat intentionally.

3. ...But this hacky workaround is *always* active whenever you're on a black screen, and *not* just when you're fading out to the menu and getting interrupted. If you're fully blacked out during a cutscene, make sure not to hit Esc accidentally, or you'll be booted back to the title screen!

4. Oh, and it seems like this hack is *so* pervasive that pressing Esc while you're faded out *in playtesting mode* won't return you to the editor, it'll return you to the main menu! Hope you didn't need to save your hard work or anything...

5. Also, hm, why do activity zone prompts, "- Press ENTER to Teleport -", and trophy text show up during the fadeout, if you're standing in one? They don't show up on the pause screen, so why here?

What you're about to see is that exiting to the menu is a giant janky Rube Goldberg kludge, mostly because for some reason it just *insists* on using Terry's State Machine to do its work, and then the entire code path has to route around all the problems that causes. Oh and there's an aggressive `script.hardreset()` right as you press ACTION to quit, which doesn't help either.

Here's how the current system does it:

1. When you press ACTION on "yes, quit to menu", `script.hardreset()` gets called and the game starts fading out (fademode 2).

2. Then when the game is fully faded out (fademode 1), it sets the gamestate to 80. However, we have a problem. MAPMODE doesn't have a `game.updatestate()`, the only time it's used is in `gamelogic()`. (And we probably shouldn't put a `game.updatestate()` in there anyway, doing that would mean the gamestate wouldn't be paused on the quit/pause/teleporter screens.)

   So what does the game do instead? It sets `graphics.resumegamemode` to true. This is simply a variable that signals "okay, we should bring the pause screen down".

3. Then the code for bringing the pause screen down is ran. It has to wait through the *entire* bringing-menu-down animation before the game-gamestate (which is `game.gamestate`, and is *not* the gamestate for Terry's State Machine, which is `game.state`) is *finally* set to GAMEMODE. This results in 15 unnecessary frames of a black screen.

4. Alright, we're now in GAMEMODE, we can run `game.updatestate()` and then get booted back to the title screen.

So in summary: the game wants to use gamestate 80, however it can't run gamestates on the pause screen (oh and on a side note, it also aggressively runs `script.hardreset()` right when you press ACTION to quit to the menu, which we'll get to later). So what it does instead is it brings down the pause screen after the screen fades out, thus being able to run the gamestate. To summarize, the game *has* to bring down the pause screen in order to be able to go back to the title screen, which is a direct consequence of using the state machine.

And with that, let me explain all the numerous issues above:

 - You can interrupt the fadeout, because it takes you back to GAMEMODE for a short bit in order to run it (the return-to-menu gamestate) in `gamelogic()`. There are many, *many* other things that use the state machine, such as script boxes, teleporters, both gravitrons. By going back to GAMEMODE like this, any number of things could interrupt the fadeout.

   But the case is especially bad in towers, mostly due to the aggressive `script.hardreset()`. One of the things that `script.hardreset()` does is turn `map.towermode` off.

   This then means that when `gamelogic()` is run, the game thinks that you're no longer in a tower, and when it takes a look at your y-position, it thinks "Oh crap you're wayyyy off-screen! You should be going to the adjacent room over!"

   Then it calls `map.gotoroom()`. One of the things that `map.gotoroom()` does is set the gamestate to 0 (which is simply a state for doing nothing):

   ```cpp
    //a very special case: if entering the communication room, room 13,4 before tag 5 is set, set the game state to a background
    //textbox thingy. if tag five is not set when changing room, reset the game state. (tag 5 is set when you get back to the ship)
    if(!game.intimetrial && !custommode)
    {
        if (!obj.flags[5] && !finalmode)
        {
            game.state = 0;
            if (game.roomx == 113 && game.roomy == 104)
            {
                game.state = 50;
            }
        }
    }
   ```

   So wait, if you've already entered Comms Relay (flag 5 would be on), or you're in Outside Dimension VVVVVV (`finalmode` would be on), or you're in a time trial, or you're in a custom level, the gamestate wouldn't be set to 0, right?

   Wrong. Remember that `script.hardreset()` from earlier? Yeah, it means that (1) `game.intimetrial` is off, (2) `finalmode` is also off, (3) flag 5 is also off, and (4) `custommode` is also off at this point in time.

   *If a `gotoroom()` happens while you're fading out to the menu, your fadeout will be interrupted.*

   So all that means is that the only time your fadeout *won't* be interrupted when exiting to the menu from inside a tower is when you're at the top of it. This explains issue 1.

 - Step 2 (doing something when the game is fully blacked out) fully explains issues 2, 3, and 4. The thing is, MAPMODE checks if the game is fully faded out *at all times*, even when you're bringing up or down the quit/pause/teleporter screen.

   If your fadeout has been interrupted and you're fully blacked-out, when you press Esc, all you're doing is just moving the game back to the MAPMODE game-gamestate. Then you're letting MAPMODE run its course, and it notices that the screen is fully blacked out, and it thinks "Well this must mean we're going back to the main menu." This janky workaround wasn't intentionally added at all, it naturally arose from this entire Rube Goldberg kludge of code!

   Same thing when pressing Esc in playtesting mode (here you can press Enter too because Enter also returns to the editor). To return to the menu from the editor, EDITORMODE fades out, and then uses fademode 1 to go back to TITLEMODE. When you exit playtesting while in fademode 1, it isn't reset, and so EDITORMODE thinks that you're in the middle of fading out to the title screen, and thus goes back to the title screen.

 - And since fading to the menu requires going back to GAMEMODE, that's why "- Press ENTER to Teleport -", activity zone prompts, and trophy text show up when you're fading out. Issue 5 is explained.

And now here's what I do to fix all these issues:

 - Exiting to the menu no longer relies on `graphics.fademode` nor `game.state`. Instead it uses `game.fadetomenu` (bool) and `game.fadetomenudelay` (int). (Same with returning to the Secret Lab when in the Super Gravitron since there's an obvious visual glitch when you do so, which I also fixed. It uses variables `game.fadetolab` (bool) and `game.fadetolabdelay` (int).)

   - This means that `fademode` is no longer relied upon, so if you're blacked out when you press Esc to bring up the quit screen, you won't suddenly quit to the menu. And this means you can no longer accidentally press Esc *during a cutscene* to immediately return to the title screen without warning (well, you can still accidentally press Esc, but at least there's a prompt).

   - More importantly, it also means you can no longer interrupt the exit-to-menu fadeout, since the logic is all self-contained in MAPMODE and the game no longer has to go back to GAMEMODE at all!

 - Also, the aggressive `script.hardreset()` *right* as you press ACTION has got to go. I moved it to right when the game switches back to the title screen, after all the fading out is done. That way all the menu kludge variables are gone, too, which is cleaner.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
