### PR TITLE
Add Shift+F1/F2/F3 hotkeys in the editor, allow using Space Station tilecol -1, and refactor editor shortcuts logic and abstract tileset/tilecol/enemy switching

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -4573,6 +4573,24 @@ void editorinput()
         else if (key.keymap[SDLK_LSHIFT] || key.keymap[SDLK_RSHIFT])
         {
             // Shift modifiers
+            if (key.keymap[SDLK_F1])
+            {
+                ed.switch_tileset(true);
+                graphics.backgrounddrawn = false;
+                ed.keydelay = 6;
+            }
+            if (key.keymap[SDLK_F2])
+            {
+                ed.switch_tilecol(true);
+                graphics.backgrounddrawn = false;
+                ed.keydelay = 6;
+            }
+            if (key.keymap[SDLK_F3])
+            {
+                ed.switch_enemy(true);
+                ed.keydelay=6;
+            }
+
             if (up_pressed || down_pressed || left_pressed || right_pressed)
             {
                 ed.keydelay=6;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -4403,11 +4403,90 @@ void editorinput()
                 }
             }
         }
+        else if (ed.keydelay > 0)
+        {
+            ed.keydelay--;
+        }
+        else if (key.keymap[SDLK_LCTRL] || key.keymap[SDLK_RCTRL])
+        {
+            // Ctrl modifiers
+            ed.dmtileeditor=10;
+            if(left_pressed)
+            {
+                ed.dmtile--;
+                ed.keydelay=3;
+                if(ed.dmtile<0) ed.dmtile+=1200;
+            }
+            else if(right_pressed)
+            {
+                ed.dmtile++;
+                ed.keydelay=3;
+
+                if(ed.dmtile>=1200) ed.dmtile-=1200;
+            }
+            if(up_pressed)
+            {
+                ed.dmtile-=40;
+                ed.keydelay=3;
+                if(ed.dmtile<0) ed.dmtile+=1200;
+            }
+            else if(down_pressed)
+            {
+                ed.dmtile+=40;
+                ed.keydelay=3;
+
+                if(ed.dmtile>=1200) ed.dmtile-=1200;
+            }
+        }
+        else if (key.keymap[SDLK_LSHIFT] || key.keymap[SDLK_RSHIFT])
+        {
+            // Shift modifiers
+            if (up_pressed || down_pressed || left_pressed || right_pressed)
+            {
+                ed.keydelay=6;
+                if(up_pressed)
+                {
+                    ed.mapheight--;
+                }
+                else if(down_pressed)
+                {
+                    ed.mapheight++;
+                }
+                else if(left_pressed)
+                {
+                    ed.mapwidth--;
+                }
+                else if(right_pressed)
+                {
+                    ed.mapwidth++;
+                }
+
+                if(ed.mapwidth<1) ed.mapwidth=1;
+                if(ed.mapheight<1) ed.mapheight=1;
+                if(ed.mapwidth>=ed.maxwidth) ed.mapwidth=ed.maxwidth;
+                if(ed.mapheight>=ed.maxheight) ed.mapheight=ed.maxheight;
+                ed.note = "Mapsize is now [" + help.String(ed.mapwidth) + "," + help.String(ed.mapheight) + "]";
+                ed.notedelay=45;
+            }
+
+            if(!ed.shiftkey)
+            {
+                if(ed.shiftmenu)
+                {
+                    ed.shiftmenu=false;
+                }
+                else
+                {
+                    ed.shiftmenu=true;
+                }
+            }
+            ed.shiftkey=true;
+        }
         else
         {
-            //Shortcut keys
-            //TO DO: make more user friendly
-            if(key.keymap[SDLK_F1] && ed.keydelay==0)
+            // No modifiers
+            ed.shiftkey=false;
+            if(key.keymap[SDLK_F1])
             {
                 ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset++;
                 graphics.backgrounddrawn=false;
@@ -4452,7 +4531,7 @@ void editorinput()
                 ed.updatetiles=true;
                 ed.keydelay=6;
             }
-            if(key.keymap[SDLK_F2] && ed.keydelay==0)
+            if(key.keymap[SDLK_F2])
             {
                 ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol++;
                 graphics.backgrounddrawn=false;
@@ -4477,26 +4556,26 @@ void editorinput()
                 ed.notedelay=45;
                 ed.note="Tileset Colour Changed";
             }
-            if(key.keymap[SDLK_F3] && ed.keydelay==0)
+            if(key.keymap[SDLK_F3])
             {
                 ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype=(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype+1)%10;
                 ed.keydelay=6;
                 ed.notedelay=45;
                 ed.note="Enemy Type Changed";
             }
-            if(key.keymap[SDLK_F4] && ed.keydelay==0)
+            if(key.keymap[SDLK_F4])
             {
                 ed.keydelay=6;
                 ed.boundarytype=1;
                 ed.boundarymod=1;
             }
-            if(key.keymap[SDLK_F5] && ed.keydelay==0)
+            if(key.keymap[SDLK_F5])
             {
                 ed.keydelay=6;
                 ed.boundarytype=2;
                 ed.boundarymod=1;
             }
-            if(key.keymap[SDLK_F10] && ed.keydelay==0)
+            if(key.keymap[SDLK_F10])
             {
                 if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].directmode==1)
                 {
@@ -4532,7 +4611,7 @@ void editorinput()
             if(key.keymap[SDLK_o]) ed.drawmode=15;
             if(key.keymap[SDLK_p]) ed.drawmode=16;
 
-            if(key.keymap[SDLK_w] && ed.keydelay==0)
+            if(key.keymap[SDLK_w])
             {
                 int j=0, tx=0, ty=0;
                 for(size_t i=0; i<edentity.size(); i++)
@@ -4582,7 +4661,7 @@ void editorinput()
                 }
                 ed.keydelay=6;
             }
