### PR TITLE
Add `-playassets` command-line option, and clean up and fix filesystem and command-line arguments code

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -166,6 +166,44 @@ void FILESYSTEM_mount(const char *fname)
 	}
 }
 
+void FILESYSTEM_mountassets(const char* path)
+{
+	const std::string _path(path);
+
+	std::string zippath = "levels/" + _path.substr(7,_path.size()-14) + ".data.zip";
+	std::string dirpath = "levels/" + _path.substr(7,_path.size()-14) + "/";
+	std::string zip_path;
+	const char* cstr = PHYSFS_getRealDir(_path.c_str());
+
+	if (cstr) {
+		zip_path = cstr;
+	}
+
+	if (cstr && FILESYSTEM_directoryExists(zippath.c_str())) {
+		printf("Custom asset directory exists at %s\n", zippath.c_str());
+		FILESYSTEM_mount(zippath.c_str());
+		graphics.reloadresources();
+	} else if (zip_path != "data.zip" && !endsWith(zip_path, "/data.zip") && endsWith(zip_path, ".zip")) {
+		printf("Custom asset directory is .zip at %s\n", zip_path.c_str());
+		PHYSFS_File* zip = PHYSFS_openRead(zip_path.c_str());
+		zip_path += ".data.zip";
+		if (zip == NULL) {
+			printf("error loading .zip: %s\n", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+		} else if (PHYSFS_mountHandle(zip, zip_path.c_str(), "/", 0) == 0) {
+			printf("error mounting .zip: %s\n", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+		} else {
+			graphics.assetdir = zip_path;
+		}
+		graphics.reloadresources();
+	} else if (FILESYSTEM_directoryExists(dirpath.c_str())) {
+		printf("Custom asset directory exists at %s\n",dirpath.c_str());
+		FILESYSTEM_mount(dirpath.c_str());
+		graphics.reloadresources();
+	} else {
+		printf("Custom asset directory does not exist\n");
+	}
+}
+
 void FILESYSTEM_unmountassets()
 {
 	if (graphics.assetdir != "")

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -15,6 +15,7 @@ char *FILESYSTEM_getUserLevelDirectory();
 
 bool FILESYSTEM_directoryExists(const char *fname);
 void FILESYSTEM_mount(const char *fname);
+void FILESYSTEM_mountassets(const char *path);
 void FILESYSTEM_unmountassets();
 
 void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem,

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -382,6 +382,7 @@ public:
     int playrx;
     int playry;
     int playgc;
+    std::string playassets;
 
     void quittomenu();
     void returntolab();

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -230,3 +230,16 @@ bool is_positive_num(const std::string& str, bool hex)
 	}
 	return true;
 }
+
+bool endsWith(const std::string& str, const std::string& suffix)
+{
+	if (str.size() < suffix.size())
+	{
+		return false;
+	}
+	return str.compare(
+		str.size() - suffix.size(),
+		suffix.size(),
+		suffix
+	) == 0;
+}

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -13,6 +13,8 @@ std::vector<std::string> split(const std::string &s, char delim);
 
 bool is_positive_num(const std::string& str, bool hex);
 
+bool endsWith(const std::string& str, const std::string& suffix);
+
 #define INBOUNDS(index, vector) ((int) index >= 0 && (int) index < (int) vector.size())
 
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1650,7 +1650,6 @@ bool editorclass::load(std::string& _path)
         printf("Custom asset directory exists at %s\n", zippath.c_str());
         FILESYSTEM_mount(zippath.c_str());
         graphics.reloadresources();
-        music.init();
     } else if (zip_path != "data.zip" && !endsWith(zip_path, "/data.zip") && endsWith(zip_path, ".zip")) {
         printf("Custom asset directory is .zip at %s\n", zip_path.c_str());
         PHYSFS_File* zip = PHYSFS_openRead(zip_path.c_str());

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1623,7 +1623,14 @@ bool editorclass::load(std::string& _path)
     }
 
     FILESYSTEM_unmountassets();
-    FILESYSTEM_mountassets(_path.c_str());
+    if (game.playassets != "")
+    {
+        FILESYSTEM_mountassets(game.playassets.c_str());
+    }
+    else
+    {
+        FILESYSTEM_mountassets(_path.c_str());
+    }
 
     tinyxml2::XMLDocument doc;
     if (!FILESYSTEM_loadTiXml2Document(_path.c_str(), doc))

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -88,19 +88,6 @@ bool compare_nocase (std::string first, std::string second)
         return false;
 }
 
