### PR TITLE
Fix music reloading

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -6,34 +6,34 @@
 
 void musicclass::init()
 {
-	soundTracks.push_back(SoundTrack( "sounds/jump.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/jump2.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/hurt.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/souleyeminijingle.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/coin.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/save.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/crumble.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/vanish.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/blip.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/preteleport.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/teleport.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/crew1.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/crew2.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/crew3.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/crew4.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/crew5.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/crew6.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/terminal.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/gamesaved.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/crashing.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/blip2.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/countdown.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/go.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/crash.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/combine.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/newrecord.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/trophy.wav" ));
-	soundTracks.push_back(SoundTrack( "sounds/rescue.wav" ));
+	soundTracks.push_back(move(SoundTrack( "sounds/jump.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/jump2.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/hurt.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/souleyeminijingle.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/coin.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/save.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/crumble.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/vanish.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/blip.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/preteleport.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/teleport.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/crew1.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/crew2.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/crew3.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/crew4.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/crew5.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/crew6.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/terminal.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/gamesaved.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/crashing.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/blip2.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/countdown.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/go.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/crash.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/combine.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/newrecord.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/trophy.wav" )));
+	soundTracks.push_back(move(SoundTrack( "sounds/rescue.wav" )));
 
 #ifdef VVV_COMPILEMUSIC
 	binaryBlob musicWriteBlob;
@@ -71,67 +71,67 @@ void musicclass::init()
 		usingmmmmmm = true;
 		int index = musicReadBlob.getIndex("data/music/0levelcomplete.ogg");
 		SDL_RWops *rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		musicTracks.push_back(move(MusicTrack( rw )));
 
 		index = musicReadBlob.getIndex("data/music/1pushingonwards.ogg");
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		musicTracks.push_back(move(MusicTrack( rw )));
 
 		index = musicReadBlob.getIndex("data/music/2positiveforce.ogg");
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		musicTracks.push_back(move(MusicTrack( rw )));
 
 		index = musicReadBlob.getIndex("data/music/3potentialforanything.ogg");
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		musicTracks.push_back(move(MusicTrack( rw )));
 
 		index = musicReadBlob.getIndex("data/music/4passionforexploring.ogg");
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		musicTracks.push_back(move(MusicTrack( rw )));
 
 		index = musicReadBlob.getIndex("data/music/5intermission.ogg");
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		musicTracks.push_back(move(MusicTrack( rw )));
 
 		index = musicReadBlob.getIndex("data/music/6presentingvvvvvv.ogg");
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		musicTracks.push_back(move(MusicTrack( rw )));
 
 		index = musicReadBlob.getIndex("data/music/7gamecomplete.ogg");
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		musicTracks.push_back(move(MusicTrack( rw )));
 
 		index = musicReadBlob.getIndex("data/music/8predestinedfate.ogg");
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		musicTracks.push_back(move(MusicTrack( rw )));
 
 		index = musicReadBlob.getIndex("data/music/9positiveforcereversed.ogg");
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		musicTracks.push_back(move(MusicTrack( rw )));
 
 		index = musicReadBlob.getIndex("data/music/10popularpotpourri.ogg");
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		musicTracks.push_back(move(MusicTrack( rw )));
 
 		index = musicReadBlob.getIndex("data/music/11pipedream.ogg");
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		musicTracks.push_back(move(MusicTrack( rw )));
 
 		index = musicReadBlob.getIndex("data/music/12pressurecooker.ogg");
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		musicTracks.push_back(move(MusicTrack( rw )));
 
 		index = musicReadBlob.getIndex("data/music/13pacedenergy.ogg");
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		musicTracks.push_back(move(MusicTrack( rw )));
 
 		index = musicReadBlob.getIndex("data/music/14piercingthesky.ogg");
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		musicTracks.push_back(move(MusicTrack( rw )));
 
 		index = musicReadBlob.getIndex("data/music/predestinedfatefinallevel.ogg");
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		musicTracks.push_back(move(MusicTrack( rw )));
 
 		bool ohCrap = musicReadBlob.unPackBinary("vvvvvvmusic.vvv");
 		SDL_assert(ohCrap && "Music not found!");
@@ -139,67 +139,67 @@ void musicclass::init()
 
 	int index = musicReadBlob.getIndex("data/music/0levelcomplete.ogg");
 	SDL_RWops *rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	musicTracks.push_back(move(MusicTrack( rw )));
 
 	index = musicReadBlob.getIndex("data/music/1pushingonwards.ogg");
 	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	musicTracks.push_back(move(MusicTrack( rw )));
 
 	index = musicReadBlob.getIndex("data/music/2positiveforce.ogg");
 	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	musicTracks.push_back(move(MusicTrack( rw )));
 
 	index = musicReadBlob.getIndex("data/music/3potentialforanything.ogg");
 	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	musicTracks.push_back(move(MusicTrack( rw )));
 
 	index = musicReadBlob.getIndex("data/music/4passionforexploring.ogg");
 	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	musicTracks.push_back(move(MusicTrack( rw )));
 
 	index = musicReadBlob.getIndex("data/music/5intermission.ogg");
 	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	musicTracks.push_back(move(MusicTrack( rw )));
 
 	index = musicReadBlob.getIndex("data/music/6presentingvvvvvv.ogg");
 	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	musicTracks.push_back(move(MusicTrack( rw )));
 
 	index = musicReadBlob.getIndex("data/music/7gamecomplete.ogg");
 	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	musicTracks.push_back(move(MusicTrack( rw )));
 
 	index = musicReadBlob.getIndex("data/music/8predestinedfate.ogg");
 	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	musicTracks.push_back(move(MusicTrack( rw )));
 
 	index = musicReadBlob.getIndex("data/music/9positiveforcereversed.ogg");
 	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	musicTracks.push_back(move(MusicTrack( rw )));
 
 	index = musicReadBlob.getIndex("data/music/10popularpotpourri.ogg");
 	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	musicTracks.push_back(move(MusicTrack( rw )));
 
 	index = musicReadBlob.getIndex("data/music/11pipedream.ogg");
 	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	musicTracks.push_back(move(MusicTrack( rw )));
 
 	index = musicReadBlob.getIndex("data/music/12pressurecooker.ogg");
 	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	musicTracks.push_back(move(MusicTrack( rw )));
 
 	index = musicReadBlob.getIndex("data/music/13pacedenergy.ogg");
 	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	musicTracks.push_back(move(MusicTrack( rw )));
 
 	index = musicReadBlob.getIndex("data/music/14piercingthesky.ogg");
 	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	musicTracks.push_back(move(MusicTrack( rw )));
 
 	index = musicReadBlob.getIndex("data/music/predestinedfatefinallevel.ogg");
 	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	musicTracks.push_back(move(MusicTrack( rw )));
 
 	safeToProcessMusic= false;
 	m_doFadeInVol = false;

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -6,6 +6,9 @@
 
 void musicclass::init()
 {
+	soundTracks.clear();
+	musicTracks.clear();
+
 	soundTracks.push_back(move(SoundTrack( "sounds/jump.wav" )));
 	soundTracks.push_back(move(SoundTrack( "sounds/jump2.wav" )));
 	soundTracks.push_back(move(SoundTrack( "sounds/hurt.wav" )));

--- a/desktop_version/src/SoundSystem.cpp
+++ b/desktop_version/src/SoundSystem.cpp
@@ -24,6 +24,15 @@ MusicTrack::MusicTrack(SDL_RWops *rw)
 	}
 }
 
