### PR TITLE
Clean up endianness and surface mess

### DIFF
--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -20,15 +20,17 @@ SDL_Surface* GetSubSurface( SDL_Surface* metaSurface, int x, int y, int width, i
     area.w = width;
     area.h = height;
 
-    // Set the RGBA mask values.
-    Uint32 r, g, b, a;
-    r = 0x000000ff;
-    g = 0x0000ff00;
-    b = 0x00ff0000;
-    a = 0xff000000;
-
     //Convert to the correct display format after nabbing the new _surface or we will slow things down.
-    SDL_Surface* preSurface = SDL_CreateRGBSurface(SDL_SWSURFACE, width, height, 32, r, g, b, a);
+    SDL_Surface* preSurface = SDL_CreateRGBSurface(
+        SDL_SWSURFACE,
+        width,
+        height,
+        metaSurface->format->BitsPerPixel,
+        metaSurface->format->Rmask,
+        metaSurface->format->Gmask,
+        metaSurface->format->Bmask,
+        metaSurface->format->Amask
+    );
     //SDL_Surface* subSurface = SDL_DisplayFormatAlpha(preSurface);
 
     //SDL_FreeSurface(preSurface);
@@ -337,7 +339,7 @@ void UpdateFilter()
 
 SDL_Surface* ApplyFilter( SDL_Surface* _src )
 {
-    SDL_Surface* _ret = SDL_CreateRGBSurface(_src->flags, _src->w, _src->h, 32,
+    SDL_Surface* _ret = SDL_CreateRGBSurface(_src->flags, _src->w, _src->h, _src->format->BitsPerPixel,
         _src->format->Rmask, _src->format->Gmask, _src->format->Bmask, _src->format->Amask);
 
     int redOffset = rand() % 4;

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -11,23 +11,6 @@ void setRect( SDL_Rect& _r, int x, int y, int w, int h )
     _r.h = h;
 }
 
-unsigned int endian_swap( unsigned int x )
-{
-    return (x>>24) |
-           ((x<<8) & 0x00FF0000) |
-           ((x>>8) & 0x0000FF00) |
-           (x<<24);
-}
-
-
-template <class T>
-void endian_swap(T *objp)
-{
-    unsigned char *memp = reinterpret_cast<unsigned char*>(objp);
-    std::reverse(memp, memp + sizeof(T));
-}
-
-
 SDL_Surface* GetSubSurface( SDL_Surface* metaSurface, int x, int y, int width, int height )
 {
     // Create an SDL_Rect with the area of the _surface

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -22,17 +22,10 @@ SDL_Surface* GetSubSurface( SDL_Surface* metaSurface, int x, int y, int width, i
 
     // Set the RGBA mask values.
     Uint32 r, g, b, a;
-#if SDL_BYTEORDER == SDL_BIG_ENDIAN
-    r = 0xff000000;
-    g = 0x00ff0000;
-    b = 0x0000ff00;
-    a = 0x000000ff;
-#else
     r = 0x000000ff;
     g = 0x0000ff00;
     b = 0x00ff0000;
     a = 0xff000000;
-#endif
 
     //Convert to the correct display format after nabbing the new _surface or we will slow things down.
     SDL_Surface* preSurface = SDL_CreateRGBSurface(SDL_SWSURFACE, width, height, 32, r, g, b, a);
@@ -64,18 +57,9 @@ void DrawPixel( SDL_Surface *_surface, int x, int y, Uint32 pixel )
         break;
 
     case 3:
-        if(SDL_BYTEORDER != SDL_BIG_ENDIAN)
-        {
-            p[0] = (pixel >> 16) & 0xff;
-            p[1] = (pixel >> 8) & 0xff;
-            p[2] = pixel & 0xff;
-        }
-        else
-        {
-            p[0] = pixel & 0xff;
-            p[1] = (pixel >> 8) & 0xff;
-            p[2] = (pixel >> 16) & 0xff;
-        }
+        p[0] = (pixel >> 16) & 0xff;
+        p[1] = (pixel >> 8) & 0xff;
+        p[2] = pixel & 0xff;
         break;
 
     case 4:
@@ -101,11 +85,7 @@ Uint32 ReadPixel( SDL_Surface *_surface, int x, int y )
         break;
 
     case 3:
-        if(SDL_BYTEORDER == SDL_BIG_ENDIAN)
-            return p[0] << 16 | p[1] << 8 | p[2];
-        else
-            return p[0] | p[1] << 8 | p[2] << 16;
-        break;
+        return p[0] | p[1] << 8 | p[2] << 16;
 
     case 4:
         return *(Uint32 *)p;

--- a/desktop_version/src/GraphicsUtil.h
+++ b/desktop_version/src/GraphicsUtil.h
@@ -11,8 +11,6 @@ struct colourTransform
 
 void setRect(SDL_Rect& _r, int x, int y, int w, int h);
 
-unsigned int endian_swap(unsigned int x);
-
 SDL_Surface* GetSubSurface( SDL_Surface* metaSurface, int x, int y, int width, int height );
 
 void DrawPixel( SDL_Surface *surface, int x, int y, Uint32 pixel );


### PR DESCRIPTION
So, there was both an `endian_swap()` function and `endian_swap()` template(!), which were both unused. SDL provides endian swap macros anyway, not sure why either of those were in here. But that template was the only instance of a template being used in the game, so the game *technically* wasn't templateless until now.

I've also axed the `SDL_BYTEORDER` checks, because (1) the game basically only runs on little-endian, anyway, (2) even if it didn't, the game doesn't check it everywhere it should (so big-endian has definitely never been tested), and (3) the endianness checks shouldn't be written anyways, the code should be endian-agnostic already.

I've also cleaned up two suspicious `SDL_CreateRGBSurfaceFrom()`s that used their own hardcoded arguments for bits-per-pixel and color masks instead of using the ones of the surface they were operating on.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
