### PR TITLE
Add special gamemode checks to Game::savetele() and Game::savequick()

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5916,7 +5916,7 @@ void Game::savetele()
 {
     //TODO make this code a bit cleaner.
 
-    if (map.custommode)
+    if (map.custommode || inspecial())
     {
         //Don't trash save data!
         return;
@@ -6112,7 +6112,7 @@ void Game::savetele()
 
 void Game::savequick()
 {
-    if (map.custommode)
+    if (map.custommode || inspecial())
     {
         //Don't trash save data!
         return;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -393,6 +393,11 @@ public:
 #endif
 
     int gametimer;
+
+    bool inline inspecial()
+    {
+        return inintermission || insecretlab || intimetrial || nodeathmode;
+    }
 };
 
 extern Game game;


### PR DESCRIPTION
This prevents the game from being saved if you manage to trigger a `Game::savetele()` during a "special" gamemode (like if you use the Gravitron out-of-bounds glitch when replaying Intermission 2, then go to Game Complete that way).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
