### PR TITLE
De-duplicate activity zone rendering, don't ignore game.act_fade

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1683,10 +1683,8 @@ void gamerender()
         game.activity_r = obj.blocks[game.activeactivity].r;
         game.activity_g = obj.blocks[game.activeactivity].g;
         game.activity_b = obj.blocks[game.activeactivity].b;
-        graphics.drawtextbox(16, 4, 36, 3, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha);
-        graphics.Print(5, 12, game.activity_lastprompt, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha, true);
     }
-    else if(game.act_fade>5 || game.prev_act_fade>5)
+    if(game.act_fade>5 || game.prev_act_fade>5)
     {
         graphics.drawtextbox(16, 4, 36, 3, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha);
         graphics.Print(5, 12, game.activity_lastprompt, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha, true);


### PR DESCRIPTION
This is a follow-up to #421.

The game would draw the activity zone if there was one active at all, and would ignore `game.act_fade`. Normally this wouldn't be a problem, but since #421, it's possible that there could be an active activity zone but `game.act_fade` would still be 5. This would happen if you entered a new activity zone while a cutscene was running.

To fix this, just make it so that the prompt gets drawn on its own and only depends on the state of `game.act_fade` (or `game.prev_act_fade`), and won't be unconditionally drawn if there's an active activity zone. As a bonus, this de-duplicates the drawing of the activity prompt, so it's no longer copy-pasted.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
