### PR TITLE
Put if-guards around usages of entity-getting functions whose return values can be out-of-bounds

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2371,8 +2371,9 @@ bool entityclass::updateentities( int i )
             case 16: //MAVERICK BUS FOLLOWS HIS OWN RULES
                 if (entities[i].state == 0)   //Init
                 {
+                    int player = getplayer();
                     //first, y position
-                    if (entities[getplayer()].yp > 14 * 8)
+                    if (player > -1 && entities[player].yp > 14 * 8)
                     {
                         entities[i].tile = 120;
                         entities[i].yp = (28*8)-62;
@@ -2383,7 +2384,7 @@ bool entityclass::updateentities( int i )
                         entities[i].yp = 24;
                     }
                     //now, x position
-                    if (entities[getplayer()].xp > 20 * 8)
+                    if (player > -1 && entities[player].xp > 20 * 8)
                     {
                         //approach from the left
                         entities[i].xp = -64;
@@ -2592,7 +2593,11 @@ bool entityclass::updateentities( int i )
 
                 game.saverx = game.roomx;
                 game.savery = game.roomy;
-                game.savedir = entities[getplayer()].dir;
+                int player = getplayer();
+                if (player > -1)
+                {
+                    game.savedir = entities[player].dir;
+                }
                 entities[i].state = 0;
             }
             break;
@@ -2622,11 +2627,11 @@ bool entityclass::updateentities( int i )
                 temp = getplayer();
                 if (game.gravitycontrol == 0)
                 {
-                    if (entities[temp].vy < 3) entities[temp].vy = 3;
+                    if (temp > -1 && entities[temp].vy < 3) entities[temp].vy = 3;
                 }
                 else
                 {
-                    if (entities[temp].vy > -3) entities[temp].vy = -3;
+                    if (temp > -1 && entities[temp].vy > -3) entities[temp].vy = -3;
                 }
             }
             else if (entities[i].state == 2)
@@ -2679,20 +2684,20 @@ bool entityclass::updateentities( int i )
                 if (entities[k].rule == 7)	entities[k].tile = 6;
                 //Stay close to the hero!
                 int j = getplayer();
-                if (entities[j].xp > entities[i].xp + 5)
+                if (j > -1 && entities[j].xp > entities[i].xp + 5)
                 {
                     entities[i].dir = 1;
                 }
-                else if (entities[j].xp < entities[i].xp - 5)
+                else if (j > -1 && entities[j].xp < entities[i].xp - 5)
                 {
                     entities[i].dir = 0;
                 }
 
-                if (entities[j].xp > entities[i].xp + 45)
+                if (j > -1 && entities[j].xp > entities[i].xp + 45)
                 {
                     entities[i].ax = 3;
                 }
-                else if (entities[j].xp < entities[i].xp - 45)
+                else if (j > -1 && entities[j].xp < entities[i].xp - 45)
                 {
                     entities[i].ax = -3;
                 }
