### PR TITLE
Crop bottom tower spikes so they don't get drawn behind room name

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -683,7 +683,7 @@ void Graphics::drawtile2( int x, int y, int t )
 
 
 
-void Graphics::drawtile3( int x, int y, int t, int off )
+void Graphics::drawtile3( int x, int y, int t, int off, int height_subtract /*= 0*/ )
 {
     t += off * 30;
     if (!INBOUNDS(t, tiles3))
@@ -691,8 +691,9 @@ void Graphics::drawtile3( int x, int y, int t, int off )
         WHINE_ONCE("drawtile3() out-of-bounds!")
         return;
     }
+    SDL_Rect src_rect = { 0, 0, tiles_rect.w, tiles_rect.h - height_subtract };
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
-    BlitSurfaceStandard(tiles3[t], NULL, backBuffer, &rect);
+    BlitSurfaceStandard(tiles3[t], &src_rect, backBuffer, &rect);
 }
 
 void Graphics::drawentcolours( int x, int y, int t)
@@ -2458,7 +2459,7 @@ void Graphics::drawtowerspikes()
     for (int i = 0; i < 40; i++)
     {
         drawtile3(i * 8, -8+spikeleveltop, 9, map.colstate);
-        drawtile3(i * 8, 230-spikelevelbottom, 8, map.colstate);
+        drawtile3(i * 8, 230-spikelevelbottom, 8, map.colstate, 8 - spikelevelbottom);
     }
 }
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -163,7 +163,7 @@ public:
 
 	void drawbackground(int t);
 	void updatebackground(int t);
-	void drawtile3( int x, int y, int t, int off );
+	void drawtile3( int x, int y, int t, int off, int height_subtract = 0 );
 	void drawentcolours( int x, int y, int t);
 	void drawtile2( int x, int y, int t );
 	void drawtile( int x, int y, int t );


### PR DESCRIPTION
If you have the translucent room name option enabled, you'd always be seeing the spikes at the bottom of the screen hidden behind the room name. This patch makes it so that the spikes get carefully cropped so they only appear above the room name when the player gets close to the bottom of the screen.

![Spikes hidden behind room name](https://user-images.githubusercontent.com/59748578/89245471-b9258300-d5bd-11ea-8eb4-621d1e8b4de1.png)

![Spikes above room name](https://user-images.githubusercontent.com/59748578/89245519-d2c6ca80-d5bd-11ea-8690-c448e0773684.png)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
