### PR TITLE
Fix wrong function being used to set color of coins

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1754,7 +1754,7 @@ void Graphics::drawentities()
             FillRect(backBuffer, prect, obj.entities[i].realcol);
             break;
         case 4:    // Small pickups
-            setcol(obj.entities[i].realcol);
+            setcolreal(obj.entities[i].realcol);
             drawhuetile(xp, yp - yoff, obj.entities[i].tile);
             break;
         case 5:    //Horizontal Line


### PR DESCRIPTION
It should be `setcolreal()`, and not `setcol()`.

Fixes #347.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
