### PR TITLE
Don't draw "Game paused" when in blackout mode

### DIFF
--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -382,11 +382,14 @@ int main(int argc, char *argv[])
             Mix_Pause(-1);
             Mix_PauseMusic();
 
-            FillRect(graphics.backBuffer, 0x00000000);
-            graphics.bprint(5, 110, "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
-            graphics.bprint(5, 120, "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
-            graphics.bprint(5, 220, "Press M to mute in game", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
-            graphics.bprint(5, 230, "Press N to mute music only", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+            if (!game.blackout)
+            {
+                FillRect(graphics.backBuffer, 0x00000000);
+                graphics.bprint(5, 110, "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
+                graphics.bprint(5, 120, "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
+                graphics.bprint(5, 220, "Press M to mute in game", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+                graphics.bprint(5, 230, "Press N to mute music only", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+            }
             graphics.render();
             //We are minimised, so lets put a bit of a delay to save CPU
             SDL_Delay(100);


### PR DESCRIPTION
Blackout mode doesn't work properly, because the game doesn't actually black out the screen, it merely stops drawing things. Oh and only some things at that, some other things are still drawn. This results in a freeze-frame effect, which is apparently fixed in the Switch version. Custom levels utilize this freeze-frame effect, so it's a bit annoying that the "Game paused" screen draws on top of it and makes it so that the freeze-frame freezes on "Game paused" until blackout is turned off.

So I'm making it so that "Game paused" doesn't get drawn in blackout mode. However it will still do `graphics.render()` because otherwise it'll just result in a black screen.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
