### PR TITLE
Remove graphics.drawgui() from maprender()

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1666,8 +1666,6 @@ void gamerender()
 
 void maprender()
 {
-    graphics.drawgui();
-
     //draw screen alliteration
     //Roomname:
     int temp = map.area(game.roomx, game.roomy);


### PR DESCRIPTION
Since this is at the start of `maprender()`, the text boxes drawn by this function will get hidden behind everything else being drawn on top of it. Thus, it'll only result in a glitchy rendering where the text boxes at the very top of the screen will be rendered in the roomname space of the map screen.

![Glitchy text box rendering](https://user-images.githubusercontent.com/59748578/81970180-f2a8ac80-95d3-11ea-9f37-ccee17253974.png)

To fix this rendering glitch, just remove the `drawgui()`. It's useless anyway since it's being drawn behind everything else, so no need to have it here.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
