### PR TITLE
Add Flip Mode to game options if in M&P or in-game menu and unlocked

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7209,6 +7209,12 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("accessibility options");
         option("glitchrunner mode");
 #if !defined(MAKEANDPLAY)
+        if (ingame_titlemode && unlock[18])
+#endif
+        {
+            option("flip mode");
+        }
+#if !defined(MAKEANDPLAY)
         option("unlock play modes");
 #endif
         option("game pad options");

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -556,10 +556,20 @@ void menuactionpress()
     case Menu::options:
     {
 #if defined(MAKEANDPLAY)
-#define OFFSET -1
+        int flipmode_offset = 0;
 #else
-#define OFFSET 0
+        int flipmode_offset = game.ingame_titlemode && game.unlock[18] ? 0 : -1;
 #endif
+
+#if defined(MAKEANDPLAY)
+        int unlockmode_offset = -1;
+#else
+        int unlockmode_offset = 0;
+#endif
+
+        int mmmmmm_offset = music.mmmmmm ? 0 : -1;
+
+        int offset = 0;
 
         switch (game.currentmenuoption)
         {
@@ -574,30 +584,58 @@ void menuactionpress()
             music.playef(11);
             game.glitchrunnermode = !game.glitchrunnermode;
             break;
-#if !defined(MAKEANDPLAY)
         case 2:
+#if !defined(MAKEANDPLAY)
+        if (game.ingame_titlemode && game.unlock[18])
+#endif
+        {
+            // toggle Flip Mode
+            graphics.setflipmode = !graphics.setflipmode;
+            game.savemystats = true;
+            if (graphics.setflipmode)
+            {
+                music.playef(18);
+                game.screenshake = 10;
+                game.flashlight = 5;
+            }
+            else
+            {
+                music.playef(11);
+            }
+        }
+            break;
+        }
+
+        offset += flipmode_offset;
+
+#if !defined(MAKEANDPLAY)
+        if (game.currentmenuoption == 3+offset)
+        {
             //unlock play options
             music.playef(11);
             game.createmenu(Menu::unlockmenu);
             map.nexttowercolour();
-            break;
+        }
 #endif
-        case OFFSET+3:
+
+        offset += unlockmode_offset;
+
+        if (game.currentmenuoption == 4+offset)
+        {
             //clear data menu
             music.playef(11);
             game.createmenu(Menu::controller);
             map.nexttowercolour();
             break;
-        case OFFSET+4:
+        }
+        else if (game.currentmenuoption == 5+offset)
+        {
             //clear data menu
             music.playef(11);
             game.createmenu(Menu::cleardatamenu);
             map.nexttowercolour();
-            break;
         }
-
-        int mmmmmm_offset = music.mmmmmm ? 0 : -1;
-        if (game.currentmenuoption == OFFSET+5+mmmmmm_offset)
+        else if (game.currentmenuoption == 6+offset && music.mmmmmm)
         {
             //**** TOGGLE MMMMMM
             if(game.usingmmmmmm > 0){
@@ -610,7 +648,10 @@ void menuactionpress()
             music.play(music.currentsong);
             game.savestats();
         }
-        else if (game.currentmenuoption == OFFSET+6+mmmmmm_offset)
+
+        offset += mmmmmm_offset;
+
+        if (game.currentmenuoption == 7+offset)
         {
             //back
             music.playef(11);
@@ -624,7 +665,6 @@ void menuactionpress()
                 map.nexttowercolour();
             }
         }
-#undef OFFSET
         break;
     }
     case Menu::unlockmenutrials:
