### PR TITLE
Re-color one-way tiles to match the tileset

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -165,6 +165,8 @@ void FILESYSTEM_mount(const char *fname)
 	}
 }
 
+bool FILESYSTEM_assetsmounted = false;
+
 void FILESYSTEM_mountassets(const char* path)
 {
 	const std::string _path(path);
@@ -182,6 +184,7 @@ void FILESYSTEM_mountassets(const char* path)
 		printf("Custom asset directory exists at %s\n", zippath.c_str());
 		FILESYSTEM_mount(zippath.c_str());
 		graphics.reloadresources();
+		FILESYSTEM_assetsmounted = true;
 	} else if (zip_path != "data.zip" && !endsWith(zip_path, "/data.zip") && endsWith(zip_path, ".zip")) {
 		printf("Custom asset directory is .zip at %s\n", zip_path.c_str());
 		PHYSFS_File* zip = PHYSFS_openRead(zip_path.c_str());
@@ -193,13 +196,16 @@ void FILESYSTEM_mountassets(const char* path)
 		} else {
 			graphics.assetdir = zip_path;
 		}
+		FILESYSTEM_assetsmounted = true;
 		graphics.reloadresources();
 	} else if (FILESYSTEM_directoryExists(dirpath.c_str())) {
 		printf("Custom asset directory exists at %s\n",dirpath.c_str());
 		FILESYSTEM_mount(dirpath.c_str());
 		graphics.reloadresources();
+		FILESYSTEM_assetsmounted = true;
 	} else {
 		printf("Custom asset directory does not exist\n");
+		FILESYSTEM_assetsmounted = false;
 	}
 }
 
@@ -216,6 +222,7 @@ void FILESYSTEM_unmountassets()
 	{
 		printf("Cannot unmount when no asset directory is mounted\n");
 	}
