### PR TITLE
Initialize bx1/by1/bx2/by2 and fix enemies in custom levels taking on the same bounds as platforms

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1723,12 +1723,24 @@ void mapclass::loadlevel(int rx, int ry)
 			// Platform and enemy bounding boxes
 			int bx1 = 0, by1 = 0, bx2 = 0, by2 = 0;
 
-			if (ent.t == 1 || (ent.t == 2 && ent.p1 <= 4))
+			bool enemy = ent.t == 1;
+			bool moving_plat = ent.t == 2 && ent.p1 <= 4;
+			if (enemy || moving_plat)
 			{
-				bx1 = room.platx1;
-				by1 = room.platy1;
-				bx2 = room.platx2;
-				by2 = room.platy2;
+				if (enemy)
+				{
+					bx1 = room.enemyx1;
+					by1 = room.enemyy1;
+					bx2 = room.enemyx2;
+					by2 = room.enemyy2;
+				}
+				else if (moving_plat)
+				{
+					bx1 = room.platx1;
+					by1 = room.platy1;
+					bx2 = room.platx2;
+					by2 = room.platy2;
+				}
 
 				// Enlarge bounding boxes to fix warping entities
 				if (warpx && bx1 == 0 && bx2 == 320)

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1721,7 +1721,7 @@ void mapclass::loadlevel(int rx, int ry)
 			const int ey = (ent.y % 30) * 8;
 
 			// Platform and enemy bounding boxes
-			int bx1, by1, bx2, by2;
+			int bx1 = 0, by1 = 0, bx2 = 0, by2 = 0;
 
 			if (ent.t == 1 || (ent.t == 2 && ent.p1 <= 4))
 			{


### PR DESCRIPTION
Four variables are now initialized upon declaration, because GCC warns that they may be used uninitialized whenever I compile in release mode (even though I can't find out how this could happen...).

And I fixed a bug where enemies in custom levels would have the same bounds as platforms.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
