### PR TITLE
Make elephant not be flashy if screen effects are disabled

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1674,7 +1674,14 @@ void Graphics::drawentities()
             BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
             break;
         case 11:    //The fucking elephant
-            setcol(obj.entities[i].colour);
+            if (game.noflashingmode)
+            {
+                setcol(22);
+            }
+            else
+            {
+                setcol(obj.entities[i].colour);
+            }
             drawimagecol(3, obj.entities[i].xp, obj.entities[i].yp - yoff);
             break;
         case 12:         // Regular sprites that don't wrap


### PR DESCRIPTION
The flashy color of the elephant can be hard on people's eyes, especially if they're the type who want screen effects disabled because they might have epilepsy. The elephant takes up a good 3/4ths of the screen, you know. If screen effects are disabled, the elephant will use color 22, which is a neutral gray.

I'm only adding this because the VVVVVV speedrun mods (@tzann, @mohoc) invalidate all runs that have the elephant texture removed, even though many people would be looking at a potentially epilepsy-inducing image many times a day grinding 100% speedruns. (Imo, their justification for this is flimsy at best.)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
