### PR TITLE
Fix Vitellary looking left for only one frame in the cutscene in "Now Stay Close To Me..."

### DIFF
--- a/desktop_version/src/Scripts.cpp
+++ b/desktop_version/src/Scripts.cpp
@@ -2651,7 +2651,7 @@ void scriptclass::load(const std::string& name)
         "speak_active",
 
         "squeak(yellow)",
-        "changedir(yellow,0)",
+        "changeai(yellow,faceleft)", // changedir(yellow,0) doesn't work
         "text(yellow,0,0,2)",
         "That big... C thing!",
         "I wonder what it does?",
@@ -2676,7 +2676,7 @@ void scriptclass::load(const std::string& name)
         "speak_active",
 
         "squeak(yellow)",
-        "changedir(yellow,1)",
+        "changeai(yellow,0)", // Make him face right again
         "text(yellow,0,0,2)",
         "Maybe we should take it back",
         "to the ship to study it?",


### PR DESCRIPTION
There's a bug in the cutscene that plays if your companion is Vitellary in the room "Now Stay Close To Me...". The relevant gamestate is gamestate 43, which for Vitellary calls the script `int1yellow_4`.

When Vitellary says the text box "That big... C thing! I wonder what it does?", Terry intended for Vitellary to change his facing direction to the left, as you can see with the command `changedir(yellow,0)` in the original scripting. `changedir()` just changes the `dir` attribute of an entity, and a `dir` of 0 means face left and a `dir` of 1 means face right.

Then when Vitellary says "Maybe we should take it back to the ship to study it?", Terry intended for him to face rightwards once again, as indicated by the `changedir(yellow,1)` command.

Unfortunately, what happens instead is that when Vitellary says the first text box ("That big... C thing! I wonder what it does?"), he turns left for precisely one frame, and then afterwards goes back to facing right. Then the second text box comes around, but he's already facing right. How come?

Well, the problem here is that Vitellary's AI for "follow Viridian" is overriding his `dir` attribute. Vitellary's AI says "get close to Viridian", but Vitellary is already close enough to them that he stays put. However, he still turns to face them as part of that AI.

To fix that, we need to put him in the AI mode that specifically says to face left, with the command `changeai(yellow,faceleft)`. That way, he no longer has the AI mode of following Viridian, and he will actually look left for the intended duration instead of only looking left for one frame.

But then we have another problem. When the cutscene ends, Vitellary no longer follows Viridian. I mean it makes sense - we just placed him in "only face left" mode, not "follow Viridian" mode! And this is not merely a visual problem, because Vitellary is a supercrewmate and the game won't let the player walk off the screen if Vitellary isn't offscreen yet.

To fix *that* issue, we'll need to put Vitellary back in "follow Viridian" mode. It turns out that the `changeai()` command was more intended for scripting crewmates (entity type 12), *not* supercrewmates (entity type 14). As such, the command assumes that you'll want state numbers that apply to entity type 12, such as 10, 11, 12, 13, and 14, even though the only one that applies to entity type 14 is state 0, and every other state number just makes it so that the entity doesn't move an inch. And specifying `faceleft`/`faceright` is just state number 17.

Luckily, we can still pass the raw state number to `changeai()`, we don't have to use its intended names. So I do a `changeai(yellow,0)` to set Vitellary's state number back to 0 when it comes time to make him face right again.

As a bonus, I added comments to the changed lines. This is a semi-obtuse method of scripting, so it's always good to clarify.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
