### PR TITLE
Clean up constructors and initializations

### DIFF
--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -11,6 +11,7 @@ binaryBlob::binaryBlob()
 {
 	numberofHeaders = 0;
 	SDL_memset(m_headers, 0, sizeof(m_headers));
+	SDL_memset(m_memblocks, 0, sizeof(m_memblocks));
 }
 
 #ifdef VVV_COMPILEMUSIC

--- a/desktop_version/src/BlockV.cpp
+++ b/desktop_version/src/BlockV.cpp
@@ -14,8 +14,6 @@ blockclass::blockclass()
 	rect.w = wp;
 	rect.h = hp;
 
-	prompt = "";
-	script = "";
 	r = 0;
 	g = 0;
 	b = 0;

--- a/desktop_version/src/BlockV.cpp
+++ b/desktop_version/src/BlockV.cpp
@@ -19,6 +19,9 @@ blockclass::blockclass()
 	r = 0;
 	g = 0;
 	b = 0;
+
+	x = 0.0f;
+	y = 0.0f;
 }
 
 void blockclass::rectset(const int xi, const int yi, const int wi, const int hi)

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -72,6 +72,28 @@ entityclass::entityclass()
     resetallflags();
     SDL_memset(collect, false, sizeof(collect));
     SDL_memset(customcollect, false, sizeof(customcollect));
+
+    colpoint1 = point();
+    colpoint2 = point();
+    tempx = 0;
+    tempy = 0;
+    tempw = 0;
+    temph = 0;
+    temp = 0;
+    temp2 = 0;
+    tpx1 = 0;
+    tpy1 = 0;
+    tpx2 = 0;
+    tpy2 = 0;
+    x = 0;
+    k = 0;
+    dx = 0.0f;
+    dy = 0.0f;
+    dr = 0.0f;
+    px = 0;
+    py = 0;
+    linetemp = 0;
+    activetrigger = 0;
 }
 
 void entityclass::resetallflags()

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -46,7 +46,7 @@ bool entityclass::checktowerspikes(int t)
     return false;
 }
 
-void entityclass::init()
+entityclass::entityclass()
 {
     skipblocks = false;
     skipdirblocks = false;

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -24,7 +24,7 @@ enum
 class entityclass
 {
 public:
-    void init();
+    entityclass();
 
     void resetallflags();
 

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -34,8 +34,8 @@
 #define MAX_PATH PATH_MAX
 #endif
 
-char saveDir[MAX_PATH];
-char levelDir[MAX_PATH];
+char saveDir[MAX_PATH] = {'\0'};
+char levelDir[MAX_PATH] = {'\0'};
 
 void PLATFORM_getOSDirectory(char* output);
 void PLATFORM_migrateSaveData(char* output);

--- a/desktop_version/src/Finalclass.cpp
+++ b/desktop_version/src/Finalclass.cpp
@@ -8,7 +8,6 @@ const int* finalclass::loadlevel(int rx, int ry)
 
 	t = rx + (ry * 100);
 	const int* result;
-	coin = 0;
 	rcol = 0;
 	warpx = false;
 	warpy = false;

--- a/desktop_version/src/Finalclass.cpp
+++ b/desktop_version/src/Finalclass.cpp
@@ -2,6 +2,12 @@
 
 #include "MakeAndPlay.h"
 
+finalclass::finalclass()
+{
+	warpx = false;
+	warpy = false;
+}
+
 const int* finalclass::loadlevel(int rx, int ry)
 {
 	int t;

--- a/desktop_version/src/Finalclass.cpp
+++ b/desktop_version/src/Finalclass.cpp
@@ -8,7 +8,6 @@ const int* finalclass::loadlevel(int rx, int ry)
 
 	t = rx + (ry * 100);
 	const int* result;
-	rcol = 0;
 	warpx = false;
 	warpy = false;
 
@@ -1410,7 +1409,6 @@ const int* finalclass::loadlevel(int rx, int ry)
 		98,98,220,218,98,98,98,98,98,98,98,98,98,98,98,98,98,220,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 		};
 
-		rcol = 6;
 		warpy = true;
 		roomname = "Temporary Fault...";
 		result = contents;

--- a/desktop_version/src/Finalclass.h
+++ b/desktop_version/src/Finalclass.h
@@ -12,7 +12,6 @@ public:
     const int* loadlevel(int rx, int ry);
 
     std::string roomname;
-    int rcol;
     bool warpx, warpy;
 };
 

--- a/desktop_version/src/Finalclass.h
+++ b/desktop_version/src/Finalclass.h
@@ -9,6 +9,8 @@
 class finalclass
 {
 public:
+    finalclass();
+
     const int* loadlevel(int rx, int ry);
 
     std::string roomname;

--- a/desktop_version/src/Finalclass.h
+++ b/desktop_version/src/Finalclass.h
@@ -12,7 +12,7 @@ public:
     const int* loadlevel(int rx, int ry);
 
     std::string roomname;
-    int coin, rcol;
+    int rcol;
     bool warpx, warpy;
 };
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -192,7 +192,6 @@ Game::Game(void)
     fullscreen = false;// true; //Assumed true at first unless overwritten at some point!
     stretchMode = 0;
     useLinearFilter = false;
-    advanced_mode = false;
     fullScreenEffect_badSignal = false;
     // 0..5
     controllerSensitivity = 2;
@@ -4633,11 +4632,6 @@ void Game::loadstats()
             swnrecord = atoi(pText);
         }
 
