### PR TITLE
Refactor script boxes in custom levels to not use gamestates

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -3876,9 +3876,11 @@ void entityclass::settemprect( int t )
     rectset(tempx, tempy, tempw, temph);
 }
 
-int entityclass::checktrigger()
+int entityclass::checktrigger(int* block_idx)
 {
     //Returns an int player entity (rule 0) collides with a trigger
+    //Also returns the index of the block
+    *block_idx = -1;
     for(size_t i=0; i < entities.size(); i++)
     {
         if(entities[i].rule==0)
@@ -3894,6 +3896,7 @@ int entityclass::checktrigger()
                 if (blocks[j].type == TRIGGER && help.intersects(blocks[j].rect, temprect))
                 {
                     activetrigger = blocks[j].trigger;
+                    *block_idx = j;
                     return blocks[j].trigger;
                 }
             }
@@ -4816,9 +4819,20 @@ void entityclass::entitycollisioncheck()
 
     // WARNING: If updating this code, don't forget to update Map.cpp mapclass::twoframedelayfix()
     activetrigger = -1;
-    if (checktrigger() > -1)
+    int block_idx = -1;
+    if (checktrigger(&block_idx) > -1 && block_idx > -1)
     {
-        game.state = activetrigger;
+        if (blocks[block_idx].script != "")
+        {
+            game.startscript = true;
+            game.newscript = blocks[block_idx].script;
+            removetrigger(activetrigger);
+            game.state = 0;
+        }
+        else
+        {
+            game.state = activetrigger;
+        }
         game.statedelay = 0;
     }
 }

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -770,7 +770,7 @@ void entityclass::generateswnwave( int t )
     }
 }
 
-void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*= 0*/ )
+void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*= 0*/, const std::string& script /*= ""*/ )
 {
     k = blocks.size();
 
@@ -793,6 +793,7 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
         block.hp = h;
         block.rectset(xp, yp, w, h);
         block.trigger = trig;
+        block.script = script;
         break;
     case DAMAGE: //Damage
         block.type = DAMAGE;

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -105,7 +105,7 @@ public:
 
     void settemprect(int t);
 
-    int checktrigger();
+    int checktrigger(int* block_idx);
 
     int checkactivity();
 

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -53,7 +53,7 @@ public:
 
     void generateswnwave(int t);
 
-    void createblock(int t, int xp, int yp, int w, int h, int trig = 0);
+    void createblock(int t, int xp, int yp, int w, int h, int trig = 0, const std::string& script = "");
 
     bool removeentity(int t);
 

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -2062,16 +2062,18 @@ void mapclass::twoframedelayfix()
 	// and when the script gets loaded script.run() has already ran for that frame, too.
 	// A bit kludge-y, but it's the least we can do without changing the frame ordering.
 
+	int block_idx = -1;
 	if (game.glitchrunnermode
 	|| game.deathseq != -1
-	// obj.checktrigger() sets obj.activetrigger
-	|| obj.checktrigger() <= -1
+	// obj.checktrigger() sets obj.activetrigger and block_idx
+	|| obj.checktrigger(&block_idx) <= -1
+	|| block_idx <= -1
 	|| obj.activetrigger < 300)
 	{
 		return;
 	}
 
-	game.newscript = "custom_" + game.customscript[obj.activetrigger - 300];
+	game.newscript = obj.blocks[block_idx].script;
 	obj.removetrigger(obj.activetrigger);
 	game.state = 0;
 	game.statedelay = 0;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1775,7 +1775,7 @@ void mapclass::loadlevel(int rx, int ry)
 				case 19: //Script Box
 				game.customscript[tempscriptbox]=edentity[edi].scriptname;
 				obj.createblock(1, (edentity[edi].x*8)- ((rx-100)*40*8), (edentity[edi].y*8)- ((ry-100)*30*8),
-								edentity[edi].p1*8, edentity[edi].p2*8, 300+tempscriptbox);
+								edentity[edi].p1*8, edentity[edi].p2*8, 300+tempscriptbox, "custom_" + edentity[edi].scriptname);
 				tempscriptbox++;
 				break;
 				case 50: //Warp Lines

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1773,7 +1773,10 @@ void mapclass::loadlevel(int rx, int ry)
 				break;
 				}
 				case 19: //Script Box
-				game.customscript[tempscriptbox]=edentity[edi].scriptname;
+				if (INBOUNDS_ARR(tempscriptbox, game.customscript))
+				{
+					game.customscript[tempscriptbox]=edentity[edi].scriptname;
+				}
 				obj.createblock(1, (edentity[edi].x*8)- ((rx-100)*40*8), (edentity[edi].y*8)- ((ry-100)*30*8),
 								edentity[edi].p1*8, edentity[edi].p2*8, 300+tempscriptbox, "custom_" + edentity[edi].scriptname);
 				tempscriptbox++;


### PR DESCRIPTION
Previously, whenever a script box was created in a custom level, the game would set the script box's script in `game.customscript` (an array of `std::string`s) and set the gamestate that the script box will execute to be one that will read from that array (gamestates 300..336). This seems to be a really unnecessary middleman, so I've made it so that the primary way a script box gets executed is by the game setting the `script` attribute of the block, and then directly reading that attribute if the player collides with it.

However, for backwards compatibility, I've left gamestates 300..336 and `game.customscript` alone, as some custom levels use those gamestates in order to enter a script box loop.

Furthermore, I've made sure that the quirks of script boxes were preserved:
 - Script boxes will not be activated if you're in the death animation. This was trivial to preserve, because collision with script boxes is done in `obj.entitycollisioncheck()`, but that function is only run if `game.deathseq` is -1 (i.e. when you're not dying). I've only had to change the logic in `obj.entitycollisioncheck()`, so this quirk is preserved.
 - Since script boxes were gamestate-based, touching a script box would interrupt the current gamestate and set the gamestate delay to be 0. I've made sure that this new way interrupts the current gamestate, too.
 - Due to script boxes being gamestate-based, there was a one-frame delay before the script box's script would actually execute after touching it (this is explained further in the PR message for #317). This one-frame delay can trivially be kept by using `game.newscript` instead of calling `script.load()` directly, because the script in `game.newscript` is executed immediately after the gamestate is processed in the frame ordering (in fact, all gamestates use this `game.newscript` system), and when we check for script box collisions we've already processed the gamestate / `game.newscript`, so there will still be a one-frame delay.
 - Script boxes that are placed first are prioritized first, so if you touch two script boxes on the same frame the first-placed one gets priority. This is because `obj.checktrigger()` stops on the first block in the blocks vector that it encounters. This quirk is still preserved, because I've only added to the logic that runs whenever it finds the first block encountered, I haven't changed how it iterates over the blocks array.

I've also made sure that this applies to the two-frame delay fix in `mapclass::twoframedelayfix()`.

(Conflicts with #359.)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
