### PR TITLE
Fix potential Undefined Behavior from not checking input passed into atoi()

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -508,7 +508,7 @@ void Game::loadcustomlevelstats()
 
                 if (stat_el->GetText() != NULL)
                 {
-                    stat.score = atoi(stat_el->GetText());
+                    stat.score = help.Int(stat_el->GetText());
                 }
 
                 if (stat_el->Attribute("name"))
@@ -542,7 +542,7 @@ void Game::loadcustomlevelstats()
                 std::vector<std::string> values = split(TextString,',');
                 for(size_t i = 0; i < values.size(); i++)
                 {
-                    customlevelscores.push_back(atoi(values[i].c_str()));
+                    customlevelscores.push_back(help.Int(values[i].c_str()));
                 }
             }
         }
@@ -4312,7 +4312,7 @@ void Game::unlocknum( int t )
             std::vector<std::string> values = split(TextString, ','); \
             for (size_t i = 0; i < SDL_min(SDL_arraysize(DEST), values.size()); i++) \
             { \
-                DEST[i] = atoi(values[i].c_str()); \
+                DEST[i] = help.Int(values[i].c_str()); \
             } \
         } \
     }
@@ -4371,62 +4371,62 @@ void Game::loadstats(int *width, int *height, bool *vsync)
 
         if (pKey == "bestgamedeaths")
         {
-            bestgamedeaths = atoi(pText);
+            bestgamedeaths = help.Int(pText);
         }
 
         if (pKey == "stat_trinkets")
         {
-            stat_trinkets = atoi(pText);
+            stat_trinkets = help.Int(pText);
         }
 
         if (pKey == "fullscreen")
         {
-            fullscreen = atoi(pText);
+            fullscreen = help.Int(pText);
         }
 
         if (pKey == "stretch")
         {
-            stretchMode = atoi(pText);
+            stretchMode = help.Int(pText);
         }
 
         if (pKey == "useLinearFilter")
         {
-            useLinearFilter = atoi(pText);
+            useLinearFilter = help.Int(pText);
         }
 
         if (pKey == "window_width")
         {
-            *width = atoi(pText);
+            *width = help.Int(pText);
         }
         if (pKey == "window_height")
         {
-            *height = atoi(pText);
+            *height = help.Int(pText);
         }
 
 
         if (pKey == "noflashingmode")
         {
-            noflashingmode = atoi(pText);
+            noflashingmode = help.Int(pText);
         }
 
         if (pKey == "colourblindmode")
         {
-            colourblindmode = atoi(pText);
+            colourblindmode = help.Int(pText);
         }
 
         if (pKey == "setflipmode")
         {
-            graphics.setflipmode = atoi(pText);
+            graphics.setflipmode = help.Int(pText);
         }
 
         if (pKey == "invincibility")
         {
-            map.invincibility = atoi(pText);
+            map.invincibility = help.Int(pText);
         }
 
         if (pKey == "slowdown")
         {
-            slowdown = atoi(pText);
+            slowdown = help.Int(pText);
             switch(slowdown)
             {
             case 30:
@@ -4450,22 +4450,22 @@ void Game::loadstats(int *width, int *height, bool *vsync)
 
         if (pKey == "swnbestrank")
         {
-            swnbestrank = atoi(pText);
+            swnbestrank = help.Int(pText);
         }
 
         if (pKey == "swnrecord")
         {
-            swnrecord = atoi(pText);
+            swnrecord = help.Int(pText);
         }
 
         if (pKey == "advanced_smoothing")
         {
-            fullScreenEffect_badSignal = atoi(pText);
+            fullScreenEffect_badSignal = help.Int(pText);
         }
 
         if (pKey == "usingmmmmmm")
         {
-            if(atoi(pText)>0){
+            if(help.Int(pText)>0){
                 usingmmmmmm = 1;
             }else{
                 usingmmmmmm = 0;
@@ -4474,47 +4474,47 @@ void Game::loadstats(int *width, int *height, bool *vsync)
 
         if (pKey == "ghostsenabled")
         {
-            ghostsenabled = atoi(pText);
+            ghostsenabled = help.Int(pText);
         }
 
         if (pKey == "skipfakeload")
         {
-            skipfakeload = atoi(pText);
+            skipfakeload = help.Int(pText);
         }
 
         if (pKey == "disablepause")
         {
-            disablepause = atoi(pText);
+            disablepause = help.Int(pText);
         }
 
         if (pKey == "over30mode")
         {
-            over30mode = atoi(pText);
+            over30mode = help.Int(pText);
         }
 
         if (pKey == "glitchrunnermode")
         {
-            glitchrunnermode = atoi(pText);
+            glitchrunnermode = help.Int(pText);
         }
 
         if (pKey == "vsync")
         {
-            *vsync = atoi(pText);
+            *vsync = help.Int(pText);
         }
 
         if (pKey == "notextoutline")
         {
-            graphics.notextoutline = atoi(pText);
+            graphics.notextoutline = help.Int(pText);
         }
 
         if (pKey == "translucentroomname")
         {
-            graphics.translucentroomname = atoi(pText);
+            graphics.translucentroomname = help.Int(pText);
         }
 
         if (pKey == "showmousecursor")
         {
-            graphics.showmousecursor = atoi(pText);
+            graphics.showmousecursor = help.Int(pText);
         }
 
         if (pKey == "flipButton")
@@ -4546,7 +4546,7 @@ void Game::loadstats(int *width, int *height, bool *vsync)
 
         if (pKey == "controllerSensitivity")
         {
-            controllerSensitivity = atoi(pText);
+            controllerSensitivity = help.Int(pText);
         }
 
     }
@@ -5064,56 +5064,56 @@ void Game::loadquick()
 
         if (pKey == "finalmode")
         {
-            map.finalmode = atoi(pText);
+            map.finalmode = help.Int(pText);
         }
         if (pKey == "finalstretch")
         {
-            map.finalstretch = atoi(pText);
+            map.finalstretch = help.Int(pText);
         }
 
         if (pKey == "finalx")
         {
-            map.finalx = atoi(pText);
+            map.finalx = help.Int(pText);
         }
         else if (pKey == "finaly")
         {
-            map.finaly = atoi(pText);
+            map.finaly = help.Int(pText);
         }
         else if (pKey == "savex")
         {
-            savex = atoi(pText);
+            savex = help.Int(pText);
         }
         else if (pKey == "savey")
         {
-            savey = atoi(pText);
+            savey = help.Int(pText);
         }
         else if (pKey == "saverx")
         {
-            saverx = atoi(pText);
+            saverx = help.Int(pText);
         }
         else if (pKey == "savery")
         {
-            savery = atoi(pText);
+            savery = help.Int(pText);
         }
         else if (pKey == "savegc")
         {
-            savegc = atoi(pText);
+            savegc = help.Int(pText);
         }
         else if (pKey == "savedir")
         {
-            savedir= atoi(pText);
+            savedir= help.Int(pText);
         }
         else if (pKey == "savepoint")
         {
-            savepoint = atoi(pText);
+            savepoint = help.Int(pText);
         }
         else if (pKey == "companion")
         {
-            companion = atoi(pText);
+            companion = help.Int(pText);
         }
         else if (pKey == "lastsaved")
         {
-            lastsaved = atoi(pText);
+            lastsaved = help.Int(pText);
         }
         else if (pKey == "teleportscript")
         {
@@ -5121,40 +5121,40 @@ void Game::loadquick()
         }
         else if (pKey == "supercrewmate")
         {
-            supercrewmate = atoi(pText);
+            supercrewmate = help.Int(pText);
         }
         else if (pKey == "scmprogress")
         {
-            scmprogress = atoi(pText);
+            scmprogress = help.Int(pText);
         }
         else if (pKey == "scmmoveme")
         {
-            scmmoveme = atoi(pText);
+            scmmoveme = help.Int(pText);
         }
         else if (pKey == "frames")
         {
-            frames = atoi(pText);
+            frames = help.Int(pText);
             frames = 0;
         }
         else if (pKey == "seconds")
         {
-            seconds = atoi(pText);
+            seconds = help.Int(pText);
         }
         else if (pKey == "minutes")
         {
-            minutes = atoi(pText);
+            minutes = help.Int(pText);
         }
         else if (pKey == "hours")
         {
-            hours = atoi(pText);
+            hours = help.Int(pText);
         }
         else if (pKey == "deathcounts")
         {
-            deathcounts = atoi(pText);
+            deathcounts = help.Int(pText);
         }
         else if (pKey == "totalflips")
         {
-            totalflips = atoi(pText);
+            totalflips = help.Int(pText);
         }
         else if (pKey == "hardestroom")
         {
@@ -5162,11 +5162,11 @@ void Game::loadquick()
         }
         else if (pKey == "hardestroomdeaths")
         {
-            hardestroomdeaths = atoi(pText);
+            hardestroomdeaths = help.Int(pText);
         }
         else if (pKey == "currentsong")
         {
-            int song = atoi(pText);
+            int song = help.Int(pText);
             if (song != -1)
             {
                 music.play(song);
@@ -5252,11 +5252,11 @@ void Game::customloadquick(std::string savfile)
 
         if (pKey == "finalmode")
         {
-            map.finalmode = atoi(pText);
+            map.finalmode = help.Int(pText);
         }
         if (pKey == "finalstretch")
         {
-            map.finalstretch = atoi(pText);
+            map.finalstretch = help.Int(pText);
         }
 
         if (map.finalmode)
@@ -5276,47 +5276,47 @@ void Game::customloadquick(std::string savfile)
 
         if (pKey == "finalx")
         {
-            map.finalx = atoi(pText);
+            map.finalx = help.Int(pText);
         }
         else if (pKey == "finaly")
         {
-            map.finaly = atoi(pText);
+            map.finaly = help.Int(pText);
         }
         else if (pKey == "savex")
         {
-            savex = atoi(pText);
+            savex = help.Int(pText);
         }
         else if (pKey == "savey")
         {
-            savey = atoi(pText);
+            savey = help.Int(pText);
         }
         else if (pKey == "saverx")
         {
-            saverx = atoi(pText);
+            saverx = help.Int(pText);
         }
         else if (pKey == "savery")
         {
-            savery = atoi(pText);
+            savery = help.Int(pText);
         }
         else if (pKey == "savegc")
         {
-            savegc = atoi(pText);
+            savegc = help.Int(pText);
         }
         else if (pKey == "savedir")
         {
-            savedir= atoi(pText);
+            savedir= help.Int(pText);
         }
         else if (pKey == "savepoint")
         {
-            savepoint = atoi(pText);
+            savepoint = help.Int(pText);
         }
         else if (pKey == "companion")
         {
-            companion = atoi(pText);
+            companion = help.Int(pText);
         }
         else if (pKey == "lastsaved")
         {
-            lastsaved = atoi(pText);
+            lastsaved = help.Int(pText);
         }
         else if (pKey == "teleportscript")
         {
@@ -5324,40 +5324,40 @@ void Game::customloadquick(std::string savfile)
         }
         else if (pKey == "supercrewmate")
         {
-            supercrewmate = atoi(pText);
+            supercrewmate = help.Int(pText);
         }
         else if (pKey == "scmprogress")
         {
-            scmprogress = atoi(pText);
+            scmprogress = help.Int(pText);
         }
         else if (pKey == "scmmoveme")
         {
-            scmmoveme = atoi(pText);
+            scmmoveme = help.Int(pText);
         }
         else if (pKey == "frames")
         {
-            frames = atoi(pText);
+            frames = help.Int(pText);
             frames = 0;
         }
         else if (pKey == "seconds")
         {
-            seconds = atoi(pText);
+            seconds = help.Int(pText);
         }
         else if (pKey == "minutes")
         {
-            minutes = atoi(pText);
+            minutes = help.Int(pText);
         }
         else if (pKey == "hours")
         {
-            hours = atoi(pText);
+            hours = help.Int(pText);
         }
         else if (pKey == "deathcounts")
         {
-            deathcounts = atoi(pText);
+            deathcounts = help.Int(pText);
         }
         else if (pKey == "totalflips")
         {
-            totalflips = atoi(pText);
+            totalflips = help.Int(pText);
         }
         else if (pKey == "hardestroom")
         {
@@ -5365,11 +5365,11 @@ void Game::customloadquick(std::string savfile)
         }
         else if (pKey == "hardestroomdeaths")
         {
-            hardestroomdeaths = atoi(pText);
+            hardestroomdeaths = help.Int(pText);
         }
         else if (pKey == "currentsong")
         {
-            int song = atoi(pText);
+            int song = help.Int(pText);
             if (song != -1)
             {
                 music.play(song);
@@ -5377,7 +5377,7 @@ void Game::customloadquick(std::string savfile)
         }
         else if (pKey == "showminimap")
         {
-            map.customshowmm = atoi(pText);
+            map.customshowmm = help.Int(pText);
         }
 
     }
@@ -5428,35 +5428,35 @@ void Game::loadsummary()
 
             else if (pKey == "seconds")
             {
-                l_second = atoi(pText);
+                l_second = help.Int(pText);
             }
             else if (pKey == "minutes")
             {
-                l_minute = atoi(pText);
+                l_minute = help.Int(pText);
             }
             else if (pKey == "hours")
             {
-                l_hours = atoi(pText);
+                l_hours = help.Int(pText);
             }
             else if (pKey == "savery")
             {
-                l_saveY = atoi(pText);
+                l_saveY = help.Int(pText);
             }
             else if (pKey == "saverx")
             {
-                l_saveX = atoi(pText);
+                l_saveX = help.Int(pText);
             }
             else if (pKey == "trinkets")
             {
-                tele_trinkets = atoi(pText);
+                tele_trinkets = help.Int(pText);
             }
             else if (pKey == "finalmode")
             {
-                map.finalmode = atoi(pText);
+                map.finalmode = help.Int(pText);
             }
             else if (pKey == "finalstretch")
             {
-                map.finalstretch = atoi(pText);
+                map.finalstretch = help.Int(pText);
             }
 
             LOAD_ARRAY_RENAME(crewstats, tele_crewstats)
@@ -5505,35 +5505,35 @@ void Game::loadsummary()
 
             else if (pKey == "seconds")
             {
-                l_second = atoi(pText);
+                l_second = help.Int(pText);
             }
             else if (pKey == "minutes")
             {
-                l_minute = atoi(pText);
+                l_minute = help.Int(pText);
             }
             else if (pKey == "hours")
             {
-                l_hours = atoi(pText);
+                l_hours = help.Int(pText);
             }
             else if (pKey == "savery")
             {
-                l_saveY = atoi(pText);
+                l_saveY = help.Int(pText);
             }
             else if (pKey == "saverx")
             {
-                l_saveX = atoi(pText);
+                l_saveX = help.Int(pText);
             }
             else if (pKey == "trinkets")
             {
-                quick_trinkets = atoi(pText);
+                quick_trinkets = help.Int(pText);
             }
             else if (pKey == "finalmode")
             {
-                map.finalmode = atoi(pText);
+                map.finalmode = help.Int(pText);
             }
             else if (pKey == "finalstretch")
             {
-                map.finalstretch = atoi(pText);
+                map.finalstretch = help.Int(pText);
             }
 
             LOAD_ARRAY_RENAME(crewstats, quick_crewstats)
@@ -6206,11 +6206,11 @@ void Game::loadtele()
 
         if (pKey == "finalmode")
         {
-            map.finalmode = atoi(pText);
+            map.finalmode = help.Int(pText);
         }
         if (pKey == "finalstretch")
         {
-            map.finalstretch = atoi(pText);
+            map.finalstretch = help.Int(pText);
         }
 
         if (map.finalmode)
@@ -6230,47 +6230,47 @@ void Game::loadtele()
 
         if (pKey == "finalx")
         {
-            map.finalx = atoi(pText);
+            map.finalx = help.Int(pText);
         }
         else if (pKey == "finaly")
         {
-            map.finaly = atoi(pText);
+            map.finaly = help.Int(pText);
         }
         else if (pKey == "savex")
         {
-            savex = atoi(pText);
+            savex = help.Int(pText);
         }
         else if (pKey == "savey")
         {
-            savey = atoi(pText);
+            savey = help.Int(pText);
         }
         else if (pKey == "saverx")
         {
-            saverx = atoi(pText);
+            saverx = help.Int(pText);
         }
         else if (pKey == "savery")
         {
-            savery = atoi(pText);
+            savery = help.Int(pText);
         }
         else if (pKey == "savegc")
         {
-            savegc = atoi(pText);
+            savegc = help.Int(pText);
         }
         else if (pKey == "savedir")
         {
-            savedir= atoi(pText);
+            savedir= help.Int(pText);
         }
         else if (pKey == "savepoint")
         {
-            savepoint = atoi(pText);
+            savepoint = help.Int(pText);
         }
         else if (pKey == "companion")
         {
-            companion = atoi(pText);
+            companion = help.Int(pText);
         }
         else if (pKey == "lastsaved")
         {
-            lastsaved = atoi(pText);
+            lastsaved = help.Int(pText);
         }
         else if (pKey == "teleportscript")
         {
@@ -6278,40 +6278,40 @@ void Game::loadtele()
         }
         else if (pKey == "supercrewmate")
         {
-            supercrewmate = atoi(pText);
+            supercrewmate = help.Int(pText);
         }
         else if (pKey == "scmprogress")
         {
-            scmprogress = atoi(pText);
+            scmprogress = help.Int(pText);
         }
         else if (pKey == "scmmoveme")
         {
-            scmmoveme = atoi(pText);
+            scmmoveme = help.Int(pText);
         }
         else if (pKey == "frames")
         {
-            frames = atoi(pText);
+            frames = help.Int(pText);
             frames = 0;
         }
         else if (pKey == "seconds")
         {
-            seconds = atoi(pText);
+            seconds = help.Int(pText);
         }
         else if (pKey == "minutes")
         {
-            minutes = atoi(pText);
+            minutes = help.Int(pText);
         }
         else if (pKey == "hours")
         {
-            hours = atoi(pText);
+            hours = help.Int(pText);
         }
         else if (pKey == "deathcounts")
         {
-            deathcounts = atoi(pText);
+            deathcounts = help.Int(pText);
         }
         else if (pKey == "totalflips")
         {
-            totalflips = atoi(pText);
+            totalflips = help.Int(pText);
         }
         else if (pKey == "hardestroom")
         {
@@ -6319,11 +6319,11 @@ void Game::loadtele()
         }
         else if (pKey == "hardestroomdeaths")
         {
-            hardestroomdeaths = atoi(pText);
+            hardestroomdeaths = help.Int(pText);
         }
         else if (pKey == "currentsong")
         {
-            int song = atoi(pText);
+            int song = help.Int(pText);
             if (song != -1)
             {
                 music.play(song);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3974,7 +3974,7 @@ void scriptclass::loadcustom(const std::string& t)
 					add("text(blue,0,0,"+words[1]+")");
 				break;
 			}
-			int ti=atoi(words[1].c_str());
+			int ti=help.Int(words[1].c_str());
 			int nti = ti>=0 && ti<=50 ? ti : 1;
 			for(int ti2=0; ti2<nti; ti2++){
 				i++;
@@ -3999,7 +3999,7 @@ void scriptclass::loadcustom(const std::string& t)
 			if(squeakmode==0) add("squeak(player)");
 			add("text(cyan,0,0,"+words[1]+")");
 
-			int ti=atoi(words[1].c_str());
+			int ti=help.Int(words[1].c_str());
 			int nti = ti>=0 && ti<=50 ? ti : 1;
 			for(int ti2=0; ti2<nti; ti2++){
 				i++;

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -205,6 +205,18 @@ void UtilityClass::updateglow()
 	}
 }
 
+bool is_number(const char* str)
+{
+	for (int i = 0; str[i] != '\0'; i++)
+	{
+		if (!SDL_isdigit(static_cast<unsigned char>(str[i])) && (i != 0 || str[0] != '-'))
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
 bool is_positive_num(const std::string& str, bool hex)
 {
 	for (size_t i = 0; i < str.length(); i++)

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -99,6 +99,16 @@ std::string UtilityClass::String( int _v )
 	return(os.str());
 }
 
+int UtilityClass::Int(const char* str)
+{
+	if (!is_number(str))
+	{
+		return 0;
+	}
+
+	return SDL_atoi(str);
+}
+
 std::string UtilityClass::GCString(std::vector<SDL_GameControllerButton> buttons)
 {
 	std::string retval = "";

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -99,11 +99,11 @@ std::string UtilityClass::String( int _v )
 	return(os.str());
 }
 
-int UtilityClass::Int(const char* str)
+int UtilityClass::Int(const char* str, int fallback /*= 0*/)
 {
 	if (!is_number(str))
 	{
-		return 0;
+		return fallback;
 	}
 
 	return SDL_atoi(str);

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -211,14 +211,14 @@ bool is_positive_num(const std::string& str, bool hex)
 	{
 		if (hex)
 		{
-			if (!std::isxdigit(static_cast<unsigned char>(str[i])))
+			if (!isxdigit(static_cast<unsigned char>(str[i])))
 			{
 				return false;
 			}
 		}
 		else
 		{
-			if (!std::isdigit(static_cast<unsigned char>(str[i])))
+			if (!SDL_isdigit(static_cast<unsigned char>(str[i])))
 			{
 				return false;
 			}

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -37,6 +37,8 @@ public:
 
     static std::string String(int _v);
 
+    static int Int(const char* str);
+
     static std::string GCString(std::vector<SDL_GameControllerButton> buttons);
 
     std::string twodigits(int t);

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -37,7 +37,7 @@ public:
 
     static std::string String(int _v);
 
-    static int Int(const char* str);
+    static int Int(const char* str, int fallback = 0);
 
     static std::string GCString(std::vector<SDL_GameControllerButton> buttons);
 

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -11,6 +11,8 @@ std::vector<std::string> split(const std::string &s, char delim, std::vector<std
 
 std::vector<std::string> split(const std::string &s, char delim);
 
+bool is_number(const char* str);
+
 bool is_positive_num(const std::string& str, bool hex);
 
 bool endsWith(const std::string& str, const std::string& suffix);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1801,22 +1801,22 @@ bool editorclass::load(std::string& _path)
 
                 if(pKey == "onewaycol_override")
                 {
-                    onewaycol_override = atoi(pText);
+                    onewaycol_override = help.Int(pText);
                 }
             }
         }
 
         if (pKey == "mapwidth")
         {
-            mapwidth = atoi(pText);
+            mapwidth = help.Int(pText);
         }
         if (pKey == "mapheight")
         {
-            mapheight = atoi(pText);
+            mapheight = help.Int(pText);
         }
         if (pKey == "levmusic")
         {
-            levmusic = atoi(pText);
+            levmusic = help.Int(pText);
         }
 
 
@@ -1831,7 +1831,7 @@ bool editorclass::load(std::string& _path)
                 int y =0;
                 for(size_t i = 0; i < values.size(); i++)
                 {
-                    contents[x + (maxwidth*40*y)] = atoi(values[i].c_str());
+                    contents[x + (maxwidth*40*y)] = help.Int(values[i].c_str());
                     x++;
                     if(x == mapwidth*40)
                     {
@@ -1853,7 +1853,7 @@ bool editorclass::load(std::string& _path)
               contents.clear();
               for(int i = 0; i < values.size(); i++)
               {
-                contents.push_back(atoi(values[i].c_str()));
+                contents.push_back(help.Int(values[i].c_str()));
               }
             }
           }
@@ -4233,8 +4233,8 @@ void editorinput()
                     ed.notedelay = 45;
                     break;
                 }
-                ed.levx = clamp(atoi(coords[0].c_str()) - 1, 0, ed.mapwidth - 1);
-                ed.levy = clamp(atoi(coords[1].c_str()) - 1, 0, ed.mapheight - 1);
+                ed.levx = clamp(help.Int(coords[0].c_str()) - 1, 0, ed.mapwidth - 1);
+                ed.levy = clamp(help.Int(coords[1].c_str()) - 1, 0, ed.mapheight - 1);
                 graphics.backgrounddrawn = false;
                 break;
             }

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -114,7 +114,7 @@ int main(int argc, char *argv[])
         {
             ARG_INNER({
                 savefileplaytest = true;
-                int v = std::atoi(argv[i+1]);
+                int v = help.Int(argv[i+1]);
                 if (ARG("-playx")) savex = v;
                 else if (ARG("-playy")) savey = v;
                 else if (ARG("-playrx")) saverx = v;


### PR DESCRIPTION
If an invalid integer is passed into `atoi()`, whether or not the behavior is undefined seems to depend on which libc you're using. So, it's best to have a wrapper function that performs the check for you, to avoid any problems from invalid input.

Additionally, this is an opportunity to replace `atoi()` with `SDL_atoi()`. If libc has `atoi()`, then `SDL_atoi()` will still call that function, so we still need to check the input, but if that function isn't available `SDL_atoi()` will call `SDL_strtol()`, which doesn't have this problem.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
