### PR TITLE
Fix the 'Game Complete' trophy stand so it no longer hovers above the ground

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -13,6 +13,7 @@ Contributors
 * Daniel Lee (@ddm999)
 * Fredrik Ljungdahl (@FredrIQ)
 * Matt Penny (@mwpenny)
+* Tynan Richards (@tzann)
 * Elliott Saltar (@eboyblue3)
 * Marvin Scholz (@ePirat)
 * Keith Stellyes (@keithstellyes)

--- a/desktop_version/src/Credits.h
+++ b/desktop_version/src/Credits.h
@@ -94,6 +94,7 @@ static const char* githubfriends[] = {
     "Daniel Lee",
     "Fredrik Ljungdahl",
     "Matt Penny",
+    "Tynan Richards",
     "Elliott Saltar",
     "Marvin Scholz",
     "Keith Stellyes",

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1768,6 +1768,7 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
                 entity.tile = 188 + vx;
                 entity.colour = 37;
                 entity.h += 3;
+                entity.oldyp -= 3;
                 entity.yp -= 3;
             }
             break;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1768,6 +1768,7 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
                 entity.tile = 188 + vx;
                 entity.colour = 37;
                 entity.h += 3;
+                entity.yp -= 3;
             }
             break;
         case 8:

--- a/desktop_version/src/Otherlevel.cpp
+++ b/desktop_version/src/Otherlevel.cpp
@@ -8997,8 +8997,8 @@ const short* otherlevelclass::loadlevel(int rx, int ry)
 		283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,
 		};
 
-		obj.createentity(152, 168, 25, 0, 19); // Trophy
 		obj.createentity(152, 168, 25, 0, 20); // Trophy placeholder
+		obj.createentity(152, 168, 25, 0, 19); // Trophy
 		result = contents;
 		break;
 	}

--- a/desktop_version/src/Otherlevel.cpp
+++ b/desktop_version/src/Otherlevel.cpp
@@ -8936,27 +8936,27 @@ const short* otherlevelclass::loadlevel(int rx, int ry)
 		295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,295,
 		};
 
-		obj.createentity(96, 48, 25, 0, 1); //Terminal
-		obj.createentity(128, 48, 25, 0, 2); //Terminal
-		obj.createentity(160, 48, 25, 0, 3); //Terminal
-		obj.createentity(192, 48, 25, 0, 4); //Terminal
-		obj.createentity(224, 48, 25, 0, 5); //Terminal
-		obj.createentity(256, 48, 25, 0, 6); //Terminal
+		obj.createentity(96, 48, 25, 0, 1); // Trophy
+		obj.createentity(128, 48, 25, 0, 2); // Trophy
+		obj.createentity(160, 48, 25, 0, 3); // Trophy
+		obj.createentity(192, 48, 25, 0, 4); // Trophy
+		obj.createentity(224, 48, 25, 0, 5); // Trophy
+		obj.createentity(256, 48, 25, 0, 6); // Trophy
 
-		obj.createentity(96, 88, 25, 1, 13); //Terminal
-		obj.createentity(128, 88, 25, 1, 14); //Terminal
-		obj.createentity(160, 88, 25, 1, 15); //Terminal
-		obj.createentity(192, 88, 25, 1, 16); //Terminal
-		obj.createentity(224, 88, 25, 1, 17); //Terminal
-		obj.createentity(256, 88, 25, 1, 18); //Terminal
+		obj.createentity(96, 88, 25, 1, 13); // Trophy
+		obj.createentity(128, 88, 25, 1, 14); // Trophy
+		obj.createentity(160, 88, 25, 1, 15); // Trophy
+		obj.createentity(192, 88, 25, 1, 16); // Trophy
+		obj.createentity(224, 88, 25, 1, 17); // Trophy
+		obj.createentity(256, 88, 25, 1, 18); // Trophy
 
-		obj.createentity(96, 128-3, 25, 0, 7); //Terminal
-		obj.createentity(96, 168, 25, 1, 8); //Terminal
+		obj.createentity(96, 128, 25, 0, 7); // Trophy
+		obj.createentity(96, 168, 25, 1, 8); // Trophy
 
-		obj.createentity(160, 128, 25, 0, 12); //Terminal
-		obj.createentity(192, 128, 25, 0, 11); //Terminal
-		obj.createentity(224, 128, 25, 0, 10); //Terminal
-		obj.createentity(256, 128, 25, 0, 9); //Terminal
+		obj.createentity(160, 128, 25, 0, 12); // Trophy
+		obj.createentity(192, 128, 25, 0, 11); // Trophy
+		obj.createentity(224, 128, 25, 0, 10); // Trophy
+		obj.createentity(256, 128, 25, 0, 9); // Trophy
 		result = contents;
 		break;
 	}
@@ -8997,8 +8997,8 @@ const short* otherlevelclass::loadlevel(int rx, int ry)
 		283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,283,
 		};
 
-		obj.createentity(152, 168, 25, 0, 20); //Terminal
-		obj.createentity(152, 168, 25, 0, 19); //Terminal
+		obj.createentity(152, 168, 25, 0, 19); // Trophy
+		obj.createentity(152, 168, 25, 0, 20); // Trophy placeholder
 		result = contents;
 		break;
 	}


### PR DESCRIPTION
## Changes:

The 'Game Complete' Trophy stand hovers above the ground. This change fixes that. Also, I changed the comments in Otherlevel.cpp so they say trophy instead of terminal, since that's what's actually being created.
Here is what it used to look like:
![image](https://user-images.githubusercontent.com/24497035/88743794-e00b3180-d145-11ea-9946-5b6dc794dcf9.png)

Note that the trophy position (line 8953 in Otherlevel.cpp) was altered by 3 pixels originally. This has been removed and instead the position is only altered if the trophy is shown.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
