### PR TITLE
Wrap around enemy type when switching enemy types

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1686,14 +1686,20 @@ void editorclass::switch_enemy(const bool reversed /*= false*/)
     }
     edlevelclass& room = level[roomnum];
 
+    int enemy = room.enemytype;
+
     if (reversed)
     {
-        room.enemytype--;
+        enemy--;
     }
     else
     {
-        room.enemytype++;
+        enemy++;
     }
+
+    const int modulus = 10;
+    enemy = (enemy % modulus + modulus) % modulus;
+    room.enemytype = enemy;
 
     note = "Enemy Type Changed";
     notedelay = 45;


### PR DESCRIPTION
Whoops. Forgot to do this earlier when adding the Shift+F3 hotkey. Otherwise the enemy type would become invalid and just turn into the default square.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
