### PR TITLE
Move some options to a new menu, "advanced options"

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7162,11 +7162,11 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
     case Menu::graphicoptions:
         option("toggle fullscreen");
         option("toggle letterbox");
+        option("resize to nearest", graphics.screenbuffer->isWindowed);
         option("toggle filter");
         option("toggle analogue");
         option("toggle fps");
         option("toggle vsync");
-        option("resize to nearest", graphics.screenbuffer->isWindowed);
         option("return");
         menuyoff = -10;
         break;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7164,7 +7164,6 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("toggle letterbox");
         option("toggle filter");
         option("toggle analogue");
-        option("toggle mouse");
         option("toggle fps");
         option("toggle vsync");
         option("resize to nearest", graphics.screenbuffer->isWindowed);
@@ -7208,7 +7207,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         break;
     case Menu::options:
         option("accessibility options");
-        option("glitchrunner mode");
+        option("advanced options");
 #if !defined(MAKEANDPLAY)
         if (ingame_titlemode && unlock[18])
 #endif
@@ -7228,17 +7227,23 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("return");
         menuyoff = 0;
         break;
+    case Menu::advancedoptions:
+        option("toggle mouse");
+        option("unfocus pause");
+        option("fake load screen");
+        option("room name background");
+        option("glitchrunner mode");
+        option("return");
+        menuyoff = 0;
+        break;
     case Menu::accessibility:
         option("animated backgrounds");
         option("screen effects");
         option("text outline");
         option("invincibility", !ingame_titlemode || (!game.insecretlab && !game.intimetrial && !game.nodeathmode));
         option("slowdown", !ingame_titlemode || (!game.insecretlab && !game.intimetrial && !game.nodeathmode));
-        option("unfocus pause");
-        option("load screen");
-        option("room name bg");
         option("return");
-        menuyoff = -10;
+        menuyoff = 0;
         break;
     case Menu::controller:
         option("analog stick sensitivity");

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7161,7 +7161,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         break;
     case Menu::graphicoptions:
         option("toggle fullscreen");
-        option("toggle letterbox");
+        option("scaling mode");
         option("resize to nearest", graphics.screenbuffer->isWindowed);
         option("toggle filter");
         option("toggle analogue");

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -31,6 +31,7 @@ namespace Menu
         ed_music,
         ed_quit,
         options,
+        advancedoptions,
         accessibility,
         controller,
         cleardatamenu,

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -351,31 +351,19 @@ void menuactionpress()
             game.currentmenuoption = 3;
             break;
         case 4:
-            //toggle mouse cursor
-            music.playef(11);
-            if (graphics.showmousecursor == true) {
-                SDL_ShowCursor(SDL_DISABLE);
-                graphics.showmousecursor = false;
-            }
-            else {
-                SDL_ShowCursor(SDL_ENABLE);
-                graphics.showmousecursor = true;
-            }
-            break;
-        case 5:
             //toggle 30+ fps
             music.playef(11);
             game.over30mode = !game.over30mode;
             game.savestats();
             break;
-        case 6:
+        case 5:
             //toggle vsync
             music.playef(11);
             graphics.vsync = !graphics.vsync;
             graphics.processVsync();
             game.savestats();
             break;
-        case 7:
+        case 6:
             // resize to nearest multiple
             if (graphics.screenbuffer->isWindowed)
             {
@@ -478,6 +466,49 @@ void menuactionpress()
             break;
         }
         break;
