### PR TITLE
Don't duplicate activity zone handling code in playtesting

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1527,17 +1527,12 @@ void gameinput()
 #if !defined(NO_CUSTOM_LEVELS)
     if(map.custommode && !map.custommodeforreal){
         if ((game.press_map || key.isDown(27)) && !game.mapheld){
-            game.mapheld = true;
             //Return to level editor
             if (game.activeactivity > -1 && game.press_map){
-               if((int(std::abs(obj.entities[obj.getplayer()].vx))<=1) && (int(obj.entities[obj.getplayer()].vy) == 0) )
-               {
-                   script.load(obj.blocks[game.activeactivity].script);
-                   obj.removeblock(game.activeactivity);
-                   game.activeactivity = -1;
-               }
+                //pass, let code block below handle it
             }else{
                 game.shouldreturntoeditor = true;
+                game.mapheld = true;
             }
         }
     }


### PR DESCRIPTION
This change makes it so that in in-editor playtesting, the code to handle pressing ENTER on activity zones is the same code to handle pressing ENTER on activity zones in `custommodeforreal`.

This removes the need to copy-paste code and adapt it to in-editor playtesting. And thus, this fixes an editor artifact where you can press ENTER on activity zones while doing the death animation, even though you can't do that when you're playing custom levels normally.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
