### PR TITLE
Remove allowspecial, replace with opaqueness check

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -2178,11 +2178,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 180, 165, 165, 255, true);
+                graphics.createtextbox("", -1, 180, 165, 165, 255);
             }
             else
             {
-                graphics.createtextbox("", -1, 12, 165, 165, 255, true);
+                graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
             //graphics.addline("      Level Complete!      ");
             graphics.addline("                                   ");
@@ -2202,11 +2202,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 104, 175,174,174, true);
+                graphics.createtextbox("", -1, 104, 175,174,174);
             }
             else
             {
-                graphics.createtextbox("", -1, 64+8+16, 175,174,174, true);
+                graphics.createtextbox("", -1, 64+8+16, 175,174,174);
             }
             graphics.addline("     You have rescued  ");
             graphics.addline("      a crew member!   ");
@@ -2295,11 +2295,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 180, 165, 165, 255, true);
+                graphics.createtextbox("", -1, 180, 165, 165, 255);
             }
             else
             {
-                graphics.createtextbox("", -1, 12, 165, 165, 255, true);
+                graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
             //graphics.addline("      Level Complete!      ");
             graphics.addline("                                   ");
@@ -2319,11 +2319,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 104, 174,175,174, true);
+                graphics.createtextbox("", -1, 104, 174,175,174);
             }
             else
             {
-                graphics.createtextbox("", -1, 64+8+16, 174,175,174, true);
+                graphics.createtextbox("", -1, 64+8+16, 174,175,174);
             }
             graphics.addline("     You have rescued  ");
             graphics.addline("      a crew member!   ");
@@ -2411,11 +2411,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 180, 165, 165, 255, true);
+                graphics.createtextbox("", -1, 180, 165, 165, 255);
             }
             else
             {
-                graphics.createtextbox("", -1, 12, 165, 165, 255, true);
+                graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
             //graphics.addline("      Level Complete!      ");
             graphics.addline("                                   ");
@@ -2435,11 +2435,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 104, 174,174,175, true);
+                graphics.createtextbox("", -1, 104, 174,174,175);
             }
             else
             {
-                graphics.createtextbox("", -1, 64+8+16, 174,174,175, true);
+                graphics.createtextbox("", -1, 64+8+16, 174,174,175);
             }
             graphics.addline("     You have rescued  ");
             graphics.addline("      a crew member!   ");
@@ -2528,11 +2528,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 180, 165, 165, 255, true);
+                graphics.createtextbox("", -1, 180, 165, 165, 255);
             }
             else
             {
-                graphics.createtextbox("", -1, 12, 165, 165, 255, true);
+                graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
             //graphics.addline("      Level Complete!      ");
             graphics.addline("                                   ");
@@ -2552,11 +2552,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 104, 175,175,174, true);
+                graphics.createtextbox("", -1, 104, 175,175,174);
             }
             else
             {
-                graphics.createtextbox("", -1, 64+8+16, 175,175,174, true);
+                graphics.createtextbox("", -1, 64+8+16, 175,175,174);
             }
             graphics.addline("     You have rescued  ");
             graphics.addline("      a crew member!   ");
@@ -2663,11 +2663,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 180, 165, 165, 255, true);
+                graphics.createtextbox("", -1, 180, 165, 165, 255);
             }
             else
             {
-                graphics.createtextbox("", -1, 12, 165, 165, 255, true);
+                graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
             //graphics.addline("      Level Complete!      ");
             graphics.addline("                                   ");
@@ -2687,11 +2687,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 104, 175,174,175, true);
+                graphics.createtextbox("", -1, 104, 175,174,175);
             }
             else
             {
-                graphics.createtextbox("", -1, 64+8+16, 175,174,175, true);
+                graphics.createtextbox("", -1, 64+8+16, 175,174,175);
             }
             graphics.addline("     You have rescued  ");
             graphics.addline("      a crew member!   ");
@@ -2959,11 +2959,11 @@ void Game::updatestate()
 
             if (graphics.flipmode)
             {
-                graphics.createtextbox("", -1, 180, 164, 165, 255, true);
+                graphics.createtextbox("", -1, 180, 164, 165, 255);
             }
             else
             {
-                graphics.createtextbox("", -1, 12, 164, 165, 255, true);
+                graphics.createtextbox("", -1, 12, 164, 165, 255);
             }
             graphics.addline("                                   ");
             graphics.addline("");

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -793,7 +793,11 @@ void Graphics::drawgui()
             }
         }
 
-        if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].r == 165 && textbox[i].allowspecial)
+        // Only draw special images when fully opaque
+        // This prevents flashes of special images during delta frames
+        bool drawspecial = textbox[i].tl >= 1.0;
+
+        if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].r == 165 && drawspecial)
         {
             if (flipmode)
             {
@@ -804,7 +808,7 @@ void Graphics::drawgui()
                 drawimage(0, 0, 12, true);
             }
         }