+	FILESYSTEM_assetsmounted = false;
 }
 
 void FILESYSTEM_loadFileToMemory(

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -15,6 +15,7 @@ char *FILESYSTEM_getUserLevelDirectory();
 
 bool FILESYSTEM_directoryExists(const char *fname);
 void FILESYSTEM_mount(const char *fname);
+extern bool FILESYSTEM_assetsmounted;
 void FILESYSTEM_mountassets(const char *path);
 void FILESYSTEM_unmountassets();
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -634,6 +634,7 @@ void Graphics::drawtile( int x, int y, int t )
 {
     if (!INBOUNDS(t, tiles))
     {
+        WHINE_ONCE("drawtile() out-of-bounds!")
         return;
     }
 
@@ -657,6 +658,7 @@ void Graphics::drawtile2( int x, int y, int t )
 {
     if (!INBOUNDS(t, tiles2))
     {
+        WHINE_ONCE("drawtile2() out-of-bounds!")
         return;
     }
 
@@ -681,6 +683,7 @@ void Graphics::drawtile3( int x, int y, int t, int off )
 {
     if (!INBOUNDS(t, tiles3))
     {
+        WHINE_ONCE("drawtile3() out-of-bounds!")
         return;
     }
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
@@ -691,6 +694,7 @@ void Graphics::drawentcolours( int x, int y, int t)
 {
     if (!INBOUNDS(t, entcolours))
     {
+        WHINE_ONCE("drawentcolours() out-of-bounds!")
         return;
     }
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
@@ -701,6 +705,7 @@ void Graphics::drawtowertile( int x, int y, int t )
 {
     if (!INBOUNDS(t, tiles2))
     {
+        WHINE_ONCE("drawtowertile() out-of-bounds!")
         return;
     }
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
@@ -713,6 +718,7 @@ void Graphics::drawtowertile3( int x, int y, int t, int off )
     t += off*30;
     if (!INBOUNDS(t, tiles3))
     {
+        WHINE_ONCE("drawtowertile3() out-of-bounds!")
         return;
     }
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
@@ -3112,6 +3118,7 @@ void Graphics::drawforetile(int x, int y, int t)
 {
 	if (!INBOUNDS(t, tiles))
 	{
+		WHINE_ONCE("drawforetile() out-of-bounds!")
 		return;
 	}
 
@@ -3135,6 +3142,7 @@ void Graphics::drawforetile2(int x, int y, int t)
 {
 	if (!INBOUNDS(t, tiles2))
 	{
+		WHINE_ONCE("drawforetile2() out-of-bounds!")
 		return;
 	}
 
@@ -3159,6 +3167,7 @@ void Graphics::drawforetile3(int x, int y, int t, int off)
 	t += off * 30;
 	if (!INBOUNDS(t, tiles3))
 	{
+		WHINE_ONCE("drawforetile3() out-of-bounds!")
 		return;
 	}
 	SDL_Rect rect;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -640,7 +640,7 @@ void Graphics::drawtile( int x, int y, int t )
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
 
 #if !defined(NO_CUSTOM_LEVELS)
-    if (t >= 14 && t <= 17)
+    if (t >= 14 && t <= 17 && !FILESYSTEM_assetsmounted)
     {
         colourTransform thect = {ed.getonewaycol()};
         BlitSurfaceTinted(tiles[t], NULL, backBuffer, &rect, thect);
@@ -663,7 +663,7 @@ void Graphics::drawtile2( int x, int y, int t )
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
 
 #if !defined(NO_CUSTOM_LEVELS)
-    if (t >= 14 && t <= 17)
+    if (t >= 14 && t <= 17 && !FILESYSTEM_assetsmounted)
     {
         colourTransform thect = {ed.getonewaycol()};
         BlitSurfaceTinted(tiles2[t], NULL, backBuffer, &rect, thect);
@@ -3119,7 +3119,7 @@ void Graphics::drawforetile(int x, int y, int t)
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
 
 #if !defined(NO_CUSTOM_LEVELS)
-	if (t >= 14 && t <= 17)
+	if (t >= 14 && t <= 17 && !FILESYSTEM_assetsmounted)
 	{
 		colourTransform thect = {ed.getonewaycol()};
 		BlitSurfaceTinted(tiles[t], NULL, foregroundBuffer, &rect, thect);
@@ -3142,7 +3142,7 @@ void Graphics::drawforetile2(int x, int y, int t)
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
 
 #if !defined(NO_CUSTOM_LEVELS)
-	if (t >= 14 && t <= 17)
+	if (t >= 14 && t <= 17 && !FILESYSTEM_assetsmounted)
 	{
 		colourTransform thect = {ed.getonewaycol()};
 		BlitSurfaceTinted(tiles2[t], NULL, foregroundBuffer, &rect, thect);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3110,6 +3110,11 @@ void Graphics::setcolreal(Uint32 t)
 
 void Graphics::drawforetile(int x, int y, int t)
 {
+	if (!INBOUNDS(t, tiles))
+	{
+		return;
+	}
+
 	SDL_Rect rect;
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
 
@@ -3128,6 +3133,11 @@ void Graphics::drawforetile(int x, int y, int t)
 
 void Graphics::drawforetile2(int x, int y, int t)
 {
+	if (!INBOUNDS(t, tiles2))
+	{
+		return;
+	}
+
 	SDL_Rect rect;
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
 
@@ -3146,9 +3156,14 @@ void Graphics::drawforetile2(int x, int y, int t)
 
 void Graphics::drawforetile3(int x, int y, int t, int off)
 {
+	t += off * 30;
+	if (!INBOUNDS(t, tiles3))
+	{
+		return;
+	}
 	SDL_Rect rect;
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
-	BlitSurfaceStandard(tiles3[t+(off*30)],NULL, foregroundBuffer, &rect  );
+	BlitSurfaceStandard(tiles3[t],NULL, foregroundBuffer, &rect  );
 }
 
 void Graphics::drawrect(int x, int y, int w, int h, int r, int g, int b)

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -640,7 +640,7 @@ void Graphics::drawtile( int x, int y, int t )
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
 
 #if !defined(NO_CUSTOM_LEVELS)
-    if (t >= 14 && t <= 17 && !FILESYSTEM_assetsmounted)
+    if (t >= 14 && t <= 17 && (!FILESYSTEM_assetsmounted || ed.onewaycol_override))
     {
         colourTransform thect = {ed.getonewaycol()};
         BlitSurfaceTinted(tiles[t], NULL, backBuffer, &rect, thect);
@@ -663,7 +663,7 @@ void Graphics::drawtile2( int x, int y, int t )
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
 
 #if !defined(NO_CUSTOM_LEVELS)
-    if (t >= 14 && t <= 17 && !FILESYSTEM_assetsmounted)
+    if (t >= 14 && t <= 17 && (!FILESYSTEM_assetsmounted || ed.onewaycol_override))
     {
         colourTransform thect = {ed.getonewaycol()};
         BlitSurfaceTinted(tiles2[t], NULL, backBuffer, &rect, thect);
@@ -3119,7 +3119,7 @@ void Graphics::drawforetile(int x, int y, int t)
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
 
 #if !defined(NO_CUSTOM_LEVELS)
-	if (t >= 14 && t <= 17 && !FILESYSTEM_assetsmounted)
+	if (t >= 14 && t <= 17 && (!FILESYSTEM_assetsmounted || ed.onewaycol_override))
 	{
 		colourTransform thect = {ed.getonewaycol()};
 		BlitSurfaceTinted(tiles[t], NULL, foregroundBuffer, &rect, thect);
@@ -3142,7 +3142,7 @@ void Graphics::drawforetile2(int x, int y, int t)
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
 
 #if !defined(NO_CUSTOM_LEVELS)
-	if (t >= 14 && t <= 17 && !FILESYSTEM_assetsmounted)
+	if (t >= 14 && t <= 17 && (!FILESYSTEM_assetsmounted || ed.onewaycol_override))
 	{
 		colourTransform thect = {ed.getonewaycol()};
 		BlitSurfaceTinted(tiles2[t], NULL, foregroundBuffer, &rect, thect);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -636,8 +636,20 @@ void Graphics::drawtile( int x, int y, int t )
     {
         return;
     }
+
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
-    BlitSurfaceStandard(tiles[t], NULL, backBuffer, &rect);
+
+#if !defined(NO_CUSTOM_LEVELS)
+    if (t >= 14 && t <= 17)
+    {
+        colourTransform thect = {ed.getonewaycol()};
+        BlitSurfaceTinted(tiles[t], NULL, backBuffer, &rect, thect);
+    }
+    else
+#endif
+    {
+        BlitSurfaceStandard(tiles[t], NULL, backBuffer, &rect);
+    }
 }
 
 
@@ -647,8 +659,20 @@ void Graphics::drawtile2( int x, int y, int t )
     {
         return;
     }
+
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
-    BlitSurfaceStandard(tiles2[t], NULL, backBuffer, &rect);
+
+#if !defined(NO_CUSTOM_LEVELS)
+    if (t >= 14 && t <= 17)
+    {
+        colourTransform thect = {ed.getonewaycol()};
+        BlitSurfaceTinted(tiles2[t], NULL, backBuffer, &rect, thect);
+    }
+    else
+#endif
+    {
+        BlitSurfaceStandard(tiles2[t], NULL, backBuffer, &rect);
+    }
 }
 
 
@@ -3088,14 +3112,36 @@ void Graphics::drawforetile(int x, int y, int t)
 {
 	SDL_Rect rect;
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
-	BlitSurfaceStandard(tiles[t],NULL, foregroundBuffer, &rect  );
+
+#if !defined(NO_CUSTOM_LEVELS)
+	if (t >= 14 && t <= 17)
+	{
+		colourTransform thect = {ed.getonewaycol()};
+		BlitSurfaceTinted(tiles[t], NULL, foregroundBuffer, &rect, thect);
+	}
+	else
+#endif
+	{
+		BlitSurfaceStandard(tiles[t],NULL, foregroundBuffer, &rect  );
+	}
 }
 
 void Graphics::drawforetile2(int x, int y, int t)
 {
 	SDL_Rect rect;
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
-	BlitSurfaceStandard(tiles2[t],NULL, foregroundBuffer, &rect  );
+
+#if !defined(NO_CUSTOM_LEVELS)
+	if (t >= 14 && t <= 17)
+	{
+		colourTransform thect = {ed.getonewaycol()};
+		BlitSurfaceTinted(tiles2[t], NULL, foregroundBuffer, &rect, thect);
+	}
+	else
+#endif
+	{
+		BlitSurfaceStandard(tiles2[t],NULL, foregroundBuffer, &rect  );
+	}
 }
 
 void Graphics::drawforetile3(int x, int y, int t, int off)

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -17,6 +17,14 @@ bool endsWith(const std::string& str, const std::string& suffix);
 
 #define INBOUNDS(index, vector) ((int) index >= 0 && (int) index < (int) vector.size())
 
+#define WHINE_ONCE(message) \
+    static bool whine = true; \
+    if (whine) \
+    { \
+        whine = false; \
+        puts(message); \
+    }
+
 
 //helperClass
 class UtilityClass

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -5558,6 +5558,183 @@ void editorinput()
 }
 #endif /* NO_EDITOR */
 
+// Return a graphics-ready color based off of the given tileset and tilecol
+// Much kudos to Dav999 for saving me a lot of work, because I stole these colors from const.lua in Ved! -Info Teddy
+Uint32 editorclass::getonewaycol(const int rx, const int ry)
+{
+    const int roomnum = rx + ry*maxwidth;
+    if (roomnum < 0 || roomnum >= 400)
+    {
+        return graphics.getRGB(255, 255, 255);
+    }
+    const edlevelclass& room = level[roomnum];
+    switch (room.tileset) {
+
+    case 0: // Space Station
+        switch (room.tilecol) {
+        case -1:
+            return graphics.getRGB(109, 109, 109);
+        case 0:
+            return graphics.getRGB(131, 141, 235);
+        case 1:
+            return graphics.getRGB(227, 140, 227);
+        case 2:
+            return graphics.getRGB(242, 126, 151);
+        case 3:
+            return graphics.getRGB(229, 235, 133);
+        case 4:
+            return graphics.getRGB(148, 238, 130);
+        case 5:
+            return graphics.getRGB(140, 165, 227);
+        case 6:
+            return graphics.getRGB(227, 140, 148);
+        case 7:
+            return graphics.getRGB(140, 173, 228);
+        case 8:
+            return graphics.getRGB(142, 235, 137);
+        case 9:
+            return graphics.getRGB(137, 235, 206);
+        case 10:
+            return graphics.getRGB(235, 139, 223);
+        case 11:
+            return graphics.getRGB(238, 130, 138);
+        case 12:
+            return graphics.getRGB(137, 235, 178);
+        case 13:
+            return graphics.getRGB(125, 205, 247);
+        case 14:
+            return graphics.getRGB(190, 137, 235);
+        case 15:
+            return graphics.getRGB(235, 137, 206);
+        case 16:
+            return graphics.getRGB(229, 247, 127);
+        case 17:
+            return graphics.getRGB(127, 200, 247);
+        case 18:
+            return graphics.getRGB(197, 137, 235);
+        case 19:
+            return graphics.getRGB(235, 131, 175);
+        case 20:
+            return graphics.getRGB(242, 210, 123);
+        case 21:
+            return graphics.getRGB(131, 235, 158);
+        case 22:
+            return graphics.getRGB(242, 126, 151);
+        case 23:
+            return graphics.getRGB(219, 243, 123);
+        case 24:
+            return graphics.getRGB(131, 234, 145);
+        case 25:
+            return graphics.getRGB(131, 199, 234);
+        case 26:
+            return graphics.getRGB(141, 131, 234);
+        case 27:
+            return graphics.getRGB(226, 140, 144);
+        case 28:
+            return graphics.getRGB(129, 236, 144);
+        case 29:
+            return graphics.getRGB(235, 231, 131);
+        case 30:
+            return graphics.getRGB(153, 235, 131);
+        case 31:
+            return graphics.getRGB(207, 131, 235);
+        }
+        break;
+
+    case 1: // Outside
+        switch (room.tilecol) {
+        case 0:
+            return graphics.getRGB(57, 86, 140);
+        case 1:
+            return graphics.getRGB(156, 42, 42);
+        case 2:
+            return graphics.getRGB(42, 156, 155);
+        case 3:
+            return graphics.getRGB(125, 36, 162);
+        case 4:
+            return graphics.getRGB(191, 198, 0);
+        case 5:
+            return graphics.getRGB(0, 198, 126);
+        case 6:
+            return graphics.getRGB(224, 110, 177);
+        case 7:
+            return graphics.getRGB(255, 142, 87);
+        }
+        break;
+
+    case 2: // Lab
+        switch (room.tilecol) {
+        case 0:
+            return graphics.getRGB(0, 165, 206);
+        case 1:
+            return graphics.getRGB(206, 5, 0);
+        case 2:
+            return graphics.getRGB(222, 0, 173);
+        case 3:
+            return graphics.getRGB(27, 67, 255);
+        case 4:
+            return graphics.getRGB(194, 206, 0);
+        case 5:
+            return graphics.getRGB(0, 206, 39);
+        case 6:
+            return graphics.getRGB(0, 165, 206);
+        }
+        break;
+
+    case 3: // Warp Zone
+        switch (room.tilecol) {
+        case 0:
+            return graphics.getRGB(113, 178, 197);
+        case 1:
+            return graphics.getRGB(197, 113, 119);
+        case 2:
+            return graphics.getRGB(196, 113, 197);
+        case 3:
+            return graphics.getRGB(149, 113, 197);
+        case 4:
+            return graphics.getRGB(197, 182, 113);
+        case 5:
+            return graphics.getRGB(141, 197, 113);
+        case 6:
+            return graphics.getRGB(109, 109, 109);
+        }
+        break;
+
+    case 4: // Ship
+        switch (room.tilecol) {
+        case 0:
+            return graphics.getRGB(0, 206, 39);
+        case 1:
+            return graphics.getRGB(0, 165, 206);
+        case 2:
+            return graphics.getRGB(194, 206, 0);
+        case 3:
+            return graphics.getRGB(206, 0, 160);
+        case 4:
+            return graphics.getRGB(27, 67, 255);
+        case 5:
+            return graphics.getRGB(206, 5, 0);
+        }
+        break;
+
+    }
+
+    // Uh, I guess return solid white
+    return graphics.getRGB(255, 255, 255);
+}
+
+// This version detects the room automatically
+Uint32 editorclass::getonewaycol()
+{
+    if (game.gamestate == EDITORMODE)
+        return getonewaycol(ed.levx, ed.levy);
+    else if (map.custommode)
+        return getonewaycol(game.roomx - 100, game.roomy - 100);
+
+    // Uh, I guess return solid white
+    return graphics.getRGB(255, 255, 255);
+}
+
 int editorclass::numtrinkets()
 {
     int temp = 0;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -398,6 +398,8 @@ void editorclass::reset()
 
     ghosts.clear();
     currentghosts = 0;
+
+    onewaycol_override = false;
 }
 
 void editorclass::gethooks()
@@ -1708,6 +1710,11 @@ bool editorclass::load(std::string& _path)
                 {
                     website = pText;
                 }
+
+                if(pKey == "onewaycol_override")
+                {
+                    onewaycol_override = atoi(pText);
+                }
             }
         }
 
@@ -1992,6 +1999,13 @@ bool editorclass::save(std::string& _path)
     meta = doc.NewElement( "website" );
     meta->LinkEndChild( doc.NewText( website.c_str() ));
     msg->LinkEndChild( meta );
+
+    if (onewaycol_override)
+    {
+        meta = doc.NewElement( "onewaycol_override" );
+        meta->LinkEndChild( doc.NewText( help.String(onewaycol_override).c_str() ));
+        msg->LinkEndChild( meta );
+    }
 
     data->LinkEndChild( msg );
 

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -241,6 +241,7 @@ class editorclass{
 
   Uint32 getonewaycol(const int rx, const int ry);
   Uint32 getonewaycol();
+  bool onewaycol_override;
 
   int returneditoralpha;
   int oldreturneditoralpha;

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -239,6 +239,9 @@ class editorclass{
   int dmtile;
   int dmtileeditor;
 
+  Uint32 getonewaycol(const int rx, const int ry);
+  Uint32 getonewaycol();
+
   int returneditoralpha;
   int oldreturneditoralpha;
 


### PR DESCRIPTION
One-ways have always had this problem where they're always yellow. That means unless you specifically use yellow, it'll never match the tileset.

The best way to fix this without requiring new graphics or changing existing ones is to simply re-tint the one-way with the given color of the room. That way, the black part of the tile is still black, but the yellow is now some other color.

But existing custom levels already re-texture the one-way tiles and some of them probably don't want the re-color. So if custom assets are mounted, then don't re-color the one-ways.

But new custom levels might want to take advantage of the re-color anyway, so there's now an override switch if a certain tag is present in the XML to use the re-color anyway even if assets are mounted.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
