### PR TITLE
Fix FILESYSTEM_openDirectory command used on Haiku and *BSD

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -486,10 +486,10 @@ bool FILESYSTEM_openDirectory(const char *dname)
 	return true;
 }
 #elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__HAIKU__) || defined(__DragonFly__)
- #ifdef __linux__
-const char* open_cmd = "xdg-open";
- #else
+ #if defined(__APPLE__) || defined(__HAIKU__)
 const char* open_cmd = "open";
+ #else
+const char* open_cmd = "xdg-open";
  #endif
 
 extern "C" char** environ;


### PR DESCRIPTION
Previously:
 - Linux: `xdg-open`
 - Everything else: `open`

Now:
 - macOS and Haiku: `open`
 - Everything else: `xdg-open`

This is all according to [a comment](/TerryCavanagh/VVVVVV/pull/203#issuecomment-616222350) by @leo60228 in PR #203.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
