### PR TITLE
Fix loading levels saved with 2.2 or earlier

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1643,7 +1643,7 @@ bool editorclass::load(std::string& _path)
         printf("Custom asset directory does not exist\n");
     }
 
-    tinyxml2::XMLDocument doc;
+    tinyxml2::XMLDocument doc(true, tinyxml2::COLLAPSE_WHITESPACE);
     if (!FILESYSTEM_loadTiXml2Document(_path.c_str(), doc))
     {
         printf("No level %s to load :(\n", _path.c_str());


### PR DESCRIPTION
2.2 and earlier had this god-awful thing where it put the closing tag of an edentity onto the next line, and then kept the indentation the same. This requires parsing the XML in an extremely specific way (i.e. ignoring the whitespace) so the newline and indentation isn't taken as part of the actual contents of the tag.

2.3 removed this awful whitespace entirely to make it easier on parsers. When I tested #270, I tested against a 2.3 re-save of Dimension Open and diffed the two, because I thought testing against the original version of the level would result in a bunch of noise I didn't want due to the whitespace change. Well, I did exactly what I intended, and ended up ignoring the whitespace change so much that levels saved in this stupid format ended up getting broken.

Luckily, we can just tell TinyXML-2 to parse a document exactly like how TinyXML-1 would've parsed it, by supplying the COLLAPSE_WHITESPACE enum to it (by default it's on PRESERVE_WHITESPACE).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
