### PR TITLE
Prevent more fuzzing of binary blob (check bounds and indices, actually mark invalid headers as invalid)

### DIFF
--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -147,7 +147,7 @@ int binaryBlob::getIndex(const char* _name)
 {
 	for (size_t i = 0; i < SDL_arraysize(m_headers); i += 1)
 	{
-		if (strcmp(_name, m_headers[i].name) == 0)
+		if (strcmp(_name, m_headers[i].name) == 0 && m_headers[i].valid)
 		{
 			return i;
 		}

--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -98,10 +98,12 @@ bool binaryBlob::unPackBinary(const char* name)
 		}
 		if (m_headers[i].size < 1)
 		{
+			m_headers[i].valid = false;
 			continue; /* Must be nonzero and positive */
 		}
 		if ((offset + m_headers[i].size) > size)
 		{
+			m_headers[i].valid = false;
 			continue; /* Bogus size value */
 		}
 

--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -27,7 +27,7 @@ void binaryBlob::AddFileToBinaryBlob(const char* _path)
 		size = ftell(file);
 		fseek(file, 0, SEEK_SET);
 
-		memblock = (char*) malloc(size);
+		memblock = (char*) SDL_malloc(size);
 		fread(memblock, 1, size, file);
 
 		fclose(file);
@@ -110,7 +110,7 @@ bool binaryBlob::unPackBinary(const char* name)
 		}
 
 		PHYSFS_seek(handle, offset);
-		m_memblocks[i] = (char*) malloc(m_headers[i].size);
+		m_memblocks[i] = (char*) SDL_malloc(m_headers[i].size);
 		if (m_memblocks[i] == NULL)
 		{
 			exit(1); /* Oh god we're out of memory, just bail */
@@ -141,7 +141,7 @@ void binaryBlob::clear()
 	{
 		if (m_headers[i].valid)
 		{
-			free(m_memblocks[i]);
+			SDL_free(m_memblocks[i]);
 			m_headers[i].valid = false;
 		}
 	}
@@ -151,7 +151,7 @@ int binaryBlob::getIndex(const char* _name)
 {
 	for (size_t i = 0; i < SDL_arraysize(m_headers); i += 1)
 	{
-		if (strcmp(_name, m_headers[i].name) == 0 && m_headers[i].valid)
+		if (SDL_strcmp(_name, m_headers[i].name) == 0 && m_headers[i].valid)
 		{
 			return i;
 		}
@@ -185,7 +185,7 @@ std::vector<int> binaryBlob::getExtra()
 	for (size_t i = 0; i < SDL_arraysize(m_headers); i += 1)
 	{
 		if (m_headers[i].valid
-#define FOREACH_TRACK(track_name) && strcmp(m_headers[i].name, track_name) != 0
+#define FOREACH_TRACK(track_name) && SDL_strcmp(m_headers[i].name, track_name) != 0
 		TRACK_NAMES
 #undef FOREACH_TRACK
 		) {

--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "UtilityClass.h"
+
 binaryBlob::binaryBlob()
 {
 	numberofHeaders = 0;
@@ -159,11 +161,21 @@ int binaryBlob::getIndex(const char* _name)
 
 int binaryBlob::getSize(int _index)
 {
+	if (!INBOUNDS_ARR(_index, m_headers))
+	{
+		puts("getSize() out-of-bounds!");
+		return 0;
+	}
 	return m_headers[_index].size;
 }
 
 char* binaryBlob::getAddress(int _index)
 {
+	if (!INBOUNDS_ARR(_index, m_memblocks))
+	{
+		puts("getAddress() out-of-bounds!");
+		return NULL;
+	}
 	return m_memblocks[_index];
 }
 

--- a/desktop_version/src/BinaryBlob.h
+++ b/desktop_version/src/BinaryBlob.h
@@ -55,10 +55,12 @@ public:
 
 	void clear();
 
+	static const int max_headers = 128;
+
 private:
 	int numberofHeaders;
-	resourceheader m_headers[128];
-	char* m_memblocks[128];
+	resourceheader m_headers[max_headers];
+	char* m_memblocks[max_headers];
 };
 
 

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -151,12 +151,15 @@ void songend()
 
 void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fadein_ms /*= 3000*/)
 {
-	// No need to check if num_tracks is greater than 0, we wouldn't be here if it wasn't
 	if (mmmmmm && usingmmmmmm)
 	{
-		t %= num_mmmmmm_tracks;
+		// Don't conjoin this if-statement with the above one...
+		if (num_mmmmmm_tracks > 0)
+		{
+			t %= num_mmmmmm_tracks;
+		}
 	}
-	else
+	else if (num_pppppp_tracks > 0)
 	{
 		t %= num_pppppp_tracks;
 	}

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -83,7 +83,14 @@ void musicclass::init()
 	if (index >= 0 && index < musicReadBlob.max_headers) \
 	{ \
 		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index)); \
-		musicTracks.push_back(MusicTrack( rw )); \
+		if (rw == NULL) \
+		{ \
+			printf("Unable to read music file header: %s\n", SDL_GetError()); \
+		} \
+		else \
+		{ \
+			musicTracks.push_back(MusicTrack( rw )); \
+		} \
 	}
 
 		TRACK_NAMES

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -80,12 +80,15 @@ void musicclass::init()
 
 #define FOREACH_TRACK(track_name) \
 	index = musicReadBlob.getIndex(track_name); \
-	rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index)); \
-	musicTracks.push_back(MusicTrack( rw ));
+	if (index >= 0 && index < musicReadBlob.max_headers) \
+	{ \
+		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index)); \
+		musicTracks.push_back(MusicTrack( rw )); \
+	}
 
 		TRACK_NAMES
 
-		num_mmmmmm_tracks += 16;
+		num_mmmmmm_tracks += musicTracks.size();
 
 		const std::vector<int> extra = musicReadBlob.getExtra();
 		for (size_t i = 0; i < extra.size(); i++)
@@ -108,7 +111,7 @@ void musicclass::init()
 
 #undef FOREACH_TRACK
 
-	num_pppppp_tracks += 16;
+	num_pppppp_tracks += musicTracks.size() - num_mmmmmm_tracks;
 
 	const std::vector<int> extra = musicReadBlob.getExtra();
 	for (size_t i = 0; i < extra.size(); i++)


### PR DESCRIPTION
So I sat down and added some more security to the binary blob code.

This particular round of fuzzing came after I attempted to TAS Unshackled 1.4, only to find that loading the level segfaulted my game. Why? Well, the root cause is a bogus `invalid` value in all headers in `vvvvvvmusic.vvv`, and the secondary cause is that the game kind of doesn't just ignore all those invalid headers and still attempts to parse them. So I decided that it really should ignore them!

By the way, @AllisonFleischer (level creator of Unshackled), you should check Unshackled 1.4's `vvvvvvmusic.vvv`. For whatever reason, all the headers' `valid` attributes are `0x01` `0x01` `0x01` `0x01`, even though the only value that will be accepted as valid is `0x01` `0x00` `0x00` `0x00`. Even stranger, `mmmmmm.vvv` loads perfectly fine and doesn't have this issue.

After this PR is applied, I can load Unshackled 1.4 without segfaulting.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
