### PR TITLE
Fix being able to softlock the game if you touch a script box on the same frame you touch a trinket or crewmate, and that script has a text box in it

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -2085,6 +2085,13 @@ void Game::updatestate()
                 }
             }
             break;
+        case 1002:
+            if (!advancetext)
+            {
+                // Prevent softlocks if we somehow don't have advancetext
+                state++;
+            }
+            break;
         case 1003:
             graphics.textboxremove();
             hascontrol = true;
@@ -2150,6 +2157,13 @@ void Game::updatestate()
                     graphics.createtextbox("     " + help.number(ed.numcrewmates()-crewmates())+ " remain    ", 50, 135, 174, 174, 174);
                 }
                 graphics.textboxcenterx();
+            }
+            break;
+        case 1012:
+            if (!advancetext)
+            {
+                // Prevent softlocks if we somehow don't have advancetext
+                state++;
             }
             break;
         case 1013:


### PR DESCRIPTION
So there's this really annoying softlock that can happen if you put script boxes next to a trinket or a crewmate. You would collect the trinket or crewmate, and there would be the "You have found a shiny trinket!" or "You have found a lost crewmate!" text box, along with the first text box of the script, and then after you pressed ACTION the rest of the script would play out. This is because the trinket/crewmate collection sequences use `game.completestop` to stop everything when their sequence runs, but that variable doesn't end up getting reset for whatever reason.

For a while it was just common wisdom that you shouldn't overlap script boxes with trinkets or crewmates or else Bad Things Will Happen.

Well, it's only a problem with script boxes that create text boxes. If a script box does *not* create text boxes, you're completely fine to put it near any trinket or crewmate you want, and you won't softlock. You might skip the entire "You have found a shiny trinket!" or "You have found a lost crewmate!" sequence, but it at least isn't a softlock.

First off, this softlock can only happen if the player touches a script box on the same frame as a crewmate or trinket. For trinkets, this will only happen 100% of the time if the edge of the script box coincides exactly with the edge of the trinket. If the script box starts one tile further from the edge of the trinket, that's where it gets more complicated. If the player can only approach the trinket and script box horizontally, nothing bad will happen, since the maximum amount of distance Viridian can move horizontally in one frame is only 6 pixels, which is less than the full width of a tile, which is 8 pixels. If the player can approach the trinket and script box vertically, however, then it is possible that Viridian can still touch both entities on the same frame despite the one-tile offset, since the maximum distance Viridian can move vertically in one frame is 10 pixels, which is greater than 8 pixels.

For crewmates, it's less likely that the edge of their hitbox coincides exactly with the edge of a script box, *and* that the player can approach a side where this coincide-ence happens. (The only way their edges could coincide is with their bottom edges, but usually you can't approach a crewmate from the bottom without them falling down. If they stood one tile off a ledge, however, they would not fall down and the edge of the script and crewmate would coincide.) This means touching a crewmate while touching a script box on the same frame is somewhat up to chance, namely your horizontal pixel alignment. Due to the intervals of 6 pixels it takes for you to get to the crewmate, it could happen that you touch the script box first, or touch the crewmate first, but there's never a guarantee that you could always touch both on the same frame.

And now: *if* you touch a crewmate or trinket on the exact same frame you touch a script box, and *if* that script box creates dialogue, then what happens?

Well, the script will create a text box, and then it will call the `speak` or `speak_active` command. (If you're in a simplified script (and if you don't know what that means, then you probably are in one), this command is automatically added by the simplified-to-internal parser when you use `say` or `reply`.) Both of these commands bring up the "- Press ACTION to advance text -" prompt, which is controlled by the variable `game.advancetext`. If `game.advancetext` is true, then that prompt will be up, else it's not.

What these commands also do is set `game.pausescript` to true, which is very important. That's because there are two purposes of pressing ACTION while `game.advancetext` is true: it's either to advance the script or advance the gamestate (and "advancing the gamestate" here means incrementing the gamestate). If `game.pausescript` is set to true, then the game takes priority over advancing the gamestate and the script is advanced instead. Otherwise, the gamestate will be advanced.

