### PR TITLE
Hotkey text input fix

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -12,6 +12,7 @@ Contributors
 * Allison Fleischer (AllisonFleischer)
 * Daniel Lee (@ddm999)
 * Fredrik Ljungdahl (@FredrIQ)
+* Nichole Mattera (@NicholeMattera)
 * Matt Penny (@mwpenny)
 * Tynan Richards (@tzann)
 * Elliott Saltar (@eboyblue3)

--- a/desktop_version/src/Credits.h
+++ b/desktop_version/src/Credits.h
@@ -93,6 +93,7 @@ static const char* githubfriends[] = {
     "Allison Fleischer",
     "Daniel Lee",
     "Fredrik Ljungdahl",
+    "Nichole Mattera",
     "Matt Penny",
     "Tynan Richards",
     "Elliott Saltar",

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -79,6 +79,7 @@ void KeyPoll::disabletextentry()
 
 void KeyPoll::Poll()
 {
+	bool modifierPressed = false;
 	SDL_Event evt;
 	while (SDL_PollEvent(&evt))
 	{
@@ -93,6 +94,8 @@ void KeyPoll::Poll()
 			{
 				pressedbackspace = true;
 			}
+
+			modifierPressed = keymap[SDLK_LCTRL] || keymap[SDLK_RCTRL] || keymap[SDLK_LALT] || keymap[SDLK_RALT] || keymap[SDLK_LGUI] || keymap[SDLK_RGUI];
 
 #ifdef __APPLE__ /* OSX prefers the command keys over the alt keys. -flibit */
 			bool altpressed = keymap[SDLK_LGUI] || keymap[SDLK_RGUI];
@@ -135,7 +138,10 @@ void KeyPoll::Poll()
 			}
 			break;
 		case SDL_TEXTINPUT:
-			keybuffer += evt.text.text;
+			if (!modifierPressed)
+			{
+				keybuffer += evt.text.text;
+			}
 			break;
 
 		/* Mouse Input */

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -79,7 +79,7 @@ void KeyPoll::disabletextentry()
 
 void KeyPoll::Poll()
 {
-	bool modifierPressed = false;
+	bool altpressed = false;
 	SDL_Event evt;
 	while (SDL_PollEvent(&evt))
 	{
@@ -95,12 +95,10 @@ void KeyPoll::Poll()
 				pressedbackspace = true;
 			}
 
-			modifierPressed = keymap[SDLK_LCTRL] || keymap[SDLK_RCTRL] || keymap[SDLK_LALT] || keymap[SDLK_RALT] || keymap[SDLK_LGUI] || keymap[SDLK_RGUI];
-
 #ifdef __APPLE__ /* OSX prefers the command keys over the alt keys. -flibit */
-			bool altpressed = keymap[SDLK_LGUI] || keymap[SDLK_RGUI];
+			altpressed = keymap[SDLK_LGUI] || keymap[SDLK_RGUI];
 #else
-			bool altpressed = keymap[SDLK_LALT] || keymap[SDLK_RALT];
+			altpressed = keymap[SDLK_LALT] || keymap[SDLK_RALT];
 #endif
 			bool returnpressed = evt.key.keysym.sym == SDLK_RETURN;
 			bool fpressed = evt.key.keysym.sym == SDLK_f;
@@ -138,7 +136,7 @@ void KeyPoll::Poll()
 			}
 			break;
 		case SDL_TEXTINPUT:
-			if (!modifierPressed)
+			if (!altpressed)
 			{
 				keybuffer += evt.text.text;
 			}

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -495,6 +495,7 @@ void editorclass::getlin(const enum textmode mode, const std::string& prompt, st
     ed.textmod = mode;
     ed.textptr = ptr;
     ed.textdesc = prompt;
+    ed.textentry = true;
     key.enabletextentry();
     if (ptr)
     {

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -495,7 +495,6 @@ void editorclass::getlin(const enum textmode mode, const std::string& prompt, st
     ed.textmod = mode;
     ed.textptr = ptr;
     ed.textdesc = prompt;
-    ed.textentry = true;
     key.enabletextentry();
     if (ptr)
     {

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -617,7 +617,7 @@ void inline fixedloop()
 
     //Mute button
 #if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
-    bool inEditor = ed.textentry || ed.scripthelppage == 1;
+    bool inEditor = ed.textentry || ed.textmod != TEXT_NONE || ed.scripthelppage == 1;
 #else
     bool inEditor = false;
 #endif


### PR DESCRIPTION
## Changes:

Fixes #366

- The fullscreen issue was solved by checking to see if any modifier buttons (Ctrl, Alt, or Super) were being held down on the key down event, and if so then we ignore the input on the text input event. This allows for future hotkeys to not cause an issue.
- The sound muting issue was because the `getlin` method in editor wasn't properly setting `ed.textentry` to true. The reason why this started happening was because the inEditor check in main.cpp:620 was changed to use just `ed.textentry` whereas before it used to also check `key.textentrymode`.
- I also went ahead and added myself as a contributor. (Hopefully that is okay.)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
