### PR TITLE
Parse all headers from binary blobs

### DIFF
--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -103,6 +103,7 @@ bool binaryBlob::unPackBinary(const char* name)
 
 		if (m_headers[i].valid & ~0x1 || !m_headers[i].valid)
 		{
+			m_headers[i].valid = false;
 			continue; /* Must be EXACTLY 1 or 0 */
 		}
 		if (m_headers[i].size < 1)

--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -173,3 +173,19 @@ char* binaryBlob::getAddress(int _index)
 {
 	return m_memblocks[_index];
 }
+
+std::vector<int> binaryBlob::getExtra()
+{
+	std::vector<int> result;
+	for (int i = 0; i < 128; i += 1)
+	{
+		if (m_headers[i].valid
+#define FOREACH_TRACK(track_name) && strcmp(m_headers[i].name, track_name) != 0
+		TRACK_NAMES
+#undef FOREACH_TRACK
+		) {
+			result.push_back(i);
+		}
+	}
+	return result;
+}

--- a/desktop_version/src/BinaryBlob.h
+++ b/desktop_version/src/BinaryBlob.h
@@ -4,6 +4,24 @@
 /* Laaaazyyyyyyy -flibit */
 // #define VVV_COMPILEMUSIC
 
+#define TRACK_NAMES \
+	FOREACH_TRACK("data/music/0levelcomplete.ogg") \
+	FOREACH_TRACK("data/music/1pushingonwards.ogg") \
+	FOREACH_TRACK("data/music/2positiveforce.ogg") \
+	FOREACH_TRACK("data/music/3potentialforanything.ogg") \
+	FOREACH_TRACK("data/music/4passionforexploring.ogg") \
+	FOREACH_TRACK("data/music/5intermission.ogg") \
+	FOREACH_TRACK("data/music/6presentingvvvvvv.ogg") \
+	FOREACH_TRACK("data/music/7gamecomplete.ogg") \
+	FOREACH_TRACK("data/music/8predestinedfate.ogg") \
+	FOREACH_TRACK("data/music/9positiveforcereversed.ogg") \
+	FOREACH_TRACK("data/music/10popularpotpourri.ogg") \
+	FOREACH_TRACK("data/music/11pipedream.ogg") \
+	FOREACH_TRACK("data/music/12pressurecooker.ogg") \
+	FOREACH_TRACK("data/music/13pacedenergy.ogg") \
+	FOREACH_TRACK("data/music/14piercingthesky.ogg") \
+	FOREACH_TRACK("data/music/predestinedfatefinallevel.ogg")
+
 struct resourceheader
 {
 	char name[48];

--- a/desktop_version/src/BinaryBlob.h
+++ b/desktop_version/src/BinaryBlob.h
@@ -1,6 +1,8 @@
 #ifndef BINARYBLOB_H
 #define BINARYBLOB_H
 
+#include <vector>
+
 /* Laaaazyyyyyyy -flibit */
 // #define VVV_COMPILEMUSIC
 
@@ -46,6 +48,8 @@ public:
 	int getIndex(const char* _name);
 
 	int getSize(int _index);
+
+	std::vector<int> getExtra();
 
 	char* getAddress(int _index);
 

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -78,6 +78,14 @@ void musicclass::init()
 
 		TRACK_NAMES
 
+		const std::vector<int> extra = musicReadBlob.getExtra();
+		for (size_t i = 0; i < extra.size(); i++)
+		{
+			const int& index = extra[i];
+			rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
+			musicTracks.push_back(MusicTrack( rw ));
+		}
+
 		bool ohCrap = musicReadBlob.unPackBinary("vvvvvvmusic.vvv");
 		SDL_assert(ohCrap && "Music not found!");
 	}
@@ -88,6 +96,14 @@ void musicclass::init()
 	TRACK_NAMES
 
 #undef FOREACH_TRACK