-            if(key.keymap[SDLK_e] && ed.keydelay==0)
+            if(key.keymap[SDLK_e])
             {
                 ed.roomnamemod=true;
                 ed.textentry=true;
@@ -4593,7 +4672,7 @@ void editorinput()
             }
 
             //Save and load
-            if(key.keymap[SDLK_s] && ed.keydelay==0)
+            if(key.keymap[SDLK_s])
             {
                 ed.savemod=true;
                 ed.textentry=true;
@@ -4604,7 +4683,7 @@ void editorinput()
                 graphics.backgrounddrawn=false;
             }
 
-            if(key.keymap[SDLK_l] && ed.keydelay==0)
+            if(key.keymap[SDLK_l])
             {
                 ed.loadmod=true;
                 ed.textentry=true;
@@ -4716,170 +4795,73 @@ void editorinput()
             ed.xmod = key.keymap[SDLK_x];
             ed.zmod = key.keymap[SDLK_z];
 
-            //Keyboard shortcuts
-            if(ed.keydelay>0)
+            if(key.keymap[SDLK_COMMA])
             {
-                ed.keydelay--;
+                ed.drawmode--;
+                ed.keydelay=6;
+            }
+            else if(key.keymap[SDLK_PERIOD])
+            {
+                ed.drawmode++;
+                ed.keydelay=6;
+            }
+
+            if(ed.drawmode<0)
+            {
+                ed.drawmode=16;
+                if(ed.spacemod) ed.spacemenu=0;
+            }
+            if(ed.drawmode>16) ed.drawmode=0;
+            if(ed.drawmode>9)
+            {
+                if(ed.spacemod) ed.spacemenu=1;
             }
             else
             {
-                if(key.keymap[SDLK_LSHIFT] || key.keymap[SDLK_RSHIFT])
-                {
-                    if(up_pressed)
-                    {
-                        ed.keydelay=6;
-                        ed.mapheight--;
-                    }
-                    else if(down_pressed)
-                    {
-                        ed.keydelay=6;
-                        ed.mapheight++;
-                    }
+                if(ed.spacemod) ed.spacemenu=0;
+            }
 
-                    if(left_pressed)
-                    {
-                        ed.keydelay=6;
-                        ed.mapwidth--;
-                    }
-                    else if(right_pressed)
-                    {
-                        ed.keydelay=6;
-                        ed.mapwidth++;
-                    }
-                    if(ed.keydelay==6)
-                    {
-                        if(ed.mapwidth<1) ed.mapwidth=1;
-                        if(ed.mapheight<1) ed.mapheight=1;
-                        if(ed.mapwidth>=ed.maxwidth) ed.mapwidth=ed.maxwidth;
-                        if(ed.mapheight>=ed.maxheight) ed.mapheight=ed.maxheight;
-                        ed.note = "Mapsize is now [" + help.String(ed.mapwidth) + "," + help.String(ed.mapheight) + "]";
-                        ed.notedelay=45;
-                    }
-                }
-                else
-                {
-                    if(key.keymap[SDLK_COMMA])
-                    {
-                        ed.drawmode--;
-                        ed.keydelay=6;
-                    }
-                    else if(key.keymap[SDLK_PERIOD])
-                    {
-                        ed.drawmode++;
-                        ed.keydelay=6;
-                    }
+            if(up_pressed)
+            {
+                ed.keydelay=6;
+                graphics.backgrounddrawn=false;
+                ed.levy--;
+                ed.updatetiles=true;
+                ed.changeroom=true;
+            }
+            else if(down_pressed)
+            {
+                ed.keydelay=6;
+                graphics.backgrounddrawn=false;
+                ed.levy++;
+                ed.updatetiles=true;
+                ed.changeroom=true;
+            }
+            else if(left_pressed)
+            {
+                ed.keydelay=6;
+                graphics.backgrounddrawn=false;
+                ed.levx--;
+                ed.updatetiles=true;
+                ed.changeroom=true;
+            }
+            else if(right_pressed)
+            {
+                ed.keydelay=6;
+                graphics.backgrounddrawn=false;
+                ed.levx++;
+                ed.updatetiles=true;
+                ed.changeroom=true;
+            }
 
-                    if(ed.drawmode<0)
-                    {
-                        ed.drawmode=16;
-                        if(ed.spacemod) ed.spacemenu=0;
-                    }
-                    if(ed.drawmode>16) ed.drawmode=0;
-                    if(ed.drawmode>9)
-                    {
-                        if(ed.spacemod) ed.spacemenu=1;
-                    }
-                    else
-                    {
-                        if(ed.spacemod) ed.spacemenu=0;
-                    }
-
-                    if(key.keymap[SDLK_LCTRL] || key.keymap[SDLK_RCTRL])
-                    {
-                        ed.dmtileeditor=10;
-                        if(left_pressed)
-                        {
-                            ed.dmtile--;
-                            ed.keydelay=3;
-                            if(ed.dmtile<0) ed.dmtile+=1200;
-                        }
-                        else if(right_pressed)
-                        {
-                            ed.dmtile++;
-                            ed.keydelay=3;
-
-                            if(ed.dmtile>=1200) ed.dmtile-=1200;
-                        }
-                        if(up_pressed)
-                        {
-                            ed.dmtile-=40;
-                            ed.keydelay=3;
-                            if(ed.dmtile<0) ed.dmtile+=1200;
-                        }
-                        else if(down_pressed)
-                        {
-                            ed.dmtile+=40;
-                            ed.keydelay=3;
-
-                            if(ed.dmtile>=1200) ed.dmtile-=1200;
-                        }
-                    }
-                    else
-                    {
-                        if(up_pressed)
-                        {
-                            ed.keydelay=6;
-                            graphics.backgrounddrawn=false;
-                            ed.levy--;
-                            ed.updatetiles=true;
-                            ed.changeroom=true;
-                        }
-                        else if(down_pressed)
-                        {
-                            ed.keydelay=6;
-                            graphics.backgrounddrawn=false;
-                            ed.levy++;
-                            ed.updatetiles=true;
-                            ed.changeroom=true;
-                        }
-                        else if(left_pressed)
-                        {
-                            ed.keydelay=6;
-                            graphics.backgrounddrawn=false;
-                            ed.levx--;
-                            ed.updatetiles=true;
-                            ed.changeroom=true;
-                        }
-                        else if(right_pressed)
-                        {
-                            ed.keydelay=6;
-                            graphics.backgrounddrawn=false;
-                            ed.levx++;
-                            ed.updatetiles=true;
-                            ed.changeroom=true;
-                        }
-                    }
-
-                    if(ed.levx<0) ed.levx+=ed.mapwidth;
-                    if(ed.levx>= ed.mapwidth) ed.levx-=ed.mapwidth;
-                    if(ed.levy<0) ed.levy+=ed.mapheight;
-                    if(ed.levy>=ed.mapheight) ed.levy-=ed.mapheight;
-                }
-                if(key.keymap[SDLK_SPACE])
-                {
-                    ed.spacemod = !ed.spacemod;
-                    ed.keydelay=6;
-                }
-
-                if(key.keymap[SDLK_LSHIFT] || key.keymap[SDLK_RSHIFT])
-                {
-                    if(!ed.shiftkey)
-                    {
-                        if(ed.shiftmenu)
-                        {
-                            ed.shiftmenu=false;
-                        }
-                        else
-                        {
-                            ed.shiftmenu=true;
-                        }
-                    }
-                    ed.shiftkey=true;
-                }
-                else
-                {
-                    ed.shiftkey=false;
-                }
+            if(ed.levx<0) ed.levx+=ed.mapwidth;
+            if(ed.levx>= ed.mapwidth) ed.levx-=ed.mapwidth;
+            if(ed.levy<0) ed.levy+=ed.mapheight;
+            if(ed.levy>=ed.mapheight) ed.levy-=ed.mapheight;
+            if(key.keymap[SDLK_SPACE])
+            {
+                ed.spacemod = !ed.spacemod;
+                ed.keydelay=6;
             }
         }
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1686,8 +1686,14 @@ void editorclass::clamp_tilecol(const int rx, const int ry, const bool wrap /*= 
     const int tileset = room.tileset;
     int tilecol = room.tilecol;
 
-    int mincol = 0;
+    int mincol = -1;
     int maxcol = 5;
+
+    // Only Space Station allows tileset -1
+    if (tileset != 0)
+    {
+        mincol = 0;
+    }
 
     switch (tileset)
     {

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1614,6 +1614,132 @@ int editorclass::findwarptoken(int t)
     return 0;
 }
 
+void editorclass::switch_tileset(const bool reversed /*= false*/)
+{
+    const char* tilesets[] = {"Space Station", "Outside", "Lab", "Warp Zone", "Ship"};
+    const size_t roomnum = levx + levy*maxwidth;
+    if (roomnum >= SDL_arraysize(level))
+    {
+        return;
+    }
+    edlevelclass& room = level[roomnum];
+
+    int tiles = room.tileset;
+
+    if (reversed)
+    {
+        tiles--;
+    }
+    else
+    {
+        tiles++;
+    }
+
+    const size_t modulus = SDL_arraysize(tilesets);
+    tiles = (tiles % modulus + modulus) % modulus;
+    room.tileset = tiles;
+
+    clamp_tilecol(levx, levy);
+
+    char buffer[64];
+    SDL_snprintf(buffer, sizeof(buffer), "Now using %s Tileset", tilesets[tiles]);
+
+    note = buffer;
+    notedelay = 45;
+    updatetiles = true;
+}
+
+void editorclass::switch_tilecol(const bool reversed /*= false*/)
+{
+    const size_t roomnum = levx + levy*maxwidth;
+    if (roomnum >= SDL_arraysize(level))
+    {
+        return;
+    }
+    edlevelclass& room = level[roomnum];
+
+    if (reversed)
+    {
+        room.tilecol--;
+    }
+    else
+    {
+        room.tilecol++;
+    }
+
+    clamp_tilecol(levx, levy, true);
+
+    notedelay = 45;
+    note = "Tileset Colour Changed";
+    updatetiles = true;
+}
+
+void editorclass::clamp_tilecol(const int rx, const int ry, const bool wrap /*= false*/)
+{
+    const size_t roomnum = rx + ry*maxwidth;
+    if (roomnum >= SDL_arraysize(level))
+    {
+        return;
+    }
+    edlevelclass& room = level[rx + ry*maxwidth];
+
+    const int tileset = room.tileset;
+    int tilecol = room.tilecol;
+
+    int mincol = 0;
+    int maxcol = 5;
+
+    switch (tileset)
+    {
+    case 0:
+        maxcol = 31;
+        break;
+    case 1:
+        maxcol = 7;
+        break;
+    case 3:
+        maxcol = 6;
+        break;
+    case 5:
+        maxcol = 29;
+        break;
+    }
+
+    // If wrap is true, wrap-around, otherwise just cap
+    if (tilecol > maxcol)
+    {
+        tilecol = (wrap ? mincol : maxcol);
+    }
+    if (tilecol < mincol)
+    {
+        tilecol = (wrap ? maxcol : mincol);
+    }
+
+    room.tilecol = tilecol;
+}
+
+void editorclass::switch_enemy(const bool reversed /*= false*/)
+{
+    const size_t roomnum = levx + levy*maxwidth;
+    if (roomnum >= SDL_arraysize(level))
+    {
+        return;
+    }
+    edlevelclass& room = level[roomnum];
+
+    if (reversed)
+    {
+        room.enemytype--;
+    }
+    else
+    {
+        room.enemytype++;
+    }
+
+    note = "Enemy Type Changed";
+    notedelay = 45;
+}
+
 bool editorclass::load(std::string& _path)
 {
     reset();
@@ -4488,80 +4614,20 @@ void editorinput()
             ed.shiftkey=false;
             if(key.keymap[SDLK_F1])
             {
-                ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset++;
-                graphics.backgrounddrawn=false;
-                if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset>=5) ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset=0;
-                if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
-                {
-                    if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol>=32) ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol=0;
-                }
-                else if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==1)
-                {
-                    if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol>=8) ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol=0;
-                }
-                else
-                {
-                    if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol>=6) ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol=0;
-                }
-                ed.notedelay=45;
-                switch(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset)
-                {
-                case 0:
-                    ed.note="Now using Space Station Tileset";
-                    break;
-                case 1:
-                    ed.note="Now using Outside Tileset";
-                    break;
-                case 2:
-                    ed.note="Now using Lab Tileset";
-                    break;
-                case 3:
-                    ed.note="Now using Warp Zone Tileset";
-                    break;
-                case 4:
-                    ed.note="Now using Ship Tileset";
-                    break;
-                case 5:
-                    ed.note="Now using Tower Tileset";
-                    break;
-                default:
-                    ed.note="Tileset Changed";
-                    break;
-                }
-                ed.updatetiles=true;
-                ed.keydelay=6;
+                ed.switch_tileset();
+                graphics.backgrounddrawn = false;
+                ed.keydelay = 6;
             }
             if(key.keymap[SDLK_F2])
             {
-                ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol++;
-                graphics.backgrounddrawn=false;
-                if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
-                {
-                    if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol>=32) ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol=0;
-                }
-                else if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==1)
-                {
-                    if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol>=8) ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol=0;
-                }
-                else if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==3)
-                {
-                    if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol>=7) ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol=0;
-                }
-                else
-                {
-                    if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol>=6) ed.level[ed.levx+(ed.levy*ed.maxwidth)].tilecol=0;
-                }
-                ed.updatetiles=true;
-                ed.keydelay=6;
-                ed.notedelay=45;
-                ed.note="Tileset Colour Changed";
+                ed.switch_tilecol();
+                graphics.backgrounddrawn = false;
+                ed.keydelay = 6;
             }
             if(key.keymap[SDLK_F3])
             {
-                ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype=(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype+1)%10;
+                ed.switch_enemy();
                 ed.keydelay=6;
-                ed.notedelay=45;
-                ed.note="Enemy Type Changed";
             }
             if(key.keymap[SDLK_F4])
             {

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -134,6 +134,11 @@ class editorclass{
 
   int backmatch(int x, int y);
 
+  void switch_tileset(const bool reversed = false);
+  void switch_tilecol(const bool reversed = false);
+  void clamp_tilecol(const int rx, const int ry, const bool wrap = false);
+  void switch_enemy(const bool reversed = false);
+
   bool load(std::string& _path);
   bool save(std::string& _path);
   void generatecustomminimap();


### PR DESCRIPTION
I added Shift+F1/F2/F3 hotkeys, and allowed using Space Station tilecol -1. Along the way I refactored a bunch of stuff too.

Shift+F1/F2/F3 hotkeys are useful if the user wants to get to a tileset/tilecol/enemy behind them without having to mash the hotkey a bajillion times.

Space Station tilecol -1 lets you use one of the unpatterned Space Station tilesets without having to use Direct Mode. It's a bit quirky but I'm pretty sure it's safe to use.

(Warning: this PR conflicts with #343.)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
