### PR TITLE
Remove unnecessary middleman ed.swapmap

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1568,17 +1568,11 @@ void mapclass::loadlevel(int rx, int ry)
 			roomname=ed.level[curlevel].roomname;
 		}
 		extrarow = 1;
-		ed.loadlevel(rx, ry);
+		contents = ed.loadlevel(rx, ry);
 
 
 		roomtexton = false;
 		roomtext.clear();
-
-		for (int edj = 0; edj < 30; edj++){
-			for(int edi = 0; edi < 40; edi++){
-			contents[edi + vmult[edj]] = ed.swapmap[edi + vmult[edj]];
-			}
-		}
 
 		//Entities have to be created HERE, akwardly
 		int tempcheckpoints=0;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -52,14 +52,6 @@ editorclass::editorclass()
         }
     }
 
-    for (int j = 0; j < 30; j++)
-    {
-        for (int i = 0; i < 40; i++)
-        {
-            swapmap.push_back(0);
-        }
-    }
-
     for (int i = 0; i < 30 * maxheight; i++)
     {
         vmult.push_back(int(i * 40 * maxwidth));
@@ -532,7 +524,7 @@ void editorclass::insertline(int t)
     sb.insert(sb.begin() + t, "");
 }
 
-void editorclass::loadlevel( int rxi, int ryi )
+std::vector<int> editorclass::loadlevel( int rxi, int ryi )
 {
     //Set up our buffer array to be picked up by mapclass
     rxi -= 100;
@@ -542,13 +534,17 @@ void editorclass::loadlevel( int rxi, int ryi )
     if(rxi>=mapwidth)rxi-=mapwidth;
     if(ryi>=mapheight)ryi-=mapheight;
 
+    std::vector<int> result;
+
     for (int j = 0; j < 30; j++)
     {
         for (int i = 0; i < 40; i++)
         {
-            swapmap[i+(j*40)]=contents[i+(rxi*40)+vmult[j+(ryi*30)]];
+            result.push_back(contents[i+(rxi*40)+vmult[j+(ryi*30)]]);
         }
     }
+
+    return result;
 }
 
 int editorclass::getlevelcol(int t)

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -95,7 +95,7 @@ class editorclass{
 
   void saveconvertor();
   void reset();
-  void loadlevel(int rxi, int ryi);
+  std::vector<int> loadlevel(int rxi, int ryi);
 
   void placetile(int x, int y, int t);
 
@@ -147,7 +147,6 @@ class editorclass{
   int getwarpbackground(int rx, int ry);
 
   std::vector<std::string> getLevelDirFileNames( );
-  std::vector <int> swapmap;
   std::vector <int> contents;
   std::vector <int> vmult;
   int numtrinkets();


### PR DESCRIPTION
When the game loads a room in a custom level, previously it would load the tilemap of that room into `ed.swapmap`, and then `mapclass::loadlevel()` would manually go through each element in `ed.swapmap` to set each tile in `contents`. Why do that, when you can just return the vector from `editorclass::loadlevel()` and set it directly? `ed.swapmap` is really unnecessary.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
