### PR TITLE
Fix H/V warp BGs not resetting and some 1-frame glitches when returning to editor from playtesting

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -375,6 +375,10 @@ void Game::init(void)
     fadetolab = false;
     fadetolabdelay = 0;
 
+#if !defined(NO_CUSTOM_LEVELS)
+    shouldreturntoeditor = false;
+#endif
+
     /* Terry's Patrons... */
     superpatrons.push_back("Anders Ekermo");
     superpatrons.push_back("Andreas K|mper");

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7381,3 +7381,30 @@ void Game::returntolab()
 
     music.play(11);
 }
+
+#if !defined(NO_CUSTOM_LEVELS)
+void Game::returntoeditor()
+{
+    game.gamestate = EDITORMODE;
+
+    graphics.textboxremove();
+    game.hascontrol = true;
+    game.advancetext = false;
+    game.completestop = false;
+    game.state = 0;
+    graphics.showcutscenebars = false;
+    graphics.fademode = 0;
+
+    graphics.backgrounddrawn=false;
+    music.fadeout();
+    //If warpdir() is used during playtesting, we need to set it back after!
+    for (int j = 0; j < ed.maxheight; j++)
+    {
+        for (int i = 0; i < ed.maxwidth; i++)
+        {
+           ed.level[i+(j*ed.maxwidth)].warpdir=ed.kludgewarpdir[i+(j*ed.maxwidth)];
+        }
+    }
+    map.scrolldir = 0;
+}
+#endif

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -385,6 +385,10 @@ public:
     int fadetomenudelay;
     bool fadetolab;
     int fadetolabdelay;
+
+#if !defined(NO_CUSTOM_LEVELS)
+    void returntoeditor();
+#endif
 };
 
 extern Game game;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -388,6 +388,7 @@ public:
 
 #if !defined(NO_CUSTOM_LEVELS)
     void returntoeditor();
+    bool shouldreturntoeditor;
 #endif
 };
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1537,7 +1537,7 @@ void gameinput()
                    game.activeactivity = -1;
                }
             }else{
-                game.returntoeditor();
+                game.shouldreturntoeditor = true;
             }
         }
     }

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1537,27 +1537,7 @@ void gameinput()
                    game.activeactivity = -1;
                }
             }else{
-                game.gamestate = EDITORMODE;
-
-                graphics.textboxremove();
-                game.hascontrol = true;
-                game.advancetext = false;
-                game.completestop = false;
-                game.state = 0;
-                graphics.showcutscenebars = false;
-                graphics.fademode = 0;
-
-                graphics.backgrounddrawn=false;
-                music.fadeout();
-                //If warpdir() is used during playtesting, we need to set it back after!
-                for (int j = 0; j < ed.maxheight; j++)
-                {
-                    for (int i = 0; i < ed.maxwidth; i++)
-                    {
-                       ed.level[i+(j*ed.maxwidth)].warpdir=ed.kludgewarpdir[i+(j*ed.maxwidth)];
-                    }
-                }
-                map.scrolldir = 0;
+                game.returntoeditor();
             }
         }
     }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1380,4 +1380,12 @@ void gamelogic()
 
     if (game.teleport_to_new_area)
         script.teleport();
+
+#if !defined(NO_CUSTOM_LEVELS)
+    if (game.shouldreturntoeditor)
+    {
+        game.shouldreturntoeditor = false;
+        game.returntoeditor();
+    }
+#endif
 }


### PR DESCRIPTION
This PR fixes a few issues:

 - Horizontal and vertical warp backgrounds do not get reset when returning to editor, which results in background desync if you exit playtesting into a different room in the editor. This is despite `graphics.backgrounddrawn` being set to false when you exit playtesting...

 - Cutscene bars start to disappear for 1 frame when you exit playtesting, if you have them up.

 - Fadeout transitions suddenly disappear for 1 frame when you exit playtesting, if there is one.

This happens because editor returning is done directly in `gameinput()`, but then after that `gamerender()` and `gamelogic()` is still ran. Thus, this results in 1 more frame of the game running after things are supposed to be reset, which means the game will still render horizontal and vertical warp backgrounds, which means `graphics.backgrounddrawn` is set to true again. This is also why the 1-frame glitches with cutscene bars and fadeouts happen too.

To solve all these issues, just move the resetting-to-editor code to the end of the frame, which means at the very bottom of `gamelogic()`.

I've attached a level where you can test this out to see the difference.

* [returning_to_editor_test.zip](https://github.com/TerryCavanagh/VVVVVV/files/4604405/returning_to_editor_test.zip)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