-static bool endsWith(const std::string& str, const std::string& suffix)
-{
-    if (str.size() < suffix.size())
-    {
-        return false;
-    }
-    return str.compare(
-        str.size() - suffix.size(),
-        suffix.size(),
-        suffix
-    ) == 0;
-}
-
 void editorclass::loadZips()
 {
     directoryList = FILESYSTEM_getLevelDirFileNames();

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1623,39 +1623,7 @@ bool editorclass::load(std::string& _path)
     }
 
     FILESYSTEM_unmountassets();
-
-    std::string zippath = "levels/" + _path.substr(7,_path.size()-14) + ".data.zip";
-    std::string dirpath = "levels/" + _path.substr(7,_path.size()-14) + "/";
-    std::string zip_path;
-    const char* cstr = PHYSFS_getRealDir(_path.c_str());
-
-    if (cstr) {
-        zip_path = cstr;
-    }
-
-    if (cstr && FILESYSTEM_directoryExists(zippath.c_str())) {
-        printf("Custom asset directory exists at %s\n", zippath.c_str());
-        FILESYSTEM_mount(zippath.c_str());
-        graphics.reloadresources();
-    } else if (zip_path != "data.zip" && !endsWith(zip_path, "/data.zip") && endsWith(zip_path, ".zip")) {
-        printf("Custom asset directory is .zip at %s\n", zip_path.c_str());
-        PHYSFS_File* zip = PHYSFS_openRead(zip_path.c_str());
-        zip_path += ".data.zip";
-        if (zip == NULL) {
-            printf("error loading .zip: %s\n", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
-        } else if (PHYSFS_mountHandle(zip, zip_path.c_str(), "/", 0) == 0) {
-            printf("error mounting .zip: %s\n", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
-        } else {
-            graphics.assetdir = zip_path;
-        }
-        graphics.reloadresources();
-    } else if (FILESYSTEM_directoryExists(dirpath.c_str())) {
-        printf("Custom asset directory exists at %s\n",dirpath.c_str());
-        FILESYSTEM_mount(dirpath.c_str());
-        graphics.reloadresources();
-    } else {
-        printf("Custom asset directory does not exist\n");
-    }
+    FILESYSTEM_mountassets(_path.c_str());
 
     tinyxml2::XMLDocument doc;
     if (!FILESYSTEM_loadTiXml2Document(_path.c_str(), doc))

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -53,6 +53,7 @@ int saverx = 0;
 int savery = 0;
 int savegc = 0;
 int savemusic = 0;
+std::string playassets;
 
 std::string playtestname;
 
@@ -111,6 +112,15 @@ int main(int argc, char *argv[])
                 i++;
             } else {
                 printf("-playing option requires one argument.\n");
+                return 1;
+            }
+        } else if (strcmp(argv[i], "-playassets") == 0) {
+            if (i + 1 < argc) {
+                i++;
+                // Even if this is a directory, FILESYSTEM_mountassets() expects '.vvvvvv' on the end
+                playassets = "levels/" + std::string(argv[i]) + ".vvvvvv";
+            } else {
+                printf("%s option requires one argument.\n", argv[i]);
                 return 1;
             }
         }
