### PR TITLE
Fix Alt+Enter Glitch if not in glitchrunner mode

### DIFF
--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -491,10 +491,13 @@ void inline fixedloop()
         key.toggleFullscreen = false;
 
         key.keymap.clear(); //we lost the input due to a new window.
-        game.press_left = false;
-        game.press_right = false;
-        game.press_action = true;
-        game.press_map = false;
+        if (game.glitchrunnermode)
+        {
+            game.press_left = false;
+            game.press_right = false;
+            game.press_action = true;
+            game.press_map = false;
+        }
     }
 
     if(!key.isActive)


### PR DESCRIPTION
The Alt+Enter Glitch is a funny glitch where if you press any toggle fullscreen keybind during a cutscene, Viridian will stop moving (if they're being moved by a `walk()`) and ACTION will start being held down for them. Meaning in most cases you can interrupt a walk and flip at the same time.

This can obviously break cutscenes if a casual just wants to toggle fullscreen, so I'm fixing it. But it will be unfixed in glitchrunner mode in case you want to glitch out custom levels (I know I do).

More information on the Alt+Enter Glitch is available here: https://gitgud.io/infoteddy/vvvvvv-knowledge/blob/master/bugs/bugs.md#the-altenter-glitch
(The page is a bit outdated, some bugs have been fixed in 2.3 already.)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
