### PR TITLE
Prevent attempts to index things out-of-bounds when drawing various things

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4582,6 +4582,8 @@ void entityclass::customwarplinecheck(int i) {
 
 void entityclass::entitycollisioncheck()
 {
+    std::vector<SDL_Surface*>& spritesvec = graphics.flipmode ? graphics.flipsprites : graphics.sprites;
+
     for (size_t i = 0; i < entities.size(); i++)
     {
         //We test entity to entity
@@ -4601,23 +4603,11 @@ void entityclass::entitycollisioncheck()
                             colpoint1.y = entities[i].yp;
                             colpoint2.x = entities[j].xp;
                             colpoint2.y = entities[j].yp;
-                            if (graphics.flipmode)
+                            if (graphics.Hitest(spritesvec[entities[i].drawframe],
+                                             colpoint1, spritesvec[entities[j].drawframe], colpoint2))
                             {
-                                if (graphics.Hitest(graphics.flipsprites[entities[i].drawframe],
-                                                 colpoint1, graphics.flipsprites[entities[j].drawframe], colpoint2))
-                                {
-                                    //Do the collision stuff
-                                    game.deathseq = 30;
-                                }
-                            }
-                            else
-                            {
-                                if (graphics.Hitest(graphics.sprites[entities[i].drawframe],
-                                                 colpoint1, graphics.sprites[entities[j].drawframe], colpoint2) )
-                                {
-                                    //Do the collision stuff
-                                    game.deathseq = 30;
-                                }
+                                //Do the collision stuff
+                                game.deathseq = 30;
                             }
                         }
                         else
@@ -4713,25 +4703,12 @@ void entityclass::entitycollisioncheck()
                                     colpoint1.y = entities[i].yp;
                                     colpoint2.x = entities[j].xp;
                                     colpoint2.y = entities[j].yp;
-                                    if (graphics.flipmode)
+                                    if (graphics.Hitest(spritesvec[entities[i].drawframe],
+                                                     colpoint1, spritesvec[entities[j].drawframe], colpoint2))
                                     {
-                                        if (graphics.Hitest(graphics.flipsprites[entities[i].drawframe],
-                                                         colpoint1, graphics.flipsprites[entities[j].drawframe], colpoint2))
-                                        {
-                                            //Do the collision stuff
-                                            game.deathseq = 30;
-                                            game.scmhurt = true;
-                                        }
-                                    }
-                                    else
-                                    {
-                                        if (graphics.Hitest(graphics.sprites[entities[i].drawframe],
-                                                         colpoint1, graphics.sprites[entities[j].drawframe], colpoint2))
-                                        {
-                                            //Do the collision stuff
-                                            game.deathseq = 30;
-                                            game.scmhurt = true;
-                                        }
+                                        //Do the collision stuff
+                                        game.deathseq = 30;
+                                        game.scmhurt = true;
                                     }
                                 }
                                 else

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4603,8 +4603,11 @@ void entityclass::entitycollisioncheck()
                             colpoint1.y = entities[i].yp;
                             colpoint2.x = entities[j].xp;
                             colpoint2.y = entities[j].yp;
-                            if (graphics.Hitest(spritesvec[entities[i].drawframe],
-                                             colpoint1, spritesvec[entities[j].drawframe], colpoint2))
+                            int drawframe1 = entities[i].drawframe;
+                            int drawframe2 = entities[j].drawframe;
+                            if (INBOUNDS(drawframe1, spritesvec) && INBOUNDS(drawframe2, spritesvec)
+                            && graphics.Hitest(spritesvec[drawframe1],
+                                             colpoint1, spritesvec[drawframe2], colpoint2))
                             {
                                 //Do the collision stuff
                                 game.deathseq = 30;
@@ -4703,8 +4706,11 @@ void entityclass::entitycollisioncheck()
                                     colpoint1.y = entities[i].yp;
                                     colpoint2.x = entities[j].xp;
                                     colpoint2.y = entities[j].yp;
-                                    if (graphics.Hitest(spritesvec[entities[i].drawframe],
-                                                     colpoint1, spritesvec[entities[j].drawframe], colpoint2))
+                                    int drawframe1 = entities[i].drawframe;
+                                    int drawframe2 = entities[j].drawframe;
+                                    if (INBOUNDS(drawframe1, spritesvec) && INBOUNDS(drawframe2, spritesvec)
+                                    && graphics.Hitest(spritesvec[drawframe1],
+                                                     colpoint1, spritesvec[drawframe2], colpoint2))
                                     {
                                         //Do the collision stuff
                                         game.deathseq = 30;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -261,6 +261,8 @@ void Graphics::Print( int _x, int _y, std::string _s, int r, int g, int b, bool 
 
 void Graphics::PrintAlpha( int _x, int _y, std::string _s, int r, int g, int b, int a, bool cen /*= false*/ )
 {
+    std::vector<SDL_Surface*>& font = flipmode ? flipbfont : bfont;
+
     r = clamp(r,0,255);
     g = clamp(g,0,255);
     b = clamp(b,0,255);
@@ -283,14 +285,7 @@ void Graphics::PrintAlpha( int _x, int _y, std::string _s, int r, int g, int b, 
         fontRect.x = tpoint.x ;
         fontRect.y = tpoint.y ;
 
-        if (flipmode)
-        {
-            BlitSurfaceColoured( flipbfont[font_idx(curr)], NULL, backBuffer, &fontRect , ct);
-        }
-        else
-        {
-            BlitSurfaceColoured( bfont[font_idx(curr)], NULL, backBuffer, &fontRect , ct);
-        }
+        BlitSurfaceColoured( font[font_idx(curr)], NULL, backBuffer, &fontRect , ct);
         bfontpos+=bfontlen(curr) ;
     }
 }
@@ -298,6 +293,8 @@ void Graphics::PrintAlpha( int _x, int _y, std::string _s, int r, int g, int b, 
 
 void Graphics::bigprint(  int _x, int _y, std::string _s, int r, int g, int b, bool cen, int sc )
 {
+    std::vector<SDL_Surface*>& font = flipmode ? flipbfont : bfont;
+
     r = clamp(r,0,255);
     g = clamp(g,0,255);
     b = clamp(b,0,255);
@@ -325,20 +322,10 @@ void Graphics::bigprint(  int _x, int _y, std::string _s, int r, int g, int b, b
         fontRect.y = tpoint.y ;
         */
 
-        if (flipmode)
-        {
-            SDL_Surface* tempPrint = ScaleSurfaceSlow(flipbfont[font_idx(curr)], bfont[font_idx(curr)]->w *sc,bfont[font_idx(curr)]->h *sc);
-            SDL_Rect printrect = { Sint16((_x) + bfontpos), Sint16(_y) , Sint16(bfont_rect.w*sc), Sint16(bfont_rect.h * sc)};
-            BlitSurfaceColoured(tempPrint, NULL, backBuffer, &printrect, ct);
-            SDL_FreeSurface(tempPrint);
-        }
-        else
-        {
-            SDL_Surface* tempPrint = ScaleSurfaceSlow(bfont[font_idx(curr)], bfont[font_idx(curr)]->w *sc,bfont[font_idx(curr)]->h *sc);
-            SDL_Rect printrect = { static_cast<Sint16>((_x) + bfontpos), static_cast<Sint16>(_y) , static_cast<Sint16>((bfont_rect.w*sc)+1), static_cast<Sint16>((bfont_rect.h * sc)+1)};
-            BlitSurfaceColoured(tempPrint, NULL, backBuffer, &printrect, ct);
-            SDL_FreeSurface(tempPrint);
-        }
+        SDL_Surface* tempPrint = ScaleSurfaceSlow(font[font_idx(curr)], font[font_idx(curr)]->w *sc,font[font_idx(curr)]->h *sc);
+        SDL_Rect printrect = { static_cast<Sint16>((_x) + bfontpos), static_cast<Sint16>(_y) , static_cast<Sint16>((bfont_rect.w*sc)+1), static_cast<Sint16>((bfont_rect.h * sc)+1)};
+        BlitSurfaceColoured(tempPrint, NULL, backBuffer, &printrect, ct);
+        SDL_FreeSurface(tempPrint);
         bfontpos+=bfontlen(curr) *sc;
     }
 }
@@ -360,6 +347,8 @@ void Graphics::PrintOff( int _x, int _y, std::string _s, int r, int g, int b, bo
 
 void Graphics::PrintOffAlpha( int _x, int _y, std::string _s, int r, int g, int b, int a, bool cen /*= false*/ )
 {
+    std::vector<SDL_Surface*>& font = flipmode ? flipbfont : bfont;
+
     r = clamp(r,0,255);
     g = clamp(g,0,255);
     b = clamp(b,0,255);
@@ -381,14 +370,7 @@ void Graphics::PrintOffAlpha( int _x, int _y, std::string _s, int r, int g, int 
         fontRect.x = tpoint.x ;
         fontRect.y = tpoint.y ;
 
-        if (flipmode)
-        {
-            BlitSurfaceColoured( flipbfont[font_idx(curr)], NULL, backBuffer, &fontRect , ct);
-        }
-        else
-        {
-            BlitSurfaceColoured( bfont[font_idx(curr)], NULL, backBuffer, &fontRect , ct);
-        }
+        BlitSurfaceColoured( font[font_idx(curr)], NULL, backBuffer, &fontRect , ct);
         bfontpos+=bfontlen(curr) ;
     }
 }
@@ -420,6 +402,8 @@ void Graphics::bprintalpha( int x, int y, std::string t, int r, int g, int b, in
 
 void Graphics::RPrint( int _x, int _y, std::string _s, int r, int g, int b, bool cen /*= false*/ )
 {
+    std::vector<SDL_Surface*>& font = flipmode ? flipbfont : bfont;
+
     r = clamp(r,0,255);
     g = clamp(g,0,255);
     b = clamp(b,0,255);
@@ -440,14 +424,7 @@ void Graphics::RPrint( int _x, int _y, std::string _s, int r, int g, int b, bool
         fontRect.x = tpoint.x ;
         fontRect.y = tpoint.y ;
 
-        if (flipmode)
-        {
-            BlitSurfaceColoured( flipbfont[font_idx(curr)], NULL, backBuffer, &fontRect , ct);
-        }
-        else
-        {
-            BlitSurfaceColoured( bfont[font_idx(curr)], NULL, backBuffer, &fontRect , ct);
-        }
+        BlitSurfaceColoured( font[font_idx(curr)], NULL, backBuffer, &fontRect , ct);
         bfontpos+=bfontlen(curr) ;
     }
 }
@@ -2742,6 +2719,8 @@ void Graphics::renderwithscreeneffects()
 
 void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool cen, float sc)
 {
+	std::vector<SDL_Surface*>& font = flipmode ? flipbfont : bfont;
+
 	if (r < 0) r = 0;
 	if (g < 0) g = 0;
 	if (b < 0) b = 0;
@@ -2776,20 +2755,10 @@ void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool
 	std::string::iterator iter = t.begin();
 	while (iter != t.end()) {
 		cur = utf8::unchecked::next(iter);
-		if (flipmode)
-		{
-			SDL_Surface* tempPrint = ScaleSurfaceSlow(flipbfont[font_idx(cur)], bfont[font_idx(cur)]->w *sc,bfont[font_idx(cur)]->h *sc);
-			SDL_Rect printrect = { Sint16(x + bfontpos), Sint16(y) , Sint16(bfont_rect.w*sc), Sint16(bfont_rect.h * sc)};
-			BlitSurfaceColoured(tempPrint, NULL, backBuffer, &printrect ,ct);
-			SDL_FreeSurface(tempPrint);
-		}
-		else
-		{
-			SDL_Surface* tempPrint = ScaleSurfaceSlow(bfont[font_idx(cur)], bfont[font_idx(cur)]->w *sc,bfont[font_idx(cur)]->h *sc);
-			SDL_Rect printrect = { Sint16((x) + bfontpos), Sint16(y) , Sint16(bfont_rect.w*sc), Sint16(bfont_rect.h * sc)};
-			BlitSurfaceColoured(tempPrint, NULL, backBuffer, &printrect, ct);
-			SDL_FreeSurface(tempPrint);
-		}
+		SDL_Surface* tempPrint = ScaleSurfaceSlow(font[font_idx(cur)], font[font_idx(cur)]->w *sc,font[font_idx(cur)]->h *sc);
+		SDL_Rect printrect = { Sint16((x) + bfontpos), Sint16(y) , Sint16(bfont_rect.w*sc), Sint16(bfont_rect.h * sc)};
+		BlitSurfaceColoured(tempPrint, NULL, backBuffer, &printrect, ct);
+		SDL_FreeSurface(tempPrint);
 		bfontpos+=bfontlen(cur)* sc;
 	}
 }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -143,6 +143,10 @@ Graphics::~Graphics()
 
 void Graphics::drawspritesetcol(int x, int y, int t, int c)
 {
+    if (!INBOUNDS(t, sprites))
+    {
+        return;
+    }
     SDL_Rect rect;
     setRect(rect,x,y,sprites_rect.w,sprites_rect.h);
     setcol(c);
@@ -1442,6 +1446,10 @@ void Graphics::drawentities()
         {
         case 0:
             // Sprites
+            if (!INBOUNDS(obj.entities[i].drawframe, (*spritesvec)))
+            {
+                continue;
+            }
             tpoint.x = obj.entities[i].xp;
             tpoint.y = obj.entities[i].yp - yoff;
             setcol(obj.entities[i].colour);
@@ -1494,6 +1502,10 @@ void Graphics::drawentities()
             break;
         case 1:
             // Tiles
+            if (!INBOUNDS(obj.entities[i].drawframe, tiles))
+            {
+                continue;
+            }
             tpoint.x = obj.entities[i].xp;
             tpoint.y = obj.entities[i].yp - yoff;
             drawRect = tiles_rect;
@@ -1505,6 +1517,10 @@ void Graphics::drawentities()
         case 8:
         {
             // Special: Moving platform, 4 tiles or 8 tiles
+            if (!INBOUNDS(obj.entities[i].drawframe, (*tilesvec)))
+            {
+                continue;
+            }
             tpoint.x = obj.entities[i].xp;
             tpoint.y = obj.entities[i].yp - yoff;
             int thiswidth = 4;
@@ -1559,6 +1575,10 @@ void Graphics::drawentities()
             // Note: This code is in the 4-tile code
             break;
         case 9:         // Really Big Sprite! (2x2)
+            if (!INBOUNDS(obj.entities[i].drawframe, (*spritesvec)))
+            {
+                continue;
+            }
             setcol(obj.entities[i].colour);
 
             tpoint.x = obj.entities[i].xp;
@@ -1594,6 +1614,10 @@ void Graphics::drawentities()
             BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe + 13],NULL, backBuffer, &drawRect, ct);
             break;
         case 10:         // 2x1 Sprite
+            if (!INBOUNDS(obj.entities[i].drawframe, (*spritesvec)))
+            {
+                continue;
+            }
             setcol(obj.entities[i].colour);
 
             tpoint.x = obj.entities[i].xp;
@@ -1617,6 +1641,10 @@ void Graphics::drawentities()
             drawimagecol(3, obj.entities[i].xp, obj.entities[i].yp - yoff);
             break;
         case 12:         // Regular sprites that don't wrap
+            if (!INBOUNDS(obj.entities[i].drawframe, (*spritesvec)))
+            {
+                continue;
+            }
             tpoint.x = obj.entities[i].xp;
             tpoint.y = obj.entities[i].yp - yoff;
             setcol(obj.entities[i].colour);
@@ -1674,6 +1702,10 @@ void Graphics::drawentities()
         case 13:
         {
             //Special for epilogue: huge hero!
+            if (!INBOUNDS(obj.entities[i].drawframe, (*spritesvec)))
+            {
+                continue;
+            }
 
             tpoint.x = obj.entities[i].xp; tpoint.y = obj.entities[i].yp - yoff;
             setcol(obj.entities[i].colour);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -539,6 +539,10 @@ void Graphics::drawsprite( int x, int y, int t, int r, int g,  int b )
 
 void Graphics::drawtile( int x, int y, int t )
 {
+    if (!INBOUNDS(t, tiles))
+    {
+        return;
+    }
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
     BlitSurfaceStandard(tiles[t], NULL, backBuffer, &rect);
 }
@@ -546,6 +550,10 @@ void Graphics::drawtile( int x, int y, int t )
 
 void Graphics::drawtile2( int x, int y, int t )
 {
+    if (!INBOUNDS(t, tiles2))
+    {
+        return;
+    }
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
     BlitSurfaceStandard(tiles2[t], NULL, backBuffer, &rect);
 }
@@ -554,18 +562,30 @@ void Graphics::drawtile2( int x, int y, int t )
 
 void Graphics::drawtile3( int x, int y, int t, int off )
 {
+    if (!INBOUNDS(t, tiles3))
+    {
+        return;
+    }
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
     BlitSurfaceStandard(tiles3[t+(off*30)], NULL, backBuffer, &rect);
 }
 
 void Graphics::drawentcolours( int x, int y, int t)
 {
+    if (!INBOUNDS(t, entcolours))
+    {
+        return;
+    }
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
     BlitSurfaceStandard(entcolours[t], NULL, backBuffer, &rect);
 }
 
 void Graphics::drawtowertile( int x, int y, int t )
 {
+    if (!INBOUNDS(t, tiles2))
+    {
+        return;
+    }
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
     BlitSurfaceStandard(tiles2[t], NULL, towerbuffer, &rect);
 }
@@ -573,8 +593,13 @@ void Graphics::drawtowertile( int x, int y, int t )
 
 void Graphics::drawtowertile3( int x, int y, int t, int off )
 {
+    t += off*30;
+    if (!INBOUNDS(t, tiles3))
+    {
+        return;
+    }
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
-    BlitSurfaceStandard(tiles3[t+(off*30)], NULL, towerbuffer, &rect);
+    BlitSurfaceStandard(tiles3[t], NULL, towerbuffer, &rect);
 }
 
 void Graphics::drawgui()
@@ -1200,6 +1225,10 @@ void Graphics::drawlevelmenu( int cr, int cg, int cb, int division /*= 30*/ )
 
 void Graphics::drawcoloredtile( int x, int y, int t, int r, int g, int b )
 {
+    if (!INBOUNDS(t, tiles))
+    {
+        return;
+    }
     setcolreal(getRGB(r,g,b));
 
     SDL_Rect rect;
@@ -2531,6 +2560,10 @@ void Graphics::menuoffrender()
 
 void Graphics::drawhuetile( int x, int y, int t, int c )
 {
+	if (!INBOUNDS(t, tiles))
+	{
+		return;
+	}
 	point tpoint;
 	tpoint.x = x;
 	tpoint.y = y;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1443,7 +1443,7 @@ void Graphics::drawentities()
     SDL_Rect drawRect;
 
     std::vector<SDL_Surface*> *tilesvec;
-    if (map.custommode)
+    if (map.custommode && !map.finalmode)
     {
         tilesvec = &entcolours;
     }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -274,6 +274,7 @@ void Graphics::PrintAlpha( int _x, int _y, std::string _s, int r, int g, int b, 
         _x = ((160 ) - ((len(_s)) / 2));
     int bfontpos = 0;
     int curr;
+    int idx;
     std::string::iterator iter = _s.begin();
     while (iter != _s.end()) {
         curr = utf8::unchecked::next(iter);
@@ -285,7 +286,11 @@ void Graphics::PrintAlpha( int _x, int _y, std::string _s, int r, int g, int b, 
         fontRect.x = tpoint.x ;
         fontRect.y = tpoint.y ;
 
-        BlitSurfaceColoured( font[font_idx(curr)], NULL, backBuffer, &fontRect , ct);
+        idx = font_idx(curr);
+        if (INBOUNDS(idx, font))
+        {
+            BlitSurfaceColoured( font[idx], NULL, backBuffer, &fontRect , ct);
+        }
         bfontpos+=bfontlen(curr) ;
     }
 }
@@ -308,6 +313,7 @@ void Graphics::bigprint(  int _x, int _y, std::string _s, int r, int g, int b, b
 
     int bfontpos = 0;
     int curr;
+    int idx;
     std::string::iterator iter = _s.begin();
     while (iter != _s.end()) {
         curr = utf8::unchecked::next(iter);
@@ -322,10 +328,14 @@ void Graphics::bigprint(  int _x, int _y, std::string _s, int r, int g, int b, b
         fontRect.y = tpoint.y ;
         */
 
-        SDL_Surface* tempPrint = ScaleSurfaceSlow(font[font_idx(curr)], font[font_idx(curr)]->w *sc,font[font_idx(curr)]->h *sc);
-        SDL_Rect printrect = { static_cast<Sint16>((_x) + bfontpos), static_cast<Sint16>(_y) , static_cast<Sint16>((bfont_rect.w*sc)+1), static_cast<Sint16>((bfont_rect.h * sc)+1)};
-        BlitSurfaceColoured(tempPrint, NULL, backBuffer, &printrect, ct);
-        SDL_FreeSurface(tempPrint);
+        idx = font_idx(curr);
+        if (INBOUNDS(idx, font))
+        {
+            SDL_Surface* tempPrint = ScaleSurfaceSlow(font[idx], font[idx]->w *sc,font[idx]->h *sc);
+            SDL_Rect printrect = { static_cast<Sint16>((_x) + bfontpos), static_cast<Sint16>(_y) , static_cast<Sint16>((bfont_rect.w*sc)+1), static_cast<Sint16>((bfont_rect.h * sc)+1)};
+            BlitSurfaceColoured(tempPrint, NULL, backBuffer, &printrect, ct);
+            SDL_FreeSurface(tempPrint);
+        }
         bfontpos+=bfontlen(curr) *sc;
     }
 }
@@ -359,6 +369,7 @@ void Graphics::PrintOffAlpha( int _x, int _y, std::string _s, int r, int g, int 
     if (cen)
         _x = ((160) - (len(_s) / 2))+_x;
     int bfontpos = 0;
+    int idx;
     std::string::iterator iter = _s.begin();
     while (iter != _s.end()) {
         int curr = utf8::unchecked::next(iter);
@@ -370,7 +381,11 @@ void Graphics::PrintOffAlpha( int _x, int _y, std::string _s, int r, int g, int 
         fontRect.x = tpoint.x ;
         fontRect.y = tpoint.y ;
 
-        BlitSurfaceColoured( font[font_idx(curr)], NULL, backBuffer, &fontRect , ct);
+        idx = font_idx(curr);
+        if (INBOUNDS(idx, font))
+        {
+            BlitSurfaceColoured( font[idx], NULL, backBuffer, &fontRect , ct);
+        }
         bfontpos+=bfontlen(curr) ;
     }
 }
@@ -413,6 +428,7 @@ void Graphics::RPrint( int _x, int _y, std::string _s, int r, int g, int b, bool
         _x = ((308) - (_s.length() / 2));
     int bfontpos = 0;
     int curr;
+    int idx;
     std::string::iterator iter = _s.begin();
     while (iter != _s.end()) {
         curr = utf8::unchecked::next(iter);
@@ -424,7 +440,11 @@ void Graphics::RPrint( int _x, int _y, std::string _s, int r, int g, int b, bool
         fontRect.x = tpoint.x ;
         fontRect.y = tpoint.y ;
 
-        BlitSurfaceColoured( font[font_idx(curr)], NULL, backBuffer, &fontRect , ct);
+        idx = font_idx(curr);
+        if (INBOUNDS(idx, font))
+        {
+            BlitSurfaceColoured( font[idx], NULL, backBuffer, &fontRect , ct);
+        }
         bfontpos+=bfontlen(curr) ;
     }
 }
@@ -2752,13 +2772,18 @@ void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool
 
 	int bfontpos = 0;
 	int cur;
+	int idx;
 	std::string::iterator iter = t.begin();
 	while (iter != t.end()) {
 		cur = utf8::unchecked::next(iter);
-		SDL_Surface* tempPrint = ScaleSurfaceSlow(font[font_idx(cur)], font[font_idx(cur)]->w *sc,font[font_idx(cur)]->h *sc);
-		SDL_Rect printrect = { Sint16((x) + bfontpos), Sint16(y) , Sint16(bfont_rect.w*sc), Sint16(bfont_rect.h * sc)};
-		BlitSurfaceColoured(tempPrint, NULL, backBuffer, &printrect, ct);
-		SDL_FreeSurface(tempPrint);
+		idx = font_idx(cur);
+		if (INBOUNDS(idx, font))
+		{
+			SDL_Surface* tempPrint = ScaleSurfaceSlow(font[idx], font[idx]->w *sc,font[idx]->h *sc);
+			SDL_Rect printrect = { Sint16((x) + bfontpos), Sint16(y) , Sint16(bfont_rect.w*sc), Sint16(bfont_rect.h * sc)};
+			BlitSurfaceColoured(tempPrint, NULL, backBuffer, &printrect, ct);
+			SDL_FreeSurface(tempPrint);
+		}
 		bfontpos+=bfontlen(cur)* sc;
 	}
 }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -753,6 +753,10 @@ void Graphics::drawgui()
 
 void Graphics::drawimagecol( int t, int xp, int yp, int r = 0, int g = 0, int b = 0, bool cent/*= false*/ )
 {
+    if (!INBOUNDS(t, images))
+    {
+        return;
+    }
     SDL_Rect trect;
     if(r+g+b != 0)
     {
@@ -784,6 +788,10 @@ void Graphics::drawimagecol( int t, int xp, int yp, int r = 0, int g = 0, int b 
 
 void Graphics::drawimage( int t, int xp, int yp, bool cent/*=false*/ )
 {
+    if (!INBOUNDS(t, images))
+    {
+        return;
+    }
 
     SDL_Rect trect;
     if (cent)
@@ -808,6 +816,11 @@ void Graphics::drawimage( int t, int xp, int yp, bool cent/*=false*/ )
 
 void Graphics::drawpartimage( int t, int xp, int yp, int wp, int hp)
 {
+  if (!INBOUNDS(t, images))
+  {
+    return;
+  }
+
   SDL_Rect trect;
 
   trect.x = xp;
@@ -2787,14 +2800,20 @@ void Graphics::drawtele(int x, int y, int t, int c)
 
 	SDL_Rect telerect;
 	setRect(telerect, x , y, tele_rect.w, tele_rect.h );
-	BlitSurfaceColoured(tele[0], NULL, backBuffer, &telerect, ct);
+	if (INBOUNDS(0, tele))
+	{
+		BlitSurfaceColoured(tele[0], NULL, backBuffer, &telerect, ct);
+	}
 
 	setcol(c);
 	if (t > 9) t = 8;
 	if (t < 0) t = 0;
 
 	setRect(telerect, x , y, tele_rect.w, tele_rect.h );
-	BlitSurfaceColoured(tele[t], NULL, backBuffer, &telerect, ct);
+	if (INBOUNDS(t, tele))
+	{
+		BlitSurfaceColoured(tele[t], NULL, backBuffer, &telerect, ct);
+	}
 }
 
 Uint32 Graphics::getRGBA(Uint8 r, Uint8 g, Uint8 b, Uint8 a)

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -13,6 +13,8 @@ std::vector<std::string> split(const std::string &s, char delim);
 
 bool is_positive_num(const std::string& str);
 
+#define INBOUNDS(index, vector) ((int) index >= 0 && (int) index < (int) vector.size())
+
 
 //helperClass
 class UtilityClass

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2816,7 +2816,8 @@ void editorrender()
         SDL_FillRect(graphics.ghostbuffer, NULL, SDL_MapRGBA(graphics.ghostbuffer->format, 0, 0, 0, 0));
         for (int i = 0; i < (int)ed.ghosts.size(); i++) {
             if (i <= ed.currentghosts) { // We don't want all of them to show up at once :)
-                if (ed.ghosts[i].rx != ed.levx || ed.ghosts[i].ry != ed.levy)
+                if (ed.ghosts[i].rx != ed.levx || ed.ghosts[i].ry != ed.levy
+                || !INBOUNDS(ed.ghosts[i].frame, graphics.sprites))
                     continue;
                 point tpoint;
                 tpoint.x = ed.ghosts[i].x;


### PR DESCRIPTION
This PR prevents an indexing out-of-bounds segfault/UB if an entity has an out-of-bounds `drawframe`, if tile numbers are out-of-bounds, if an out-of-bounds image or teleporter is requested to be drawn, or if an out-of-bounds font index is requested to be drawn.

Also I cleaned up some more duplicated Flip Mode code. And added a convenient `INBOUNDS` macro.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
