### PR TITLE
Revert old fix, hardcode fix for next-line </edentity>

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1659,7 +1659,7 @@ bool editorclass::load(std::string& _path)
         printf("Custom asset directory does not exist\n");
     }
 
-    tinyxml2::XMLDocument doc(true, tinyxml2::COLLAPSE_WHITESPACE);
+    tinyxml2::XMLDocument doc;
     if (!FILESYSTEM_loadTiXml2Document(_path.c_str(), doc))
     {
         printf("No level %s to load :(\n", _path.c_str());


### PR DESCRIPTION
This is really awful, but there's not much we can do.

TinyXML-2 no matter what will never stop on newlines, so without changing the XML parser, this is the best we can do - just remove the `"\n            "` (that's a linefeed plus exactly 12 spaces) if it appears at the end of the contents of an edentity tag.

Also a giant comment for good measure.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
