### PR TITLE
Fix <hardestroom> having atoi() called on it when loading quicksave

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5118,7 +5118,7 @@ void Game::loadquick()
         }
         else if (pKey == "hardestroom")
         {
-            hardestroom = atoi(pText);
+            hardestroom = pText;
         }
         else if (pKey == "hardestroomdeaths")
         {
@@ -5387,7 +5387,7 @@ void Game::customloadquick(std::string savfile)
         }
         else if (pKey == "hardestroom")
         {
-            hardestroom = atoi(pText);
+            hardestroom = pText;
         }
         else if (pKey == "hardestroomdeaths")
         {


### PR DESCRIPTION
For some reason (probably a copy-paste error), this XML tag gets `atoi()` called on it before being assigned to `Game::hardestroom`. And only when loading a quicksave, at that.

This would result in `Game::hardestroom` being set to an empty string, which if you kept until Game Complete, would end up rendering as a single null byte (if you even have a font face for said null byte).

I'm not sure how this error compiles in the first place, but whatever.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
