### PR TITLE
Read and write best time trial frames

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -213,6 +213,7 @@ void Game::init(void)
     tele_crewstats.resize(6);
     quick_crewstats.resize(6);
     besttimes.resize(6, -1);
+    ::memset(bestframes, -1, sizeof(bestframes) * sizeof(int));
     besttrinkets.resize(6, -1);
     bestlives.resize(6, -1);
     bestrank.resize(6, -1);
@@ -1447,9 +1448,12 @@ void Game::updatestate()
             if (trinkets() >= timetrialshinytarget) timetrialrank++;
             if (deathcounts == 0) timetrialrank++;
 
-            if (timetrialresulttime < besttimes[timetriallevel] || besttimes[timetriallevel]==-1)
+            if (timetrialresulttime < besttimes[timetriallevel]
+            || (timetrialresulttime == besttimes[timetriallevel] && timetrialresultframes < bestframes[timetriallevel])
+            || besttimes[timetriallevel]==-1)
             {
                 besttimes[timetriallevel] = timetrialresulttime;
+                bestframes[timetriallevel] = timetrialresultframes;
             }
             if (trinkets() > besttrinkets[timetriallevel] || besttrinkets[timetriallevel]==-1)
             {
@@ -4549,6 +4553,7 @@ void Game::deletestats()
         for (int i = 0; i < 6; i++)
         {
             besttimes[i] = -1;
+            bestframes[i] = -1;
             besttrinkets[i] = -1;
             bestlives[i] = -1;
             bestrank[i] = -1;
@@ -4644,6 +4649,19 @@ void Game::loadstats()
                 for(size_t i = 0; i < values.size(); i++)
                 {
                     besttimes.push_back(atoi(values[i].c_str()));
+                }
+            }
+        }
+
+        if (pKey == "bestframes")
+        {
+            std::string TextString = pText;
+            if (TextString.length())
+            {
+                std::vector<std::string> values = split(TextString, ',');
+                for (size_t i = 0; i < std::min(sizeof(bestframes), values.size()); i++)
+                {
+                    bestframes[i] = atoi(values[i].c_str());
                 }
             }
         }
@@ -4959,6 +4977,15 @@ void Game::savestats()
     }
     msg = doc.NewElement( "besttimes" );
     msg->LinkEndChild( doc.NewText( s_besttimes.c_str() ));
+    dataNode->LinkEndChild( msg );
+
+    std::string s_bestframes;
+    for (size_t i = 0; i < sizeof(bestframes); i++)
+    {
+        s_bestframes += help.String(bestframes[i]) + ",";
+    }
+    msg = doc.NewElement( "bestframes" );
+    msg->LinkEndChild( doc.NewText( s_bestframes.c_str() ) );
     dataNode->LinkEndChild( msg );
 
     std::string s_besttrinkets;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -297,6 +297,7 @@ public:
 
 
     std::vector<int>besttimes;
+    int bestframes[6];
     std::vector<int>besttrinkets;
     std::vector<int>bestlives;
     std::vector<int> bestrank;


### PR DESCRIPTION
This is basically just bolting on the "frames" part of a time trial score. There's not enough space to properly show it on the time trial select screen, maybe we can figure something out later. But I at least want to implement the functionality now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
