### PR TITLE
Fix 'Prize for the Reckless' spikes when switching game modes

### DIFF
--- a/desktop_version/src/Spacestation2.cpp
+++ b/desktop_version/src/Spacestation2.cpp
@@ -2535,13 +2535,12 @@ const int* spacestation2class::loadlevel(int rx, int ry)
 		492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,
 		492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,492,
 		};
-		if(game.nodeathmode || game.intimetrial)
+
+		//Remove spikes in modes where the player shouldn't kill themselves
+		int spikevalue = (game.nodeathmode || game.intimetrial) ? 0 : 9;
+		for (int i = 23; i < 23+14; i++)
 		{
-			for (int i = 23; i < 23+14; i++)
-			{
-				//Remove spikes
-				contents[i + 8*40] = 0;
-			}
+			contents[i + 8*40] = spikevalue;
 		}
 
 		obj.platformtile = 747;


### PR DESCRIPTION
## Changes:

The spikes are removed if the game is in no death or time trial mode,
however the removal is accomplished by modifying a static array. So if
the player switches to no death or time trial mode and switches back to
regular play, the spikes will no longer be present until the game is
restarted (since the static initialization only happens once).

This simple fix writes the spikes back to the static array if the game
is not in no death or time trial mode. Another option is to maintain 2
static arrays - one with the spikes and one without - but that is
needlessly wasteful and prone to mistakes (one array updated but not the
other).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
