### PR TITLE
Refactor custom scripts to not be stored in one giant vector containing every single script's lines

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2822,50 +2822,50 @@ bool Graphics::onscreen(int t)
 }
 
 void Graphics::reloadresources() {
-    grphx.destroy();
-    grphx = GraphicsResources();
-    grphx.init();
+	grphx.destroy();
+	grphx = GraphicsResources();
+	grphx.init();
 
-    #define CLEAR_ARRAY(name) \
-        for (size_t i = 0; i < name.size(); i += 1) \
-        { \
-            SDL_FreeSurface(name[i]); \
-        } \
-        name.clear();
+	#define CLEAR_ARRAY(name) \
+		for (size_t i = 0; i < name.size(); i += 1) \
+		{ \
+			SDL_FreeSurface(name[i]); \
+		} \
+		name.clear();
 
-    CLEAR_ARRAY(tiles)
-    CLEAR_ARRAY(tiles2)
-    CLEAR_ARRAY(tiles3)
-    CLEAR_ARRAY(entcolours)
-    CLEAR_ARRAY(sprites)
-    CLEAR_ARRAY(flipsprites)
-    CLEAR_ARRAY(tele)
-    CLEAR_ARRAY(bfont)
-    CLEAR_ARRAY(flipbfont)
+	CLEAR_ARRAY(tiles)
+	CLEAR_ARRAY(tiles2)
+	CLEAR_ARRAY(tiles3)
+	CLEAR_ARRAY(entcolours)
+	CLEAR_ARRAY(sprites)
+	CLEAR_ARRAY(flipsprites)
+	CLEAR_ARRAY(tele)
+	CLEAR_ARRAY(bfont)
+	CLEAR_ARRAY(flipbfont)
 
-    #undef CLEAR_ARRAY
+	#undef CLEAR_ARRAY
 
-    MakeTileArray();
-    MakeSpriteArray();
-    maketelearray();
-    Makebfont();
+	MakeTileArray();
+	MakeSpriteArray();
+	maketelearray();
+	Makebfont();
 
-    images.clear();
+	images.clear();
 
-    images.push_back(grphx.im_image0);
-    images.push_back(grphx.im_image1);
-    images.push_back(grphx.im_image2);
-    images.push_back(grphx.im_image3);
-    images.push_back(grphx.im_image4);
-    images.push_back(grphx.im_image5);
-    images.push_back(grphx.im_image6);
+	images.push_back(grphx.im_image0);
+	images.push_back(grphx.im_image1);
+	images.push_back(grphx.im_image2);
+	images.push_back(grphx.im_image3);
+	images.push_back(grphx.im_image4);
+	images.push_back(grphx.im_image5);
+	images.push_back(grphx.im_image6);
 
-    images.push_back(grphx.im_image7);
-    images.push_back(grphx.im_image8);
-    images.push_back(grphx.im_image9);
-    images.push_back(grphx.im_image10);
-    images.push_back(grphx.im_image11);
-    images.push_back(grphx.im_image12);
+	images.push_back(grphx.im_image7);
+	images.push_back(grphx.im_image8);
+	images.push_back(grphx.im_image9);
+	images.push_back(grphx.im_image10);
+	images.push_back(grphx.im_image11);
+	images.push_back(grphx.im_image12);
 
-    music.init();
+	music.init();
 }

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -184,7 +184,7 @@ public:
 	void drawtowerspikes();
 
 	bool onscreen(int t);
-	
+
 	void reloadresources();
 	std::string assetdir;
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -30,7 +30,7 @@ scriptclass::scriptclass()
 }
 
 void scriptclass::clearcustom(){
-	customscript.clear();
+	customscripts.clear();
 }
 
 void scriptclass::tokenize( std::string t )
@@ -3553,38 +3553,24 @@ void scriptclass::loadcustom(std::string t)
 		if(i>=7) cscriptname+=t[i];
 	}
 
-	int scriptstart=-1;
-	int scriptend=-1;
 	std::string tstring;
 
