### PR TITLE
Fixed some custom asset bugs, added .zip level loading

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2839,6 +2839,7 @@ void Graphics::reloadresources() {
     CLEAR_ARRAY(sprites)
     CLEAR_ARRAY(flipsprites)
     CLEAR_ARRAY(tele)
+    CLEAR_ARRAY(bfont)
 
     #undef CLEAR_ARRAY
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -6,6 +6,8 @@
 #include "KeyPoll.h"
 #include "Map.h"
 
+#include "FileSystemUtils.h"
+
 scriptclass::scriptclass()
 {
 	//Start SDL
@@ -2506,6 +2508,7 @@ void scriptclass::resetgametomenu()
 
 void scriptclass::startgamemode( int t )
 {
+	FILESYSTEM_unmountassets();
 	switch(t)
 	{
 	case 0:  //Normal new game

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -92,6 +92,26 @@ static bool endsWith(const std::string& str, const std::string& suffix)
     ) == 0;
 }
 
+void editorclass::loadZips()
+{
+    directoryList = FILESYSTEM_getLevelDirFileNames();
+    bool needsReload = false;
+
+    for(size_t i = 0; i < directoryList.size(); i++)
+    {
+        if (endsWith(directoryList[i], ".zip")) {
+            PHYSFS_File* zip = PHYSFS_openRead(directoryList[i].c_str());
+            if (!PHYSFS_mountHandle(zip, directoryList[i].c_str(), "levels", 1)) {
+                printf("%s\n", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+            } else {
+                needsReload = true;
+            }
+        }
+    }
+
+    if (needsReload) directoryList = FILESYSTEM_getLevelDirFileNames();
+}
+
 void replace_all(std::string& str, const std::string& from, const std::string& to)
 {
     if (from.empty())
@@ -181,6 +201,8 @@ void editorclass::getDirectoryData()
 
     ListOfMetaData.clear();
     directoryList.clear();
+
+    loadZips();
 
     directoryList = FILESYSTEM_getLevelDirFileNames();
 

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -89,6 +89,7 @@ class editorclass{
   std::vector<std::string> directoryList;
   std::vector<LevelMetaData> ListOfMetaData;
 
+  void loadZips();
   void getDirectoryData();
   bool getLevelMetaData(std::string& filename, LevelMetaData& _data );
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -260,17 +260,20 @@ int main(int argc, char *argv[])
         game.levelpage = 0;
         game.playcustomlevel = 0;
 
-        ed.directoryList = { playtestname };
+        ed.directoryList.clear();
+        ed.directoryList.push_back(playtestname);
 
         LevelMetaData meta;
         if (ed.getLevelMetaData(playtestname, meta)) {
-            ed.ListOfMetaData = { meta };
+            ed.ListOfMetaData.clear();
+            ed.ListOfMetaData.push_back(meta);
         } else {
             ed.loadZips();
 
             ed.directoryList = { playtestname };
             if (ed.getLevelMetaData(playtestname, meta)) {
-                ed.ListOfMetaData = { meta };
+                ed.ListOfMetaData.clear();
+                ed.ListOfMetaData.push_back(meta);
             } else {
                 printf("Level not found\n");
                 return 1;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -269,8 +269,6 @@ int main(int argc, char *argv[])
             ed.ListOfMetaData.push_back(meta);
         } else {
             ed.loadZips();
-
-            ed.directoryList = { playtestname };
             if (ed.getLevelMetaData(playtestname, meta)) {
                 ed.ListOfMetaData.clear();
                 ed.ListOfMetaData.push_back(meta);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -260,16 +260,21 @@ int main(int argc, char *argv[])
         game.levelpage = 0;
         game.playcustomlevel = 0;
 
-        ed.directoryList.clear();
-        ed.directoryList.push_back(playtestname);
+        ed.directoryList = { playtestname };
 
         LevelMetaData meta;
         if (ed.getLevelMetaData(playtestname, meta)) {
-            ed.ListOfMetaData.clear();
-            ed.ListOfMetaData.push_back(meta);
+            ed.ListOfMetaData = { meta };
         } else {
-            printf("Level not found\n");
-            return 1;
+            ed.loadZips();
+
+            ed.directoryList = { playtestname };
+            if (ed.getLevelMetaData(playtestname, meta)) {
+                ed.ListOfMetaData = { meta };
+            } else {
+                printf("Level not found\n");
+                return 1;
+            }
         }
 
         game.loadcustomlevelstats();


### PR DESCRIPTION
## Changes:

Previously, loading a level with assets and then loading the main game would retain the assets; this has been fixed. Additionally, custom font files are now loaded properly. Finally, you can now load a level as a .zip file, with the .vvvvvv and `graphics/` (etc) folders at the root of the archive.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
