### PR TITLE
Wrap entities

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1659,26 +1659,22 @@ void Graphics::drawentities()
                 wrappedPoint.y -= 230;
             }
 
-            if (map.warpx ||
-                (map.towermode && !map.minitowermode
-                    && map.ypos >= 500 && map.ypos <= 5000))   //The "wrapping" area of the tower
+            bool isInWrappingAreaOfTower = map.towermode && !map.minitowermode && map.ypos >= 500 && map.ypos <= 5000;
+            if (wrapX && (map.warpx || isInWrappingAreaOfTower))
             {
-                if (wrapX)
-                {
-                    drawRect = sprites_rect;
-                    drawRect.x += wrappedPoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
-                }
+                drawRect = sprites_rect;
+                drawRect.x += wrappedPoint.x;
+                drawRect.y += tpoint.y;
+                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
             }
-            if (map.warpy && wrapY)
+            if (wrapY && map.warpy)
             {
                 drawRect = sprites_rect;
                 drawRect.x += tpoint.x;
                 drawRect.y += wrappedPoint.y;
                 BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
             }
-            if (map.warpx && map.warpy && wrapX && wrapY)
+            if (wrapX && wrapY && map.warpx && map.warpy)
             {
                 drawRect = sprites_rect;
                 drawRect.x += wrappedPoint.x;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1615,6 +1615,7 @@ void Graphics::drawentities()
         switch (obj.entities[i].size)
         {
         case 0:
+        {
             // Sprites
             if (!INBOUNDS(obj.entities[i].drawframe, (*spritesvec)))
             {
@@ -1627,86 +1628,68 @@ void Graphics::drawentities()
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
-            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
+            
             //screenwrapping!
+            bool wrapX = false;
+            bool wrapY = false;
+
+            int wrappedXCoord = tpoint.x;
+            if (tpoint.x < 0) {
+                wrapX = true;
+                wrappedXCoord += 320;
+            }
+            else if (tpoint.x > 300) {
+                wrapX = true;
+                wrappedXCoord -= 320;
+            }
+
+            int wrappedYCoord = tpoint.y;
+            if (tpoint.y < 0) {
+                wrapY = true;
+                wrappedYCoord += 230;
+            }
+            else if (tpoint.y > 210) {
+                wrapY = true;
+                wrappedYCoord -= 230;
+            }
+
             if (map.warpx ||
-				(map.towermode && !map.minitowermode
-				&& map.ypos >= 500 && map.ypos <= 5000))   //The "wrapping" area of the tower
+                (map.towermode && !map.minitowermode
+                    && map.ypos >= 500 && map.ypos <= 5000))   //The "wrapping" area of the tower
             {
-                if (tpoint.x < 0)
-                {
-                    tpoint.x += 320;
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                }
-                else if (tpoint.x > 300)
-                {
-                    tpoint.x -= 320;
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                drawRect = sprites_rect;
+                drawRect.x += wrappedXCoord;
+                drawRect.y += tpoint.y;
+
+                if (wrapX) {
+                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
                 }
             }
             if (map.warpy)
             {
-                if (tpoint.y < 0)
+                drawRect = sprites_rect;
+                drawRect.x += tpoint.x;
+                drawRect.y += wrappedYCoord;
+
+                if (wrapY)
                 {
-                    tpoint.y += 230;
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-                }
-                else if (tpoint.y > 210)
-                {
-                    tpoint.y -= 230;
-                    drawRect = sprites_rect;
-                    drawRect.x += tpoint.x;
-                    drawRect.y += tpoint.y;
-                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
                 }
             }
-			if (map.warpx && map.warpy)
-			{
-				bool drawWrappedSprite = false;
-				
-				if (tpoint.x < 0 && tpoint.y < 0)
-				{
-					tpoint.x += 320;
-					tpoint.y += 230;
-					drawWrappedSprite = true;
-				}
-				else if (tpoint.x > 300 && tpoint.y < 0)
-				{
-					tpoint.x -= 320;
-					tpoint.y += 230;
-					drawWrappedSprite = true;
-				}
-				else if (tpoint.x < 0 && tpoint.y > 210)
-				{
-					tpoint.x += 320;
-					tpoint.y -= 230;
-					drawWrappedSprite = true;
-				}
-				else if (tpoint.x > 300 && tpoint.y > 210)
-				{
-					tpoint.x -= 320;
-					tpoint.y -= 230;
-					drawWrappedSprite = true;
-				}
-				
-				if (drawWrappedSprite)
-				{
-					drawRect = sprites_rect;
-					drawRect.x += tpoint.x;
-					drawRect.y += tpoint.y;
-                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-				}
-			}
+            if (map.warpx && map.warpy)
+            {
+                drawRect = sprites_rect;
+                drawRect.x += wrappedXCoord;
+                drawRect.y += wrappedYCoord;
+
+                if (wrapX && wrapY)
+                {
+                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
+                }
+            }
             break;
+        }
         case 1:
             // Tiles
             if (!INBOUNDS(obj.entities[i].drawframe, tiles))

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1630,8 +1630,8 @@ void Graphics::drawentities()
             BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
             //screenwrapping!
             if (map.warpx ||
-            (map.towermode && !map.minitowermode
-            && map.ypos >= 500 && map.ypos <= 5000))   //The "wrapping" area of the tower
+				(map.towermode && !map.minitowermode
+				&& map.ypos >= 500 && map.ypos <= 5000))   //The "wrapping" area of the tower
             {
                 if (tpoint.x < 0)
                 {
@@ -1650,7 +1650,7 @@ void Graphics::drawentities()
                     BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                 }
             }
-            else if (map.warpy)
+            if (map.warpy)
             {
                 if (tpoint.y < 0)
                 {
@@ -1669,6 +1669,43 @@ void Graphics::drawentities()
                     BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
                 }
             }
+			if (map.warpx && map.warpy)
+			{
+				bool drawWrappedSprite = false;
+				
+				if (tpoint.x < 0 && tpoint.y < 0)
+				{
+					tpoint.x += 320;
+					tpoint.y += 230;
+					drawWrappedSprite = true;
+				}
+				else if (tpoint.x > 300 && tpoint.y < 0)
+				{
+					tpoint.x -= 320;
+					tpoint.y += 230;
+					drawWrappedSprite = true;
+				}
+				else if (tpoint.x < 0 && tpoint.y > 210)
+				{
+					tpoint.x += 320;
+					tpoint.y -= 230;
+					drawWrappedSprite = true;
+				}
+				else if (tpoint.x > 300 && tpoint.y > 210)
+				{
+					tpoint.x -= 320;
+					tpoint.y -= 230;
+					drawWrappedSprite = true;
+				}
+				
+				if (drawWrappedSprite)
+				{
+					drawRect = sprites_rect;
+					drawRect.x += tpoint.x;
+					drawRect.y += tpoint.y;
+                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+				}
+			}
             break;
         case 1:
             // Tiles

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1631,62 +1631,59 @@ void Graphics::drawentities()
             BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
             
             //screenwrapping!
+            point wrappedPoint;
             bool wrapX = false;
             bool wrapY = false;
 
-            int wrappedXCoord = tpoint.x;
-            if (tpoint.x < 0) {
+            wrappedPoint.x = tpoint.x;
+            if (tpoint.x < 0)
+            {
                 wrapX = true;
-                wrappedXCoord += 320;
+                wrappedPoint.x += 320;
             }
-            else if (tpoint.x > 300) {
+            else if (tpoint.x > 300)
+            {
                 wrapX = true;
-                wrappedXCoord -= 320;
+                wrappedPoint.x -= 320;
             }
 
-            int wrappedYCoord = tpoint.y;
-            if (tpoint.y < 0) {
+            wrappedPoint.y = tpoint.y;
+            if (tpoint.y < 0)
+            {
                 wrapY = true;
-                wrappedYCoord += 230;
+                wrappedPoint.y += 230;
             }
-            else if (tpoint.y > 210) {
+            else if (tpoint.y > 210)
+            {
                 wrapY = true;
-                wrappedYCoord -= 230;
+                wrappedPoint.y -= 230;
             }
 
             if (map.warpx ||
                 (map.towermode && !map.minitowermode
                     && map.ypos >= 500 && map.ypos <= 5000))   //The "wrapping" area of the tower
             {
-                drawRect = sprites_rect;
-                drawRect.x += wrappedXCoord;
-                drawRect.y += tpoint.y;
-
-                if (wrapX) {
+                if (wrapX)
+                {
+                    drawRect = sprites_rect;
+                    drawRect.x += wrappedPoint.x;
+                    drawRect.y += tpoint.y;
                     BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
                 }
             }
-            if (map.warpy)
+            if (map.warpy && wrapY)
             {
                 drawRect = sprites_rect;
                 drawRect.x += tpoint.x;
-                drawRect.y += wrappedYCoord;
-
-                if (wrapY)
-                {
-                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
-                }
+                drawRect.y += wrappedPoint.y;
+                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
             }
-            if (map.warpx && map.warpy)
+            if (map.warpx && map.warpy && wrapX && wrapY)
             {
                 drawRect = sprites_rect;
-                drawRect.x += wrappedXCoord;
-                drawRect.y += wrappedYCoord;
-
-                if (wrapX && wrapY)
-                {
-                    BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
-                }
+                drawRect.x += wrappedPoint.x;
+                drawRect.y += wrappedPoint.y;
+                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
             }
             break;
         }


### PR DESCRIPTION
## Changes:

Fix Graphics::drawentities() screen wrapping logic to allow for simultaneous horizontal and vertical wrapping of sprites. Closes #404.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
