### PR TITLE
Allow using Warp Zone gray tileset in editor

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -4343,6 +4343,10 @@ void editorinput()
                 {
                     if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol>=8) ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol=0;
                 }
+                else if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==3)
+                {
+                    if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol>=7) ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol=0;
+                }
                 else
                 {
                     if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol>=6) ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol=0;


### PR DESCRIPTION
## Changes:

This was added by Info Teddy in VCE, but their message in #267 says it should be upstreamed, so here we are.
This adds support to switch to the gray variant of the Warp Zone tileset in the editor. This was already possible by editing the level file, but now it should just be easier to do.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
