### PR TITLE
Call game.savestats() when setting new Super Gravitron record

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -395,6 +395,7 @@ void gamelogic()
                     if (game.swnmessage == 0) music.playef(25);
                     game.swnmessage = 1;
                     game.swnrecord = game.swntimer;
+                    game.savestats();
                 }
             }
         }


### PR DESCRIPTION
This is to be extra safe and ensure that your hard-earned record isn't lost at all.

In 2.2, the game didn't save your Super Gravitron record at all. It only saved it if you closed the game by quitting to the title screen and pressing ACTION on "quit game". You couldn't press Alt+F4, and you couldn't press X, you had to do it that way, otherwise your record would be lost.

In 2.3 right now, the game *will* save your `unlock.vvv` when you close the game gracefully by any means, but this still means that if it doesn't otherwise close gracefully (like, say, a crash), it won't save your record. It feels like we shouldn't rely on this catch-all saving to save Super Gravitron records.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
