### PR TITLE
Add catch-all softlock protection

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -649,6 +649,12 @@ void Game::updatestate()
         {
         case 0:
             //Do nothing here! Standard game state
+
+            //Prevent softlocks if there's no cutscene running right now
+            if (!script.running)
+            {
+                hascontrol = true;
+            }
             break;
         case 1:
             //Game initilisation


### PR DESCRIPTION
What this simply does is make it so that in the event that `game.hascontrol` is somehow set to false when there isn't a cutscene
running (i.e. when `game.state` is 0 and `script.running` is false), it gets set back to true again.

There's many ways to interrupt a gamestate and/or a running script, most notably telejumping and doing a screen transition in the middle of the animation, interrupting it.

This implements the first part of my idea in [this comment](https://github.com/TerryCavanagh/VVVVVV/issues/391#issuecomment-659757071).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
