### PR TITLE
Print an error message and return if the game is given an invalid command-line argument

### DIFF
--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -134,6 +134,11 @@ int main(int argc, char *argv[])
         }
 #undef ARG_INNER
 #undef ARG
+        else
+        {
+            printf("Error: invalid option: %s\n", argv[i]);
+            return 1;
+        }
     }
 
     if(!FILESYSTEM_init(argv[0], baseDir, assetsPath))


### PR DESCRIPTION
This is helpful to know if the user either spelled an argument wrong, or spelled it right but nothing is happening.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
