### PR TITLE
Fallback to loading music from loose files if vvvvvvmusic.vvv is invalid or missing

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -174,6 +174,7 @@ set(PFS_SRC
 	../third_party/physfs/physfs_platform_unix.c
 	../third_party/physfs/physfs_platform_windows.c
 	../third_party/physfs/physfs_platform_haiku.cpp
+	../third_party/physfs/physfsrwops.c
 )
 if(APPLE)
 	# Are you noticing a pattern with this Apple crap yet?

--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -113,6 +113,7 @@ set(VVV_SRC
 	src/Network.c
 	src/ThirdPartyDeps.c
 	src/Xoshiro.c
+	../third_party/physfs/physfsrwops.c
 )
 if(NOT CUSTOM_LEVEL_SUPPORT STREQUAL "DISABLED")
 	list(APPEND VVV_SRC src/editor.cpp)
@@ -174,7 +175,6 @@ set(PFS_SRC
 	../third_party/physfs/physfs_platform_unix.c
 	../third_party/physfs/physfs_platform_windows.c
 	../third_party/physfs/physfs_platform_haiku.cpp
-	../third_party/physfs/physfsrwops.c
 )
 if(APPLE)
 	# Are you noticing a pattern with this Apple crap yet?

--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -134,9 +134,8 @@ bool binaryBlob::nextExtra(size_t* start)
 	for (idx = start; *idx < SDL_arraysize(m_headers); *idx += 1)
 	{
 		if (m_headers[*idx].valid
-#define FOREACH_TRACK(_, track_name) && SDL_strcmp(m_headers[*idx].name, track_name) != 0
+#define FOREACH_TRACK(_, track_name) && SDL_strcmp(m_headers[*idx].name, "data/" track_name) != 0
 		TRACK_NAMES(_)
-#undef FOREACH_TRACK
 		) {
 			return true;
 		}

--- a/desktop_version/src/BinaryBlob.h
+++ b/desktop_version/src/BinaryBlob.h
@@ -7,22 +7,22 @@
 // #define VVV_COMPILEMUSIC
 
 #define TRACK_NAMES(blob) \
-	FOREACH_TRACK(blob, "data/music/0levelcomplete.ogg") \
-	FOREACH_TRACK(blob, "data/music/1pushingonwards.ogg") \
-	FOREACH_TRACK(blob, "data/music/2positiveforce.ogg") \
-	FOREACH_TRACK(blob, "data/music/3potentialforanything.ogg") \
-	FOREACH_TRACK(blob, "data/music/4passionforexploring.ogg") \
-	FOREACH_TRACK(blob, "data/music/5intermission.ogg") \
-	FOREACH_TRACK(blob, "data/music/6presentingvvvvvv.ogg") \
-	FOREACH_TRACK(blob, "data/music/7gamecomplete.ogg") \
-	FOREACH_TRACK(blob, "data/music/8predestinedfate.ogg") \
-	FOREACH_TRACK(blob, "data/music/9positiveforcereversed.ogg") \
-	FOREACH_TRACK(blob, "data/music/10popularpotpourri.ogg") \
-	FOREACH_TRACK(blob, "data/music/11pipedream.ogg") \
-	FOREACH_TRACK(blob, "data/music/12pressurecooker.ogg") \
-	FOREACH_TRACK(blob, "data/music/13pacedenergy.ogg") \
-	FOREACH_TRACK(blob, "data/music/14piercingthesky.ogg") \
-	FOREACH_TRACK(blob, "data/music/predestinedfatefinallevel.ogg")
+	FOREACH_TRACK(blob, "music/0levelcomplete.ogg") \
+	FOREACH_TRACK(blob, "music/1pushingonwards.ogg") \
+	FOREACH_TRACK(blob, "music/2positiveforce.ogg") \
+	FOREACH_TRACK(blob, "music/3potentialforanything.ogg") \
+	FOREACH_TRACK(blob, "music/4passionforexploring.ogg") \
+	FOREACH_TRACK(blob, "music/5intermission.ogg") \
+	FOREACH_TRACK(blob, "music/6presentingvvvvvv.ogg") \
+	FOREACH_TRACK(blob, "music/7gamecomplete.ogg") \
+	FOREACH_TRACK(blob, "music/8predestinedfate.ogg") \
+	FOREACH_TRACK(blob, "music/9positiveforcereversed.ogg") \
+	FOREACH_TRACK(blob, "music/10popularpotpourri.ogg") \
+	FOREACH_TRACK(blob, "music/11pipedream.ogg") \
+	FOREACH_TRACK(blob, "music/12pressurecooker.ogg") \
+	FOREACH_TRACK(blob, "music/13pacedenergy.ogg") \
+	FOREACH_TRACK(blob, "music/14piercingthesky.ogg") \
+	FOREACH_TRACK(blob, "music/predestinedfatefinallevel.ogg")
 
 struct resourceheader
 {

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -770,7 +770,7 @@ bool FILESYSTEM_loadBinaryBlob(binaryBlob* blob, const char* filename)
 {
 	PHYSFS_sint64 size;
 	PHYSFS_File* handle;
-	int offset;
+	int valid, offset;
 	size_t i;
 	char path[MAX_PATH];
 
@@ -796,6 +796,7 @@ bool FILESYSTEM_loadBinaryBlob(binaryBlob* blob, const char* filename)
 		sizeof(blob->m_headers)
 	);
 
+	valid = 0;
 	offset = sizeof(blob->m_headers);
 
 	for (i = 0; i < SDL_arraysize(blob->m_headers); ++i)
@@ -828,14 +829,19 @@ bool FILESYSTEM_loadBinaryBlob(binaryBlob* blob, const char* filename)
 		}
 		PHYSFS_readBytes(handle, *memblock, header->size);
 		offset += header->size;
+		valid += 1;
 
 		continue;
-
 fail:
 		header->valid = false;
 	}
 
 	PHYSFS_close(handle);