-        if (pKey == "advanced_mode")
-        {
-            advanced_mode = atoi(pText);
-        }
-
         if (pKey == "advanced_smoothing")
         {
             fullScreenEffect_badSignal = atoi(pText);
@@ -4903,10 +4897,6 @@ void Game::savestats()
     msg->LinkEndChild( doc.NewText( help.String(swnrecord).c_str()));
     dataNode->LinkEndChild( msg );
 
-
-    msg = doc.NewElement( "advanced_mode" );
-    msg->LinkEndChild( doc.NewText( help.String(advanced_mode).c_str()));
-    dataNode->LinkEndChild( msg );
 
     msg = doc.NewElement( "advanced_smoothing" );
     msg->LinkEndChild( doc.NewText( help.String(fullScreenEffect_badSignal).c_str()));

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -398,10 +398,6 @@ void Game::init(void)
 
 }
 
-Game::~Game(void)
-{
-}
-
 void Game::lifesequence()
 {
     if (lifeseq > 0)

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -140,7 +140,6 @@ Game::Game(void)
     roomchange = false;
 
 
-    teleportscript = "";
     savemystats = false;
     quickrestartkludge = false;
 
@@ -159,7 +158,6 @@ Game::Game(void)
     prev_act_fade = 0;
     backgroundtext = false;
     startscript = false;
-    newscript = "";
     inintermission = false;
 
     alarmon = false;
@@ -176,7 +174,6 @@ Game::Game(void)
     activetele = false;
     readytotele = 0;
     oldreadytotele = 0;
-    activity_lastprompt = "";
     activity_r = 0;
     activity_g = 0;
     activity_b = 0;
@@ -203,10 +200,6 @@ Game::Game(void)
     nodeathmode = false;
     nocutscenes = false;
 
-    for(int i=0; i<50; i++)
-    {
-        customscript[i]="";
-    }
     customcol=0;
 
     SDL_memset(crewstats, false, sizeof(crewstats));
@@ -239,7 +232,6 @@ Game::Game(void)
     menucountdown = 0;
     levelpage=0;
     playcustomlevel=0;
-    customleveltitle="";
     createmenu(Menu::mainmenu);
 
     deathcounts = 0;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -114,7 +114,7 @@ bool GetButtonFromString(const char *pText, SDL_GameControllerButton *button)
 }
 
 
