### PR TITLE
Set oldxp/oldyp when being teleported around during teleport

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1979,6 +1979,8 @@ void Game::updatestate()
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[i].oldxp = obj.entities[i].xp;
+                    obj.entities[i].oldyp = obj.entities[i].yp;
                 }
                 obj.entities[i].ay = -6;
                 obj.entities[i].ax = 6;
@@ -3322,6 +3324,8 @@ void Game::updatestate()
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[i].oldxp = obj.entities[i].xp;
+                    obj.entities[i].oldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
                     obj.entities[j].colour = 101;
                 }
@@ -3435,6 +3439,8 @@ void Game::updatestate()
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[i].oldxp = obj.entities[i].xp;
+                    obj.entities[i].oldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
                     obj.entities[j].colour = 101;
                 }
@@ -3532,6 +3538,8 @@ void Game::updatestate()
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[i].oldxp = obj.entities[i].xp;
+                    obj.entities[i].oldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
                     obj.entities[j].colour = 101;
                 }
@@ -3629,6 +3637,8 @@ void Game::updatestate()
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[i].oldxp = obj.entities[i].xp;
+                    obj.entities[i].oldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
                     obj.entities[j].colour = 101;
                 }
@@ -3731,6 +3741,8 @@ void Game::updatestate()
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[i].oldxp = obj.entities[i].xp;
+                    obj.entities[i].oldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
                     obj.entities[j].colour = 101;
                 }
@@ -3833,6 +3845,8 @@ void Game::updatestate()
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[i].oldxp = obj.entities[i].xp;
+                    obj.entities[i].oldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
                     obj.entities[j].colour = 101;
                 }
@@ -3933,6 +3947,8 @@ void Game::updatestate()
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[i].oldxp = obj.entities[i].xp;
+                    obj.entities[i].oldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
                     obj.entities[j].colour = 101;
                 }
@@ -4030,6 +4046,8 @@ void Game::updatestate()
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[i].oldxp = obj.entities[i].xp;
+                    obj.entities[i].oldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
                     obj.entities[j].colour = 101;
                 }
@@ -4127,6 +4145,8 @@ void Game::updatestate()
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
+                    obj.entities[i].oldxp = obj.entities[i].xp;
+                    obj.entities[i].oldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
                     obj.entities[j].colour = 101;
                 }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3427,6 +3427,8 @@ void scriptclass::teleport()
 		obj.entities[i].xp = 150;
 		obj.entities[i].yp = 110;
 		if(game.teleport_to_x==17 && game.teleport_to_y==17) obj.entities[i].xp = 88; //prevent falling!
+		obj.entities[i].oldxp = obj.entities[i].xp;
+		obj.entities[i].oldyp = obj.entities[i].yp;
 	}
 
 	if (game.teleportscript == "levelonecomplete")


### PR DESCRIPTION
This fixes the bug where Viridian would appear to "zip" when they would be teleported to the position of the teleporter before being flung out of it.

As discussed in #393, I've also set the `oldxp`/`oldyp` when Viridian is temporarily positioned in the center of the room, even though at this point they should already be invisible. This is just to be safe.

Fixes #393.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
