### PR TITLE
De-duplicate menu tab name printing and custom level CREW page printing

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -301,6 +301,19 @@ void Graphics::MakeSpriteArray()
 }
 
 
+void Graphics::map_tab(int opt, const std::string& text, bool selected /*= false*/)
+{
+    int x = opt*80 + 40 - len(text)/2;
+    if (selected)
+    {
+        Print(x-8, 220, "[" + text + "]", 196, 196, 255 - help.glow);
+    }
+    else
+    {
+        Print(x, 220, text, 64, 64, 64);
+    }
+}
+
 void Graphics::Print( int _x, int _y, std::string _s, int r, int g, int b, bool cen /*= false*/ ) {
     return PrintAlpha(_x,_y,_s,r,g,b,255,cen);
 }

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -111,6 +111,8 @@ public:
 
 	void printcrewnamedark(int x, int y, int t);
 
+	void map_tab(int opt, const std::string& text, bool selected = false);
+
 	void Print(int _x, int _y, std::string _s, int r, int g, int b, bool cen = false);
 
 	void PrintAlpha(int _x, int _y, std::string _s, int r, int g, int b, int a, bool cen = false);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1648,25 +1648,36 @@ void maprender()
 
     //Menubar:
     graphics.drawtextbox( -10, 212, 42, 3, 65, 185, 207);
-    switch(game.menupage)
+
+    // Draw the selected page name at the bottom
+    // menupage 0 - 3 is the pause screen
+    if (game.menupage <= 3)
     {
-    case 0:
-        graphics.Print(30 - 8, 220, "[MAP]", 196, 196, 255 - help.glow);
+        std::string tab1;
         if (game.insecretlab)
         {
-            graphics.Print(103, 220, "GRAV", 64, 64, 64);
+            tab1 = "GRAV";
         }
         else if (obj.flags[67] && !map.custommode)
         {
-            graphics.Print(103, 220, "SHIP", 64,64,64);
+            tab1 = "SHIP";
         }
         else
         {
-            graphics.Print(103, 220, "CREW", 64,64,64);
+            tab1 = "CREW";
         }
-        graphics.Print(185-4, 220, "STATS", 64,64,64);
-        graphics.Print(258, 220, "SAVE", 64,64,64);
+#define TAB(opt, text) graphics.map_tab(opt, text, game.menupage == opt)
+        TAB(0, "MAP");
+        TAB(1, tab1);
+        TAB(2, "STATS");
+        TAB(3, "SAVE");
+#undef TAB
+    }
 
