### PR TITLE
Fix compatibility with levels that rely on gamestate-based script boxes, and add custommode check to mapclass::twoframedelayfix()

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4828,7 +4828,8 @@ void entityclass::entitycollisioncheck()
     int block_idx = -1;
     if (checktrigger(&block_idx) > -1 && block_idx > -1)
     {
-        if (blocks[block_idx].script != "")
+        // Load the block's script if its gamestate is out of range
+        if (blocks[block_idx].script != "" && (activetrigger < 300 || activetrigger > 336))
         {
             game.startscript = true;
             game.newscript = blocks[block_idx].script;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -2126,6 +2126,7 @@ void mapclass::twoframedelayfix()
 
 	int block_idx = -1;
 	if (game.glitchrunnermode
+	|| !custommode
 	|| game.deathseq != -1
 	// obj.checktrigger() sets obj.activetrigger and block_idx
 	|| obj.checktrigger(&block_idx) <= -1


### PR DESCRIPTION
* **Fix compatibility with levels that rely on gamestate-based script boxes**

  Some levels rely specifically on the fact that certain script boxes are loaded using gamestates, instead of directly loading the script and bypassing the gamestate system. Then weird things could happen. This restores compatibility with those levels.

  `mapclass::twoframedelayfix()` doesn't need to be updated because the point of that function is to bypass the gamestate system entirely anyways.

* **Add custommode check to `mapclass::twoframedelayfix()`**

  This is to ensure that this function only has an effect inside custom levels. It might do something weird or bad in the main game.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
