### PR TITLE
Refactor entity text input, add G keybind to go to room in editor, and allow terminals to use any sprite they want

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1728,10 +1728,27 @@ void mapclass::loadlevel(int rx, int ry)
 				break;
 				}
 				case 18: //Terminals
+				{
 				obj.customscript=edentity[edi].scriptname;
-				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8)+8, 20, 1);
-				obj.createblock(5, (edentity[edi].x*8)- ((rx-100)*40*8)-8, (edentity[edi].y*8)- ((ry-100)*30*8)+8, 20, 16, 35);
+
+				int usethistile = edentity[edi].p1;
+				int usethisy = (edentity[edi].y*8)- ((ry-100)*30*8);
+
+				// This isn't a boolean: we just swap 0 and 1 around and leave the rest alone
+				if (usethistile == 0)
+				{
+					usethistile = 1; // Unflipped
+				}
+				else if (usethistile == 1)
+				{
+					usethistile = 0; // Flipped;
+					usethisy -= 8;
+				}
+
+				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8), usethisy+8, 20, usethistile);
+				obj.createblock(5, (edentity[edi].x*8)- ((rx-100)*40*8)-8, usethisy+8, 20, 16, 35);
 				break;
+				}
 				case 19: //Script Box
 				game.customscript[tempscriptbox]=edentity[edi].scriptname;
 				obj.createblock(1, (edentity[edi].x*8)- ((rx-100)*40*8), (edentity[edi].y*8)- ((ry-100)*30*8),

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -4295,6 +4295,20 @@ void editorinput()
             key.disabletextentry();
             switch (ed.textmod)
             {
+            case TEXT_GOTOROOM:
+            {
+                std::vector<std::string> coords = split(key.keybuffer, ',');
+                if (coords.size() != 2)
+                {
+                    ed.note = "[ ERROR: Invalid format ]";
+                    ed.notedelay = 45;
+                    break;
+                }
+                ed.levx = clamp(atoi(coords[0].c_str()) - 1, 0, ed.mapwidth - 1);
+                ed.levy = clamp(atoi(coords[1].c_str()) - 1, 0, ed.mapheight - 1);
+                graphics.backgrounddrawn = false;
+                break;
+            }
             case TEXT_LOAD:
             {
                 std::string loadstring = ed.filename + ".vvvvvv";
@@ -4690,6 +4704,12 @@ void editorinput()
             {
                 ed.keydelay = 6;
                 ed.getlin(TEXT_ROOMNAME, "Enter new room name:", &(ed.level[ed.levx+(ed.levy*ed.maxwidth)].roomname));
+                game.mapheld=true;
+            }
+            if (key.keymap[SDLK_g])
+            {
+                ed.keydelay = 6;
+                ed.getlin(TEXT_GOTOROOM, "Enter room coordinates x,y:", NULL);
                 game.mapheld=true;
             }
 

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -18,7 +18,8 @@ enum textmode {
   TEXT_ROOMNAME,
   TEXT_SCRIPT,
   TEXT_ROOMTEXT,
-  LAST_EDTEXT = TEXT_ROOMTEXT,
+  TEXT_GOTOROOM,
+  LAST_EDTEXT = TEXT_GOTOROOM,
 
   // Settings-mode text fields
   TEXT_TITLE,

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -8,6 +8,30 @@
 #include "Script.h"
 #include "Graphics.h"
 
+// Text entry field type
+enum textmode {
+  TEXT_NONE,
+
+  // In-editor text fields
+  TEXT_LOAD,
+  TEXT_SAVE,
+  TEXT_ROOMNAME,
+  TEXT_SCRIPT,
+  TEXT_ROOMTEXT,
+  LAST_EDTEXT = TEXT_ROOMTEXT,
+
+  // Settings-mode text fields
+  TEXT_TITLE,
+  TEXT_DESC,
+  TEXT_WEBSITE,
+  TEXT_CREATOR,
+  NUM_TEXTMODES,
+
+  // Text modes with an entity
+  FIRST_ENTTEXT = TEXT_SCRIPT,
+  LAST_ENTTEXT = TEXT_ROOMTEXT
+};
+
 class edentities{
 public:
   int x, y, t;
@@ -105,6 +129,7 @@ class editorclass{
 
   void saveconvertor();
   void reset();
+  void getlin(const enum textmode mode, const std::string& prompt, std::string* ptr);
   std::vector<int> loadlevel(int rxi, int ryi);
 
   void placetile(int x, int y, int t);
@@ -184,14 +209,17 @@ class editorclass{
   int levx, levy;
   int entframe, entframedelay;
 
-  bool roomtextmod;
-
-  bool scripttextmod;
-  int textent;
   int scripttexttype;
   std::string oldenttext;
 
-  bool xmod, zmod, cmod, vmod, bmod, hmod, spacemod, warpmod, roomnamemod, textentry, savemod, loadmod;
+  enum textmode textmod; // In text entry
+  std::string* textptr; // Pointer to text we're changing
+  std::string textdesc; // Description (for editor mode text fields)
+  union {
+    int desc; // Which description row we're changing
+    int textent; // Entity ID for text prompt
+  };
+  bool xmod, zmod, cmod, vmod, bmod, hmod, spacemod, warpmod, textentry;
   bool titlemod, creatormod, desc1mod, desc2mod, desc3mod, websitemod;
 
   int roomnamehide;


### PR DESCRIPTION
Yet another three-in-one pull request.

I've refactored entity text input the same way VCE did it, which is basically just de-duplicating all the text input starting and finishing code. I've also added the G keybind to go to a room given its coordinates from VCE, which VCE got from Ved. Also, edentity terminals are now allowed to use any sprite they want to.

Unfortunately, this pull request will conflict with #342.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
