### PR TITLE
Fix resumemusic and musicfadein not working

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -117,7 +117,6 @@ bool GetButtonFromString(const char *pText, SDL_GameControllerButton *button)
 void Game::init(void)
 {
     mutebutton = 0;
-    infocus = true;
     muted = false;
     musicmuted = false;
     musicmutebutton = 0;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -179,7 +179,6 @@ public:
     int jumppressed;
     int gravitycontrol;
 
-    bool infocus;
     bool muted;
     int mutebutton;
     bool musicmuted;

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -1,5 +1,6 @@
 #include "KeyPoll.h"
 #include "Graphics.h"
+#include "Music.h"
 #include <stdio.h>
 #include <string.h>
 #include <utf8/unchecked.h>
@@ -54,6 +55,8 @@ KeyPoll::KeyPoll()
 	}
 
 	linealreadyemptykludge = false;
+
+	pauseStart = 0;
 }
 
 void KeyPoll::enabletextentry()
@@ -254,6 +257,11 @@ void KeyPoll::Poll()
 					}
 				}
 				SDL_DisableScreenSaver();
+				if (Mix_PlayingMusic())
+				{
+					// Correct songStart for how long we were paused
+					music.songStart += SDL_GetPerformanceCounter() - pauseStart;
+				}
 				break;
 			case SDL_WINDOWEVENT_FOCUS_LOST:
 				isActive = false;
@@ -267,6 +275,7 @@ void KeyPoll::Poll()
 					);
 				}
 				SDL_EnableScreenSaver();
+				pauseStart = SDL_GetPerformanceCounter();
 				break;
 
 			/* Mouse Focus */

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -74,8 +74,10 @@ void KeyPoll::Poll()
 	SDL_Event evt;
 	while (SDL_PollEvent(&evt))
 	{
+		switch (evt.type)
+		{
 		/* Keyboard Input */
-		if (evt.type == SDL_KEYDOWN)
+		case SDL_KEYDOWN:
 		{
 			keymap[evt.key.keysym.sym] = true;
 
@@ -115,82 +117,76 @@ void KeyPoll::Poll()
 					keybuffer += SDL_GetClipboardText();
 				}
 			}
+			break;
 		}
-		else if (evt.type == SDL_KEYUP)
-		{
+		case SDL_KEYUP:
 			keymap[evt.key.keysym.sym] = false;
 			if (evt.key.keysym.sym == SDLK_BACKSPACE)
 			{
 				pressedbackspace = false;
 			}
-		}
-		else if (evt.type == SDL_TEXTINPUT)
-		{
+			break;
+		case SDL_TEXTINPUT:
 			keybuffer += evt.text.text;
-		}
+			break;
 
 		/* Mouse Input */
-		else if (evt.type == SDL_MOUSEMOTION)
-		{
+		case SDL_MOUSEMOTION:
 			mx = evt.motion.x;
 			my = evt.motion.y;
-		}
-		else if (evt.type == SDL_MOUSEBUTTONDOWN)
-		{
-			if (evt.button.button == SDL_BUTTON_LEFT)
+			break;
+		case SDL_MOUSEBUTTONDOWN:
+			switch (evt.button.button)
 			{
+			case SDL_BUTTON_LEFT:
 				mx = evt.button.x;
 				my = evt.button.y;
 				leftbutton = 1;
-			}
-			else if (evt.button.button == SDL_BUTTON_RIGHT)
-			{
+				break;
+			case SDL_BUTTON_RIGHT:
 				mx = evt.button.x;
 				my = evt.button.y;
 				rightbutton = 1;
-			}
-			else if (evt.button.button == SDL_BUTTON_MIDDLE)
-			{
+				break;
+			case SDL_BUTTON_MIDDLE:
 				mx = evt.button.x;
 				my = evt.button.y;
 				middlebutton = 1;
+				break;
 			}
-		}
-		else if (evt.type == SDL_MOUSEBUTTONUP)
-		{
-			if (evt.button.button == SDL_BUTTON_LEFT)
+			break;
+		case SDL_MOUSEBUTTONUP:
+			switch (evt.button.button)
 			{
+			case SDL_BUTTON_LEFT:
 				mx = evt.button.x;
 				my = evt.button.y;
 				leftbutton=0;
-			}
-			else if (evt.button.button == SDL_BUTTON_RIGHT)
-			{
+				break;
+			case SDL_BUTTON_RIGHT:
 				mx = evt.button.x;
 				my = evt.button.y;
 				rightbutton=0;
-			}
-			else if (evt.button.button == SDL_BUTTON_MIDDLE)
-			{
+				break;
+			case SDL_BUTTON_MIDDLE:
 				mx = evt.button.x;
 				my = evt.button.y;
 				middlebutton=0;
+				break;
 			}
-		}
+			break;
 
 		/* Controller Input */
