### PR TITLE
Fix dupe stack frame when creating unlock notif menu

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6874,12 +6874,12 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
 
             if (temp == 1)
             {
-                createmenu(Menu::unlocktimetrial);
+                createmenu(Menu::unlocktimetrial, true);
                 savemystats = true;
             }
             else if (temp > 1)
             {
-                createmenu(Menu::unlocktimetrials);
+                createmenu(Menu::unlocktimetrials, true);
                 savemystats = true;
             }
         }
@@ -6898,7 +6898,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
                 //Unlock No Death Mode
                 unlocknotify[17] = true;
                 unlock[17] = true;
-                createmenu(Menu::unlocknodeathmode);
+                createmenu(Menu::unlocknodeathmode, true);
                 savemystats = true;
             }
             //Alright then! Flip mode?
@@ -6906,7 +6906,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
             {
                 unlock[18] = true;
                 unlocknotify[18] = true;
-                createmenu(Menu::unlockflipmode);
+                createmenu(Menu::unlockflipmode, true);
                 savemystats = true;
             }
             //What about the intermission levels?
@@ -6914,7 +6914,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
             {
                 unlock[16] = true;
                 unlocknotify[16] = true;
-                createmenu(Menu::unlockintermission);
+                createmenu(Menu::unlockintermission, true);
                 savemystats = true;
             }
             else


### PR DESCRIPTION
The `samemenu` argument to `createmenu()` just has to be set to true so another stack frame doesn't get added.

Fixes #415.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
