### PR TITLE
Clean up includes so other headers are not unnecessarily included in header files, and neatly organize and order them

### DIFF
--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -1,11 +1,9 @@
 #include "BinaryBlob.h"
 
+#include <physfs.h> /* FIXME: Abstract to FileSystemUtils! */
+#include <SDL.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <SDL.h>
-
-/* FIXME: Abstract to FileSystemUtils! */
-#include <physfs.h>
 
 binaryBlob::binaryBlob()
 {

--- a/desktop_version/src/BlockV.h
+++ b/desktop_version/src/BlockV.h
@@ -1,7 +1,7 @@
 #ifndef BLOCKV_H
 #define BLOCKV_H
 
-#include "SDL.h"
+#include <SDL.h>
 #include <string>
 
 class blockclass

--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -1,5 +1,8 @@
 #include "Ent.h"
 
+#include "Game.h"
+#include "Graphics.h"
+
 entclass::entclass()
 {
 	invis = false;

--- a/desktop_version/src/Ent.h
+++ b/desktop_version/src/Ent.h
@@ -1,7 +1,7 @@
 #ifndef ENT_H
 #define ENT_H
 
-#include "Graphics.h"
+#include <SDL.h>
 
 #define		rn( rx,  ry) ((rx) + ((ry) * 100))
 

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1,6 +1,10 @@
 #include "Entity.h"
+
+#include "editor.h"
 #include "Game.h"
+#include "Graphics.h"
 #include "Map.h"
+#include "Music.h"
 #include "UtilityClass.h"
 
 bool entityclass::checktowerspikes(int t)

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -1,13 +1,13 @@
 #ifndef ENTITY_H
 #define ENTITY_H
 
+#include <string>
+#include <vector>
+
 #include "Maths.h"
 #include "Ent.h"
 #include "BlockV.h"
 #include "Game.h"
-
-#include <vector>
-#include <string>
 
 #define removeentity_iter(index) { if (obj.removeentity(index)) index--; }
 #define removeblock_iter(index) { obj.removeblock(index); index--; }

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -4,6 +4,7 @@
 #include "Maths.h"
 #include "Ent.h"
 #include "BlockV.h"
+#include "Game.h"
 
 #include <vector>
 #include <string>

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -16,7 +16,7 @@
 #include <SDL.h>
 #include <physfs.h>
 
-#include "tinyxml2.h"
+#include <tinyxml2.h>
 
 /* These are needed for PLATFORM_* crap */
 #if defined(_WIN32)

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -1,21 +1,16 @@
-#include <vector>
-#include <string>
-
+#include <algorithm>
+#include <iostream>
+#include <iterator>
+#include <physfs.h>
+#include <SDL.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+#include <string>
+#include <tinyxml2.h>
+#include <vector>
 
 #include "Graphics.h"
 #include "UtilityClass.h"
-
-#include <iterator>
-#include <algorithm>
-#include <iostream>
-
-#include <SDL.h>
-#include <physfs.h>
-
-#include <tinyxml2.h>
 
 /* These are needed for PLATFORM_* crap */
 #if defined(_WIN32)

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -1,5 +1,3 @@
-#include "FileSystemUtils.h"
-
 #include <vector>
 #include <string>
 
@@ -8,6 +6,7 @@
 #include <string.h>
 
 #include "Graphics.h"
+#include "UtilityClass.h"
 
 #include <iterator>
 #include <algorithm>
@@ -230,6 +229,8 @@ void FILESYSTEM_unmountassets()
 	}
 	FILESYSTEM_assetsmounted = false;
 }
