### PR TITLE
Don't selectively undraw tiles in towers if backgrounds are off

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2441,20 +2441,6 @@ void Graphics::drawtowermap()
     }
 }
 
-void Graphics::drawtowermap_nobackground()
-{
-    int temp;
-    int yoff = lerp(map.oldypos, map.ypos);
-    for (int j = 0; j < 31; j++)
-    {
-        for (int i = 0; i < 40; i++)
-        {
-            temp = map.tower.at(i, j, yoff);
-            if (temp > 0 && temp<28) drawtile3(i * 8, (j * 8) - (yoff % 8), temp, map.colstate);
-        }
-    }
-}
-
 void Graphics::drawtowerspikes()
 {
     int spikeleveltop = lerp(map.oldspikeleveltop, map.spikeleveltop);

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -191,8 +191,6 @@ public:
 
 	void drawtowermap();
 
-	void drawtowermap_nobackground();
-
 	void drawtowerspikes();
 
 	bool onscreen(int t);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1382,13 +1382,12 @@ void gamerender()
             if (!game.colourblindmode)
             {
                 graphics.drawtowerbackground();
-                graphics.drawtowermap();
             }
             else
             {
                 FillRect(graphics.backBuffer,0x00000);
-                graphics.drawtowermap_nobackground();
             }
+            graphics.drawtowermap();
         }
         else
         {


### PR DESCRIPTION
The game for some reason had this thing where it would not draw the diagonal background tiles if you had animated backgrounds turned off. Which is weird, because spikes with that background are still drawn as spikes with that background. And also, it doesn't do this for any of the tower hallway rooms, which is inconsistent.

Better to simplify the logic in `Render.cpp` anyways by removing `graphics.drawtower_nobackground()` and making it really clear what exactly we'll do if backgrounds are turned off. ("Aren't we already not drawing the background? What's this `_nobackground()` function for?")

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