+    case Menu::advancedoptions:
+        switch (game.currentmenuoption)
+        {
+        case 0:
+            //toggle mouse cursor
+            music.playef(11);
+            if (graphics.showmousecursor == true) {
+                SDL_ShowCursor(SDL_DISABLE);
+                graphics.showmousecursor = false;
+            }
+            else {
+                SDL_ShowCursor(SDL_ENABLE);
+                graphics.showmousecursor = true;
+            }
+            break;
+        case 1:
+            // toggle unfocus pause
+            game.disablepause = !game.disablepause;
+            music.playef(11);
+            break;
+        case 2:
+            // toggle fake load screen
+            game.skipfakeload = !game.skipfakeload;
+            music.playef(11);
+            break;
+        case 3:
+            // toggle translucent roomname BG
+            graphics.translucentroomname = !graphics.translucentroomname;
+            music.playef(11);
+            break;
+        case 4:
+            // Glitchrunner mode
+            music.playef(11);
+            game.glitchrunnermode = !game.glitchrunnermode;
+            break;
+        case 5:
+            //back
+            music.playef(11);
+            game.returnmenu();
+            map.nexttowercolour();
+            break;
+        }
+        break;
     case Menu::accessibility:
         switch (game.currentmenuoption)
         {
@@ -543,21 +574,6 @@ void menuactionpress()
             }
             break;
         case 5:
-            // toggle unfocus pause
-            game.disablepause = !game.disablepause;
-            music.playef(11);
-            break;
-        case 6:
-            // toggle fake load screen
-            game.skipfakeload = !game.skipfakeload;
-            music.playef(11);
-            break;
-        case 7:
-            // toggle translucent roomname BG
-            graphics.translucentroomname = !graphics.translucentroomname;
-            music.playef(11);
-            break;
-        case 8:
             //back
             music.playef(11);
             game.returnmenu();
@@ -596,9 +612,10 @@ void menuactionpress()
             map.nexttowercolour();
             break;
         case 1:
-            // Glitchrunner mode
+            //advanced options
             music.playef(11);
-            game.glitchrunnermode = !game.glitchrunnermode;
+            game.createmenu(Menu::advancedoptions);
+            map.nexttowercolour();
             break;
         case 2:
 #if !defined(MAKEANDPLAY)

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -333,37 +333,8 @@ void menuactionpress()
             graphics.screenbuffer->toggleStretchMode();
             game.stretchMode = (game.stretchMode + 1) % 3;
             game.savestats();
-            game.currentmenuoption = 1;
             break;
         case 2:
-            music.playef(11);
-            graphics.screenbuffer->toggleLinearFilter();
-            game.useLinearFilter = !game.useLinearFilter;
-            game.savestats();
-            game.currentmenuoption = 2;
-            break;
-        case 3:
-            //change smoothing
-            music.playef(11);
-            game.fullScreenEffect_badSignal = !game.fullScreenEffect_badSignal;
-            graphics.screenbuffer->badSignalEffect= !graphics.screenbuffer->badSignalEffect;
-            game.savestats();
-            game.currentmenuoption = 3;
-            break;
-        case 4:
-            //toggle 30+ fps
-            music.playef(11);
-            game.over30mode = !game.over30mode;
-            game.savestats();
-            break;
-        case 5:
-            //toggle vsync
-            music.playef(11);
-            graphics.vsync = !graphics.vsync;
-            graphics.processVsync();
-            game.savestats();
-            break;
-        case 6:
             // resize to nearest multiple
             if (graphics.screenbuffer->isWindowed)
             {
@@ -375,6 +346,32 @@ void menuactionpress()
             {
                 music.playef(2);
             }
+            break;
+        case 3:
+            music.playef(11);
+            graphics.screenbuffer->toggleLinearFilter();
+            game.useLinearFilter = !game.useLinearFilter;
+            game.savestats();
+            break;
+        case 4:
+            //change smoothing
+            music.playef(11);
+            game.fullScreenEffect_badSignal = !game.fullScreenEffect_badSignal;
+            graphics.screenbuffer->badSignalEffect= !graphics.screenbuffer->badSignalEffect;
+            game.savestats();
+            break;
+        case 5:
+            //toggle 30+ fps
+            music.playef(11);
+            game.over30mode = !game.over30mode;
+            game.savestats();
+            break;
+        case 6:
+            //toggle vsync
+            music.playef(11);
+            graphics.vsync = !graphics.vsync;
+            graphics.processVsync();
+            game.savestats();
             break;
         default:
             //back

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -175,7 +175,7 @@ void menurender()
             break;
 
         case 1:
-            graphics.bigprint( -1, 30, "Toggle Letterbox", tr, tg, tb, true);
+            graphics.bigprint( -1, 30, "Scaling Mode", tr, tg, tb, true);
             graphics.Print( -1, 65, "Choose letterbox/stretch/integer mode.", tr, tg, tb, true);
 
             if(game.stretchMode == 2){

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -98,17 +98,10 @@ void menurender()
             graphics.Print( -1, 75, "slowdown modes or invincibility", tr, tg, tb, true);
             break;
         case 1:
-            graphics.bigprint( -1, 30, "Glitchrunner Mode", tr, tg, tb, true);
-            graphics.Print( -1, 65, "Re-enable glitches that existed", tr, tg, tb, true);
-            graphics.Print( -1, 75, "in previous versions of the game", tr, tg, tb, true);
-            if (game.glitchrunnermode)
-            {
-                graphics.Print( -1, 95, "Glitchrunner mode is ON", tr, tg, tb, true);
-            }
-            else
-            {
-                graphics.Print( -1, 95, "Glitchrunner mode is OFF", tr/2, tg/2, tb/2, true);
-            }
+            graphics.bigprint( -1, 30, "Advanced Options", tr, tg, tb, true);
+            graphics.Print( -1, 65, "Hide the mouse cursor, remove", tr, tg, tb, true);
+            graphics.Print( -1, 75, "the loading screen, turn on", tr, tg, tb, true);
+            graphics.Print( -1, 85, "glitchrunner mode and more", tr, tg, tb, true);
             break;
         case 2:
 #if !defined(MAKEANDPLAY)
@@ -211,17 +204,6 @@ void menurender()
             graphics.Print( -1, 85, "adjust the picture.", tr, tg, tb, true);
             break;
         case 4:
-            graphics.bigprint(-1, 30, "Toggle Mouse Cursor", tr, tg, tb, true);
-            graphics.Print(-1, 65, "Show/hide the system mouse cursor.", tr, tg, tb, true);
-
-            if (graphics.showmousecursor) {
-                graphics.Print(-1, 85, "Current mode: SHOW", tr, tg, tb, true);
-            }
-            else {
-                graphics.Print(-1, 85, "Current mode: HIDE", tr/2, tg/2, tb/2, true);
-            }
-            break;
-        case 5:
             graphics.bigprint(-1, 30, "Toggle 30+ FPS", tr, tg, tb, true);
             graphics.Print(-1, 65, "Change whether the game", tr, tg, tb, true);
             graphics.Print(-1, 75, "runs at 30 or over 30 FPS.", tr, tg, tb, true);
@@ -235,7 +217,7 @@ void menurender()
                 graphics.Print(-1, 95, "Current mode: Over 30 FPS", tr, tg, tb, true);
             }
             break;
-        case 6:
+        case 5:
             graphics.bigprint(-1, 30, "Toggle VSync", tr, tg, tb, true);
             graphics.Print(-1, 65, "Turn VSync on or off.", tr, tg, tb, true);
 
@@ -248,7 +230,7 @@ void menurender()
                 graphics.Print(-1, 95, "Current mode: VSYNC ON", tr, tg, tb, true);
             }
             break;
-        case 7:
+        case 6:
             graphics.bigprint(-1, 30, "Resize to Nearest", tr, tg, tb, true);
             graphics.Print(-1, 65, "Resize to the nearest window size", tr, tg, tb, true);
             graphics.Print(-1, 75, "that is of an integer multiple.", tr, tg, tb, true);
@@ -437,6 +419,64 @@ void menurender()
 
 
         break;
