### PR TITLE
Fix 1x1 quicksand collision optimization not working

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4685,10 +4685,10 @@ void entityclass::entitycollisioncheck()
                     {
                         //ok; only check the actual collision if they're in a close proximity
                         temp = entities[i].yp - entities[j].yp;
-                        if (temp < 30 || temp > -30)
+                        if (temp > -30 && temp < 30)
                         {
                             temp = entities[i].xp - entities[j].xp;
-                            if (temp < 30 || temp > -30)
+                            if (temp > -30 && temp < 30)
                             {
                                 if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
                             }

--- a/mobile_version/src/entityclass.as
+++ b/mobile_version/src/entityclass.as
@@ -3851,9 +3851,9 @@
 							if (entities[j].onentity > 0) {
 								//ok; only check the actual collision if they're in a close proximity
 								temp = entities[i].yp - entities[j].yp;
-								if (temp < 30 || temp > -30) {
+								if (temp > -30 && temp < 30) {
 									temp = entities[i].xp - entities[j].xp;
-									if (temp < 30 || temp > -30) {
+									if (temp > -30 && temp < 30) {
 										if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
 									}
 								}


### PR DESCRIPTION
## Changes:

We need to replace an "or" with an "and".

My best guess for this oversight happening was because of the weird ordering. The code originally did `temp < 30` first and `temp > -30` second instead of the other way around. With the weird ordering, it becomes more natural to insert an "or" instead of an "and". So I swapped around the ordering just for good measure.

This is also fixed in the mobile version, too.

Closes #237.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
