### PR TITLE
Clean up FileSystemUtils string operations, EXCEPT for PLATFORM_migrateSaveData()

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -47,13 +47,13 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 	/* Determine the OS user directory */
 	if (baseDir && baseDir[0] != '\0')
 	{
-		strcpy(output, baseDir);
-
 		/* We later append to this path and assume it ends in a slash */
-		if (SDL_strcmp(output + SDL_strlen(output) - SDL_strlen(pathSep), pathSep) != 0)
-		{
-			strcat(output, pathSep);
-		}
+		bool trailing_pathsep = SDL_strcmp(baseDir + SDL_strlen(baseDir) - SDL_strlen(pathSep), pathSep) == 0;
+
+		SDL_snprintf(output, sizeof(output), "%s%s",
+			baseDir,
+			!trailing_pathsep ? pathSep : ""
+		);
 	}
 	else
 	{
@@ -97,12 +97,14 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 	/* Mount the stock content last */
 	if (assetsPath)
 	{
-		strcpy(output, assetsPath);
+		SDL_strlcpy(output, assetsPath, sizeof(output));
 	}
 	else
 	{
-		strcpy(output, PHYSFS_getBaseDir());
-		strcat(output, "data.zip");
+		SDL_snprintf(output, sizeof(output), "%s%s",
+			PHYSFS_getBaseDir(),
+			"data.zip"
+		);
 	}
 	if (!PHYSFS_mount(output, NULL, 1))
 	{
@@ -350,9 +352,9 @@ void PLATFORM_getOSDirectory(char* output)
 	WCHAR utf16_path[MAX_PATH];
 	SHGetFolderPathW(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, utf16_path);
 	WideCharToMultiByte(CP_UTF8, 0, utf16_path, -1, output, MAX_PATH, NULL, NULL);
-	strcat(output, "\\VVVVVV\\");
+	SDL_strlcat(output, "\\VVVVVV\\", sizeof(output));
 #else
-	strcpy(output, PHYSFS_getPrefDir("distractionware", "VVVVVV"));
+	SDL_strlcpy(output, PHYSFS_getPrefDir("distractionware", "VVVVVV"), sizeof(output));
 #endif
 }
 

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -50,7 +50,7 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 		strcpy(output, baseDir);
 
 		/* We later append to this path and assume it ends in a slash */
-		if (strcmp(std::string(1, output[strlen(output) - 1]).c_str(), pathSep) != 0)
+		if (SDL_strcmp(output + SDL_strlen(output) - SDL_strlen(pathSep), pathSep) != 0)
 		{
 			strcat(output, pathSep);
 		}

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -45,7 +45,7 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 	PHYSFS_permitSymbolicLinks(1);
 
 	/* Determine the OS user directory */
-	if (baseDir && strlen(baseDir) > 0)
+	if (baseDir && baseDir[0] != '\0')
 	{
 		strcpy(output, baseDir);
 


### PR DESCRIPTION
As the title says, this cleans up some string-related code in `FileSystemUtils.cpp`. Mostly the `strcat()`s and `strcpy()`s, but mwpenny's basedir code gets an honorable mention for a Rube Goldberg-like if-statement that I cleaned up to be less unnecessarily complicated.

I decided not to clean up `PLATFORM_migrateSaveData()` because it's going to be axed in 2.4 anyway. That function is most likely susceptible to a million different buffer overrun attacks, but I really don't want to touch it.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
