### PR TITLE
Reset game.activeactivity and game.act_fade in scriptclass::hardreset()

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3503,6 +3503,9 @@ void scriptclass::hardreset()
 	game.flashlight = 0;
 	game.screenshake = 0;
 
+	game.activeactivity = -1;
+	game.act_fade = 5;
+
 	//dwgraphicsclass
 	graphics.backgrounddrawn = false;
 	graphics.textboxremovefast();


### PR DESCRIPTION
Resetting `game.activeactivity` fixes triggering Undefined Behavior if you quit to the menu while standing inside an activity zone, and then re-entered the game. Resetting `game.act_fade` also fixes the activity zone prompt fadeout that happens once the above segfault is fixed.

Don't worry, other activity-zone like variables such as teleporter prompts and trophy text are already covered. `obj.trophytext` is reset in `scriptclass::hardreset()`, too, and `game.readytotele` is reset every time `mapclass::gotoroom()` is called, and `mapclass::gotoroom()` is called every time a gamemode is started.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