+
+	const std::vector<int> extra = musicReadBlob.getExtra();
+	for (size_t i = 0; i < extra.size(); i++)
+	{
+		const int& index = extra[i];
+		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
+		musicTracks.push_back(MusicTrack( rw ));
+	}
 
 	safeToProcessMusic= false;
 	m_doFadeInVol = false;

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -163,6 +163,12 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 		if (t != -1)
 		{
 			currentsong = t;
+			if (!INBOUNDS(t, musicTracks))
+			{
+				puts("play() out-of-bounds!");
+				currentsong = -1;
+				return;
+			}
 			if (currentsong == 0 || currentsong == 7 || (!map.custommode && (currentsong == 0+num_pppppp_tracks || currentsong == 7+num_pppppp_tracks)))
 			{
 				// Level Complete theme, no fade in or repeat

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -50,22 +50,9 @@ void musicclass::init()
 
 #ifdef VVV_COMPILEMUSIC
 	binaryBlob musicWriteBlob;
-	musicWriteBlob.AddFileToBinaryBlob("data/music/0levelcomplete.ogg");
-	musicWriteBlob.AddFileToBinaryBlob("data/music/1pushingonwards.ogg");
-	musicWriteBlob.AddFileToBinaryBlob("data/music/2positiveforce.ogg");
-	musicWriteBlob.AddFileToBinaryBlob("data/music/3potentialforanything.ogg");
-	musicWriteBlob.AddFileToBinaryBlob("data/music/4passionforexploring.ogg");
-	musicWriteBlob.AddFileToBinaryBlob("data/music/5intermission.ogg");
-	musicWriteBlob.AddFileToBinaryBlob("data/music/6presentingvvvvvv.ogg");
-	musicWriteBlob.AddFileToBinaryBlob("data/music/7gamecomplete.ogg");
-	musicWriteBlob.AddFileToBinaryBlob("data/music/8predestinedfate.ogg");
-	musicWriteBlob.AddFileToBinaryBlob("data/music/9positiveforcereversed.ogg");
-	musicWriteBlob.AddFileToBinaryBlob("data/music/10popularpotpourri.ogg");
-	musicWriteBlob.AddFileToBinaryBlob("data/music/11pipedream.ogg");
-	musicWriteBlob.AddFileToBinaryBlob("data/music/12pressurecooker.ogg");
-	musicWriteBlob.AddFileToBinaryBlob("data/music/13pacedenergy.ogg");
-	musicWriteBlob.AddFileToBinaryBlob("data/music/14piercingthesky.ogg");
-	musicWriteBlob.AddFileToBinaryBlob("data/music/predestinedfatefinallevel.ogg");
+#define FOREACH_TRACK(track_name) musicWriteBlob.AddFileToBinaryBlob(track_name);
+	TRACK_NAMES
+#undef FOREACH_TRACK
 
 	musicWriteBlob.writeBinaryBlob("data/BinaryMusic.vvv");
 #endif
@@ -81,137 +68,26 @@ void musicclass::init()
 	{
 		mmmmmm = true;
 		usingmmmmmm = true;
-		int index = musicReadBlob.getIndex("data/music/0levelcomplete.ogg");
-		SDL_RWops *rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		int index;
+		SDL_RWops *rw;
 
-		index = musicReadBlob.getIndex("data/music/1pushingonwards.ogg");
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+#define FOREACH_TRACK(track_name) \
+	index = musicReadBlob.getIndex(track_name); \
+	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index)); \
+	musicTracks.push_back(MusicTrack( rw ));
 
-		index = musicReadBlob.getIndex("data/music/2positiveforce.ogg");
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
-
-		index = musicReadBlob.getIndex("data/music/3potentialforanything.ogg");
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
-
-		index = musicReadBlob.getIndex("data/music/4passionforexploring.ogg");
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
-
-		index = musicReadBlob.getIndex("data/music/5intermission.ogg");
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
-
-		index = musicReadBlob.getIndex("data/music/6presentingvvvvvv.ogg");
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
-
-		index = musicReadBlob.getIndex("data/music/7gamecomplete.ogg");
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
-
-		index = musicReadBlob.getIndex("data/music/8predestinedfate.ogg");
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
-
-		index = musicReadBlob.getIndex("data/music/9positiveforcereversed.ogg");
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
-
-		index = musicReadBlob.getIndex("data/music/10popularpotpourri.ogg");
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
-
-		index = musicReadBlob.getIndex("data/music/11pipedream.ogg");
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
-
-		index = musicReadBlob.getIndex("data/music/12pressurecooker.ogg");
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
-
-		index = musicReadBlob.getIndex("data/music/13pacedenergy.ogg");
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
-
-		index = musicReadBlob.getIndex("data/music/14piercingthesky.ogg");
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
-
-		index = musicReadBlob.getIndex("data/music/predestinedfatefinallevel.ogg");
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-		musicTracks.push_back(MusicTrack( rw ));
+		TRACK_NAMES
 
 		bool ohCrap = musicReadBlob.unPackBinary("vvvvvvmusic.vvv");
 		SDL_assert(ohCrap && "Music not found!");
 	}
 
-	int index = musicReadBlob.getIndex("data/music/0levelcomplete.ogg");
-	SDL_RWops *rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	int index;
+	SDL_RWops *rw;
 
-	index = musicReadBlob.getIndex("data/music/1pushingonwards.ogg");
-	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+	TRACK_NAMES
 
