### PR TITLE
Fix silent music saves playing MMMMMM track 15 if you're using PPPPPP while having MMMMMM available

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5166,7 +5166,11 @@ void Game::loadquick()
         }
         else if (pKey == "currentsong")
         {
-            music.play(atoi(pText));
+            int song = atoi(pText);
+            if (song != -1)
+            {
+                music.play(song);
+            }
         }
 
     }
@@ -5365,7 +5369,11 @@ void Game::customloadquick(std::string savfile)
         }
         else if (pKey == "currentsong")
         {
-            music.play(atoi(pText));
+            int song = atoi(pText);
+            if (song != -1)
+            {
+                music.play(song);
+            }
         }
         else if (pKey == "showminimap")
         {
@@ -6315,7 +6323,11 @@ void Game::loadtele()
         }
         else if (pKey == "currentsong")
         {
-            music.play(atoi(pText));
+            int song = atoi(pText);
+            if (song != -1)
+            {
+                music.play(song);
+            }
         }
 
     }


### PR DESCRIPTION
This PR fixes a bug that's existed since MMMMMM was added (so, 2.2), where if you quicksaved in a custom level while no music was playing, then quit and loaded that quicksave, and you were using PPPPPP while having MMMMMM available, it would play MMMMMM track 15, even though the game intends for the music to simply be silent.

This is due to the same bug that lets you play MMMMMM tracks if you're on PPPPPP - `musicclass::play()` does a modulo, but C++ modulo is not guaranteed to be positive given negative inputs, so the 16-track offset is added to a negative number, resulting in targeting the MMMMMM soundtrack instead of PPPPPP.

That exploit doesn't harm anyone and shouldn't be fixed, *except* it causes a problem in this specific case. But this bug can be fixed without removing that exploit.

Note that I made the check do not-equal to -1 instead of greater-than -1, so levels that intend on using track -2, -3, -4, etc. upon loading a quicksave will still work as their creator intended. It's just that specifically -1 is patched out, just to fix this issue.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
