### PR TITLE
Fix vector indexing out-of-bounds if say()/reply()/text() asks for more lines than there are

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -376,7 +376,10 @@ void scriptclass::run()
 				for (int i = 0; i < ss_toi(words[4]); i++)
 				{
 					position++;
-					txt.push_back(commands[position]);
+					if (position < (int) commands.size())
+					{
+						txt.push_back(commands[position]);
+					}
 				}
 			}
 			else if (words[0] == "position")
@@ -3794,7 +3797,10 @@ void scriptclass::loadcustom(std::string t)
 				int ti=atoi(words[1].c_str());
 				int nti = ti>=0 && ti<=50 ? ti : 1;
 				for(int ti2=0; ti2<nti; ti2++){
-					i++; add(customscript[i]);
+					i++;
+					if(i < (int) customscript.size()){
+						add(customscript[i]);
+					}
 				}
 
 				switch(speakermode){
@@ -3816,7 +3822,10 @@ void scriptclass::loadcustom(std::string t)
 				int ti=atoi(words[1].c_str());
 				int nti = ti>=0 && ti<=50 ? ti : 1;
 				for(int ti2=0; ti2<nti; ti2++){
-					i++; add(customscript[i]);
+					i++;
+					if(i < (int) customscript.size()){
+						add(customscript[i]);
+					}
 				}
 				add("position(player,above)");
 				add("speak_active");

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3792,11 +3792,8 @@ void scriptclass::loadcustom(std::string t)
 					break;
 				}
 				int ti=atoi(words[1].c_str());
-				if(ti>=0 && ti<=50){
-					for(int ti2=0; ti2<ti; ti2++){
-						i++; add(customscript[i]);
-					}
-				}else{
+				int nti = ti>=0 && ti<=50 ? ti : 1;
+				for(int ti2=0; ti2<nti; ti2++){
 					i++; add(customscript[i]);
 				}
 
@@ -3817,11 +3814,8 @@ void scriptclass::loadcustom(std::string t)
 				add("text(cyan,0,0,"+words[1]+")");
 
 				int ti=atoi(words[1].c_str());
-				if(ti>=0 && ti<=50){
-					for(int ti2=0; ti2<ti; ti2++){
-						i++; add(customscript[i]);
-					}
-				}else{
+				int nti = ti>=0 && ti<=50 ? ti : 1;
+				for(int ti2=0; ti2<nti; ti2++){
 					i++; add(customscript[i]);
 				}
 				add("position(player,above)");

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3557,12 +3557,12 @@ void scriptclass::loadcustom(std::string t)
 	for(size_t i=0; i<customscript.size(); i++){
 		if(scriptstart==-1){
 			//Find start of the script
-			if(script.customscript[i]==cscriptname+":"){
+			if(customscript[i]==cscriptname+":"){
 				scriptstart=i+1;
 			}
 		}else if(scriptend==-1){
 			//Find the end
-			tstring=script.customscript[i];
+			tstring=customscript[i];
 			if (tstring.size() > 0) {
 				tstring=tstring[tstring.size()-1];
 			} else {
@@ -3581,7 +3581,7 @@ void scriptclass::loadcustom(std::string t)
 		//Ok, we've got the relavent script segment, we do a pass to assess it, then run it!
 		int customcutscenemode=0;
 		for(int i=scriptstart; i<scriptend; i++){
-			tokenize(script.customscript[i]);
+			tokenize(customscript[i]);
 			if(words[0] == "say"){
 				customcutscenemode=1;
 			}else if(words[0] == "reply"){
@@ -3600,7 +3600,7 @@ void scriptclass::loadcustom(std::string t)
 		for(int i=scriptstart; i<scriptend; i++){
 			words[0]="nothing"; //Default!
 			words[1]="1"; //Default!
-			tokenize(script.customscript[i]);
+			tokenize(customscript[i]);
 			std::transform(words[0].begin(), words[0].end(), words[0].begin(), ::tolower);
 			if(words[0] == "music"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
@@ -3712,28 +3712,28 @@ void scriptclass::loadcustom(std::string t)
 				}
 			}else if(words[0] == "delay"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add(script.customscript[i]);
+				add(customscript[i]);
 			}else if(words[0] == "flag"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add(script.customscript[i]);
+				add(customscript[i]);
 			}else if(words[0] == "map"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add("custom"+script.customscript[i]);
+				add("custom"+customscript[i]);
 			}else if(words[0] == "warpdir"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add(script.customscript[i]);
+				add(customscript[i]);
 			}else if(words[0] == "ifwarp"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add(script.customscript[i]);
+				add(customscript[i]);
 			}else if(words[0] == "iftrinkets"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add("custom"+script.customscript[i]);
+				add("custom"+customscript[i]);
 			}else if(words[0] == "ifflag"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add("custom"+script.customscript[i]);
+				add("custom"+customscript[i]);
 			}else if(words[0] == "iftrinketsless"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add("custom"+script.customscript[i]);
+				add("custom"+customscript[i]);
 			}else if(words[0] == "destroy"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
 				if(words[1]=="gravitylines"){
@@ -3794,10 +3794,10 @@ void scriptclass::loadcustom(std::string t)
 				int ti=atoi(words[1].c_str());
 				if(ti>=0 && ti<=50){
 					for(int ti2=0; ti2<ti; ti2++){
-						i++; add(script.customscript[i]);
+						i++; add(customscript[i]);
 					}
 				}else{
-					i++; add(script.customscript[i]);
+					i++; add(customscript[i]);
 				}
 
 				switch(speakermode){
@@ -3819,10 +3819,10 @@ void scriptclass::loadcustom(std::string t)
 				int ti=atoi(words[1].c_str());
 				if(ti>=0 && ti<=50){
 					for(int ti2=0; ti2<ti; ti2++){
-						i++; add(script.customscript[i]);
+						i++; add(customscript[i]);
 					}
 				}else{
-					i++; add(script.customscript[i]);
+					i++; add(customscript[i]);
 				}
 				add("position(player,above)");
 				add("speak_active");


### PR DESCRIPTION
This PR adds bounds checks to those commands in case `say()`/`reply()` asks for more lines than there are left in the all-script-lines buffer (not just the current script, so in order for it to segfault your script has to be last in the all-script-lines vector), and in case `text()` asks for more lines than there are in the rest of the rest of the parsed internal script.

Also some small refactors.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
