### PR TITLE
Ifdef out network code for Make & Play edition

### DIFF
--- a/desktop_version/src/GOGNetwork.c
+++ b/desktop_version/src/GOGNetwork.c
@@ -1,3 +1,7 @@
+#include "MakeAndPlay.h"
+
+#ifndef MAKEANDPLAY
+
 #include <stdint.h>
 
 /* Totally unimplemented right now! */
@@ -27,3 +31,5 @@ int32_t GOG_getAchievementProgress(const char *name)
 void GOG_setAchievementProgress(const char *name, int32_t stat)
 {
 }
+
+#endif /* MAKEANDPLAY */

--- a/desktop_version/src/Network.c
+++ b/desktop_version/src/Network.c
@@ -1,6 +1,17 @@
 #include <stdint.h>
 
+#include "MakeAndPlay.h"
+
 #define UNUSED(expr) (void)(expr)
+
+#ifdef MAKEANDPLAY
+	#ifdef STEAM_NETWORK
+		#undef STEAM_NETWORK
+	#endif
+	#ifdef GOG_NETWORK
+		#undef GOG_NETWORK
+	#endif
+#endif
 
 #ifdef STEAM_NETWORK
 #define STEAM_NUM 1

--- a/desktop_version/src/Network.c
+++ b/desktop_version/src/Network.c
@@ -26,12 +26,12 @@
 
 #define NUM_BACKENDS (STEAM_NUM+GOG_NUM)
 #define DECLARE_BACKEND(name) \
-	extern int32_t name##_init(); \
-	extern void name##_shutdown(); \
-	extern void name##_update(); \
-	extern void name##_unlockAchievement(); \
-	extern int32_t name##_getAchievementProgress(const char *name); \
-	extern void name##_setAchievementProgress(const char *name, int32_t stat);
+	int32_t name##_init(); \
+	void name##_shutdown(); \
+	void name##_update(); \
+	void name##_unlockAchievement(); \
+	int32_t name##_getAchievementProgress(const char *name); \
+	void name##_setAchievementProgress(const char *name, int32_t stat);
 #ifdef STEAM_NETWORK
 DECLARE_BACKEND(STEAM)
 #endif

--- a/desktop_version/src/SteamNetwork.c
+++ b/desktop_version/src/SteamNetwork.c
@@ -1,3 +1,7 @@
+#include "MakeAndPlay.h"
+
+#ifndef MAKEANDPLAY
+
 #include <stdio.h>
 #include <stdint.h>
 #include <SDL.h>
@@ -218,3 +222,5 @@ void STEAM_setAchievementProgress(const char *name, int32_t stat)
 		SteamAPI_ISteamUserStats_StoreStats(steamUserStats);
 	}
 }
+
+#endif /* MAKEANDPLAY */


### PR DESCRIPTION
M&P contains network code despite M&P not being a Steam/GOG release (as Steam/GOG releases are full releases of the game, not custom-levels-only releases).

While unlocking achievements is already ifdef'd out in M&P, let's remove the network code entirely to make sure people can't do other shenanigans with M&P builds, and also to have a smaller binary size.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
