### PR TITLE
Disable pressing R in No Death Mode

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1899,7 +1899,7 @@ void gameinput()
                     }
                 }
 
-                if (key.keymap[SDLK_r] && game.deathseq<=0)// && map.custommode) //Have fun glitchrunners!
+                if (key.keymap[SDLK_r] && !game.nodeathmode)// && map.custommode) //Have fun glitchrunners!
                 {
                     game.deathseq = 30;
                 }


### PR DESCRIPTION
All that pressing R does in No Death Mode is end your run. As a result, it'll only be pressed by accident, so it's better to just disable it instead.

It's not even useful to quick-restart, because it's faster to quit and go through the menu again than it is to wait through the Game Over screen.

Additionally, I removed the `game.deathseq<=0` conditional because it's unnecessary due to the if-statement already being inside a `game.deathseq == -1` conditional.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
