### PR TITLE
Only remove duplicate player entities in scriptclass::hardreset()

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -855,13 +855,11 @@ void mapclass::gotoroom(int rx, int ry)
 		}
 	}
 
-	int theplayer = obj.getplayer();
-	for (int i = 0; i < (int) obj.entities.size(); i++)
+	for (size_t i = 0; i < obj.entities.size(); i++)
 	{
-		if (i != theplayer)
+		if (obj.entities[i].rule != 0)
 		{
 			removeentity_iter(i);
-			theplayer--; //just in case indice of player is not 0
 		}
 	}
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3628,8 +3628,19 @@ void scriptclass::hardreset()
 	obj.customcollect.resize(100);
 	i = 100; //previously a for-loop iterating over collect/customcollect set this to 100
 
-	if (obj.getplayer() > -1){
-		obj.entities[obj.getplayer()].tile = 0;
+	int theplayer = obj.getplayer();
+	if (theplayer > -1){
+		obj.entities[theplayer].tile = 0;
+	}
+
+	// Remove duplicate player entities
+	for (int i = 0; i < (int) obj.entities.size(); i++)
+	{
+		if (i != theplayer)
+		{
+			removeentity_iter(i);
+			theplayer--; // just in case indice of player is not 0
+		}
 	}
 
 	//Script Stuff


### PR DESCRIPTION
Looks like duplicate player entities persisting across rooms is a semi-useful feature used by some levels. Still, though, it's a bit of a nuisance to have duplicate player entities persisting across game sessions. And levels can't rely on this persistence anyway, anyone could just close the game and re-open it to get rid of the duplicate entities regardless.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