@@ -280,6 +290,7 @@ int main(int argc, char *argv[])
     if (startinplaytest) {
         game.levelpage = 0;
         game.playcustomlevel = 0;
+        game.playassets = playassets;
 
         ed.directoryList.clear();
         ed.directoryList.push_back(playtestname);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -143,6 +143,7 @@ int main(int argc, char *argv[])
 
     if(!FILESYSTEM_init(argv[0], baseDir, assetsPath))
     {
+        puts("Unable to initialize filesystem!");
         return 1;
     }
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -73,57 +73,72 @@ int main(int argc, char *argv[])
     char* baseDir = NULL;
     char* assetsPath = NULL;
 
-    for (int i = 1; i < argc; ++i) {
-        if (strcmp(argv[i], "-renderer") == 0) {
-            ++i;
-            SDL_SetHintWithPriority(SDL_HINT_RENDER_DRIVER, argv[i], SDL_HINT_OVERRIDE);
-        } else if (strcmp(argv[i], "-basedir") == 0) {
-            ++i;
-            baseDir = argv[i];
-        } else if (strcmp(argv[i], "-assets") == 0) {
-            ++i;
-            assetsPath = argv[i];
-        } else if (strcmp(argv[i], "-playing") == 0 || strcmp(argv[i], "-p") == 0) {
-            if (i + 1 < argc) {
+    for (int i = 1; i < argc; ++i)
+    {
+#define ARG(name) (strcmp(argv[i], name) == 0)
+#define ARG_INNER(code) \
+    if (i + 1 < argc) \
+    { \
+        i++; \
+        code \
+    } \
+    else \
+    { \
+        printf("%s option requires one argument.\n", argv[i]); \
+        return 1; \
+    }
+
+        if (ARG("-renderer"))
+        {
+            ARG_INNER({
+                SDL_SetHintWithPriority(SDL_HINT_RENDER_DRIVER, argv[i], SDL_HINT_OVERRIDE);
+            })
+        }
+        else if (ARG("-basedir"))
+        {
+            ARG_INNER({
+                baseDir = argv[i];
+            })
+        }
+        else if (ARG("-assets"))
+        {
+            ARG_INNER({
+                assetsPath = argv[i];
+            })
+        }
+        else if (ARG("-playing") || ARG("-p"))
+        {
+            ARG_INNER({
                 startinplaytest = true;
-                i++;
                 playtestname = std::string("levels/");
                 playtestname.append(argv[i]);
                 playtestname.append(std::string(".vvvvvv"));
-            } else {
-                printf("-playing option requires one argument.\n");
-                return 1;
-            }
-        } else if (strcmp(argv[i], "-playx") == 0 ||
-                strcmp(argv[i], "-playy") == 0 ||
-                strcmp(argv[i], "-playrx") == 0 ||
-                strcmp(argv[i], "-playry") == 0 ||
-                strcmp(argv[i], "-playgc") == 0 ||
-                strcmp(argv[i], "-playmusic") == 0) {
-            if (i + 1 < argc) {
-                savefileplaytest = true;
-                int v = std::atoi(argv[i+1]);
-                if (strcmp(argv[i], "-playx") == 0) savex = v;
-                else if (strcmp(argv[i], "-playy") == 0) savey = v;
-                else if (strcmp(argv[i], "-playrx") == 0) saverx = v;
-                else if (strcmp(argv[i], "-playry") == 0) savery = v;
-                else if (strcmp(argv[i], "-playgc") == 0) savegc = v;
-                else if (strcmp(argv[i], "-playmusic") == 0) savemusic = v;
-                i++;
-            } else {
-                printf("-playing option requires one argument.\n");
-                return 1;
-            }
-        } else if (strcmp(argv[i], "-playassets") == 0) {
-            if (i + 1 < argc) {
-                i++;
-                // Even if this is a directory, FILESYSTEM_mountassets() expects '.vvvvvv' on the end
-                playassets = "levels/" + std::string(argv[i]) + ".vvvvvv";
-            } else {
-                printf("%s option requires one argument.\n", argv[i]);
-                return 1;
-            }
+            })
         }
+        else if (ARG("-playx") || ARG("-playy") ||
+        ARG("-playrx") || ARG("-playry") ||
+        ARG("-playgc") || ARG("-playmusic"))
+        {
+            ARG_INNER({
+                savefileplaytest = true;
+                int v = std::atoi(argv[i]);
+                if (ARG("-playx")) savex = v;
+                else if (ARG("-playy")) savey = v;
+                else if (ARG("-playrx")) saverx = v;
+                else if (ARG("-playry")) savery = v;
+                else if (ARG("-playgc")) savegc = v;
+                else if (ARG("-playmusic")) savemusic = v;
+            })
+        }
+        else if (ARG("-playassets"))
+        {
+            // Even if this is a directory, FILESYSTEM_mountassets() expects '.vvvvvv' on the end
+            ARG_INNER({
+                playassets = "levels/" + std::string(argv[i]) + ".vvvvvv";
+            })
+        }
+#undef ARG_INNER
+#undef ARG_IS
     }
 
     if(!FILESYSTEM_init(argv[0], baseDir, assetsPath))


### PR DESCRIPTION
If the game was loading a level file from STDIN, and that level file had custom assets, they wouldn't be loaded in. This is because of the fundamental problem where if the game loads a level file from STDIN, it doesn't know the actual filename of the level. To fix this, it needs to be able to be provided the name of the actual filename, so it can load the assets.

After this is merged, a trivial amount of work (compared to this patch) just needs to be done on Ved's end.

Also cleaned up and fixed some filesystem/CLI code (read the commits).

Anyone who wants to test this, but doesn't know how to or want to modify Ved to make it use `-playassets`, but knows how to use the command-line... don't abuse `cat`! I went out of my way to figure out how to avoid abusing `cat`. The command I used was:
```
./VVVVVV -p special/stdin -playassets custom_assets_test < ~/v/levels/open_1.1.3.vvvvvv
```

Fixes #309.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
