### PR TITLE
Fix flag 67 turning on too early

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -3282,8 +3282,6 @@ void Game::updatestate()
             i = obj.getplayer();
             obj.entities[i].colour = 102;
 
-            obj.flags[67] = true;
-
             state++;
             statedelay = 30;
             flashlight = 5;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -102,6 +102,7 @@ void gamecompletelogic2()
         game.deletequick();
         int tmp=music.currentsong;
         music.currentsong=4;
+        obj.flags[67] = true;
         game.savetele();
         music.currentsong=tmp;
         //Return to game


### PR DESCRIPTION
Flag 67 seems to be a general-purpose Game Complete flag. It's used to replace the CREW option with the SHIP option on the pause screen.

Unfortunately, it gets turned on too early during Game Complete. Right when Viridian starts to teleport, you can bring up the pause screen and select the SHIP option.

It will teleport you to the ship coordinates, but still keep you in finalmode, and since the ship coordinates are at 102,111 (finalmode is only around 46,54), you'll still be stuck in Outside Dimension VVVVVV, and you've interrupted the Game Complete gamestate by switching to the teleporting gamestate. Oh, and your checkpoint is set, too, so you can't even press R. Oh and since there's no teleporter, and checkpoint setting doesn't check the sentinel value, this results in Undefined Behavior, too.

So this results in an in-game softlock. The only option you can do is quit the game at this point.

To fix this issue, just move turning on flag 67 to before the `savetele()` in `gamecompletelogic2()`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
