### PR TITLE
Fix variables that weren't being reset when exiting out of playtesting (some of them specifically when you exited playtesting by rescuing the last crewmate in the level), and fix some input relating to teleporters

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1878,8 +1878,7 @@ void Game::updatestate()
                 }
                 else
                 {
-                    gamestate = EDITORMODE;
-                    graphics.backgrounddrawn=false;
+                    shouldreturntoeditor = true;
                     if(!muted && ed.levmusic>0) music.fadeMusicVolumeIn(3000);
                     if(ed.levmusic>0) music.fadeout();
                 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7308,6 +7308,8 @@ void Game::returntoeditor()
 
     ed.keydelay = 6;
     ed.settingskey = true;
+    ed.oldnotedelay = 0;
+    ed.notedelay = 0;
 
     graphics.backgrounddrawn=false;
     music.fadeout();

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7298,7 +7298,7 @@ void Game::returntoeditor()
 {
     game.gamestate = EDITORMODE;
 
-    graphics.textboxremove();
+    graphics.textbox.clear();
     game.hascontrol = true;
     game.advancetext = false;
     game.completestop = false;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7306,6 +7306,8 @@ void Game::returntoeditor()
     graphics.showcutscenebars = false;
     graphics.fademode = 0;
 
+    ed.keydelay = 6;
+
     graphics.backgrounddrawn=false;
     music.fadeout();
     //If warpdir() is used during playtesting, we need to set it back after!

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7307,6 +7307,7 @@ void Game::returntoeditor()
     graphics.fademode = 0;
 
     ed.keydelay = 6;
+    ed.settingskey = true;
 
     graphics.backgrounddrawn=false;
     music.fadeout();

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7310,6 +7310,7 @@ void Game::returntoeditor()
     ed.settingskey = true;
     ed.oldnotedelay = 0;
     ed.notedelay = 0;
+    ed.roomnamehide = 0;
 
     graphics.backgrounddrawn=false;
     music.fadeout();

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1924,7 +1924,7 @@ void Game::updatestate()
 
         case 2000:
             //Game Saved!
-            if (intimetrial || nodeathmode || inintermission)
+            if (inspecial() || map.custommode)
             {
                 state = 0;
             }

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2336,9 +2336,9 @@ void teleporterinput()
         {
             if (!map.custommode || map.custommodeforreal)
             {
-                // Go to "Do you want to quit?" screen
+                // Go to pause menu
                 game.mapheld = true;
-                game.menupage = 10;
+                game.menupage = 30;
                 game.gamestate = MAPMODE;
             }
             else

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1720,6 +1720,8 @@ void gameinput()
             //Return to level editor
             if (game.activeactivity > -1 && game.press_map){
                 //pass, let code block below handle it
+            }else if(game.activetele && game.readytotele > 20 && game.press_map){
+                //pass, let code block below handle it
             }else{
                 game.shouldreturntoeditor = true;
                 game.mapheld = true;
@@ -2332,10 +2334,18 @@ void teleporterinput()
 
         if (key.isDown(27))
         {
-            // Go to "Do you want to quit?" screen
-            game.mapheld = true;
-            game.menupage = 10;
-            game.gamestate = MAPMODE;
+            if (!map.custommode || map.custommodeforreal)
+            {
+                // Go to "Do you want to quit?" screen
+                game.mapheld = true;
+                game.menupage = 10;
+                game.gamestate = MAPMODE;
+            }
+            else
+            {
+                // Close teleporter menu
+                graphics.resumegamemode = true;
+            }
         }
     }
     else

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3648,7 +3648,7 @@ void scriptclass::hardreset()
 
 	//dwgraphicsclass
 	graphics.backgrounddrawn = false;
-	graphics.textboxremovefast();
+	graphics.textbox.clear();
 	graphics.flipmode = false; //This will be reset if needs be elsewhere
 	graphics.showcutscenebars = false;
 	graphics.cutscenebarspos = 0;


### PR DESCRIPTION
I intended to fix one bug, but then got carried away and fixed a bunch of others. And so it goes.

In no particular order, the bugs fixed were:

 - The horizontal/vertical warp background is not reset if exiting playtesting via rescuing the last crewmate, leading to the background of the room you rescued the crewmate in scrolling off in the room you re-entered the editor in, instead of the background of the new room being properly drawn.
 - Warp dirs changed by the `warpdir()` command are not properly reset if exiting playtesting via rescuing the last crewmate.
 - Rescuing the last crewmate during playtesting and exiting to editor via pressing Up or Down on the "- Press ACTION to advance text -" prompt moves you to the room above or below the one you started playtesting from. Most noticeable and annoying if the room you started playtesting from is also the room you exited playtesting room.
 - Pressing Esc to exit playtesting immediately brings up settings menu, unless you have frame-perfect skill and only press it for 1 frame.
 - Text boxes are not being properly reset when exiting or entering playtesting, causing a one-frame glitch when entering playtesting if you exited playtesting with text boxes onscreen.
 - Pressing Enter on teleporters during playtesting exits playtesting instead.
 - Pressing Esc in the teleporter menu screen brings you to the "Do you want to quit?" screen instead of the pause menu.
 - The "Game Saved" text box is shown when touching a teleporter in a custom level.
 - The editor note is not reset when exiting playtesting.
 - The editor roomname hiding is not reset when exiting playtesting.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
