### PR TITLE
Make warpdir only re-draw background if targeted room is current room

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -102,11 +102,11 @@ void scriptclass::run()
 				{
 					ed.level[curlevel].warpdir=ss_toi(words[3]);
 				}
-				//If screen warping, then override all that:
-				graphics.backgrounddrawn = false;
 
 				//Do we update our own room?
 				if(inbounds && game.roomx-100==temprx && game.roomy-100==tempry){
+					//If screen warping, then override all that:
+					graphics.backgrounddrawn = false;
 					map.warpx=false; map.warpy=false;
 					if(ed.level[curlevel].warpdir==0){
 						map.background = 1;


### PR DESCRIPTION
It's unnecessary to re-draw the background if you're modifying the warp direction of some other room.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
