### PR TITLE
Fix wrong Tower music when toggling Flip Mode from in-game options

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -635,6 +635,23 @@ void menuactionpress()
             {
                 music.playef(11);
             }
+            // Fix wrong area music in Tower (Positive Force vs. ecroF evitisoP)
+            if (map.custommode)
+            {
+                break;
+            }
+            int area = map.area(game.roomx, game.roomy);
+            if (area == 3 || area == 11)
+            {
+                if (graphics.setflipmode)
+                {
+                    music.play(9); // ecroF evitisoP
+                }
+                else
+                {
+                    music.play(2); // Positive Force
+                }
+            }
         }
             break;
         }


### PR DESCRIPTION
The music for the Tower is supposed to be ecroF evitisoP in Flip Mode, and Positive Force when not in Flip Mode. However, if you go to the options from the pause menu and toggle Flip Mode, the music isn't changed.

Fixing this is pretty simple, just check the current area if not in a custom level and play the correct track accordingly when toggling Flip Mode from in-game.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
