### PR TITLE
Re-create menu if returntomenu() is given current menu

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7357,6 +7357,11 @@ void Game::quittomenu()
     else if (save_exists() || anything_unlocked())
     {
         returntomenu(Menu::play);
+        if (!insecretlab)
+        {
+            //Select "continue"
+            currentmenuoption = 0;
+        }
     }
     else
     {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6583,7 +6583,13 @@ void Game::returntomenu(enum Menu::MenuName t)
 {
     if (currentmenuname == t)
     {
-        //Why are you calling this function then?
+        //Re-create the menu
+        int keep_menu_option = currentmenuoption;
+        createmenu(t, true);
+        if (keep_menu_option < (int) menuoptions.size())
+        {
+            currentmenuoption = keep_menu_option;
+        }
         return;
     }
 


### PR DESCRIPTION
This fixes a bug where if you had the play menu in a state where the first option was "new game", then kept playing up until a quicksave or telesave was created, then quit to the menu, the menu wouldn't update. Thanks to KSSBrawl for reporting this bug to me: https://cdn.discordapp.com/attachments/708567577978470410/712060797924147240/untitled.webm

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
