### PR TITLE
Reset vvvvvvman size in mapclass::resetplayer()

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -833,6 +833,10 @@ void mapclass::resetplayer()
 		obj.entities[i].colour = 0;
 		game.lifeseq = 10;
 		obj.entities[i].invis = true;
+		obj.entities[i].size = 0;
+		obj.entities[i].cx = 6;
+		obj.entities[i].cy = 2;
+		obj.entities[i].h = 21;
 
 		// If we entered a tower as part of respawn, reposition camera
 		if (!was_in_tower && towermode)


### PR DESCRIPTION
It's a bit annoying how vvvvvvman status is preserved between in-game sessions if the script command `undovvvvvvman()` isn't called, and the only thing reset is the color. This is annoying because it means you have to close the game to reset vvvvvvman.

But now it'll be reset properly. I chose to put this reset code in `mapclass::resetplayer()` instead of `scriptclass::hardreset()` because it seemed like the more appropriate place. It's where all other properties of the player are reset, after all.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
