### PR TITLE
Add note to README about "compiler quirks" only applying to 2.2

### DIFF
--- a/desktop_version/README.md
+++ b/desktop_version/README.md
@@ -57,6 +57,11 @@ file, [get in touch](http://distractionware.com/email/)!)
 A Word About Compiler Quirks
 ----------------------------
 
+_(Note: This section only applies to version 2.2 of the source code, which is
+the initial commit of this repository. Since then, much hard work has been put
+in to fix many undefined behaviors. If you're compiling the latest version of
+the source code, ignore this section.)_
+
 This engine is _super_ fussy about optimization levels and runtime checks. In
 particular, the Windows version _absolutely positively must_ be compiled in
 Debug mode, with /RTC enabled. If you build in Release mode, or have /RTC


### PR DESCRIPTION
Only the 2.2 version has these problems, so you don't need to worry about this section when compiling 2.3.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