And this distinction between script and gamestate is important to make, because the script is script-based, while the "You have found a shiny trinket!" and "You have found a lost crewmate!" sequences are gamestate-based.

Specifically, when collecting a trinket, gamestate 1000 is used to start the cutscene bar animation and increment to the next state, while having a gamestate delay of 15 frames in order to wait for the cutscene bars to fully cover the top and bottom of the screen. Next, gamestate 1001 creates the text boxes, sets `game.advancetext` and `game.completestop` to true, and advances to gamestate 1002. Gamestate 1002 doesn't actually exist, which is a convenient trick because non-existent gamestates are maintained by the game, so the gamestate will keep being 1002 *until* you press ACTION to increment the gamestate, at which point gamestate 1003 is ran, which just resets all the variables (including `game.completestop`) and music, and goes back to gamestate 0 (the do-nothing null gamestate). These gamestates are the exact same for crewmates, except they're gamestates 1010, 1011, 1012, and 1013 respectively.

So, since scripts and gamestates are different and have different priorities when you press ACTION, if you have a script and either of those trinket/crewmate collection sequences running at the same time, when `game.advancetext` is set to true and that "- Press ACTION to advance text -" prompt pops up: whenever you press ACTION, the *script* will be advanced instead, and *not* the trinket/crewmate collection dialogue boxes.<sup>[note 1]</sup>

This (the thing where the script gets priority over the gamestate) will continue to happen until the sequence of text boxes runs out in the script, at which point the script will call `endtext` or `endtextfast` to close all the text boxes. One important side effect of `endtext` and `endtextfast` is that they set `game.advancetext` to false.<sup>[note 2]</sup> And this is a bad thing, because currently, we're on gamestate 1002 (or 1012) and we *need* that `game.advancetext` prompt to be up in order for ACTION to increment the gamestate and get us to gamestate 1003 (or 1013) and reset `game.completestop`. If we don't have `game.advancetext`, well, we're softlocked.

And then at this point the script ends, dooming Viridian and the entire dimension to the fate of being stuck in completestop. The script could've saved us by calling gamestate 1003 (or 1013) manually, but most dialogue scripts don't do this, *especially* if they're a simplified script (you need to use the `gamestate()` command to set the gamestate, and that's an internal command, not a simplified one). But after it ends, there's no hope and Viridian is doomed.<sup>[note 3]</sup>

------

So what's the solution?

Well, it's simple. Since the gamestate gets stuck on 1002 (or 1012) without advancing, why not just make those gamestates actually exist and make them advance to the next state automatically if `game.advancetext` is false?

That way, all the above can happen, but as soon as `game.advancetext` is set to false by the script, the gamestate will automatically kick in and advance to the next state anyway.

So that's exactly what I do in this pull request here. You can see the difference before and after this patch by taking a look at the demonstration level I've attached here:

* [completestop_softlock.zip](https://github.com/TerryCavanagh/VVVVVV/files/4874535/completestop_softlock.zip)

------

<sup>[note 1]:</sup> On a side note, if a script's text box(es) appear earlier (i.e. while the cutscene bars are coming in from the sides of the screen) and are short enough, you could avoid this problem (that the trinket/crewmate collection sequence expects ACTION being pressed to advance the trinket/crewmate collection sequence instead of the script) by quickly mashing ACTION through the text box(es) and avoid that problem, and thus, avoid the softlock. However, typical simplified scripts create the text box and set `game.pausescript` to true on the exact same frame that the gamestate creates its text boxes and sets `game.advancetext` to true, because the script waits for 15 frames for the cutscene bars to come in from the sides, while the gamestate does, too, so in order for a text box to be created *during* cutscene bars coming in from the side and not after, the script has to be an internal script.

<sup>[note 2]:</sup> They also close all the text boxes from the trinket/crewmate collection sequence as well (because those commands close *every* text box onscreen, not just the script's), but don't confuse this for the gamestate advancing, because it hasn't.

<sup>[note 3]:</sup> This is probably a good thing, [given what they've done](http://distractionware.com/forum/index.php?topic=2382.0).

------

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
