### PR TITLE
Overhaul the menu brought up by pressing Escape

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7762,4 +7762,5 @@ void Game::returntopausemenu()
     returntomenu(kludge_ingametemp);
     gamestate = MAPMODE;
     map.kludge_to_bg();
+    map.tdrawback = true;
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -389,6 +389,8 @@ void Game::init(void)
 
     over30mode = false;
 
+    ingame_titlemode = false;
+
     /* Terry's Patrons... */
     const char* superpatrons_arr[] = {
     "Anders Ekermo",

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7755,3 +7755,11 @@ void Game::returntoeditor()
     map.scrolldir = 0;
 }
 #endif
+
+void Game::returntopausemenu()
+{
+    ingame_titlemode = false;
+    returntomenu(kludge_ingametemp);
+    gamestate = MAPMODE;
+    map.kludge_to_bg();
+}

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -391,6 +391,7 @@ void Game::init(void)
 
     ingame_titlemode = false;
     kludge_ingametemp = Menu::mainmenu;
+    shouldreturntopausemenu = false;
 
     /* Terry's Patrons... */
     const char* superpatrons_arr[] = {
@@ -7766,4 +7767,5 @@ void Game::returntopausemenu()
     graphics.backgrounddrawn = false;
     game.mapheld = true;
     graphics.flipmode = graphics.setflipmode;
+    game.shouldreturntopausemenu = true;
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7764,4 +7764,5 @@ void Game::returntopausemenu()
     map.kludge_to_bg();
     map.tdrawback = true;
     game.mapheld = true;
+    graphics.flipmode = graphics.setflipmode;
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7147,8 +7147,8 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("animated backgrounds");
         option("screen effects");
         option("text outline");
-        option("invincibility");
-        option("slowdown");
+        option("invincibility", !ingame_titlemode || !inspecial());
+        option("slowdown", !ingame_titlemode || !inspecial());
         option("load screen");
         option("room name bg");
         option("return");

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7763,6 +7763,7 @@ void Game::returntopausemenu()
     gamestate = MAPMODE;
     map.kludge_to_bg();
     map.tdrawback = true;
+    graphics.backgrounddrawn = false;
     game.mapheld = true;
     graphics.flipmode = graphics.setflipmode;
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -390,6 +390,7 @@ void Game::init(void)
     over30mode = false;
 
     ingame_titlemode = false;
+    kludge_ingametemp = Menu::mainmenu;
 
     /* Terry's Patrons... */
     const char* superpatrons_arr[] = {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7763,4 +7763,5 @@ void Game::returntopausemenu()
     gamestate = MAPMODE;
     map.kludge_to_bg();
     map.tdrawback = true;
+    game.mapheld = true;
 }

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -407,6 +407,8 @@ public:
     bool over30mode;
 
     bool ingame_titlemode;
+
+    void returntopausemenu();
 };
 
 extern Game game;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -404,6 +404,8 @@ public:
     }
 
     bool over30mode;
+
+    bool ingame_titlemode;
 };
 
 extern Game game;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -216,6 +216,7 @@ public:
     std::vector<MenuOption> menuoptions;
     int currentmenuoption ;
     enum Menu::MenuName currentmenuname;
+    enum Menu::MenuName kludge_ingametemp;
     int current_credits_list_index;
     int menuxoff, menuyoff;
     std::vector<MenuStackFrame> menustack;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -408,6 +408,7 @@ public:
 
     bool ingame_titlemode;
 
