### PR TITLE
Move text entry start to script open instead of script list open

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3786,7 +3786,6 @@ void editormenuactionpress()
             music.playef(11);
             ed.scripteditmod=true;
             ed.clearscriptbuffer();
-            key.enabletextentry();
             key.keybuffer="";
             ed.hookmenupage=0;
             ed.hookmenu=0;
@@ -4070,6 +4069,7 @@ void editorinput()
                 {
                     game.mapheld=true;
                     ed.scripthelppage=1;
+                    key.enabletextentry();
                     key.keybuffer="";
                     ed.sbscript=ed.hooklist[(ed.hooklist.size()-1)-ed.hookmenu];
                     ed.loadhookineditor(ed.sbscript);


### PR DESCRIPTION
This fixes a bug where opening a script, then closing the script but not exiting the script list, then opening a script again (it can be the same script as before) would result in you being unable to type in the script. You would have to close the script, then close the script list, then re-open the script list in order to be able to type properly.

This was caused by the fact that `key.enabletextentry()` was being called when the script list was opened, but `key.disabletextentry()` was being called when closing a script. So the fix for this is to simply move the `key.enabletextentry()` to its proper place, which is when the script is being opened, and not when the script list is.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
