### PR TITLE
Add editor ghosts

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -365,6 +365,7 @@ void Game::init(void)
     skipfakeload = false;
 
     ghostsenabled = false;
+    gametimer = 0;
 
     cliplaytest = false;
     playx = 0;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -364,6 +364,8 @@ void Game::init(void)
 
     skipfakeload = false;
 
+    ghostsenabled = false;
+
     cliplaytest = false;
     playx = 0;
     playy = 0;
@@ -4461,6 +4463,11 @@ void Game::loadstats()
             }
         }
 
+        if (pKey == "ghostsenabled")
+        {
+            ghostsenabled = atoi(pText);
+        }
+
         if (pKey == "skipfakeload")
         {
             skipfakeload = atoi(pText);
@@ -4690,6 +4697,10 @@ void Game::savestats()
     msg = doc.NewElement( "usingmmmmmm" );
     msg->LinkEndChild( doc.NewText( help.String(usingmmmmmm).c_str()));
     dataNode->LinkEndChild( msg );
+
+    msg = doc.NewElement("ghostsenabled");
+    msg->LinkEndChild(doc.NewText(help.String((int) ghostsenabled).c_str()));
+    dataNode->LinkEndChild(msg);
 
     msg = doc.NewElement("skipfakeload");
     msg->LinkEndChild(doc.NewText(help.String((int) skipfakeload).c_str()));
@@ -6778,11 +6789,12 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("change description");
         option("edit scripts");
         option("change music");
+        option("editor ghosts");
         option("load level");
         option("save level");
         option("quit to main menu");
 
-        menuxoff = -50;
+        menuxoff = -46;
         menuyoff = -20;
         break;
     case Menu::ed_desc:

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -392,7 +392,7 @@ public:
     bool shouldreturntoeditor;
 #endif
 
-    int gametimer = 0;
+    int gametimer;
 };
 
 extern Game game;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -371,6 +371,7 @@ public:
     std::vector<SDL_GameControllerButton> controllerButton_esc;
 
     bool skipfakeload;
+    bool ghostsenabled;
 
     bool cliplaytest;
     int playx;
@@ -390,6 +391,8 @@ public:
     void returntoeditor();
     bool shouldreturntoeditor;
 #endif
+
+    int gametimer = 0;
 };
 
 extern Game game;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -286,6 +286,8 @@ public:
 	bool showmousecursor;
 
 	std::map<int, int> font_positions;
+
+    SDL_Surface* ghostbuffer;
 };
 
 extern Graphics graphics;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -287,7 +287,7 @@ public:
 
 	std::map<int, int> font_positions;
 
-    SDL_Surface* ghostbuffer;
+	SDL_Surface* ghostbuffer;
 };
 
 extern Graphics graphics;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1382,6 +1382,7 @@ void gamerender()
             graphics.drawtowerspikes();
         }
 
+#if !defined(NO_CUSTOM_LEVELS)
         // Editor ghosts!
         if (game.ghostsenabled)
         {
@@ -1405,6 +1406,7 @@ void gamerender()
                 }
             }
         }
+#endif
     }
 
     if(map.extrarow==0 || (map.custommode && map.roomname!=""))

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1,4 +1,4 @@
-    #include "Render.h"
+#include "Render.h"
 
 #include "Graphics.h"
 #include "UtilityClass.h"

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1,4 +1,4 @@
-#include "Render.h"
+    #include "Render.h"
 
 #include "Graphics.h"
 #include "UtilityClass.h"
@@ -1380,6 +1380,30 @@ void gamerender()
         if (map.towermode)
         {
             graphics.drawtowerspikes();
+        }
+
+        // Editor ghosts!
+        if (game.ghostsenabled)
+        {
+            if (map.custommode && !map.custommodeforreal)
+            {
+                if (game.gametimer % 3 == 0)
+                {
+                    int i = obj.getplayer();
+                    GhostInfo ghost;
+                    ghost.rx = game.roomx-100;
+                    ghost.ry = game.roomy-100;
+                    ghost.x = obj.entities[i].xp;
+                    ghost.y = obj.entities[i].yp;
+                    ghost.col = obj.entities[i].colour;
+                    ghost.frame = obj.entities[i].drawframe;
+                    ed.ghosts.push_back(ghost);
+                }
+                if (ed.ghosts.size() > 100)
+                {
+                    ed.ghosts.erase(ed.ghosts.begin());
+                }
+            }
         }
     }
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3151,6 +3151,7 @@ void scriptclass::startgamemode( int t )
 		game.customstart();
 		game.jumpheld = true;
 