+    bool shouldreturntopausemenu;
     void returntopausemenu();
 };
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -334,7 +334,9 @@ void Graphics::map_option(int opt, int num_opts, const std::string& text, bool s
 
     if (selected)
     {
-        Print(x - 16, y, "[ " + text + " ]", 196, 196, 255 - help.glow);
+        std::string text_upper(text);
+        std::transform(text_upper.begin(), text_upper.end(), text_upper.begin(), ::toupper);
+        Print(x - 16, y, "[ " + text_upper + " ]", 196, 196, 255 - help.glow);
     }
     else
     {

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -314,6 +314,34 @@ void Graphics::map_tab(int opt, const std::string& text, bool selected /*= false
     }
 }
 
+void Graphics::map_option(int opt, int num_opts, const std::string& text, bool selected /*= false*/)
+{
+    int x = 80 + opt*32;
+    int y = 136; // start from middle of menu
+
+    int yoff = -(num_opts * 12) / 2; // could be simplified to -num_opts * 6, this conveys my intent better though
+    yoff += opt * 12;
+
+    if (flipmode)
+    {
+        y -= yoff; // going down, which in Flip Mode means going up
+        y -= 40;
+    }
+    else
+    {
+        y += yoff; // going up
+    }
+
+    if (selected)
+    {
+        Print(x - 16, y, "[ " + text + " ]", 196, 196, 255 - help.glow);
+    }
+    else
+    {
+        Print(x, y, text, 96, 96, 96);
+    }
+}
+
 void Graphics::Print( int _x, int _y, std::string _s, int r, int g, int b, bool cen /*= false*/ ) {
     return PrintAlpha(_x,_y,_s,r,g,b,255,cen);
 }

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -113,6 +113,8 @@ public:
 
 	void map_tab(int opt, const std::string& text, bool selected = false);
 
+	void map_option(int opt, int num_opts, const std::string& text, bool selected = false);
+
 	void Print(int _x, int _y, std::string _s, int r, int g, int b, bool cen = false);
 
 	void PrintAlpha(int _x, int _y, std::string _s, int r, int g, int b, int a, bool cen = false);

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2120,6 +2120,7 @@ void mapmenuactionpress()
             game.createmenu(Menu::options);
         }
         map.nexttowercolour();
+        map.scrolldir = 0;
 
         // Fix delta rendering glitch
         graphics.updatetowerbackground();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -375,15 +375,16 @@ void menuactionpress()
         default:
             //back
             music.playef(11);
-            game.returnmenu();
             if (game.ingame_titlemode)
             {
                 game.ingame_titlemode = false;
+                game.returntomenu(game.kludge_ingametemp);
                 game.gamestate = MAPMODE;
                 map.kludge_to_bg();
             }
             else
             {
+                game.returnmenu();
                 map.nexttowercolour();
             }
             break;
@@ -590,15 +591,16 @@ void menuactionpress()
         {
             //back
             music.playef(11);
-            game.returnmenu();
             if (game.ingame_titlemode)
             {
                 game.ingame_titlemode = false;
+                game.returntomenu(game.kludge_ingametemp);
                 game.gamestate = MAPMODE;
                 map.kludge_to_bg();
             }
             else
             {
+                game.returnmenu();
                 map.nexttowercolour();
             }
         }
@@ -2122,6 +2124,7 @@ void mapmenuactionpress()
             game.createmenu(Menu::options);
         }
         map.bg_to_kludge();
+        game.kludge_ingametemp = game.currentmenuname;
 
         map.nexttowercolour();
         map.scrolldir = 0;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1744,7 +1744,7 @@ void gameinput()
                     game.gamestate = MAPMODE;
                     game.gamesaved = false;
                     graphics.resumegamemode = false;
-                    game.menupage = 10; // The Map Page
+                    game.menupage = 30; // Pause screen
 
                     BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
                     graphics.menuoffset = 240; //actually this should count the roomname
@@ -1924,7 +1924,7 @@ void mapinput()
             if (key.isDown(27))
             {
                 game.mapheld = true;
-                game.menupage = 10;
+                game.menupage = 30;
             }
         }
         else
@@ -2066,6 +2066,8 @@ void mapinput()
         if (game.menupage == 19) game.menupage = 21;
         if (game.menupage == 22) game.menupage = 20;
 
+        if (game.menupage == 29) game.menupage = 33;
+        if (game.menupage == 34) game.menupage = 30;
     }
 }
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2143,8 +2143,9 @@ void mapmenuactionpress()
         map.bg_to_kludge();
         game.kludge_ingametemp = game.currentmenuname;
 
-        map.nexttowercolour();
         map.scrolldir = 0;
+        map.colstate = ((int) (map.colstate / 5)) * 5;
+        map.nexttowercolour();
 
         // Fix delta rendering glitch
         graphics.updatetowerbackground();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1936,7 +1936,7 @@ void mapinput()
         }
     }
 
-    if(graphics.menuoffset==0)
+    if(graphics.menuoffset==0 && game.fadetomenudelay <= 0 && game.fadetolabdelay <= 0)
     {
         if (graphics.flipmode)
         {

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -597,7 +597,7 @@ void menuactionpress()
             }
             music.usingmmmmmm = !music.usingmmmmmm;
             music.playef(11);
-            music.play(6);
+            music.play(music.currentsong);
             game.savestats();
         }
         else if (game.currentmenuoption == OFFSET+5+mmmmmm_offset)

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2145,6 +2145,7 @@ void mapmenuactionpress()
 
         map.scrolldir = 0;
         map.colstate = ((int) (map.colstate / 5)) * 5;
+        map.bypos = 0;
         map.nexttowercolour();
 
         // Fix delta rendering glitch

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2079,6 +2079,29 @@ void mapmenuactionpress()
         game.fadetolab = true;
         game.fadetolabdelay = 16;
         break;