@@ -2710,20 +2715,20 @@ bool entityclass::updateentities( int i )
             {
                 //Basic rules, don't change expression
                 int j = getplayer();
-                if (entities[j].xp > entities[i].xp + 5)
+                if (j > -1 && entities[j].xp > entities[i].xp + 5)
                 {
                     entities[i].dir = 1;
                 }
-                else if (entities[j].xp < entities[i].xp - 5)
+                else if (j > -1 && entities[j].xp < entities[i].xp - 5)
                 {
                     entities[i].dir = 0;
                 }
 
-                if (entities[j].xp > entities[i].xp + 45)
+                if (j > -1 && entities[j].xp > entities[i].xp + 45)
                 {
                     entities[i].ax = 3;
                 }
-                else if (entities[j].xp < entities[i].xp - 45)
+                else if (j > -1 && entities[j].xp < entities[i].xp - 45)
                 {
                     entities[i].ax = -3;
                 }
@@ -2733,20 +2738,20 @@ bool entityclass::updateentities( int i )
                 //Everything from 10 on is for cutscenes
                 //Basic rules, don't change expression
                 int j = getplayer();
-                if (entities[j].xp > entities[i].xp + 5)
+                if (j > -1 && entities[j].xp > entities[i].xp + 5)
                 {
                     entities[i].dir = 1;
                 }
-                else if (entities[j].xp < entities[i].xp - 5)
+                else if (j > -1 && entities[j].xp < entities[i].xp - 5)
                 {
                     entities[i].dir = 0;
                 }
 
-                if (entities[j].xp > entities[i].xp + 45)
+                if (j > -1 && entities[j].xp > entities[i].xp + 45)
                 {
                     entities[i].ax = 3;
                 }
-                else if (entities[j].xp < entities[i].xp - 45)
+                else if (j > -1 && entities[j].xp < entities[i].xp - 45)
                 {
                     entities[i].ax = -3;
                 }
@@ -2890,11 +2895,11 @@ bool entityclass::updateentities( int i )
             {
                 //Stand still and face the player
                 int j = getplayer();
-                if (entities[j].xp > entities[i].xp + 5)
+                if (j > -1 && entities[j].xp > entities[i].xp + 5)
                 {
                     entities[i].dir = 1;
                 }
-                else if (entities[j].xp < entities[i].xp - 5)
+                else if (j > -1 && entities[j].xp < entities[i].xp - 5)
                 {
                     entities[i].dir = 0;
                 }
@@ -3006,7 +3011,7 @@ bool entityclass::updateentities( int i )
             {
                 //follow player, but only if he's on the floor!
                 int j = getplayer();
-                if(entities[j].onground>0)
+                if(j > -1 && entities[j].onground>0)
                 {
                     if (entities[j].xp > entities[i].xp + 5)
                     {
@@ -3032,11 +3037,11 @@ bool entityclass::updateentities( int i )
                 }
                 else
                 {
-                    if (entities[j].xp > entities[i].xp + 5)
+                    if (j > -1 && entities[j].xp > entities[i].xp + 5)
                     {
                         entities[i].dir = 1;
                     }
-                    else if (entities[j].xp < entities[i].xp - 5)
+                    else if (j > -1 && entities[j].xp < entities[i].xp - 5)
                     {
                         entities[i].dir = 0;
                     }
@@ -3100,7 +3105,7 @@ bool entityclass::updateentities( int i )
         case 51: //Vertical warp line
             if (entities[i].state == 2){
               int j=getplayer();
-              if(entities[j].xp<=307){
+              if(j > -1 && entities[j].xp<=307){
                 customwarpmodevon=false;
                 entities[i].state = 0;
               }
@@ -3115,7 +3120,7 @@ bool entityclass::updateentities( int i )
         case 52: //Vertical warp line
             if (entities[i].state == 2){
               int j=getplayer();
-              if(entities[j].xp<=307){
+              if(j > -1 && entities[j].xp<=307){
                 customwarpmodevon=false;
                 entities[i].state = 0;
               }
@@ -3157,11 +3162,11 @@ bool entityclass::updateentities( int i )
             {
                 //Basic rules, don't change expression
                 int j = getplayer();
-                if (entities[j].xp > entities[i].xp + 5)
+                if (j > -1 && entities[j].xp > entities[i].xp + 5)
                 {
                     entities[i].dir = 1;
                 }
-                else if (entities[j].xp < entities[i].xp - 5)
+                else if (j > -1 && entities[j].xp < entities[i].xp - 5)
                 {
                     entities[i].dir = 0;
                 }
@@ -3226,7 +3231,11 @@ bool entityclass::updateentities( int i )
 
                     game.saverx = game.roomx;
                     game.savery = game.roomy;
-                    game.savedir = entities[getplayer()].dir;
+                    int player = getplayer();
+                    if (player > -1)
+                    {
+                        game.savedir = entities[player].dir;
+                    }
                     entities[i].state = 0;
                 }
 
@@ -4464,7 +4473,7 @@ void entityclass::movingplatformfix( int t )
 
     //If this intersects the player, then we move the player along it
     int j = getplayer();
-    if (entitycollide(t, j))
+    if (j > -1 && entitycollide(t, j))
     {
         //ok, bollox, let's make sure
         entities[j].yp = entities[j].yp + int(entities[j].vy);
@@ -4759,7 +4768,7 @@ void entityclass::entitycollisioncheck()
     //can't have the player being stuck...
     int j = getplayer();
     skipdirblocks = true;
-    if (!testwallsx(j, entities[j].xp, entities[j].yp))
+    if (j > -1 && !testwallsx(j, entities[j].xp, entities[j].yp))
     {
         //Let's try to get out...
         if (entities[j].rule == 0)

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1533,8 +1533,11 @@ void Game::updatestate()
 
             companion = 6;
             i = obj.getcompanion();
-            obj.entities[i].tile = 0;
-            obj.entities[i].state = 1;
+            if (i > -1)
+            {
+                obj.entities[i].tile = 0;
+                obj.entities[i].state = 1;
+            }
 
             advancetext = true;
             hascontrol = false;
@@ -1559,8 +1562,11 @@ void Game::updatestate()
             music.playef(2);
             graphics.textboxactive();
             i = obj.getcompanion();
-            obj.entities[i].tile = 54;
-            obj.entities[i].state = 0;
+            if (i > -1)
+            {
+                obj.entities[i].tile = 54;
+                obj.entities[i].state = 0;
+            }
         }
         break;
         case 108:
@@ -1574,8 +1580,11 @@ void Game::updatestate()
         {
 
             i = obj.getcompanion();
-            obj.entities[i].tile = 0;
-            obj.entities[i].state = 1;
+            if (i > -1)
+            {
+                obj.entities[i].tile = 0;
+                obj.entities[i].state = 1;
+            }
             graphics.createtextbox("Follow me!", 185, 154, 164, 164, 255);
             state++;
             music.playef(11);
@@ -1649,8 +1658,11 @@ void Game::updatestate()
         case 122:
             companion = 7;
             i = obj.getcompanion();
-            obj.entities[i].tile = 6;
-            obj.entities[i].state = 1;
+            if (i > -1)
+            {
+                obj.entities[i].tile = 6;
+                obj.entities[i].state = 1;
+            }
 
             advancetext = true;
             hascontrol = false;
@@ -1665,7 +1677,7 @@ void Game::updatestate()
             state++;
             music.playef(2);
             graphics.textboxactive();
-            i = obj.getcompanion();	//obj.entities[i].tile = 66;	obj.entities[i].state = 0;
+            i = obj.getcompanion(); if (i > -1) {	/*obj.entities[i].tile = 66;	obj.entities[i].state = 0;*/	}
             break;
         case 126:
             graphics.createtextbox("I can help with that!", 125, 152-40, 164, 164, 255);
@@ -1687,8 +1699,11 @@ void Game::updatestate()
             music.playef(14);
             graphics.textboxactive();
             i = obj.getcompanion();
-            obj.entities[i].tile = 6;
-            obj.entities[i].state = 1;
+            if (i > -1)
+            {
+                obj.entities[i].tile = 6;
+                obj.entities[i].state = 1;
+            }
             break;
         case 132:
             graphics.textboxremove();

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -504,14 +504,17 @@ void Game::lifesequence()
     if (lifeseq > 0)
     {
         int i = obj.getplayer();
-        obj.entities[i].invis = false;
-        if (lifeseq == 2) obj.entities[i].invis = true;
-        if (lifeseq == 6) obj.entities[i].invis = true;
-        if (lifeseq >= 8) obj.entities[i].invis = true;
+        if (i > -1)
+        {
+            obj.entities[i].invis = false;
+            if (lifeseq == 2) obj.entities[i].invis = true;
+            if (lifeseq == 6) obj.entities[i].invis = true;
+            if (lifeseq >= 8) obj.entities[i].invis = true;
+        }
         if (lifeseq > 5) gravitycontrol = savegc;
 
         lifeseq--;
-        if (lifeseq <= 0)
+        if (i > -1 && lifeseq <= 0)
         {
             obj.entities[i].invis = false;
         }
@@ -906,19 +909,28 @@ void Game::updatestate()
             break;
 
         case 15:
+        {
             //leaving the naughty corner
-            obj.entities[obj.getplayer()].tile = 0;
+            int i = obj.getplayer();
+            if (i > -1)
+            {
+                obj.entities[obj.getplayer()].tile = 0;
+            }
             state = 0;
             break;
+        }
         case 16:
+        {
             //entering the naughty corner
-            if(obj.entities[obj.getplayer()].tile == 0)
+            int i = obj.getplayer();
+            if(i > -1 && obj.entities[i].tile == 0)
             {
-                obj.entities[obj.getplayer()].tile = 144;
+                obj.entities[i].tile = 144;
                 music.playef(2);
             }
             state = 0;
             break;
+        }
 
         case 17:
             //Arrow key tutorial
@@ -1504,12 +1516,12 @@ void Game::updatestate()
 
             i = obj.getplayer();
             hascontrol = false;
-            if (obj.entities[i].onroof > 0 && gravitycontrol == 1)
+            if (i > -1 && obj.entities[i].onroof > 0 && gravitycontrol == 1)
             {
                 gravitycontrol = 0;
                 music.playef(1);
             }
-            if (obj.entities[i].onground > 0)
+            if (i > -1 && obj.entities[i].onground > 0)
             {
                 state++;
             }
@@ -1622,12 +1634,12 @@ void Game::updatestate()
 
             i = obj.getplayer();
             hascontrol = false;
-            if (obj.entities[i].onground > 0 && gravitycontrol == 0)
+            if (i > -1 && obj.entities[i].onground > 0 && gravitycontrol == 0)
             {
                 gravitycontrol = 1;
                 music.playef(1);
             }
-            if (obj.entities[i].onroof > 0)
+            if (i > -1 && obj.entities[i].onroof > 0)
             {
                 state++;
             }
@@ -2163,19 +2175,22 @@ void Game::updatestate()
             statedelay = 5;
 
             i = obj.getplayer();
-            obj.entities[i].colour = 0;
-            obj.entities[i].invis = false;
-
-            int j = obj.getteleporter();
-            if (j > -1)
+            if (i > -1)
             {
-                obj.entities[i].xp = obj.entities[j].xp+44;
-                obj.entities[i].yp = obj.entities[j].yp+44;
+                obj.entities[i].colour = 0;
+                obj.entities[i].invis = false;
+
+                int j = obj.getteleporter();
+                if (j > -1)
+                {
+                    obj.entities[i].xp = obj.entities[j].xp+44;
+                    obj.entities[i].yp = obj.entities[j].yp+44;
+                }
+                obj.entities[i].ay = -6;
+                obj.entities[i].ax = 6;
+                obj.entities[i].vy = -6;
+                obj.entities[i].vx = 6;
             }
-            obj.entities[i].ay = -6;
-            obj.entities[i].ax = 6;
-            obj.entities[i].vy = -6;
-            obj.entities[i].vx = 6;
 
             i = obj.getteleporter();
             if (i > -1)
@@ -2188,38 +2203,59 @@ void Game::updatestate()
         case 2503:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 10;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 10;
+            }
             break;
         case 2504:
             state++;
             i = obj.getplayer();
-            //obj.entities[i].xp += 10;
+            if (i > -1)
+            {
+                //obj.entities[i].xp += 10;
+            }
             break;
         case 2505:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 8;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 8;
+            }
             break;
         case 2506:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 6;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 6;
+            }
             break;
         case 2507:
             state++;
             i = obj.getplayer();
-            //obj.entities[i].xp += 4;
+            if (i > -1)
+            {
+                //obj.entities[i].xp += 4;
+            }
             break;
         case 2508:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 2;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 2;
+            }
             break;
         case 2509:
             state++;
             statedelay = 15;
             i = obj.getplayer();
-            obj.entities[i].xp += 1;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 1;
+            }
             break;
         case 2510:
             advancetext = true;
@@ -2315,8 +2351,11 @@ void Game::updatestate()
             }
 
             i = obj.getplayer();
-            obj.entities[i].colour = 0;
-            obj.entities[i].invis = true;
+            if (i > -1)
+            {
+                obj.entities[i].colour = 0;
+                obj.entities[i].invis = true;
+            }
 
             i = obj.getcompanion();
             if(i>-1)
@@ -3309,7 +3348,10 @@ void Game::updatestate()
         case 3511:
             //Activating a teleporter (long version for level complete)
             i = obj.getplayer();
-            obj.entities[i].colour = 102;
+            if (i > -1)
+            {
+                obj.entities[i].colour = 102;
+            }
 
             state++;
             statedelay = 30;
@@ -3346,8 +3388,11 @@ void Game::updatestate()
             screenshake = 0;
 
             i = obj.getplayer();
-            obj.entities[i].colour = 0;
-            obj.entities[i].invis = true;
+            if (i > -1)
+            {
+                obj.entities[i].colour = 0;
+                obj.entities[i].invis = true;
+            }
 
             //we're done here!
             music.playef(10);
@@ -3433,8 +3478,11 @@ void Game::updatestate()
             //state = 3040; //Lab
 
             i = obj.getplayer();
-            obj.entities[i].colour = 0;
-            obj.entities[i].invis = true;
+            if (i > -1)
+            {
+                obj.entities[i].colour = 0;
+                obj.entities[i].invis = true;
+            }
 
             i = obj.getteleporter();
             if(i>-1)
@@ -3472,52 +3520,73 @@ void Game::updatestate()
 
             i = obj.getplayer();
             j = obj.getteleporter();
-            if (j != -1)
+            if (i > -1)
             {
-                obj.entities[i].xp = obj.entities[j].xp+44;
-                obj.entities[i].yp = obj.entities[j].yp+44;
-                obj.entities[j].tile = 2;
-                obj.entities[j].colour = 101;
-            }
-            obj.entities[i].colour = 0;
-            obj.entities[i].invis = false;
-            obj.entities[i].dir = 1;
+                if (j != -1)
+                {
+                    obj.entities[i].xp = obj.entities[j].xp+44;
+                    obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[j].tile = 2;
+                    obj.entities[j].colour = 101;
+                }
+                obj.entities[i].colour = 0;
+                obj.entities[i].invis = false;
+                obj.entities[i].dir = 1;
 
-            obj.entities[i].ay = -6;
-            obj.entities[i].ax = 6;
-            obj.entities[i].vy = -6;
-            obj.entities[i].vx = 6;
+                obj.entities[i].ay = -6;
+                obj.entities[i].ax = 6;
+                obj.entities[i].vy = -6;
+                obj.entities[i].vx = 6;
+            }
             break;
         case 4013:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 10;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 10;
+            }
             break;
         case 4014:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 10;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 10;
+            }
             break;
         case 4015:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 8;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 8;
+            }
             break;
         case 4016:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 6;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 6;
+            }
             break;
         case 4017:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 3;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 3;
+            }
             break;
         case 4018:
             state++;
             statedelay = 15;
             i = obj.getplayer();
-            obj.entities[i].xp += 1;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 1;
+            }
             break;
         case 4019:
             if (intimetrial || nodeathmode || inintermission)
@@ -3564,52 +3633,73 @@ void Game::updatestate()
 
             i = obj.getplayer();
             j = obj.getteleporter();
