### PR TITLE
De-duplicate case 12 (custom levels) in mapclass::loadlevel(), mostly entity creation

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1611,6 +1611,7 @@ void mapclass::loadlevel(int rx, int ry)
 #endif
 #if !defined(NO_CUSTOM_LEVELS)
 	case 12: //Custom level
+	{
 		const int curlevel = rx-100 + (ry-100) * ed.maxwidth;
 		const edlevelclass* room_ptr = NULL;
 		if (!INBOUNDS_ARR(curlevel, ed.level))
@@ -1815,6 +1816,7 @@ void mapclass::loadlevel(int rx, int ry)
 
 		//do the appear/remove roomname here
 		break;
+	}
 #endif
 	}
 	//The room's loaded: now we fill out damage blocks based on the tiles.

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1626,27 +1626,29 @@ void mapclass::loadlevel(int rx, int ry)
 		}
 		const edlevelclass& room = *room_ptr;
 
-		game.customcol=ed.getlevelcol(curlevel)+1;
-		obj.customplatformtile=game.customcol*12;
-		switch(room.tileset){
-		case 0: //Space Station
+		game.customcol = ed.getlevelcol(curlevel) + 1;
+		obj.customplatformtile = game.customcol * 12;
+
+		switch (room.tileset)
+		{
+		case 0: // Space Station
 			tileset = 0;
 			background = 1;
 			break;
-		case 1: //Outside
+		case 1: // Outside
 			tileset = 1;
 			background = 1;
 			break;
-		case 2: //Lab
+		case 2: // Lab
 			tileset = 1;
 			background = 2;
 			graphics.rcol = room.tilecol;
 			break;
-		case 3: //Warp Zone/intermission
+		case 3: // Warp Zone/intermission
 			tileset = 1;
 			background = 6;
 			break;
-		case 4://Ship
+		case 4: // Ship
 			tileset = 1;
 			background = 1;
 			break;
@@ -1656,29 +1658,32 @@ void mapclass::loadlevel(int rx, int ry)
 			break;
 		}
 
-		//If screen warping, then override all that:
+		// If screen warping, then override all that:
 		bool redrawbg = game.roomx != game.prevroomx || game.roomy != game.prevroomy;
-		if(redrawbg){
+		if (redrawbg)
+		{
 			graphics.backgrounddrawn = false;
 		}
+
 		switch (room.warpdir)
 		{
 		case 1:
-			warpx=true;
-			background=3;
+			warpx = true;
+			background = 3;
 			break;
 		case 2:
-			warpy=true;
-			background=4;
+			warpy = true;
+			background = 4;
 			break;
 		case 3:
-			warpx=true; warpy=true;
+			warpx = true;
+			warpy = true;
 			background = 5;
 			break;
 		}
 		if (room.warpdir > 0)
 		{
-			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
+			graphics.rcol = ed.getwarpbackground(rx - 100, ry - 100);
 		}
 
 		roomname = room.roomname;
@@ -1690,18 +1695,21 @@ void mapclass::loadlevel(int rx, int ry)
 		roomtexton = false;
 		roomtext.clear();
 
-		//Entities have to be created HERE, akwardly
-		int tempcheckpoints=0;
-		int tempscriptbox=0;
-		for(size_t edi=0; edi<edentity.size(); edi++){
-			//If entity is in this room, create it
+		// Entities have to be created HERE, akwardly
+		int tempcheckpoints = 0;
+		int tempscriptbox = 0;
+		for (size_t edi = 0; edi < edentity.size(); edi++)
+		{
+			// If entity is in this room, create it
 			const edentities& ent = edentity[edi];
 			const int tsx = ent.x / 40;
 			const int tsy = ent.y / 30;
+
 			if (tsx != rx-100 || tsy != ry-100)
 			{
 				continue;
 			}
+
 			const int ex = (ent.x % 40) * 8;
 			const int ey = (ent.y % 30) * 8;
 
@@ -1723,46 +1731,49 @@ void mapclass::loadlevel(int rx, int ry)
 				by2 += 100;
 			}
 
-			switch(ent.t){
-			case 1: //Enemies
-				obj.customenemy=room.enemytype;
-				obj.createentity(ex, ey, 56,
-				ent.p1, 4, bx1, by1, bx2, by2);
+			switch (ent.t)
+			{
+			case 1: // Enemies
+				obj.customenemy = room.enemytype;
+				obj.createentity(ex, ey, 56, ent.p1, 4, bx1, by1, bx2, by2);
 				break;
-			case 2: //Platforms and conveyors
-				if(ent.p1<=4){
-					obj.createentity(ex, ey, 2,
-					ent.p1, room.platv, bx1, by1, bx2, by2);
-				}else if(ent.p1 >= 5 && ent.p1 <= 8){ // Conveyor
-					obj.createentity(ex, ey, 2,
-					ent.p1 + 3, 4);
+			case 2: // Platforms and conveyors
+				if (ent.p1 <= 4)
+				{
+					obj.createentity(ex, ey, 2, ent.p1, room.platv, bx1, by1, bx2, by2);
+				}
+				else if (ent.p1 >= 5 && ent.p1 <= 8) // Conveyor
+				{
+					obj.createentity(ex, ey, 2, ent.p1 + 3, 4);
 				}
 				break;
-			case 3: //Disappearing platforms
+			case 3: // Disappearing platforms
 				obj.createentity(ex, ey, 3);
 				break;
 			case 9: // Trinkets
 				obj.createentity(ex, ey, 9, ed.findtrinket(edi));
 				break;
-			case 10: //Checkpoints
-				obj.createentity(ex, ey, 10,
-				ent.p1, ((rx+(ry*100))*20)+tempcheckpoints);
+			case 10: // Checkpoints
+				obj.createentity(ex, ey, 10, ent.p1, (rx + ry*100) * 20 + tempcheckpoints);
 				tempcheckpoints++;
 				break;
-			case 11: //Gravity Lines
-				if(ent.p1==0){ //Horizontal
+			case 11: // Gravity Lines
+				if (ent.p1 == 0) //Horizontal
+				{
 					obj.createentity(ent.p2 * 8, ey + 4, 11, ent.p3);
-				}else{ //Vertical
+				}
+				else //Vertical
+				{
 					obj.createentity(ex + 3, ent.p2 * 8, 12, ent.p3);
 				}
 				break;
-			case 13: //Warp Tokens
+			case 13: // Warp Tokens
 				obj.createentity(ex, ey, 13, ent.p1, ent.p2);
 				break;
-			case 15: //Collectable crewmate
+			case 15: // Collectable crewmate
 				obj.createentity(ex - 4, ey + 1, 55, ed.findcrewmate(edi), ent.p1, ent.p2);
 				break;
-			case 17: //Roomtext!
+			case 17: // Roomtext!
 			{
 				roomtexton = true;
 				Roomtext text;
@@ -1772,7 +1783,7 @@ void mapclass::loadlevel(int rx, int ry)
 				roomtext.push_back(text);
 				break;
 			}
-			case 18: //Terminals
+			case 18: // Terminals
 			{
 				obj.customscript = ent.scriptname;
 
@@ -1794,13 +1805,12 @@ void mapclass::loadlevel(int rx, int ry)
 				obj.createblock(ACTIVITY, ex - 8, usethisy + 8, 20, 16, 35);
 				break;
 			}
-			case 19: //Script Box
-				game.customscript[tempscriptbox]=ent.scriptname;
-				obj.createblock(TRIGGER, ex, ey,
-								ent.p1 * 8, ent.p2 * 8, 300+tempscriptbox);
+			case 19: // Script Box
+				game.customscript[tempscriptbox] = ent.scriptname;
+				obj.createblock(TRIGGER, ex, ey, ent.p1 * 8, ent.p2 * 8, 300 + tempscriptbox);
 				tempscriptbox++;
 				break;
-			case 50: //Warp Lines
+			case 50: // Warp Lines
 				obj.customwarpmode=true;
 				switch (ent.p1)
 				{

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1629,28 +1629,28 @@ void mapclass::loadlevel(int rx, int ry)
 		game.customcol=ed.getlevelcol(curlevel)+1;
 		obj.customplatformtile=game.customcol*12;
 		switch(room.tileset){
-			case 0: //Space Station
+		case 0: //Space Station
 			tileset = 0;
 			background = 1;
 			break;
-			case 1: //Outside
+		case 1: //Outside
 			tileset = 1;
 			background = 1;
 			break;
-			case 2: //Lab
+		case 2: //Lab
 			tileset = 1;
 			background = 2;
 			graphics.rcol = room.tilecol;
 			break;
-			case 3: //Warp Zone/intermission
+		case 3: //Warp Zone/intermission
 			tileset = 1;
 			background = 6;
 			break;
-			case 4://Ship
+		case 4://Ship
 			tileset = 1;
 			background = 1;
 			break;
-			default:
+		default:
 			tileset = 1;
 			background = 1;
 			break;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1701,32 +1701,32 @@ void mapclass::loadlevel(int rx, int ry)
 			const int ex = (ent.x % 40) * 8;
 			const int ey = (ent.y % 30) * 8;
 
+			// Platform and enemy bounding boxes
+			int bx1 = room.platx1;
+			int by1 = room.platy1;
+			int bx2 = room.platx2;
+			int by2 = room.platy2;
+
+			// Enlarge bounding boxes to fix warping entities
+			if (warpx && bx1 == 0 && bx2 == 320)
+			{
+				bx1 -= 100;
+				bx2 += 100;
+			}
+			if (warpy && by1 == 0 && by2 == 240)
+			{
+				by1 -= 100;
+				by2 += 100;
+			}
+
 			switch(ent.t){
 			case 1: //Enemies
-				int bx1, by1, bx2, by2;
-				bx1=room.enemyx1;
-				by1=room.enemyy1;
-				bx2=room.enemyx2;
-				by2=room.enemyy2;
-
-				if(warpx){ if(bx1==0 && bx2==320){ bx1=-100; bx2=420; } }
-				if(warpy){ if(by1==0 && by2==240){ by1=-100; by2=340; } }
-
 				obj.customenemy=room.enemytype;
 				obj.createentity(ex, ey, 56,
 				ent.p1, 4, bx1, by1, bx2, by2);
 				break;
 			case 2: //Platforms and Threadmills
 				if(ent.p1<=4){
-					int bx1, by1, bx2, by2;
-					bx1=room.platx1;
-					by1=room.platy1;
-					bx2=room.platx2;
-					by2=room.platy2;
-
-					if(warpx){ if(bx1==0 && bx2==320){ bx1=-100; bx2=420; } }
-					if(warpy){ if(by1==0 && by2==240){ by1=-100; by2=340; } }
-
 					obj.createentity(ex, ey, 2,
 					ent.p1, room.platv, bx1, by1, bx2, by2);
 				}else if(ent.p1 >= 5 && ent.p1 <= 8){ //Threadmill

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1794,7 +1794,7 @@ void mapclass::loadlevel(int rx, int ry)
 				}
 				break;
 			}
-			}
+		}
 
 		//do the appear/remove roomname here
 		break;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1666,18 +1666,19 @@ void mapclass::loadlevel(int rx, int ry)
 		case 1:
 			warpx=true;
 			background=3;
-			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
 			break;
 		case 2:
 			warpy=true;
 			background=4;
-			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
 			break;
 		case 3:
 			warpx=true; warpy=true;
 			background = 5;
-			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
 			break;
+		}
+		if (room.warpdir > 0)
+		{
+			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
 		}
 
 		roomname = room.roomname;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1680,15 +1680,16 @@ void mapclass::loadlevel(int rx, int ry)
 		int tempscriptbox=0;
 		for(size_t edi=0; edi<edentity.size(); edi++){
 			//If entity is in this room, create it
-			const int tsx = edentity[edi].x / 40;
-			const int tsy = edentity[edi].y / 30;
+			const edentities& ent = edentity[edi];
+			const int tsx = ent.x / 40;
+			const int tsy = ent.y / 30;
 			if (tsx != rx-100 || tsy != ry-100)
 			{
 				continue;
 			}
-			const int ex = (edentity[edi].x % 40) * 8;
-			const int ey = (edentity[edi].y % 30) * 8;
-			switch(edentity[edi].t){
+			const int ex = (ent.x % 40) * 8;
+			const int ey = (ent.y % 30) * 8;
+			switch(ent.t){
 			case 1: //Enemies
 				int bx1, by1, bx2, by2;
 				bx1=ed.level[rx-100+((ry-100)*ed.maxwidth)].enemyx1;
@@ -1701,10 +1702,10 @@ void mapclass::loadlevel(int rx, int ry)
 
 				obj.customenemy=ed.level[tsx+((ed.maxwidth)*tsy)].enemytype;
 				obj.createentity(ex, ey, 56,
-				edentity[edi].p1, 4, bx1, by1, bx2, by2);
+				ent.p1, 4, bx1, by1, bx2, by2);
 				break;
 			case 2: //Platforms and Threadmills
-				if(edentity[edi].p1<=4){
+				if(ent.p1<=4){
 					int bx1, by1, bx2, by2;
 					bx1=ed.level[rx-100+((ry-100)*ed.maxwidth)].platx1;
 					by1=ed.level[rx-100+((ry-100)*ed.maxwidth)].platy1;
@@ -1715,10 +1716,10 @@ void mapclass::loadlevel(int rx, int ry)
 					if(warpy){ if(by1==0 && by2==240){ by1=-100; by2=340; } }
 
 					obj.createentity(ex, ey, 2,
-					edentity[edi].p1, ed.level[rx-100+((ry-100)*ed.mapwidth)].platv, bx1, by1, bx2, by2);
-				}else if(edentity[edi].p1>=5 && edentity[edi].p1<=8){ //Threadmill
+					ent.p1, ed.level[rx-100+((ry-100)*ed.mapwidth)].platv, bx1, by1, bx2, by2);
+				}else if(ent.p1 >= 5 && ent.p1 <= 8){ //Threadmill
 					obj.createentity(ex, ey, 2,
-					edentity[edi].p1+3, 4);
+					ent.p1 + 3, 4);
 				}
 				break;
 			case 3: //Disappearing platforms
@@ -1729,21 +1730,21 @@ void mapclass::loadlevel(int rx, int ry)
 				break;
 			case 10: //Checkpoints
 				obj.createentity(ex, ey, 10,
-				edentity[edi].p1,((rx+(ry*100))*20)+tempcheckpoints);
+				ent.p1, ((rx+(ry*100))*20)+tempcheckpoints);
 				tempcheckpoints++;
 				break;
 			case 11: //Gravity Lines
-				if(edentity[edi].p1==0){ //Horizontal
-					obj.createentity((edentity[edi].p2*8), ey + 4, 11, edentity[edi].p3);
+				if(ent.p1==0){ //Horizontal
+					obj.createentity(ent.p2 * 8, ey + 4, 11, ent.p3);
 				}else{ //Vertical
-					obj.createentity(ex + 3,(edentity[edi].p2*8), 12, edentity[edi].p3);
+					obj.createentity(ex + 3, ent.p2 * 8, 12, ent.p3);
 				}
 				break;
 			case 13: //Warp Tokens
-				obj.createentity(ex, ey, 13, edentity[edi].p1, edentity[edi].p2);
+				obj.createentity(ex, ey, 13, ent.p1, ent.p2);
 				break;
 			case 15: //Collectable crewmate
-				obj.createentity(ex - 4, ey + 1, 55, ed.findcrewmate(edi), edentity[edi].p1, edentity[edi].p2);
+				obj.createentity(ex - 4, ey + 1, 55, ed.findcrewmate(edi), ent.p1, ent.p2);
 				break;
 			case 17: //Roomtext!
 			{
@@ -1751,15 +1752,15 @@ void mapclass::loadlevel(int rx, int ry)
 				Roomtext text;
 				text.x = ex / 8;
 				text.y = ey / 8;
-				text.text = edentity[edi].scriptname;
+				text.text = ent.scriptname;
 				roomtext.push_back(text);
 				break;
 			}
 			case 18: //Terminals
 			{
-				obj.customscript=edentity[edi].scriptname;
+				obj.customscript = ent.scriptname;
 
-				int usethistile = edentity[edi].p1;
+				int usethistile = ent.p1;
 				int usethisy = ey;
 
 				// This isn't a boolean: we just swap 0 and 1 around and leave the rest alone
@@ -1778,21 +1779,21 @@ void mapclass::loadlevel(int rx, int ry)
 				break;
 			}
 			case 19: //Script Box
-				game.customscript[tempscriptbox]=edentity[edi].scriptname;
+				game.customscript[tempscriptbox]=ent.scriptname;
 				obj.createblock(1, ex, ey,
-								edentity[edi].p1*8, edentity[edi].p2*8, 300+tempscriptbox);
+								ent.p1 * 8, ent.p2 * 8, 300+tempscriptbox);
 				tempscriptbox++;
 				break;
 			case 50: //Warp Lines
 				obj.customwarpmode=true;
-				if(edentity[edi].p1==0){ //
-					obj.createentity(ex + 4,(edentity[edi].p2*8), 51, edentity[edi].p3);
-				}else if(edentity[edi].p1==1){ //Horizontal, right
-					obj.createentity(ex + 4,(edentity[edi].p2*8), 52, edentity[edi].p3);
-				}else if(edentity[edi].p1==2){ //Vertical, top
-					obj.createentity((edentity[edi].p2*8), ey + 7, 53, edentity[edi].p3);
-				}else if(edentity[edi].p1==3){
-					obj.createentity((edentity[edi].p2*8), ey, 54, edentity[edi].p3);
+				if(ent.p1==0){ //
+					obj.createentity(ex + 4, ent.p2 * 8, 51, ent.p3);
+				}else if(ent.p1==1){ //Horizontal, right
+					obj.createentity(ex + 4, ent.p2 * 8, 52, ent.p3);
+				}else if(ent.p1==2){ //Vertical, top
+					obj.createentity(ent.p2 * 8, ey + 7, 53, ent.p3);
+				}else if(ent.p1==3){
+					obj.createentity(ent.p2 * 8, ey, 54, ent.p3);
 				}
 				break;
 			}

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1680,8 +1680,8 @@ void mapclass::loadlevel(int rx, int ry)
 		int tempscriptbox=0;
 		for(size_t edi=0; edi<edentity.size(); edi++){
 			//If entity is in this room, create it
-			int tsx=(edentity[edi].x-(edentity[edi].x%40))/40;
-			int tsy=(edentity[edi].y-(edentity[edi].y%30))/30;
+			const int tsx = edentity[edi].x / 40;
+			const int tsy = edentity[edi].y / 30;
 			if (tsx != rx-100 || tsy != ry-100)
 			{
 				continue;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1611,10 +1611,23 @@ void mapclass::loadlevel(int rx, int ry)
 #endif
 #if !defined(NO_CUSTOM_LEVELS)
 	case 12: //Custom level
-		int curlevel=(rx-100)+((ry-100)*ed.maxwidth);
+		const int curlevel = rx-100 + (ry-100) * ed.maxwidth;
+		const edlevelclass* room_ptr = NULL;
+		if (!INBOUNDS_ARR(curlevel, ed.level))
+		{
+			static edlevelclass blank;
+			blank.tileset = 1;
+			room_ptr = &blank;
+		}
+		else
+		{
+			room_ptr = &ed.level[curlevel];
+		}
+		const edlevelclass& room = *room_ptr;
+
 		game.customcol=ed.getlevelcol(curlevel)+1;
 		obj.customplatformtile=game.customcol*12;
-		switch(ed.level[curlevel].tileset){
+		switch(room.tileset){
 			case 0: //Space Station
 			tileset = 0;
 			background = 1;
@@ -1626,7 +1639,7 @@ void mapclass::loadlevel(int rx, int ry)
 			case 2: //Lab
 			tileset = 1;
 			background = 2;
-			graphics.rcol = ed.level[curlevel].tilecol;
+			graphics.rcol = room.tilecol;
 			break;
 			case 3: //Warp Zone/intermission
 			tileset = 1;
@@ -1647,16 +1660,16 @@ void mapclass::loadlevel(int rx, int ry)
 		if(redrawbg){
 			graphics.backgrounddrawn = false;
 		}
-		if(ed.level[curlevel].warpdir>0){
-			if(ed.level[curlevel].warpdir==1){
+		if(room.warpdir>0){
+			if(room.warpdir==1){
 			warpx=true;
 			background=3;
 			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
-			}else if(ed.level[curlevel].warpdir==2){
+			}else if(room.warpdir==2){
 			warpy=true;
 			background=4;
 			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
-			}else if(ed.level[curlevel].warpdir==3){
+			}else if(room.warpdir==3){
 			warpx=true; warpy=true;
 			background = 5;
 			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
@@ -1664,8 +1677,8 @@ void mapclass::loadlevel(int rx, int ry)
 		}
 
 		roomname="";
-		if(ed.level[curlevel].roomname!=""){
-			roomname=ed.level[curlevel].roomname;
+		if(room.roomname!=""){
+			roomname=room.roomname;
 		}
 		extrarow = 1;
 		const int* tmap = ed.loadlevel(rx, ry);
@@ -1689,34 +1702,35 @@ void mapclass::loadlevel(int rx, int ry)
 			}
 			const int ex = (ent.x % 40) * 8;
 			const int ey = (ent.y % 30) * 8;
+
 			switch(ent.t){
 			case 1: //Enemies
 				int bx1, by1, bx2, by2;
-				bx1=ed.level[rx-100+((ry-100)*ed.maxwidth)].enemyx1;
-				by1=ed.level[rx-100+((ry-100)*ed.maxwidth)].enemyy1;
-				bx2=ed.level[rx-100+((ry-100)*ed.maxwidth)].enemyx2;
-				by2=ed.level[rx-100+((ry-100)*ed.maxwidth)].enemyy2;
+				bx1=room.enemyx1;
+				by1=room.enemyy1;
+				bx2=room.enemyx2;
+				by2=room.enemyy2;
 
 				if(warpx){ if(bx1==0 && bx2==320){ bx1=-100; bx2=420; } }
 				if(warpy){ if(by1==0 && by2==240){ by1=-100; by2=340; } }
 
-				obj.customenemy=ed.level[tsx+((ed.maxwidth)*tsy)].enemytype;
+				obj.customenemy=room.enemytype;
 				obj.createentity(ex, ey, 56,
 				ent.p1, 4, bx1, by1, bx2, by2);
 				break;
 			case 2: //Platforms and Threadmills
 				if(ent.p1<=4){
 					int bx1, by1, bx2, by2;
-					bx1=ed.level[rx-100+((ry-100)*ed.maxwidth)].platx1;
-					by1=ed.level[rx-100+((ry-100)*ed.maxwidth)].platy1;
-					bx2=ed.level[rx-100+((ry-100)*ed.maxwidth)].platx2;
-					by2=ed.level[rx-100+((ry-100)*ed.maxwidth)].platy2;
+					bx1=room.platx1;
+					by1=room.platy1;
+					bx2=room.platx2;
+					by2=room.platy2;
 
 					if(warpx){ if(bx1==0 && bx2==320){ bx1=-100; bx2=420; } }
 					if(warpy){ if(by1==0 && by2==240){ by1=-100; by2=340; } }
 
 					obj.createentity(ex, ey, 2,
-					ent.p1, ed.level[rx-100+((ry-100)*ed.mapwidth)].platv, bx1, by1, bx2, by2);
+					ent.p1, room.platv, bx1, by1, bx2, by2);
 				}else if(ent.p1 >= 5 && ent.p1 <= 8){ //Threadmill
 					obj.createentity(ex, ey, 2,
 					ent.p1 + 3, 4);

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1682,7 +1682,10 @@ void mapclass::loadlevel(int rx, int ry)
 			//If entity is in this room, create it
 			int tsx=(edentity[edi].x-(edentity[edi].x%40))/40;
 			int tsy=(edentity[edi].y-(edentity[edi].y%30))/30;
-			if(tsx==rx-100 && tsy==ry-100){
+			if (tsx != rx-100 || tsy != ry-100)
+			{
+				continue;
+			}
 			switch(edentity[edi].t){
 				case 1: //Enemies
 				int bx1, by1, bx2, by2;
@@ -1790,7 +1793,6 @@ void mapclass::loadlevel(int rx, int ry)
 					obj.createentity((edentity[edi].p2*8),(edentity[edi].y*8)- ((ry-100)*30*8), 54, edentity[edi].p3);
 				}
 				break;
-			}
 			}
 			}
 

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1725,11 +1725,11 @@ void mapclass::loadlevel(int rx, int ry)
 				obj.createentity(ex, ey, 56,
 				ent.p1, 4, bx1, by1, bx2, by2);
 				break;
-			case 2: //Platforms and Threadmills
+			case 2: //Platforms and conveyors
 				if(ent.p1<=4){
 					obj.createentity(ex, ey, 2,
 					ent.p1, room.platv, bx1, by1, bx2, by2);
-				}else if(ent.p1 >= 5 && ent.p1 <= 8){ //Threadmill
+				}else if(ent.p1 >= 5 && ent.p1 <= 8){ // Conveyor
 					obj.createentity(ex, ey, 2,
 					ent.p1 + 3, 4);
 				}
@@ -1737,7 +1737,7 @@ void mapclass::loadlevel(int rx, int ry)
 			case 3: //Disappearing platforms
 				obj.createentity(ex, ey, 3);
 				break;
-			case 9:
+			case 9: // Trinkets
 				obj.createentity(ex, ey, 9, ed.findtrinket(edi));
 				break;
 			case 10: //Checkpoints
@@ -1800,7 +1800,7 @@ void mapclass::loadlevel(int rx, int ry)
 				obj.customwarpmode=true;
 				switch (ent.p1)
 				{
-				case 0: //
+				case 0: // Vertical, left
 					obj.createentity(ex + 4, ent.p2 * 8, 51, ent.p3);
 					break;
 				case 1: //Horizontal, right
@@ -1809,7 +1809,7 @@ void mapclass::loadlevel(int rx, int ry)
 				case 2: //Vertical, top
 					obj.createentity(ent.p2 * 8, ey + 7, 53, ent.p3);
 					break;
-				case 3:
+				case 3: // Horizontal, bottom
 					obj.createentity(ent.p2 * 8, ey, 54, ent.p3);
 					break;
 				}

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1787,12 +1787,12 @@ void mapclass::loadlevel(int rx, int ry)
 				}
 
 				obj.createentity(ex, usethisy + 8, 20, usethistile);
-				obj.createblock(5, ex - 8, usethisy + 8, 20, 16, 35);
+				obj.createblock(ACTIVITY, ex - 8, usethisy + 8, 20, 16, 35);
 				break;
 			}
 			case 19: //Script Box
 				game.customscript[tempscriptbox]=ent.scriptname;
-				obj.createblock(1, ex, ey,
+				obj.createblock(TRIGGER, ex, ey,
 								ent.p1 * 8, ent.p2 * 8, 300+tempscriptbox);
 				tempscriptbox++;
 				break;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1686,6 +1686,8 @@ void mapclass::loadlevel(int rx, int ry)
 			{
 				continue;
 			}
+			const int ex = (edentity[edi].x % 40) * 8;
+			const int ey = (edentity[edi].y % 30) * 8;
 			switch(edentity[edi].t){
 				case 1: //Enemies
 				int bx1, by1, bx2, by2;
@@ -1698,7 +1700,7 @@ void mapclass::loadlevel(int rx, int ry)
 				if(warpy){ if(by1==0 && by2==240){ by1=-100; by2=340; } }
 
 				obj.customenemy=ed.level[tsx+((ed.maxwidth)*tsy)].enemytype;
-				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 56,
+				obj.createentity(ex, ey, 56,
 				edentity[edi].p1, 4, bx1, by1, bx2, by2);
 				break;
 				case 2: //Platforms and Threadmills
@@ -1712,43 +1714,43 @@ void mapclass::loadlevel(int rx, int ry)
 					if(warpx){ if(bx1==0 && bx2==320){ bx1=-100; bx2=420; } }
 					if(warpy){ if(by1==0 && by2==240){ by1=-100; by2=340; } }
 
-					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 2,
+					obj.createentity(ex, ey, 2,
 					edentity[edi].p1, ed.level[rx-100+((ry-100)*ed.mapwidth)].platv, bx1, by1, bx2, by2);
 				}else if(edentity[edi].p1>=5 && edentity[edi].p1<=8){ //Threadmill
-					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 2,
+					obj.createentity(ex, ey, 2,
 					edentity[edi].p1+3, 4);
 				}
 				break;
 				case 3: //Disappearing platforms
-				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 3);
+				obj.createentity(ex, ey, 3);
 				break;
 				case 9:
-				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 9, ed.findtrinket(edi));
+				obj.createentity(ex, ey, 9, ed.findtrinket(edi));
 				break;
 				case 10: //Checkpoints
-				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 10,
+				obj.createentity(ex, ey, 10,
 				edentity[edi].p1,((rx+(ry*100))*20)+tempcheckpoints);
 				tempcheckpoints++;
 				break;
 				case 11: //Gravity Lines
 				if(edentity[edi].p1==0){ //Horizontal
-					obj.createentity((edentity[edi].p2*8),(edentity[edi].y*8)- ((ry-100)*30*8)+4, 11, edentity[edi].p3);
+					obj.createentity((edentity[edi].p2*8), ey + 4, 11, edentity[edi].p3);
 				}else{ //Vertical
-					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8)+3,(edentity[edi].p2*8), 12, edentity[edi].p3);
+					obj.createentity(ex + 3,(edentity[edi].p2*8), 12, edentity[edi].p3);
 				}
 				break;
 				case 13: //Warp Tokens
-				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8),(edentity[edi].y*8)- ((ry-100)*30*8), 13, edentity[edi].p1, edentity[edi].p2);
+				obj.createentity(ex, ey, 13, edentity[edi].p1, edentity[edi].p2);
 				break;
 				case 15: //Collectable crewmate
-				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8)-4,(edentity[edi].y*8)- ((ry-100)*30*8)+1, 55, ed.findcrewmate(edi), edentity[edi].p1, edentity[edi].p2);
+				obj.createentity(ex - 4, ey + 1, 55, ed.findcrewmate(edi), edentity[edi].p1, edentity[edi].p2);
 				break;
 				case 17: //Roomtext!
 				{
 				roomtexton = true;
 				Roomtext text;
-				text.x = edentity[edi].x - ((rx-100)*40);
-				text.y = edentity[edi].y - ((ry-100)*30);
+				text.x = ex / 8;
+				text.y = ey / 8;
 				text.text = edentity[edi].scriptname;
 				roomtext.push_back(text);
 				break;
@@ -1758,7 +1760,7 @@ void mapclass::loadlevel(int rx, int ry)
 				obj.customscript=edentity[edi].scriptname;
 
 				int usethistile = edentity[edi].p1;
-				int usethisy = (edentity[edi].y*8)- ((ry-100)*30*8);
+				int usethisy = ey;
 
 				// This isn't a boolean: we just swap 0 and 1 around and leave the rest alone
 				if (usethistile == 0)
@@ -1771,26 +1773,26 @@ void mapclass::loadlevel(int rx, int ry)
 					usethisy -= 8;
 				}
 
-				obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8), usethisy+8, 20, usethistile);
-				obj.createblock(5, (edentity[edi].x*8)- ((rx-100)*40*8)-8, usethisy+8, 20, 16, 35);
+				obj.createentity(ex, usethisy + 8, 20, usethistile);
+				obj.createblock(5, ex - 8, usethisy + 8, 20, 16, 35);
 				break;
 				}
 				case 19: //Script Box
 				game.customscript[tempscriptbox]=edentity[edi].scriptname;
