### PR TITLE
Add being able to press Esc to go to quit menu from teleporter menu

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2093,6 +2093,14 @@ void teleporterinput()
         //In the menu system, all keypresses are single taps rather than holds. Therefore this test has to be done for all presses
         if (!game.press_action && !game.press_left && !game.press_right) game.jumpheld = false;
         if (!game.press_map) game.mapheld = false;
+
+        if (key.isDown(27))
+        {
+            // Go to "Do you want to quit?" screen
+            game.mapheld = true;
+            game.menupage = 10;
+            game.gamestate = MAPMODE;
+        }
     }
     else
     {


### PR DESCRIPTION
It's always been a bit annoying that if you're in the teleporter menu, you can't press Escape to go to the "Do you want to quit?" menu.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
