### PR TITLE
Fix deltaframe render glitch when spawning animated double-size entities

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2032,13 +2032,15 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         case 0: // Simple Loop
         case 1: // Simple Loop
         case 2: // Simpler Loop (just two frames)
-        case 3: // Simpler Loop (just two frames, but double sized)
-        case 4: // Simpler Loop (just two frames, but double sized) (as above, but slower)
         case 5: // Simpler Loop (just two frames) (slower)
-        case 6: // Normal Loop (four frames, double sized)
         case 7: // Simpler Loop (just two frames) (slower) (with directions!)
         case 11: // Conveyor right
             entity.drawframe++;
+            break;
+        case 3: // Simpler Loop (just two frames, but double sized)
+        case 4: // Simpler Loop (just two frames, but double sized) (as above, but slower)
+        case 6: // Normal Loop (four frames, double sized)
+            entity.drawframe += 2;
             break;
         case 10: // Conveyor left
             entity.drawframe += 3;


### PR DESCRIPTION
Their drawframe needs to be incremented by 2 instead of 1, because they're double-sized.

Animation type 3 is used by the cloud emitter in The Solution is Dilution, animation type 6 is used by the radar dish in Comms Relay. Animation type 4 is used by the maverick bus in B-B-B-Busted, but it's not noticeable since it spawns offscreen. This bug would cause all of those entities to appear incorrectly for the deltaframes between the tick the room got loaded and the next tick after that.

This is noticeable in flibit's tweet showing off my over-30-FPS patch: https://twitter.com/flibitijibibo/status/1273983014930993153

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