-				obj.createblock(1, (edentity[edi].x*8)- ((rx-100)*40*8), (edentity[edi].y*8)- ((ry-100)*30*8),
+				obj.createblock(1, ex, ey,
 								edentity[edi].p1*8, edentity[edi].p2*8, 300+tempscriptbox);
 				tempscriptbox++;
 				break;
 				case 50: //Warp Lines
 				obj.customwarpmode=true;
 				if(edentity[edi].p1==0){ //
-					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8)+4,(edentity[edi].p2*8), 51, edentity[edi].p3);
+					obj.createentity(ex + 4,(edentity[edi].p2*8), 51, edentity[edi].p3);
 				}else if(edentity[edi].p1==1){ //Horizontal, right
-					obj.createentity((edentity[edi].x*8)- ((rx-100)*40*8)+4,(edentity[edi].p2*8), 52, edentity[edi].p3);
+					obj.createentity(ex + 4,(edentity[edi].p2*8), 52, edentity[edi].p3);
 				}else if(edentity[edi].p1==2){ //Vertical, top
-					obj.createentity((edentity[edi].p2*8),(edentity[edi].y*8)- ((ry-100)*30*8)+7, 53, edentity[edi].p3);
+					obj.createentity((edentity[edi].p2*8), ey + 7, 53, edentity[edi].p3);
 				}else if(edentity[edi].p1==3){
-					obj.createentity((edentity[edi].p2*8),(edentity[edi].y*8)- ((ry-100)*30*8), 54, edentity[edi].p3);
+					obj.createentity((edentity[edi].p2*8), ey, 54, edentity[edi].p3);
 				}
 				break;
 			}

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1689,7 +1689,7 @@ void mapclass::loadlevel(int rx, int ry)
 			const int ex = (edentity[edi].x % 40) * 8;
 			const int ey = (edentity[edi].y % 30) * 8;
 			switch(edentity[edi].t){
-				case 1: //Enemies
+			case 1: //Enemies
 				int bx1, by1, bx2, by2;
 				bx1=ed.level[rx-100+((ry-100)*ed.maxwidth)].enemyx1;
 				by1=ed.level[rx-100+((ry-100)*ed.maxwidth)].enemyy1;
@@ -1703,7 +1703,7 @@ void mapclass::loadlevel(int rx, int ry)
 				obj.createentity(ex, ey, 56,
 				edentity[edi].p1, 4, bx1, by1, bx2, by2);
 				break;
-				case 2: //Platforms and Threadmills
+			case 2: //Platforms and Threadmills
 				if(edentity[edi].p1<=4){
 					int bx1, by1, bx2, by2;
 					bx1=ed.level[rx-100+((ry-100)*ed.maxwidth)].platx1;
@@ -1721,32 +1721,32 @@ void mapclass::loadlevel(int rx, int ry)
 					edentity[edi].p1+3, 4);
 				}
 				break;
