### PR TITLE
Move tele/activity/trophytext conds to collision detection

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -5,6 +5,7 @@
 #include "Graphics.h"
 #include "Map.h"
 #include "Music.h"
+#include "Script.h"
 #include "UtilityClass.h"
 
 bool entityclass::checktowerspikes(int t)
@@ -3083,7 +3084,7 @@ bool entityclass::updateentities( int i )
             //wait for collision
             if (entities[i].state == 1)
             {
-                trophytext+=2;
+                if (!script.running) trophytext+=2;
                 if (trophytext > 30) trophytext = 30;
                 trophytype = entities[i].para;
 

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1599,7 +1599,7 @@ void gamelogic()
     game.activeactivity = obj.checkactivity();
 
     game.oldreadytotele = game.readytotele;
-    if (game.activetele)
+    if (game.activetele && !game.advancetext && game.hascontrol && !script.running && !game.intimetrial)
     {
         int i = obj.getplayer();
         if (i > -1)
@@ -1637,7 +1637,7 @@ void gamelogic()
 #endif
 
     game.prev_act_fade = game.act_fade;
-    if (game.activeactivity > -1)
+    if (game.activeactivity > -1 && game.hascontrol && !script.running)
     {
         if (game.act_fade < 5)
         {

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1483,7 +1483,7 @@ void gamerender()
         if (game.advancetext) graphics.bprint(5, 5, "- Press ACTION to advance text -", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
 
-    if ((game.readytotele > 100 || game.oldreadytotele > 100) && !game.advancetext && game.hascontrol && !script.running && !game.intimetrial)
+    if (game.readytotele > 100 || game.oldreadytotele > 100)
     {
         int alpha = graphics.lerp(game.oldreadytotele, game.readytotele);
         if(graphics.flipmode)
@@ -1675,7 +1675,7 @@ void gamerender()
     }
 
     float act_alpha = graphics.lerp(game.prev_act_fade, game.act_fade) / 10.0f;
-    if (game.activeactivity > -1 && game.hascontrol && !script.running)
+    if (game.activeactivity > -1)
     {
         game.activity_lastprompt = obj.blocks[game.activeactivity].prompt;
         game.activity_r = obj.blocks[game.activeactivity].r;
@@ -1684,13 +1684,13 @@ void gamerender()
         graphics.drawtextbox(16, 4, 36, 3, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha);
         graphics.Print(5, 12, game.activity_lastprompt, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha, true);
     }
-    else if((game.act_fade>5 || game.prev_act_fade>5) && game.hascontrol && !script.running)
+    else if(game.act_fade>5 || game.prev_act_fade>5)
     {
         graphics.drawtextbox(16, 4, 36, 3, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha);
         graphics.Print(5, 12, game.activity_lastprompt, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha, true);
     }
 
-    if ((obj.trophytext > 0 || obj.oldtrophytext > 0) && !script.running)
+    if (obj.trophytext > 0 || obj.oldtrophytext > 0)
     {
         graphics.drawtrophytext();
     }


### PR DESCRIPTION
This moves the teleporter, activity prompt, and trophy text "don't draw" conditionals to the part where the game checks collision with them, instead of whenever the game draws them.

This makes it so that the game smoothly does the fade-in/fade-out animation instead of suddenly stopping rendering them whenever their "don't draw" conditions apply. Now, the "Press ENTER to activate terminal" prompt will no longer suddenly disappear whenever you activate one, and the "- Press ENTER to Teleport -" prompt will smoothly fade back in after teleporting, instead of suddenly popping in on screen.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
