### PR TITLE
Adhere to "locked" gravity/warp lines

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2657,26 +2657,46 @@ void editorrender()
                     int tx=edentity[i].x-(ed.levx*40);
                     int tx2=edentity[i].x-(ed.levx*40);
                     int ty=edentity[i].y-(ed.levy*30);
-                    while(ed.spikefree(tx,ty)==0) tx--;
-                    while(ed.spikefree(tx2,ty)==0) tx2++;
-                    tx++;
+                    if (edentity[i].p4 != 1)
+                    {
+                        // Unlocked
+                        while(ed.spikefree(tx,ty)==0) tx--;
+                        while(ed.spikefree(tx2,ty)==0) tx2++;
+                        tx++;
+                        edentity[i].p2=tx;
+                        edentity[i].p3=(tx2-tx)*8;
+                    }
+                    else
+                    {
+                        // Locked
+                        tx = edentity[i].p2;
+                        tx2 = tx + edentity[i].p3/8;
+                    }
                     FillRect(graphics.backBuffer, (tx*8),(ty*8)+4, (tx2-tx)*8,1, graphics.getRGB(194,194,194));
                     fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(164,255,164));
-                    edentity[i].p2=tx;
-                    edentity[i].p3=(tx2-tx)*8;
                 }
                 else  //Vertical
                 {
                     int tx=edentity[i].x-(ed.levx*40);
                     int ty=edentity[i].y-(ed.levy*30);
                     int ty2=edentity[i].y-(ed.levy*30);
-                    while(ed.spikefree(tx,ty)==0) ty--;
-                    while(ed.spikefree(tx,ty2)==0) ty2++;
-                    ty++;
+                    if (edentity[i].p4 != 1)
+                    {
+                        // Unlocked
+                        while(ed.spikefree(tx,ty)==0) ty--;
+                        while(ed.spikefree(tx,ty2)==0) ty2++;
+                        ty++;
+                        edentity[i].p2=ty;
+                        edentity[i].p3=(ty2-ty)*8;
+                    }
+                    else
+                    {
+                        // Locked
+                        ty = edentity[i].p2;
+                        ty2 = ty + edentity[i].p3/8;
+                    }
                     FillRect(graphics.backBuffer, (tx*8)+3,(ty*8), 1,(ty2-ty)*8, graphics.getRGB(194,194,194));
                     fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(164,255,164));
-                    edentity[i].p2=ty;
-                    edentity[i].p3=(ty2-ty)*8;
                 }
                 break;
             case 13://Warp tokens
@@ -2749,26 +2769,46 @@ void editorrender()
                     int tx=edentity[i].x-(ed.levx*40);
                     int tx2=edentity[i].x-(ed.levx*40);
                     int ty=edentity[i].y-(ed.levy*30);
-                    while(ed.free(tx,ty)==0) tx--;
-                    while(ed.free(tx2,ty)==0) tx2++;
-                    tx++;
+                    if (edentity[i].p4 != 1)
+                    {
+                        // Unlocked
+                        while(ed.free(tx,ty)==0) tx--;
+                        while(ed.free(tx2,ty)==0) tx2++;
+                        tx++;
+                        edentity[i].p2=tx;
+                        edentity[i].p3=(tx2-tx)*8;
+                    }
+                    else
+                    {
+                        // Locked
+                        tx = edentity[i].p2;
+                        tx2 = tx + edentity[i].p3/8;
+                    }
                     fillboxabs((tx*8),(ty*8)+1, (tx2-tx)*8,6, graphics.getRGB(255,255,194));
                     fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(255,255,164));
-                    edentity[i].p2=tx;
-                    edentity[i].p3=(tx2-tx)*8;
                 }
                 else  //Vertical
                 {
                     int tx=edentity[i].x-(ed.levx*40);
                     int ty=edentity[i].y-(ed.levy*30);
                     int ty2=edentity[i].y-(ed.levy*30);
-                    while(ed.free(tx,ty)==0) ty--;
-                    while(ed.free(tx,ty2)==0) ty2++;
-                    ty++;
+                    if (edentity[i].p4 != 1)
+                    {
+                        // Unlocked
+                        while(ed.free(tx,ty)==0) ty--;
+                        while(ed.free(tx,ty2)==0) ty2++;
+                        ty++;
+                        edentity[i].p2=ty;
+                        edentity[i].p3=(ty2-ty)*8;
+                    }
+                    else
+                    {
+                        // Locked
+                        ty = edentity[i].p2;
+                        ty2 = ty + edentity[i].p3/8;
+                    }
                     fillboxabs((tx*8)+1,(ty*8), 6,(ty2-ty)*8, graphics.getRGB(255,255,194));
                     fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(255,255,164));
-                    edentity[i].p2=ty;
-                    edentity[i].p3=(ty2-ty)*8;
                 }
                 break;
             }


### PR DESCRIPTION
Ved has this useful feature where you can "lock" a gravity line or warp line in place, meaning it'll no longer extend its length until it touches a tile. A line is locked if the p4 of the edentity is 1.

VVVVVV doesn't support this, but now it does. The horrifying thing is that it stretches the lines out *while rendering the line*, so it looks like logic and rendering aren't that separate after all (although, I already learned that when I did my over-30-FPS patch).

## Changes:

Describe your patch here!


## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
