### PR TITLE
Remove unnecessary cursor toggling when toggling fullscreen

### DIFF
--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -466,22 +466,6 @@ void inline fixedloop()
     key.Poll();
     if(key.toggleFullscreen)
     {
-        if(!gameScreen.isWindowed)
-        {
-            SDL_ShowCursor(SDL_DISABLE);
-            SDL_ShowCursor(SDL_ENABLE);
-        }
-        else
-        {
-            SDL_ShowCursor(SDL_ENABLE);
-        }
-
-
-        if(game.gamestate == EDITORMODE)
-        {
-            SDL_ShowCursor(SDL_ENABLE);
-        }
-
         gameScreen.toggleFullScreen();
         game.fullscreen = !game.fullscreen;
         key.toggleFullscreen = false;


### PR DESCRIPTION
For some reason, the cursor would be either disabled and re-enabled if you switched to windowed mode, or it would be always enabled if you switched to fullscreen mode. This only happened when you toggled fullscreen using the Alt+Enter, Alt+F, or F11 keybinds, and the fullscreen option in graphic options doesn't have this problem.

This cursor toggling business seems like an arcane incantation back in the days of SDL1.2, now since no longer necessary with SDL2. However, after some testing, it seems like removing these indecipherable runes don't cause any harm, so I'm going to remove them.

Fixes #371.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
