### PR TITLE
Fix the two-frame-delay when entering a room with an "init" script

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4780,6 +4780,7 @@ void entityclass::entitycollisioncheck()
         }
     }
 
+    // WARNING: If updating this code, don't forget to update Map.cpp mapclass::twoframedelayfix()
     activetrigger = -1;
     if (checktrigger() > -1)
     {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1753,6 +1753,7 @@ void Game::updatestate()
             break;
 
 
+        // WARNING: If updating this code, make sure to update Map.cpp mapclass::twoframedelayfix()
         case 300:
             startscript = true;
             newscript="custom_"+customscript[0];

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1117,6 +1117,8 @@ void gamelogic()
             }
         }
 
+        bool screen_transition = false;
+
         if (!map.warpy && !map.towermode)
         {
             //Normal! Just change room
@@ -1125,11 +1127,13 @@ void gamelogic()
             {
                 obj.entities[player].yp -= 240;
                 map.gotoroom(game.roomx, game.roomy + 1);
+                screen_transition = true;
             }
             if (player > -1 && game.door_up > -2 && obj.entities[player].yp < -2)
             {
                 obj.entities[player].yp += 240;
                 map.gotoroom(game.roomx, game.roomy - 1);
+                screen_transition = true;
             }
         }
 
@@ -1141,11 +1145,13 @@ void gamelogic()
             {
                 obj.entities[player].xp += 320;
                 map.gotoroom(game.roomx - 1, game.roomy);
+                screen_transition = true;
             }
             if (player > -1 && game.door_right > -2 && obj.entities[player].xp >= 308)
             {
                 obj.entities[player].xp -= 320;
                 map.gotoroom(game.roomx + 1, game.roomy);
+                screen_transition = true;
             }
         }
 
@@ -1363,6 +1369,11 @@ void gamelogic()
                     game.screenshake = 25;
                 }
             }
+        }
+
+        if (screen_transition)
+        {
+            map.twoframedelayfix();
         }
     }
 

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1980,3 +1980,30 @@ void mapclass::loadlevel(int rx, int ry)
 		}
 	}
 }
+
+void mapclass::twoframedelayfix()
+{
+	// Fixes the two-frame delay in custom levels that use scripts to spawn an entity upon room load.
+	// Because when the room loads and newscript is set to run, newscript has already ran for that frame,
+	// and when the script gets loaded script.run() has already ran for that frame, too.
+	// A bit kludge-y, but it's the least we can do without changing the frame ordering.
+
+	if (game.deathseq != -1
+	// obj.checktrigger() sets obj.activetrigger
+	|| obj.checktrigger() <= -1
+	|| obj.activetrigger < 300)
+	{
+		return;
+	}
+
+	game.newscript = "custom_" + game.customscript[obj.activetrigger - 300];
+	obj.removetrigger(obj.activetrigger);
+	game.state = 0;
+	game.statedelay = 0;
+	script.load(game.newscript);
+	if (script.running)
+	{
+		script.run();
+		script.dontrunnextframe = true;
+	}
+}

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1170,8 +1170,6 @@ void mapclass::loadlevel(int rx, int ry)
 	obj.customwarpmodevon=false;
 	obj.customwarpmodehon=false;
 
-	std::vector<std::string> tmap;
-
 	if (finalmode)
 	{
 		t = 6;

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -75,6 +75,8 @@ public:
 
     void loadlevel(int rx, int ry);
 
+    void twoframedelayfix();
+
 
     std::vector <int> roomdeaths;
     std::vector <int> roomdeathsfinal;

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -82,7 +82,6 @@ public:
     std::vector <int> contents;
     std::vector <int> explored;
     std::vector <int> vmult;
-    std::vector <std::string> tmap;
 
     int temp;
     int temp2;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -16,6 +16,7 @@ scriptclass::scriptclass()
 	position = 0;
 	scriptdelay = 0;
 	running = false;
+	dontrunnextframe = false;
 
 	b = 0;
 	g = 0;

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -56,7 +56,7 @@ public:
     int looppoint, loopcount;
 
     int scriptdelay;
-    bool running;
+    bool running, dontrunnextframe;
     std::string tempword;
     std::string currentletter;
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -542,7 +542,14 @@ void inline fixedloop()
             titlelogic();
             break;
         case GAMEMODE:
-            if (script.running)
+            // WARNING: If updating this code, don't forget to update Map.cpp mapclass::twoframedelayfix()
+
+            // Ugh, I hate this kludge variable but it's the only way to do it
+            if (script.dontrunnextframe)
+            {
+                script.dontrunnextframe = false;
+            }
+            else if (script.running)
             {
                 script.run();
             }


### PR DESCRIPTION
This patch is very kludge-y, but at least it fixes a semi-noticeable visual issue in custom levels that use internal scripts to spawn entities when loading a room.

Basically, the problem here is that when the game checks for script boxes and sets `newscript`, `newscript` has already been processed for that frame, and when the game does load a script, `script.run()` has already been processed for that frame.

That issue can be fixed, but it turns out that due to my over-30-FPS game loop changes, there's now *another* visible frame of delay between room load and entity creation, because the render function gets called in between the script being loaded at the end of `gamelogic()` and the script actually getting run.

So... I have to temporary move `script.run()` to the end of `gamelogic()` (in `map.twoframedelayfix()`), and make sure it doesn't get run next frame, because double-evaluations are bad. To do that, I have to introduce the kludge variable `script.dontrunnextframe`, which does exactly as it says.

And with all that work, the two-frame (now three-frame) delay is fixed.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
