### PR TITLE
Fix sprite of player if they are stuck in a wall

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -3326,6 +3326,12 @@ void entityclass::animateentities( int _i )
                 }
 
                 if (entities[_i].onroof > 0) entities[_i].drawframe += 6;
+                // Stuck in a wall? Then default to gravitycontrol
+                if (entities[_i].onground > 0 && entities[_i].onroof > 0
+                && game.gravitycontrol == 0)
+                {
+                    entities[_i].drawframe -= 6;
+                }
             }
             else
             {


### PR DESCRIPTION
If the player is stuck in a wall (which shouldn't happen in the first place), their sprite would always default to being flipped, even if they were unflipped.

Being stuck in a wall is characterized by having both positive `onfloor` and `onground`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