-				case 3: //Disappearing platforms
+			case 3: //Disappearing platforms
 				obj.createentity(ex, ey, 3);
 				break;
-				case 9:
+			case 9:
 				obj.createentity(ex, ey, 9, ed.findtrinket(edi));
 				break;
-				case 10: //Checkpoints
+			case 10: //Checkpoints
 				obj.createentity(ex, ey, 10,
 				edentity[edi].p1,((rx+(ry*100))*20)+tempcheckpoints);
 				tempcheckpoints++;
 				break;
-				case 11: //Gravity Lines
+			case 11: //Gravity Lines
 				if(edentity[edi].p1==0){ //Horizontal
 					obj.createentity((edentity[edi].p2*8), ey + 4, 11, edentity[edi].p3);
 				}else{ //Vertical
 					obj.createentity(ex + 3,(edentity[edi].p2*8), 12, edentity[edi].p3);
 				}
 				break;
-				case 13: //Warp Tokens
+			case 13: //Warp Tokens
 				obj.createentity(ex, ey, 13, edentity[edi].p1, edentity[edi].p2);
 				break;
-				case 15: //Collectable crewmate
+			case 15: //Collectable crewmate
 				obj.createentity(ex - 4, ey + 1, 55, ed.findcrewmate(edi), edentity[edi].p1, edentity[edi].p2);
 				break;
