### PR TITLE
Expose all 9 arguments of createentity()

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -703,7 +703,17 @@ void scriptclass::run()
 			}
 			else if (words[0] == "createentity")
 			{
-				obj.createentity(ss_toi(words[1]), ss_toi(words[2]), ss_toi(words[3]), ss_toi(words[4]), ss_toi(words[5]));
+				if (words[6] == "") words[6] = "0";
+				if (words[7] == "") words[7] = "0";
+				if (words[8] == "") words[8] = "320";
+				if (words[9] == "") words[9] = "240";
+				obj.createentity(ss_toi(words[1]), ss_toi(words[2]), ss_toi(words[3]),
+					ss_toi(words[4]), ss_toi(words[5]),
+					ss_toi(words[6]), ss_toi(words[7]), ss_toi(words[8]), ss_toi(words[9]));
+				words[6] = "";
+				words[7] = "";
+				words[8] = "";
+				words[9] = "";
 			}
 			else if (words[0] == "createcrewman")
 			{


### PR DESCRIPTION
For whatever reason, not all arguments of createentity() are exposed in the command.

We have to keep in mind that (1) unspecified arguments default to 0 (instead of the 320 and 240 for argument 8 and 9 that `createentity()` usually defaults to), and that (2) arguments persist across commands. (Why not get rid of argument persistence, you say? Unfortunately, some levels rely on argument persistence to call `gotoposition()` without specifying the third argument, even though you're supposed to specify all three arguments.)

To add these arguments without breaking levels, I re-added the `createentity()` defaults of 320 and 240 for args 8 and 9, and then I reset the new arguments afterwards when I'm done. Technically this could be bad if other commands used those higher arguments, but none of them really do. (Except `createcrewman()`, but it only sets argument 6 to 0 sometimes anyway, but argument 6 is already supposed to default to 0.)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