+MusicTrack::MusicTrack(MusicTrack&& moved) : m_music(move(moved.m_music)), m_isValid(move(moved.m_isValid)) {
+	moved.m_isValid = false;
+}
+
+MusicTrack::~MusicTrack() {
+	if (m_isValid) Mix_FreeMusic(m_music);
+	m_isValid = false;
+}
+
 SoundTrack::SoundTrack(const char* fileName)
 {
 	sound = NULL;
@@ -38,10 +47,20 @@ SoundTrack::SoundTrack(const char* fileName)
 		FILESYSTEM_freeMemory(&mem);
 	}
 
-	if (sound == NULL)
-	{
+	if (sound == NULL) {
 		fprintf(stderr, "Unable to load WAV file: %s\n", Mix_GetError());
+	} else {
+		isValid = true;
 	}
+}
+
+SoundTrack::SoundTrack(SoundTrack&& moved) : sound(move(moved.sound)), isValid(move(moved.isValid)) {
+	moved.isValid = false;
+}
+
+SoundTrack::~SoundTrack() {
+	if (isValid) Mix_FreeChunk(sound);
+	isValid = false;
 }
 
 SoundSystem::SoundSystem()

--- a/desktop_version/src/SoundSystem.h
+++ b/desktop_version/src/SoundSystem.h
@@ -8,6 +8,9 @@ class MusicTrack
 public:
 	MusicTrack(const char* fileName);
 	MusicTrack(SDL_RWops *rw);
+	MusicTrack(MusicTrack&& moved);
+	MusicTrack& operator=(const MusicTrack& other) = default;
+	~MusicTrack();
 	Mix_Music *m_music;
 	bool m_isValid;
 };
@@ -16,7 +19,12 @@ class SoundTrack
 {
 public:
 	SoundTrack(const char* fileName);
+	SoundTrack(SoundTrack&& moved);
+	SoundTrack& operator=(const SoundTrack& other) = default;
+	SoundTrack() = default;
+	~SoundTrack();
 	Mix_Chunk *sound;
+	bool isValid = false;
 };
 
 class SoundSystem
@@ -25,5 +33,15 @@ public:
 	SoundSystem();
 	void playMusic(MusicTrack* music);
 };
+
+// polyfill of std::move
+template<typename T> struct remove_reference      {typedef T type;};
+template<typename T> struct remove_reference<T&>  {typedef T type;};
+template<typename T> struct remove_reference<T&&> {typedef T type;};
+
+template<typename T>
+typename remove_reference<T>::type&& move(T&& t) {
+	return static_cast<typename remove_reference<T>::type&&>(t);
+}
 
 #endif /* SOUNDSYSTEM_H */


### PR DESCRIPTION
## Changes:

This merges the commits missed by @Fussmatte necessary for music to be properly reloaded. Partially fixes #271.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