-        else if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].g == 165 && textbox[i].allowspecial)
+        else if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].g == 165 && drawspecial)
         {
             if (flipmode)
             {
@@ -817,27 +821,27 @@ void Graphics::drawgui()
         }
         if (flipmode)
         {
-            if (textbox[i].r == 175 && textbox[i].g == 175 && textbox[i].allowspecial)
+            if (textbox[i].r == 175 && textbox[i].g == 175 && drawspecial)
             {
                 //purple guy
                 drawsprite(80 - 6, 64 + 48 + 4, 6, 220- help.glow/4 - int(fRandom()*20), 120- help.glow/4, 210 - help.glow/4);
             }
-            else if (textbox[i].r == 175 && textbox[i].b == 175 && textbox[i].allowspecial)
+            else if (textbox[i].r == 175 && textbox[i].b == 175 && drawspecial)
             {
                 //red guy
                 drawsprite(80 - 6, 64 + 48+ 4, 6, 255 - help.glow/8, 70 - help.glow/4, 70 - help.glow / 4);
             }
-            else if (textbox[i].r == 175 && textbox[i].allowspecial)
+            else if (textbox[i].r == 175 && drawspecial)
             {
                 //green guy
                 drawsprite(80 - 6, 64 + 48 + 4, 6, 120 - help.glow / 4 - int(fRandom() * 20), 220 - help.glow / 4, 120 - help.glow / 4);
             }
-            else if (textbox[i].g == 175 && textbox[i].allowspecial)
+            else if (textbox[i].g == 175 && drawspecial)
             {
                 //yellow guy
                 drawsprite(80 - 6, 64 + 48+ 4, 6, 220- help.glow/4 - int(fRandom()*20), 210 - help.glow/4, 120- help.glow/4);
             }
-            else if (textbox[i].b == 175 && textbox[i].allowspecial)
+            else if (textbox[i].b == 175 && drawspecial)
             {
                 //blue guy
                 drawsprite(80 - 6, 64 + 48+ 4, 6, 75, 75, 255- help.glow/4 - int(fRandom()*20));
@@ -845,27 +849,27 @@ void Graphics::drawgui()
         }
         else
         {
-            if (textbox[i].r == 175 && textbox[i].g == 175 && textbox[i].allowspecial)
+            if (textbox[i].r == 175 && textbox[i].g == 175 && drawspecial)
             {
                 //purple guy
                 drawsprite(80 - 6, 64 + 32 + 4, 0, 220- help.glow/4 - int(fRandom()*20), 120- help.glow/4, 210 - help.glow/4);
             }
-            else if (textbox[i].r == 175 && textbox[i].b == 175 && textbox[i].allowspecial)
+            else if (textbox[i].r == 175 && textbox[i].b == 175 && drawspecial)
             {
                 //red guy
                 drawsprite(80 - 6, 64 + 32 + 4, 0, 255 - help.glow/8, 70 - help.glow/4, 70 - help.glow / 4);
             }
-            else if (textbox[i].r == 175 && textbox[i].allowspecial)
+            else if (textbox[i].r == 175 && drawspecial)
             {
                 //green guy
                 drawsprite(80 - 6, 64 + 32 + 4, 0, 120 - help.glow / 4 - int(fRandom() * 20), 220 - help.glow / 4, 120 - help.glow / 4);
             }
-            else if (textbox[i].g == 175 && textbox[i].allowspecial)
+            else if (textbox[i].g == 175 && drawspecial)
             {
                 //yellow guy
                 drawsprite(80 - 6, 64 + 32 + 4, 0, 220- help.glow/4 - int(fRandom()*20), 210 - help.glow/4, 120- help.glow/4);
             }
-            else if (textbox[i].b == 175 && textbox[i].allowspecial)
+            else if (textbox[i].b == 175 && drawspecial)
             {
                 //blue guy
                 drawsprite(80 - 6, 64 + 32 + 4, 0, 75, 75, 255- help.glow/4 - int(fRandom()*20));
@@ -1209,7 +1213,7 @@ void Graphics::textboxadjust()
 }
 
 
-void Graphics::createtextbox( std::string t, int xp, int yp, int r/*= 255*/, int g/*= 255*/, int b /*= 255*/, bool allowspecial/*= false*/ )
+void Graphics::createtextbox( std::string t, int xp, int yp, int r/*= 255*/, int g/*= 255*/, int b /*= 255*/ )
 {
     m = textbox.size();
 
@@ -1223,7 +1227,6 @@ void Graphics::createtextbox( std::string t, int xp, int yp, int r/*= 255*/, int
         text.yp = yp;
         text.initcol(r, g, b);
         text.resize();
-        text.allowspecial = allowspecial;
         textbox.push_back(text);
     }
 }

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -46,7 +46,7 @@ public:
 
 	void setwarprect(int a, int b, int c, int d);
 
-	void createtextbox(std::string t, int xp, int yp, int r= 255, int g= 255, int b = 255, bool allowspecial = false);
+	void createtextbox(std::string t, int xp, int yp, int r= 255, int g= 255, int b = 255);
 
 	void textboxcenter();
 

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -13,7 +13,6 @@ textboxclass::textboxclass()
     prev_tl = 0;
     tm = 0;
     timer = 0;
-    allowspecial = false;
 
     xp = 0;
     yp = 0;

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -45,8 +45,6 @@ public:
 
     int max;
 
-    bool allowspecial;
-
 };
 
 #endif /* TEXTBOX_H */


### PR DESCRIPTION
When I added the over-30-FPS mode, I kept running into this problem where the special images of text boxes would render during the deltaframes of fade-in/fade-out animations, even though they shouldn't be. So I simply added a flag to the text box that enables drawing these special images.

However, this doesn't solve the problem fully, and there's still a small chance that a special-image text box could draw another special image during its deltaframes. It's really rare and you have to have your deltaframe luck juuuuuust right (or you could use libTAS, probably), but it helps to be in 40% slowmode and have a high refresh rate (which, if it isn't a multiple of 30, you should disable VSync, too, in order to not have a low framerate).

So instead, special images will only be drawn if the text box has fully faded in completely. That solves the issue completely.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
