### PR TITLE
Fix aggressive glitchrunner hardreset causing issues quitting to menu

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2100,7 +2100,8 @@ void mapinput()
         else
         {
             // Produces more glitchiness! Necessary for credits warp to work.
-            script.hardreset();
+            script.running = false;
+            graphics.textbox.clear();
 
             game.state = 80;
             game.statedelay = 0;


### PR DESCRIPTION
This fixes the bug where in glitchrunner mode, quitting to the menu would always put you back at the play menu on the first option, instead of the menu you entered the game from.

The problem is the `script.hardreset()` that gets called before the game actually quits to the menu, so when `Game::quittomenu()` gets called to quit to the menu, all the variables that keep track of whether you're in a certain gamemode, such as `game.insecretlab` and `map.custommode`, all get prematurely reset before that function can read them and put you back to the correct menu.

The solution here is to simply reset only what's needed when quitting to the menu. Specifically, in order for credits warp to work, `script.running` needs to be set to false and all the text boxes need to be removed. Text boxes need to be gone so the "- Press ACTION to advance text -" prompt will stay up without a text box, enabling the player to increment the gamestate at will by pressing ACTION, and the script needs to stop running so further text boxes don't spawn in.

Fixes #389.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
