### PR TITLE
Add bounds check to textbox functions that use `m`

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1143,6 +1143,7 @@ void Graphics::textboxtimer( int t )
 {
     if (!INBOUNDS(m, textbox))
     {
+        puts("textboxtimer() out-of-bounds!");
         return;
     }
 
@@ -1153,6 +1154,7 @@ void Graphics::addline( std::string t )
 {
     if (!INBOUNDS(m, textbox))
     {
+        puts("addline() out-of-bounds!");
         return;
     }
 
@@ -1163,6 +1165,7 @@ void Graphics::textboxadjust()
 {
     if (!INBOUNDS(m, textbox))
     {
+        puts("textboxadjust() out-of-bounds!");
         return;
     }
 
@@ -2804,6 +2807,7 @@ void Graphics::textboxcenter()
 {
 	if (!INBOUNDS(m, textbox))
 	{
+		puts("textboxcenter() out-of-bounds!");
 		return;
 	}
 
@@ -2815,6 +2819,7 @@ void Graphics::textboxcenterx()
 {
 	if (!INBOUNDS(m, textbox))
 	{
+		puts("textboxcenterx() out-of-bounds!");
 		return;
 	}
 
@@ -2825,6 +2830,7 @@ int Graphics::textboxwidth()
 {
 	if (!INBOUNDS(m, textbox))
 	{
+		puts("textboxwidth() out-of-bounds!");
 		return 0;
 	}
 
@@ -2835,6 +2841,7 @@ void Graphics::textboxmove(int xo, int yo)
 {
 	if (!INBOUNDS(m, textbox))
 	{
+		puts("textboxmove() out-of-bounds!");
 		return;
 	}
 
@@ -2846,6 +2853,7 @@ void Graphics::textboxmoveto(int xo)
 {
 	if (!INBOUNDS(m, textbox))
 	{
+		puts("textboxmoveto() out-of-bounds!");
 		return;
 	}
 
@@ -2856,6 +2864,7 @@ void Graphics::textboxcentery()
 {
 	if (!INBOUNDS(m, textbox))
 	{
+		puts("textboxcentery() out-of-bounds!");
 		return;
 	}
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1141,16 +1141,31 @@ void Graphics::textboxremove()
 
 void Graphics::textboxtimer( int t )
 {
+    if (!INBOUNDS(m, textbox))
+    {
+        return;
+    }
+
     textbox[m].timer=t;
 }
 
 void Graphics::addline( std::string t )
 {
+    if (!INBOUNDS(m, textbox))
+    {
+        return;
+    }
+
     textbox[m].addline(t);
 }
 
 void Graphics::textboxadjust()
 {
+    if (!INBOUNDS(m, textbox))
+    {
+        return;
+    }
+
     textbox[m].adjust();
 }
 
@@ -2787,33 +2802,63 @@ void Graphics::setwarprect( int a, int b, int c, int d )
 
 void Graphics::textboxcenter()
 {
+	if (!INBOUNDS(m, textbox))
+	{
+		return;
+	}
+
 	textbox[m].centerx();
 	textbox[m].centery();
 }
 
 void Graphics::textboxcenterx()
 {
+	if (!INBOUNDS(m, textbox))
+	{
+		return;
+	}
+
 	textbox[m].centerx();
 }
 
 int Graphics::textboxwidth()
 {
+	if (!INBOUNDS(m, textbox))
+	{
+		return 0;
+	}
+
 	return textbox[m].w;
 }
 
 void Graphics::textboxmove(int xo, int yo)
 {
+	if (!INBOUNDS(m, textbox))
+	{
+		return;
+	}
+
 	textbox[m].xp += xo;
 	textbox[m].yp += yo;
 }
 
 void Graphics::textboxmoveto(int xo)
 {
+	if (!INBOUNDS(m, textbox))
+	{
+		return;
+	}
+
 	textbox[m].xp = xo;
 }
 
 void Graphics::textboxcentery()
 {
+	if (!INBOUNDS(m, textbox))
+	{
+		return;
+	}
+
 	textbox[m].centery();
 }
 


### PR DESCRIPTION
It seems to be a bit bad to blindly use `m` without checking it. In fact, this has caused a few segfaults already, actually.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
