### PR TITLE
Fix custom assets being unmounted in scriptclass::hardreset()

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7385,6 +7385,7 @@ void Game::quittomenu()
         createmenu(Menu::mainmenu);
     }
     script.hardreset();
+    FILESYSTEM_unmountassets();
 }
 
 void Game::returntolab()

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -6,8 +6,6 @@
 #include "KeyPoll.h"
 #include "Map.h"
 
-#include "FileSystemUtils.h"
-
 scriptclass::scriptclass()
 {
 	//Start SDL
@@ -2508,7 +2506,6 @@ void scriptclass::resetgametomenu()
 
 void scriptclass::startgamemode( int t )
 {
-	FILESYSTEM_unmountassets();
 	switch(t)
 	{
 	case 0:  //Normal new game


### PR DESCRIPTION
This resulted in two bugs:
 1. Custom assets would not be unmounted when quitting to the menu.
 2. Custom assets would be unmounted when playtesting a level.

The solution is to unmount assets in Game::quittomenu() instead.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