+
+void FILESYSTEM_freeMemory(unsigned char **mem);
 
 void FILESYSTEM_loadFileToMemory(
 	const char *name,

--- a/desktop_version/src/Finalclass.cpp
+++ b/desktop_version/src/Finalclass.cpp
@@ -2,6 +2,10 @@
 
 #include "MakeAndPlay.h"
 
+#include "Game.h"
+#include "Entity.h"
+#include "UtilityClass.h"
+
 const short* finalclass::loadlevel(int rx, int ry)
 {
 	int t;

--- a/desktop_version/src/Finalclass.cpp
+++ b/desktop_version/src/Finalclass.cpp
@@ -1,9 +1,8 @@
 #include "Finalclass.h"
 
-#include "MakeAndPlay.h"
-
 #include "Game.h"
 #include "Entity.h"
+#include "MakeAndPlay.h"
 #include "UtilityClass.h"
 
 const short* finalclass::loadlevel(int rx, int ry)

--- a/desktop_version/src/Finalclass.h
+++ b/desktop_version/src/Finalclass.h
@@ -1,9 +1,6 @@
 #ifndef FINALCLASS_H
 #define FINALCLASS_H
 
-#include "Game.h"
-#include "Entity.h"
-
 #include <string>
 
 class finalclass

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1,10 +1,13 @@
 #include "Enums.h"
 
+#include "editor.h"
 #include "Game.h"
 #include "Graphics.h"
 #include "Entity.h"
 #include "Map.h"
+#include "Music.h"
 #include "Script.h"
+#include "UtilityClass.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1,27 +1,22 @@
-#include "Enums.h"
-
-#include "editor.h"
 #include "Game.h"
-#include "Graphics.h"
-#include "Entity.h"
-#include "Map.h"
-#include "Music.h"
-#include "Script.h"
-#include "UtilityClass.h"
 
+#include <sstream>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <sstream>
-
-#include "FileSystemUtils.h"
-
 #include <tinyxml2.h>
 
-#include "Network.h"
-
+#include "editor.h"
+#include "Entity.h"
+#include "Enums.h"
+#include "FileSystemUtils.h"
+#include "Graphics.h"
 #include "MakeAndPlay.h"
+#include "Map.h"
+#include "Music.h"
+#include "Network.h"
+#include "Script.h"
+#include "UtilityClass.h"
 
 // lol, Win32 -flibit
 #ifdef _WIN32

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -14,7 +14,7 @@
 
 #include "FileSystemUtils.h"
 
-#include "tinyxml2.h"
+#include <tinyxml2.h>
 
 #include "Network.h"
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include <string>
-#include "SDL.h"
+#include <SDL.h>
 #include "Maths.h"
 #include "UtilityClass.h"
 #include "GraphicsUtil.h"

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include <string>
 #include <SDL.h>
-#include "Maths.h"
-#include "UtilityClass.h"
-#include "GraphicsUtil.h"
 
 struct MenuOption
 {

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -1,9 +1,9 @@
 #ifndef GAME_H
 #define GAME_H
 
-#include <vector>
-#include <string>
 #include <SDL.h>
+#include <string>
+#include <vector>
 
 struct MenuOption
 {

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1,9 +1,11 @@
 #include "Graphics.h"
-#include "Maths.h"
+#include "editor.h"
 #include "Entity.h"
 #include "Map.h"
+#include "Music.h"
 #include "Screen.h"
 #include "FileSystemUtils.h"
+#include "UtilityClass.h"
 #include <utf8/unchecked.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1,14 +1,16 @@
 #include "Graphics.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <utf8/unchecked.h>
+
 #include "editor.h"
 #include "Entity.h"
+#include "FileSystemUtils.h"
 #include "Map.h"
 #include "Music.h"
 #include "Screen.h"
-#include "FileSystemUtils.h"
 #include "UtilityClass.h"
-#include <utf8/unchecked.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 void Graphics::init()
 {

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -9,8 +9,6 @@
 
 #include "Maths.h"
 #include "Textbox.h"
-#include "UtilityClass.h"
-#include "Game.h"
 
 
 #include <string>

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -1,21 +1,16 @@
 #ifndef GRAPHICS_H
 #define GRAPHICS_H
 
-#include "GraphicsResources.h"
-#include <vector>
-#include <map>
-
-
-
-#include "Maths.h"
-#include "Textbox.h"
-
-
-#include <string>
 #include <algorithm>
+#include <map>
+#include <string>
+#include <vector>
 
+#include "GraphicsResources.h"
 #include "GraphicsUtil.h"
+#include "Maths.h"
 #include "Screen.h"
+#include "Textbox.h"
 
 class Graphics
 {

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -1,7 +1,9 @@
 #include "GraphicsResources.h"
-#include "FileSystemUtils.h"
+
 #include <stdio.h>
 #include <stdlib.h>
+
+#include "FileSystemUtils.h"
 
 // Used to load PNG data
 extern "C"

--- a/desktop_version/src/GraphicsResources.h
+++ b/desktop_version/src/GraphicsResources.h
@@ -1,7 +1,7 @@
 #ifndef GRAPHICSRESOURCES_H
 #define GRAPHICSRESOURCES_H
 
-#include "SDL.h"
+#include <SDL.h>
 
 class GraphicsResources
 {

--- a/desktop_version/src/GraphicsUtil.h
+++ b/desktop_version/src/GraphicsUtil.h
@@ -1,7 +1,7 @@
 #ifndef GRAPHICSUTIL_H
 #define GRAPHICSUTIL_H
 
-#include "SDL.h"
+#include <SDL.h>
 
 struct colourTransform
 {

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -5,7 +5,7 @@
 
 #include "MakeAndPlay.h"
 
-#include "tinyxml2.h"
+#include <tinyxml2.h>
 
 #include "FileSystemUtils.h"
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1,4 +1,3 @@
-#include "Input.h"
 #include "Logic.h"
 #include "Script.h"
 #include "Credits.h"
@@ -8,6 +7,15 @@
 #include <tinyxml2.h>
 
 #include "FileSystemUtils.h"
+
+#include "editor.h"
+#include "Entity.h"
+#include "Enums.h"
+#include "Game.h"
+#include "Graphics.h"
+#include "KeyPoll.h"
+#include "Map.h"
+#include "Music.h"
 
 void updatebuttonmappings(int bind)
 {

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1,21 +1,18 @@
-#include "Logic.h"
-#include "Script.h"
-#include "Credits.h"
-
-#include "MakeAndPlay.h"
-
 #include <tinyxml2.h>
 
-#include "FileSystemUtils.h"
-
+#include "Credits.h"
 #include "editor.h"
 #include "Entity.h"
 #include "Enums.h"
+#include "FileSystemUtils.h"
 #include "Game.h"
 #include "Graphics.h"
 #include "KeyPoll.h"
+#include "Logic.h"
+#include "MakeAndPlay.h"
 #include "Map.h"
 #include "Music.h"
+#include "Script.h"
 
 void updatebuttonmappings(int bind)
 {

--- a/desktop_version/src/Input.h
+++ b/desktop_version/src/Input.h
@@ -1,14 +1,6 @@
 #ifndef INPUT_H
 #define INPUT_H
 
-#include "KeyPoll.h"
-#include "Graphics.h"
-#include "Game.h"
-#include "Entity.h"
-#include "UtilityClass.h"
-#include "Music.h"
-#include "Map.h"
-
 void titleinput();
 
 void gameinput();

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -1,10 +1,12 @@
 #include "KeyPoll.h"
-#include "Game.h"
-#include "Graphics.h"
-#include "Music.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <utf8/unchecked.h>
+
+#include "Game.h"
+#include "Graphics.h"
+#include "Music.h"
 
 void KeyPoll::setSensitivity(int _value)
 {

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -1,4 +1,5 @@
 #include "KeyPoll.h"
+#include "Game.h"
 #include "Graphics.h"
 #include "Music.h"
 #include <stdio.h>

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -1,11 +1,10 @@
 #ifndef KEYPOLL_H
 #define KEYPOLL_H
 
+#include <map> // FIXME: I should feel very bad for using C++ -flibit
+#include <SDL.h>
 #include <string>
 #include <vector>
-#include <map> // FIXME: I should feel very bad for using C++ -flibit
-
-#include <SDL.h>
 
 enum Kybrd
 {

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include <map> // FIXME: I should feel very bad for using C++ -flibit
 
-#include "SDL.h"
+#include <SDL.h>
 
 #include "Screen.h"
 

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -7,8 +7,6 @@
 
 #include <SDL.h>
 
-#include "Screen.h"
-
 enum Kybrd
 {
 	KEYBOARD_UP = SDLK_UP,

--- a/desktop_version/src/Labclass.cpp
+++ b/desktop_version/src/Labclass.cpp
@@ -2,6 +2,10 @@
 
 #include "MakeAndPlay.h"
 
+#include "Game.h"
+#include "Entity.h"
+#include "UtilityClass.h"
+
 const short* labclass::loadlevel(int rx, int ry)
 {
 	int t;

--- a/desktop_version/src/Labclass.cpp
+++ b/desktop_version/src/Labclass.cpp
@@ -1,9 +1,8 @@
 #include "Labclass.h"
 
-#include "MakeAndPlay.h"
-
 #include "Game.h"
 #include "Entity.h"
+#include "MakeAndPlay.h"
 #include "UtilityClass.h"
 
 const short* labclass::loadlevel(int rx, int ry)

--- a/desktop_version/src/Labclass.h
+++ b/desktop_version/src/Labclass.h
@@ -1,9 +1,6 @@
 #ifndef LABCLASS_H
 #define LABCLASS_H
 
-#include "Game.h"
-#include "Entity.h"
-
 #include <string>
 
 class labclass

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1,15 +1,14 @@
-#include "Script.h"
-#include "Network.h"
-#include "FileSystemUtils.h"
 #include "Credits.h"
-
 #include "editor.h"
 #include "Entity.h"
 #include "Enums.h"
+#include "FileSystemUtils.h"
 #include "Game.h"
 #include "Graphics.h"
 #include "Map.h"
 #include "Music.h"
+#include "Network.h"
+#include "Script.h"
 #include "UtilityClass.h"
 
 void titleupdatetextcol()

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1,8 +1,16 @@
-#include "Logic.h"
 #include "Script.h"
 #include "Network.h"
 #include "FileSystemUtils.h"
 #include "Credits.h"
+
+#include "editor.h"
+#include "Entity.h"
+#include "Enums.h"
+#include "Game.h"
+#include "Graphics.h"
+#include "Map.h"
+#include "Music.h"
+#include "UtilityClass.h"
 
 void titleupdatetextcol()
 {

--- a/desktop_version/src/Logic.h
+++ b/desktop_version/src/Logic.h
@@ -1,13 +1,6 @@
 #ifndef LOGIC_H
 #define LOGIC_H
 
-#include "Graphics.h"
-#include "Game.h"
-#include "Entity.h"
-#include "UtilityClass.h"
-#include "Music.h"
-#include "Map.h"
-
 void titleupdatetextcol();
 
 void titlelogic();

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -3,6 +3,13 @@
 
 #include "MakeAndPlay.h"
 
+#include "editor.h"
+#include "Entity.h"
+#include "Game.h"
+#include "Graphics.h"
+#include "Music.h"
+#include "UtilityClass.h"
+
 mapclass::mapclass()
 {
 	//Start here!

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1,13 +1,12 @@
 #include "Map.h"
-#include "Script.h"
-
-#include "MakeAndPlay.h"
 
 #include "editor.h"
 #include "Entity.h"
 #include "Game.h"
 #include "Graphics.h"
+#include "MakeAndPlay.h"
 #include "Music.h"
+#include "Script.h"
 #include "UtilityClass.h"
 
 mapclass::mapclass()

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -1,15 +1,15 @@
 #ifndef MAPGAME_H
 #define MAPGAME_H
 
-#include "Tower.h"
-#include "WarpClass.h"
-#include "Finalclass.h"
-#include "Labclass.h"
-#include "Spacestation2.h"
-#include "Otherlevel.h"
 #include <vector>
 
+#include "Finalclass.h"
+#include "Labclass.h"
 #include "Maths.h"
+#include "Otherlevel.h"
+#include "Spacestation2.h"
+#include "Tower.h"
+#include "WarpClass.h"
 
 struct Roomtext
 {

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -7,11 +7,9 @@
 #include "Labclass.h"
 #include "Spacestation2.h"
 #include "Otherlevel.h"
-#include "Entity.h"
-#include "Graphics.h"
 #include <vector>
-#include "Music.h"
-#include "editor.h"
+
+#include "Maths.h"
 
 struct Roomtext
 {

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -3,6 +3,7 @@
 #include "Music.h"
 #include "BinaryBlob.h"
 #include "Map.h"
+#include "UtilityClass.h"
 
 void songend();
 

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -1,6 +1,8 @@
+#include "Music.h"
+
 #include <SDL.h>
 #include <stdio.h>
-#include "Music.h"
+
 #include "BinaryBlob.h"
 #include "Map.h"
 #include "UtilityClass.h"

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -1,10 +1,10 @@
 #ifndef MUSIC_H
 #define MUSIC_H
 
-#include "SoundSystem.h"
-#include "BinaryBlob.h"
-
 #include <vector>
+
+#include "BinaryBlob.h"
+#include "SoundSystem.h"
 
 #define musicroom(rx, ry) ((rx) + ((ry) * 20))
 

--- a/desktop_version/src/Network.c
+++ b/desktop_version/src/Network.c
@@ -1,4 +1,4 @@
-#include "Network.h"
+#include <stdint.h>
 
 #define UNUSED(expr) (void)(expr)
 

--- a/desktop_version/src/Otherlevel.cpp
+++ b/desktop_version/src/Otherlevel.cpp
@@ -2,6 +2,9 @@
 
 #include "MakeAndPlay.h"
 
+#include "Game.h"
+#include "Entity.h"
+
 const short* otherlevelclass::loadlevel(int rx, int ry)
 {
 	int t;

--- a/desktop_version/src/Otherlevel.cpp
+++ b/desktop_version/src/Otherlevel.cpp
@@ -1,9 +1,8 @@
 #include "Otherlevel.h"
 
-#include "MakeAndPlay.h"
-
 #include "Game.h"
 #include "Entity.h"
+#include "MakeAndPlay.h"
 
 const short* otherlevelclass::loadlevel(int rx, int ry)
 {

--- a/desktop_version/src/Otherlevel.h
+++ b/desktop_version/src/Otherlevel.h
@@ -1,9 +1,6 @@
 #ifndef OTHERLEVEL_H
 #define OTHERLEVEL_H
 
-#include "Game.h"
-#include "Entity.h"
-
 #include <string>
 
 class otherlevelclass

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1,15 +1,14 @@
+#include "Credits.h"
 #include "editor.h"
-#include "Graphics.h"
-#include "UtilityClass.h"
-#include "Maths.h"
 #include "Entity.h"
+#include "FileSystemUtils.h"
+#include "Graphics.h"
+#include "MakeAndPlay.h"
 #include "Map.h"
+#include "Maths.h"
 #include "Music.h"
 #include "Script.h"
-#include "FileSystemUtils.h"
-#include "Credits.h"
-
-#include "MakeAndPlay.h"
+#include "UtilityClass.h"
 
 int tr;
 int tg;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1,10 +1,10 @@
-#include "Render.h"
-
+#include "editor.h"
 #include "Graphics.h"
 #include "UtilityClass.h"
 #include "Maths.h"
 #include "Entity.h"
 #include "Map.h"
+#include "Music.h"
 #include "Script.h"
 #include "FileSystemUtils.h"
 #include "Credits.h"

--- a/desktop_version/src/Render.h
+++ b/desktop_version/src/Render.h
@@ -1,13 +1,6 @@
 #ifndef RENDER_H
 #define RENDER_H
 
-#include "Graphics.h"
-#include "UtilityClass.h"
-#include "Maths.h"
-#include "Entity.h"
-#include "Map.h"
-#include "Script.h"
-
 void titlerender();
 
 void gamerender();

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -1,9 +1,9 @@
 #include "Screen.h"
 
+#include <stdlib.h>
+
 #include "FileSystemUtils.h"
 #include "GraphicsUtil.h"
-
-#include <stdlib.h>
 
 // Used to create the window icon
 extern "C"

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1,10 +1,13 @@
 #include "Script.h"
 #include "Graphics.h"
 
+#include "editor.h"
 #include "Entity.h"
+#include "Enums.h"
 #include "Music.h"
 #include "KeyPoll.h"
 #include "Map.h"
+#include "UtilityClass.h"
 
 scriptclass::scriptclass()
 {

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1,12 +1,12 @@
 #include "Script.h"
-#include "Graphics.h"
 
 #include "editor.h"
 #include "Entity.h"
 #include "Enums.h"
-#include "Music.h"
+#include "Graphics.h"
 #include "KeyPoll.h"
 #include "Map.h"
+#include "Music.h"
 #include "UtilityClass.h"
 
 scriptclass::scriptclass()

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -4,8 +4,6 @@
 #include <string>
 #include <vector>
 
-#include "Enums.h"
-
 #define filllines(lines) commands.insert(commands.end(), lines, lines + sizeof(lines)/sizeof(lines[0]))
 
 

--- a/desktop_version/src/Scripts.cpp
+++ b/desktop_version/src/Scripts.cpp
@@ -1,4 +1,5 @@
 #include "Script.h"
+
 #include <SDL.h>
 
 void scriptclass::load(const std::string& name)

--- a/desktop_version/src/SoundSystem.cpp
+++ b/desktop_version/src/SoundSystem.cpp
@@ -1,5 +1,7 @@
-#include <SDL.h>
 #include "SoundSystem.h"
+
+#include <SDL.h>
+
 #include "FileSystemUtils.h"
 
 MusicTrack::MusicTrack(const char* fileName)

--- a/desktop_version/src/Spacestation2.cpp
+++ b/desktop_version/src/Spacestation2.cpp
@@ -1,9 +1,8 @@
 #include "Spacestation2.h"
 
-#include "MakeAndPlay.h"
-
 #include "Game.h"
 #include "Entity.h"
+#include "MakeAndPlay.h"
 #include "UtilityClass.h"
 
 const short* spacestation2class::loadlevel(int rx, int ry)

--- a/desktop_version/src/Spacestation2.cpp
+++ b/desktop_version/src/Spacestation2.cpp
@@ -2,6 +2,10 @@
 
 #include "MakeAndPlay.h"
 
+#include "Game.h"
+#include "Entity.h"
+#include "UtilityClass.h"
+
 const short* spacestation2class::loadlevel(int rx, int ry)
 {
 	int t;

--- a/desktop_version/src/Spacestation2.h
+++ b/desktop_version/src/Spacestation2.h
@@ -1,9 +1,6 @@
 #ifndef SPACESTATION2_H
 #define SPACESTATION2_H
 
-#include "Game.h"
-#include "Entity.h"
-
 #include <string>
 
 class spacestation2class

--- a/desktop_version/src/TerminalScripts.cpp
+++ b/desktop_version/src/TerminalScripts.cpp
@@ -1,4 +1,5 @@
 #include "Script.h"
+
 #include <SDL.h>
 
 void scriptclass::loadother(const char* t)

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -1,4 +1,5 @@
 #include "Textbox.h"
+
 #include <utf8/unchecked.h>
 
 textboxclass::textboxclass()

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -1,7 +1,7 @@
 #ifndef TEXTBOX_H
 #define TEXTBOX_H
 
-#include "SDL.h"
+#include <SDL.h>
 #include <string>
 #include <vector>
 

--- a/desktop_version/src/Tower.cpp
+++ b/desktop_version/src/Tower.cpp
@@ -1,7 +1,6 @@
 #include "Tower.h"
 
 #include "MakeAndPlay.h"
-
 #include "UtilityClass.h"
 
 towerclass::towerclass()

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -1,6 +1,6 @@
 #include "UtilityClass.h"
 
-#include "SDL.h"
+#include <SDL.h>
 
 #include <cctype>
 #include <sstream>

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -1,8 +1,7 @@
 #include "UtilityClass.h"
 
-#include <SDL.h>
-
 #include <cctype>
+#include <SDL.h>
 #include <sstream>
 
 /* Used by UtilityClass::GCString to generate a button list */

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -2,8 +2,8 @@
 #define UTILITYCLASS_H
 
 #include <SDL.h>
-#include <vector>
 #include <string>
+#include <vector>
 
 int ss_toi(std::string _s);
 

--- a/desktop_version/src/WarpClass.cpp
+++ b/desktop_version/src/WarpClass.cpp
@@ -1,9 +1,8 @@
 #include "WarpClass.h"
 
-#include "MakeAndPlay.h"
-
 #include "Game.h"
 #include "Entity.h"
+#include "MakeAndPlay.h"
 #include "UtilityClass.h"
 
 const short* warpclass::loadlevel(int rx, int ry)

--- a/desktop_version/src/WarpClass.cpp
+++ b/desktop_version/src/WarpClass.cpp
@@ -2,6 +2,10 @@
 
 #include "MakeAndPlay.h"
 
+#include "Game.h"
+#include "Entity.h"
+#include "UtilityClass.h"
+
 const short* warpclass::loadlevel(int rx, int ry)
 {
 	int t;

--- a/desktop_version/src/WarpClass.h
+++ b/desktop_version/src/WarpClass.h
@@ -1,9 +1,6 @@
 #ifndef WARPCLASS_H
 #define WARPCLASS_H
 
-#include "Game.h"
-#include "Entity.h"
-
 #include <string>
 
 class warpclass

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -9,7 +9,6 @@
 #include "Map.h"
 #include "Script.h"
 #include "UtilityClass.h"
-#include "time.h"
 
 #include <tinyxml2.h>
 
@@ -2036,20 +2035,6 @@ bool editorclass::save(std::string& _path)
     root->LinkEndChild( data );
 
     msg = doc.NewElement( "MetaData" );
-
-    time_t rawtime;
-    struct tm * timeinfo;
-
-    time ( &rawtime );
-    timeinfo = localtime ( &rawtime );
-
-    std::string timeAndDate = asctime (timeinfo);
-
-    EditorData::GetInstance().timeModified =  timeAndDate;
-    if(EditorData::GetInstance().timeModified == "")
-    {
-        EditorData::GetInstance().timeCreated =  timeAndDate;
-    }
 
     //getUser
     tinyxml2::XMLElement* meta = doc.NewElement( "Creator" );

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -8,6 +8,7 @@
 #include "KeyPoll.h"
 #include "Map.h"
 #include "Script.h"
+#include "UtilityClass.h"
 #include "time.h"
 
 #include <tinyxml2.h>

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -10,7 +10,7 @@
 #include "Script.h"
 #include "time.h"
 
-#include "tinyxml2.h"
+#include <tinyxml2.h>
 
 #include "Enums.h"
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2,23 +2,21 @@
 
 #include "editor.h"
 
-#include "Graphics.h"
+#include <physfs.h>
+#include <stdio.h>
+#include <string>
+#include <tinyxml2.h>
+#include <utf8/unchecked.h>
+
 #include "Entity.h"
-#include "Music.h"
+#include "Enums.h"
+#include "FileSystemUtils.h"
+#include "Graphics.h"
 #include "KeyPoll.h"
 #include "Map.h"
+#include "Music.h"
 #include "Script.h"
 #include "UtilityClass.h"
-
-#include <tinyxml2.h>
-
-#include "Enums.h"
-
-#include "FileSystemUtils.h"
-
-#include <string>
-#include <utf8/unchecked.h>
-#include <physfs.h>
 
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
@@ -27,7 +25,6 @@
 #define _POSIX_SOURCE
 #endif
 #include <inttypes.h>
-#include <cstdio>
 
 edlevelclass::edlevelclass()
 {

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -5,8 +5,8 @@
 
 #include <vector>
 #include <string>
-#include "Script.h"
-#include "Graphics.h"
+
+#include <SDL.h>
 
 // Text entry field type
 enum textmode {

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -89,14 +89,6 @@ class EditorData
   std::string creator;
 
   std::string modifier;
-
-private:
-
-
-  EditorData()
-  {
-  }
-
 };
 
 struct GhostInfo {

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -3,10 +3,9 @@
 #ifndef EDITOR_H
 #define EDITOR_H
 
-#include <vector>
-#include <string>
-
 #include <SDL.h>
+#include <string>
+#include <vector>
 
 // Text entry field type
 enum textmode {

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -89,8 +89,6 @@ class EditorData
   std::string creator;
 
   std::string modifier;
-  std::string timeCreated;
-  std::string timeModified;
 
 private:
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -1,36 +1,25 @@
 #include <SDL.h>
-#include "SoundSystem.h"
-
-#include "UtilityClass.h"
-#include "Enums.h"
-#include "Entity.h"
-#include "Game.h"
-#include "Graphics.h"
-#include "KeyPoll.h"
-#include "Render.h"
-
-#include "Tower.h"
-#include "WarpClass.h"
-#include "Labclass.h"
-#include "Finalclass.h"
-#include "Map.h"
-#include "Music.h"
-
-#include "Screen.h"
-
-#include "Script.h"
-
-#include "Logic.h"
-
-#include "Input.h"
-#include "editor.h"
-#include "preloader.h"
-
-#include "FileSystemUtils.h"
-#include "Network.h"
-
 #include <stdio.h>
 #include <string.h>
+
+#include "editor.h"
+#include "Enums.h"
+#include "Entity.h"
+#include "FileSystemUtils.h"
+#include "Game.h"
+#include "Graphics.h"
+#include "Input.h"
+#include "KeyPoll.h"
+#include "Logic.h"
+#include "Map.h"
+#include "Music.h"
+#include "Network.h"
+#include "preloader.h"
+#include "Render.h"
+#include "Screen.h"
+#include "Script.h"
+#include "SoundSystem.h"
+#include "UtilityClass.h"
 
 scriptclass script;
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -2,6 +2,8 @@
 #include "SoundSystem.h"
 
 #include "UtilityClass.h"
+#include "Enums.h"
+#include "Entity.h"
 #include "Game.h"
 #include "Graphics.h"
 #include "KeyPoll.h"
@@ -12,6 +14,7 @@
 #include "Labclass.h"
 #include "Finalclass.h"
 #include "Map.h"
+#include "Music.h"
 
 #include "Screen.h"
 

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -1,5 +1,3 @@
-#include "preloader.h"
-
 #include "Enums.h"
 #include "Game.h"
 #include "Graphics.h"

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -1,6 +1,9 @@
 #include "preloader.h"
 
 #include "Enums.h"
+#include "Game.h"
+#include "Graphics.h"
+#include "UtilityClass.h"
 
 int pre_fakepercent=0, pre_transition=30;
 bool pre_startgame=false;

--- a/desktop_version/src/preloader.h
+++ b/desktop_version/src/preloader.h
@@ -1,10 +1,6 @@
 #ifndef PRELOADER_H
 #define PRELOADER_H
 
-#include "Graphics.h"
-#include "Game.h"
-#include "UtilityClass.h"
-
 void preloaderrender();
 
 void preloaderlogic();


### PR DESCRIPTION
The game used to include a bunch of header files inside other header files, which would result in a few unnecessary rebuilds of files whenever the inner included header got changed. Now I've "flattened" it so that header includes are mainly done in the `.cpp` file, and the only includes in `.h` files are the ones that are strictly necessary (e.g. if a class has another class inside it as a class member of that class). Except for the TinyXML-2 include, because it's a huge header file and I'd rather just forward declare it instead of including it in a bunch of unnecessary places.

Also, include order has been alphabetized, and files included follow a certain pattern of sections: there's the include of the "main" header file (e.g. `#include "Graphics.h"` for `Graphics.cpp`), then system or third-party includes, then includes from the rest of the project. And additionally sometimes there's a section where you have to do something special, like `#define`s or `#ifdef`s to include some other files (see `FileSystemUtils.cpp` and `editor.cpp` for examples of this).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
