### PR TITLE
Allow for conditional building of Steam and GOG APIs

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -10,6 +10,14 @@ OPTION(ENABLE_WERROR "Treat compilation warnings as errors" OFF)
 SET(CUSTOM_LEVEL_SUPPORT ENABLED CACHE STRING "Optionally disable playing and/or editing of custom levels")
 SET_PROPERTY(CACHE CUSTOM_LEVEL_SUPPORT PROPERTY STRINGS ENABLED NO_EDITOR DISABLED)
 
+SET(STEAM OFF CACHE BOOL "Use the Steam API")
+SET(GOG OFF CACHE BOOL "Use the GOG API")
+
+IF(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+	SET(STEAM ON)
+	SET(GOG ON)
+ENDIF()
+
 # Architecture Flags
 IF(APPLE)
 	# Wow, Apple is a huge jerk these days huh?
@@ -95,11 +103,17 @@ SET(VVV_SRC
 	src/WarpClass.cpp
 	src/main.cpp
 	src/Network.c
-	src/SteamNetwork.c
-	src/GOGNetwork.c
 )
 IF(NOT CUSTOM_LEVEL_SUPPORT STREQUAL "DISABLED")
 	LIST(APPEND VVV_SRC src/editor.cpp)
+ENDIF()
+IF(STEAM)
+	LIST(APPEND VVV_SRC src/SteamNetwork.c)
+	ADD_DEFINITIONS(-DSTEAM_NETWORK)
+ENDIF()
+IF(GOG)
+	LIST(APPEND VVV_SRC src/GOGNetwork.c)
+	ADD_DEFINITIONS(-DGOG_NETWORK)
 ENDIF()
 
 SET(XML_SRC

--- a/desktop_version/src/Network.c
+++ b/desktop_version/src/Network.c
@@ -1,6 +1,19 @@
 #include "Network.h"
 
-#define NUM_BACKENDS 2
+#define UNUSED(expr) (void)(expr)
+
+#ifdef STEAM_NETWORK
+#define STEAM_NUM 1
+#else
+#define STEAM_NUM 0
+#endif
+#ifdef GOG_NETWORK
+#define GOG_NUM 1
+#else
+#define GOG_NUM 0
+#endif
+
+#define NUM_BACKENDS (STEAM_NUM+GOG_NUM)
 #define DECLARE_BACKEND(name) \
 	extern int32_t name##_init(); \
 	extern void name##_shutdown(); \
@@ -8,8 +21,12 @@
 	extern void name##_unlockAchievement(); \
 	extern int32_t name##_getAchievementProgress(const char *name); \
 	extern void name##_setAchievementProgress(const char *name, int32_t stat);
+#ifdef STEAM_NETWORK
 DECLARE_BACKEND(STEAM)
+#endif
+#ifdef GOG_NETWORK
 DECLARE_BACKEND(GOG)
+#endif
 #undef DECLARE_BACKEND
 
 typedef struct NetworkBackend
@@ -23,11 +40,13 @@ typedef struct NetworkBackend
 	void (*SetAchievementProgress)(const char*, int32_t);
 } NetworkBackend;
 
+#if NUM_BACKENDS > 0
 static NetworkBackend backends[NUM_BACKENDS];
+#endif
 
 int NETWORK_init()
 {
-	int32_t i, any = 0;
+	int32_t any = 0;
 	#define ASSIGN_BACKEND(name, index) \
 		backends[index].Init = name##_init; \
 		backends[index].Shutdown = name##_shutdown; \
@@ -35,51 +54,68 @@ int NETWORK_init()
 		backends[index].UnlockAchievement = name##_unlockAchievement; \
 		backends[index].GetAchievementProgress = name##_getAchievementProgress; \
 		backends[index].SetAchievementProgress = name##_setAchievementProgress;
+	#ifdef STEAM_NETWORK
 	ASSIGN_BACKEND(STEAM, 0)
-	ASSIGN_BACKEND(GOG, 1)
+	#endif
+	#ifdef GOG_NETWORK
+	ASSIGN_BACKEND(GOG, STEAM_NUM)
+	#endif
 	#undef ASSIGN_BACKEND
+	#if NUM_BACKENDS > 0
+	int32_t i;
 	for (i = 0; i < NUM_BACKENDS; i += 1)
 	{
 		backends[i].IsInit = backends[i].Init();
 		any |= backends[i].IsInit;
 	}
+	#endif
 	return any;
 }
 
 void NETWORK_shutdown()
 {
+	#if NUM_BACKENDS > 0
 	int32_t i;
 	for (i = 0; i < NUM_BACKENDS; i += 1)
 	if (backends[i].IsInit)
 	{
 		backends[i].Shutdown();
 	}
+	#endif
 }
 
 void NETWORK_update()
 {
+	#if NUM_BACKENDS > 0
 	int32_t i;
 	for (i = 0; i < NUM_BACKENDS; i += 1)
 	if (backends[i].IsInit)
 	{
 		backends[i].Update();
 	}
+	#endif
 }
 
 void NETWORK_unlockAchievement(const char *name)
 {
+	#if NUM_BACKENDS > 0
 	int32_t i;
 	for (i = 0; i < NUM_BACKENDS; i += 1)
 	if (backends[i].IsInit)
 	{
 		backends[i].UnlockAchievement(name);
 	}
+	#else
+	UNUSED(name);
+	#endif
 }
 
 int32_t NETWORK_getAchievementProgress(const char *name)
 {
 	/* The highest stat gets priority, will eventually pass to the others */
-	int32_t i, stat, max = 0;
+	int32_t max = 0;
+	#if NUM_BACKENDS > 0
+	int32_t i, stat;
 	for (i = 0; i < NUM_BACKENDS; i += 1)
 	if (backends[i].IsInit)
 	{
@@ -89,15 +125,23 @@ int32_t NETWORK_getAchievementProgress(const char *name)
 			max = stat;
 		}
 	}
+	#else
+	UNUSED(name);
+	#endif
 	return max;
 }
 
 void NETWORK_setAchievementProgress(const char *name, int32_t stat)
 {
+	#if NUM_BACKENDS > 0
 	int32_t i;
 	for (i = 0; i < NUM_BACKENDS; i += 1)
 	if (backends[i].IsInit)
 	{
 		backends[i].SetAchievementProgress(name, stat);
 	}
+	#else
+	UNUSED(name);
+	UNUSED(stat);
+	#endif
 }


### PR DESCRIPTION
I think it's a bit silly to always include the Steam and GOG APIs whenever we build VVVVVV, since the only time they'll ever be used is in a live build and not a dev build.

So now Steam and GOG are disabled by default. If you want them, you'll need to add `-DSTEAM=ON` or `-DGOG=ON` respectively at CMake time.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
