### PR TITLE
Use game.returntomenu(Menu::timetrials) instead of game.returnmenu() in Menu::timetrialcomplete3

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1372,7 +1372,7 @@ void menuactionpress()
             //back
             music.playef(11);
             music.play(6);
-            game.returnmenu();
+            game.returntomenu(Menu::timetrials);
             map.nexttowercolour();
             break;
         case 1:


### PR DESCRIPTION
This fixes a corner case where using gamestate 82 from the editor would put you in a softlock because it would return to the editor settings menu, which only functions in EDITORMODE and results in a softlock in TITLEMODE.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