-void Game::init(void)
+Game::Game(void)
 {
     roomx = 0;
     roomy = 0;
@@ -289,6 +289,47 @@ void Game::init(void)
 
     clearcustomlevelstats();
 
+    screenshake = flashlight = 0 ;
+
+    stat_trinkets = 0;
+
+    state = 1;
+    statedelay = 0;
+    //updatestate();
+
+    skipfakeload = false;
+
+    ghostsenabled = false;
+    gametimer = 0;
+
+    cliplaytest = false;
+    playx = 0;
+    playy = 0;
+    playrx = 0;
+    playry = 0;
+    playgc = 0;
+
+    fadetomenu = false;
+    fadetomenudelay = 0;
+    fadetolab = false;
+    fadetolabdelay = 0;
+
+#if !defined(NO_CUSTOM_LEVELS)
+    shouldreturntoeditor = false;
+#endif
+
+    over30mode = false;
+    glitchrunnermode = false;
+
+    ingame_titlemode = false;
+    kludge_ingametemp = Menu::mainmenu;
+    shouldreturntopausemenu = false;
+
+    disablepause = false;
+}
+
+void Game::init(void)
+{
     saveFilePath = FILESYSTEM_getUserSaveDirectory();
 
     tinyxml2::XMLDocument doc;
@@ -366,43 +407,6 @@ void Game::init(void)
         }
     }
 
-    screenshake = flashlight = 0 ;
-
-    stat_trinkets = 0;
-
-    state = 1;
-    statedelay = 0;
-    //updatestate();
-
-    skipfakeload = false;
-
-    ghostsenabled = false;
-    gametimer = 0;
-
-    cliplaytest = false;
-    playx = 0;
-    playy = 0;
-    playrx = 0;
-    playry = 0;
-    playgc = 0;
-
-    fadetomenu = false;
-    fadetomenudelay = 0;
-    fadetolab = false;
-    fadetolabdelay = 0;
-
-#if !defined(NO_CUSTOM_LEVELS)
-    shouldreturntoeditor = false;
-#endif
-
-    over30mode = false;
-    glitchrunnermode = false;
-
-    ingame_titlemode = false;
-    kludge_ingametemp = Menu::mainmenu;
-    shouldreturntopausemenu = false;
-
-    disablepause = false;
 }
 
 Game::~Game(void)

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -150,7 +150,6 @@ Game::Game(void)
     press_left = 0;
 
 
-    advancetext = false;
     pausescript = false;
     completestop = false;
     activeactivity = -1;
@@ -192,7 +191,6 @@ Game::Game(void)
     fullscreen = false;// true; //Assumed true at first unless overwritten at some point!
     stretchMode = 0;
     useLinearFilter = false;
-    fullScreenEffect_badSignal = false;
     // 0..5
     controllerSensitivity = 2;
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -352,7 +352,6 @@ public:
     bool savemystats;
 
 
-    bool advanced_mode;
     bool fullScreenEffect_badSignal;
     bool useLinearFilter;
     int stretchMode;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -90,7 +90,6 @@ class Game
 public:
     Game(void);
     void init(void);
-    ~Game(void);
 
 
     int crewrescued();

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -88,6 +88,7 @@ struct CustomLevelStat
 class Game
 {
 public:
+    Game(void);
     void init(void);
     ~Game(void);
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -164,11 +164,6 @@ int Graphics::font_idx(uint32_t ch) {
     }
 }
 
