### PR TITLE
Fix Map.cpp relying on editor.h to include Script.h

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1,4 +1,5 @@
 #include "Map.h"
+#include "Script.h"
 
 #include "MakeAndPlay.h"
 


### PR DESCRIPTION
This would mean that NO_CUSTOM_LEVEL builds wouldn't compile.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
