### PR TITLE
Add bounds checks to roomdeaths and roomdeathsfinal

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4799,13 +4799,19 @@ void Game::deathsequence()
         obj.entities[i].invis = true;
         if (map.finalmode)
         {
-            map.roomdeathsfinal[roomx - 41 + (20 * (roomy - 48))]++;
-            currentroomdeaths = map.roomdeathsfinal[roomx - 41 + (20 * (roomy - 48))];
+            if (roomx - 41 >= 0 && roomx - 41 < 20 && roomy - 48 >= 0 && roomy - 48 < 20)
+            {
+                map.roomdeathsfinal[roomx - 41 + (20 * (roomy - 48))]++;
+                currentroomdeaths = map.roomdeathsfinal[roomx - 41 + (20 * (roomy - 48))];
+            }
         }
         else
         {
-            map.roomdeaths[roomx - 100 + (20*(roomy - 100))]++;
-            currentroomdeaths = map.roomdeaths[roomx - 100 + (20 * (roomy - 100))];
+            if (roomx - 100 >= 0 && roomx - 100 < 20 && roomy - 100 >= 0 && roomy - 100 < 20)
+            {
+                map.roomdeaths[roomx - 100 + (20*(roomy - 100))]++;
+                currentroomdeaths = map.roomdeaths[roomx - 100 + (20 * (roomy - 100))];
+            }
         }
     }
     if (deathseq == 25) obj.entities[i].invis = true;


### PR DESCRIPTION
This fixes being able to trigger Undefined Behavior by pressing R when not in-bounds in the Outside Dimension VVVVVV map, usually when you're falling upwards towards Game Complete.

I also put bounds checks on normal `roomdeaths` for good measure. You'll never know when you need it.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
