### PR TITLE
Account for hours when calculating time trial result time

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1372,7 +1372,7 @@ void Game::updatestate()
             //Time Trial Complete!
             obj.removetrigger(82);
             hascontrol = false;
-            timetrialresulttime = seconds + (minutes * 60);
+            timetrialresulttime = seconds + (minutes * 60) + (hours * 60 * 60);
             timetrialrank = 0;
             if (timetrialresulttime <= timetrialpar) timetrialrank++;
             if (trinkets() >= timetrialshinytarget) timetrialrank++;


### PR DESCRIPTION
This prevents being able to "roll over" the amount of minutes to 0 (by simply waiting for the timer to tick past one hour) and being able to get a result of 00:13 when your result is really 01:00:13 or 03:00:13.

![3 hours 13 seconds](https://user-images.githubusercontent.com/59748578/84983901-9d8a1a00-b0ee-11ea-946f-d18bfab32cc4.png)

By looking only at the minutes, the game would read 01:00:13 as 00:13 instead. So simply add the amount of hours to the time trial result.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
