### PR TITLE
Simplify inits/resets in entityclass/mapclass

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -78,10 +78,8 @@ void entityclass::init()
 
 void entityclass::resetallflags()
 {
-    for (int i = 0; i < 100; i++)
-    {
-        flags[i] = false;
-    }
+    flags.clear();
+    flags.resize(100);
 }
 
 int entityclass::swncolour( int t )

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -59,32 +59,16 @@ mapclass::mapclass()
 		vmult.push_back(int(i * 40));
 	}
 	//We create a blank map
-	for (int j = 0; j < 30; j++)
-	{
-		for (int i = 0; i < 40; i++)
-		{
-			contents.push_back(0);
-		}
-	}
+	contents.resize(40 * 30);
 
-	for (int j = 0; j < 20; j++)
-	{
-		for (int i = 0; i < 20; i++)
-		{
-			areamap.push_back(0);
-			roomdeaths.push_back(0);
-			roomdeathsfinal.push_back(0);
-			explored.push_back(0);
-		}
-	}
+	roomdeaths.resize(20 * 20);
+	roomdeathsfinal.resize(20 * 20);
+	explored.resize(20 * 20);
 
 	tileset = 0;
 	initmapdata();
 
-	for (int i = 0; i < 8; i++)
-	{
-		specialnames.push_back(std::string());
-	}
+	specialnames.resize(8);
 	resetnames();
 
 	//Areamap starts at 100,100 and extends 20x20
@@ -110,7 +94,6 @@ mapclass::mapclass()
 	2,2,2,2,2,0,0,2,0,3,0,0,0,0,0,0,0,0,0,0,
 	2,2,2,2,2,0,0,2,0,3,0,0,0,0,0,0,0,0,0,0,
 	};
-	areamap.clear();
 	areamap.insert(areamap.end(), tmap, tmap+400);
 }
 
@@ -143,13 +126,8 @@ void mapclass::settrinket(int x, int y)
 void mapclass::resetmap()
 {
 	//clear the explored area of the map
-	for (int j = 0; j < 20; j++)
-	{
-		for (int i = 0; i < 20; i++)
-		{
-			explored[i + (j * 20)] = 0;
-		}
-	}
+	explored.clear();
+	explored.resize(20 * 20);
 }
 
 void mapclass::resetnames()

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3536,15 +3536,12 @@ void scriptclass::hardreset()
 	map.scrolldir = 0;
 	map.customshowmm=true;
 
-	for (j = 0; j < 20; j++)
-	{
-		for (i = 0; i < 20; i++)
-		{
-			map.roomdeaths[i + (j * 20)] = 0;
-			map.roomdeathsfinal[i + (j * 20)] = 0;
-			map.explored[i + (j * 20)] = 0;
-		}
-	}
+	map.roomdeaths.clear();
+	map.roomdeaths.resize(20 * 20);
+	map.roomdeathsfinal.clear();
+	map.roomdeathsfinal.resize(20 * 20);
+	map.explored.clear();
+	map.explored.resize(20 * 20);
 	//entityclass
 	obj.nearelephant = false;
 	obj.upsetmode = false;
@@ -3554,20 +3551,18 @@ void scriptclass::hardreset()
 	obj.trophytype = 0;
 	obj.altstates = 0;
 
-	for (i = 0; i < 100; i++)
-	{
-		obj.flags[i] = false;
-	}
+	obj.flags.clear();
+	obj.flags.resize(100);
 
 	for (i = 0; i < 6; i++){
 		obj.customcrewmoods[i]=1;
 	}
 
-	for (i = 0; i < 100; i++)
-	{
-		obj.collect[i] = false;
-		obj.customcollect[i] = false;
-	}
+	obj.collect.clear();
+	obj.collect.resize(100);
+	obj.customcollect.clear();
+	obj.customcollect.resize(100);
+	i = 100; //previously a for-loop iterating over collect/customcollect set this to 100
 
 	if (obj.getplayer() > -1){
 		obj.entities[obj.getplayer()].tile = 0;


### PR DESCRIPTION
Instead of using somewhat-obtuse for-loops to initialize or reset these vectors, it takes up less lines of code and is clearer if we use `std::vector::resize()` and `std::vector::clear()` instead.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
