### PR TITLE
Add C++98/C++03 standards declaration to CMakeFiles.txt

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -18,6 +18,10 @@ IF(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebI
 	SET(GOG ON)
 ENDIF()
 
+# Set standard to C++98/C++03
+SET(CMAKE_CXX_STANDARD 98)
+SET(CMAKE_CXX_EXTENSIONS OFF) # prevent mixing stdlib implementations (dangerous!)
+
 # Architecture Flags
 IF(APPLE)
 	# Wow, Apple is a huge jerk these days huh?


### PR DESCRIPTION
This enforces the C++03 standard for people making pull requests who may not realize their fancy features are too new and shouldn't be used (_\*cough*_, _\*cough*_, @leo60228).

I did some internet searching and this is what I got from this page: https://crascit.com/2015/03/28/enabling-cxx11-in-cmake/

CI will fail because of #273 (i.e. it's Leo's fault).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
