### PR TITLE
Don't fade music out when returning to the menu if it's Presenting VVVVVV

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2310,7 +2310,9 @@ void mapmenuactionpress()
         //This fixes an apparent frame flicker.
         FillRect(graphics.tempBuffer, 0x000000);
         graphics.fademode = 2;
-        music.fadeout();
+        if (music.currentsong != 6) {
+            music.fadeout();
+        }
         map.nexttowercolour();
         if (!game.glitchrunnermode)
         {


### PR DESCRIPTION
## Changes:

If Presenting VVVVVV is playing when you exit to the menu, the song will fade out, and then Presenting VVVVVV won't fade (back) in. This fixes that by avoiding fading the music out if it's already playing Presenting VVVVVV for a smooth transition between the level and the menu. The alternative would have been making it fade out and then back in, which wouldn't really be ideal.

Fixes #452.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
