### PR TITLE
Remove half-second delay when exiting to menu in glitchrunner mode

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2027,9 +2027,10 @@ void mapinput()
         // glitchrunner mode.
         // Also have to check graphics.menuoffset so this doesn't run every frame
 
-        // Have to close the menu in order to run gamestates. This adds
-        // about an extra half second of completely black screen.
+        // Have to close the menu in order to run gamestates
         graphics.resumegamemode = true;
+        // Remove half-second delay
+        graphics.menuoffset = 250;
 
         // Technically this was in <=2.2 as well
         obj.removeallblocks();


### PR DESCRIPTION
The half-second delay comes from the fact that the game uses `graphics.resumegamemode` to go back to GAMEMODE. This system waits for `graphics.menuoffset` to reach a certain threshold before actually going back (this is the animation of the map screen being brought down). To speed it up, I'll just set `graphics.menuoffset` directly.

I could've directly set `game.gamestate` to GAMEMODE, but I wanted to be safe and use the existing system instead.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