-	index = musicReadBlob.getIndex("data/music/2positiveforce.ogg");
-	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
-
-	index = musicReadBlob.getIndex("data/music/3potentialforanything.ogg");
-	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
-
-	index = musicReadBlob.getIndex("data/music/4passionforexploring.ogg");
-	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
-
-	index = musicReadBlob.getIndex("data/music/5intermission.ogg");
-	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
-
-	index = musicReadBlob.getIndex("data/music/6presentingvvvvvv.ogg");
-	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
-
-	index = musicReadBlob.getIndex("data/music/7gamecomplete.ogg");
-	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
-
-	index = musicReadBlob.getIndex("data/music/8predestinedfate.ogg");
-	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
-
-	index = musicReadBlob.getIndex("data/music/9positiveforcereversed.ogg");
-	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
-
-	index = musicReadBlob.getIndex("data/music/10popularpotpourri.ogg");
-	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
-
-	index = musicReadBlob.getIndex("data/music/11pipedream.ogg");
-	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
-
-	index = musicReadBlob.getIndex("data/music/12pressurecooker.ogg");
-	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
-
-	index = musicReadBlob.getIndex("data/music/13pacedenergy.ogg");
-	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
-
-	index = musicReadBlob.getIndex("data/music/14piercingthesky.ogg");
-	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
-
-	index = musicReadBlob.getIndex("data/music/predestinedfatefinallevel.ogg");
-	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
-	musicTracks.push_back(MusicTrack( rw ));
+#undef FOREACH_TRACK
 
 	safeToProcessMusic= false;
 	m_doFadeInVol = false;

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -57,6 +57,9 @@ void musicclass::init()
 	musicWriteBlob.writeBinaryBlob("data/BinaryMusic.vvv");
 #endif
 
+	num_mmmmmm_tracks = 0;
+	num_pppppp_tracks = 0;
+
 	if (!musicReadBlob.unPackBinary("mmmmmm.vvv"))
 	{
 		mmmmmm = false;
@@ -78,12 +81,16 @@ void musicclass::init()
 
 		TRACK_NAMES
 
+		num_mmmmmm_tracks += 16;
+
 		const std::vector<int> extra = musicReadBlob.getExtra();
 		for (size_t i = 0; i < extra.size(); i++)
 		{
 			const int& index = extra[i];
 			rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
 			musicTracks.push_back(MusicTrack( rw ));
+
+			num_mmmmmm_tracks++;
 		}
 
 		bool ohCrap = musicReadBlob.unPackBinary("vvvvvvmusic.vvv");
@@ -97,12 +104,16 @@ void musicclass::init()
 
 #undef FOREACH_TRACK
 
+	num_pppppp_tracks += 16;
+
 	const std::vector<int> extra = musicReadBlob.getExtra();
 	for (size_t i = 0; i < extra.size(); i++)
 	{
 		const int& index = extra[i];
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
 		musicTracks.push_back(MusicTrack( rw ));
+
+		num_pppppp_tracks++;
 	}
 
 	safeToProcessMusic= false;
@@ -131,14 +142,19 @@ void songend()
 
 void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fadein_ms /*= 3000*/)
 {
-	t = (t % 16);
-
-	if(mmmmmm)
+	// No need to check if num_tracks is greater than 0, we wouldn't be here if it wasn't
+	if (mmmmmm && usingmmmmmm)
 	{
-		if(!usingmmmmmm)
-		{
-			t += 16;
-		}
+		t %= num_mmmmmm_tracks;
+	}
+	else
+	{
+		t %= num_pppppp_tracks;
+	}
+
+	if(mmmmmm && !usingmmmmmm)
+	{
+		t += num_mmmmmm_tracks;
 	}
 	safeToProcessMusic = true;
 	Mix_VolumeMusic(128);
@@ -147,7 +163,7 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 		if (t != -1)
 		{
 			currentsong = t;
-			if (currentsong == 0 || currentsong == 7 || (!map.custommode && (currentsong == 16 || currentsong == 23)))
+			if (currentsong == 0 || currentsong == 7 || (!map.custommode && (currentsong == 0+num_pppppp_tracks || currentsong == 7+num_pppppp_tracks)))
 			{
 				// Level Complete theme, no fade in or repeat
 				if(Mix_FadeInMusicPos(musicTracks[t].m_music, 0, 0, position_sec)==-1)

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -51,6 +51,8 @@ public:
 	bool usingmmmmmm;
 
 	binaryBlob musicReadBlob;
+	int num_pppppp_tracks;
+	int num_mmmmmm_tracks;
 
 	Uint64 songStart;
 	Uint64 songEnd;

--- a/desktop_version/src/SoundSystem.cpp
+++ b/desktop_version/src/SoundSystem.cpp
@@ -8,7 +8,7 @@ MusicTrack::MusicTrack(const char* fileName)
 	m_isValid = true;
 	if(m_music == NULL)
 	{
-		fprintf(stderr, "Unable to load Ogg Music file: %s\n", Mix_GetError());;
+		fprintf(stderr, "Unable to load Ogg Music file: %s\n", Mix_GetError());
 		m_isValid = false;
 	}
 }


### PR DESCRIPTION
Previously, the game didn't parse all headers from a given binary blob. It would look for headers with very specific names and only parse those.

This patch makes it so that all headers will be parsed and loaded. Headers with said specific names will still get priority and be loaded first, though, in case there happen to be binary blobs where the index of one of those headers isn't in the range 0..16. Then the extra headers are parsed in order according to their index.

`musicclass::play()` has been adjusted accordingly to accomodate for the new tracks, and the `music(-1)` trick still works (it plays the last MMMMMM track if you have MMMMMM and you're on PPPPPP).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
