### PR TITLE
Allow using tracks 0..15 in the editor

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2404,11 +2404,20 @@ void editormenurender(int tr, int tg, int tb)
         case 4:
             songname = "4: Passion for Exploring";
             break;
+        case 5:
+            songname = "N/A: Pause";
+            break;
         case 6:
             songname = "5: Presenting VVVVVV";
             break;
+        case 7:
+            songname = "N/A: Plenary";
+            break;
         case 8:
             songname = "6: Predestined Fate";
+            break;
+        case 9:
+            songname = "N/A: ecroF evitisoP";
             break;
         case 10:
             songname = "7: Popular Potpourri";
@@ -2424,6 +2433,9 @@ void editormenurender(int tr, int tg, int tb)
             break;
         case 14:
             songname = "11: Piercing the Sky";
+            break;
+        case 15:
+            songname = "N/A: Predestined Fate Remix";
             break;
         default:
             songname = "?: something else";

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2382,52 +2382,56 @@ void editormenurender(int tr, int tg, int tb)
         }
         break;
     case Menu::ed_music:
+    {
         graphics.bigprint( -1, 65, "Map Music", tr, tg, tb, true);
 
         graphics.Print( -1, 85, "Current map music:", tr, tg, tb, true);
+        std::string songname;
         switch(ed.levmusic)
         {
         case 0:
-            graphics.Print( -1, 120, "No background music", tr, tg, tb, true);
+            songname = "No background music";
             break;
         case 1:
-            graphics.Print( -1, 120, "1: Pushing Onwards", tr, tg, tb, true);
+            songname = "1: Pushing Onwards";
             break;
         case 2:
-            graphics.Print( -1, 120, "2: Positive Force", tr, tg, tb, true);
+            songname = "2: Positive Force";
             break;
         case 3:
-            graphics.Print( -1, 120, "3: Potential for Anything", tr, tg, tb, true);
+            songname = "3: Potential for Anything";
             break;
         case 4:
-            graphics.Print( -1, 120, "4: Passion for Exploring", tr, tg, tb, true);
+            songname = "4: Passion for Exploring";
             break;
         case 6:
-            graphics.Print( -1, 120, "5: Presenting VVVVVV", tr, tg, tb, true);
+            songname = "5: Presenting VVVVVV";
             break;
         case 8:
-            graphics.Print( -1, 120, "6: Predestined Fate", tr, tg, tb, true);
+            songname = "6: Predestined Fate";
             break;
         case 10:
-            graphics.Print( -1, 120, "7: Popular Potpourri", tr, tg, tb, true);
+            songname = "7: Popular Potpourri";
             break;
         case 11:
-            graphics.Print( -1, 120, "8: Pipe Dream", tr, tg, tb, true);
+            songname = "8: Pipe Dream";
             break;
         case 12:
-            graphics.Print( -1, 120, "9: Pressure Cooker", tr, tg, tb, true);
+            songname = "9: Pressure Cooker";
             break;
         case 13:
-            graphics.Print( -1, 120, "10: Paced Energy", tr, tg, tb, true);
+            songname = "10: Paced Energy";
             break;
         case 14:
-            graphics.Print( -1, 120, "11: Piercing the Sky", tr, tg, tb, true);
+            songname = "11: Piercing the Sky";
             break;
         default:
-            graphics.Print( -1, 120, "?: something else", tr, tg, tb, true);
+            songname = "?: something else";
             break;
         }
+        graphics.Print( -1, 120, songname, tr, tg, tb, true);
         break;
+    }
     case Menu::ed_quit:
         graphics.bigprint( -1, 90, "Save before", tr, tg, tb, true);
         graphics.bigprint( -1, 110, "quitting?", tr, tg, tb, true);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3817,10 +3817,7 @@ void editormenuactionpress()
         {
         case 0:
             ed.levmusic++;
-            if(ed.levmusic==5) ed.levmusic=6;
-            if(ed.levmusic==7) ed.levmusic=8;
-            if(ed.levmusic==9) ed.levmusic=10;
-            if(ed.levmusic==15) ed.levmusic=0;
+            if(ed.levmusic==16) ed.levmusic=0;
             if(ed.levmusic>0)
             {
                 music.play(ed.levmusic);


### PR DESCRIPTION
This was already possible by editing the XML or using Ved, yet for some reason the in-game editor interface just wouldn't allow you to do it. Namely, the songs Pause, Plenary, ecroF evitsoP, and Predestined Fate Remix were missing from the track list.

I see no good reason to not allow these songs, so I'm enabling them again.

I kept the old track numbers (e.g. Piercing the Sky is track 11 instead of 14) because otherwise they wouldn't correlate with the track numbers you use for the `music()` simplified command.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
