### PR TITLE
Fix 1-frame render glitch with running teleport scripts

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3509,6 +3509,10 @@ void scriptclass::teleport()
 		game.state = 0;
 		load(game.teleportscript);
 		game.teleportscript = "";
+
+		// FIXME: Remove this once game loop order is fixed in 2.4!
+		run();
+		dontrunnextframe = true;
 	}
 	else
 	{


### PR DESCRIPTION
Fixes #402 (Violet appearing 1 frame after the Ship teleporter room appears).

The root cause of this bug is due to the game loop order changes made with the over-30-FPS patch. 2.2's game loop order was `gameinput()`, `gamerender()`, then `gamelogic()`. In 2.3, `gamerender()` was moved to the end as it required special code to render more than 30 frames a second. So 2.3's game loop order is `gameinput()`, `gamelogic()`, then `gamerender()`.

In hindsight, I could have preserved the game loop order, but this would require some more complex code in the game loop than what is there currently. Fixing it now would fix rendering glitches such as this one (along with being able to remove script.dontrunnextframe with the two-frame-delay fix), but it could also introduce new rendering glitches we don't yet know about. After discussing this in Discord DMs with flibit, we agreed that the game loop order should be fixed in 2.4 instead.

When the game teleports you, `gamelogic()` runs `script.teleport()`. This function will gotoroom to the teleporter destination, then it loads the teleport script. Some teleport scripts (such as `levelonecomplete`, which creates Violet) expect that their entities will be created, and more generally that their script will be ran, on the same frame that the gotoroom happens, i.e. by the time that the next `gamerender()` happens, i.e. `script.run()` should be ran before the next `gamerender()` happens. This would be true on the old game loop order, but with the new game loop order, `gamerender()` gets ran directly after `gamelogic()` with no `script.run()` in between.

To fix this, I did the same thing I did with the two-frame-delay fix (#317), where I ran the script for that frame, but in order to prevent running it twice I set `script.dontrunnextframe` to true.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
