### PR TITLE
Fixed the title screen showing up when going to graphics options while playtesting.

### DIFF
--- a/desktop_version/.gitignore
+++ b/desktop_version/.gitignore
@@ -12,3 +12,6 @@ VVVVVV
 
 # Game data
 data.zip
+
+# macOS files
+.DS_Store

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -320,6 +320,7 @@ int main(int argc, char *argv[])
         game.levelpage = 0;
         game.playcustomlevel = 0;
         game.playassets = playassets;
+        game.menustart = true;
 
         ed.directoryList.clear();
         ed.directoryList.push_back(playtestname);


### PR DESCRIPTION
## Changes:

Fixes #450 

Sets `menustart` to true when using the playtesting argument. This prevents the title screen from showing up when going to the Graphics Options while playtesting. Also added `.DS_Store` to the gitignore file for macOS. 🙄 

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