+    case 30:
+        // Return to game
+        graphics.resumegamemode = true;
+        break;
+    case 31:
+        // Go to quit prompt
+        music.playef(11);
+        game.menupage = 10;
+        break;
+    case 32:
+        // Graphic options
+        music.playef(11);
+        game.gamestate = TITLEMODE;
+        game.createmenu(Menu::graphicoptions);
+        map.nexttowercolour();
+        break;
+    case 33:
+        // Game options
+        music.playef(11);
+        game.gamestate = TITLEMODE;
+        game.createmenu(Menu::options);
+        map.nexttowercolour();
+        break;
     }
 }
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1958,19 +1958,23 @@ void mapinput()
         {
             game.press_action = true;
         }
-        if (game.menupage < 12)
+        if (game.menupage < 12 || (game.menupage >= 30 && game.menupage <= 33))
         {
             if (key.isDown(KEYBOARD_ENTER) || key.isDown(game.controllerButton_map) ) game.press_map = true;
-            if (key.isDown(27))
+            if (key.isDown(27) && !game.mapheld)
             {
                 game.mapheld = true;
                 if (game.menupage < 9)
                 {
                     game.menupage = 30;
                 }
-                else
+                else if (game.menupage < 12)
                 {
                     game.menupage = 31;
+                }
+                else
+                {
+                    graphics.resumegamemode = true;
                 }
             }
         }

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -514,7 +514,7 @@ void menuactionpress()
             break;
         case 4:
             //change game speed
