### PR TITLE
Fix a few menu inconsistencies

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1103,11 +1103,18 @@ void menuactionpress()
         }
         else if (game.currentmenuoption == 3 && game.unlock[18])    //enable/disable flip mode
         {
-            music.playef(18);
-            game.screenshake = 10;
-            game.flashlight = 5;
             graphics.setflipmode = !graphics.setflipmode;
             game.savemystats = true;
+            if (graphics.setflipmode)
+            {
+                music.playef(18);
+                game.screenshake = 10;
+                game.flashlight = 5;
+            }
+            else
+            {
+                music.playef(11);
+            }
         }
         else if (game.currentmenuoption == 4)
         {

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -137,6 +137,7 @@ void menuactionpress()
             if (!game.save_exists() && !game.anything_unlocked())
             {
                 //No saves exist, just start a new game
+                music.playef(11);
                 game.mainmenu = 0;
                 graphics.fademode = 2;
             }
@@ -244,10 +245,12 @@ void menuactionpress()
         switch (game.currentmenuoption)
         {
         case 0: //continue save
+            music.playef(11);
             game.mainmenu = 23;
             graphics.fademode = 2;
             break;
         case 1:
+            music.playef(11);
             game.mainmenu = 22;
             graphics.fademode = 2;
             break;
@@ -958,18 +961,21 @@ void menuactionpress()
             if (!game.save_exists())
             {
                 //You have no saves but have something unlocked, or you couldn't have gotten here
+                music.playef(11);
                 game.mainmenu = 0;
                 graphics.fademode = 2;
             }
             else if (game.telesummary == "")
             {
                 //You at least have a quicksave, or you couldn't have gotten here
+                music.playef(11);
                 game.mainmenu = 2;
                 graphics.fademode = 2;
             }
             else if (game.quicksummary == "")
             {
                 //You at least have a telesave, or you couldn't have gotten here
+                music.playef(11);
                 game.mainmenu = 1;
                 graphics.fademode = 2;
             }
@@ -984,6 +990,7 @@ void menuactionpress()
         else if (game.currentmenuoption == 1 && game.unlock[8])
         {
             if(!map.invincibility && game.slowdown == 30){
+                music.playef(11);
                 game.mainmenu = 11;
                 graphics.fademode = 2;
             }else{
@@ -1019,6 +1026,7 @@ void menuactionpress()
         {
         case 0:
             //yep
+            music.playef(11);
             game.mainmenu = 0;
             graphics.fademode = 2;
             game.deletequick();
@@ -1118,10 +1126,12 @@ void menuactionpress()
         switch (game.currentmenuoption)
         {
         case 0:   //start no death mode, disabling cutscenes
+            music.playef(11);
             game.mainmenu = 10;
             graphics.fademode = 2;
             break;
         case 1:
+            music.playef(11);
             game.mainmenu = 9;
             graphics.fademode = 2;
             break;
@@ -1137,10 +1147,12 @@ void menuactionpress()
         switch (game.currentmenuoption)
         {
         case 0:
+            music.playef(11);
             game.mainmenu = 1;
             graphics.fademode = 2;
             break;
         case 1:
+            music.playef(11);
             game.mainmenu = 2;
             graphics.fademode = 2;
             break;
@@ -1179,18 +1191,22 @@ void menuactionpress()
         switch (game.currentmenuoption)
         {
         case 0:
+            music.playef(11);
             game.mainmenu = 12;
             graphics.fademode = 2;
             break;
         case 1:
+            music.playef(11);
             game.mainmenu = 13;
             graphics.fademode = 2;
             break;
         case 2:
+            music.playef(11);
             game.mainmenu = 14;
             graphics.fademode = 2;
             break;
         case 3:
+            music.playef(11);
             game.mainmenu = 15;
             graphics.fademode = 2;
             break;
@@ -1206,18 +1222,22 @@ void menuactionpress()
         switch (game.currentmenuoption)
         {
         case 0:
+            music.playef(11);
             game.mainmenu = 16;
             graphics.fademode = 2;
             break;
         case 1:
+            music.playef(11);
             game.mainmenu = 17;
             graphics.fademode = 2;
             break;
         case 2:
+            music.playef(11);
             game.mainmenu = 18;
             graphics.fademode = 2;
             break;
         case 3:
+            music.playef(11);
             game.mainmenu = 19;
             graphics.fademode = 2;
             break;
@@ -1249,31 +1269,37 @@ void menuactionpress()
     case Menu::timetrials:
         if (game.currentmenuoption == 0 && game.unlock[9])   //space station 1
         {
+            music.playef(11);
             game.mainmenu = 3;
             graphics.fademode = 2;
         }
         else if (game.currentmenuoption == 1 && game.unlock[10])    //lab
         {
+            music.playef(11);
             game.mainmenu = 4;
             graphics.fademode = 2;
         }
         else if (game.currentmenuoption == 2 && game.unlock[11])    //tower
         {
+            music.playef(11);
             game.mainmenu = 5;
             graphics.fademode = 2;
         }
         else if (game.currentmenuoption == 3 && game.unlock[12])    //station 2
         {
+            music.playef(11);
             game.mainmenu = 6;
             graphics.fademode = 2;
         }
         else if (game.currentmenuoption == 4 && game.unlock[13])    //warp
         {
+            music.playef(11);
             game.mainmenu = 7;
             graphics.fademode = 2;
         }
         else if (game.currentmenuoption == 5 && game.unlock[14])    //final
         {
+            music.playef(11);
             game.mainmenu = 8;
             graphics.fademode = 2;
         }
@@ -1313,31 +1339,37 @@ void menuactionpress()
             //duplicate the above based on given time trial level!
             if (game.timetriallevel == 0)   //space station 1
             {
+                music.playef(11);
                 game.mainmenu = 3;
                 graphics.fademode = 2;
             }
             else if (game.timetriallevel == 1)    //lab
             {
+                music.playef(11);
                 game.mainmenu = 4;
                 graphics.fademode = 2;
             }
             else if (game.timetriallevel == 2)    //tower
             {
+                music.playef(11);
                 game.mainmenu = 5;
                 graphics.fademode = 2;
             }
             else if (game.timetriallevel == 3)    //station 2
             {
+                music.playef(11);
                 game.mainmenu = 6;
                 graphics.fademode = 2;
             }
             else if (game.timetriallevel == 4)    //warp
             {
+                music.playef(11);
                 game.mainmenu = 7;
                 graphics.fademode = 2;
             }
             else if (game.timetriallevel == 5)    //final
             {
+                music.playef(11);
                 game.mainmenu = 8;
                 graphics.fademode = 2;
             }


### PR DESCRIPTION
Just fixing things that were a bit inconsistent.

## Changes:

- **Make all gamemode starts play a Viridan squeak**

  It's always personally irked me that the only time you get a Viridian squeak when pressing ACTION to start fading out and going in-game is when you start playing a custom level. And that's only if you don't have a quicksave.

  To make things more consistent (and to add more polish to the game), I made sure there was a `music.playef(11)` every time `game.mainmenu` gets set. I also made sure that this doesn't result in double-squeaking, i.e. `music.playef(11)` being called twice, which can be very loud and ear-hurting.

- **When toggling Flip Mode, only flash and shake screen when enabling it**

  It's a bit inconsistent how every time you toggle flip mode, it does this flashing and shaking (and different SFX), regardless of whether or not you're turning it on or off. To be more consistent with what happens when you toggle screen effects, only turning on Flip Mode should do the flashing/shaking/game-saved sound, and turning it off should just play the Viridian squeak.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