-Graphics::~Graphics()
-{
-
-}
-
 void Graphics::drawspritesetcol(int x, int y, int t, int c)
 {
     if (!INBOUNDS(t, sprites))

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -11,7 +11,10 @@
 void Graphics::init()
 {
     grphx.init();
+}
 
+Graphics::Graphics()
+{
     flipmode = false;
     setRect(tiles_rect, 0,0,8,8);
     setRect(sprites_rect, 0,0,32,32);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -117,6 +117,8 @@ Graphics::Graphics()
     tl = point();
     towerbuffer = NULL;
     towerbuffer_lerp = NULL;
+    footerbuffer = NULL;
+    ghostbuffer = NULL;
     trinketr = 0;
     trinketg = 0;
     trinketb = 0;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -23,6 +23,7 @@ class Graphics
 {
 public:
 	void init();
+	Graphics();
 	~Graphics();
 
 	GraphicsResources grphx;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -24,7 +24,6 @@ class Graphics
 public:
 	void init();
 	Graphics();
-	~Graphics();
 
 	GraphicsResources grphx;
 

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -80,6 +80,32 @@ SDL_Surface* LoadImage(const char *filename, bool noBlend = true, bool noAlpha =
 	}
 }
 
+GraphicsResources::GraphicsResources()
+{
+	im_tiles = NULL;
+	im_tiles2 = NULL;
+	im_tiles3 = NULL;
+	im_entcolours = NULL;
+	im_sprites = NULL;
+	im_flipsprites = NULL;
+	im_bfont = NULL;
+	im_teleporter = NULL;
+
+	im_image0 = NULL;
+	im_image1 = NULL;
+	im_image2 = NULL;
+	im_image3 = NULL;
+	im_image4 = NULL;
+	im_image5 = NULL;
+	im_image6 = NULL;
+	im_image7 = NULL;
+	im_image8 = NULL;
+	im_image9 = NULL;
+	im_image10 = NULL;
+	im_image11 = NULL;
+	im_image12 = NULL;
+}
+
 void GraphicsResources::init(void)
 {
 	im_tiles =		LoadImage("graphics/tiles.png");
@@ -109,26 +135,31 @@ void GraphicsResources::init(void)
 
 void GraphicsResources::destroy(void)
 {
-	SDL_FreeSurface(im_tiles);
-	SDL_FreeSurface(im_tiles2);
-	SDL_FreeSurface(im_tiles3);
-	SDL_FreeSurface(im_entcolours);
-	SDL_FreeSurface(im_sprites);
-	SDL_FreeSurface(im_flipsprites);
-	SDL_FreeSurface(im_bfont);
-	SDL_FreeSurface(im_teleporter);
+#define CLEAR(img) \
+	SDL_FreeSurface(img); \
+	img = NULL;
 
-	SDL_FreeSurface(im_image0);
-	SDL_FreeSurface(im_image1);
-	SDL_FreeSurface(im_image2);
-	SDL_FreeSurface(im_image3);
-	SDL_FreeSurface(im_image4);
-	SDL_FreeSurface(im_image5);
-	SDL_FreeSurface(im_image6);
-	SDL_FreeSurface(im_image7);
-	SDL_FreeSurface(im_image8);
-	SDL_FreeSurface(im_image9);
-	SDL_FreeSurface(im_image10);
-	SDL_FreeSurface(im_image11);
-	SDL_FreeSurface(im_image12);
+	CLEAR(im_tiles);
+	CLEAR(im_tiles2);
+	CLEAR(im_tiles3);
+	CLEAR(im_entcolours);
+	CLEAR(im_sprites);
+	CLEAR(im_flipsprites);
+	CLEAR(im_bfont);
+	CLEAR(im_teleporter);
+
+	CLEAR(im_image0);
+	CLEAR(im_image1);
+	CLEAR(im_image2);
+	CLEAR(im_image3);
+	CLEAR(im_image4);
+	CLEAR(im_image5);
+	CLEAR(im_image6);
+	CLEAR(im_image7);
+	CLEAR(im_image8);
+	CLEAR(im_image9);
+	CLEAR(im_image10);
+	CLEAR(im_image11);
+	CLEAR(im_image12);
+#undef CLEAR
 }

--- a/desktop_version/src/GraphicsResources.h
+++ b/desktop_version/src/GraphicsResources.h
@@ -6,6 +6,7 @@
 class GraphicsResources
 {
 public:
+    GraphicsResources();
     void init(void);
     void destroy(void);
 

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -57,6 +57,8 @@ KeyPoll::KeyPoll()
 	linealreadyemptykludge = false;
 
 	pauseStart = 0;
+
+	isActive = true;
 }
 
 void KeyPoll::enabletextentry()

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -40,7 +40,6 @@ public:
 
 	bool resetWindow;
 
-	bool escapeWasPressedPreviously;
 	bool quitProgram;
 	bool toggleFullscreen;
 
@@ -70,7 +69,6 @@ public:
 	int mx, my;
 
 	bool textentrymode;
-	int keyentered, keybufferlen;
 	bool pressedbackspace;
 	std::string keybuffer;
 

--- a/desktop_version/src/Labclass.cpp
+++ b/desktop_version/src/Labclass.cpp
@@ -2,6 +2,11 @@
 
 #include "MakeAndPlay.h"
 
+labclass::labclass()
+{
+	rcol = 0;
+}
+
 const int* labclass::loadlevel(int rx, int ry)
 {
 	int t;

--- a/desktop_version/src/Labclass.cpp
+++ b/desktop_version/src/Labclass.cpp
@@ -21,7 +21,6 @@ const int* labclass::loadlevel(int rx, int ry)
 
 	t = rx + (ry * 100);
 	const int* result;
-	coin = 0;
 	rcol = 0;
 	roomname = "Untitled room ["+help.String(rx) + "," + help.String(ry)+"]";
 

--- a/desktop_version/src/Labclass.h
+++ b/desktop_version/src/Labclass.h
@@ -12,6 +12,6 @@ public:
     const int* loadlevel(int rx, int ry);
 
     std::string roomname;
-    int coin, rcol;
+    int rcol;
 };
 #endif /* LABCLASS_H */

--- a/desktop_version/src/Labclass.h
+++ b/desktop_version/src/Labclass.h
@@ -9,6 +9,8 @@
 class labclass
 {
 public:
+    labclass();
+
     const int* loadlevel(int rx, int ry);
 
     std::string roomname;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -76,6 +76,21 @@ mapclass::mapclass()
 	ypos = 0;
 	oldypos = 0;
 	bypos = 0;
+
+	background = 0;
+	cameramode = 0;
+	cameraseek = 0;
+	minitowermode = false;
+	scrolldir = 0;
+	check = 0;
+	cmode = 0;
+	towercol = 0;
+	tdrawback = false;
+	bscroll = 0;
+	roomtexton = false;
+	kludge_bypos = 0;
+	kludge_colstate = 0;
+	kludge_scrolldir = 0;
 }
 
 //Areamap starts at 100,100 and extends 20x20

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1315,12 +1315,6 @@ void mapclass::loadlevel(int rx, int ry)
 		tileset = otherlevel.roomtileset;
 		//do the appear/remove roomname here
 
-		if (otherlevel.roomtexton)
-		{
-			roomtexton = true;
-			roomtext = std::vector<Roomtext>(otherlevel.roomtext);
-		}
-
 		if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111)
 		{
 			hiddenname = "The Ship";

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1406,7 +1406,6 @@ void mapclass::loadlevel(int rx, int ry)
 		roomname = finallevel.roomname;
 		tileset = 1;
 		background = 3;
-		graphics.rcol = finallevel.rcol;
 		graphics.backgrounddrawn = false;
 
 		if (finalstretch)

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -13,6 +13,12 @@
 #include "Music.h"
 #include "editor.h"
 
+struct Roomtext
+{
+    int x, y;
+    std::string text;
+};
+
 class mapclass
 {
 public:

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -135,6 +135,9 @@ musicclass::musicclass()
 	songEnd = 0;
 
 	Mix_HookMusicFinished(&songend);
+
+	mmmmmm = false;
+	usingmmmmmm = false;
 }
 
 void songend()

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -57,9 +57,6 @@ void musicclass::init()
 	musicWriteBlob.writeBinaryBlob("data/BinaryMusic.vvv");
 #endif
 
-	num_mmmmmm_tracks = 0;
-	num_pppppp_tracks = 0;
-
 	if (!musicReadBlob.unPackBinary("mmmmmm.vvv"))
 	{
 		mmmmmm = false;
@@ -115,6 +112,12 @@ void musicclass::init()
 
 		num_pppppp_tracks++;
 	}
+}
+
+musicclass::musicclass()
+{
+	num_mmmmmm_tracks = 0;
+	num_pppppp_tracks = 0;
 
 	safeToProcessMusic= false;
 	m_doFadeInVol = false;

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -12,6 +12,7 @@ class musicclass
 {
 public:
 	void init();
+	musicclass();
 
 	void play(int t, const double position_sec = 0.0, const int fadein_ms = 3000);
 	void resume(const int fadein_ms = 0);

--- a/desktop_version/src/Otherlevel.cpp
+++ b/desktop_version/src/Otherlevel.cpp
@@ -2,15 +2,6 @@
 
 #include "MakeAndPlay.h"
 
-void otherlevelclass::addline(std::string t)
-{
-	Roomtext text;
-	text.x = 0;
-	text.y = 0;
-	text.text = t;
-	roomtext.push_back(text);
-}
-
 const int* otherlevelclass::loadlevel(int rx, int ry)
 {
 	int t;
@@ -21,9 +12,6 @@ const int* otherlevelclass::loadlevel(int rx, int ry)
 	t = rx + (ry * 100);
 	const int* result;
 	roomname = "";
-
-	roomtext.clear();
-	roomtexton = false;
 
 	switch(t)
 	{

--- a/desktop_version/src/Otherlevel.cpp
+++ b/desktop_version/src/Otherlevel.cpp
@@ -2,6 +2,11 @@
 
 #include "MakeAndPlay.h"
 
+otherlevelclass::otherlevelclass()
+{
+	roomtileset = 0;
+}
+
 const int* otherlevelclass::loadlevel(int rx, int ry)
 {
 	int t;

--- a/desktop_version/src/Otherlevel.h
+++ b/desktop_version/src/Otherlevel.h
@@ -7,12 +7,6 @@
 #include <string>
 #include <vector>
 
-struct Roomtext
-{
-    int x, y;
-    std::string text;
-};
-
 class otherlevelclass
 {
 public:

--- a/desktop_version/src/Otherlevel.h
+++ b/desktop_version/src/Otherlevel.h
@@ -16,16 +16,6 @@ struct Roomtext
 class otherlevelclass
 {
 public:
-    enum
-    {
-        BLOCK = 0,
-        TRIGGER,
-        DAMAGE,
-        DIRECTIONAL,
-        SAFE,
-        ACTIVITY
-    };
-
     const int* loadlevel(int rx, int ry);
 
     std::string roomname;

--- a/desktop_version/src/Otherlevel.h
+++ b/desktop_version/src/Otherlevel.h
@@ -26,16 +26,11 @@ public:
         ACTIVITY
     };
 
-    void addline(std::string t);
     const int* loadlevel(int rx, int ry);
 
     std::string roomname;
 
     int roomtileset;
-
-    // roomtext thing in other level
-    bool roomtexton;
-    std::vector<Roomtext> roomtext;
 };
 
 #endif /* OTHERLEVEL_H */

--- a/desktop_version/src/Otherlevel.h
+++ b/desktop_version/src/Otherlevel.h
@@ -9,6 +9,8 @@
 class otherlevelclass
 {
 public:
+    otherlevelclass();
+
     const int* loadlevel(int rx, int ry);
 
     std::string roomname;

--- a/desktop_version/src/Otherlevel.h
+++ b/desktop_version/src/Otherlevel.h
@@ -5,7 +5,6 @@
 #include "Entity.h"
 
 #include <string>
-#include <vector>
 
 class otherlevelclass
 {

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -17,7 +17,7 @@ extern "C"
 	);
 }
 
-void Screen::init()
+Screen::Screen()
 {
 	m_window = NULL;
 	m_renderer = NULL;
@@ -31,6 +31,12 @@ void Screen::init()
 	filterSubrect.y = 1;
 	filterSubrect.w = 318;
 	filterSubrect.h = 238;
+
+	badSignalEffect = false;
+}
+
+void Screen::init()
+{
 	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
 
 	// Uncomment this next line when you need to debug -flibit
@@ -86,8 +92,6 @@ void Screen::init()
 		320,
 		240
 	);
-
-	badSignalEffect = false;
 }
 
 void Screen::ResizeScreen(int x, int y)

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -6,6 +6,7 @@
 class Screen
 {
 public:
+	Screen();
 	void init();
 
 	void ResizeScreen(int x, int y);

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -13,6 +13,20 @@ textboxclass::textboxclass()
     tm = 0;
     timer = 0;
     allowspecial = false;
+
+    xp = 0;
+    yp = 0;
+    r = 0;
+    g = 0;
+    b = 0;
+    tr = 0;
+    tg = 0;
+    tb = 0;
+    max = 0;
+    textrect.x = 0;
+    textrect.y = 0;
+    textrect.w = 0;
+    textrect.h = 0;
 }
 
 void textboxclass::centerx()

--- a/desktop_version/src/WarpClass.cpp
+++ b/desktop_version/src/WarpClass.cpp
@@ -13,7 +13,6 @@ const int* warpclass::loadlevel(int rx, int ry)
 
 	t = rx + (ry * 100);
 	const int* result;
-	coin = 0;
 	rcol = 0;
 	warpx = false;
 	warpy = false;

--- a/desktop_version/src/WarpClass.cpp
+++ b/desktop_version/src/WarpClass.cpp
@@ -2,6 +2,13 @@
 
 #include "MakeAndPlay.h"
 
+warpclass::warpclass()
+{
+	rcol = 0;
+	warpx = false;
+	warpy = false;
+}
+
 const int* warpclass::loadlevel(int rx, int ry)
 {
 	int t;

--- a/desktop_version/src/WarpClass.h
+++ b/desktop_version/src/WarpClass.h
@@ -9,6 +9,8 @@
 class warpclass
 {
 public:
+	warpclass();
+
 	const int* loadlevel(int rx, int ry);
 	std::string roomname;
 	int rcol;

--- a/desktop_version/src/WarpClass.h
+++ b/desktop_version/src/WarpClass.h
@@ -11,7 +11,7 @@ class warpclass
 public:
 	const int* loadlevel(int rx, int ry);
 	std::string roomname;
-	int coin, rcol;
+	int rcol;
 	bool warpx, warpy;
 };
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -33,7 +33,6 @@ edlevelclass::edlevelclass()
 {
     tileset=0;
     tilecol=0;
-    roomname="";
     warpdir=0;
     platx1=0;
     platy1=0;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -304,8 +304,6 @@ int main(int argc, char *argv[])
     if(game.bestrank[4]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_warp_fixed");
     if(game.bestrank[5]>=3) NETWORK_unlockAchievement("vvvvvvtimetrial_final_fixed");
 
-    obj.init();
-
 #if !defined(NO_CUSTOM_LEVELS)
     if (startinplaytest) {
         game.levelpage = 0;


### PR DESCRIPTION
Another PR of *code quality improvement* (that's the name of the branch).

This time, I re-added constructors to every class that has member fields, and only the things that need to be strictly initialized in the delayed `init()` function are initialized there (namely, stuff that depends on the filesystem being initialized already). Most notably, `entityclass` no longer has a delayed `init()` function (and it's had said `init()` function since at least 2.2!).

Then I ran the codebase through `cppcheck` and found out every last member field that wasn't initialized, and properly initialized them. And there were a lot of them, actually.

I would've changed the constructors to (mostly) use initialization lists, but the compiler gives off a bunch of warning about the fact that the initialization list isn't the order in which the member fields will be initialized. Apparently this is just to prevent errors with regards to initialization of member fields that depend on other member fields being initialized first, but I don't think the game does that anywhere, so I just didn't bother with the whole thing.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
