### PR TITLE
Add being able to disable unfocus pause

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7214,8 +7214,8 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("animated backgrounds");
         option("screen effects");
         option("text outline");
-        option("invincibility", !ingame_titlemode || !inspecial());
-        option("slowdown", !ingame_titlemode || !inspecial());
+        option("invincibility", !ingame_titlemode || (!game.insecretlab && !game.intimetrial && !game.nodeathmode));
+        option("slowdown", !ingame_titlemode || (!game.insecretlab && !game.intimetrial && !game.nodeathmode));
         option("load screen");
         option("room name bg");
         option("return");

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -401,6 +401,8 @@ void Game::init(void)
     kludge_ingametemp = Menu::mainmenu;
     shouldreturntopausemenu = false;
 
+    disablepause = false;
+
     /* Terry's Patrons... */
     const char* superpatrons_arr[] = {
     "Anders Ekermo",
@@ -4811,6 +4813,11 @@ void Game::loadstats()
             skipfakeload = atoi(pText);
         }
 
+        if (pKey == "disablepause")
+        {
+            disablepause = atoi(pText);
+        }
+
         if (pKey == "over30mode")
         {
             over30mode = atoi(pText);
@@ -5057,6 +5064,10 @@ void Game::savestats()
 
     msg = doc.NewElement("skipfakeload");
     msg->LinkEndChild(doc.NewText(help.String((int) skipfakeload).c_str()));
+    dataNode->LinkEndChild(msg);
+
+    msg = doc.NewElement("disablepause");
+    msg->LinkEndChild(doc.NewText(help.String((int) disablepause).c_str()));
     dataNode->LinkEndChild(msg);
 
     msg = doc.NewElement("notextoutline");
@@ -7216,6 +7227,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("text outline");
         option("invincibility", !ingame_titlemode || (!game.insecretlab && !game.intimetrial && !game.nodeathmode));
         option("slowdown", !ingame_titlemode || (!game.insecretlab && !game.intimetrial && !game.nodeathmode));
+        option("unfocus pause");
         option("load screen");
         option("room name bg");
         option("return");

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -415,6 +415,8 @@ public:
 
     bool shouldreturntopausemenu;
     void returntopausemenu();
+
+    bool disablepause;
 };
 
 extern Game game;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -527,16 +527,21 @@ void menuactionpress()
             }
             break;
         case 5:
+            // toggle unfocus pause
+            game.disablepause = !game.disablepause;
+            music.playef(11);
+            break;
+        case 6:
             // toggle fake load screen
             game.skipfakeload = !game.skipfakeload;
             music.playef(11);
             break;
-        case 6:
+        case 7:
             // toggle translucent roomname BG
             graphics.translucentroomname = !graphics.translucentroomname;
             music.playef(11);
             break;
-        case 7:
+        case 8:
             //back
             music.playef(11);
             game.returnmenu();

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -244,7 +244,10 @@ void KeyPoll::Poll()
 
 			/* Window Focus */
 			case SDL_WINDOWEVENT_FOCUS_GAINED:
-				isActive = true;
+				if (!game.disablepause)
+				{
+					isActive = true;
+				}
 				if (!useFullscreenSpaces)
 				{
 					if (wasFullscreen)
@@ -257,14 +260,17 @@ void KeyPoll::Poll()
 					}
 				}
 				SDL_DisableScreenSaver();
-				if (Mix_PlayingMusic())
+				if (!game.disablepause && Mix_PlayingMusic())
 				{
 					// Correct songStart for how long we were paused
 					music.songStart += SDL_GetPerformanceCounter() - pauseStart;
 				}
 				break;
 			case SDL_WINDOWEVENT_FOCUS_LOST:
-				isActive = false;
+				if (!game.disablepause)
+				{
+					isActive = false;
+				}
 				if (!useFullscreenSpaces)
 				{
 					wasFullscreen = !graphics.screenbuffer->isWindowed;
@@ -275,7 +281,10 @@ void KeyPoll::Poll()
 					);
 				}
 				SDL_EnableScreenSaver();
-				pauseStart = SDL_GetPerformanceCounter();
+				if (!game.disablepause)
+				{
+					pauseStart = SDL_GetPerformanceCounter();
+				}
 				break;
 
 			/* Mouse Focus */

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -465,13 +465,26 @@ void menurender()
             }
             break;
         case 5:
+            graphics.bigprint( -1, 40, "Unfocus Pause", tr, tg, tb, true);
+            graphics.Print( -1, 75, "Toggle if the game will pause", tr, tg, tb, true);
+            graphics.Print( -1, 85, "when you're unfocused.", tr, tg, tb, true);
+            if (game.disablepause)
+            {
+                graphics.Print(-1, 105, "Unfocus pause is OFF", tr/2, tg/2, tb/2, true);
+            }
+            else
+            {
+                graphics.Print(-1, 105, "Unfocus pause is ON", tr, tg, tb, true);
+            }
+            break;
+        case 6:
             graphics.bigprint(-1, 30, "Fake Load Screen", tr, tg, tb, true);
             if (game.skipfakeload)
                 graphics.Print(-1, 75, "Fake loading screen is OFF", tr/2, tg/2, tb/2, true);
             else
                 graphics.Print(-1, 75, "Fake loading screen is ON", tr, tg, tb, true);
             break;
-        case 6:
+        case 7:
             graphics.bigprint(-1, 30, "Room Name BG", tr, tg, tb, true);
             graphics.Print( -1, 75, "Lets you see through what is behind", tr, tg, tb, true);
             graphics.Print( -1, 85, "the name at the bottom of the screen.", tr, tg, tb, true);


### PR DESCRIPTION
It's sometimes unwanted by people, and it's unwanted enough that there exist [instructions to hexedit the binary to remove it](
https://distractionware.com/forum/index.php?topic=3247.0).

Fun fact, the unfocus pause didn't exist in 2.0.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
