### PR TITLE
Don't draw activity zone or trophy text when cutscene is running

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1675,7 +1675,7 @@ void gamerender()
     }
 
     float act_alpha = graphics.lerp(game.prev_act_fade, game.act_fade) / 10.0f;
-    if (game.activeactivity > -1)
+    if (game.activeactivity > -1 && game.hascontrol && !script.running)
     {
         game.activity_lastprompt = obj.blocks[game.activeactivity].prompt;
         game.activity_r = obj.blocks[game.activeactivity].r;
@@ -1684,13 +1684,13 @@ void gamerender()
         graphics.drawtextbox(16, 4, 36, 3, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha);
         graphics.Print(5, 12, game.activity_lastprompt, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha, true);
     }
-    else if(game.act_fade>5 || game.prev_act_fade>5)
+    else if((game.act_fade>5 || game.prev_act_fade>5) && game.hascontrol && !script.running)
     {
         graphics.drawtextbox(16, 4, 36, 3, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha);
         graphics.Print(5, 12, game.activity_lastprompt, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha, true);
     }
 
-    if (obj.trophytext > 0 || obj.oldtrophytext > 0)
+    if ((obj.trophytext > 0 || obj.oldtrophytext > 0) && !script.running)
     {
         graphics.drawtrophytext();
     }


### PR DESCRIPTION
This fixes a possible graphical issue where the "Press ENTER to activate terminal" prompt gets drawn on top of the "- Press ACTION to advance text -" prompt, which looks bad. Trophy text gets drawn on top, too, so there's a check there as well.

I've also made it so the activity prompt doesn't get drawn if the player doesn't have control. After all, what use is it to say "press ENTER" if the player isn't allowed to?

Here are some example screenshots with Dimension Open, in the cutscene that plays after rescuing Voon from the Space Station.

Before:
![Activity prompt clash before](https://user-images.githubusercontent.com/59748578/89140543-c297e800-d4f6-11ea-8974-314cd1caf443.png)

After:
![Activity prompt clash after](https://user-images.githubusercontent.com/59748578/89140542-c166bb00-d4f6-11ea-868d-96daebfcf814.png)



## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