-				case 17: //Roomtext!
-				{
+			case 17: //Roomtext!
+			{
 				roomtexton = true;
 				Roomtext text;
 				text.x = ex / 8;
@@ -1754,9 +1754,9 @@ void mapclass::loadlevel(int rx, int ry)
 				text.text = edentity[edi].scriptname;
 				roomtext.push_back(text);
 				break;
-				}
-				case 18: //Terminals
-				{
+			}
+			case 18: //Terminals
+			{
 				obj.customscript=edentity[edi].scriptname;
 
 				int usethistile = edentity[edi].p1;
@@ -1776,14 +1776,14 @@ void mapclass::loadlevel(int rx, int ry)
 				obj.createentity(ex, usethisy + 8, 20, usethistile);
 				obj.createblock(5, ex - 8, usethisy + 8, 20, 16, 35);
 				break;
-				}
-				case 19: //Script Box
+			}
+			case 19: //Script Box
 				game.customscript[tempscriptbox]=edentity[edi].scriptname;
 				obj.createblock(1, ex, ey,
 								edentity[edi].p1*8, edentity[edi].p2*8, 300+tempscriptbox);
 				tempscriptbox++;
 				break;
-				case 50: //Warp Lines
+			case 50: //Warp Lines
 				obj.customwarpmode=true;
 				if(edentity[edi].p1==0){ //
 					obj.createentity(ex + 4,(edentity[edi].p2*8), 51, edentity[edi].p3);

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1798,14 +1798,20 @@ void mapclass::loadlevel(int rx, int ry)
 				break;
 			case 50: //Warp Lines
 				obj.customwarpmode=true;
-				if(ent.p1==0){ //
+				switch (ent.p1)
+				{
+				case 0: //
 					obj.createentity(ex + 4, ent.p2 * 8, 51, ent.p3);
-				}else if(ent.p1==1){ //Horizontal, right
+					break;
+				case 1: //Horizontal, right
 					obj.createentity(ex + 4, ent.p2 * 8, 52, ent.p3);
-				}else if(ent.p1==2){ //Vertical, top
+					break;
+				case 2: //Vertical, top
 					obj.createentity(ent.p2 * 8, ey + 7, 53, ent.p3);
-				}else if(ent.p1==3){
+					break;
+				case 3:
 					obj.createentity(ent.p2 * 8, ey, 54, ent.p3);
+					break;
 				}
 				break;
 			}

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1677,10 +1677,7 @@ void mapclass::loadlevel(int rx, int ry)
 			}
 		}
 