-            if (j != -1)
+            if (i > -1)
             {
-                obj.entities[i].xp = obj.entities[j].xp+44;
-                obj.entities[i].yp = obj.entities[j].yp+44;
-                obj.entities[j].tile = 2;
-                obj.entities[j].colour = 101;
-            }
-            obj.entities[i].colour = 0;
-            obj.entities[i].invis = false;
-            obj.entities[i].dir = 1;
+                if (j != -1)
+                {
+                    obj.entities[i].xp = obj.entities[j].xp+44;
+                    obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[j].tile = 2;
+                    obj.entities[j].colour = 101;
+                }
+                obj.entities[i].colour = 0;
+                obj.entities[i].invis = false;
+                obj.entities[i].dir = 1;
 
-            obj.entities[i].ay = -6;
-            obj.entities[i].ax = 6;
-            obj.entities[i].vy = -6;
-            obj.entities[i].vx = 6;
+                obj.entities[i].ay = -6;
+                obj.entities[i].ax = 6;
+                obj.entities[i].vy = -6;
+                obj.entities[i].vx = 6;
+            }
             break;
         case 4023:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 12;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 12;
+            }
             break;
         case 4024:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 12;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 12;
+            }
             break;
         case 4025:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 10;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 10;
+            }
             break;
         case 4026:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 8;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 8;
+            }
             break;
         case 4027:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 5;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 5;
+            }
             break;
         case 4028:
             state++;
             statedelay = 15;
             i = obj.getplayer();
-            obj.entities[i].xp += 2;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 2;
+            }
             break;
         case 4029:
             hascontrol = true;
@@ -3640,52 +3730,73 @@ void Game::updatestate()
 
             i = obj.getplayer();
             j = obj.getteleporter();
-            if (j != -1)
+            if (i > -1)
             {
-                obj.entities[i].xp = obj.entities[j].xp+44;
-                obj.entities[i].yp = obj.entities[j].yp+44;
-                obj.entities[j].tile = 2;
-                obj.entities[j].colour = 101;
-            }
-            obj.entities[i].colour = 0;
-            obj.entities[i].invis = false;
-            obj.entities[i].dir = 0;
+                if (j != -1)
+                {
+                    obj.entities[i].xp = obj.entities[j].xp+44;
+                    obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[j].tile = 2;
+                    obj.entities[j].colour = 101;
+                }
+                obj.entities[i].colour = 0;
+                obj.entities[i].invis = false;
+                obj.entities[i].dir = 0;
 
-            obj.entities[i].ay = -6;
-            obj.entities[i].ax = -6;
-            obj.entities[i].vy = -6;
-            obj.entities[i].vx = -6;
+                obj.entities[i].ay = -6;
+                obj.entities[i].ax = -6;
+                obj.entities[i].vy = -6;
+                obj.entities[i].vx = -6;
+            }
             break;
         case 4033:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp -= 12;
+            if (i > -1)
+            {
+                obj.entities[i].xp -= 12;
+            }
             break;
         case 4034:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp -= 12;
+            if (i > -1)
+            {
+                obj.entities[i].xp -= 12;
+            }
             break;
         case 4035:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp -= 10;
+            if (i > -1)
+            {
+                obj.entities[i].xp -= 10;
+            }
             break;
         case 4036:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp -= 8;
+            if (i > -1)
+            {
+                obj.entities[i].xp -= 8;
+            }
             break;
         case 4037:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp -= 5;
+            if (i > -1)
+            {
+                obj.entities[i].xp -= 5;
+            }
             break;
         case 4038:
             state++;
             statedelay = 15;
             i = obj.getplayer();
-            obj.entities[i].xp -= 2;
+            if (i > -1)
+            {
+                obj.entities[i].xp -= 2;
+            }
             break;
         case 4039:
             hascontrol = true;
@@ -3716,57 +3827,78 @@ void Game::updatestate()
 
             i = obj.getplayer();
             j = obj.getteleporter();
-            if (j != -1)
+            if (i > -1)
             {
-                obj.entities[i].xp = obj.entities[j].xp+44;
-                obj.entities[i].yp = obj.entities[j].yp+44;
-                obj.entities[j].tile = 2;
-                obj.entities[j].colour = 101;
-            }
-            obj.entities[i].colour = 0;
-            obj.entities[i].invis = false;
-            obj.entities[i].dir = 1;
+                if (j != -1)
+                {
+                    obj.entities[i].xp = obj.entities[j].xp+44;
+                    obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[j].tile = 2;
+                    obj.entities[j].colour = 101;
+                }
+                obj.entities[i].colour = 0;
+                obj.entities[i].invis = false;
+                obj.entities[i].dir = 1;
 
-            obj.entities[i].ay = -6;
-            obj.entities[i].ax = 6;
-            obj.entities[i].vy = -6;
-            obj.entities[i].vx = 6;
+                obj.entities[i].ay = -6;
+                obj.entities[i].ax = 6;
+                obj.entities[i].vy = -6;
+                obj.entities[i].vx = 6;
+            }
             break;
         case 4043:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 12;
-            obj.entities[i].yp -= 15;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 12;
+                obj.entities[i].yp -= 15;
+            }
             break;
         case 4044:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 12;
-            obj.entities[i].yp -= 10;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 12;
+                obj.entities[i].yp -= 10;
+            }
             break;
         case 4045:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 12;
-            obj.entities[i].yp -= 10;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 12;
+                obj.entities[i].yp -= 10;
+            }
             break;
         case 4046:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 8;
-            obj.entities[i].yp -= 8;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 8;
+                obj.entities[i].yp -= 8;
+            }
             break;
         case 4047:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 6;
-            obj.entities[i].yp -= 8;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 6;
+                obj.entities[i].yp -= 8;
+            }
             break;
         case 4048:
             state++;
             statedelay = 15;
             i = obj.getplayer();
-            obj.entities[i].xp += 3;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 3;
+            }
             break;
         case 4049:
             hascontrol = true;
@@ -3797,57 +3929,78 @@ void Game::updatestate()
 
             i = obj.getplayer();
             j = obj.getteleporter();
-            if (j != -1)
+            if (i > -1)
             {
-                obj.entities[i].xp = obj.entities[j].xp+44;
-                obj.entities[i].yp = obj.entities[j].yp+44;
-                obj.entities[j].tile = 2;
-                obj.entities[j].colour = 101;
-            }
-            obj.entities[i].colour = 0;
-            obj.entities[i].invis = false;
-            obj.entities[i].dir = 1;
+                if (j != -1)
+                {
+                    obj.entities[i].xp = obj.entities[j].xp+44;
+                    obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[j].tile = 2;
+                    obj.entities[j].colour = 101;
+                }
+                obj.entities[i].colour = 0;
+                obj.entities[i].invis = false;
+                obj.entities[i].dir = 1;
 
-            obj.entities[i].ay = -6;
-            obj.entities[i].ax = 6;
-            obj.entities[i].vy = -6;
-            obj.entities[i].vx = 6;
+                obj.entities[i].ay = -6;
+                obj.entities[i].ax = 6;
+                obj.entities[i].vy = -6;
+                obj.entities[i].vx = 6;
+            }
             break;
         case 4053:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 4;
-            obj.entities[i].yp -= 15;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 4;
+                obj.entities[i].yp -= 15;
+            }
             break;
         case 4054:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 4;
-            obj.entities[i].yp -= 10;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 4;
+                obj.entities[i].yp -= 10;
+            }
             break;
         case 4055:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 4;
-            obj.entities[i].yp -= 10;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 4;
+                obj.entities[i].yp -= 10;
+            }
             break;
         case 4056:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 4;
-            obj.entities[i].yp -= 8;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 4;
+                obj.entities[i].yp -= 8;
+            }
             break;
         case 4057:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 2;
-            obj.entities[i].yp -= 8;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 2;
+                obj.entities[i].yp -= 8;
+            }
             break;
         case 4058:
             state++;
             statedelay = 15;
             i = obj.getplayer();
-            obj.entities[i].xp += 1;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 1;
+            }
             break;
         case 4059:
             hascontrol = true;
@@ -3878,54 +4031,75 @@ void Game::updatestate()
 
             i = obj.getplayer();
             j = obj.getteleporter();
-            if (j != -1)
+            if (i > -1)
             {
-                obj.entities[i].xp = obj.entities[j].xp+44;
-                obj.entities[i].yp = obj.entities[j].yp+44;
-                obj.entities[j].tile = 2;
-                obj.entities[j].colour = 101;
-            }
-            obj.entities[i].colour = 0;
-            obj.entities[i].invis = false;
-            obj.entities[i].dir = 0;
+                if (j != -1)
+                {
+                    obj.entities[i].xp = obj.entities[j].xp+44;
+                    obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[j].tile = 2;
+                    obj.entities[j].colour = 101;
+                }
+                obj.entities[i].colour = 0;
+                obj.entities[i].invis = false;
+                obj.entities[i].dir = 0;
 
-            obj.entities[i].ay = -6;
-            obj.entities[i].ax = -6;
-            obj.entities[i].vy = -6;
-            obj.entities[i].vx = -6;
+                obj.entities[i].ay = -6;
+                obj.entities[i].ax = -6;
+                obj.entities[i].vy = -6;
+                obj.entities[i].vx = -6;
+            }
             break;
         case 4063:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp -= 28;
-            obj.entities[i].yp -= 8;
+            if (i > -1)
+            {
+                obj.entities[i].xp -= 28;
+                obj.entities[i].yp -= 8;
+            }
             break;
         case 4064:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp -= 28;