-	for(size_t i=0; i<customscript.size(); i++){
-		if(scriptstart==-1){
-			//Find start of the script
-			if(customscript[i]==cscriptname+":"){
-				scriptstart=i+1;
-			}
-		}else if(scriptend==-1){
-			//Find the end
-			tstring=customscript[i];
-			if (tstring.size() > 0) {
-				tstring=tstring[tstring.size()-1];
-			} else {
-				tstring="";
-			}
-			if(tstring==":"){
-				scriptend=i;
-			}
+	std::vector<std::string>* contents = NULL;
+	for(size_t i = 0; i < customscripts.size(); i++){
+		Script& script_ = customscripts[i];
+
+		if(script_.name == cscriptname){
+			contents = &script_.contents;
+			break;
 		}
 	}
-	if(scriptstart>-1){
-		if(scriptend==-1){
-			scriptend=customscript.size();
-		}
+	if(contents != NULL){
+		std::vector<std::string>& lines = *contents;
 
 		//Ok, we've got the relavent script segment, we do a pass to assess it, then run it!
 		int customcutscenemode=0;
-		for(int i=scriptstart; i<scriptend; i++){
-			tokenize(customscript[i]);
+		for(size_t i=0; i<lines.size(); i++){
+			tokenize(lines[i]);
 			if(words[0] == "say"){
 				customcutscenemode=1;
 			}else if(words[0] == "reply"){
@@ -3600,10 +3586,10 @@ void scriptclass::loadcustom(std::string t)
 		int speakermode=0; //0, terminal, numbers for crew
 		int squeakmode=0;//default on
 		//Now run the script
-		for(int i=scriptstart; i<scriptend; i++){
+		for(size_t i=0; i<lines.size(); i++){
 			words[0]="nothing"; //Default!
 			words[1]="1"; //Default!
-			tokenize(customscript[i]);
+			tokenize(lines[i]);
 			std::transform(words[0].begin(), words[0].end(), words[0].begin(), ::tolower);
 			if(words[0] == "music"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
@@ -3715,28 +3701,28 @@ void scriptclass::loadcustom(std::string t)
 				}
 			}else if(words[0] == "delay"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add(customscript[i]);
+				add(lines[i]);
 			}else if(words[0] == "flag"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add(customscript[i]);
+				add(lines[i]);
 			}else if(words[0] == "map"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add("custom"+customscript[i]);
+				add("custom"+lines[i]);
 			}else if(words[0] == "warpdir"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add(customscript[i]);
+				add(lines[i]);
 			}else if(words[0] == "ifwarp"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add(customscript[i]);
+				add(lines[i]);
 			}else if(words[0] == "iftrinkets"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add("custom"+customscript[i]);
+				add("custom"+lines[i]);
 			}else if(words[0] == "ifflag"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add("custom"+customscript[i]);
+				add("custom"+lines[i]);
 			}else if(words[0] == "iftrinketsless"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add("custom"+customscript[i]);
+				add("custom"+lines[i]);
 			}else if(words[0] == "destroy"){
 				if(customtextmode==1){ add("endtext"); customtextmode=0;}
 				if(words[1]=="gravitylines"){
@@ -3798,8 +3784,8 @@ void scriptclass::loadcustom(std::string t)
 				int nti = ti>=0 && ti<=50 ? ti : 1;
 				for(int ti2=0; ti2<nti; ti2++){
 					i++;
-					if(i < (int) customscript.size()){
-						add(customscript[i]);
+					if(i < lines.size()){
+						add(lines[i]);
 					}
 				}
 
@@ -3823,8 +3809,8 @@ void scriptclass::loadcustom(std::string t)
 				int nti = ti>=0 && ti<=50 ? ti : 1;
 				for(int ti2=0; ti2<nti; ti2++){
 					i++;
-					if(i < (int) customscript.size()){
-						add(customscript[i]);
+					if(i < lines.size()){
+						add(lines[i]);
 					}
 				}
 				add("position(player,above)");

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3568,263 +3568,263 @@ void scriptclass::loadcustom(std::string t)
 		return;
 	}
 
-		std::vector<std::string>& lines = *contents;
+	std::vector<std::string>& lines = *contents;
 
-		//Ok, we've got the relavent script segment, we do a pass to assess it, then run it!
-		int customcutscenemode=0;
-		for(size_t i=0; i<lines.size(); i++){
-			tokenize(lines[i]);
-			if(words[0] == "say"){
-				customcutscenemode=1;
-			}else if(words[0] == "reply"){
-				customcutscenemode=1;
+	//Ok, we've got the relavent script segment, we do a pass to assess it, then run it!
+	int customcutscenemode=0;
+	for(size_t i=0; i<lines.size(); i++){
+		tokenize(lines[i]);
+		if(words[0] == "say"){
+			customcutscenemode=1;
+		}else if(words[0] == "reply"){
+			customcutscenemode=1;
+		}
+	}
+
+	if(customcutscenemode==1){
+		add("cutscene()");
+		add("untilbars()");
+	}
+	int customtextmode=0;
+	int speakermode=0; //0, terminal, numbers for crew
+	int squeakmode=0;//default on
+	//Now run the script
+	for(size_t i=0; i<lines.size(); i++){
+		words[0]="nothing"; //Default!
+		words[1]="1"; //Default!
+		tokenize(lines[i]);
+		std::transform(words[0].begin(), words[0].end(), words[0].begin(), ::tolower);
+		if(words[0] == "music"){
+			if(customtextmode==1){ add("endtext"); customtextmode=0;}
+			if(words[1]=="0"){
+				tstring="stopmusic()";
+			}else{
+				if(words[1]=="11"){ tstring="play(14)";
+				}else if(words[1]=="10"){ tstring="play(13)";
+				}else if(words[1]=="9"){ tstring="play(12)";
+				}else if(words[1]=="8"){ tstring="play(11)";
+				}else if(words[1]=="7"){ tstring="play(10)";
+				}else if(words[1]=="6"){ tstring="play(8)";
+				}else if(words[1]=="5"){ tstring="play(6)";
+				}else { tstring="play("+words[1]+")"; }
 			}
-		}
-
-		if(customcutscenemode==1){
-			add("cutscene()");
-			add("untilbars()");
-		}
-		int customtextmode=0;
-		int speakermode=0; //0, terminal, numbers for crew
-		int squeakmode=0;//default on
-		//Now run the script
-		for(size_t i=0; i<lines.size(); i++){
-			words[0]="nothing"; //Default!
-			words[1]="1"; //Default!
-			tokenize(lines[i]);
-			std::transform(words[0].begin(), words[0].end(), words[0].begin(), ::tolower);
-			if(words[0] == "music"){
-				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				if(words[1]=="0"){
-					tstring="stopmusic()";
-				}else{
-					if(words[1]=="11"){ tstring="play(14)";
-					}else if(words[1]=="10"){ tstring="play(13)";
-					}else if(words[1]=="9"){ tstring="play(12)";
-					}else if(words[1]=="8"){ tstring="play(11)";
-					}else if(words[1]=="7"){ tstring="play(10)";
-					}else if(words[1]=="6"){ tstring="play(8)";
-					}else if(words[1]=="5"){ tstring="play(6)";
-					}else { tstring="play("+words[1]+")"; }
-				}
-				add(tstring);
-			}else if(words[0] == "playremix"){
-				add("play(15)");
-			}else if(words[0] == "flash"){
-				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add("flash(5)");
-				add("shake(20)");
-				add("playef(9)");
-			}else if(words[0] == "sad" || words[0] == "cry"){
-				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				if(words[1]=="player"){
-					add("changemood(player,1)");
-				}else if(words[1]=="cyan" || words[1]=="viridian" || words[1]=="1"){
-					add("changecustommood(customcyan,1)");
-				}else if(words[1]=="purple" || words[1]=="violet" || words[1]=="pink" || words[1]=="2"){
-					add("changecustommood(purple,1)");
-				}else if(words[1]=="yellow" || words[1]=="vitellary" || words[1]=="3"){
-					add("changecustommood(yellow,1)");
-				}else if(words[1]=="red" || words[1]=="vermilion" || words[1]=="4"){
-					add("changecustommood(red,1)");
-				}else if(words[1]=="green" || words[1]=="verdigris" || words[1]=="5"){
-					add("changecustommood(green,1)");
-				}else if(words[1]=="blue" || words[1]=="victoria" || words[1]=="6"){
-					add("changecustommood(blue,1)");
-				}else if(words[1]=="all" || words[1]=="everybody" || words[1]=="everyone"){
-					add("changemood(player,1)");
-					add("changecustommood(customcyan,1)");
-					add("changecustommood(purple,1)");
-					add("changecustommood(yellow,1)");
-					add("changecustommood(red,1)");
-					add("changecustommood(green,1)");
-					add("changecustommood(blue,1)");
-				}else{
-					add("changemood(player,1)");
-				}
-				if(squeakmode==0) add("squeak(cry)");
-			}else if(words[0] == "happy"){
-				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				if(words[1]=="player"){
-					add("changemood(player,0)");
-					if(squeakmode==0) add("squeak(player)");
-				}else if(words[1]=="cyan" || words[1]=="viridian" || words[1]=="1"){
-					add("changecustommood(customcyan,0)");
-					if(squeakmode==0) add("squeak(player)");
-				}else if(words[1]=="purple" || words[1]=="violet" || words[1]=="pink" || words[1]=="2"){
-					add("changecustommood(purple,0)");
-					if(squeakmode==0) add("squeak(purple)");
-				}else if(words[1]=="yellow" || words[1]=="vitellary" || words[1]=="3"){
-					add("changecustommood(yellow,0)");
-					if(squeakmode==0) add("squeak(yellow)");
-				}else if(words[1]=="red" || words[1]=="vermilion" || words[1]=="4"){
-					add("changecustommood(red,0)");
-					if(squeakmode==0) add("squeak(red)");
-				}else if(words[1]=="green" || words[1]=="verdigris" || words[1]=="5"){
-					add("changecustommood(green,0)");
-					if(squeakmode==0) add("squeak(green)");
-				}else if(words[1]=="blue" || words[1]=="victoria" || words[1]=="6"){
-					add("changecustommood(blue,0)");
-					if(squeakmode==0) add("squeak(blue)");
-				}else if(words[1]=="all" || words[1]=="everybody" || words[1]=="everyone"){
-					add("changemood(player,0)");
-					add("changecustommood(customcyan,0)");
-					add("changecustommood(purple,0)");
-					add("changecustommood(yellow,0)");
-					add("changecustommood(red,0)");
-					add("changecustommood(green,0)");
-					add("changecustommood(blue,0)");
-				}else{
-					add("changemood(player,0)");
-					if(squeakmode==0) add("squeak(player)");
-				}
-			}else if(words[0] == "squeak"){
-				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				if(words[1]=="player"){
-					add("squeak(player)");
-				}else if(words[1]=="cyan" || words[1]=="viridian" || words[1]=="1"){
-					add("squeak(player)");
-				}else if(words[1]=="purple" || words[1]=="violet" || words[1]=="pink" || words[1]=="2"){
-					add("squeak(purple)");
-				}else if(words[1]=="yellow" || words[1]=="vitellary" || words[1]=="3"){
-					add("squeak(yellow)");
-				}else if(words[1]=="red" || words[1]=="vermilion" || words[1]=="4"){
-					add("squeak(red)");
-				}else if(words[1]=="green" || words[1]=="verdigris" || words[1]=="5"){
-					add("squeak(green)");
-				}else if(words[1]=="blue" || words[1]=="victoria" || words[1]=="6"){
-					add("squeak(blue)");
-				}else if(words[1]=="cry" || words[1]=="sad"){
-					add("squeak(cry)");
-				}else if(words[1]=="on"){
-					squeakmode=0;
-				}else if(words[1]=="off"){
-					squeakmode=1;
-				}
-			}else if(words[0] == "delay"){
-				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add(lines[i]);
-			}else if(words[0] == "flag"){
-				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add(lines[i]);
-			}else if(words[0] == "map"){
-				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add("custom"+lines[i]);
-			}else if(words[0] == "warpdir"){
-				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add(lines[i]);
-			}else if(words[0] == "ifwarp"){
-				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add(lines[i]);
-			}else if(words[0] == "iftrinkets"){
-				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add("custom"+lines[i]);
-			}else if(words[0] == "ifflag"){
-				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add("custom"+lines[i]);
-			}else if(words[0] == "iftrinketsless"){
-				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				add("custom"+lines[i]);
-			}else if(words[0] == "destroy"){
-				if(customtextmode==1){ add("endtext"); customtextmode=0;}
-				if(words[1]=="gravitylines"){
-					add("destroy(gravitylines)");
-				}else if(words[1]=="warptokens"){
-					add("destroy(warptokens)");
-				}else if(words[1]=="platforms"){
-					add("destroy(platforms)");
-				}
-			}else if(words[0] == "speaker"){
-				speakermode=0;
-				if(words[1]=="gray" || words[1]=="grey" || words[1]=="terminal" || words[1]=="0") speakermode=0;
-				if(words[1]=="cyan" || words[1]=="viridian" || words[1]=="player" || words[1]=="1") speakermode=1;
-				if(words[1]=="purple" || words[1]=="violet" || words[1]=="pink" || words[1]=="2") speakermode=2;
-				if(words[1]=="yellow" || words[1]=="vitellary" || words[1]=="3") speakermode=3;
-				if(words[1]=="red" || words[1]=="vermilion" || words[1]=="4") speakermode=4;
-				if(words[1]=="green" || words[1]=="verdigris" || words[1]=="5") speakermode=5;
-				if(words[1]=="blue" || words[1]=="victoria" || words[1]=="6") speakermode=6;
-			}else if(words[0] == "say"){
-				//Speakers!
-				if(words[2]=="terminal" || words[2]=="gray" || words[2]=="grey" || words[2]=="0") speakermode=0;
-				if(words[2]=="cyan" || words[2]=="viridian" || words[2]=="player" || words[2]=="1") speakermode=1;
-				if(words[2]=="purple" || words[2]=="violet" || words[2]=="pink" || words[2]=="2") speakermode=2;
-				if(words[2]=="yellow" || words[2]=="vitellary" || words[2]=="3") speakermode=3;
-				if(words[2]=="red" || words[2]=="vermilion" || words[2]=="4") speakermode=4;
-				if(words[2]=="green" || words[2]=="verdigris" || words[2]=="5") speakermode=5;
-				if(words[2]=="blue" || words[2]=="victoria" || words[2]=="6") speakermode=6;
-				switch(speakermode){
-					case 0:
-						if(squeakmode==0) add("squeak(terminal)");
-						add("text(gray,0,114,"+words[1]+")");
-					break;
-					case 1: //NOT THE PLAYER
-						if(squeakmode==0) add("squeak(cyan)");
-						add("text(cyan,0,0,"+words[1]+")");
-					break;
-					case 2:
-						if(squeakmode==0) add("squeak(purple)");
-						add("text(purple,0,0,"+words[1]+")");
-					break;
-					case 3:
-						if(squeakmode==0) add("squeak(yellow)");
-						add("text(yellow,0,0,"+words[1]+")");
-					break;
-					case 4:
-						if(squeakmode==0) add("squeak(red)");
-						add("text(red,0,0,"+words[1]+")");
-					break;
-					case 5:
-						if(squeakmode==0) add("squeak(green)");
-						add("text(green,0,0,"+words[1]+")");
-					break;
-					case 6:
-						if(squeakmode==0) add("squeak(blue)");
-						add("text(blue,0,0,"+words[1]+")");
-					break;
-				}
-				int ti=atoi(words[1].c_str());
-				int nti = ti>=0 && ti<=50 ? ti : 1;
-				for(int ti2=0; ti2<nti; ti2++){
-					i++;
-					if(i < lines.size()){
-						add(lines[i]);
-					}
-				}
-
-				switch(speakermode){
-					case 0: add("customposition(center)"); break;
-					case 1: add("customposition(cyan,above)"); break;
-					case 2: add("customposition(purple,above)"); break;
-					case 3: add("customposition(yellow,above)"); break;
-					case 4: add("customposition(red,above)"); break;
-					case 5: add("customposition(green,above)"); break;
-					case 6: add("customposition(blue,above)"); break;
-				}
-				add("speak_active");
-				customtextmode=1;
-			}else if(words[0] == "reply"){
-				//For this version, terminal only
+			add(tstring);
+		}else if(words[0] == "playremix"){
+			add("play(15)");
+		}else if(words[0] == "flash"){
+			if(customtextmode==1){ add("endtext"); customtextmode=0;}
+			add("flash(5)");
+			add("shake(20)");
+			add("playef(9)");
+		}else if(words[0] == "sad" || words[0] == "cry"){
+			if(customtextmode==1){ add("endtext"); customtextmode=0;}
+			if(words[1]=="player"){
+				add("changemood(player,1)");
+			}else if(words[1]=="cyan" || words[1]=="viridian" || words[1]=="1"){
+				add("changecustommood(customcyan,1)");
+			}else if(words[1]=="purple" || words[1]=="violet" || words[1]=="pink" || words[1]=="2"){
+				add("changecustommood(purple,1)");
+			}else if(words[1]=="yellow" || words[1]=="vitellary" || words[1]=="3"){
+				add("changecustommood(yellow,1)");
+			}else if(words[1]=="red" || words[1]=="vermilion" || words[1]=="4"){
+				add("changecustommood(red,1)");
+			}else if(words[1]=="green" || words[1]=="verdigris" || words[1]=="5"){
+				add("changecustommood(green,1)");
+			}else if(words[1]=="blue" || words[1]=="victoria" || words[1]=="6"){
+				add("changecustommood(blue,1)");
+			}else if(words[1]=="all" || words[1]=="everybody" || words[1]=="everyone"){
+				add("changemood(player,1)");
+				add("changecustommood(customcyan,1)");
+				add("changecustommood(purple,1)");
+				add("changecustommood(yellow,1)");
+				add("changecustommood(red,1)");
+				add("changecustommood(green,1)");
+				add("changecustommood(blue,1)");
+			}else{
+				add("changemood(player,1)");
+			}
+			if(squeakmode==0) add("squeak(cry)");
+		}else if(words[0] == "happy"){
+			if(customtextmode==1){ add("endtext"); customtextmode=0;}
+			if(words[1]=="player"){
+				add("changemood(player,0)");
 				if(squeakmode==0) add("squeak(player)");
-				add("text(cyan,0,0,"+words[1]+")");
-
-				int ti=atoi(words[1].c_str());
-				int nti = ti>=0 && ti<=50 ? ti : 1;
-				for(int ti2=0; ti2<nti; ti2++){
-					i++;
-					if(i < lines.size()){
-						add(lines[i]);
-					}
-				}
-				add("position(player,above)");
-				add("speak_active");
-				customtextmode=1;
+			}else if(words[1]=="cyan" || words[1]=="viridian" || words[1]=="1"){
+				add("changecustommood(customcyan,0)");
+				if(squeakmode==0) add("squeak(player)");
+			}else if(words[1]=="purple" || words[1]=="violet" || words[1]=="pink" || words[1]=="2"){
+				add("changecustommood(purple,0)");
+				if(squeakmode==0) add("squeak(purple)");
+			}else if(words[1]=="yellow" || words[1]=="vitellary" || words[1]=="3"){
+				add("changecustommood(yellow,0)");
+				if(squeakmode==0) add("squeak(yellow)");
+			}else if(words[1]=="red" || words[1]=="vermilion" || words[1]=="4"){
+				add("changecustommood(red,0)");
+				if(squeakmode==0) add("squeak(red)");
+			}else if(words[1]=="green" || words[1]=="verdigris" || words[1]=="5"){
+				add("changecustommood(green,0)");
+				if(squeakmode==0) add("squeak(green)");
+			}else if(words[1]=="blue" || words[1]=="victoria" || words[1]=="6"){
+				add("changecustommood(blue,0)");
+				if(squeakmode==0) add("squeak(blue)");
+			}else if(words[1]=="all" || words[1]=="everybody" || words[1]=="everyone"){
+				add("changemood(player,0)");
+				add("changecustommood(customcyan,0)");
+				add("changecustommood(purple,0)");
+				add("changecustommood(yellow,0)");
+				add("changecustommood(red,0)");
+				add("changecustommood(green,0)");
+				add("changecustommood(blue,0)");
+			}else{
+				add("changemood(player,0)");
+				if(squeakmode==0) add("squeak(player)");
 			}
-		}
+		}else if(words[0] == "squeak"){
+			if(customtextmode==1){ add("endtext"); customtextmode=0;}
+			if(words[1]=="player"){
+				add("squeak(player)");
+			}else if(words[1]=="cyan" || words[1]=="viridian" || words[1]=="1"){
+				add("squeak(player)");
+			}else if(words[1]=="purple" || words[1]=="violet" || words[1]=="pink" || words[1]=="2"){
+				add("squeak(purple)");
+			}else if(words[1]=="yellow" || words[1]=="vitellary" || words[1]=="3"){
+				add("squeak(yellow)");
+			}else if(words[1]=="red" || words[1]=="vermilion" || words[1]=="4"){
+				add("squeak(red)");
+			}else if(words[1]=="green" || words[1]=="verdigris" || words[1]=="5"){
+				add("squeak(green)");
+			}else if(words[1]=="blue" || words[1]=="victoria" || words[1]=="6"){
+				add("squeak(blue)");
+			}else if(words[1]=="cry" || words[1]=="sad"){
+				add("squeak(cry)");
+			}else if(words[1]=="on"){
+				squeakmode=0;
+			}else if(words[1]=="off"){
+				squeakmode=1;
+			}
+		}else if(words[0] == "delay"){
+			if(customtextmode==1){ add("endtext"); customtextmode=0;}
+			add(lines[i]);
+		}else if(words[0] == "flag"){
+			if(customtextmode==1){ add("endtext"); customtextmode=0;}
+			add(lines[i]);
+		}else if(words[0] == "map"){
+			if(customtextmode==1){ add("endtext"); customtextmode=0;}
+			add("custom"+lines[i]);
+		}else if(words[0] == "warpdir"){
+			if(customtextmode==1){ add("endtext"); customtextmode=0;}
+			add(lines[i]);
+		}else if(words[0] == "ifwarp"){
+			if(customtextmode==1){ add("endtext"); customtextmode=0;}
+			add(lines[i]);
+		}else if(words[0] == "iftrinkets"){
+			if(customtextmode==1){ add("endtext"); customtextmode=0;}
+			add("custom"+lines[i]);
+		}else if(words[0] == "ifflag"){
+			if(customtextmode==1){ add("endtext"); customtextmode=0;}
+			add("custom"+lines[i]);
+		}else if(words[0] == "iftrinketsless"){
+			if(customtextmode==1){ add("endtext"); customtextmode=0;}
+			add("custom"+lines[i]);
+		}else if(words[0] == "destroy"){
+			if(customtextmode==1){ add("endtext"); customtextmode=0;}
+			if(words[1]=="gravitylines"){
+				add("destroy(gravitylines)");
+			}else if(words[1]=="warptokens"){
+				add("destroy(warptokens)");
+			}else if(words[1]=="platforms"){
+				add("destroy(platforms)");
+			}
+		}else if(words[0] == "speaker"){
+			speakermode=0;
+			if(words[1]=="gray" || words[1]=="grey" || words[1]=="terminal" || words[1]=="0") speakermode=0;
+			if(words[1]=="cyan" || words[1]=="viridian" || words[1]=="player" || words[1]=="1") speakermode=1;
+			if(words[1]=="purple" || words[1]=="violet" || words[1]=="pink" || words[1]=="2") speakermode=2;
+			if(words[1]=="yellow" || words[1]=="vitellary" || words[1]=="3") speakermode=3;
+			if(words[1]=="red" || words[1]=="vermilion" || words[1]=="4") speakermode=4;
+			if(words[1]=="green" || words[1]=="verdigris" || words[1]=="5") speakermode=5;
+			if(words[1]=="blue" || words[1]=="victoria" || words[1]=="6") speakermode=6;
+		}else if(words[0] == "say"){
+			//Speakers!
+			if(words[2]=="terminal" || words[2]=="gray" || words[2]=="grey" || words[2]=="0") speakermode=0;
+			if(words[2]=="cyan" || words[2]=="viridian" || words[2]=="player" || words[2]=="1") speakermode=1;
+			if(words[2]=="purple" || words[2]=="violet" || words[2]=="pink" || words[2]=="2") speakermode=2;
+			if(words[2]=="yellow" || words[2]=="vitellary" || words[2]=="3") speakermode=3;
+			if(words[2]=="red" || words[2]=="vermilion" || words[2]=="4") speakermode=4;
+			if(words[2]=="green" || words[2]=="verdigris" || words[2]=="5") speakermode=5;
+			if(words[2]=="blue" || words[2]=="victoria" || words[2]=="6") speakermode=6;
+			switch(speakermode){
+				case 0:
+					if(squeakmode==0) add("squeak(terminal)");
+					add("text(gray,0,114,"+words[1]+")");
+				break;
+				case 1: //NOT THE PLAYER
+					if(squeakmode==0) add("squeak(cyan)");
+					add("text(cyan,0,0,"+words[1]+")");
+				break;
+				case 2:
+					if(squeakmode==0) add("squeak(purple)");
+					add("text(purple,0,0,"+words[1]+")");
+				break;
+				case 3:
+					if(squeakmode==0) add("squeak(yellow)");
+					add("text(yellow,0,0,"+words[1]+")");
+				break;
+				case 4:
+					if(squeakmode==0) add("squeak(red)");
+					add("text(red,0,0,"+words[1]+")");
+				break;
+				case 5:
+					if(squeakmode==0) add("squeak(green)");
+					add("text(green,0,0,"+words[1]+")");
+				break;
+				case 6:
+					if(squeakmode==0) add("squeak(blue)");
+					add("text(blue,0,0,"+words[1]+")");
+				break;
+			}
+			int ti=atoi(words[1].c_str());
+			int nti = ti>=0 && ti<=50 ? ti : 1;
+			for(int ti2=0; ti2<nti; ti2++){
+				i++;
+				if(i < lines.size()){
+					add(lines[i]);
+				}
+			}
 
-		if(customtextmode==1){ add("endtext"); customtextmode=0;}
-		if(customcutscenemode==1){
-			add("endcutscene()");
-			add("untilbars()");
+			switch(speakermode){
+				case 0: add("customposition(center)"); break;
+				case 1: add("customposition(cyan,above)"); break;
+				case 2: add("customposition(purple,above)"); break;
+				case 3: add("customposition(yellow,above)"); break;
+				case 4: add("customposition(red,above)"); break;
+				case 5: add("customposition(green,above)"); break;
+				case 6: add("customposition(blue,above)"); break;
+			}
+			add("speak_active");
+			customtextmode=1;
+		}else if(words[0] == "reply"){
+			//For this version, terminal only
+			if(squeakmode==0) add("squeak(player)");
+			add("text(cyan,0,0,"+words[1]+")");
+
+			int ti=atoi(words[1].c_str());
+			int nti = ti>=0 && ti<=50 ? ti : 1;
+			for(int ti2=0; ti2<nti; ti2++){
+				i++;
+				if(i < lines.size()){
+					add(lines[i]);
+				}
+			}
+			add("position(player,above)");
+			add("speak_active");
+			customtextmode=1;
 		}
+	}
+
+	if(customtextmode==1){ add("endtext"); customtextmode=0;}
+	if(customcutscenemode==1){
+		add("endcutscene()");
+		add("untilbars()");
+	}
 }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3564,7 +3564,10 @@ void scriptclass::loadcustom(std::string t)
 			break;
 		}
 	}
-	if(contents != NULL){
+	if(contents == NULL){
+		return;
+	}
+
 		std::vector<std::string>& lines = *contents;
 
 		//Ok, we've got the relavent script segment, we do a pass to assess it, then run it!
@@ -3824,5 +3827,4 @@ void scriptclass::loadcustom(std::string t)
 			add("endcutscene()");
 			add("untilbars()");
 		}
-	}
 }

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -9,6 +9,12 @@
 #define filllines(lines) commands.insert(commands.end(), lines, lines + sizeof(lines)/sizeof(lines[0]))
 
 
+struct Script
+{
+    std::string name;
+    std::vector<std::string> contents;
+};
+
 class scriptclass
 {
 public:
@@ -63,7 +69,7 @@ public:
     int i, j, k;
 
     //Custom level stuff
-     std::vector <std::string>  customscript;
+    std::vector<Script> customscripts;
 };
 
 extern scriptclass script;

--- a/desktop_version/src/Scripts.cpp
+++ b/desktop_version/src/Scripts.cpp
@@ -3,8 +3,6 @@
 
 #include "Script.h"
 
-#include <algorithm>
-
 void scriptclass::load(std::string t)
 {
     //loads script name t into the array
@@ -12,10 +10,9 @@ void scriptclass::load(std::string t)
     commands.clear();
     running = true;
 
-    int maxlength = (std::min(int(t.length()),7));
     std::string customstring="";
-    for(int i=0; i<maxlength; i++){
-      customstring+=t[i];
+    if(t.length()){
+        customstring=t.substr(0, 7);
     }
 
     if (customstring == "custom_"){

--- a/desktop_version/src/Scripts.cpp
+++ b/desktop_version/src/Scripts.cpp
@@ -1,6 +1,3 @@
-#ifndef SCRIPTS_H
-#define SCRIPTS_H
-
 #include "Script.h"
 
 void scriptclass::load(std::string t)
@@ -6756,4 +6753,3 @@ void scriptclass::load(std::string t)
     }
 
 }
-#endif /* SCRIPTS_H */

--- a/desktop_version/src/TerminalScripts.cpp
+++ b/desktop_version/src/TerminalScripts.cpp
@@ -1,6 +1,3 @@
-#ifndef TERMINALSCRIPTS_H
-#define TERMINALSCRIPTS_H
-
 #include "Script.h"
 
 void scriptclass::loadother(std::string t)
@@ -1019,5 +1016,3 @@ void scriptclass::loadother(std::string t)
         filllines(lines);
     }
 }
-
-#endif /* TERMINALSCRIPTS_H */

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -9,39 +9,39 @@
 
 class edentities{
 public:
-	int x, y, t;
-	//parameters
-	int p1, p2, p3, p4, p5, p6;
-	std::string scriptname;
+  int x, y, t;
+  //parameters
+  int p1, p2, p3, p4, p5, p6;
+  std::string scriptname;
 };
 
 
 class edlevelclass{
 public:
   edlevelclass();
-	int tileset, tilecol;
-	std::string roomname;
-	int warpdir;
-	int platx1, platy1, platx2, platy2, platv;
-	int enemyx1, enemyy1, enemyx2, enemyy2, enemytype;
-	int directmode;
+  int tileset, tilecol;
+  std::string roomname;
+  int warpdir;
+  int platx1, platy1, platx2, platy2, platv;
+  int enemyx1, enemyy1, enemyx2, enemyy2, enemytype;
+  int directmode;
 };
 
 struct LevelMetaData
 {
-	std::string title;
-	std::string creator;
-	std::string Desc1;
-	std::string Desc2;
-	std::string Desc3;
-	std::string website;
-	std::string filename;
+  std::string title;
+  std::string creator;
+  std::string Desc1;
+  std::string Desc2;
+  std::string Desc3;
+  std::string website;
+  std::string filename;
 
-	std::string modifier;
-	std::string timeCreated;
-	std::string timeModified;
+  std::string modifier;
+  std::string timeCreated;
+  std::string timeModified;
 
-	int version;
+  int version;
 };
 
 
@@ -49,29 +49,29 @@ extern std::vector<edentities> edentity;
 
 class EditorData
 {
-	public:
+  public:
 
-	static EditorData& GetInstance()
-	{
-		static EditorData  instance; // Guaranteed to be destroyed.
-		// Instantiated on first use.
-		return instance;
-	}
+  static EditorData& GetInstance()
+  {
+    static EditorData  instance; // Guaranteed to be destroyed.
+    // Instantiated on first use.
+    return instance;
+  }
 
 
-	std::string title;
-	std::string creator;
+  std::string title;
+  std::string creator;
 
-	std::string modifier;
-	std::string timeCreated;
-	std::string timeModified;
+  std::string modifier;
+  std::string timeCreated;
+  std::string timeModified;
 
 private:
 
 
-	EditorData()
-	{
-	}
+  EditorData()
+  {
+  }
 
 };
 
@@ -84,7 +84,7 @@ class editorclass{
   std::string Desc1;
   std::string Desc2;
   std::string Desc3;
-	std::string website;
+  std::string website;
 
   std::vector<std::string> directoryList;
   std::vector<LevelMetaData> ListOfMetaData;


### PR DESCRIPTION
This PR refactors custom level scripts to no longer be stored in one giant vector containing not only every single script name, but every single script's contents as well. More specifically, `scriptclass::customscript` has been converted to an `std::vector<Script> scriptclass::customscripts` (note the extra S), and a `Script` is just a struct with an `std::string name` and `std::vector<std::string> contents`.

This is an improvement in both performance and maintainability. The game no longer has to look through script contents in case they're actually script names, and then manually extract the script contents from there. Instead, all it has to do is look for script names only. And the contents are provided for free. This results in a performance gain.

Also, the old system resulted in lots of boilerplate everywhere anytime scripts had to be handled or parsed. Now, the boilerplate is only done when saving or loading a custom level. This makes code quality much, much better.

To be sure I didn't actually change anything, I tested by first saving Dimension Open in current 2.3 (because current 2.3 gets rid of the awful edentity whitespace), and then resaved it on this patch. There is absolutely no difference between the current-2.3-resave and this-patch-resave.

I would've used an `std::map` for semi-nicer interfacing with custom scripts (you'd be able to just do `customscripts["scriptname"]` directly), but alas, it has this annoying thing where it puts all scripts in alphabetical order. Not that order matters, but it is an unnecessary difference which I don't want. I can't use an `std::unordered_map`, that's C++11. And plus, making a dedicated `Script` struct better conveys my intention, and also allows forks to easily add their own attributes to the custom script object (such as if they're adding Lua scripting like VCE is).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
