### PR TITLE
Don't remove non-player entities in scriptclass::hardreset()

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3713,7 +3713,7 @@ void scriptclass::hardreset()
 	// Remove duplicate player entities
 	for (int i = 0; i < (int) obj.entities.size(); i++)
 	{
-		if (i != theplayer)
+		if (obj.entities[i].rule == 0 && i != theplayer)
 		{
 			removeentity_iter(i);
 			theplayer--; // just in case indice of player is not 0


### PR DESCRIPTION
When I moved duplicate player entity removal to `scriptclass::hardreset()`, I also inadvertently made it so all non-player entities got removed as well, even though this wasn't my intent. And thus, pressing Enter to restart a time trial removes every entity except the player, since it calls `script.hardreset()`.

The time trial `script.hardreset()` is bad for other reasons (see #367), however it's still a good idea to reset only what's needed in `script.hardreset()`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