+    case Menu::advancedoptions:
+        switch (game.currentmenuoption)
+        {
+        case 0:
+            graphics.bigprint(-1, 30, "Toggle Mouse Cursor", tr, tg, tb, true);
+            graphics.Print(-1, 65, "Show/hide the system mouse cursor.", tr, tg, tb, true);
+
+            if (graphics.showmousecursor) {
+                graphics.Print(-1, 95, "Current mode: SHOW", tr, tg, tb, true);
+            }
+            else {
+                graphics.Print(-1, 95, "Current mode: HIDE", tr/2, tg/2, tb/2, true);
+            }
+            break;
+        case 1:
+            graphics.bigprint( -1, 30, "Unfocus Pause", tr, tg, tb, true);
+            graphics.Print( -1, 65, "Toggle if the game will pause", tr, tg, tb, true);
+            graphics.Print( -1, 75, "when the window is unfocused.", tr, tg, tb, true);
+            if (game.disablepause)
+            {
+                graphics.Print(-1, 95, "Unfocus pause is OFF", tr/2, tg/2, tb/2, true);
+            }
+            else
+            {
+                graphics.Print(-1, 95, "Unfocus pause is ON", tr, tg, tb, true);
+            }
+            break;
+        case 2:
+            graphics.bigprint(-1, 30, "Fake Load Screen", tr, tg, tb, true);
+            if (game.skipfakeload)
+                graphics.Print(-1, 65, "Fake loading screen is OFF", tr/2, tg/2, tb/2, true);
+            else
+                graphics.Print(-1, 65, "Fake loading screen is ON", tr, tg, tb, true);
+            break;
+        case 3:
+            graphics.bigprint(-1, 30, "Room Name BG", tr, tg, tb, true);
+            graphics.Print( -1, 65, "Lets you see through what is behind", tr, tg, tb, true);
+            graphics.Print( -1, 75, "the name at the bottom of the screen.", tr, tg, tb, true);
+            if (graphics.translucentroomname)
+                graphics.Print(-1, 95, "Room name background is TRANSLUCENT", tr/2, tg/2, tb/2, true);
+            else
+                graphics.Print(-1, 95, "Room name background is OPAQUE", tr, tg, tb, true);
+            break;
+        case 4:
+            graphics.bigprint( -1, 30, "Glitchrunner Mode", tr, tg, tb, true);
+            graphics.Print( -1, 65, "Re-enable glitches that existed", tr, tg, tb, true);
+            graphics.Print( -1, 75, "in previous versions of the game", tr, tg, tb, true);
+            if (game.glitchrunnermode)
+            {
+                graphics.Print( -1, 95, "Glitchrunner mode is ON", tr, tg, tb, true);
+            }
+            else
+            {
+                graphics.Print( -1, 95, "Glitchrunner mode is OFF", tr/2, tg/2, tb/2, true);
+            }
+            break;
+        }
+        break;
     case Menu::accessibility:
         switch (game.currentmenuoption)
         {
@@ -509,35 +549,6 @@ void menurender()
             {
                 graphics.Print( -1, 105, "Game speed is at 40%", tr, tg, tb, true);
             }
-            break;
-        case 5:
-            graphics.bigprint( -1, 40, "Unfocus Pause", tr, tg, tb, true);
-            graphics.Print( -1, 75, "Toggle if the game will pause", tr, tg, tb, true);
-            graphics.Print( -1, 85, "when you're unfocused.", tr, tg, tb, true);
-            if (game.disablepause)
-            {
-                graphics.Print(-1, 105, "Unfocus pause is OFF", tr/2, tg/2, tb/2, true);
-            }
-            else
-            {
-                graphics.Print(-1, 105, "Unfocus pause is ON", tr, tg, tb, true);
-            }
-            break;
-        case 6:
-            graphics.bigprint(-1, 30, "Fake Load Screen", tr, tg, tb, true);
-            if (game.skipfakeload)
-                graphics.Print(-1, 75, "Fake loading screen is OFF", tr/2, tg/2, tb/2, true);
-            else
-                graphics.Print(-1, 75, "Fake loading screen is ON", tr, tg, tb, true);
-            break;
-        case 7:
-            graphics.bigprint(-1, 30, "Room Name BG", tr, tg, tb, true);
-            graphics.Print( -1, 75, "Lets you see through what is behind", tr, tg, tb, true);
-            graphics.Print( -1, 85, "the name at the bottom of the screen.", tr, tg, tb, true);
-            if (graphics.translucentroomname)
-                graphics.Print(-1, 105, "Room name background is TRANSLUCENT", tr/2, tg/2, tb/2, true);
-            else
-                graphics.Print(-1, 105, "Room name background is OPAQUE", tr, tg, tb, true);
             break;
         }
         break;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -187,6 +187,16 @@ void menurender()
             }
             break;
         case 2:
+            graphics.bigprint(-1, 30, "Resize to Nearest", tr, tg, tb, true);
+            graphics.Print(-1, 65, "Resize to the nearest window size", tr, tg, tb, true);
+            graphics.Print(-1, 75, "that is of an integer multiple.", tr, tg, tb, true);
+            if (!graphics.screenbuffer->isWindowed)
+            {
+                graphics.Print(-1, 95, "You must be in windowed mode", tr, tg, tb, true);
+                graphics.Print(-1, 105, "to use this option.", tr, tg, tb, true);
+            }
+            break;
+        case 3:
             graphics.bigprint( -1, 30, "Toggle Filter", tr, tg, tb, true);
             graphics.Print( -1, 65, "Change to nearest/linear filter.", tr, tg, tb, true);
 
@@ -197,13 +207,13 @@ void menurender()
             }
             break;
 
-        case 3:
+        case 4:
             graphics.bigprint( -1, 30, "Analogue Mode", tr, tg, tb, true);
             graphics.Print( -1, 65, "There is nothing wrong with your", tr, tg, tb, true);
             graphics.Print( -1, 75, "television set. Do not attempt to", tr, tg, tb, true);
             graphics.Print( -1, 85, "adjust the picture.", tr, tg, tb, true);
             break;
-        case 4:
+        case 5:
             graphics.bigprint(-1, 30, "Toggle 30+ FPS", tr, tg, tb, true);
             graphics.Print(-1, 65, "Change whether the game", tr, tg, tb, true);
             graphics.Print(-1, 75, "runs at 30 or over 30 FPS.", tr, tg, tb, true);
@@ -217,7 +227,7 @@ void menurender()
                 graphics.Print(-1, 95, "Current mode: Over 30 FPS", tr, tg, tb, true);
             }
             break;
-        case 5:
+        case 6:
             graphics.bigprint(-1, 30, "Toggle VSync", tr, tg, tb, true);
             graphics.Print(-1, 65, "Turn VSync on or off.", tr, tg, tb, true);
 
@@ -228,16 +238,6 @@ void menurender()
             else
             {
                 graphics.Print(-1, 95, "Current mode: VSYNC ON", tr, tg, tb, true);
-            }
-            break;
-        case 6:
-            graphics.bigprint(-1, 30, "Resize to Nearest", tr, tg, tb, true);
-            graphics.Print(-1, 65, "Resize to the nearest window size", tr, tg, tb, true);
-            graphics.Print(-1, 75, "that is of an integer multiple.", tr, tg, tb, true);
-            if (!graphics.screenbuffer->isWindowed)
-            {
-                graphics.Print(-1, 95, "You must be in windowed mode", tr, tg, tb, true);
-                graphics.Print(-1, 105, "to use this option.", tr, tg, tb, true);
             }
             break;
         }


### PR DESCRIPTION
## Changes:

VVVVVV's menus are kind of packed to the brim, so I thought it was time to recategorize the menus a little bit. There's now a new "advanced options" menu which holds the following options which were moved out of graphic options, game options and especially accessibility options:

- toggle mouse
- unfocus pause
- fake load screen
- room name background
- glitchrunner mode

I also moved the "resize to nearest" option to be grouped more logically and changed "toggle letterbox" to "scaling mode" (further explained in the commit messages).


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