+        ed.ghosts.clear();
 
 		map.custommode = true;
 		map.customx = 100;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3151,7 +3151,7 @@ void scriptclass::startgamemode( int t )
 		game.customstart();
 		game.jumpheld = true;
 
-        ed.ghosts.clear();
+		ed.ghosts.clear();
 
 		map.custommode = true;
 		map.customx = 100;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -385,6 +385,7 @@ void editorclass::reset()
     returneditoralpha = 0;
 
     ghosts.clear();
+    currentghosts = 0;
 }
 
 void editorclass::gethooks()

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -238,7 +238,7 @@ class editorclass{
   int returneditoralpha;
 
   std::vector<GhostInfo> ghosts;
-  int currentghosts = 0;
+  int currentghosts;
 };
 
 void addedentity(int xp, int yp, int tp, int p1=0, int p2=0, int p3=0, int p4=0, int p5=320, int p6=240);

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -75,6 +75,14 @@ private:
 
 };
 
+struct GhostInfo {
+    int rx; // game.roomx-100
+    int ry; // game.roomy-100
+    int x; // .xp
+    int y; // .yp
+    int col; // .colour
+    int frame; // .drawframe
+};
 
 class editorclass{
   //Special class to handle ALL editor variables locally
@@ -228,6 +236,9 @@ class editorclass{
   int dmtileeditor;
 
   int returneditoralpha;
+
+  std::vector<GhostInfo> ghosts;
+  int currentghosts = 0;
 };
 
 void addedentity(int xp, int yp, int tp, int p1=0, int p2=0, int p3=0, int p4=0, int p5=320, int p6=240);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -177,6 +177,11 @@ int main(int argc, char *argv[])
     SDL_SetSurfaceBlendMode(graphics.footerbuffer, SDL_BLENDMODE_BLEND);
     SDL_SetSurfaceAlphaMod(graphics.footerbuffer, 127);
     FillRect(graphics.footerbuffer, SDL_MapRGB(fmt, 0, 0, 0));
+
+    graphics.ghostbuffer = SDL_CreateRGBSurface(SDL_SWSURFACE, 320, 240, fmt->BitsPerPixel, fmt->Rmask, fmt->Gmask, fmt->Bmask, fmt->Amask);
+    SDL_SetSurfaceBlendMode(graphics.ghostbuffer, SDL_BLENDMODE_BLEND);
+    SDL_SetSurfaceAlphaMod(graphics.ghostbuffer, 127);
+
     graphics.Makebfont();
 
     graphics.foregroundBuffer =  SDL_CreateRGBSurface(SDL_SWSURFACE ,320 ,240 ,fmt->BitsPerPixel,fmt->Rmask,fmt->Gmask,fmt->Bmask,fmt->Amask  );
@@ -301,6 +306,7 @@ int main(int argc, char *argv[])
     volatile Uint32 time, timePrev = 0;
     game.infocus = true;
     key.isActive = true;
+    game.gametimer = 0;
 
     while(!key.quitProgram)
     {
@@ -386,7 +392,7 @@ int main(int argc, char *argv[])
         {
             Mix_Resume(-1);
             Mix_ResumeMusic();
-
+            game.gametimer++;
             switch(game.gamestate)
             {
             case PRELOADER:


### PR DESCRIPTION
## Changes:
A few months ago, I added ghosts to the VVVVVV: Community Edition editor. I was told recently I should think about upstreaming it, and with Terry saying go ahead I finally ported them into VVVVVV. There's one slight difference however--you can choose whether you have them or not in the editor's settings menu. They're off by default, and this is saved to the save file.
Anyway, when you're playtesting, the game saves the players position, color, room coordinates and sprite every 3 frames. The max is 100, where if it tries to add more, the oldest one gets removed.
When you exit playtesting, the saved positions appear one at a time, and you can use the Z key to speed it up.

[Here's a video of them in action.](https://o.lol-sa.me/4H21zCv.mp4)
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
