### PR TITLE
Fix undeffing ARG_IS instead of ARG

### DIFF
--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -141,7 +141,7 @@ int main(int argc, char *argv[])
             })
         }
 #undef ARG_INNER
-#undef ARG_IS
+#undef ARG
     }
 
     if(!FILESYSTEM_init(argv[0], baseDir, assetsPath))


### PR DESCRIPTION
Whoops.

Noticed this earlier when I was merging upstream back into VCE, and interestingly enough, it doesn't look like cppcheck warns about undeffing a non-existent define.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
