### PR TITLE
Clean up Graphics::Hitest() a little bit

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1396,7 +1396,9 @@ bool Graphics::Hitest(SDL_Surface* surface1, point p1, SDL_Surface* surface2, po
     int r2_bottom  = p2.y;
     int r2_top = p2.y + surface2->h;
 
-    bool intersection = intersectRect(r1_left, r1_right, r1_bottom, r1_top, r2_left, r2_right, r2_bottom, r2_top);
+    SDL_Rect rect1 = {p1.x, p1.y, surface1->w, surface1->h};
+    SDL_Rect rect2 = {p2.x, p2.y, surface2->w, surface2->h};
+    bool intersection = help.intersects(rect1, rect2);
 
     if(intersection)
     {

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1402,10 +1402,10 @@ bool Graphics::Hitest(SDL_Surface* surface1, point p1, SDL_Surface* surface2, po
 
     if(intersection)
     {
-        int r3_left = std::max(r1_left, r2_left);
-        int r3_top = std::min(r1_top, r2_top);
-        int r3_right = std::min(r1_right, r2_right);
-        int r3_bottom= std::max(r1_bottom, r2_bottom);
+        int r3_left = SDL_max(r1_left, r2_left);
+        int r3_top = SDL_min(r1_top, r2_top);
+        int r3_right = SDL_min(r1_right, r2_right);
+        int r3_bottom= SDL_max(r1_bottom, r2_bottom);
 
         //for every pixel inside rectangle
         for(int x = r3_left; x < r3_right; x++)

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1420,12 +1420,8 @@ bool Graphics::Hitest(SDL_Surface* surface1, point p1, SDL_Surface* surface2, po
                 }
             }
         }
-        return false;
     }
-    else
-    {
-        return false;
-    }
+    return false;
 
 }
 

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -501,11 +501,6 @@ void FillRect( SDL_Surface* _surface, SDL_Rect rect, int rgba )
     SDL_FillRect(_surface, &rect, rgba);
 }
 
-bool intersectRect( float left1, float right1, float bottom1, float top1, float left2, float right2, float bottom2, float top2 )
-{
-    return !( left2 > right1 || right2 < left1	|| top2 < bottom1 || bottom2 > top1);
-}
-
 void OverlaySurfaceKeyed( SDL_Surface* _src, SDL_Surface* _dest, Uint32 _key )
 {
     // const SDL_PixelFormat& fmt = *(_src->format);

--- a/desktop_version/src/GraphicsUtil.h
+++ b/desktop_version/src/GraphicsUtil.h
@@ -39,8 +39,6 @@ void FillRect( SDL_Surface* surface, SDL_Rect& rect, const int r, int g, int b )
 
 void FillRect( SDL_Surface* surface, SDL_Rect rect, int rgba );
 
-bool intersectRect(float left1, float right1, float bottom1, float top1, float left2, float right2, float bottom2, float top2);
-
 void OverlaySurfaceKeyed(SDL_Surface* _src, SDL_Surface* _dest, Uint32 _key);
 
 void ScrollSurface(SDL_Surface* _src, int pX, int py);


### PR DESCRIPTION
* The superfluous `intersectRect()` function has been axed in favor of the already-existing and much better `UtilityClass::intersects()`.
* The return logic of the function has been cleaned up a bit.
* `SDL_max()` and `SDL_min()` are used instead of `std::max()` and `std::min()`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
