### PR TITLE
Fix usage of std::isdigit() in UtilityClass.cpp

### DIFF
--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -213,7 +213,7 @@ bool is_positive_num(const std::string& str)
 {
 	for (size_t i = 0; i < str.length(); i++)
 	{
-		if (!std::isdigit(str[i]))
+		if (!std::isdigit(static_cast<unsigned char>(str[i])))
 		{
 			return false;
 		}

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -2,6 +2,7 @@
 
 #include "SDL.h"
 
+#include <cctype>
 #include <sstream>
 
 /* Used by UtilityClass::GCString to generate a button list */


### PR DESCRIPTION
So there were two problems with using `std::isdigit()`:

- It needs to be properly included with `#include <cctype>`. This has only been reported as an issue by one person, but after looking it up, all the relevant authorities *do* say you have to `#include <cctype>`. Which is puzzling, because today is the first time I've ever heard of this being an issue, and no one else has ever had a problem with it.

  (A small hint I noticed: it looks like `tinyxml2.h` has `#include <cctype>`. So I guess the game was relying on TinyXML-2 having that include. However this doesn't fully explain the mystery, because where was the game getting that include from before TinyXML-2?)

- Undefined Behavior could happen if the argument passed to it can't be parsed as an `unsigned char`. This means that not all plain `char`s and `signed char`s are safe. The solution, apparently, [is to wrap the argument in a `static_cast<unsigned char>()`](https://en.cppreference.com/w/cpp/string/byte/isdigit).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
