### PR TITLE
Fix INBOUNDS() check for Graphics::drawtile3()

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -685,13 +685,14 @@ void Graphics::drawtile2( int x, int y, int t )
 
 void Graphics::drawtile3( int x, int y, int t, int off )
 {
+    t += off * 30;
     if (!INBOUNDS(t, tiles3))
     {
         WHINE_ONCE("drawtile3() out-of-bounds!")
         return;
     }
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
-    BlitSurfaceStandard(tiles3[t+(off*30)], NULL, backBuffer, &rect);
+    BlitSurfaceStandard(tiles3[t], NULL, backBuffer, &rect);
 }
 
 void Graphics::drawentcolours( int x, int y, int t)


### PR DESCRIPTION
The function was not actually checking the number that would end up being used to index the `tiles3` vector, and as a result there could potentially be out-of-bounds indexing. But this is fixed now.

(Conflicts with #428.)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
