### PR TITLE
Fix softlock if you teleported with the Ship teleporter, while standing inside its hitbox, immediately after getting back from rescuing a crewmate or an intermission

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -3209,7 +3209,6 @@ bool entityclass::updateentities( int i )
                 if (entities[i].tile == 1)
                 {
                     music.playef(18);
-                    entities[i].onentity = 0;
                     entities[i].tile = 2;
                     entities[i].colour = 101;
                     if(!game.intimetrial && !game.nodeathmode)
@@ -3247,9 +3246,9 @@ bool entityclass::updateentities( int i )
                     {
                         game.savedir = entities[player].dir;
                     }
-                    entities[i].state = 0;
                 }
 
+                entities[i].onentity = 0;
                 entities[i].state = 0;
             }
             else if (entities[i].state == 2)


### PR DESCRIPTION
There were many different ways I could've fixed it, but one thing that stood out to me was the fact that touching the teleporter wasn't guaranteed to set its `onentity` to 0, even though it should be. So now, every time Viridian touches the teleporter, the teleporter's `onentity` will be set to 0, and thus there's no chance of the teleporter interrupting its own teleport animation and softlocking the game.

We should still do what I suggested in #391, namely setting `game.hascontrol` to true if the game is in gamestate 0 and `script.running` is false, and also always allowing Esc/Enter to be pressed regardless of `game.hascontrol`. But this softlock is fixed now.

Fixes #391.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