-            obj.entities[i].yp -= 8;
+            if (i > -1)
+            {
+                obj.entities[i].xp -= 28;
+                obj.entities[i].yp -= 8;
+            }
             break;
         case 4065:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp -= 25;
+            if (i > -1)
+            {
+                obj.entities[i].xp -= 25;
+            }
             break;
         case 4066:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp -= 25;
+            if (i > -1)
+            {
+                obj.entities[i].xp -= 25;
+            }
             break;
         case 4067:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp -= 20;
+            if (i > -1)
+            {
+                obj.entities[i].xp -= 20;
+            }
             break;
         case 4068:
             state++;
             statedelay = 15;
             i = obj.getplayer();
-            obj.entities[i].xp -= 16;
+            if (i > -1)
+            {
+                obj.entities[i].xp -= 16;
+            }
             break;
         case 4069:
             hascontrol = true;
@@ -3957,52 +4131,73 @@ void Game::updatestate()
 
             i = obj.getplayer();
             j = obj.getteleporter();
-            if (j != -1)
+            if (i > -1)
             {
-                obj.entities[i].xp = obj.entities[j].xp+44;
-                obj.entities[i].yp = obj.entities[j].yp+44;
-                obj.entities[j].tile = 2;
-                obj.entities[j].colour = 101;
-            }
-            obj.entities[i].invis = false;
-            obj.entities[i].dir = 1;
-            obj.entities[i].colour = obj.crewcolour(lastsaved);
+                if (j != -1)
+                {
+                    obj.entities[i].xp = obj.entities[j].xp+44;
+                    obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[j].tile = 2;
+                    obj.entities[j].colour = 101;
+                }
+                obj.entities[i].invis = false;
+                obj.entities[i].dir = 1;
+                obj.entities[i].colour = obj.crewcolour(lastsaved);
 
-            obj.entities[i].ay = -6;
-            obj.entities[i].ax = 6;
-            obj.entities[i].vy = -6;
-            obj.entities[i].vx = 6;
+                obj.entities[i].ay = -6;
+                obj.entities[i].ax = 6;
+                obj.entities[i].vy = -6;
+                obj.entities[i].vx = 6;
+            }
             break;
         case 4073:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 10;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 10;
+            }
             break;
         case 4074:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 10;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 10;
+            }
             break;
         case 4075:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 8;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 8;
+            }
             break;
         case 4076:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 6;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 6;
+            }
             break;
         case 4077:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 3;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 3;
+            }
             break;
         case 4078:
             state++;
             statedelay = 15;
             i = obj.getplayer();
-            obj.entities[i].xp += 1;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 1;
+            }
             break;
         case 4079:
             state = 0;
@@ -4033,52 +4228,73 @@ void Game::updatestate()
 
             i = obj.getplayer();
             j = obj.getteleporter();
-            if (j != -1)
+            if (i > -1)
             {
-                obj.entities[i].xp = obj.entities[j].xp+44;
-                obj.entities[i].yp = obj.entities[j].yp+44;
-                obj.entities[j].tile = 2;
-                obj.entities[j].colour = 101;
-            }
-            obj.entities[i].colour = 0;
-            obj.entities[i].invis = false;
-            obj.entities[i].dir = 1;
+                if (j != -1)
+                {
+                    obj.entities[i].xp = obj.entities[j].xp+44;
+                    obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[j].tile = 2;
+                    obj.entities[j].colour = 101;
+                }
+                obj.entities[i].colour = 0;
+                obj.entities[i].invis = false;
+                obj.entities[i].dir = 1;
 
-            obj.entities[i].ay = -6;
-            obj.entities[i].ax = 6;
-            obj.entities[i].vy = -6;
-            obj.entities[i].vx = 6;
+                obj.entities[i].ay = -6;
+                obj.entities[i].ax = 6;
+                obj.entities[i].vy = -6;
+                obj.entities[i].vx = 6;
+            }
             break;
         case 4083:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 10;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 10;
+            }
             break;
         case 4084:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 10;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 10;
+            }
             break;
         case 4085:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 8;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 8;
+            }
             break;
         case 4086:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 6;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 6;
+            }
             break;
         case 4087:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 3;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 3;
+            }
             break;
         case 4088:
             state++;
             statedelay = 15;
             i = obj.getplayer();
-            obj.entities[i].xp += 1;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 1;
+            }
             break;
         case 4089:
             startscript = true;
@@ -4109,52 +4325,73 @@ void Game::updatestate()
 
             i = obj.getplayer();
             j = obj.getteleporter();
-            if (j != -1)
+            if (i > -1)
             {
-                obj.entities[i].xp = obj.entities[j].xp+44;
-                obj.entities[i].yp = obj.entities[j].yp+44;
-                obj.entities[j].tile = 2;
-                obj.entities[j].colour = 101;
-            }
-            obj.entities[i].colour = 0;
-            obj.entities[i].invis = false;
-            obj.entities[i].dir = 1;
+                if (j != -1)
+                {
+                    obj.entities[i].xp = obj.entities[j].xp+44;
+                    obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[j].tile = 2;
+                    obj.entities[j].colour = 101;
+                }
+                obj.entities[i].colour = 0;
+                obj.entities[i].invis = false;
+                obj.entities[i].dir = 1;
 
-            obj.entities[i].ay = -6;
-            obj.entities[i].ax = 6;
-            obj.entities[i].vy = -6;
-            obj.entities[i].vx = 6;
+                obj.entities[i].ay = -6;
+                obj.entities[i].ax = 6;
+                obj.entities[i].vy = -6;
+                obj.entities[i].vx = 6;
+            }
             break;
         case 4093:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 10;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 10;
+            }
             break;
         case 4094:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 10;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 10;
+            }
             break;
         case 4095:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 8;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 8;
+            }
             break;
         case 4096:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 6;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 6;
+            }
             break;
         case 4097:
             state++;
             i = obj.getplayer();
-            obj.entities[i].xp += 3;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 3;
+            }
             break;
         case 4098:
             state++;
             statedelay = 15;
             i = obj.getplayer();
-            obj.entities[i].xp += 1;
+            if (i > -1)
+            {
+                obj.entities[i].xp += 1;
+            }
             break;
         case 4099:
             if (nocutscenes)
@@ -4820,9 +5057,12 @@ void Game::deathsequence()
     {
         i = obj.getplayer();
     }
-    obj.entities[i].colour = 1;
+    if (i > -1)
+    {
+        obj.entities[i].colour = 1;
 
-    obj.entities[i].invis = false;
+        obj.entities[i].invis = false;
+    }
     if (deathseq == 30)
     {
         if (nodeathmode)
@@ -4832,7 +5072,10 @@ void Game::deathsequence()
         }
         deathcounts++;
         music.playef(2);
-        obj.entities[i].invis = true;
+        if (i > -1)
+        {
+            obj.entities[i].invis = true;
+        }
         if (map.finalmode)
         {
             if (roomx - 41 >= 0 && roomx - 41 < 20 && roomy - 48 >= 0 && roomy - 48 < 20)
@@ -4850,15 +5093,18 @@ void Game::deathsequence()
             }
         }
     }
-    if (deathseq == 25) obj.entities[i].invis = true;
-    if (deathseq == 20) obj.entities[i].invis = true;
-    if (deathseq == 16) obj.entities[i].invis = true;
-    if (deathseq == 14) obj.entities[i].invis = true;
-    if (deathseq == 12) obj.entities[i].invis = true;
-    if (deathseq < 10) obj.entities[i].invis = true;
+    if (i > -1)
+    {
+        if (deathseq == 25) obj.entities[i].invis = true;
+        if (deathseq == 20) obj.entities[i].invis = true;
+        if (deathseq == 16) obj.entities[i].invis = true;
+        if (deathseq == 14) obj.entities[i].invis = true;
+        if (deathseq == 12) obj.entities[i].invis = true;
+        if (deathseq < 10) obj.entities[i].invis = true;
+    }
     if (!nodeathmode)
     {
-        if (deathseq <= 1) obj.entities[i].invis = false;
+        if (i > -1 && deathseq <= 1) obj.entities[i].invis = false;
     }
     else
     {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -2157,6 +2157,7 @@ void Game::updatestate()
             music.playef(10);
             break;
         case 2502:
+        {
             //Activating a teleporter 2
             state++;
             statedelay = 5;
@@ -2165,17 +2166,25 @@ void Game::updatestate()
             obj.entities[i].colour = 0;
             obj.entities[i].invis = false;
 
-            obj.entities[i].xp = obj.entities[obj.getteleporter()].xp+44;
-            obj.entities[i].yp = obj.entities[obj.getteleporter()].yp+44;
+            int j = obj.getteleporter();
+            if (j > -1)
+            {
+                obj.entities[i].xp = obj.entities[j].xp+44;
+                obj.entities[i].yp = obj.entities[j].yp+44;
+            }
             obj.entities[i].ay = -6;
             obj.entities[i].ax = 6;
             obj.entities[i].vy = -6;
             obj.entities[i].vx = 6;
 
             i = obj.getteleporter();
-            obj.entities[i].tile = 1;
-            obj.entities[i].colour = 101;
+            if (i > -1)
+            {
+                obj.entities[i].tile = 1;
+                obj.entities[i].colour = 101;
+            }
             break;
+        }
         case 2503:
             state++;
             i = obj.getplayer();
@@ -2316,8 +2325,11 @@ void Game::updatestate()
             }
 
             i = obj.getteleporter();
-            obj.entities[i].tile = 1;
-            obj.entities[i].colour = 100;
+            if (i > -1)
+            {
+                obj.entities[i].tile = 1;
+                obj.entities[i].colour = 100;
+            }
             break;
 
         case 3006:
@@ -3517,8 +3529,11 @@ void Game::updatestate()
             }
             i = obj.getteleporter();
             activetele = true;
-            teleblock.x = obj.entities[i].xp - 32;
-            teleblock.y = obj.entities[i].yp - 32;
+            if (i > -1)
+            {
+                teleblock.x = obj.entities[i].xp - 32;
+                teleblock.y = obj.entities[i].yp - 32;
+            }
             teleblock.w = 160;
             teleblock.h = 160;
             hascontrol = true;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1605,7 +1605,10 @@ void gameinput()
                                 music.fadeout();
 
                                 int player = obj.getplayer();
-                                obj.entities[player].colour = 102;
+                                if (player > -1)
+                                {
+                                    obj.entities[player].colour = 102;
+                                }
 
                                 int teleporter = obj.getteleporter();
                                 if (teleporter > -1)
@@ -1639,7 +1642,10 @@ void gameinput()
                                 music.fadeout();
 
                                 int player = obj.getplayer();
-                                obj.entities[player].colour = 102;
+                                if (player > -1)
+                                {
+                                    obj.entities[player].colour = 102;
+                                }
                                 int companion = obj.getcompanion();
                                 if(companion>-1) obj.entities[companion].colour = 102;
 
@@ -1948,7 +1954,10 @@ void mapinput()
             game.hascontrol = false;
 
             int i = obj.getplayer();
-            obj.entities[i].colour = 102;
+            if (i > -1)
+            {
+                obj.entities[i].colour = 102;
+            }
 
             //which teleporter script do we use? it depends on the companion!
             game.state = 4000;
@@ -2116,7 +2125,10 @@ void teleporterinput()
                 game.hascontrol = false;
 
                 int i = obj.getplayer();
-                obj.entities[i].colour = 102;
+                if (i > -1)
+                {
+                    obj.entities[i].colour = 102;
+                }
 
                 i = obj.getteleporter();
                 if (i > -1)

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1608,8 +1608,11 @@ void gameinput()
                                 obj.entities[player].colour = 102;
 
                                 int teleporter = obj.getteleporter();
-                                obj.entities[teleporter].tile = 6;
-                                obj.entities[teleporter].colour = 102;
+                                if (teleporter > -1)
+                                {
+                                    obj.entities[teleporter].tile = 6;
+                                    obj.entities[teleporter].colour = 102;
+                                }
                                 //which teleporter script do we use? it depends on the companion!
                                 game.state = 4000;
                                 game.statedelay = 0;
@@ -1641,8 +1644,11 @@ void gameinput()
                                 if(companion>-1) obj.entities[companion].colour = 102;
 
                                 int teleporter = obj.getteleporter();
-                                obj.entities[teleporter].tile = 6;
-                                obj.entities[teleporter].colour = 102;
+                                if (teleporter > -1)
+                                {
+                                    obj.entities[teleporter].tile = 6;
+                                    obj.entities[teleporter].colour = 102;
+                                }
                                 //which teleporter script do we use? it depends on the companion!
                                 game.state = 3000;
                                 game.statedelay = 0;
@@ -2113,8 +2119,11 @@ void teleporterinput()
                 obj.entities[i].colour = 102;
 
                 i = obj.getteleporter();
-                obj.entities[i].tile = 6;
-                obj.entities[i].colour = 102;
+                if (i > -1)
+                {
+                    obj.entities[i].tile = 6;
+                    obj.entities[i].colour = 102;
+                }
                 //which teleporter script do we use? it depends on the companion!
                 game.state = 4000;
                 game.statedelay = 0;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -142,7 +142,10 @@ void gamelogic()
             obj.upsetmode = true;
             //change player to sad
             int i = obj.getplayer();
-            obj.entities[i].tile = 144;
+            if (i > -1)
+            {
+                obj.entities[i].tile = 144;
+            }
             music.playef(2);
         }
         if (obj.upset > 301) obj.upset = 301;
@@ -156,7 +159,10 @@ void gamelogic()
             obj.upsetmode = false;
             //change player to happy
             int i = obj.getplayer();
-            obj.entities[i].tile = 0;
+            if (i > -1)
+            {
+                obj.entities[i].tile = 0;
+            }
         }
     }
     else
