### PR TITLE
Add 7x7, 9x9, full horizontal and vertical brush sizes

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -288,6 +288,10 @@ void editorclass::reset()
     roomnamehide=0;
     zmod=false;
     xmod=false;
+    cmod=false;
+    vmod=false;
+    hmod=false;
+    bmod=false;
     spacemod=false;
     spacemenu=0;
     shiftmenu=false;
@@ -2943,6 +2947,22 @@ void editorrender()
         {
             fillboxabs((ed.tilex*8)-16,(ed.tiley*8)-16,24+16,24+16, graphics.getRGB(200,32,32));
         }
+        else if(ed.cmod && ed.drawmode<2)
+        {
+            fillboxabs((ed.tilex*8)-24,(ed.tiley*8)-24,24+32,24+32, graphics.getRGB(200,32,32));
+        }
+        else if(ed.vmod && ed.drawmode<2)
+        {
+            fillboxabs((ed.tilex*8)-32,(ed.tiley*8)-32,24+48,24+48, graphics.getRGB(200,32,32));
+        }
+        else if(ed.hmod && ed.drawmode<2)
+        {
+            fillboxabs(0,(ed.tiley*8),320,8,graphics.getRGB(200,32,32));
+        }
+        else if(ed.bmod && ed.drawmode<2)
+        {
+            fillboxabs((ed.tilex*8),0,8,240,graphics.getRGB(200,32,32));
+        }
     }
 
     //If in directmode, show current directmode tile
@@ -4583,24 +4603,12 @@ void editorinput()
                 }
             }
 
-            if(key.keymap[SDLK_x])
-            {
-                ed.xmod=true;
-            }
-            else
-            {
-                ed.xmod=false;
-            }
-
-
-            if(key.keymap[SDLK_z])
-            {
-                ed.zmod=true;
-            }
-            else
-            {
-                ed.zmod=false;
-            }
+            ed.hmod = key.keymap[SDLK_h];
+            ed.vmod = key.keymap[SDLK_v];
+            ed.bmod = key.keymap[SDLK_b];
+            ed.cmod = key.keymap[SDLK_c];
+            ed.xmod = key.keymap[SDLK_x];
+            ed.zmod = key.keymap[SDLK_z];
 
             //Keyboard shortcuts
             if(ed.keydelay>0)