+
+	if (valid == 0)
+	{
+		return false;
+	}
 
 	printf("The complete reloaded file size: %lli\n", size);
 

--- a/third_party/physfs/physfsrwops.c
+++ b/third_party/physfs/physfsrwops.c
@@ -1,0 +1,251 @@
+/*
+ * This code provides a glue layer between PhysicsFS and Simple Directmedia
+ *  Layer's (SDL) RWops i/o abstraction.
+ *
+ * License: this code is public domain. I make no warranty that it is useful,
+ *  correct, harmless, or environmentally safe.
+ *
+ * This particular file may be used however you like, including copying it
+ *  verbatim into a closed-source project, exploiting it commercially, and
+ *  removing any trace of my name from the source (although I hope you won't
+ *  do that). I welcome enhancements and corrections to this file, but I do
+ *  not require you to send me patches if you make changes. This code has
+ *  NO WARRANTY.
+ *
+ * Unless otherwise stated, the rest of PhysicsFS falls under the zlib license.
+ *  Please see LICENSE.txt in the root of the source tree.
+ *
+ * SDL 1.2 falls under the LGPL license. SDL 1.3+ is zlib, like PhysicsFS.
+ *  You can get SDL at https://www.libsdl.org/
+ *
+ *  This file was written by Ryan C. Gordon. (icculus@icculus.org).
+ */
+
+#include <stdio.h>  /* used for SEEK_SET, SEEK_CUR, SEEK_END ... */
+#include "physfsrwops.h"
+
+/* SDL's RWOPS interface changed a little in SDL 2.0... */
+#if defined(SDL_VERSION_ATLEAST)
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+#define TARGET_SDL2 1
+#endif
+#endif
+
+#if !TARGET_SDL2
+#ifndef RW_SEEK_SET
+#define RW_SEEK_SET SEEK_SET
+#endif
+#ifndef RW_SEEK_CUR
+#define RW_SEEK_CUR SEEK_CUR
+#endif
+#ifndef RW_SEEK_END
+#define RW_SEEK_END SEEK_END
+#endif
+#endif
+
+#if TARGET_SDL2
+static Sint64 SDLCALL physfsrwops_size(struct SDL_RWops *rw)
+{
+    PHYSFS_File *handle = (PHYSFS_File *) rw->hidden.unknown.data1;
+    return (Sint64) PHYSFS_fileLength(handle);
+} /* physfsrwops_size */
+#endif
+
+
+#if TARGET_SDL2
+static Sint64 SDLCALL physfsrwops_seek(struct SDL_RWops *rw, Sint64 offset, int whence)
+#else
+static int physfsrwops_seek(SDL_RWops *rw, int offset, int whence)
+#endif
+{
+    PHYSFS_File *handle = (PHYSFS_File *) rw->hidden.unknown.data1;
+    PHYSFS_sint64 pos = 0;
+
+    if (whence == RW_SEEK_SET)
+        pos = (PHYSFS_sint64) offset;
+
+    else if (whence == RW_SEEK_CUR)
+    {
+        const PHYSFS_sint64 current = PHYSFS_tell(handle);
+        if (current == -1)
+        {
+            SDL_SetError("Can't find position in file: %s",
+                          PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+            return -1;
+        } /* if */
+
+        if (offset == 0)  /* this is a "tell" call. We're done. */
+        {
+            #if TARGET_SDL2
+            return (Sint64) current;
+            #else
+            return (int) current;
+            #endif
+        } /* if */
+
+        pos = current + ((PHYSFS_sint64) offset);
+    } /* else if */
+
+    else if (whence == RW_SEEK_END)
+    {
+        const PHYSFS_sint64 len = PHYSFS_fileLength(handle);
+        if (len == -1)
+        {
+            SDL_SetError("Can't find end of file: %s", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+            return -1;
+        } /* if */
+
+        pos = len + ((PHYSFS_sint64) offset);
+    } /* else if */
+
+    else
+    {
+        SDL_SetError("Invalid 'whence' parameter.");
+        return -1;
+    } /* else */
+
+    if ( pos < 0 )
+    {
+        SDL_SetError("Attempt to seek past start of file.");
+        return -1;
+    } /* if */
+    
+    if (!PHYSFS_seek(handle, (PHYSFS_uint64) pos))
+    {
+        SDL_SetError("PhysicsFS error: %s", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+        return -1;
+    } /* if */
+
+    #if TARGET_SDL2
+    return (Sint64) pos;
+    #else
+    return (int) pos;
+    #endif
+} /* physfsrwops_seek */
+
+
+#if TARGET_SDL2
+static size_t SDLCALL physfsrwops_read(struct SDL_RWops *rw, void *ptr,
+                                       size_t size, size_t maxnum)
+#else
+static int physfsrwops_read(SDL_RWops *rw, void *ptr, int size, int maxnum)
+#endif
+{
+    PHYSFS_File *handle = (PHYSFS_File *) rw->hidden.unknown.data1;
+    const PHYSFS_uint64 readlen = (PHYSFS_uint64) (maxnum * size);
+    const PHYSFS_sint64 rc = PHYSFS_readBytes(handle, ptr, readlen);
+    if (rc != ((PHYSFS_sint64) readlen))
+    {
+        if (!PHYSFS_eof(handle)) /* not EOF? Must be an error. */
+        {
+            SDL_SetError("PhysicsFS error: %s", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+
+            #if TARGET_SDL2
+            return 0;
+            #else
+            return -1;
+            #endif
+        } /* if */
+    } /* if */
+
+    #if TARGET_SDL2
+    return (size_t) rc / size;
+    #else
+    return (int) rc / size;
+    #endif
+} /* physfsrwops_read */
+
+
+#if TARGET_SDL2
+static size_t SDLCALL physfsrwops_write(struct SDL_RWops *rw, const void *ptr,
+                                        size_t size, size_t num)
+#else
+static int physfsrwops_write(SDL_RWops *rw, const void *ptr, int size, int num)
+#endif
+{
+    PHYSFS_File *handle = (PHYSFS_File *) rw->hidden.unknown.data1;
+    const PHYSFS_uint64 writelen = (PHYSFS_uint64) (num * size);
+    const PHYSFS_sint64 rc = PHYSFS_writeBytes(handle, ptr, writelen);
+    if (rc != ((PHYSFS_sint64) writelen))
+        SDL_SetError("PhysicsFS error: %s", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+
+    #if TARGET_SDL2
+    return (size_t) rc;
+    #else
+    return (int) rc;
+    #endif
+} /* physfsrwops_write */
+
+
+static int physfsrwops_close(SDL_RWops *rw)
+{
+    PHYSFS_File *handle = (PHYSFS_File *) rw->hidden.unknown.data1;
+    if (!PHYSFS_close(handle))
+    {
+        SDL_SetError("PhysicsFS error: %s", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+        return -1;
+    } /* if */
+
+    SDL_FreeRW(rw);
+    return 0;
+} /* physfsrwops_close */
+
+
+static SDL_RWops *create_rwops(PHYSFS_File *handle)
+{
+    SDL_RWops *retval = NULL;
+
+    if (handle == NULL)
+        SDL_SetError("PhysicsFS error: %s", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+    else
+    {
+        retval = SDL_AllocRW();
+        if (retval != NULL)
+        {
+            #if TARGET_SDL2
+            retval->size  = physfsrwops_size;
+            #endif
+            retval->seek  = physfsrwops_seek;
+            retval->read  = physfsrwops_read;
+            retval->write = physfsrwops_write;
+            retval->close = physfsrwops_close;
+            retval->hidden.unknown.data1 = handle;
+        } /* if */
+    } /* else */
+
+    return retval;
+} /* create_rwops */
+
+
+SDL_RWops *PHYSFSRWOPS_makeRWops(PHYSFS_File *handle)
+{
+    SDL_RWops *retval = NULL;
+    if (handle == NULL)
+        SDL_SetError("NULL pointer passed to PHYSFSRWOPS_makeRWops().");
+    else
+        retval = create_rwops(handle);
+
+    return retval;
+} /* PHYSFSRWOPS_makeRWops */
+
+
+SDL_RWops *PHYSFSRWOPS_openRead(const char *fname)
+{
+    return create_rwops(PHYSFS_openRead(fname));
+} /* PHYSFSRWOPS_openRead */
+
+
+SDL_RWops *PHYSFSRWOPS_openWrite(const char *fname)
+{
+    return create_rwops(PHYSFS_openWrite(fname));
+} /* PHYSFSRWOPS_openWrite */
+
+
+SDL_RWops *PHYSFSRWOPS_openAppend(const char *fname)
+{
+    return create_rwops(PHYSFS_openAppend(fname));
+} /* PHYSFSRWOPS_openAppend */
+
+
+/* end of physfsrwops.c ... */
+

--- a/third_party/physfs/physfsrwops.h
+++ b/third_party/physfs/physfsrwops.h
@@ -25,7 +25,7 @@
 #define _INCLUDE_PHYSFSRWOPS_H_
 
 #include "physfs.h"
-#include "SDL2/SDL.h"
+#include <SDL.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/third_party/physfs/physfsrwops.h
+++ b/third_party/physfs/physfsrwops.h
@@ -1,0 +1,89 @@
+/*
+ * This code provides a glue layer between PhysicsFS and Simple Directmedia
+ *  Layer's (SDL) RWops i/o abstraction.
+ *
+ * License: this code is public domain. I make no warranty that it is useful,
+ *  correct, harmless, or environmentally safe.
+ *
+ * This particular file may be used however you like, including copying it
+ *  verbatim into a closed-source project, exploiting it commercially, and
+ *  removing any trace of my name from the source (although I hope you won't
+ *  do that). I welcome enhancements and corrections to this file, but I do
+ *  not require you to send me patches if you make changes. This code has
+ *  NO WARRANTY.
+ *
+ * Unless otherwise stated, the rest of PhysicsFS falls under the zlib license.
+ *  Please see LICENSE.txt in the root of the source tree.
+ *
+ * SDL 1.2 falls under the LGPL license. SDL 1.3+ is zlib, like PhysicsFS.
+ *  You can get SDL at https://www.libsdl.org/
+ *
+ *  This file was written by Ryan C. Gordon. (icculus@icculus.org).
+ */
+
+#ifndef _INCLUDE_PHYSFSRWOPS_H_
+#define _INCLUDE_PHYSFSRWOPS_H_
+
+#include "physfs.h"
+#include "SDL2/SDL.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Open a platform-independent filename for reading, and make it accessible
+ *  via an SDL_RWops structure. The file will be closed in PhysicsFS when the
+ *  RWops is closed. PhysicsFS should be configured to your liking before
+ *  opening files through this method.
+ *
+ *   @param filename File to open in platform-independent notation.
+ *  @return A valid SDL_RWops structure on success, NULL on error. Specifics
+ *           of the error can be gleaned from PHYSFS_getLastError().
+ */
+PHYSFS_DECL SDL_RWops *PHYSFSRWOPS_openRead(const char *fname);
+
+/**
+ * Open a platform-independent filename for writing, and make it accessible
+ *  via an SDL_RWops structure. The file will be closed in PhysicsFS when the
+ *  RWops is closed. PhysicsFS should be configured to your liking before
+ *  opening files through this method.
+ *
+ *   @param filename File to open in platform-independent notation.
+ *  @return A valid SDL_RWops structure on success, NULL on error. Specifics
+ *           of the error can be gleaned from PHYSFS_getLastError().
+ */
+PHYSFS_DECL SDL_RWops *PHYSFSRWOPS_openWrite(const char *fname);
+
+/**
+ * Open a platform-independent filename for appending, and make it accessible
+ *  via an SDL_RWops structure. The file will be closed in PhysicsFS when the
+ *  RWops is closed. PhysicsFS should be configured to your liking before
+ *  opening files through this method.
+ *
+ *   @param filename File to open in platform-independent notation.
+ *  @return A valid SDL_RWops structure on success, NULL on error. Specifics
+ *           of the error can be gleaned from PHYSFS_getLastError().
+ */
+PHYSFS_DECL SDL_RWops *PHYSFSRWOPS_openAppend(const char *fname);
+
+/**
+ * Make a SDL_RWops from an existing PhysicsFS file handle. You should
+ *  dispose of any references to the handle after successful creation of
+ *  the RWops. The actual PhysicsFS handle will be destroyed when the
+ *  RWops is closed.
+ *
+ *   @param handle a valid PhysicsFS file handle.
+ *  @return A valid SDL_RWops structure on success, NULL on error. Specifics
+ *           of the error can be gleaned from PHYSFS_getLastError().
+ */
+PHYSFS_DECL SDL_RWops *PHYSFSRWOPS_makeRWops(PHYSFS_File *handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* include-once blocker */
+
+/* end of physfsrwops.h ... */
+


### PR DESCRIPTION
## Changes:

Files are loaded from paths like `/home/leo60228/.local/share/VVVVVV/music/6presentingvvvvvv.ogg`. This allows the game to have less than 20MB of peak heap usage (though still ~100MB of non-heap RAM usage, which I'm investigating).


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