-            if (!game.insecretlab && !game.intimetrial && !game.nodeathmode)
+            if (!game.ingame_titlemode || (!game.insecretlab && !game.intimetrial && !game.nodeathmode))
             {
                 game.createmenu(Menu::setslowdown);
                 map.nexttowercolour();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2143,6 +2143,7 @@ void mapmenuactionpress()
         // Graphic options and game options
         music.playef(11);
         game.gamestate = TITLEMODE;
+        graphics.flipmode = false;
         game.ingame_titlemode = true;
         if (game.menupage == 32)
         {

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2089,8 +2089,9 @@ void mapmenuactionpress()
         break;
 
     case 10:
-        //return to game
-        graphics.resumegamemode = true;
+        //return to pause menu
+        music.playef(11);
+        game.menupage = 31;
         break;
     case 11:
         //quit to menu

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1996,7 +1996,10 @@ void mapinput()
 
 void mapmenuactionpress()
 {
-    if (game.menupage == 1 && obj.flags[67] && !game.insecretlab && !map.custommode)
+    switch (game.menupage)
+    {
+    case 1:
+    if (obj.flags[67] && !game.insecretlab && !map.custommode)
     {
         //Warp back to the ship
         graphics.resumegamemode = true;
@@ -2019,8 +2022,9 @@ void mapmenuactionpress()
         game.state = 4000;
         game.statedelay = 0;
     }
-
-    if (game.menupage == 3 && !game.gamesaved && !game.intimetrial
+        break;
+    case 3:
+    if (!game.gamesaved && !game.intimetrial
             && !game.nodeathmode && !game.insecretlab && !game.inintermission)
     {
         game.flashlight = 5;
@@ -2045,14 +2049,13 @@ void mapmenuactionpress()
             game.savequick();
         }
     }
+        break;
 
-    if (game.menupage == 10)
-    {
+    case 10:
         //return to game
         graphics.resumegamemode = true;
-    }
-    if (game.menupage == 11)
-    {
+        break;
+    case 11:
         //quit to menu
 
         //Kill contents of offset render buffer, since we do that for some reason.
@@ -2063,21 +2066,20 @@ void mapmenuactionpress()
         map.nexttowercolour();
         game.fadetomenu = true;
         game.fadetomenudelay = 16;
-    }
+        break;
 
-    if (game.menupage == 20)
-    {
+    case 20:
         //return to game
         graphics.resumegamemode = true;
-    }
-    if (game.menupage == 21)
-    {
+        break;
+    case 21:
         //quit to menu
         game.swnmode = false;
         graphics.fademode = 2;
         music.fadeout();
         game.fadetolab = true;
         game.fadetolabdelay = 16;
+        break;
     }
 }
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1958,13 +1958,20 @@ void mapinput()
         {
             game.press_action = true;
         }
-        if (game.menupage < 9)
+        if (game.menupage < 12)
         {
             if (key.isDown(KEYBOARD_ENTER) || key.isDown(game.controllerButton_map) ) game.press_map = true;
             if (key.isDown(27))
             {
                 game.mapheld = true;
-                game.menupage = 30;
+                if (game.menupage < 9)
+                {
+                    game.menupage = 30;
+                }
+                else
+                {
+                    game.menupage = 31;
+                }
             }
         }
         else

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1975,7 +1975,10 @@ void mapinput()
             game.menupage++;
         }
 
-        mapmenuactionpress();
+        if (game.press_action)
+        {
+            mapmenuactionpress();
+        }
 
         if (game.menupage < 0) game.menupage = 3;
         if (game.menupage > 3 && game.menupage < 9) game.menupage = 0;
@@ -1993,7 +1996,7 @@ void mapinput()
 
 void mapmenuactionpress()
 {
-    if (game.menupage == 1 && obj.flags[67] && game.press_action && !game.insecretlab && !map.custommode)
+    if (game.menupage == 1 && obj.flags[67] && !game.insecretlab && !map.custommode)
     {
         //Warp back to the ship
         graphics.resumegamemode = true;
@@ -2017,7 +2020,7 @@ void mapmenuactionpress()
         game.statedelay = 0;
     }
 
-    if (game.menupage == 3 && !game.gamesaved && game.press_action && !game.intimetrial
+    if (game.menupage == 3 && !game.gamesaved && !game.intimetrial
             && !game.nodeathmode && !game.insecretlab && !game.inintermission)
     {
         game.flashlight = 5;
@@ -2043,12 +2046,12 @@ void mapmenuactionpress()
         }
     }
 
-    if (game.menupage == 10 && game.press_action)
+    if (game.menupage == 10)
     {
         //return to game
         graphics.resumegamemode = true;
     }
-    if (game.menupage == 11 && game.press_action)
+    if (game.menupage == 11)
     {
         //quit to menu
 
@@ -2062,12 +2065,12 @@ void mapmenuactionpress()
         game.fadetomenudelay = 16;
     }
 
-    if (game.menupage == 20 && game.press_action)
+    if (game.menupage == 20)
     {
         //return to game
         graphics.resumegamemode = true;
     }
-    if (game.menupage == 21 && game.press_action)
+    if (game.menupage == 21)
     {
         //quit to menu
         game.swnmode = false;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2106,23 +2106,19 @@ void mapmenuactionpress()
         game.menupage = 10;
         break;
     case 32:
-        // Graphic options
-        music.playef(11);
-        game.gamestate = TITLEMODE;
-        game.ingame_titlemode = true;
-        game.createmenu(Menu::graphicoptions);
-        map.nexttowercolour();
-
-        // Fix delta rendering glitch
-        graphics.updatetowerbackground();
-        titleupdatetextcol();
-        break;
     case 33:
-        // Game options
+        // Graphic options and game options
         music.playef(11);
         game.gamestate = TITLEMODE;
         game.ingame_titlemode = true;
-        game.createmenu(Menu::options);
+        if (game.menupage == 32)
+        {
+            game.createmenu(Menu::graphicoptions);
+        }
+        else
+        {
+            game.createmenu(Menu::options);
+        }
         map.nexttowercolour();
 
         // Fix delta rendering glitch

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1468,8 +1468,15 @@ void titleinput()
         if (key.isDown(27) && game.currentmenuname != Menu::youwannaquit && game.menustart)
         {
             music.playef(11);
-            game.createmenu(Menu::youwannaquit);
-            map.nexttowercolour();
+            if (game.ingame_titlemode)
+            {
+                game.returntopausemenu();
+            }
+            else
+            {
+                game.createmenu(Menu::youwannaquit);
+                map.nexttowercolour();
+            }
         }
 
         if(game.menustart)

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -493,7 +493,7 @@ void menuactionpress()
             break;
         case 3:
             //invincibility
-            if (!game.ingame_titlemode || !game.inspecial())
+            if (!game.ingame_titlemode || (!game.insecretlab && !game.intimetrial && !game.nodeathmode))
             {
                 if (!map.invincibility)
                 {
@@ -514,7 +514,7 @@ void menuactionpress()
             break;
         case 4:
             //change game speed
-            if (!game.inspecial())
+            if (!game.insecretlab && !game.intimetrial && !game.nodeathmode)
             {
                 game.createmenu(Menu::setslowdown);
                 map.nexttowercolour();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -380,6 +380,7 @@ void menuactionpress()
             {
                 game.ingame_titlemode = false;
                 game.gamestate = MAPMODE;
+                map.kludge_to_bg();
             }
             else
             {
@@ -594,6 +595,7 @@ void menuactionpress()
             {
                 game.ingame_titlemode = false;
                 game.gamestate = MAPMODE;
+                map.kludge_to_bg();
             }
             else
             {
@@ -2119,6 +2121,8 @@ void mapmenuactionpress()
         {
             game.createmenu(Menu::options);
         }
+        map.bg_to_kludge();
+
         map.nexttowercolour();
         map.scrolldir = 0;
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -376,7 +376,15 @@ void menuactionpress()
             //back
             music.playef(11);
             game.returnmenu();
-            map.nexttowercolour();
+            if (game.ingame_titlemode)
+            {
+                game.ingame_titlemode = false;
+                game.gamestate = MAPMODE;
+            }
+            else
+            {
+                map.nexttowercolour();
+            }
             break;
         }
         break;
@@ -582,7 +590,15 @@ void menuactionpress()
             //back
             music.playef(11);
             game.returnmenu();
-            map.nexttowercolour();
+            if (game.ingame_titlemode)
+            {
+                game.ingame_titlemode = false;
+                game.gamestate = MAPMODE;
+            }
+            else
+            {
+                map.nexttowercolour();
+            }
         }
 #undef OFFSET
         break;
@@ -2093,6 +2109,7 @@ void mapmenuactionpress()
         // Graphic options
         music.playef(11);
         game.gamestate = TITLEMODE;
+        game.ingame_titlemode = true;
         game.createmenu(Menu::graphicoptions);
         map.nexttowercolour();
 
@@ -2104,6 +2121,7 @@ void mapmenuactionpress()
         // Game options
         music.playef(11);
         game.gamestate = TITLEMODE;
+        game.ingame_titlemode = true;
         game.createmenu(Menu::options);
         map.nexttowercolour();
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1999,7 +1999,7 @@ void mapmenuactionpress()
     switch (game.menupage)
     {
     case 1:
-    if (obj.flags[67] && !game.insecretlab && !map.custommode)
+    if (obj.flags[67] && !game.inspecial() && !map.custommode)
     {
         //Warp back to the ship
         graphics.resumegamemode = true;
@@ -2024,8 +2024,7 @@ void mapmenuactionpress()
     }
         break;
     case 3:
-    if (!game.gamesaved && !game.intimetrial
-            && !game.nodeathmode && !game.insecretlab && !game.inintermission)
+    if (!game.gamesaved && !game.inspecial())
     {
         game.flashlight = 5;
         game.screenshake = 10;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1859,6 +1859,8 @@ void gameinput()
     }
 }
 
+void mapmenuactionpress();
+
 void mapinput()
 {
     //TODO Mouse Input!
@@ -1973,6 +1975,24 @@ void mapinput()
             game.menupage++;
         }
 
+        mapmenuactionpress();
+
+        if (game.menupage < 0) game.menupage = 3;
+        if (game.menupage > 3 && game.menupage < 9) game.menupage = 0;
+
+        if (game.menupage == 9) game.menupage = 11;
+        if (game.menupage == 12) game.menupage = 10;
+
+        if (game.menupage == 19) game.menupage = 21;
+        if (game.menupage == 22) game.menupage = 20;
+
+        if (game.menupage == 29) game.menupage = 33;
+        if (game.menupage == 34) game.menupage = 30;
+    }
+}
+
+void mapmenuactionpress()
+{
         if (game.menupage == 1 && obj.flags[67] && game.press_action && !game.insecretlab && !map.custommode)
         {
             //Warp back to the ship
@@ -2056,19 +2076,6 @@ void mapinput()
             game.fadetolab = true;
             game.fadetolabdelay = 16;
         }
-
-        if (game.menupage < 0) game.menupage = 3;
-        if (game.menupage > 3 && game.menupage < 9) game.menupage = 0;
-
-        if (game.menupage == 9) game.menupage = 11;
-        if (game.menupage == 12) game.menupage = 10;
-
-        if (game.menupage == 19) game.menupage = 21;
-        if (game.menupage == 22) game.menupage = 20;
-
-        if (game.menupage == 29) game.menupage = 33;
-        if (game.menupage == 34) game.menupage = 30;
-    }
 }
 
 void teleporterinput()

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -493,22 +493,38 @@ void menuactionpress()
             break;
         case 3:
             //invincibility
-            if (!map.invincibility)
+            if (!game.ingame_titlemode || !game.inspecial())
             {
-                game.createmenu(Menu::setinvincibility);
-                map.nexttowercolour();
+                if (!map.invincibility)
+                {
+                    game.createmenu(Menu::setinvincibility);
+                    map.nexttowercolour();
+                }
+                else
+                {
+                    map.invincibility = !map.invincibility;
+                }
+                music.playef(11);
             }
             else
             {
-                map.invincibility = !map.invincibility;
+                music.playef(2);
+                map.invincibility = false;
             }
-            music.playef(11);
             break;
         case 4:
             //change game speed
-            game.createmenu(Menu::setslowdown);
-            map.nexttowercolour();
-            music.playef(11);
+            if (!game.inspecial())
+            {
+                game.createmenu(Menu::setslowdown);
+                map.nexttowercolour();
+                music.playef(11);
+            }
+            else
+            {
+                music.playef(2);
+                game.gameframerate = 34;
+            }
             break;
         case 5:
             // toggle fake load screen

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1,4 +1,5 @@
 #include "Input.h"
+#include "Logic.h"
 #include "Script.h"
 
 #include "MakeAndPlay.h"
@@ -2094,6 +2095,10 @@ void mapmenuactionpress()
         game.gamestate = TITLEMODE;
         game.createmenu(Menu::graphicoptions);
         map.nexttowercolour();
+
+        // Fix delta rendering glitch
+        graphics.updatetowerbackground();
+        titleupdatetextcol();
         break;
     case 33:
         // Game options
@@ -2101,6 +2106,10 @@ void mapmenuactionpress()
         game.gamestate = TITLEMODE;
         game.createmenu(Menu::options);
         map.nexttowercolour();
+
+        // Fix delta rendering glitch
+        graphics.updatetowerbackground();
+        titleupdatetextcol();
         break;
     }
 }

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1993,89 +1993,89 @@ void mapinput()
 
 void mapmenuactionpress()
 {
-        if (game.menupage == 1 && obj.flags[67] && game.press_action && !game.insecretlab && !map.custommode)
+    if (game.menupage == 1 && obj.flags[67] && game.press_action && !game.insecretlab && !map.custommode)
+    {
+        //Warp back to the ship
+        graphics.resumegamemode = true;
+
+        game.teleport_to_x = 2;
+        game.teleport_to_y = 11;
+
+        //trace(game.recordstring);
+        //We're teleporting! Yey!
+        game.activetele = false;
+        game.hascontrol = false;
+
+        int i = obj.getplayer();
+        if (i > -1)
         {
-            //Warp back to the ship
-            graphics.resumegamemode = true;
-
-            game.teleport_to_x = 2;
-            game.teleport_to_y = 11;
-
-            //trace(game.recordstring);
-            //We're teleporting! Yey!
-            game.activetele = false;
-            game.hascontrol = false;
-
-            int i = obj.getplayer();
-            if (i > -1)
-            {
-                obj.entities[i].colour = 102;
-            }
-
-            //which teleporter script do we use? it depends on the companion!
-            game.state = 4000;
-            game.statedelay = 0;
+            obj.entities[i].colour = 102;
         }
 
-        if (game.menupage == 3 && !game.gamesaved && game.press_action && !game.intimetrial
-                && !game.nodeathmode && !game.insecretlab && !game.inintermission)
-        {
-            game.flashlight = 5;
-            game.screenshake = 10;
-            music.playef(18);
-            game.gamesaved = true;
+        //which teleporter script do we use? it depends on the companion!
+        game.state = 4000;
+        game.statedelay = 0;
+    }
 
-            game.savetime = game.timestring();
-            game.savearea = map.currentarea(map.area(game.roomx, game.roomy));
-            game.savetrinkets = game.trinkets();
+    if (game.menupage == 3 && !game.gamesaved && game.press_action && !game.intimetrial
+            && !game.nodeathmode && !game.insecretlab && !game.inintermission)
+    {
+        game.flashlight = 5;
+        game.screenshake = 10;
+        music.playef(18);
+        game.gamesaved = true;
 
-            if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111) game.savearea = "The Ship";
+        game.savetime = game.timestring();
+        game.savearea = map.currentarea(map.area(game.roomx, game.roomy));
+        game.savetrinkets = game.trinkets();
+
+        if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111) game.savearea = "The Ship";
 
 #if !defined(NO_CUSTOM_LEVELS)
-            if(map.custommodeforreal)
-            {
-                game.customsavequick(ed.ListOfMetaData[game.playcustomlevel].filename);
-            }
-            else
+        if(map.custommodeforreal)
+        {
+            game.customsavequick(ed.ListOfMetaData[game.playcustomlevel].filename);
+        }
+        else
 #endif
-            {
-                game.savequick();
-            }
+        {
+            game.savequick();
         }
+    }
 
-        if (game.menupage == 10 && game.press_action)
-        {
-            //return to game
-            graphics.resumegamemode = true;
-        }
-        if (game.menupage == 11 && game.press_action)
-        {
-            //quit to menu
+    if (game.menupage == 10 && game.press_action)
+    {
+        //return to game
+        graphics.resumegamemode = true;
+    }
+    if (game.menupage == 11 && game.press_action)
+    {
+        //quit to menu
 
-            //Kill contents of offset render buffer, since we do that for some reason.
-            //This fixes an apparent frame flicker.
-            FillRect(graphics.tempBuffer, 0x000000);
-            graphics.fademode = 2;
-            music.fadeout();
-            map.nexttowercolour();
-            game.fadetomenu = true;
-            game.fadetomenudelay = 16;
-        }
+        //Kill contents of offset render buffer, since we do that for some reason.
+        //This fixes an apparent frame flicker.
+        FillRect(graphics.tempBuffer, 0x000000);
+        graphics.fademode = 2;
+        music.fadeout();
+        map.nexttowercolour();
+        game.fadetomenu = true;
+        game.fadetomenudelay = 16;
+    }
 
-        if (game.menupage == 20 && game.press_action)
-        {
-            //return to game
-            graphics.resumegamemode = true;
-        }
-        if (game.menupage == 21 && game.press_action)
-        {
-            //quit to menu
-            game.swnmode = false;
-            graphics.fademode = 2;
-            music.fadeout();
-            game.fadetolab = true;
-            game.fadetolabdelay = 16;
-        }
+    if (game.menupage == 20 && game.press_action)
+    {
+        //return to game
+        graphics.resumegamemode = true;
+    }
+    if (game.menupage == 21 && game.press_action)
+    {
+        //quit to menu
+        game.swnmode = false;
+        graphics.fademode = 2;
+        music.fadeout();
+        game.fadetolab = true;
+        game.fadetolabdelay = 16;
+    }
 }
 
 void teleporterinput()

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -377,10 +377,7 @@ void menuactionpress()
             music.playef(11);
             if (game.ingame_titlemode)
             {
-                game.ingame_titlemode = false;
-                game.returntomenu(game.kludge_ingametemp);
-                game.gamestate = MAPMODE;
-                map.kludge_to_bg();
+                game.returntopausemenu();
             }
             else
             {
@@ -593,10 +590,7 @@ void menuactionpress()
             music.playef(11);
             if (game.ingame_titlemode)
             {
-                game.ingame_titlemode = false;
-                game.returntomenu(game.kludge_ingametemp);
-                game.gamestate = MAPMODE;
-                map.kludge_to_bg();
+                game.returntopausemenu();
             }
             else
             {

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -3,6 +3,19 @@
 #include "Network.h"
 #include "FileSystemUtils.h"
 
+void titleupdatetextcol()
+{
+    graphics.col_tr = map.r - (help.glow / 4) - int(fRandom() * 4);
+    graphics.col_tg = map.g - (help.glow / 4) - int(fRandom() * 4);
+    graphics.col_tb = map.b - (help.glow / 4) - int(fRandom() * 4);
+    if (graphics.col_tr < 0) graphics.col_tr = 0;
+    if(graphics.col_tr>255) graphics.col_tr=255;
+    if (graphics.col_tg < 0) graphics.col_tg = 0;
+    if(graphics.col_tg>255) graphics.col_tg=255;
+    if (graphics.col_tb < 0) graphics.col_tb = 0;
+    if(graphics.col_tb>255) graphics.col_tb=255;
+}
+
 void titlelogic()
 {
     //Misc
@@ -25,15 +38,7 @@ void titlelogic()
     }
     else
     {
-        graphics.col_tr = map.r - (help.glow / 4) - int(fRandom() * 4);
-        graphics.col_tg = map.g - (help.glow / 4) - int(fRandom() * 4);
-        graphics.col_tb = map.b - (help.glow / 4) - int(fRandom() * 4);
-        if (graphics.col_tr < 0) graphics.col_tr = 0;
-        if(graphics.col_tr>255) graphics.col_tr=255;
-        if (graphics.col_tg < 0) graphics.col_tg = 0;
-        if(graphics.col_tg>255) graphics.col_tg=255;
-        if (graphics.col_tb < 0) graphics.col_tb = 0;
-        if(graphics.col_tb>255) graphics.col_tb=255;
+        titleupdatetextcol();
 
         graphics.updatetitlecolours();
     }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -79,6 +79,16 @@ void maplogic()
     graphics.updatetextboxes();
     graphics.updatetitlecolours();
 
+    if (game.shouldreturntopausemenu)
+    {
+        game.shouldreturntopausemenu = false;
+        graphics.backgrounddrawn = false;
+        if (map.background == 3 || map.background || 4)
+        {
+            graphics.updatebackground(map.background);
+        }
+    }
+
     graphics.crewframedelay--;
     if (graphics.crewframedelay <= 0)
     {

--- a/desktop_version/src/Logic.h
+++ b/desktop_version/src/Logic.h
@@ -8,6 +8,8 @@
 #include "Music.h"
 #include "Map.h"
 
+void titleupdatetextcol();
+
 void titlelogic();
 
 void maplogic();

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -168,6 +168,22 @@ public:
 
     //Map cursor
     int cursorstate, cursordelay;
+
+    int kludge_bypos;
+    int kludge_colstate;
+    int kludge_scrolldir;
+    void inline bg_to_kludge()
+    {
+        kludge_bypos = bypos;
+        kludge_colstate = colstate;
+        kludge_scrolldir = scrolldir;
+    }
+    void inline kludge_to_bg()
+    {
+        bypos = kludge_bypos;
+        colstate = kludge_colstate;
+        scrolldir = kludge_scrolldir;
+    }
 };
 
 extern mapclass map;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2215,7 +2215,7 @@ void maprender()
 
         if (graphics.flipmode)
         {
-            if (game.intimetrial || game.insecretlab || game.nodeathmode)
+            if (game.inspecial())
             {
                 graphics.Print(0, 135, "Return to main menu?", 196, 196, 255 - help.glow, true);
             }
@@ -2231,7 +2231,7 @@ void maprender()
         else
         {
 
-            if (game.intimetrial || game.insecretlab || game.nodeathmode)
+            if (game.inspecial())
             {
                 graphics.Print(0, 80, "Return to main menu?", 196, 196, 255 - help.glow, true);
             }
@@ -2251,7 +2251,7 @@ void maprender()
 
         if (graphics.flipmode)
         {
-            if (game.intimetrial || game.insecretlab || game.nodeathmode)
+            if (game.inspecial())
             {
                 graphics.Print(0, 135, "Return to main menu?", 196, 196, 255 - help.glow, true);
             }
@@ -2266,7 +2266,7 @@ void maprender()
         }
         else
         {
-            if (game.intimetrial || game.insecretlab || game.nodeathmode)
+            if (game.inspecial())
             {
                 graphics.Print(0, 80, "Return to main menu?", 196, 196, 255 - help.glow, true);
             }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1685,6 +1685,27 @@ void maprender()
 #undef TAB
     }
 
+    // Draw menu header
+    switch (game.menupage)
+    {
+    case 30:
+    case 31:
+    case 32:
+    case 33:
+        graphics.Print(-1, 220, "[ PAUSE ]", 196, 196, 255 - help.glow, true);
+    }
+
+    // Draw menu options
+    if (game.menupage >= 30 && game.menupage <= 33)
+    {
+#define OPTION(opt, text) graphics.map_option(opt, 4, text, game.menupage - 30 == opt)
+        OPTION(0, "return to game");
+        OPTION(1, "quit to menu");
+        OPTION(2, "graphic options");
+        OPTION(3, "game options");
+#undef OPTION
+    }
+
     // Draw the actual menu
     switch(game.menupage)
     {


### PR DESCRIPTION
The Esc menu is now overhauled. There are four options: "return to game", "quit to menu", "graphic options", and "game options". It's always been a bit annoying how you had to actually exit the game in order to change some options, which necessitated having to quicksave beforehand, and then you have to back into the level, etc.

![Overhauled pause menu](https://user-images.githubusercontent.com/59748578/85365891-13b9c280-b4db-11ea-9b63-9a88c2fd5c67.png)

"return to game" just closes the menu. You can also press Esc again to close it (you couldn't do this before). "quit to menu" takes you to the old quit menu, where it gives you the option of either "no, keep playing" or "yes, quit to menu", and you can also press Esc to return back to the new menu.

"graphic options" and "game options" take you to the graphic options and game options menus respectively. I made sure you couldn't toggle invincibility or slowdown when in the Secret Lab (because of the Super Gravitron), in a Time Trial, or in No Death Mode. When in any of these menus, you can press Esc to instantly return to the new pause menu.

Surprisingly enough, the most frustrating part of writing this pull request wasn't the horrifying copy-pasted kludge of MAPMODE menu code, but dealing with the fact that `towerbuffer` is used by *three* (!) separate things:
 - Tower rooms
 - The menu background
 - Horizontal and vertical warp backgrounds

As a result, I spent an inordinate amount of time fixing glitches where one of these things persisted into other things (like the tower background showing up in a horizontal/vertical warp background room), and tracking down and squashing annoying little deltaframe bugs that made me want to pull my hair out.

Seriously, could we *please* put towers, the menu background, and horizontal/vertical warp backgrounds in their own separate buffers?!

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
