### PR TITLE
Fix build with CUSTOM_LEVEL_SUPPORT=DISABLED

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4,6 +4,7 @@
 #include "Graphics.h"
 #include "Entity.h"
 #include "Map.h"
+#include "Script.h"
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
## Changes:

Very small change. `Game.cpp` relied on other headers importing `script.h`, which is not the case when building with `CUSTOM_LEVEL_SUPPORT=DISABLED`


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
