### PR TITLE
Remove having to pass around gameScreen in function arguments

### DIFF
--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -68,7 +68,7 @@ void KeyPoll::disabletextentry()
 	SDL_StopTextInput();
 }
 
-void KeyPoll::Poll(Screen *screen)
+void KeyPoll::Poll()
 {
 	SDL_Event evt;
 	while (SDL_PollEvent(&evt))
@@ -248,7 +248,7 @@ void KeyPoll::Poll(Screen *screen)
 				{
 					if (wasFullscreen)
 					{
-						screen->isWindowed = false;
+						gameScreen.isWindowed = false;
 						SDL_SetWindowFullscreen(
 							SDL_GetWindowFromID(evt.window.windowID),
 							SDL_WINDOW_FULLSCREEN_DESKTOP
@@ -262,8 +262,8 @@ void KeyPoll::Poll(Screen *screen)
 				isActive = false;
 				if (!useFullscreenSpaces)
 				{
-					wasFullscreen = !screen->isWindowed;
-					screen->isWindowed = true;
+					wasFullscreen = !gameScreen.isWindowed;
+					gameScreen.isWindowed = true;
 					SDL_SetWindowFullscreen(
 						SDL_GetWindowFromID(evt.window.windowID),
 						0

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -54,7 +54,7 @@ public:
 
 	void disabletextentry();
 
-	void Poll(Screen *screen);
+	void Poll();
 
 	bool isDown(SDL_Keycode key);
 

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -17,7 +17,7 @@ extern "C"
 	);
 }
 
-Screen::Screen()
+void Screen::init()
 {
 	m_window = NULL;
 	m_renderer = NULL;

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -6,7 +6,7 @@
 class Screen
 {
 public:
-	Screen();
+	void init();
 
 	void ResizeScreen(int x, int y);
 	void GetWindowSize(int* x, int* y);
@@ -33,6 +33,6 @@ public:
 	SDL_Rect filterSubrect;
 };
 
-
+extern Screen gameScreen;
 
 #endif /* SCREEN_H */

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -339,7 +339,7 @@ int main(int argc, char *argv[])
 
 
 
-        key.Poll(&gameScreen);
+        key.Poll();
         if(key.toggleFullscreen)
         {
             if(!gameScreen.isWindowed)

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -545,11 +545,11 @@ int main(int argc, char *argv[])
             }
         }
 
-		if(key.resetWindow)
-		{
-			key.resetWindow = false;
-			gameScreen.ResizeScreen(-1, -1);
-		}
+        if(key.resetWindow)
+        {
+            key.resetWindow = false;
+            gameScreen.ResizeScreen(-1, -1);
+        }
 
         music.processmusic();
         graphics.processfade();

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -43,6 +43,7 @@ Game game;
 KeyPoll key;
 mapclass map;
 entityclass obj;
+Screen gameScreen;
 
 bool startinplaytest = false;
 bool savefileplaytest = false;
@@ -121,7 +122,7 @@ int main(int argc, char *argv[])
 
     NETWORK_init();
 
-    Screen gameScreen;
+    gameScreen.init();
 
     printf("\t\t\n");
     printf("\t\t\n");


### PR DESCRIPTION
Just wanted to put to a stop a somewhat huge code smell that existed in 2.2, before it starts again.

`gameScreen` is now `extern`ed and moved off the stack. The constructor has been moved to a delayed `init()` function now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
