### PR TITLE
Add define __STDC_FORMAT_MACROS, _POSIX_SOURCE

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -23,6 +23,9 @@
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
+#ifndef _POSIX_SOURCE
+#define _POSIX_SOURCE
+#endif
 #include <inttypes.h>
 #include <cstdio>
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -20,6 +20,9 @@
 #include <utf8/unchecked.h>
 #include <physfs.h>
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
 #include <cstdio>
 


### PR DESCRIPTION
`__STDC_FORMAT_MACROS` is needed in order for the `SCNx32`/`SCNu32` in `find_tag()` to be compiled correctly on older `glibc`s, and `_POSIX_SOURCE` is needed in order for them to work on MinGW (when compiling C++98), apparently. I put ifndef guards around both just to be sure, because I got a warning about redefining `_POSIX_SOURCE` from my compiler.

Fixes #300.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
