### PR TITLE
Add '#if !defined(NO_EDITOR)' guards around editorinput/render/logic

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2299,6 +2299,7 @@ void editorclass::generatecustomminimap()
     }
 }
 
+#if !defined(NO_EDITOR)
 void editormenurender(int tr, int tg, int tb)
 {
     switch (game.currentmenuname)
@@ -5594,6 +5595,7 @@ void editorinput()
         }
     }
 }
+#endif /* NO_EDITOR */
 
 int editorclass::numtrinkets()
 {

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -259,11 +259,13 @@ void fillbox(int x, int y, int x2, int y2, int c);
 
 void fillboxabs(int x, int y, int x2, int y2, int c);
 
+#if !defined(NO_EDITOR)
 void editorrender();
 
 void editorlogic();
 
 void editorinput();
+#endif
 
 extern editorclass ed;
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -400,7 +400,7 @@ void inline deltaloop()
         case PRELOADER:
             preloaderrender();
             break;
-#if !defined(NO_CUSTOM_LEVELS)
+#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
         case EDITORMODE:
             graphics.flipmode = false;
             editorrender();
@@ -499,7 +499,7 @@ void inline fixedloop()
         case PRELOADER:
             preloaderlogic();
             break;
-#if !defined(NO_CUSTOM_LEVELS)
+#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
         case EDITORMODE:
             //Input
             editorinput();
@@ -598,7 +598,7 @@ void inline fixedloop()
     }
 
     //Mute button
-#if !defined(NO_CUSTOM_LEVELS)
+#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
     bool inEditor = ed.textentry || ed.scripthelppage == 1;
 #else
     bool inEditor = false;


### PR DESCRIPTION
These functions aren't needed in a `NO_EDITOR` build, so it's useful to reduce the binary size this way.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
