### PR TITLE
Make text() have the same colors as blockclass::setblockcolour(), and ignore slowdown on the map screen

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -366,11 +366,23 @@ void scriptclass::run()
 					g = 134;
 					b = 255;
 				}
+				else if (words[1] == "white")
+				{
+					r = 244;
+					g = 244;
+					b = 244;
+				}
 				else if (words[1] == "gray")
 				{
 					r = 174;
 					g = 174;
 					b = 174;
+				}
+				else if (words[1] == "orange")
+				{
+					r = 255;
+					g = 130;
+					b = 20;
 				}
 				else
 				{

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -405,7 +405,7 @@ void inline deltaloop()
     {
         timesteplimit = 24;
     }
-    else if (game.gamestate == GAMEMODE || game.gamestate == MAPMODE || game.gamestate == TELEPORTERMODE)
+    else if (game.gamestate == GAMEMODE)
     {
         timesteplimit = game.gameframerate;
     }


### PR DESCRIPTION
Ok, this'll be my last PR before the feature freeze. For real this time.

* **Make `text()` colors consistent with `blockclass::setblockcolour()`**

  It seems a bit strange to have two separate color indexes that are mostly the same, don'tcha think?

* **Don't adhere to slowdown in MAPMODE/TELEPORTERMODE**

  Now that you have a mini menu in MAPMODE, it's a bit annoying to have to deal with the slowed-down timestep when pressing left/right/ACTION inside it. Especially since going to an options menu restores the timestep back to normal (because it's in TITLEMODE). Also removed it from TELEPORTERMODE for consistency.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
