### PR TITLE
Fix -playmusic command line option not working

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5163,6 +5163,7 @@ void Game::customloadquick(std::string savfile)
         saverx = playrx;
         savery = playry;
         savegc = playgc;
+        music.play(playmusic);
         return;
     }
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -387,6 +387,7 @@ public:
     int playrx;
     int playry;
     int playgc;
+    int playmusic;
     std::string playassets;
 
     void quittomenu();

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -353,8 +353,8 @@ int main(int argc, char *argv[])
             game.playrx = saverx;
             game.playry = savery;
             game.playgc = savegc;
+            game.playmusic = savemusic;
             game.cliplaytest = true;
-            music.play(savemusic);
             script.startgamemode(23);
         } else {
             script.startgamemode(22);


### PR DESCRIPTION
There's a bug where playtesting from Ved doesn't properly play the music of the level, due to no fault with Ved.

This was because the music was being faded out by `scriptclass::startgamemode()` case 23 after `main()` called `music.play()`. To fix this, just call `music.play()` when all the other variables are being set in `Game::customloadquick()`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
