### PR TITLE
 Fix using `speak`/`speak_active` without a `text` beforehand

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -573,9 +573,10 @@ void scriptclass::run()
 			{
 				if(graphics.flipmode) texty += 2*(120 - texty) - 8*(txt.size()+2);
 			}
-			else if (words[0] == "speak_active")
+			else if (words[0] == "speak_active" || words[0] == "speak")
 			{
 				//Ok, actually display the textbox we've initilised now!
+				//If using "speak", don't make the textbox active (so we can use multiple textboxes)
 				graphics.createtextbox(txt[0], textx, texty, r, g, b);
 				if ((int) txt.size() > 1)
 				{
@@ -606,52 +607,10 @@ void scriptclass::run()
 				}
 
 				graphics.textboxadjust();
-				graphics.textboxactive();
-
-				if (!game.backgroundtext)
+				if (words[0] == "speak_active")
 				{
-					game.advancetext = true;
-					game.hascontrol = false;
-					game.pausescript = true;
-					if (key.isDown(90) || key.isDown(32) || key.isDown(86)
-						|| key.isDown(KEYBOARD_UP) || key.isDown(KEYBOARD_DOWN)) game.jumpheld = true;
+					graphics.textboxactive();
 				}
-				game.backgroundtext = false;
-			}
-			else if (words[0] == "speak")
-			{
-				//Exactly as above, except don't make the textbox active (so we can use multiple textboxes)
-				graphics.createtextbox(txt[0], textx, texty, r, g, b);
-				if ((int) txt.size() > 1)
-				{
-					for (i = 1; i < (int) txt.size(); i++)
-					{
-						graphics.addline(txt[i]);
-					}
-				}
-
-				//the textbox cannot be outside the screen. Fix if it is.
-				if (textx <= -1000)
-				{
-					//position to the left of the player
-					textx += 10000;
-					textx -= graphics.textboxwidth();
-					textx += 16;
-					graphics.textboxmoveto(textx);
-				}
-
-				if (textx == -500 || textx == -1)
-				{
-					graphics.textboxcenterx();
-				}
-
-				if (texty == -500)
-				{
-					graphics.textboxcentery();
-				}
-
-				graphics.textboxadjust();
-				//graphics.textboxactive();
 
 				if (!game.backgroundtext)
 				{

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -577,6 +577,10 @@ void scriptclass::run()
 			{
 				//Ok, actually display the textbox we've initilised now!
 				//If using "speak", don't make the textbox active (so we can use multiple textboxes)
+				if (txt.empty())
+				{
+					txt.resize(1);
+				}
 				graphics.createtextbox(txt[0], textx, texty, r, g, b);
 				if ((int) txt.size() > 1)
 				{


### PR DESCRIPTION
Otherwise, it would end up indexing a vector out-of-bounds, which is UB and causes a segfault, too. This is used in some constructs like

    say(-1)
    <internal command>

where the text contents don't matter, only that a text box shows up.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
