### PR TITLE
Fix checkpoint starts in editor

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -4711,19 +4711,12 @@ void editorinput()
                             //Checkpoint spawn
                             int tx=(edentity[testeditor].x-(edentity[testeditor].x%40))/40;
                             int ty=(edentity[testeditor].y-(edentity[testeditor].y%30))/30;
-                            game.edsavex = (edentity[testeditor].x%40)*8;
+                            game.edsavex = (edentity[testeditor].x%40)*8 - 4;
                             game.edsavey = (edentity[testeditor].y%30)*8;
                             game.edsaverx = 100+tx;
                             game.edsavery = 100+ty;
-                            game.edsavegc = edentity[testeditor].p1;
-                            if(game.edsavegc==0)
-                            {
-                                game.edsavey--;
-                            }
-                            else
-                            {
-                                game.edsavey-=8;
-                            }
+                            game.edsavegc = 1-edentity[testeditor].p1;
+                            game.edsavey--;
                             game.edsavedir = 0;
                         }
                         else
@@ -4731,7 +4724,7 @@ void editorinput()
                             //Start point spawn
                             int tx=(edentity[testeditor].x-(edentity[testeditor].x%40))/40;
                             int ty=(edentity[testeditor].y-(edentity[testeditor].y%30))/30;
-                            game.edsavex = ((edentity[testeditor].x%40)*8)-4;
+                            game.edsavex = (edentity[testeditor].x%40)*8 - 4;
                             game.edsavey = (edentity[testeditor].y%30)*8;
                             game.edsaverx = 100+tx;
                             game.edsavery = 100+ty;


### PR DESCRIPTION
## Changes:

This makes starting from a checkpoint in the editor put you in the same position as when respawning from it after a death. Closes #378.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
