### PR TITLE
Actually finally fix rendering of translucent pixels on tiles (remove OverlaySurfaceKeyed() and set proper foregroundBuffer blend mode)

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2406,8 +2406,7 @@ void Graphics::drawmap()
         }
         foregrounddrawn = true;
     }
-    OverlaySurfaceKeyed(foregroundBuffer, backBuffer, 0x00000000);
-    //SDL_BlitSurface(foregroundBuffer, NULL, backBuffer, NULL);
+    SDL_BlitSurface(foregroundBuffer, NULL, backBuffer, NULL);
 
 }
 
@@ -2433,7 +2432,7 @@ void Graphics::drawfinalmap()
         foregrounddrawn=true;
     }
 
-    OverlaySurfaceKeyed(foregroundBuffer, backBuffer, 0x00000000);
+    SDL_BlitSurface(foregroundBuffer, NULL, backBuffer, NULL);
 }
 
 void Graphics::drawtowermap()

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -501,23 +501,6 @@ void FillRect( SDL_Surface* _surface, SDL_Rect rect, int rgba )
     SDL_FillRect(_surface, &rect, rgba);
 }
 
-void OverlaySurfaceKeyed( SDL_Surface* _src, SDL_Surface* _dest, Uint32 _key )
-{
-    // const SDL_PixelFormat& fmt = *(_src->format);
-    for(int x = 0; x < _src->w; x++)
-    {
-        for(int y = 0; y < _src->h; y++)
-        {
-            Uint32 pixel = ReadPixel(_src, x,y);
-            //endian_swap(pixel);
-            if (( pixel != _key))
-            {
-                DrawPixel(_dest,x,y, pixel);
-            }
-        }
-    }
-}
-
 void ScrollSurface( SDL_Surface* _src, int _pX, int _pY )
 {
     SDL_Surface* part1 = NULL;

--- a/desktop_version/src/GraphicsUtil.h
+++ b/desktop_version/src/GraphicsUtil.h
@@ -39,8 +39,6 @@ void FillRect( SDL_Surface* surface, SDL_Rect& rect, const int r, int g, int b )
 
 void FillRect( SDL_Surface* surface, SDL_Rect rect, int rgba );
 
-void OverlaySurfaceKeyed(SDL_Surface* _src, SDL_Surface* _dest, Uint32 _key);
-
 void ScrollSurface(SDL_Surface* _src, int pX, int py);
 
 SDL_Surface * FlipSurfaceHorizontal(SDL_Surface* _src);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -247,7 +247,7 @@ int main(int argc, char *argv[])
     graphics.Makebfont();
 
     graphics.foregroundBuffer =  CREATE_SURFACE(320, 240);
-    SDL_SetSurfaceBlendMode(graphics.foregroundBuffer, SDL_BLENDMODE_NONE);
+    SDL_SetSurfaceBlendMode(graphics.foregroundBuffer, SDL_BLENDMODE_BLEND);
 
     graphics.menubuffer = CREATE_SURFACE(320, 240);
     SDL_SetSurfaceBlendMode(graphics.menubuffer, SDL_BLENDMODE_NONE);


### PR DESCRIPTION
So, earlier in the development of 2.0, Simon Roth (I presume) encountered a problem: Oh no, all my backgrounds aren't appearing! And this is because my `foregroundBuffer`, which contains all the drawn tiles, is drawing complete black over it!

So he had a solution that seems ingenius, but is actually really really hacky and super 100% *not* the proper solution. Just, take the `foregroundBuffer`, iterate over each pixel, and *don't* draw any pixel that's `0xDEADBEEF`. `0xDEADBEEF` is a special signal meaning "don't draw this pixel". It is called a 'key'.

Unfortunately, this causes a bug where translucent pixels on tiles (pixels between 0% and 100% opacity) didn't get drawn correctly. They would be drawn against this weird blue color.

Now, in #103, I came across this weird constant and decided "hey, this looks awfully like that weird blue color I came across, maybe if I set it to `0x00000000`, i.e. complete and transparent black, the issue will be fixed". And it *did* appear to be fixed. However, I didn't look too closely, nor did I test it that much, and all that ended up doing was drawing the pixels against black, which more subtly disguised the problem with translucent pixels.

So, after some investigation, I noticed that `BlitSurfaceColoured()` was drawing translucent pixels just fine. And I thought at the time that there was something wrong with `BlitSurfaceStandard()`, or something. Further along later I realized that all drawn tiles were passing through this weird `OverlaySurfaceKeyed()` function. And removing it in favor of a straight `SDL_BlitSurface()` produced the bug I mentioned above: Oh no, all the backgrounds don't show up, because my `foregroundBuffer` is drawing pure black over them!

Well... just... set the proper blend mode for `foregroundBuffer`. It should be `SDL_BLENDMODE_BLEND` instead of `SDL_BLENDMODE_NONE`.

Then you don't have to worry about your transparency at all. If you did it right, you won't have to resort this hacky color-keying business.

_\*sigh*_

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
