### PR TITLE
Allow crewmate to be cyan when initially placing it down

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -4948,7 +4948,7 @@ void editorinput()
                             {
                                 if(ed.numcrewmates()<100)
                                 {
-                                    addedentity(ed.tilex+ (ed.levx*40),ed.tiley+ (ed.levy*30),15,1 + int(fRandom() * 5));
+                                    addedentity(ed.tilex+ (ed.levx*40),ed.tiley+ (ed.levy*30),15,int(fRandom() * 6));
                                     ed.lclickdelay=1;
                                 }
                                 else


### PR DESCRIPTION
For some reason, the only way to get a cyan crewmate is by cycling through an already-existing crewmate by keeping left-clicking on it. This is because when you cycle through crewmate colors, the allowed colors are 0-5, but when you place down a crewmate, it picks a random color from 1-5, which seems to be a bit consistent.

So placing and cycling a crewmate now use the same color ranges.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
