### PR TITLE
Added ability to bind restart to a controller.

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4544,6 +4544,15 @@ void Game::loadstats(int *width, int *height, bool *vsync)
             }
         }
 
+        if (pKey == "restartButton")
+        {
+            SDL_GameControllerButton newButton;
+            if (GetButtonFromString(pText, &newButton))
+            {
+                controllerButton_restart.push_back(newButton);
+            }
+        }
+
         if (pKey == "controllerSensitivity")
         {
             controllerSensitivity = help.Int(pText);
@@ -4570,6 +4579,10 @@ void Game::loadstats(int *width, int *height, bool *vsync)
     if (controllerButton_esc.size() < 1)
     {
         controllerButton_esc.push_back(SDL_CONTROLLER_BUTTON_B);
+    }
+    if (controllerButton_restart.size() < 1)
+    {
+        controllerButton_restart.push_back(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER);
     }
 }
 
@@ -4787,6 +4800,12 @@ void Game::savestats()
     {
         msg = doc.NewElement("escButton");
         msg->LinkEndChild(doc.NewText(help.String((int) controllerButton_esc[i]).c_str()));
+        dataNode->LinkEndChild(msg);
+    }
+    for (size_t i = 0; i < controllerButton_restart.size(); i += 1)
+    {
+        msg = doc.NewElement("restartButton");
+        msg->LinkEndChild(doc.NewText(help.String((int) controllerButton_restart[i]).c_str()));
         dataNode->LinkEndChild(msg);
     }
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -374,6 +374,7 @@ public:
     std::vector<SDL_GameControllerButton> controllerButton_map;
     std::vector<SDL_GameControllerButton> controllerButton_flip;
     std::vector<SDL_GameControllerButton> controllerButton_esc;
+    std::vector<SDL_GameControllerButton> controllerButton_restart;
 
     bool skipfakeload;
     bool ghostsenabled;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -52,6 +52,13 @@ void updatebuttonmappings(int bind)
                         game.controllerButton_esc.erase(game.controllerButton_esc.begin() + j);
                     }
                 }
+                for (size_t j = 0; j < game.controllerButton_restart.size(); j += 1)
+                {
+                    if (i == game.controllerButton_restart[j])
+                    {
+                        game.controllerButton_restart.erase(game.controllerButton_restart.begin() + j);
+                    }
+                }
             }
             if (bind == 2)
             {
@@ -81,6 +88,13 @@ void updatebuttonmappings(int bind)
                         game.controllerButton_esc.erase(game.controllerButton_esc.begin() + j);
                     }
                 }
+                for (size_t j = 0; j < game.controllerButton_restart.size(); j += 1)
+                {
+                    if (i == game.controllerButton_restart[j])
+                    {
+                        game.controllerButton_restart.erase(game.controllerButton_restart.begin() + j);
+                    }
+                }
             }
             if (bind == 3)
             {
@@ -108,6 +122,49 @@ void updatebuttonmappings(int bind)
                     if (i == game.controllerButton_map[j])
                     {
                         game.controllerButton_map.erase(game.controllerButton_map.begin() + j);
+                    }
+                }
+                for (size_t j = 0; j < game.controllerButton_restart.size(); j += 1)
+                {
+                    if (i == game.controllerButton_restart[j])
+                    {
+                        game.controllerButton_restart.erase(game.controllerButton_restart.begin() + j);
+                    }
+                }
+            }
+            if (bind == 4)
+            {
+                for (size_t j = 0; j < game.controllerButton_restart.size(); j += 1)
+                {
+                    if (i == game.controllerButton_restart[j])
+                    {
+                        dupe = true;
+                    }
+                }
+                if (!dupe)
+                {
+                    game.controllerButton_restart.push_back(i);
+                    music.playef(11);
+                }
+                for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
+                {
+                    if (i == game.controllerButton_flip[j])
+                    {
+                        game.controllerButton_flip.erase(game.controllerButton_flip.begin() + j);
+                    }
+                }
+                for (size_t j = 0; j < game.controllerButton_map.size(); j += 1)
+                {
+                    if (i == game.controllerButton_map[j])
+                    {
+                        game.controllerButton_map.erase(game.controllerButton_map.begin() + j);
+                    }
+                }
+                for (size_t j = 0; j < game.controllerButton_esc.size(); j += 1)
+                {
+                    if (i == game.controllerButton_esc[j])
+                    {
+                        game.controllerButton_esc.erase(game.controllerButton_esc.begin() + j);
                     }
                 }
             }
@@ -1200,7 +1257,7 @@ void menuactionpress()
             }
             break;
 
-        case 4:
+        case 5:
             music.playef(11);
             game.returnmenu();
             break;
@@ -1635,7 +1692,7 @@ void titleinput()
         }
         if (    game.currentmenuname == Menu::controller &&
                 game.currentmenuoption > 0 &&
-                game.currentmenuoption < 4 &&
+                game.currentmenuoption < 5 &&
                 key.controllerButtonDown()      )
         {
             updatebuttonmappings(game.currentmenuoption);
@@ -1899,7 +1956,7 @@ void gameinput()
                     }
                 }
 
-                if (key.keymap[SDLK_r] && !game.nodeathmode)// && map.custommode) //Have fun glitchrunners!
+                if ((key.isDown(SDLK_r) || key.isDown(game.controllerButton_restart)) && !game.nodeathmode)// && map.custommode) //Have fun glitchrunners!
                 {
                     game.deathseq = 30;
                 }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -415,9 +415,11 @@ void menurender()
         case 1:
         case 2:
         case 3:
+        case 4:
             graphics.Print( -1, 85, "Flip is bound to: " + std::string(help.GCString(game.controllerButton_flip)) , tr, tg, tb, true);
             graphics.Print( -1, 95, "Enter is bound to: "  + std::string(help.GCString(game.controllerButton_map)), tr, tg, tb, true);
             graphics.Print( -1, 105, "Menu is bound to: " + std::string(help.GCString(game.controllerButton_esc)) , tr, tg, tb, true);
+            graphics.Print( -1, 115, "Restart is bound to: " + std::string(help.GCString(game.controllerButton_restart)) , tr, tg, tb, true);
             break;
         }
 


### PR DESCRIPTION
## Changes:

Saw pull request #440 and noticed that you could only restart to a checkpoint with a keyboard. So I added another a key binding for controllers to allow people to be able to restart to a checkpoint. I'm not sure if "Restart" is a good name for it, but it was the best I could think of. Also wasn't sure if right shoulder was the best default for it either.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
