### PR TITLE
Fix assets unmounting causing main menu music silence, and assets not being unmounted when returning from editor or credits screen

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7631,6 +7631,7 @@ void Game::quittomenu()
 {
     gamestate = TITLEMODE;
     graphics.fademode = 4;
+    FILESYSTEM_unmountassets(); // should be before music.play(6)
     music.play(6);
     graphics.backgrounddrawn = false;
     map.tdrawback = true;
@@ -7669,7 +7670,6 @@ void Game::quittomenu()
         createmenu(Menu::mainmenu);
     }
     script.hardreset();
-    FILESYSTEM_unmountassets();
 }
 
 void Game::returntolab()

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1,6 +1,7 @@
 #include "Logic.h"
 #include "Script.h"
 #include "Network.h"
+#include "FileSystemUtils.h"
 
 void titlelogic()
 {
@@ -107,6 +108,7 @@ void gamecompletelogic2()
         map.colstate = 10;
         game.gamestate = TITLEMODE;
         graphics.fademode = 4;
+        FILESYSTEM_unmountassets(); // should be before music.playef(18)
         music.playef(18);
         game.returntomenu(Menu::play);
         game.createmenu(Menu::gamecompletecontinue);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3589,6 +3589,7 @@ void editorlogic()
         script.hardreset();
         graphics.fademode = 4;
         music.haltdasmusik();
+        FILESYSTEM_unmountassets(); // should be before music.play(6)
         music.play(6);
         map.nexttowercolour();
         ed.settingsmod=false;


### PR DESCRIPTION
This fully fixes #271.

The cause of the first issue (menu music silence) was wrong frame ordering, the cause of the second issue was a missing `FILESYSTEM_unmountassets()` in two places. (Also, I made sure to avoid the first issue and checked my frame ordering carefully, as well as tested it.)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