@@ -4889,7 +4897,41 @@ void editorinput()
                             //Are we in direct mode?
                             if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].directmode>=1)
                             {
-                                if(ed.xmod)
+                                if(ed.bmod)
+                                {
+                                    for(int i=0; i<30; i++)
+                                    {
+                                        ed.placetilelocal(ed.tilex, i, ed.dmtile);
+                                    }
+                                }
+                                else if(ed.hmod)
+                                {
+                                    for(int i=0; i<40; i++)
+                                    {
+                                        ed.placetilelocal(i, ed.tiley, ed.dmtile);
+                                    }
+                                }
+                                else if(ed.vmod)
+                                {
+                                    for(int j=-4; j<5; j++)
+                                    {
+                                        for(int i=-4; i<5; i++)
+                                        {
+                                            ed.placetilelocal(ed.tilex+i, ed.tiley+j, ed.dmtile);
+                                        }
+                                    }
+                                }
+                                else if(ed.cmod)
+                                {
+                                    for(int j=-3; j<4; j++)
+                                    {
+                                        for(int i=-3; i<4; i++)
+                                        {
+                                            ed.placetilelocal(ed.tilex+i, ed.tiley+j, ed.dmtile);
+                                        }
+                                    }
+                                }
+                                else if(ed.xmod)
                                 {
                                     for(int j=-2; j<3; j++)
                                     {
@@ -4916,7 +4958,41 @@ void editorinput()
                             }
                             else
                             {
-                                if(ed.xmod)
+                                if(ed.bmod)
+                                {
+                                    for(int i=0; i<30; i++)
+                                    {
+                                        ed.placetilelocal(ed.tilex, i, 80);
+                                    }
+                                }
+                                else if(ed.hmod)
+                                {
+                                    for(int i=0; i<40; i++)
+                                    {
+                                        ed.placetilelocal(i, ed.tiley, 80);
+                                    }
+                                }
+                                else if(ed.vmod)
+                                {
+                                    for(int j=-4; j<5; j++)
+                                    {
+                                        for(int i=-4; i<5; i++)
+                                        {
+                                            ed.placetilelocal(ed.tilex+i, ed.tiley+j, 80);
+                                        }
+                                    }
+                                }
+                                else if(ed.cmod)
+                                {
+                                    for(int j=-3; j<4; j++)
+                                    {
+                                        for(int i=-3; i<4; i++)
+                                        {
+                                            ed.placetilelocal(ed.tilex+i, ed.tiley+j, 80);
+                                        }
+                                    }
+                                }
+                                else if(ed.xmod)
                                 {
                                     for(int j=-2; j<3; j++)
                                     {
@@ -4945,7 +5021,41 @@ void editorinput()
                         else if(ed.drawmode==1)
                         {
                             //place background tiles
-                            if(ed.xmod)
+                            if(ed.bmod)
+                            {
+                                for(int i=0; i<30; i++)
+                                {
+                                    ed.placetilelocal(ed.tilex, i, 2);
+                                }
+                            }
+                            else if(ed.hmod)
+                            {
+                                for(int i=0; i<40; i++)
+                                {
+                                    ed.placetilelocal(i, ed.tiley, 2);
+                                }
+                            }
+                            else if(ed.vmod)
+                            {
+                                for(int j=-4; j<5; j++)
+                                {
+                                    for(int i=-4; i<5; i++)
+                                    {
+                                        ed.placetilelocal(ed.tilex+i, ed.tiley+j, 2);
+                                    }
+                                }
+                            }
+                            else if(ed.cmod)
+                            {
+                                for(int j=-3; j<4; j++)
+                                {
+                                    for(int i=-3; i<4; i++)
+                                    {
+                                        ed.placetilelocal(ed.tilex+i, ed.tiley+j, 2);
+                                    }
+                                }
+                            }
+                            else if(ed.xmod)
                             {
                                 for(int j=-2; j<3; j++)
                                 {
@@ -5198,7 +5308,41 @@ void editorinput()
                 if(key.rightbutton)
                 {
                     //place tiles
-                    if(ed.xmod)
+                    if(ed.bmod)
+                    {
+                        for(int i=0; i<30; i++)
+                        {
+                            ed.placetilelocal(ed.tilex, i, 0);
+                        }
+                    }
+                    else if(ed.hmod)
+                    {
+                        for(int i=0; i<40; i++)
+                        {
+                            ed.placetilelocal(i, ed.tiley, 0);
+                        }
+                    }
+                    else if(ed.vmod)
+                    {
+                        for(int j=-4; j<5; j++)
+                        {
+                            for(int i=-4; i<5; i++)
+                            {
+                                ed.placetilelocal(ed.tilex+i, ed.tiley+j, 0);
+                            }
+                        }
+                    }
+                    else if(ed.cmod)
+                    {
+                        for(int j=-3; j<4; j++)
+                        {
+                            for(int i=-3; i<4; i++)
+                            {
+                                ed.placetilelocal(ed.tilex+i, ed.tiley+j, 0);
+                            }
+                        }
+                    }
+                    else if(ed.xmod)
                     {
                         for(int j=-2; j<3; j++)
                         {

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -182,7 +182,7 @@ class editorclass{
   int scripttexttype;
   std::string oldenttext;
 
-  bool xmod, zmod, spacemod, warpmod, roomnamemod, textentry, savemod, loadmod;
+  bool xmod, zmod, cmod, vmod, bmod, hmod, spacemod, warpmod, roomnamemod, textentry, savemod, loadmod;
   bool titlemod, creatormod, desc1mod, desc2mod, desc3mod, websitemod;
 
   int roomnamehide;


### PR DESCRIPTION
## Changes:

Adds the 7x7, 9x9, horizontal and vertical subtools from VED/VVVVVV: Community Edition to vanilla.
These are just like the default vanilla subtools for placing/removing walls/background, except larger.
There's a few gifs on [this page](https://vsix.dev/vce/#new_tool_sizes), which explains what they are and why they were added to VVVVVV: Community Edition.
This was requested in #267.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
