### PR TITLE
Axe manual state trackers and use SDL_IsTextInputActive()

### DIFF
--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -38,7 +38,6 @@ KeyPoll::KeyPoll()
 	setSensitivity(2);
 
 	quitProgram = 0;
-	textentrymode=true;
 	keybuffer="";
 	leftbutton=0; rightbutton=0; middlebutton=0;
 	mx=0; my=0;
@@ -67,14 +66,17 @@ KeyPoll::KeyPoll()
 void KeyPoll::enabletextentry()
 {
 	keybuffer="";
-	textentrymode = true;
 	SDL_StartTextInput();
 }
 
 void KeyPoll::disabletextentry()
 {
-	textentrymode = false;
 	SDL_StopTextInput();
+}
+
+bool KeyPoll::textentry()
+{
+	return SDL_IsTextInputActive() == SDL_TRUE;
 }
 
 void KeyPoll::Poll()
@@ -108,7 +110,7 @@ void KeyPoll::Poll()
 				toggleFullscreen = true;
 			}
 
-			if (textentrymode)
+			if (textentry())
 			{
 				if (evt.key.keysym.sym == SDLK_BACKSPACE && !keybuffer.empty())
 				{

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -65,7 +65,7 @@ public:
 	int leftbutton, rightbutton, middlebutton;
 	int mx, my;
 
-	bool textentrymode;
+	bool textentry();
 	bool pressedbackspace;
 	std::string keybuffer;
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -280,7 +280,6 @@ void editorclass::reset()
     note="";
     notedelay=0;
     oldnotedelay=0;
-    textentry=false;
     deletekeyheld=false;
     textmod = TEXT_NONE;
 
@@ -3747,25 +3746,21 @@ void editormenuactionpress()
         switch (game.currentmenuoption)
         {
         case 0:
-            ed.textentry=true;
             ed.titlemod=true;
             key.enabletextentry();
             key.keybuffer=EditorData::GetInstance().title;
             break;
         case 1:
-            ed.textentry=true;
             ed.creatormod=true;
             key.enabletextentry();
             key.keybuffer=EditorData::GetInstance().creator;
             break;
         case 2:
-            ed.textentry=true;
             ed.desc1mod=true;
             key.enabletextentry();
             key.keybuffer=ed.Desc1;
             break;
         case 3:
-            ed.textentry=true;
             ed.websitemod=true;
             key.enabletextentry();
             key.keybuffer=ed.website;
@@ -3961,10 +3956,9 @@ void editorinput()
             ed.shiftmenu = false;
             ed.shiftkey = false;
         }
-        else if (ed.textentry)
+        else if (key.textentry())
         {
             key.disabletextentry();
-            ed.textentry=false;
             ed.titlemod=false;
             ed.desc1mod=false;
             ed.desc2mod=false;
@@ -4293,7 +4287,7 @@ void editorinput()
             ed.textmod = TEXT_NONE;
         }
     }
-    else if (ed.textentry)
+    else if (key.textentry())
     {
         if(ed.titlemod)
         {
@@ -4355,13 +4349,11 @@ void editorinput()
                     ed.desc3mod=false;
                 }
                 key.disabletextentry();
-                ed.textentry=false;
 
                 if(ed.desc1mod)
                 {
                     ed.desc1mod=false;
 
-                    ed.textentry=true;
                     ed.desc2mod=true;
                     key.enabletextentry();
                     key.keybuffer=ed.Desc2;
@@ -4370,7 +4362,6 @@ void editorinput()
                 {
                     ed.desc2mod=false;
 
-                    ed.textentry=true;
                     ed.desc3mod=true;
                     key.enabletextentry();
                     key.keybuffer=ed.Desc3;

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -209,7 +209,7 @@ class editorclass{
     int desc; // Which description row we're changing
     int textent; // Entity ID for text prompt
   };
-  bool xmod, zmod, cmod, vmod, bmod, hmod, spacemod, warpmod, textentry;
+  bool xmod, zmod, cmod, vmod, bmod, hmod, spacemod, warpmod;
   bool titlemod, creatormod, desc1mod, desc2mod, desc3mod, websitemod;
 
   int roomnamehide;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -153,6 +153,10 @@ int main(int argc, char *argv[])
         SDL_INIT_JOYSTICK |
         SDL_INIT_GAMECONTROLLER
     );
+    if (SDL_IsTextInputActive() == SDL_TRUE)
+    {
+        SDL_StopTextInput();
+    }
 
     NETWORK_init();
 
@@ -617,12 +621,7 @@ void inline fixedloop()
     }
 
     //Mute button
-#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
-    bool inEditor = ed.textentry || ed.textmod != TEXT_NONE || ed.scripthelppage == 1;
-#else
-    bool inEditor = false;
-#endif
-    if (key.isDown(KEYBOARD_m) && game.mutebutton<=0 && !inEditor)
+    if (key.isDown(KEYBOARD_m) && game.mutebutton<=0 && !key.textentry())
     {
         game.mutebutton = 8;
         if (game.muted)
@@ -639,7 +638,7 @@ void inline fixedloop()
         game.mutebutton--;
     }
 
-    if (key.isDown(KEYBOARD_n) && game.musicmutebutton <= 0 && !inEditor)
+    if (key.isDown(KEYBOARD_n) && game.musicmutebutton <= 0 && !key.textentry())
     {
         game.musicmutebutton = 8;
         game.musicmuted = !game.musicmuted;


### PR DESCRIPTION
After looking at pull request #446, I got a bit annoyed that we have *two* variables, `key.textentrymode` and `ed.textentry`, that we rolled ourselves to track the state of something SDL already provides us a function to easily query: `SDL_IsTextInputActive()`. We don't need to have either of these two variables, and we shouldn't.

So that's what I do in this patch. Both variables have been axed in favor of using this function, and I just made a wrapper out of it, named `key.textentry()`.

For bonus points, this gets rid of the ugly `NO_CUSTOM_LEVELS` and `NO_EDITOR` ifdef in main.cpp, since text entry is enabled when entering the script list and disabled when exiting it. This makes the code there easier to read, too.

Furthermore, apparently `key.textentrymode` was initialized to *true* instead of false... for whatever reason. But that's gone now, too.

Now, you'd think there wouldn't be any downside to using `SDL_IsTextInputActive()`. After all, it's a function that SDL itself provides, right?

Wrong. For whatever reason, it seems like text input is active *from the start of the program*, meaning that what would happen is I would go into the editor, and find that I can't move around nor place tiles nor anything else. Then I would press Esc, and then suddenly become able to do those things I wanted to do before.

I have no idea why the above happens, but all I can do is to just insert an `SDL_StopTextInput()` immediately after the `SDL_Init()` in `main.cpp`. Of course, I have to surround it with an `SDL_IsTextInputActive()` check to make sure I don't do anything extraneous by stopping input when it's already stopped.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
