### PR TITLE
Remove ScaleSurfaceSlow() in favor of ScaleSurface() and fix the offset in ScaleSurface()

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -424,7 +424,7 @@ void Graphics::bigprint(  int _x, int _y, std::string _s, int r, int g, int b, b
         idx = font_idx(curr);
         if (INBOUNDS(idx, font))
         {
-            SDL_Surface* tempPrint = ScaleSurfaceSlow(font[idx], font[idx]->w *sc,font[idx]->h *sc);
+            SDL_Surface* tempPrint = ScaleSurface(font[idx], font[idx]->w *sc,font[idx]->h *sc);
             SDL_Rect printrect = { static_cast<Sint16>((_x) + bfontpos), static_cast<Sint16>(_y) , static_cast<Sint16>((bfont_rect.w*sc)+1), static_cast<Sint16>((bfont_rect.h * sc)+1)};
             BlitSurfaceColoured(tempPrint, NULL, backBuffer, &printrect, ct);
             SDL_FreeSurface(tempPrint);
@@ -3024,7 +3024,7 @@ void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool
 		idx = font_idx(cur);
 		if (INBOUNDS(idx, font))
 		{
-			SDL_Surface* tempPrint = ScaleSurfaceSlow(font[idx], font[idx]->w *sc,font[idx]->h *sc);
+			SDL_Surface* tempPrint = ScaleSurface(font[idx], font[idx]->w *sc,font[idx]->h *sc);
 			SDL_Rect printrect = { Sint16((x) + bfontpos), Sint16(y) , Sint16(bfont_rect.w*sc), Sint16(bfont_rect.h * sc)};
 			BlitSurfaceColoured(tempPrint, NULL, backBuffer, &printrect, ct);
 			SDL_FreeSurface(tempPrint);

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -161,7 +161,7 @@ SDL_Surface * ScaleSurface( SDL_Surface *_surface, int Width, int Height, SDL_Su
     for(Sint32 y = 0; y < _surface->h; y++)
         for(Sint32 x = 0; x < _surface->w; x++)
         {
-            setRect(gigantoPixel, static_cast<Sint32>((float(x)*_stretch_factor_x) -1), static_cast<Sint32>((float(y) *_stretch_factor_y)-1), static_cast<Sint32>(_stretch_factor_x +1.0),static_cast<Sint32>( _stretch_factor_y+1.0)) ;
+            setRect(gigantoPixel, static_cast<Sint32>(float(x)*_stretch_factor_x), static_cast<Sint32>(float(y) *_stretch_factor_y), static_cast<Sint32>(_stretch_factor_x),static_cast<Sint32>( _stretch_factor_y)) ;
             SDL_FillRect(_ret, &gigantoPixel, ReadPixel(_surface, x, y));
         }
 

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -171,38 +171,6 @@ SDL_Surface * ScaleSurface( SDL_Surface *_surface, int Width, int Height, SDL_Su
     return _ret;
 }
 
-SDL_Surface * ScaleSurfaceSlow( SDL_Surface *_surface, int Width, int Height)
-{
-    if(!_surface || !Width || !Height)
-        return 0;
-
-    SDL_Surface *_ret;
-
-    _ret = SDL_CreateRGBSurface(_surface->flags, Width, Height, _surface->format->BitsPerPixel,
-        _surface->format->Rmask, _surface->format->Gmask, _surface->format->Bmask, _surface->format->Amask);
-    if(_ret == NULL)
-    {
-        return NULL;
-    }
-
-
-
-    float  _stretch_factor_x = (static_cast<double>(Width)  / static_cast<double>(_surface->w)), _stretch_factor_y = (static_cast<double>(Height) / static_cast<double>(_surface->h));
-
-
-    for(Sint32 y = 0; y < _surface->h; y++)
-        for(Sint32 x = 0; x < _surface->w; x++)
-            for(Sint32 o_y = 0; o_y < _stretch_factor_y; ++o_y)
-                for(Sint32 o_x = 0; o_x < _stretch_factor_x; ++o_x)
-                    DrawPixel(_ret, static_cast<Sint32>(_stretch_factor_x * x) + o_x,
-                    static_cast<Sint32>(_stretch_factor_y * y) + o_y, ReadPixel(_surface, x, y));
-
-                    // DrawPixel(_ret, static_cast<Sint32>(_stretch_factor_x * x) + o_x,
-                    //static_cast<Sint32>(_stretch_factor_y * y) + o_y, ReadPixel(_surface, x, y));
-
-    return _ret;
-}
-
 SDL_Surface *  FlipSurfaceHorizontal(SDL_Surface* _src)
 {
     SDL_Surface * ret = SDL_CreateRGBSurface(_src->flags, _src->w, _src->h, _src->format->BitsPerPixel,

--- a/desktop_version/src/GraphicsUtil.h
+++ b/desktop_version/src/GraphicsUtil.h
@@ -45,7 +45,6 @@ void ScrollSurface(SDL_Surface* _src, int pX, int py);
 
 SDL_Surface * FlipSurfaceHorizontal(SDL_Surface* _src);
 SDL_Surface * FlipSurfaceVerticle(SDL_Surface* _src);
-SDL_Surface * ScaleSurfaceSlow( SDL_Surface *_surface, int Width, int Height );
 void UpdateFilter();
 SDL_Surface* ApplyFilter( SDL_Surface* _src );
 


### PR DESCRIPTION
So, `ScaleSurfaceSlow()` does a slower `DrawPixel()`-based method of scaling the given surface, unlike `ScaleSurface()`, which uses a much more efficient `SDL_FillRect()`.

So, why use `ScaleSurfaceSlow()` over `ScaleSurface()`? It turns out it's because `ScaleSurface()` has this weird 1-pixel offset for no reason, causing not only the result to be offset by one pixel, but also completely dropping scaled pixels, too. So I removed that offset as well, and Big Viridian no longer looks like they're floating on the ground when they're standing on the floor.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
