### PR TITLE
Fix enemies, platforms, and conveyors in Warp Zone gray tileset not being colored gray

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1163,6 +1163,15 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
     //Rule 4 is a horizontal line, 5 is vertical
     //Rule 6 is a crew member
 
+#if !defined(NO_CUSTOM_LEVELS)
+    // Special case for gray Warp Zone tileset!
+    int room = game.roomx-100 + (game.roomy-100) * ed.maxwidth;
+    bool custom_gray = room >= 0 && room < 400
+    && ed.level[room].tileset == 3 && ed.level[room].tilecol == 6;
+#else
+    bool custom_gray = false;
+#endif
+
     entclass entity;
     entity.xp = xp;
     entity.yp = yp;
@@ -2002,6 +2011,10 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
               entity.colour = 6;
             break;
           }
+        }
+
+        if(custom_gray){
+          entity.colour = 18;
         }
 
         break;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1566,6 +1566,15 @@ void Graphics::drawentities()
 
     SDL_Rect drawRect;
 
+#if !defined(NO_CUSTOM_LEVELS)
+    // Special case for gray Warp Zone tileset!
+    int room = game.roomx-100 + (game.roomy-100) * ed.maxwidth;
+    bool custom_gray = room >= 0 && room < 400
+    && ed.level[room].tileset == 3 && ed.level[room].tilecol == 6;
+#else
+    bool custom_gray = false;
+#endif
+
     std::vector<SDL_Surface*> *tilesvec;
     if (map.custommode && !map.finalmode)
     {
@@ -1698,7 +1707,16 @@ void Graphics::drawentities()
                 drawRect.x += tpoint.x;
                 drawRect.y += tpoint.y;
                 drawRect.x += 8 * ii;
-                BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                if (custom_gray)
+                {
+                    colourTransform temp_ct;
+                    temp_ct.colour = 0xFFFFFFFF;
+                    BlitSurfaceTinted((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, temp_ct);
+                }
+                else
+                {
+                    BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                }
             }
             break;
         }

--- a/desktop_version/src/GraphicsUtil.h
+++ b/desktop_version/src/GraphicsUtil.h
@@ -25,6 +25,8 @@ void BlitSurfaceStandard( SDL_Surface* _src, SDL_Rect* _srcRect, SDL_Surface* _d
 
 void BlitSurfaceColoured( SDL_Surface* _src, SDL_Rect* _srcRect, SDL_Surface* _dest, SDL_Rect* _destRect, colourTransform& ct );
 
+void BlitSurfaceTinted( SDL_Surface* _src, SDL_Rect* _srcRect, SDL_Surface* _dest, SDL_Rect* _destRect, colourTransform& ct );
+
 void FillRect( SDL_Surface* surface, const int x, const int y, const int w, const int h, const int r, int g, int b );
 
 void FillRect( SDL_Surface* surface, const int r, int g, int b );


### PR DESCRIPTION
The only reason why gray Warp Zone entities were green originally was because there is a giant concatenated list of tileset+tilecol combinations, and by using tileset 3 tilecol 6 you're using the entry of tileset 4 tilecol 0, which is the green Ship tileset.

So without interfering with the green Ship tileset's entry, I've decided that the best thing to do is to just add special cases. The enemy color was easy enough to fix. The platform color was also easy to fix. However, there exist no existing textures for gray conveyors, so at that point I decided to just tint the existing green one gray, and then I did the same for platforms.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
