### PR TITLE
Reposition game time and trinket count in game save box

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -633,7 +633,7 @@ void menurender()
         {
         case 0:
             //Show teleporter save info
-            graphics.drawpixeltextbox(25, 65-20, 270, 90, 34,12, 65, 185, 207,0,4);
+            graphics.drawpixeltextbox(17, 65-20, 286, 90, 36,12, 65, 185, 207,0,4);
 
             graphics.bigprint(-1, 20, "Tele Save", tr, tg, tb, true);
             graphics.Print(0, 80-20, game.tele_currentarea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
@@ -649,7 +649,7 @@ void menurender()
             break;
         case 1:
             //Show quick save info
-            graphics.drawpixeltextbox(25, 65-20, 270, 90, 34,12, 65, 185, 207,0,4);
+            graphics.drawpixeltextbox(17, 65-20, 286, 90, 36,12, 65, 185, 207,0,4);
 
             graphics.bigprint(-1, 20, "Quick Save", tr, tg, tb, true);
             graphics.Print(0, 80-20, game.quick_currentarea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
@@ -2215,7 +2215,7 @@ void maprender()
             {
                 graphics.Print(0, 36, "Game saved ok!", 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2), true);
 
-                graphics.drawpixeltextbox(25, 65, 270, 90, 34,12, 65, 185, 207,0,4);
+                graphics.drawpixeltextbox(17, 65, 286, 90, 36,12, 65, 185, 207,0,4);
 
                 if (graphics.flipmode)
                 {
@@ -2258,7 +2258,7 @@ void maprender()
             {
                 graphics.Print(0, 36, "Game saved ok!", 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2), true);
 
-                graphics.drawpixeltextbox(25, 65, 270, 90, 34,12, 65, 185, 207,0,4);
+                graphics.drawpixeltextbox(17, 65, 286, 90, 36,12, 65, 185, 207,0,4);
 
                 if (graphics.flipmode)
                 {

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -632,6 +632,7 @@ void menurender()
         switch (game.currentmenuoption)
         {
         case 0:
+        {
             //Show teleporter save info
             graphics.drawpixeltextbox(17, 65-20, 286, 90, 36,12, 65, 185, 207,0,4);
 
@@ -641,13 +642,16 @@ void menurender()
             {
                 graphics.drawcrewman(169-(3*42)+(i*42), 95-20, i, game.tele_crewstats[i], true);
             }
-            graphics.Print(160 - 84, 132-20, game.tele_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-            graphics.Print(160 + 40, 132-20, help.number(game.tele_trinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+            graphics.Print(59, 132-20, game.tele_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+            const std::string& trinketcount = help.number(game.tele_trinkets);
+            graphics.Print(262-graphics.len(trinketcount), 132-20, trinketcount, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-            graphics.drawsprite(50, 126-20, 50, graphics.col_clock);
-            graphics.drawsprite(175, 126-20, 22, graphics.col_trinket);
+            graphics.drawsprite(34, 126-20, 50, graphics.col_clock);
+            graphics.drawsprite(270, 126-20, 22, graphics.col_trinket);
             break;
+        }
         case 1:
+        {
             //Show quick save info
             graphics.drawpixeltextbox(17, 65-20, 286, 90, 36,12, 65, 185, 207,0,4);
 
@@ -657,12 +661,14 @@ void menurender()
             {
                 graphics.drawcrewman(169-(3*42)+(i*42), 95-20, i, game.quick_crewstats[i], true);
             }
-            graphics.Print(160 - 84, 132-20, game.quick_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-            graphics.Print(160 + 40, 132-20, help.number(game.quick_trinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+            graphics.Print(59, 132-20, game.quick_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+            const std::string& trinketcount = help.number(game.quick_trinkets);
+            graphics.Print(262-graphics.len(trinketcount), 132-20, trinketcount, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-            graphics.drawsprite(50, 126-20, 50, graphics.col_clock);
-            graphics.drawsprite(175, 126-20, 22, graphics.col_trinket);
+            graphics.drawsprite(34, 126-20, 50, graphics.col_clock);
+            graphics.drawsprite(270, 126-20, 22, graphics.col_trinket);
             break;
+        }
         }
         break;
     case Menu::gameover:
@@ -2220,20 +2226,22 @@ void maprender()
                 if (graphics.flipmode)
                 {
                     graphics.Print(0, 122, game.customleveltitle, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
-                    graphics.Print(160 - 84, 78, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-                    graphics.Print(160 + 40, 78, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(59, 78, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    const std::string& trinketcount = help.number(game.savetrinkets);
+                    graphics.Print(262-graphics.len(trinketcount), 78, trinketcount, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    graphics.drawsprite(50, 74, 50, graphics.col_clock);
-                    graphics.drawsprite(175, 74, 22, graphics.col_trinket);
+                    graphics.drawsprite(34, 74, 50, graphics.col_clock);
+                    graphics.drawsprite(270, 74, 22, graphics.col_trinket);
                 }
                 else
                 {
                     graphics.Print(0, 90, game.customleveltitle, 25, 255 - (help.glow / 2), 255 - (help.glow / 2), true);
-                    graphics.Print(160 - 84, 132, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-                    graphics.Print(160 + 40, 132, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(59, 132, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    const std::string& trinketcount = help.number(game.savetrinkets);
+                    graphics.Print(262-graphics.len(trinketcount), 132, trinketcount, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    graphics.drawsprite(50, 126, 50, graphics.col_clock);
-                    graphics.drawsprite(175, 126, 22, graphics.col_trinket);
+                    graphics.drawsprite(34, 126, 50, graphics.col_clock);
+                    graphics.drawsprite(270, 126, 22, graphics.col_trinket);
                 }
             }
             else
@@ -2267,11 +2275,12 @@ void maprender()
                     {
                         graphics.drawcrewman(169-(3*42)+(i*42), 98, i, game.crewstats[i], true);
                     }
-                    graphics.Print(160 - 84, 78, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-                    graphics.Print(160 + 40, 78, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(59, 78, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    const std::string& trinketcount = help.number(game.savetrinkets);
+                    graphics.Print(262-graphics.len(trinketcount), 78, trinketcount, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    graphics.drawsprite(50, 74, 50, graphics.col_clock);
-                    graphics.drawsprite(175, 74, 22, graphics.col_trinket);
+                    graphics.drawsprite(34, 74, 50, graphics.col_clock);
+                    graphics.drawsprite(270, 74, 22, graphics.col_trinket);
                 }
                 else
                 {
@@ -2280,11 +2289,12 @@ void maprender()
                     {
                         graphics.drawcrewman(169-(3*42)+(i*42), 95, i, game.crewstats[i], true);
                     }
-                    graphics.Print(160 - 84, 132, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-                    graphics.Print(160 + 40, 132, help.number(game.savetrinkets), 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    graphics.Print(59, 132, game.savetime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+                    const std::string& trinketcount = help.number(game.savetrinkets);
+                    graphics.Print(262-graphics.len(trinketcount), 132, trinketcount, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-                    graphics.drawsprite(50, 126, 50, graphics.col_clock);
-                    graphics.drawsprite(175, 126, 22, graphics.col_trinket);
+                    graphics.drawsprite(34, 126, 50, graphics.col_clock);
+                    graphics.drawsprite(270, 126, 22, graphics.col_trinket);
                 }
             }
             else


### PR DESCRIPTION
## Changes:

Fixes #376.

Since trinket counts in the "game saved" box can now go above Twenty in custom levels, some numbers can run out of the box:

![seventy eight before](https://user-images.githubusercontent.com/44736680/89133938-0ba86600-d510-11ea-970e-c248ed269445.png)

Now the trinket count is positioned automatically based on its length. The trinket icon is now also displayed at the far right (instead of to the left of the count) for better symmetry, and so that switching between the menu options for tele save and quick save doesn't make the trinket icon move if the trinket counts have different lengths. Lastly, I've repositioned the time and trinket count a bit and made the box a little wider to account for future localizations of the game (I mean, I could have done the minimum necessary to fix the overflow in English in this branch and do the rest in the localization branch, but why not get it out of the way while I'm at it)

This is the result:

![seventy eight after](https://user-images.githubusercontent.com/44736680/89134018-ee27cc00-d510-11ea-8ac6-d1b317414cd7.png)

These changes affect all game save boxes, so the main game ones as well.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
