### PR TITLE
Disable two-frame delay fix in glitchrunner mode, and reset width of player if not in glitchrunner mode

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1988,7 +1988,8 @@ void mapclass::twoframedelayfix()
 	// and when the script gets loaded script.run() has already ran for that frame, too.
 	// A bit kludge-y, but it's the least we can do without changing the frame ordering.
 
-	if (game.deathseq != -1
+	if (game.glitchrunnermode
+	|| game.deathseq != -1
 	// obj.checktrigger() sets obj.activetrigger
 	|| obj.checktrigger() <= -1
 	|| obj.activetrigger < 300)

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -797,6 +797,7 @@ void mapclass::resetplayer()
 			obj.entities[i].size = 0;
 			obj.entities[i].cx = 6;
 			obj.entities[i].cy = 2;
+			obj.entities[i].w = 12;
 			obj.entities[i].h = 21;
 		}
 


### PR DESCRIPTION
The two-frame delay can be utilized to trigger a glitch that spawns entities in the wrong room.

The width of the player can be changed by using the Gravitron OoB glitch. It will not be reset if the game is in glitchrunner mode.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
