### PR TITLE
Fix infinite loop if left or right is pressed in the teleporter screen while no teleporters are unlocked

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2337,31 +2337,25 @@ void teleporterinput()
 
         if (game.press_left)
         {
-            game.teleport_to_teleporter--;
-            if (game.teleport_to_teleporter < 0) game.teleport_to_teleporter = map.teleporters.size() - 1;
-            tempx = map.teleporters[game.teleport_to_teleporter].x;
-            tempy = map.teleporters[game.teleport_to_teleporter].y;
-            while (map.explored[tempx + (20 * tempy)] == 0)
+            do
             {
                 game.teleport_to_teleporter--;
                 if (game.teleport_to_teleporter < 0) game.teleport_to_teleporter = map.teleporters.size() - 1;
                 tempx = map.teleporters[game.teleport_to_teleporter].x;
                 tempy = map.teleporters[game.teleport_to_teleporter].y;
             }
+            while (map.explored[tempx + (20 * tempy)] == 0);
         }
         else if (game.press_right)
         {
-            game.teleport_to_teleporter++;
-            if (game.teleport_to_teleporter >= (int) map.teleporters.size()) game.teleport_to_teleporter = 0;
-            tempx = map.teleporters[game.teleport_to_teleporter].x;
-            tempy = map.teleporters[game.teleport_to_teleporter].y;
-            while (map.explored[tempx + (20 * tempy)] == 0)
+            do
             {
                 game.teleport_to_teleporter++;
                 if (game.teleport_to_teleporter >= (int) map.teleporters.size()) game.teleport_to_teleporter = 0;
                 tempx = map.teleporters[game.teleport_to_teleporter].x;
                 tempy = map.teleporters[game.teleport_to_teleporter].y;
             }
+            while (map.explored[tempx + (20 * tempy)] == 0);
         }
 
         if (game.press_map)

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2335,7 +2335,22 @@ void teleporterinput()
             game.jumpheld = true;
         }
 
-        if (game.press_left)
+        bool any_tele_unlocked = false;
+        if (game.press_left || game.press_right)
+        {
+            for (size_t i = 0; i < map.teleporters.size(); i++)
+            {
+                point& tele = map.teleporters[i];
+
+                if (map.explored[tele.x + tele.y*20])
+                {
+                    any_tele_unlocked = true;
+                    break;
+                }
+            }
+        }
+
+        if (game.press_left && any_tele_unlocked)
         {
             do
             {
@@ -2346,7 +2361,7 @@ void teleporterinput()
             }
             while (map.explored[tempx + (20 * tempy)] == 0);
         }
-        else if (game.press_right)
+        else if (game.press_right && any_tele_unlocked)
         {
             do
             {


### PR DESCRIPTION
This infinite loop would occur because once you pressed left or right, the game keeps searching through all the list of teleporters until it finds one that is unlocked. But if there's none that are unlocked, then the game goes into an infinite loop, which brings up the Not Responding dialog on Windows so you can kill it.

Normally, you're not supposed to have no teleporters unlocked while being able to access a teleporter, but you can achieve this by going to Class Dismissed from a custom level (while making sure you don't start in 0,0, because there's a teleporter there that you would unlock).

The solution is to make sure at least one teleporter is unlocked before doing any searching.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