@@ -1155,6 +1195,7 @@ void menuactionpress()
         }
         else if (game.currentmenuoption == 3 && game.unlock[18])    //enable/disable flip mode
         {
+            // WARNING: Partially duplicated in Menu::options
             graphics.setflipmode = !graphics.setflipmode;
             game.savemystats = true;
             if (graphics.setflipmode)

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -75,11 +75,20 @@ void menurender()
       graphics.Print( -1, 75, "no start point!", tr, tg, tb, true);
       break;
     case Menu::options:
+    {
 #if defined(MAKEANDPLAY)
-#define OFFSET -1
+        int flipmode_offset = 0;
 #else
-#define OFFSET 0
+        int flipmode_offset = game.ingame_titlemode && game.unlock[18] ? 0 : -1;
 #endif
+
+#if defined(MAKEANDPLAY)
+        int unlockmode_offset = -1;
+#else
+        int unlockmode_offset = 0;
+#endif
+
+        int offset = 0;
 
         switch (game.currentmenuoption)
         {
@@ -101,37 +110,63 @@ void menurender()
                 graphics.Print( -1, 95, "Glitchrunner mode is OFF", tr/2, tg/2, tb/2, true);
             }
             break;
-#if !defined(MAKEANDPLAY)
         case 2:
+#if !defined(MAKEANDPLAY)
+        if (game.ingame_titlemode && game.unlock[18])
+#endif
+        {
+            graphics.bigprint( -1, 30, "Flip Mode", tr, tg, tb, true);
+            graphics.Print( -1, 65, "Flip the entire game vertically.", tr, tg, tb, true);
+            if (graphics.setflipmode)
+            {
+                graphics.Print( -1, 85, "Currently ENABLED!", tr, tg, tb, true);
+            }
+            else
+            {
+                graphics.Print( -1, 85, "Currently Disabled.", tr/2, tg/2, tb/2, true);
+            }
+        }
+            break;
+        }
+
+        offset += flipmode_offset;
+
+#if !defined(MAKEANDPLAY)
+        if (game.currentmenuoption == 3+offset)
+        {
             graphics.bigprint( -1, 30, "Unlock Play Modes", tr, tg, tb, true);
             graphics.Print( -1, 65, "Unlock parts of the game normally", tr, tg, tb, true);
             graphics.Print( -1, 75, "unlocked as you progress", tr, tg, tb, true);
-            break;
+        }
 #endif
-        case OFFSET+3:
+
+        offset += unlockmode_offset;
+
+        if (game.currentmenuoption == 4+offset)
+        {
             graphics.bigprint( -1, 30, "Game Pad Options", tr, tg, tb, true);
             graphics.Print( -1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
             graphics.Print( -1, 75, "and adjust sensitivity", tr, tg, tb, true);
-            break;
-        case OFFSET+4:
+        }
+        else if (game.currentmenuoption == 5+offset)
+        {
             graphics.bigprint( -1, 30, "Clear Data", tr, tg, tb, true);
             graphics.Print( -1, 65, "Delete your save data", tr, tg, tb, true);
             graphics.Print( -1, 75, "and unlocked play modes", tr, tg, tb, true);
-            break;
-        case OFFSET+5:
-            if(music.mmmmmm){
-                graphics.bigprint( -1, 30, "Soundtrack", tr, tg, tb, true);
-                graphics.Print( -1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);
-                if(music.usingmmmmmm){
-                    graphics.Print( -1, 85, "Current soundtrack: MMMMMM", tr, tg, tb, true);
-                }else{
-                    graphics.Print( -1, 85, "Current soundtrack: PPPPPP", tr, tg, tb, true);
-                }
+        }
+        else if (game.currentmenuoption == 6+offset && music.mmmmmm)
+        {
+            graphics.bigprint( -1, 30, "Soundtrack", tr, tg, tb, true);
+            graphics.Print( -1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);
+            if(music.usingmmmmmm){
+                graphics.Print( -1, 85, "Current soundtrack: MMMMMM", tr, tg, tb, true);
+            }else{
+                graphics.Print( -1, 85, "Current soundtrack: PPPPPP", tr, tg, tb, true);
             }
             break;
         }
-#undef OFFSET
         break;
+    }
     case Menu::graphicoptions:
         switch (game.currentmenuoption)
         {
@@ -541,6 +576,7 @@ void menurender()
             }
             break;
         case 3:
+            // WARNING: Partially duplicated in Menu::options
             graphics.bigprint( -1, 30, "Flip Mode", tr, tg, tb, true);
             graphics.Print( -1, 65, "Flip the entire game vertically.", tr, tg, tb, true);
             graphics.Print( -1, 75, "Compatible with other game modes.", tr, tg, tb, true);


### PR DESCRIPTION
Flip Mode will now be in the game options menu if either:
1. You're playing the M&P version.
2. You have it unlocked and you came here from the in-game pause screen.

This is because if you're playing M&P, you'd have to close the game, edit `unlock.vvv`, and re-launch the game to toggle Flip Mode, since there's no other way to do so. And if you're playing the full version, you'd have to save and exit your session in order to toggle Flip Mode.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
