### PR TITLE
Don't savestats() every frame of New Record animation

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -556,10 +556,13 @@ void gamelogic()
                 game.swndelay = 0;
                 if (game.swntimer >= game.swnrecord)
                 {
-                    if (game.swnmessage == 0) music.playef(25);
-                    game.swnmessage = 1;
                     game.swnrecord = game.swntimer;
-                    game.savestats();
+                    if (game.swnmessage == 0)
+                    {
+                        music.playef(25);
+                        game.savestats();
+                    }
+                    game.swnmessage = 1;
                 }
             }
         }


### PR DESCRIPTION
Otherwise, this would cause immense slowdown during the New Record animation that plays when you die, as the game would be writing `unlock.vvv` every frame.

To fix this, I just put it under the same if-guard as the `music.playef()`, since the sound effect also only plays once. But I have to watch out for frame ordering and make sure the record is actually set before I call `game.savestats()`, and then of course I have to move `game.swnmessage = 1` over because that's the variable being checked in the conditional.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
