### PR TITLE
Set oldxp/oldyp when player teleports through warp token

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -889,7 +889,7 @@ void mapclass::warpto(int rx, int ry , int t, int tx, int ty)
 {
 	gotoroom(rx, ry);
 	game.teleport = false;
-	if (t >= 0 && t < (int) obj.entities.size())
+	if (INBOUNDS(t, obj.entities))
 	{
 		obj.entities[t].xp = tx * 8;
 		obj.entities[t].yp = (ty * 8) - obj.entities[t].h;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -893,6 +893,8 @@ void mapclass::warpto(int rx, int ry , int t, int tx, int ty)
 	{
 		obj.entities[t].xp = tx * 8;
 		obj.entities[t].yp = (ty * 8) - obj.entities[t].h;
+		obj.entities[t].oldxp = obj.entities[t].xp;
+		obj.entities[t].oldyp = obj.entities[t].yp;
 	}
 	game.gravitycontrol = 0;
 }


### PR DESCRIPTION
This fixes the bug where it would appear as if they "zipped" to the destination from the warp token.

Fixes #384.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
