### PR TITLE
Fix still being able to unlock things in custommode

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -3390,7 +3390,7 @@ void Game::updatestate()
             {
                 //flip mode complete
                 NETWORK_unlockAchievement("vvvvvvgamecompleteflip");
-                unlock[19] = true;
+                unlocknum(19);
             }
 
             if (bestgamedeaths == -1)
@@ -3425,7 +3425,7 @@ void Game::updatestate()
             if (nodeathmode)
             {
                 NETWORK_unlockAchievement("vvvvvvmaster"); //bloody hell
-                unlock[20] = true;
+                unlocknum(20);
                 state = 3520;
                 statedelay = 0;
             }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1515,7 +1515,7 @@ void scriptclass::run()
 			}
 			else if (words[0] == "entersecretlab")
 			{
-				game.unlock[8] = true;
+				game.unlocknum(8);
 				game.insecretlab = true;
 			}
 			else if (words[0] == "leavesecretlab")


### PR DESCRIPTION
This was caused by the fact that not all unlocks were done through the `Game::unlocknum()` function. Some just set the unlock number directly. But it's fixed now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
