### PR TITLE
Remove script.hardreset() when restarting Time Trial

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1909,12 +1909,9 @@ void gameinput()
                     else if (game.intimetrial && graphics.fademode==0)
                     {
                         //Quick restart of time trial
-                        script.hardreset();
-                        if (graphics.setflipmode) graphics.flipmode = true;
                         graphics.fademode = 2;
                         game.completestop = true;
                         music.fadeout();
-                        game.intimetrial = true;
                         game.quickrestartkludge = true;
                     }
                     else if (graphics.fademode==0)


### PR DESCRIPTION
There's not really any need for it to be there. It gets called when the Time Trial restarts, as restarting the Time Trial calls `script.startgamemode()`, which calls `script.hardreset()` anyway.

Furthermore, since `script.hardreset()` is removed, we can also remove two lines that are meant to work around the fact that everything gets reset, which is now no longer the case.

Fixes #367.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
