### PR TITLE
Add editor saving/loading error messages

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -4050,14 +4050,14 @@ void editorinput()
                 else if(ed.savemod)
                 {
                     std::string savestring=ed.filename+".vvvvvv";
-                    bool success = ed.save(savestring);
-                    if (success)
+                    if (ed.save(savestring))
                     {
                         ed.note="[ Saved map: " + ed.filename+ ".vvvvvv]";
                     }
                     else
                     {
                         ed.note="[ ERROR: Could not save level! ]";
+                        ed.saveandquit = false;
                     }
                     ed.notedelay=45;
                     ed.savemod=false;
@@ -4065,7 +4065,7 @@ void editorinput()
                     ed.shiftmenu=false;
                     ed.shiftkey=false;
 
-                    if(ed.saveandquit && success)
+                    if(ed.saveandquit)
                     {
                         //quit editor
                         graphics.fademode = 2;
@@ -4074,8 +4074,7 @@ void editorinput()
                 else if(ed.loadmod)
                 {
                     std::string loadstring=ed.filename+".vvvvvv";
-                    bool success = ed.load(loadstring);
-                    if (success)
+                    if (ed.load(loadstring))
                     {
                         ed.note="[ Loaded map: " + ed.filename+ ".vvvvvv]";
                     }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1644,7 +1644,7 @@ int editorclass::findwarptoken(int t)
     return 0;
 }
 
-void editorclass::load(std::string& _path)
+bool editorclass::load(std::string& _path)
 {
     reset();
 
@@ -1694,7 +1694,7 @@ void editorclass::load(std::string& _path)
     if (!FILESYSTEM_loadTiXmlDocument(_path.c_str(), &doc))
     {
         printf("No level %s to load :(\n", _path.c_str());
-        return;
+        return false;
     }
 
 
@@ -1905,9 +1905,11 @@ void editorclass::load(std::string& _path)
 
     gethooks();
     version=2;
+
+    return true;
 }
 
-void editorclass::save(std::string& _path)
+bool editorclass::save(std::string& _path)
 {
     TiXmlDocument doc;
     TiXmlElement* msg;
@@ -2058,7 +2060,7 @@ void editorclass::save(std::string& _path)
     msg->LinkEndChild( new TiXmlText( scriptString.c_str() ));
     data->LinkEndChild( msg );
 
-    FILESYSTEM_saveTiXmlDocument(("levels/" + _path).c_str(), &doc);
+    return FILESYSTEM_saveTiXmlDocument(("levels/" + _path).c_str(), &doc);
 }
 
 
@@ -4048,15 +4050,22 @@ void editorinput()
                 else if(ed.savemod)
                 {
                     std::string savestring=ed.filename+".vvvvvv";
-                    ed.save(savestring);
-                    ed.note="[ Saved map: " + ed.filename+ ".vvvvvv]";
+                    bool success = ed.save(savestring);
+                    if (success)
+                    {
+                        ed.note="[ Saved map: " + ed.filename+ ".vvvvvv]";
+                    }
+                    else
+                    {
+                        ed.note="[ ERROR: Could not save level! ]";
+                    }
                     ed.notedelay=45;
                     ed.savemod=false;
 
                     ed.shiftmenu=false;
                     ed.shiftkey=false;
 
-                    if(ed.saveandquit)
+                    if(ed.saveandquit && success)
                     {
                         //quit editor
                         graphics.fademode = 2;
@@ -4065,8 +4074,15 @@ void editorinput()
                 else if(ed.loadmod)
                 {
                     std::string loadstring=ed.filename+".vvvvvv";
-                    ed.load(loadstring);
-                    ed.note="[ Loaded map: " + ed.filename+ ".vvvvvv]";
+                    bool success = ed.load(loadstring);
+                    if (success)
+                    {
+                        ed.note="[ Loaded map: " + ed.filename+ ".vvvvvv]";
+                    }
+                    else
+                    {
+                        ed.note="[ ERROR: Could not load level ]";
+                    }
                     ed.notedelay=45;
                     ed.loadmod=false;
 

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -123,8 +123,8 @@ class editorclass{
 
   int backmatch(int x, int y);
 
-  void load(std::string& _path);
-  void save(std::string& _path);
+  bool load(std::string& _path);
+  bool save(std::string& _path);
   void generatecustomminimap();
   int edgetile(int x, int y);
   int warpzoneedgetile(int x, int y);


### PR DESCRIPTION
## Changes:

Previously, the editor would always say it saved or loaded a level, even if it was not successful. For example, because a file to load does not exist, a file to save has illegal characters in its name or the
name is too long to be stored. Now failure is reported. Also, when quitting the editor and saving before quitting is unsuccessful, the editor will abort quitting.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