-		else if (evt.type == SDL_CONTROLLERBUTTONDOWN)
-		{
+		case SDL_CONTROLLERBUTTONDOWN:
 			buttonmap[(SDL_GameControllerButton) evt.cbutton.button] = true;
-		}
-		else if (evt.type == SDL_CONTROLLERBUTTONUP)
-		{
+			break;
+		case SDL_CONTROLLERBUTTONUP:
 			buttonmap[(SDL_GameControllerButton) evt.cbutton.button] = false;
-		}
-		else if (evt.type == SDL_CONTROLLERAXISMOTION)
-		{
-			if (evt.caxis.axis == SDL_CONTROLLER_AXIS_LEFTX)
+			break;
+		case SDL_CONTROLLERAXISMOTION:
+			switch (evt.caxis.axis)
 			{
+			case SDL_CONTROLLER_AXIS_LEFTX:
 				if (	evt.caxis.value > -sensitivity &&
 					evt.caxis.value < sensitivity	)
 				{
@@ -200,9 +196,8 @@ void KeyPoll::Poll()
 				{
 					xVel = (evt.caxis.value > 0) ? 1 : -1;
 				}
-			}
-			if (evt.caxis.axis == SDL_CONTROLLER_AXIS_LEFTY)
-			{
+				break;
+			case SDL_CONTROLLER_AXIS_LEFTY:
 				if (	evt.caxis.value > -sensitivity &&
 					evt.caxis.value < sensitivity	)
 				{
@@ -212,9 +207,10 @@ void KeyPoll::Poll()
 				{
 					yVel = (evt.caxis.value > 0) ? 1 : -1;
 				}
+				break;
 			}
-		}
-		else if (evt.type == SDL_CONTROLLERDEVICEADDED)
+			break;
+		case SDL_CONTROLLERDEVICEADDED:
 		{
 			SDL_GameController *toOpen = SDL_GameControllerOpen(evt.cdevice.which);
 			printf(
@@ -223,27 +219,28 @@ void KeyPoll::Poll()
 				SDL_GameControllerName(toOpen)
 			);
 			controllers[SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(toOpen))] = toOpen;
+			break;
 		}
-		else if (evt.type == SDL_CONTROLLERDEVICEREMOVED)
+		case SDL_CONTROLLERDEVICEREMOVED:
 		{
 			SDL_GameController *toClose = controllers[evt.cdevice.which];
 			controllers.erase(evt.cdevice.which);
 			printf("Closing %s\n", SDL_GameControllerName(toClose));
 			SDL_GameControllerClose(toClose);
+			break;
 		}
 
 		/* Window Events */
-		else if (evt.type == SDL_WINDOWEVENT)
-		{
-			/* Window Resize */
-			if (evt.window.event == SDL_WINDOWEVENT_RESIZED)
+		case SDL_WINDOWEVENT:
+			switch (evt.window.event)
 			{
+			/* Window Resize */
+			case SDL_WINDOWEVENT_RESIZED:
 				resetWindow = true;
-			}
+				break;
 
 			/* Window Focus */
-			else if (evt.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
-			{
+			case SDL_WINDOWEVENT_FOCUS_GAINED:
 				isActive = true;
 				if (!useFullscreenSpaces)
 				{
@@ -257,9 +254,8 @@ void KeyPoll::Poll()
 					}
 				}
 				SDL_DisableScreenSaver();
-			}
-			else if (evt.window.event == SDL_WINDOWEVENT_FOCUS_LOST)
-			{
+				break;
+			case SDL_WINDOWEVENT_FOCUS_LOST:
 				isActive = false;
 				if (!useFullscreenSpaces)
 				{
@@ -271,23 +267,22 @@ void KeyPoll::Poll()
 					);
 				}
 				SDL_EnableScreenSaver();
-			}
+				break;
 
 			/* Mouse Focus */
-			else if (evt.window.event == SDL_WINDOWEVENT_ENTER)
-			{
+			case SDL_WINDOWEVENT_ENTER:
 				SDL_DisableScreenSaver();
-			}
-			else if (evt.window.event == SDL_WINDOWEVENT_LEAVE)
-			{
+				break;
+			case SDL_WINDOWEVENT_LEAVE:
 				SDL_EnableScreenSaver();
+				break;
 			}
-		}
+			break;
 
 		/* Quit Event */
