### PR TITLE
Support hex entities in metadata

### DIFF
--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -209,13 +209,23 @@ void UtilityClass::updateglow()
 	}
 }
 
-bool is_positive_num(const std::string& str)
+bool is_positive_num(const std::string& str, bool hex)
 {
 	for (size_t i = 0; i < str.length(); i++)
 	{
-		if (!std::isdigit(static_cast<unsigned char>(str[i])))
+		if (hex)
 		{
-			return false;
+			if (!std::isxdigit(static_cast<unsigned char>(str[i])))
+			{
+				return false;
+			}
+		}
+		else
+		{
+			if (!std::isdigit(static_cast<unsigned char>(str[i])))
+			{
+				return false;
+			}
 		}
 	}
 	return true;

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -11,7 +11,7 @@ std::vector<std::string> split(const std::string &s, char delim, std::vector<std
 
 std::vector<std::string> split(const std::string &s, char delim);
 
-bool is_positive_num(const std::string& str);
+bool is_positive_num(const std::string& str, bool hex);
 
 #define INBOUNDS(index, vector) ((int) index >= 0 && (int) index < (int) vector.size())
 


### PR DESCRIPTION
## Changes:

This adds support for hex entities in level metadata.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
