### PR TITLE
Add glitchrunner mode, with initial un-fixes for (1) unbounded gamestate increment (2) advancetext persistence (3) gamestate-based fadeout (4) hitbox persistence

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -387,6 +387,7 @@ void Game::init(void)
 #endif
 
     over30mode = false;
+    glitchrunnermode = false;
 
     ingame_titlemode = false;
     kludge_ingametemp = Menu::mainmenu;
@@ -4756,6 +4757,11 @@ void Game::loadstats()
             over30mode = atoi(pText);
         }
 
+        if (pKey == "glitchrunnermode")
+        {
+            glitchrunnermode = atoi(pText);
+        }
+
         if (pKey == "vsync")
         {
             graphics.vsync = atoi(pText);
@@ -5008,6 +5014,10 @@ void Game::savestats()
 
     msg = doc.NewElement("over30mode");
     msg->LinkEndChild(doc.NewText(help.String((int) over30mode).c_str()));
+    dataNode->LinkEndChild(msg);
+
+    msg = doc.NewElement("glitchrunnermode");
+    msg->LinkEndChild(doc.NewText(help.String((int) glitchrunnermode).c_str()));
     dataNode->LinkEndChild(msg);
 
     msg = doc.NewElement("vsync");
@@ -7129,6 +7139,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         break;
     case Menu::options:
         option("accessibility options");
+        option("glitchrunner mode");
 #if !defined(MAKEANDPLAY)
         option("unlock play modes");
 #endif
@@ -7140,7 +7151,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         }
 
         option("return");
-        menuxoff = -40;
+        menuxoff = -50;
         menuyoff = 0;
         break;
     case Menu::accessibility:

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -116,6 +116,13 @@ bool GetButtonFromString(const char *pText, SDL_GameControllerButton *button)
 
 void Game::init(void)
 {
+    roomx = 0;
+    roomy = 0;
+    prevroomx = 0;
+    prevroomy = 0;
+    saverx = 0;
+    savery = 0;
+
     mutebutton = 0;
     muted = false;
     musicmuted = false;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -404,6 +404,7 @@ public:
     }
 
     bool over30mode;
+    bool glitchrunnermode; // Have fun speedrunners! <3 Misa
 
     bool ingame_titlemode;
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1597,10 +1597,11 @@ void gameinput()
             }
             else
             {
-                if(!game.glitchrunkludge) game.state++;
+                if(game.glitchrunnermode || !game.glitchrunkludge) game.state++;
                     game.jumpheld = true;
                     game.glitchrunkludge=true;
                     //Bug fix! You should only be able to do this ONCE.
+                    //...Unless you're in glitchrunner mode
             }
         }
     }

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -564,21 +564,26 @@ void menuactionpress()
             game.createmenu(Menu::accessibility);
             map.nexttowercolour();
             break;
-#if !defined(MAKEANDPLAY)
         case 1:
+            // Glitchrunner mode
+            music.playef(11);
+            game.glitchrunnermode = !game.glitchrunnermode;
+            break;
+#if !defined(MAKEANDPLAY)
+        case 2:
             //unlock play options
             music.playef(11);
             game.createmenu(Menu::unlockmenu);
             map.nexttowercolour();
             break;
 #endif
-        case OFFSET+2:
+        case OFFSET+3:
             //clear data menu
             music.playef(11);
             game.createmenu(Menu::controller);
             map.nexttowercolour();
             break;
-        case OFFSET+3:
+        case OFFSET+4:
             //clear data menu
             music.playef(11);
             game.createmenu(Menu::cleardatamenu);
@@ -587,7 +592,7 @@ void menuactionpress()
         }
 
         int mmmmmm_offset = music.mmmmmm ? 0 : -1;
