### PR TITLE
Fix softlock if exiting Super Grav and bringing up map in glitchrunner

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2071,8 +2071,8 @@ void mapinput()
     }
 
     if(graphics.menuoffset==0
-    && (!game.glitchrunnermode || graphics.fademode == 0)
-    && game.fadetomenudelay <= 0 && game.fadetolabdelay <= 0)
+    && ((!game.glitchrunnermode && game.fadetomenudelay <= 0 && game.fadetolabdelay <= 0)
+    || graphics.fademode == 0))
     {
         if (graphics.flipmode)
         {
@@ -2265,8 +2265,11 @@ void mapmenuactionpress()
         game.swnmode = false;
         graphics.fademode = 2;
         music.fadeout();
-        game.fadetolab = true;
-        game.fadetolabdelay = 16;
+        if (!game.glitchrunnermode)
+        {
+            game.fadetolab = true;
+            game.fadetolabdelay = 16;
+        }
         break;
     case 30:
         // Return to game


### PR DESCRIPTION
The game would softlock if you brought up the map screen or quit screen after exiting the Super Gravitron to the Secret Lab. This softlock would only happen if you were in glitchrunner mode.

This is because glitchrunner mode set `game.fadetolabdelay` when it shouldn't have, and also checked `game.fadetolabdelay` when it shouldn't have.

So I made it so that the game will only set `game.fadetolabdelay` when not in glitchrunner mode (I already had a check for `game.fadetomenudelay`, too!) and the game will only check for `game.fadetomenudelay` and `game.fadetolabdelay` when not in glitchrunner mode, as well.

I originally made the game check `game.fadetomenudelay` and `game.fadetolabdelay` to prevent being able to re-press ACTION to re-start the fadeout if the game was already fading out. And I made sure that this wasn't broken, both in glitchrunner mode and normal mode.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