-		else if (evt.type == SDL_QUIT)
-		{
+		case SDL_QUIT:
 			quitProgram = true;
+			break;
 		}
 	}
 }

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -76,6 +76,8 @@ public:
 
 	bool linealreadyemptykludge;
 
+	Uint64 pauseStart;
+
 private:
 	std::map<SDL_JoystickID, SDL_GameController*> controllers;
 	std::map<SDL_GameControllerButton, bool> buttonmap;

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -218,15 +218,10 @@ void musicclass::init()
 	musicVolume = 128;
 	FadeVolAmountPerFrame = 0;
 
-	custompd = false;
-
 	currentsong = 0;
-	musicfade = 0;
-	musicfadein = 0;
 	nicechange = 0;
 	nicefade = 0;
 	resumesong = 0;
-	volume = 0.0f;
 	fadeoutqueuesong = -1;
 	dontquickfade = false;
 

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -13,11 +13,13 @@ class musicclass
 public:
 	void init();
 
-	void play(int t);
+	void play(int t, const double position_sec = 0.0, const int fadein_ms = 3000);
+	void resume(const int fadein_ms = 0);
 	void haltdasmusik();
 	void silencedasmusik();
 	void fadeMusicVolumeIn(int ms);
 	void fadeout();
+	void fadein();
 	void processmusicfadein();
 	void processmusic();
 	void niceplay(int t);
@@ -53,6 +55,9 @@ public:
 	bool usingmmmmmm;
 
 	binaryBlob musicReadBlob;
+
+	Uint64 songStart;
+	Uint64 songEnd;
 };
 
 extern musicclass music;

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -26,7 +26,7 @@ public:
 
 	void changemusicarea(int x, int y);
 
-	int currentsong, musicfade, musicfadein;
+	int currentsong;
 	int resumesong;
 
 	void playef(int t);
@@ -42,10 +42,6 @@ public:
 	bool m_doFadeInVol;
 	int FadeVolAmountPerFrame;
 	int musicVolume;
-
-	float volume;
-
-	bool custompd;
 
 	int fadeoutqueuesong; // -1 if no song queued
 	bool dontquickfade;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -260,7 +260,7 @@ void scriptclass::run()
 			}
 			if (words[0] == "resumemusic")
 			{
-				music.play(music.resumesong);
+				music.resume();
 			}
 			if (words[0] == "musicfadeout")
 			{
@@ -269,8 +269,7 @@ void scriptclass::run()
 			}
 			if (words[0] == "musicfadein")
 			{
-				music.musicfadein = 90;
-				//if(!game.muted) music.fadeMusicVolumeIn(3000);
+				music.fadein();
 			}
 			if (words[0] == "trinketscriptmusic")
 			{

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -203,7 +203,6 @@ int main(int argc, char *argv[])
     graphics.init();
 
     game.init();
-    game.infocus = true;
 
     // This loads music too...
     graphics.reloadresources();
@@ -351,7 +350,6 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    game.infocus = true;
     key.isActive = true;
     game.gametimer = 0;
 
@@ -425,7 +423,7 @@ void inline deltaloop()
     const float alpha = game.over30mode ? static_cast<float>(accumulator) / timesteplimit : 1.0f;
     graphics.alpha = alpha;
 
-    if (game.infocus)
+    if (key.isActive)
     {
         switch (game.gamestate)
         {
@@ -466,8 +464,6 @@ void inline deltaloop()
 
 void inline fixedloop()
 {
-    game.infocus = key.isActive;
-
     // Update network per frame.
     NETWORK_update();
 
@@ -501,7 +497,7 @@ void inline fixedloop()
         game.press_map = false;
     }
 
-    if(!game.infocus)
+    if(!key.isActive)
     {
         Mix_Pause(-1);
         Mix_PauseMusic();
@@ -605,11 +601,11 @@ void inline fixedloop()
     }
 
     //Screen effects timers
-    if (game.infocus && game.flashlight > 0)
+    if (key.isActive && game.flashlight > 0)
     {
         game.flashlight--;
     }
-    if (game.infocus && game.screenshake > 0)
+    if (key.isActive && game.screenshake > 0)
     {
         game.screenshake--;
         graphics.updatescreenshake();


### PR DESCRIPTION
This patch makes it so that resumemusic and musicfadein actually work properly. Namely, if you use stopmusic or musicfadeout, the position where the song ended will be remembered, and using resumemusic or musicfadein will start the song from that position again. Also there's some miscellaneous cleanups I did along the way.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