@@ -199,7 +205,10 @@ void gamelogic()
             else if (map.cameramode == 4)
             {
                 int i = obj.getplayer();
-                map.cameraseek = map.ypos - (obj.entities[i].yp - 120);
+                if (i > -1)
+                {
+                    map.cameraseek = map.ypos - (obj.entities[i].yp - 120);
+                }
 
                 map.cameraseek = map.cameraseek / 10;
                 map.cameraseekframe = 10;
@@ -217,14 +226,14 @@ void gamelogic()
                 {
                     int i = obj.getplayer();
                     map.ypos -= map.cameraseek;
-                    if (map.cameraseek > 0)
+                    if (map.cameraseek > 0 && i > -1)
                     {
                         if (map.ypos < obj.entities[i].yp - 120)
                         {
                             map.ypos = obj.entities[i].yp - 120;
                         }
                     }
-                    else
+                    else if (i > -1)
                     {
                         if (map.ypos > obj.entities[i].yp - 120)
                         {
@@ -237,7 +246,10 @@ void gamelogic()
                 else
                 {
                     int i = obj.getplayer();
-                    map.ypos = obj.entities[i].yp - 120;
+                    if (i > -1)
+                    {
+                        map.ypos = obj.entities[i].yp - 120;
+                    }
                     map.bypos = map.ypos / 2;
                     map.cameramode = 0;
                     map.colsuperstate = 0;
@@ -481,7 +493,7 @@ void gamelogic()
             if (game.roomx == 41 + game.scmprogress)   //he's in the same room
             {
                 int i = obj.getplayer();
-                if (obj.entities[i].ax > 0 && obj.entities[i].xp > 280)
+                if (i > -1 && obj.entities[i].ax > 0 && obj.entities[i].xp > 280)
                 {
                     obj.entities[i].ax = 0;
                     obj.entities[i].dir = 0;
@@ -759,7 +771,7 @@ void gamelogic()
                 //is the player standing on a moving platform?
                 int i = obj.getplayer();
                 float j = obj.entitycollideplatformfloor(i);
-                if (j > -1000)
+                if (i > -1 && j > -1000)
                 {
                     obj.entities[i].newxp = obj.entities[i].xp + j;
                     obj.entitymapcollision(i);
@@ -767,7 +779,7 @@ void gamelogic()
                 else
                 {
                     j = obj.entitycollideplatformroof(i);
-                    if (j > -1000)
+                    if (i > -1 && j > -1000)
                     {
                         obj.entities[i].newxp = obj.entities[i].xp + j;
                         obj.entitymapcollision(i);
@@ -792,7 +804,7 @@ void gamelogic()
             {
                 //special for tower: is the player touching any spike blocks?
                 int player = obj.getplayer();
-                if(obj.checktowerspikes(player) && graphics.fademode==0)
+                if(player > -1 && obj.checktowerspikes(player) && graphics.fademode==0)
                 {
                     game.deathseq = 30;
                 }
@@ -801,7 +813,7 @@ void gamelogic()
             if(map.towermode && game.lifeseq==0)
             {
                 int player = obj.getplayer();
-                if(!map.invincibility)
+                if(!map.invincibility && player > -1)
                 {
                     if (obj.entities[player].yp-map.ypos <= 0)
                     {
@@ -812,7 +824,7 @@ void gamelogic()
                         game.deathseq = 30;
                     }
                 }
-                else
+                else if (player > -1)
                 {
                     if (obj.entities[player].yp-map.ypos <= 0)
                     {
@@ -828,7 +840,7 @@ void gamelogic()
                     }
                 }
 
-                if (obj.entities[player].yp - map.ypos <= 40)
+                if (player > -1 && obj.entities[player].yp - map.ypos <= 40)
                 {
                     map.spikeleveltop++;
                     if (map.spikeleveltop >= 8) map.spikeleveltop = 8;
@@ -838,7 +850,7 @@ void gamelogic()
                     if (map.spikeleveltop > 0) map.spikeleveltop--;
                 }
 
-                if (obj.entities[player].yp - map.ypos >= 164)
+                if (player > -1 && obj.entities[player].yp - map.ypos >= 164)
                 {
                     map.spikelevelbottom++;
                     if (map.spikelevelbottom >= 8) map.spikelevelbottom = 8;
@@ -860,7 +872,7 @@ void gamelogic()
             obj.customwarpmodevon = false;
 
             int i = obj.getplayer();
-            if ((game.door_down > -2 && obj.entities[i].yp >= 226-16) || (game.door_up > -2 && obj.entities[i].yp < -2+16) ||	(game.door_left > -2 && obj.entities[i].xp < -14+16) ||	(game.door_right > -2 && obj.entities[i].xp >= 308-16)){
+            if (i > -1 && ((game.door_down > -2 && obj.entities[i].yp >= 226-16) || (game.door_up > -2 && obj.entities[i].yp < -2+16) ||	(game.door_left > -2 && obj.entities[i].xp < -14+16) ||	(game.door_right > -2 && obj.entities[i].xp >= 308-16))){
             //Player is leaving room
             obj.customwarplinecheck(i);
         }
@@ -955,12 +967,12 @@ void gamelogic()
         {
             //Normal! Just change room
             int player = obj.getplayer();
-            if (game.door_down > -2 && obj.entities[player].yp >= 238)
+            if (player > -1 && game.door_down > -2 && obj.entities[player].yp >= 238)
             {
                 obj.entities[player].yp -= 240;
                 map.gotoroom(game.roomx, game.roomy + 1);
             }
-            if (game.door_up > -2 && obj.entities[player].yp < -2)
+            if (player > -1 && game.door_up > -2 && obj.entities[player].yp < -2)
             {
                 obj.entities[player].yp += 240;
                 map.gotoroom(game.roomx, game.roomy - 1);
@@ -971,12 +983,12 @@ void gamelogic()
         {
             //Normal! Just change room
             int player = obj.getplayer();
-            if (game.door_left > -2 && obj.entities[player].xp < -14)
+            if (player > -1 && game.door_left > -2 && obj.entities[player].xp < -14)
             {
                 obj.entities[player].xp += 320;
                 map.gotoroom(game.roomx - 1, game.roomy);
             }
-            if (game.door_right > -2 && obj.entities[player].xp >= 308)
+            if (player > -1 && game.door_right > -2 && obj.entities[player].xp >= 308)
             {
                 obj.entities[player].xp -= 320;
                 map.gotoroom(game.roomx + 1, game.roomy);
@@ -990,12 +1002,12 @@ void gamelogic()
             {
                 //This is minitower 1!
                 int player = obj.getplayer();
-                if (game.door_left > -2 && obj.entities[player].xp < -14)
+                if (player > -1 && game.door_left > -2 && obj.entities[player].xp < -14)
                 {
                     obj.entities[player].xp += 320;
                     map.gotoroom(48, 52);
                 }
-                if (game.door_right > -2 && obj.entities[player].xp >= 308)
+                if (player > -1 && game.door_right > -2 && obj.entities[player].xp >= 308)
                 {
                     obj.entities[player].xp -= 320;
                     obj.entities[player].yp -= (71*8);
@@ -1006,7 +1018,7 @@ void gamelogic()
             {
                 //This is minitower 2!
                 int player = obj.getplayer();
-                if (game.door_left > -2 && obj.entities[player].xp < -14)
+                if (player > -1 && game.door_left > -2 && obj.entities[player].xp < -14)
                 {
                     if (obj.entities[player].yp > 300)
                     {
@@ -1020,7 +1032,7 @@ void gamelogic()
                         map.gotoroom(50, 53);
                     }
                 }
-                if (game.door_right > -2 && obj.entities[player].xp >= 308)
+                if (player > -1 && game.door_right > -2 && obj.entities[player].xp >= 308)
                 {
                     obj.entities[player].xp -= 320;
                     map.gotoroom(52, 53);
@@ -1051,13 +1063,13 @@ void gamelogic()
             {
                 //Do not wrap! Instead, go to the correct room
                 int player = obj.getplayer();
-                if (game.door_left > -2 && obj.entities[player].xp < -14)
+                if (player > -1 && game.door_left > -2 && obj.entities[player].xp < -14)
                 {
                     obj.entities[player].xp += 320;
                     obj.entities[player].yp -= (671 * 8);
                     map.gotoroom(108, 109);
                 }
-                if (game.door_right > -2 && obj.entities[player].xp >= 308)
+                if (player > -1 && game.door_right > -2 && obj.entities[player].xp >= 308)
                 {
                     obj.entities[player].xp -= 320;
                     map.gotoroom(110, 104);
@@ -1090,42 +1102,60 @@ void gamelogic()
                 if (game.roomx == 117 && game.roomy == 102)
                 {
                     int i = obj.getplayer();
-                    obj.entities[i].yp = 225;
+                    if (i > -1)
+                    {
+                        obj.entities[i].yp = 225;
+                    }
                     map.gotoroom(119, 100);
                     game.teleport = false;
                 }
                 else if (game.roomx == 119 && game.roomy == 100)
                 {
                     int i = obj.getplayer();
-                    obj.entities[i].yp = 225;
+                    if (i > -1)
+                    {
+                        obj.entities[i].yp = 225;
+                    }
                     map.gotoroom(119, 103);
                     game.teleport = false;
                 }
                 else if (game.roomx == 119 && game.roomy == 103)
                 {
                     int i = obj.getplayer();
-                    obj.entities[i].xp = 0;
+                    if (i > -1)
+                    {
+                        obj.entities[i].xp = 0;
+                    }
                     map.gotoroom(116, 103);
                     game.teleport = false;
                 }
                 else if (game.roomx == 116 && game.roomy == 103)
                 {
                     int i = obj.getplayer();
-                    obj.entities[i].yp = 225;
+                    if (i > -1)
+                    {
+                        obj.entities[i].yp = 225;
+                    }
                     map.gotoroom(116, 100);
                     game.teleport = false;
                 }
                 else if (game.roomx == 116 && game.roomy == 100)
                 {
                     int i = obj.getplayer();
-                    obj.entities[i].xp = 0;
+                    if (i > -1)
+                    {
+                        obj.entities[i].xp = 0;
+                    }
                     map.gotoroom(114, 102);
                     game.teleport = false;
                 }
                 else if (game.roomx == 114 && game.roomy == 102)
                 {
                     int i = obj.getplayer();
-                    obj.entities[i].yp = 225;
+                    if (i > -1)
+                    {
+                        obj.entities[i].yp = 225;
+                    }
                     map.gotoroom(113, 100);
                     game.teleport = false;
                 }
@@ -1187,9 +1217,9 @@ void gamelogic()
     {
         //We've changed room? Let's bring our companion along!
         game.roomchange = false;
-        if (game.companion > 0)
+        int i = obj.getplayer();
+        if (game.companion > 0 && i > -1)
         {
-            int i = obj.getplayer();
             //ok, we'll presume our companion has been destroyed in the room change. So:
             switch(game.companion)
             {
@@ -1355,7 +1385,10 @@ void gamelogic()
     if (game.activetele)
     {
         int i = obj.getplayer();
-        obj.settemprect(i);
+        if (i > -1)
+        {
+            obj.settemprect(i);
+        }
         if (help.intersects(game.teleblock, obj.temprect))
         {
             game.readytotele += 25;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1226,8 +1226,11 @@ void gamelogic()
             case 6:
                 obj.createentity(obj.entities[i].xp, 121.0f, 15.0f,1);  //Y=121, the floor in that particular place!
                 j = obj.getcompanion();
-                obj.entities[j].vx = obj.entities[i].vx;
-                obj.entities[j].dir = obj.entities[i].dir;
+                if (j > -1)
+                {
+                    obj.entities[j].vx = obj.entities[i].vx;
+                    obj.entities[j].dir = obj.entities[i].dir;
+                }
                 break;
             case 7:
                 if (game.roomy <= 105)   //don't jump after him!
@@ -1241,8 +1244,11 @@ void gamelogic()
                         obj.createentity(obj.entities[i].xp, 86.0f, 16.0f, 1);  //Y=86, the ROOF in that particular place!
                     }
                     j = obj.getcompanion();
-                    obj.entities[j].vx = obj.entities[i].vx;
-                    obj.entities[j].dir = obj.entities[i].dir;
+                    if (j > -1)
+                    {
+                        obj.entities[j].vx = obj.entities[i].vx;
+                        obj.entities[j].dir = obj.entities[i].dir;
+                    }
                 }
                 break;
             case 8:
@@ -1252,15 +1258,21 @@ void gamelogic()
                     {
                         obj.createentity(310, 177, 17, 1);
                         j = obj.getcompanion();
-                        obj.entities[j].vx = obj.entities[i].vx;
-                        obj.entities[j].dir = obj.entities[i].dir;
+                        if (j > -1)
+                        {
+                            obj.entities[j].vx = obj.entities[i].vx;
+                            obj.entities[j].dir = obj.entities[i].dir;
+                        }
                     }
                     else
                     {
                         obj.createentity(obj.entities[i].xp, 177.0f, 17.0f, 1);
                         j = obj.getcompanion();
-                        obj.entities[j].vx = obj.entities[i].vx;
-                        obj.entities[j].dir = obj.entities[i].dir;
+                        if (j > -1)
+                        {
+                            obj.entities[j].vx = obj.entities[i].vx;
+                            obj.entities[j].dir = obj.entities[i].dir;
+                        }
                     }
                 }
                 break;
@@ -1276,8 +1288,11 @@ void gamelogic()
                         obj.createentity(obj.entities[i].xp, 185.0f, 18.0f, 15, 0, 1);
                     }
                     j = obj.getcompanion();
-                    obj.entities[j].vx = obj.entities[i].vx;
-                    obj.entities[j].dir = obj.entities[i].dir;
+                    if (j > -1)
+                    {
+                        obj.entities[j].vx = obj.entities[i].vx;
+                        obj.entities[j].dir = obj.entities[i].dir;
+                    }
                 }
                 break;
             case 10:
@@ -1288,8 +1303,11 @@ void gamelogic()
                     {
                         obj.createentity(225.0f, 169.0f, 18, graphics.crewcolour(game.lastsaved), 0, 10);
                         j = obj.getcompanion();
-                        obj.entities[j].vx = obj.entities[i].vx;
-                        obj.entities[j].dir = obj.entities[i].dir;
+                        if (j > -1)
+                        {
+                            obj.entities[j].vx = obj.entities[i].vx;
+                            obj.entities[j].dir = obj.entities[i].dir;
+                        }
                     }
                 }
                 else	if (game.roomy >= 52)
@@ -1298,16 +1316,22 @@ void gamelogic()
                     {
                         obj.createentity(160.0f, 177.0f, 18, graphics.crewcolour(game.lastsaved), 0, 18, 1);
                         j = obj.getcompanion();
-                        obj.entities[j].vx = obj.entities[i].vx;
-                        obj.entities[j].dir = obj.entities[i].dir;
+                        if (j > -1)
+                        {
+                            obj.entities[j].vx = obj.entities[i].vx;
+                            obj.entities[j].dir = obj.entities[i].dir;
+                        }
                     }
                     else
                     {
                         obj.flags[59] = true;
                         obj.createentity(obj.entities[i].xp, -20.0f, 18.0f, graphics.crewcolour(game.lastsaved), 0, 10, 0);
                         j = obj.getcompanion();
-                        obj.entities[j].vx = obj.entities[i].vx;
-                        obj.entities[j].dir = obj.entities[i].dir;
+                        if (j > -1)
+                        {
+                            obj.entities[j].vx = obj.entities[i].vx;
+                            obj.entities[j].dir = obj.entities[i].dir;
+                        }
                     }
                 }
                 break;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -825,8 +825,11 @@ void mapclass::warpto(int rx, int ry , int t, int tx, int ty)
 {
 	gotoroom(rx, ry);
 	game.teleport = false;
-	obj.entities[t].xp = tx * 8;
-	obj.entities[t].yp = (ty * 8) - obj.entities[t].h;
+	if (t >= 0 && t < (int) obj.entities.size())
+	{
+		obj.entities[t].xp = tx * 8;
+		obj.entities[t].yp = (ty * 8) - obj.entities[t].h;
+	}
 	game.gravitycontrol = 0;
 }
 
@@ -1191,7 +1194,10 @@ void mapclass::loadlevel(int rx, int ry)
 			{
 				//entered from ground floor
 				int player = obj.getplayer();
-				obj.entities[player].yp += (671 * 8);
+				if (player > -1)
+				{
+					obj.entities[player].yp += (671 * 8);
+				}
 
 				ypos = (700-29) * 8;
 				bypos = ypos / 2;
@@ -1392,7 +1398,10 @@ void mapclass::loadlevel(int rx, int ry)
 		tower.loadminitower1();
 
 		int i = obj.getplayer();
-		obj.entities[i].yp += (71 * 8);
+		if (i > -1)
+		{
+			obj.entities[i].yp += (71 * 8);
+		}
 		game.roomy--;
 		finaly--;
 
@@ -1433,7 +1442,10 @@ void mapclass::loadlevel(int rx, int ry)
 		obj.createentity(72, 156, 11, 200); // (horizontal gravity line)
 
 		int i = obj.getplayer();
-		obj.entities[i].yp += (71 * 8);
+		if (i > -1)
+		{
+			obj.entities[i].yp += (71 * 8);
+		}
 		game.roomy--;
 		finaly--;
 
@@ -1907,11 +1919,11 @@ void mapclass::loadlevel(int rx, int ry)
 			{
 				//face the player
 				j = obj.getplayer();
-				if (obj.entities[j].xp > obj.entities[i].xp + 5)
+				if (j > -1 && obj.entities[j].xp > obj.entities[i].xp + 5)
 				{
 					obj.entities[i].dir = 1;
 				}
-				else if (obj.entities[j].xp < obj.entities[i].xp - 5)
+				else if (j > -1 && obj.entities[j].xp < obj.entities[i].xp - 5)
 				{
 					obj.entities[i].dir = 0;
 				}

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1394,10 +1394,13 @@ void gamerender()
                     GhostInfo ghost;
                     ghost.rx = game.roomx-100;
                     ghost.ry = game.roomy-100;
-                    ghost.x = obj.entities[i].xp;
-                    ghost.y = obj.entities[i].yp;
-                    ghost.col = obj.entities[i].colour;
-                    ghost.frame = obj.entities[i].drawframe;
+                    if (i > -1)
+                    {
+                        ghost.x = obj.entities[i].xp;
+                        ghost.y = obj.entities[i].yp;
+                        ghost.col = obj.entities[i].colour;
+                        ghost.frame = obj.entities[i].drawframe;
+                    }
                     ed.ghosts.push_back(ghost);
                 }
                 if (ed.ghosts.size() > 100)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1097,8 +1097,11 @@ void scriptclass::run()
 			else if (words[0] == "activateteleporter")
 			{
 				i = obj.getteleporter();
-				obj.entities[i].tile = 6;
-				obj.entities[i].colour = 102;
+				if (i > -1)
+				{
+					obj.entities[i].tile = 6;
+					obj.entities[i].colour = 102;
+				}
 			}
 			else if (words[0] == "changecolour")
 			{
@@ -1835,7 +1838,10 @@ void scriptclass::run()
 			else if (words[0] == "activeteleporter")
 			{
 				i = obj.getteleporter();
-				obj.entities[i].colour = 101;
+				if (i > -1)
+				{
+					obj.entities[i].colour = 101;
+				}
 			}
 			else if (words[0] == "foundtrinket")
 			{
@@ -3290,12 +3296,18 @@ void scriptclass::teleport()
 	game.gravitycontrol = 0;
 	map.gotoroom(100+game.teleport_to_x, 100+game.teleport_to_y);
 	j = obj.getteleporter();
-	obj.entities[j].state = 2;
+	if (j > -1)
+	{
+		obj.entities[j].state = 2;
+	}
 	game.teleport_to_new_area = false;
 
-	game.savepoint = obj.entities[j].para;
-	game.savex = obj.entities[j].xp + 44;
-	game.savey = obj.entities[j].yp + 44;
+	if (j > -1)
+	{
+		game.savepoint = obj.entities[j].para;
+		game.savex = obj.entities[j].xp + 44;
+		game.savey = obj.entities[j].yp + 44;
+	}
 	game.savegc = 0;
 
 	game.saverx = game.roomx;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -84,8 +84,11 @@ void scriptclass::run()
 			{
 				//USAGE: moveplayer(x offset, y offset)
 				int player = obj.getplayer();
-				obj.entities[player].xp += ss_toi(words[1]);
-				obj.entities[player].yp += ss_toi(words[2]);
+				if (player > -1)
+				{
+					obj.entities[player].xp += ss_toi(words[1]);
+					obj.entities[player].yp += ss_toi(words[2]);
+				}
 				scriptdelay = 1;
 			}
 #if !defined(NO_CUSTOM_LEVELS)
@@ -230,7 +233,8 @@ void scriptclass::run()
 			}
 			if (words[0] == "tofloor")
 			{
-				if(obj.entities[obj.getplayer()].onroof>0)
+				int player = obj.getplayer();
+				if(player > -1 && obj.entities[player].onroof>0)
 				{
 					game.press_action = true;
 					scriptdelay = 1;
@@ -270,8 +274,11 @@ void scriptclass::run()
 			{
 				//USAGE: gotoposition(x position, y position, gravity position)
 				int player = obj.getplayer();
-				obj.entities[player].xp = ss_toi(words[1]);
-				obj.entities[player].yp = ss_toi(words[2]);
+				if (player > -1)
+				{
+					obj.entities[player].xp = ss_toi(words[1]);
+					obj.entities[player].yp = ss_toi(words[2]);
+				}
 				game.gravitycontrol = ss_toi(words[3]);
 
 			}
@@ -391,7 +398,10 @@ void scriptclass::run()
 				if (words[1] == "player")
 				{
 					i = obj.getplayer();
-					j = obj.entities[i].dir;
+					if (i > -1)
+					{
+						j = obj.entities[i].dir;
+					}
 				}
 				else if (words[1] == "cyan")
 				{
@@ -444,7 +454,7 @@ void scriptclass::run()
 				}
 
 				//next is whether to position above or below
-				if (words[2] == "above")
+				if (i > -1 && words[2] == "above")
 				{
 					if (j == 1)    //left
 					{
@@ -457,7 +467,7 @@ void scriptclass::run()
 						texty = obj.entities[i].yp - 18 - (txt.size() * 8);
 					}
 				}
-				else
+				else if (i > -1)
 				{
 					if (j == 1)    //left
 					{
@@ -660,24 +670,30 @@ void scriptclass::run()
 			{
 				//Create the super VVVVVV combo!
 				i = obj.getplayer();
-				obj.entities[i].xp = 30;
-				obj.entities[i].yp = 46;
-				obj.entities[i].size = 13;
-				obj.entities[i].colour = 23;
-				obj.entities[i].cx = 36;// 6;
-				obj.entities[i].cy = 12+80;// 2;
-				obj.entities[i].h = 126-80;// 21;
+				if (i > -1)
+				{
+					obj.entities[i].xp = 30;
+					obj.entities[i].yp = 46;
+					obj.entities[i].size = 13;
+					obj.entities[i].colour = 23;
+					obj.entities[i].cx = 36;// 6;
+					obj.entities[i].cy = 12+80;// 2;
+					obj.entities[i].h = 126-80;// 21;
+				}
 			}
 			else if (words[0] == "undovvvvvvman")
 			{
 				//Create the super VVVVVV combo!
 				i = obj.getplayer();
-				obj.entities[i].xp = 100;
-				obj.entities[i].size = 0;
-				obj.entities[i].colour = 0;
-				obj.entities[i].cx = 6;
-				obj.entities[i].cy = 2;
-				obj.entities[i].h = 21;
+				if (i > -1)
+				{
+					obj.entities[i].xp = 100;
+					obj.entities[i].size = 0;
+					obj.entities[i].colour = 0;
+					obj.entities[i].cx = 6;
+					obj.entities[i].cy = 2;
+					obj.entities[i].h = 21;
+				}
 			}
 			else if (words[0] == "createentity")
 			{
@@ -796,11 +812,11 @@ void scriptclass::run()
 					i=obj.getcrewman(1);
 				}
 
-				if (ss_toi(words[2]) == 0)
+				if (i > -1 && ss_toi(words[2]) == 0)
 				{
 					obj.entities[i].tile = 0;
 				}
-				else
+				else if (i > -1)
 				{
 					obj.entities[i].tile = 144;
 				}
@@ -893,7 +909,10 @@ void scriptclass::run()
 					i=obj.getcrewman(1);
 				}
 
-				obj.entities[i].tile = ss_toi(words[2]);
+				if (i > -1)
+				{
+					obj.entities[i].tile = ss_toi(words[2]);
+				}
 			}
 			else if (words[0] == "flipgravity")
 			{
@@ -973,7 +992,10 @@ void scriptclass::run()
 					i=obj.getcrewman(1);
 				}
 
-				obj.entities[i].tile +=12;
+				if (i > -1)
+				{
+					obj.entities[i].tile +=12;
+				}
 			}
 			else if (words[0] == "changedir")
 			{
@@ -1006,11 +1028,11 @@ void scriptclass::run()
 					i=obj.getcrewman(1);
 				}
 
-				if (ss_toi(words[2]) == 0)
+				if (i > -1 && ss_toi(words[2]) == 0)
 				{
 					obj.entities[i].dir = 0;
 				}
-				else
+				else if (i > -1)
 				{
 					obj.entities[i].dir = 1;
 				}
@@ -1075,14 +1097,17 @@ void scriptclass::run()
 				}
 
 
-				obj.entities[i].state = ss_toi(words[2]);
-				if (obj.entities[i].state == 16)
+				if (i > -1)
 				{
-					obj.entities[i].para=ss_toi(words[3]);
-				}
-				else if (obj.entities[i].state == 17)
-				{
-					obj.entities[i].dir=ss_toi(words[3]);
+					obj.entities[i].state = ss_toi(words[2]);
+					if (obj.entities[i].state == 16)
+					{
+						obj.entities[i].para=ss_toi(words[3]);
+					}
+					else if (obj.entities[i].state == 17)
+					{
+						obj.entities[i].dir=ss_toi(words[3]);
+					}
 				}
 			}
 			else if (words[0] == "alarmon")
@@ -1134,33 +1159,36 @@ void scriptclass::run()
 					i=obj.getcrewman(1);
 				}
 
-				if (words[2] == "cyan")
+				if (i > -1)
 				{
-					obj.entities[i].colour = 0;
-				}
-				else if (words[2] == "red")
-				{
-					obj.entities[i].colour = 15;
-				}
-				else if (words[2] == "green")
-				{
-					obj.entities[i].colour = 13;
-				}
-				else if (words[2] == "yellow")
-				{
-					obj.entities[i].colour = 14;
-				}
-				else if (words[2] == "blue")
-				{
-					obj.entities[i].colour = 16;
-				}
-				else if (words[2] == "purple")
-				{
-					obj.entities[i].colour = 20;
-				}
-				else if (words[2] == "teleporter")
-				{
-					obj.entities[i].colour = 102;
+					if (words[2] == "cyan")
+					{
+						obj.entities[i].colour = 0;
+					}
+					else if (words[2] == "red")
+					{
+						obj.entities[i].colour = 15;
+					}
+					else if (words[2] == "green")
+					{
+						obj.entities[i].colour = 13;
+					}
+					else if (words[2] == "yellow")
+					{
+						obj.entities[i].colour = 14;
+					}
+					else if (words[2] == "blue")
+					{
+						obj.entities[i].colour = 16;
+					}
+					else if (words[2] == "purple")
+					{
+						obj.entities[i].colour = 20;
+					}
+					else if (words[2] == "teleporter")
+					{
+						obj.entities[i].colour = 102;
+					}
 				}
 			}
 			else if (words[0] == "squeak")
@@ -1214,12 +1242,18 @@ void scriptclass::run()
 			{
 				i = obj.getplayer();
 				game.savepoint = 0;
-				game.savex = obj.entities[i].xp ;
-				game.savey = obj.entities[i].yp;
+				if (i > -1)
+				{
+					game.savex = obj.entities[i].xp ;
+					game.savey = obj.entities[i].yp;
+				}
 				game.savegc = game.gravitycontrol;
 				game.saverx = game.roomx;
 				game.savery = game.roomy;
-				game.savedir = obj.entities[i].dir;
+				if (i > -1)
+				{
+					game.savedir = obj.entities[i].dir;
+				}
 			}
 			else if (words[0] == "gamestate")
 			{
@@ -1368,11 +1402,19 @@ void scriptclass::run()
 			}
 			else if (words[0] == "hideplayer")
 			{
-				obj.entities[obj.getplayer()].invis = true;
+				int player = obj.getplayer();
+				if (player > -1)
+				{
+					obj.entities[player].invis = true;
+				}
 			}
 			else if (words[0] == "showplayer")
 			{
-				obj.entities[obj.getplayer()].invis = false;
+				int player = obj.getplayer();
+				if (player > -1)
+				{
+					obj.entities[player].invis = false;
+				}
 			}
 			else if (words[0] == "teleportscript")
 			{
@@ -1433,7 +1475,10 @@ void scriptclass::run()
 
 				obj.resetallflags();
 				i = obj.getplayer();
-				obj.entities[i].tile = 0;
+				if (i > -1)
+				{
+					obj.entities[i].tile = 0;
+				}
 
 				for (i = 0; i < 100; i++)
 				{
@@ -1606,11 +1651,11 @@ void scriptclass::run()
 					j=obj.getcrewman(1);
 				}
 
-				if (obj.entities[j].xp > obj.entities[i].xp + 5)
+				if (i > -1 && j > -1 && obj.entities[j].xp > obj.entities[i].xp + 5)
 				{
 					obj.entities[i].dir = 1;
 				}
-				else if (obj.entities[j].xp < obj.entities[i].xp - 5)
+				else if (i > -1 && j > -1 && obj.entities[j].xp < obj.entities[i].xp - 5)
 				{
 					obj.entities[i].dir = 0;
 				}
@@ -1796,39 +1841,45 @@ void scriptclass::run()
 			else if (words[0] == "restoreplayercolour")
 			{
 				i = obj.getplayer();
-				obj.entities[i].colour = 0;
+				if (i > -1)
+				{
+					obj.entities[i].colour = 0;
+				}
 			}
 			else if (words[0] == "changeplayercolour")
 			{
 				i = obj.getplayer();
 
-				if (words[1] == "cyan")
+				if (i > -1)
 				{
-					obj.entities[i].colour = 0;
-				}
-				else if (words[1] == "red")
-				{
-					obj.entities[i].colour = 15;
-				}
-				else if (words[1] == "green")
-				{
-					obj.entities[i].colour = 13;
-				}
-				else if (words[1] == "yellow")
-				{
-					obj.entities[i].colour = 14;
-				}
-				else if (words[1] == "blue")
-				{
-					obj.entities[i].colour = 16;
-				}
-				else if (words[1] == "purple")
-				{
-					obj.entities[i].colour = 20;
-				}
-				else if (words[1] == "teleporter")
-				{
-					obj.entities[i].colour = 102;
+					if (words[1] == "cyan")
+					{
+						obj.entities[i].colour = 0;
+					}
+					else if (words[1] == "red")
+					{
+						obj.entities[i].colour = 15;
+					}
+					else if (words[1] == "green")
+					{
+						obj.entities[i].colour = 13;
+					}
+					else if (words[1] == "yellow")
+					{
+						obj.entities[i].colour = 14;
+					}
+					else if (words[1] == "blue")
+					{
+						obj.entities[i].colour = 16;
+					}
+					else if (words[1] == "purple")
+					{
+						obj.entities[i].colour = 20;
+					}
+					else if (words[1] == "teleporter")
+					{
+						obj.entities[i].colour = 102;
+					}
 				}
 			}
 			else if (words[0] == "altstates")
@@ -2585,7 +2636,10 @@ void scriptclass::startgamemode( int t )
 			map.resetplayer();
 
 			i = obj.getplayer();
-			map.ypos = obj.entities[i].yp - 120;
+			if (i > -1)
+			{
+				map.ypos = obj.entities[i].yp - 120;
+			}
 			map.bypos = map.ypos / 2;
 			map.cameramode = 0;
 			map.colsuperstate = 0;
@@ -3278,9 +3332,12 @@ void scriptclass::teleport()
 	game.companion = 0;
 
 	i = obj.getplayer(); //less likely to have a serious collision error if the player is centered
-	obj.entities[i].xp = 150;
-	obj.entities[i].yp = 110;
-	if(game.teleport_to_x==17 && game.teleport_to_y==17) obj.entities[i].xp = 88; //prevent falling!
+	if (i > -1)
+	{
+		obj.entities[i].xp = 150;
+		obj.entities[i].yp = 110;
+		if(game.teleport_to_x==17 && game.teleport_to_y==17) obj.entities[i].xp = 88; //prevent falling!
+	}
 
 	if (game.teleportscript == "levelonecomplete")
 	{
@@ -3312,7 +3369,11 @@ void scriptclass::teleport()
 
 	game.saverx = game.roomx;
 	game.savery = game.roomy;
-	game.savedir = obj.entities[obj.getplayer()].dir;
+	int player = obj.getplayer();
+	if (player > -1)
+	{
+		game.savedir = obj.entities[player].dir;
+	}
 
 	if(game.teleport_to_x==0 && game.teleport_to_y==0)
 	{


### PR DESCRIPTION
There are three functions that return a sentinel value of -1 if the entity it is looking for doesn't exist: `obj.getteleporter()`, `obj.getplayer()`, and `obj.getcompanion()`. There are many places in the code that blindly use the return values from those functions without checking that it isn't -1 first, and could thus end up indexing out-of-bounds, which is bad bad Undefined Behavior.

So to fix the potential for UB, this PR adds if-guards to all of those cases.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