-		roomname="";
-		if(room.roomname!=""){
-			roomname=room.roomname;
-		}
+		roomname = room.roomname;
 		extrarow = 1;
 		const int* tmap = ed.loadlevel(rx, ry);
 		SDL_memcpy(contents, tmap, sizeof(contents));

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1544,8 +1544,8 @@ void mapclass::loadlevel(int rx, int ry)
 		cameramode = 0;
 		colstate = 0;
 		colsuperstate = 0;
-	}
 		break;
+	}
 	case 10: //Final Level, Tower 2
 	{
 
@@ -1583,8 +1583,8 @@ void mapclass::loadlevel(int rx, int ry)
 		cameramode = 0;
 		colstate = 0;
 		colsuperstate = 0;
-	}
 		break;
+	}
 	case 11: //Tower Hallways //Content is held in final level routine
 	{
 		const int* tmap = finallevel.loadlevel(rx, ry);
@@ -1606,8 +1606,8 @@ void mapclass::loadlevel(int rx, int ry)
 			background = 9;
 			rcol = 0;
 		}
-	}
 		break;
+	}
 #endif
 #if !defined(NO_CUSTOM_LEVELS)
 	case 12: //Custom level

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1661,20 +1661,23 @@ void mapclass::loadlevel(int rx, int ry)
 		if(redrawbg){
 			graphics.backgrounddrawn = false;
 		}
-		if(room.warpdir>0){
-			if(room.warpdir==1){
+		switch (room.warpdir)
+		{
+		case 1:
 			warpx=true;
 			background=3;
 			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
-			}else if(room.warpdir==2){
+			break;
+		case 2:
 			warpy=true;
 			background=4;
 			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
-			}else if(room.warpdir==3){
+			break;
+		case 3:
 			warpx=true; warpy=true;
 			background = 5;
 			graphics.rcol = ed.getwarpbackground(rx-100,ry-100);
-			}
+			break;
 		}
 
 		roomname = room.roomname;


### PR DESCRIPTION
Case 12 in `mapclass::loadlevel()` is a hot mess. A lot of it is a bunch of copy-pasted code, especially the part where edentities are converted into actual entities by a bunch of `obj.createentity()` calls. Luckily, I'm here to clean it all up and make it better.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
