### PR TITLE
Remove i/j/k attributes from classes that don't need them

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -696,7 +696,7 @@ void Game::savecustomlevelstats()
 
 void Game::updatestate()
 {
-    int i;
+    int i, j;
     statedelay--;
     if(statedelay<=0){
         statedelay=0;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -159,7 +159,6 @@ public:
     int door_down;
     int roomx, roomy, roomchangedir;
     int prevroomx, prevroomy;
-    int j, k;
 
     int savex, savey, saverx, savery;
     int savegc, savedir;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -102,8 +102,6 @@ void Graphics::init()
     foregroundBuffer = NULL;
     backgrounddrawn = false;
     images_rect = SDL_Rect();
-    j = 0;
-    k = 0;
     m = 0;
     linedelay = 0;
     menubuffer = NULL;
@@ -618,14 +616,14 @@ void Graphics::drawgui()
         {
             if(flipmode)
             {
-                for (j = 0; j < (int) textbox[i].line.size(); j++)
+                for (size_t j = 0; j < textbox[i].line.size(); j++)
                 {
                     Print(textbox[i].xp + 8, textbox[i].yp + (textbox[i].line.size()*8) - (j * 8), textbox[i].line[j], 196, 196, 255 - help.glow);
                 }
             }
             else
             {
-                for (j = 0; j < (int) textbox[i].line.size(); j++)
+                for (size_t j = 0; j < textbox[i].line.size(); j++)
                 {
                     Print(textbox[i].xp + 8, textbox[i].yp + 8 + (j * 8), textbox[i].line[j], 196, 196, 255 - help.glow);
                 }
@@ -653,14 +651,14 @@ void Graphics::drawgui()
 
             if(flipmode)
             {
-                for (j = 0; j < (int) textbox[i].line.size(); j++)
+                for (size_t j = 0; j < textbox[i].line.size(); j++)
                 {
                     Print(textbox[i].xp + 8, textbox[i].yp  + (textbox[i].line.size()*8) - (j * 8), textbox[i].line[j], textbox[i].r, textbox[i].g, textbox[i].b);
                 }
             }
             else
             {
-                for (j = 0; j < (int) textbox[i].line.size(); j++)
+                for (size_t j = 0; j < textbox[i].line.size(); j++)
                 {
                     Print(textbox[i].xp + 8, textbox[i].yp +8 + (j * 8), textbox[i].line[j], textbox[i].r, textbox[i].g, textbox[i].b);
                 }
@@ -922,13 +920,13 @@ void Graphics::drawpixeltextbox( int x, int y, int w, int h, int w2, int h2, int
     //madrect.x = x; madrect.y = y; madrect.w = w; madrect.h = h;
     FillRect(backBuffer,x,y,w,h, r/6, g/6, b/6 );
 
-    for (k = 0; k < w2-2; k++)
+    for (int k = 0; k < w2-2; k++)
     {
         drawcoloredtile(x + 8-xo + (k * 8), y, 41, r, g, b);
         drawcoloredtile(x + 8-xo + (k * 8), y + (h) - 8, 46, r, g, b);
     }
 
-    for (k = 0; k < h2-2; k++)
+    for (int k = 0; k < h2-2; k++)
     {
         drawcoloredtile(x, y + 8-yo + (k * 8), 43, r, g, b);
         drawcoloredtile(x + (w) - 8, y + 8-yo + (k * 8), 44, r, g, b);
@@ -946,7 +944,7 @@ void Graphics::drawcustompixeltextbox( int x, int y, int w, int h, int w2, int h
 
     FillRect(backBuffer,x,y,w,h, r/6, g/6, b/6 );
 
-    for (k = 0; k < w2-2; k++)
+    for (int k = 0; k < w2-2; k++)
     {
         drawcoloredtile(x + 8-xo + (k * 8), y, 41, r, g, b);
         drawcoloredtile(x + 8-xo + (k * 8), y + (h) - 8, 46, r, g, b);
@@ -958,7 +956,7 @@ void Graphics::drawcustompixeltextbox( int x, int y, int w, int h, int w2, int h
     drawcoloredtile(x+ (w) - 24, y, 41, r, g, b);
     drawcoloredtile(x+ (w) - 24, y + (h) - 8, 46, r, g, b);
 
-    for (k = 0; k < h2-2; k++)
+    for (int k = 0; k < h2-2; k++)
     {
         drawcoloredtile(x, y + 8-yo + (k * 8), 43, r, g, b);
         drawcoloredtile(x + (w) - 8, y + 8-yo + (k * 8), 44, r, g, b);
@@ -2021,7 +2019,7 @@ void Graphics::drawbackground( int t )
             //draw the whole thing for the first time!
             backoffset = 0;
             FillRect(towerbuffer,0x000000 );
-            for (j = 0; j < 15; j++)
+            for (int j = 0; j < 15; j++)
             {
                 for (int i = 0; i < 21; i++)
                 {
@@ -2163,7 +2161,7 @@ void Graphics::drawmap()
         FillRect(foregroundBuffer, 0x00000000);
         if(map.tileset==0)
         {
-            for (j = 0; j < 30; j++)
+            for (int j = 0; j < 30; j++)
             {
                 for (int i = 0; i < 40; i++)
                 {
@@ -2183,7 +2181,7 @@ void Graphics::drawmap()
         }
         else if (map.tileset == 2)
         {
-            for (j = 0; j < 30; j++)
+            for (int j = 0; j < 30; j++)
             {
                 for (int i = 0; i < 40; i++)
                 {
@@ -2254,7 +2252,7 @@ void Graphics::drawtowermap()
 void Graphics::drawtowermap_nobackground()
 {
     int temp;
-    for (j = 0; j < 31; j++)
+    for (int j = 0; j < 31; j++)
     {
         for (int i = 0; i < 40; i++)
         {

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -202,7 +202,7 @@ public:
 
 
 
-	int j, k, m;
+	int m;
 
 	std::vector <SDL_Surface*> backgrounds;
 	std::vector <SDL_Surface*> images;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1047,7 +1047,7 @@ void mapclass::gotoroom(int rx, int ry)
 			if (obj.entities[i].xp <= 0 || obj.entities[i].xp + obj.entities[i].w >= 312)
 			{
 				//it's on a screen edge
-				for (j = 0; j < (int) obj.linecrosskludge.size(); j++)
+				for (size_t j = 0; j < obj.linecrosskludge.size(); j++)
 				{
 					if (obj.entities[i].yp == obj.linecrosskludge[j].yp)
 					{
@@ -1901,7 +1901,7 @@ void mapclass::loadlevel(int rx, int ry)
 			{
 				//A slight varation - she's upside down
 				obj.createentity(249, 62, 18, 16, 0, 18);
-				j = obj.getcrewman(5);
+				int j = obj.getcrewman(5);
 				obj.entities[j].rule = 7;
 				obj.entities[j].tile +=6;
 				//What script do we use?
@@ -1918,7 +1918,7 @@ void mapclass::loadlevel(int rx, int ry)
 			if (obj.entities[i].state == 18)
 			{
 				//face the player
-				j = obj.getplayer();
+				int j = obj.getplayer();
 				if (j > -1 && obj.entities[j].xp > obj.entities[i].xp + 5)
 				{
 					obj.entities[i].dir = 1;

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -86,7 +86,6 @@ public:
 
     int temp;
     int temp2;
-    int j;
     int background;
     int rcol;
     int tileset;

--- a/desktop_version/src/Otherlevel.h
+++ b/desktop_version/src/Otherlevel.h
@@ -32,7 +32,6 @@ public:
     std::string roomname;
 
     int roomtileset;
-    int i;
 
     // roomtext thing in other level
     bool roomtexton;

--- a/desktop_version/src/Tower.h
+++ b/desktop_version/src/Tower.h
@@ -34,8 +34,6 @@ public:
     std::vector<int> vmult;
 
     bool minitowermode;
-    int i;
-    int k;
 };
 
 


### PR DESCRIPTION
The only class that actually needs its i/j/k kept is scriptclass, because some custom levels rely on it for creating custom activity zones. So I haven't touched that.

Other than that, there's no chance that anything important relies on i/j/k in any other class. For that to be the case, it would have to use i/j/k without initializing it beforehand, and that can simply be detected by removing the attribute from the header file and seeing where the compiler complains. And the compiler complains only about cases where it's initialized first. (Note that due to this check, I *haven't* removed Graphics's `m` as it precisely does exactly this, using it without initializing it first.)

Interestingly enough, otherlevelclass and towerclass have unused i/k variables for whatever reason.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