+    // Draw the actual menu
+    switch(game.menupage)
+    {
+    case 0:
         if (map.finalmode || (map.custommode&&!map.customshowmm))
         {
             //draw the map image
@@ -1866,11 +1877,6 @@ void maprender()
     case 1:
         if (game.insecretlab)
         {
-            graphics.Print(30, 220, "MAP", 64,64,64);
-            graphics.Print(103-8, 220, "[GRAV]", 196, 196, 255 - help.glow);
-            graphics.Print(185-4, 220, "STATS", 64,64,64);
-            graphics.Print(258, 220, "SAVE", 64, 64, 64);
-
             if (graphics.flipmode)
             {
                 graphics.Print(0, 174, "SUPER GRAVITRON HIGHSCORE", 196, 196, 255 - help.glow, true);
@@ -1940,20 +1946,10 @@ void maprender()
         }
         else if (obj.flags[67] && !map.custommode)
         {
-            graphics.Print(30, 220, "MAP", 64,64,64);
-            graphics.Print(103-8, 220, "[SHIP]", 196, 196, 255 - help.glow);
-            graphics.Print(185-4, 220, "STATS", 64,64,64);
-            graphics.Print(258, 220, "SAVE", 64, 64, 64);
-
             graphics.Print(0, 105, "Press ACTION to warp to the ship.", 196, 196, 255 - help.glow, true);
         }
 #if !defined(NO_CUSTOM_LEVELS)
         else if(map.custommode){
-            graphics.Print(30, 220, "MAP", 64,64,64);
-            graphics.Print(103-8, 220, "[CREW]", 196, 196, 255 - help.glow);
-            graphics.Print(185-4, 220, "STATS", 64,64,64);
-            graphics.Print(258, 220, "SAVE", 64, 64, 64);
-
             if (graphics.flipmode)
             {
                 graphics.bigprint( -1, 220-45, ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
@@ -1988,11 +1984,6 @@ void maprender()
 #endif
         else
         {
-            graphics.Print(30, 220, "MAP", 64,64,64);
-            graphics.Print(103-8, 220, "[CREW]", 196, 196, 255 - help.glow);
-            graphics.Print(185-4, 220, "STATS", 64,64,64);
-            graphics.Print(258, 220, "SAVE", 64, 64, 64);
-
             if (graphics.flipmode)
             {
                 for (int i = 0; i < 3; i++)
@@ -2054,22 +2045,6 @@ void maprender()
         }
         break;
     case 2:
-        graphics.Print(30, 220, "MAP", 64,64,64);
-        if (game.insecretlab)
-        {
-            graphics.Print(103, 220, "GRAV", 64, 64, 64);
-        }
-        else if (obj.flags[67] && !map.custommode)
-        {
-            graphics.Print(103, 220, "SHIP", 64,64,64);
-        }
-        else
-        {
-            graphics.Print(103, 220, "CREW", 64,64,64);
-        }
-        graphics.Print(185-12, 220, "[STATS]", 196, 196, 255 - help.glow);
-        graphics.Print(258, 220, "SAVE", 64, 64, 64);
-
 #if !defined(NO_CUSTOM_LEVELS)
         if(map.custommode)
         {
@@ -2124,22 +2099,6 @@ void maprender()
         }
         break;
     case 3:
-        graphics.Print(30, 220, "MAP", 64,64,64);
-        if (game.insecretlab)
-        {
-            graphics.Print(103, 220, "GRAV", 64, 64, 64);
-        }
-        else if (obj.flags[67] && !map.custommode)
-        {
-            graphics.Print(103, 220, "SHIP", 64,64,64);
-        }
-        else
-        {
-            graphics.Print(103, 220, "CREW", 64,64,64);
-        }
-        graphics.Print(185-4, 220, "STATS", 64,64,64);
-        graphics.Print(258 - 8, 220, "[SAVE]", 196, 196, 255 - help.glow);
-
         if (game.inintermission)
         {
             graphics.Print(0, 115, "Cannot Save in Level Replay", 146, 146, 180, true);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1961,12 +1961,14 @@ void maprender()
         }
 #if !defined(NO_CUSTOM_LEVELS)
         else if(map.custommode){
-            graphics.bigprint( -1, FLIP(45), ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
-            graphics.Print( -1, FLIP(70), "by " + ed.ListOfMetaData[game.playcustomlevel].creator, 196, 196, 255 - help.glow, true);
-            graphics.Print( -1, FLIP(80), ed.ListOfMetaData[game.playcustomlevel].website, 196, 196, 255 - help.glow, true);
-            graphics.Print( -1, FLIP(100), ed.ListOfMetaData[game.playcustomlevel].Desc1, 196, 196, 255 - help.glow, true);
-            graphics.Print( -1, FLIP(110), ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
-            graphics.Print( -1, FLIP(120), ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
+            LevelMetaData& meta = ed.ListOfMetaData[game.playcustomlevel];
+
+            graphics.bigprint( -1, FLIP(45), meta.title, 196, 196, 255 - help.glow, true);
+            graphics.Print( -1, FLIP(70), "by " + meta.creator, 196, 196, 255 - help.glow, true);
+            graphics.Print( -1, FLIP(80), meta.website, 196, 196, 255 - help.glow, true);
+            graphics.Print( -1, FLIP(100), meta.Desc1, 196, 196, 255 - help.glow, true);
+            graphics.Print( -1, FLIP(110), meta.Desc2, 196, 196, 255 - help.glow, true);
+            graphics.Print( -1, FLIP(120), meta.Desc3, 196, 196, 255 - help.glow, true);
 
             if(ed.numcrewmates()-game.crewmates()==1){
                 graphics.Print(1,FLIP(165), help.number(ed.numcrewmates()-game.crewmates())+ " crewmate remains", 196, 196, 255 - help.glow, true);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1961,35 +1961,17 @@ void maprender()
         }
 #if !defined(NO_CUSTOM_LEVELS)
         else if(map.custommode){
-            if (graphics.flipmode)
-            {
-                graphics.bigprint( -1, 220-45, ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
-                graphics.Print( -1, 220-70, "by " + ed.ListOfMetaData[game.playcustomlevel].creator, 196, 196, 255 - help.glow, true);
-                graphics.Print( -1, 220-80, ed.ListOfMetaData[game.playcustomlevel].website, 196, 196, 255 - help.glow, true);
-                graphics.Print( -1, 220-100, ed.ListOfMetaData[game.playcustomlevel].Desc1, 196, 196, 255 - help.glow, true);
-                graphics.Print( -1, 220-110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
-                graphics.Print( -1, 220-120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
+            graphics.bigprint( -1, FLIP(45), ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
+            graphics.Print( -1, FLIP(70), "by " + ed.ListOfMetaData[game.playcustomlevel].creator, 196, 196, 255 - help.glow, true);
+            graphics.Print( -1, FLIP(80), ed.ListOfMetaData[game.playcustomlevel].website, 196, 196, 255 - help.glow, true);
+            graphics.Print( -1, FLIP(100), ed.ListOfMetaData[game.playcustomlevel].Desc1, 196, 196, 255 - help.glow, true);
+            graphics.Print( -1, FLIP(110), ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
+            graphics.Print( -1, FLIP(120), ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
 
-                if(ed.numcrewmates()-game.crewmates()==1){
-                    graphics.Print(1,220-165, help.number(ed.numcrewmates()-game.crewmates())+ " crewmate remains", 196, 196, 255 - help.glow, true);
-                }else if(ed.numcrewmates()-game.crewmates()>0){
-                    graphics.Print(1,220-165, help.number(ed.numcrewmates()-game.crewmates())+ " crewmates remain", 196, 196, 255 - help.glow, true);
-                }
-            }
-            else
-            {
-                graphics.bigprint( -1, 45, ed.ListOfMetaData[game.playcustomlevel].title, 196, 196, 255 - help.glow, true);
-                graphics.Print( -1, 70, "by " + ed.ListOfMetaData[game.playcustomlevel].creator, 196, 196, 255 - help.glow, true);
-                graphics.Print( -1, 80, ed.ListOfMetaData[game.playcustomlevel].website, 196, 196, 255 - help.glow, true);
-                graphics.Print( -1, 100, ed.ListOfMetaData[game.playcustomlevel].Desc1, 196, 196, 255 - help.glow, true);
-                graphics.Print( -1, 110, ed.ListOfMetaData[game.playcustomlevel].Desc2, 196, 196, 255 - help.glow, true);
-                graphics.Print( -1, 120, ed.ListOfMetaData[game.playcustomlevel].Desc3, 196, 196, 255 - help.glow, true);
-
-                if(ed.numcrewmates()-game.crewmates()==1){
-                    graphics.Print(1,165, help.number(ed.numcrewmates()-game.crewmates())+ " crewmate remains", 196, 196, 255 - help.glow, true);
-                }else if(ed.numcrewmates()-game.crewmates()>0){
-                    graphics.Print(1,165, help.number(ed.numcrewmates()-game.crewmates())+ " crewmates remain", 196, 196, 255 - help.glow, true);
-                }
+            if(ed.numcrewmates()-game.crewmates()==1){
+                graphics.Print(1,FLIP(165), help.number(ed.numcrewmates()-game.crewmates())+ " crewmate remains", 196, 196, 255 - help.glow, true);
+            }else if(ed.numcrewmates()-game.crewmates()>0){
+                graphics.Print(1,FLIP(165), help.number(ed.numcrewmates()-game.crewmates())+ " crewmates remain", 196, 196, 255 - help.glow, true);
             }
         }
 #endif

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -14,6 +14,17 @@ int tr;
 int tg;
 int tb;
 
+// Macro-like inline function used in maprender()
+// Used to keep some text positions the same in Flip Mode
+int inline FLIP(int ypos)
+{
+    if (graphics.flipmode)
+    {
+        return 220 - ypos;
+    }
+    return ypos;
+}
+
 void menurender()
 {
     int temp = 50;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1970,10 +1970,12 @@ void maprender()
             graphics.Print( -1, FLIP(110), meta.Desc2, 196, 196, 255 - help.glow, true);
             graphics.Print( -1, FLIP(120), meta.Desc3, 196, 196, 255 - help.glow, true);
 
-            if(ed.numcrewmates()-game.crewmates()==1){
-                graphics.Print(1,FLIP(165), help.number(ed.numcrewmates()-game.crewmates())+ " crewmate remains", 196, 196, 255 - help.glow, true);
-            }else if(ed.numcrewmates()-game.crewmates()>0){
-                graphics.Print(1,FLIP(165), help.number(ed.numcrewmates()-game.crewmates())+ " crewmates remain", 196, 196, 255 - help.glow, true);
+            int remaining = ed.numcrewmates() - game.crewmates();
+
+            if(remaining==1){
+                graphics.Print(1,FLIP(165), help.number(remaining)+ " crewmate remains", 196, 196, 255 - help.glow, true);
+            }else if(remaining>0){
+                graphics.Print(1,FLIP(165), help.number(remaining)+ " crewmates remain", 196, 196, 255 - help.glow, true);
             }
         }
 #endif


### PR DESCRIPTION
`maprender()` has lots of copy-pasted code, so I thought I'd start to de-duplicate at least some of it.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