-        if (game.currentmenuoption == OFFSET+4+mmmmmm_offset)
+        if (game.currentmenuoption == OFFSET+5+mmmmmm_offset)
         {
             //**** TOGGLE MMMMMM
             if(game.usingmmmmmm > 0){
@@ -600,7 +605,7 @@ void menuactionpress()
             music.play(music.currentsong);
             game.savestats();
         }
-        else if (game.currentmenuoption == OFFSET+5+mmmmmm_offset)
+        else if (game.currentmenuoption == OFFSET+6+mmmmmm_offset)
         {
             //back
             music.playef(11);

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1916,7 +1916,41 @@ void mapinput()
     game.press_action = false;
     game.press_map = false;
 
-    if (game.fadetomenu)
+    if (game.glitchrunnermode && graphics.fademode == 1 && graphics.menuoffset == 0)
+    {
+        // Deliberate re-addition of the glitchy gamestate-based fadeout!
+
+        // First of all, detecting a black screen means if the glitchy fadeout
+        // gets interrupted but you're still on a black screen, opening a menu
+        // immediately quits you to the title. This has the side effect that if
+        // you accidentally press Esc during a cutscene when it's black, you'll
+        // immediately be quit and lose all your progress, but that's fair in
+        // glitchrunner mode.
+        // Also have to check graphics.menuoffset so this doesn't run every frame
+
+        // Have to close the menu in order to run gamestates. This adds
+        // about an extra half second of completely black screen.
+        graphics.resumegamemode = true;
+
+        // Technically this was in <=2.2 as well
+        obj.removeallblocks();
+
+        if (game.menupage >= 20 && game.menupage <= 21)
+        {
+            game.state = 96;
+            game.statedelay = 0;
+        }
+        else
+        {
+            // Produces more glitchiness! Necessary for credits warp to work.
+            script.hardreset();
+
+            game.state = 80;
+            game.statedelay = 0;
+        }
+    }
+
+    if (game.fadetomenu && !game.glitchrunnermode)
     {
         if (game.fadetomenudelay > 0)
         {
@@ -1929,7 +1963,7 @@ void mapinput()
         }
     }
 
-    if (game.fadetolab)
+    if (game.fadetolab && !game.glitchrunnermode)
     {
         if (game.fadetolabdelay > 0)
         {
@@ -1942,7 +1976,9 @@ void mapinput()
         }
     }
 
-    if(graphics.menuoffset==0 && game.fadetomenudelay <= 0 && game.fadetolabdelay <= 0)
+    if(graphics.menuoffset==0
+    && (!game.glitchrunnermode || graphics.fademode == 0)
+    && game.fadetomenudelay <= 0 && game.fadetolabdelay <= 0)
     {
         if (graphics.flipmode)
         {
@@ -2119,8 +2155,11 @@ void mapmenuactionpress()
         graphics.fademode = 2;
         music.fadeout();
         map.nexttowercolour();
-        game.fadetomenu = true;
-        game.fadetomenudelay = 16;
+        if (!game.glitchrunnermode)
+        {
+            game.fadetomenu = true;
+            game.fadetomenudelay = 16;
+        }
         break;
 
     case 20:

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -792,10 +792,13 @@ void mapclass::resetplayer()
 		obj.entities[i].colour = 0;
 		game.lifeseq = 10;
 		obj.entities[i].invis = true;
-		obj.entities[i].size = 0;
-		obj.entities[i].cx = 6;
-		obj.entities[i].cy = 2;
-		obj.entities[i].h = 21;
+		if (!game.glitchrunnermode)
+		{
+			obj.entities[i].size = 0;
+			obj.entities[i].cx = 6;
+			obj.entities[i].cy = 2;
+			obj.entities[i].h = 21;
+		}
 
 		// If we entered a tower as part of respawn, reposition camera
 		if (!was_in_tower && towermode)

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -31,6 +31,10 @@ mapclass::mapclass()
 	cursorstate = 0;
 	cursordelay = 0;
 
+	towermode = false;
+	cameraseekframe = 0;
+	resumedelay = 0;
+
 	final_colormode = false;
 	final_colorframe = 0;
 	final_colorframedelay = 0;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -88,24 +88,37 @@ void menurender()
             graphics.Print( -1, 65, "Disable screen effects, enable", tr, tg, tb, true);
             graphics.Print( -1, 75, "slowdown modes or invincibility", tr, tg, tb, true);
             break;
-#if !defined(MAKEANDPLAY)
         case 1:
+            graphics.bigprint( -1, 30, "Glitchrunner Mode", tr, tg, tb, true);
+            graphics.Print( -1, 65, "Re-enable glitches that existed", tr, tg, tb, true);
+            graphics.Print( -1, 75, "in previous versions of the game", tr, tg, tb, true);
+            if (game.glitchrunnermode)
+            {
+                graphics.Print( -1, 95, "Glitchrunner mode is ON", tr, tg, tb, true);
+            }
+            else
+            {
+                graphics.Print( -1, 95, "Glitchrunner mode is OFF", tr/2, tg/2, tb/2, true);
+            }
+            break;
+#if !defined(MAKEANDPLAY)
+        case 2:
             graphics.bigprint( -1, 30, "Unlock Play Modes", tr, tg, tb, true);
             graphics.Print( -1, 65, "Unlock parts of the game normally", tr, tg, tb, true);
             graphics.Print( -1, 75, "unlocked as you progress", tr, tg, tb, true);
             break;
 #endif
-        case OFFSET+2:
+        case OFFSET+3:
             graphics.bigprint( -1, 30, "Game Pad Options", tr, tg, tb, true);
             graphics.Print( -1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
             graphics.Print( -1, 75, "and adjust sensitivity", tr, tg, tb, true);
             break;
-        case OFFSET+3:
+        case OFFSET+4:
             graphics.bigprint( -1, 30, "Clear Data", tr, tg, tb, true);
             graphics.Print( -1, 65, "Delete your save data", tr, tg, tb, true);
             graphics.Print( -1, 75, "and unlocked play modes", tr, tg, tb, true);
             break;
-        case OFFSET+4:
+        case OFFSET+5:
             if(music.mmmmmm){
                 graphics.bigprint( -1, 30, "Soundtrack", tr, tg, tb, true);
                 graphics.Print( -1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2356,7 +2356,10 @@ void maprender()
 
 
 
-    if (graphics.fademode == 3 || graphics.fademode == 5)
+    // We need to draw the black screen above the menu in order to disguise it
+    // being jankily brought down in glitchrunner mode when exiting to the title
+    // Otherwise, there's no reason to obscure the menu
+    if (game.glitchrunnermode || graphics.fademode == 3 || graphics.fademode == 5)
     {
         graphics.drawfade();
     }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3564,7 +3564,12 @@ void scriptclass::hardreset()
 	game.statedelay = 0;
 
 	game.hascontrol = true;
-	game.advancetext = false;
+	if (!game.glitchrunnermode)
+	{
+		// Keep the "- Press ACTION to advance text -" prompt around,
+		// apparently the speedrunners call it the "text storage" glitch
+		game.advancetext = false;
+	}
 
 	game.pausescript = false;
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3482,8 +3482,12 @@ void scriptclass::hardreset()
 	game.teleport = false;
 	game.companion = 0;
 	game.roomchange = false;
-	game.roomx = 0;
-	game.roomy = 0;
+	if (!game.glitchrunnermode)
+	{
+		// Ironically, resetting more variables makes the janky fadeout system in glitchrunnermode even more glitchy
+		game.roomx = 0;
+		game.roomy = 0;
+	}
 	game.prevroomx = 0;
 	game.prevroomy = 0;
 	game.teleport_to_new_area = false;
@@ -3521,8 +3525,12 @@ void scriptclass::hardreset()
 	game.savetime = "00:00";
 	game.savearea = "nowhere";
 	game.savetrinkets = 0;
-	game.saverx = 0;
-	game.savery = 0;
+	if (!game.glitchrunnermode)
+	{
+		// Ironically, resetting more variables makes the janky fadeout system in glitchrunnermode even more glitchy
+		game.saverx = 0;
+		game.savery = 0;
+	}
 
 	game.intimetrial = false;
 	game.timetrialcountdown = 0;
@@ -3606,7 +3614,11 @@ void scriptclass::hardreset()
 	map.resetnames();
 	map.custommode=false;
 	map.custommodeforreal=false;
-	map.towermode=false;
+	if (!game.glitchrunnermode)
+	{
+		// Ironically, resetting more variables makes the janky fadeout system even more glitchy
+		map.towermode=false;
+	}
 	map.cameraseekframe = 0;
 	map.resumedelay = 0;
 	map.scrolldir = 0;


### PR DESCRIPTION
Glitchrunner mode is an option in game options that lets you re-enable glitches that existed in previous versions of VVVVVV.

(Btw, thanks to the speedrunner named "ash" for helping me figure out how credits warp worked.)

The idea is to make it easy and convenient to run credits warp without having to switch back to 2.0, if only because going back to older versions of the game has the risk of undoing all of your settings in 2.3. Maybe we should add some sort of XML forwards compatibility going forwards...

But anyways, these glitches were fixed mostly because casual players were likely to run into them and have their game experience adversely affected. Glitches based on pressing R will not be fixed, which includes telejumping, Gravitron out-of-bounds, Space Station 1 skip, etc. because it's a deliberate choice on the casual's part to press R anyway.

Here are the list of un-fixes that will be activated if you turn on glitchrunner mode. The first three are necessary in order to make credits warp possible again:

1. **Unbounded gamestate increment**

   This lets you increment the gamestate by pressing ACTION without bound if you have the "- Press ACTION to advance text -" prompt up, and don't have a text box (else your prompt would be removed).

   This was fixed in 2.1.

2. **"- Press ACTION to advance text -" persistence**

   Normally the game calls `script.hardreset()` when you quit to the menu, which is intended to reset all variables. Keyword being "intended". In 2.0 they missed `game.advancetext`, which is the variable that controls the "- Press ACTION to advance text -" prompt.

   And by abusing this fact, people are able to get that prompt without having a text box open, because `script.hardreset()` resets all text boxes too. The speedrunners call this "text box storage".

   This was fixed in 2.1.

3. **Gamestate-based fadeout**

   By far the most janky part of the game casual players will encounter unexpectedly in versions 2.2 and below.

   Because for some god-awful reason, the game just *has* to use gamestates to quit to the title. Gamestates can't run on the map screen, so while the screen is blacked out the game has to go through the bringing-down animation to bring the menu back down in order to close the menu and run gamestates, adding about a half second of unnecessary black screen. Then after all that, since it uses gamestates the fadeout has the potential to be interrupted.

   The most egregious side effect of this system is the fact that accidentally pressing Esc during a cutscene that's fully black will immediately quit you to the menu, with absolutely no chance to save. This is because the janky system detects a black screen in order to quit to the title, but only if you have the menu open. So if you open the menu while having a black screen, it'll automatically boot you back to the title.

   This was fixed in 2.3 (#230).

4. **Hitbox persistence**

   Specifically, `vvvvvvman()` persisting between sessions until you close the game. (Unless you die in No Death Mode. For whatever reason, dying in No Death Mode removes every single entity, which means the game recognizes that there are 0 entities when starting a new session and re-creates the player accordingly. I have no idea why this is done but it seems to be very cursed.)

   Speedrunners/glitchrunners like messing around with VVVVVV-Man (well, they call it "Big Viridian"), so this is going to be re-added as well.

   This was fixed in 2.3 (#234).

One of the glitches I would like to re-add to glitchrunner mode is being able to ignore warp lines in custom levels by passing between them quickly enough. But since this was already fixed by the time of 2.2, I have no idea how it got fixed, and no debug symbols to help me. I'll have to figure it out later.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
