### PR TITLE
Consolidate player and supercrewmate collision detection

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4497,17 +4497,16 @@ void entityclass::entitymapcollision( int t )
     }
 }
 
-void entityclass::movingplatformfix( int t )
+void entityclass::movingplatformfix( int t, int j )
 {
-    if (t < 0 || t >= (int) entities.size())
+    if (!INBOUNDS(t, entities) || !INBOUNDS(j, entities))
     {
         puts("movingplatformfix() out-of-bounds!");
         return;
     }
 
-    //If this intersects the player, then we move the player along it
-    int j = getplayer();
-    if (j > -1 && entitycollide(t, j))
+    //If this intersects the entity, then we move them along it
+    if (entitycollide(t, j))
     {
         //ok, bollox, let's make sure
         entities[j].yp = entities[j].yp + int(entities[j].vy);
@@ -4518,7 +4517,7 @@ void entityclass::movingplatformfix( int t )
             entities[j].newyp = entities[j].yp + int(entities[j].vy);
             if (testwallsy(j, entities[j].xp, entities[j].newyp))
             {
-                 if (entities[t].vy > 0)
+                if (entities[t].vy > 0)
                 {
                     entities[j].yp = entities[t].yp + entities[t].h;
                     entities[j].vy = 0;
@@ -4529,46 +4528,6 @@ void entityclass::movingplatformfix( int t )
                     entities[j].yp = entities[t].yp - entities[j].h-entities[j].cy;
                     entities[j].vy = 0;
                     entities[j].onground = true;
-                }
-            }
-            else
-            {
-                entities[t].state = entities[t].onwall;
-            }
-        }
-    }
-}
-
-void entityclass::scmmovingplatformfix( int t )
-{
-    if (t < 0 || t >= (int) entities.size())
-    {
-        puts("scmmovingplatformfix() out-of-bounds!");
-        return;
-    }
-
-    //If this intersects the SuperCrewMate, then we move them along it
-    int j = getscm();
-    if (entitycollide(t, j))
-    {
-        //ok, bollox, let's make sure
-        entities[j].yp = entities[j].yp +  (entities[j].vy);
-        if (entitycollide(t, j))
-        {
-            entities[j].yp = entities[j].yp -  (entities[j].vy);
-            entities[j].vy = entities[t].vy;
-            entities[j].newyp = static_cast<float>(entities[j].yp) + entities[j].vy;
-            if (testwallsy(j, entities[j].xp, entities[j].newyp))
-            {
-                if (entities[t].vy > 0)
-                {
-                    entities[j].yp = entities[t].yp + entities[t].h;
-                    entities[j].vy = 0;
-                }
-                else
-                {
-                    entities[j].yp = entities[t].yp - entities[j].h-entities[j].cy;
-                    entities[j].vy = 0;
                 }
             }
             else

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4603,43 +4603,12 @@ void entityclass::entitycollisioncheck()
     }
 
     //can't have the player being stuck...
-    int j = getplayer();
-    skipdirblocks = true;
-    if (j > -1 && !testwallsx(j, entities[j].xp, entities[j].yp))
-    {
-        //Let's try to get out...
-        if (entities[j].rule == 0)
-        {
-            if(game.gravitycontrol==0)
-            {
-                entities[j].yp -= 3;
-            }
-            else
-            {
-                entities[j].yp += 3;
-            }
-        }
-    }
-    skipdirblocks = false;
+    stuckprevention(getplayer());
 
     //Can't have the supercrewmate getting stuck either!
     if (game.supercrewmate)
     {
-        j = getscm();
-        skipdirblocks = true;
-        if (!testwallsx(j, entities[j].xp, entities[j].yp))
-        {
-            //Let's try to get out...
-            if(game.gravitycontrol==0)
-            {
-                entities[j].yp -= 3;
-            }
-            else
-            {
-                entities[j].yp += 3;
-            }
-        }
-        skipdirblocks = false;
+        stuckprevention(getscm());
     }
 
     //Is the player colliding with any damageblocks?
@@ -4801,4 +4770,29 @@ void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
         }
         break;
     }
+}
+
+void entityclass::stuckprevention(int t)
+{
+    if (!INBOUNDS(t, entities))
+    {
+        puts("stuckprevention() out-of-bounds!");
+        return;
+    }
+
+    skipdirblocks = true;
+    // Can't have this entity (player or supercrewmate) being stuck...
+    if (!testwallsx(t, entities[t].xp, entities[t].yp))
+    {
+        // Let's try to get out...
+        if (game.gravitycontrol == 0)
+        {
+            entities[t].yp -= 3;
+        }
+        else
+        {
+            entities[t].yp += 3;
+        }
+    }
+    skipdirblocks = false;
 }

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -3859,37 +3859,12 @@ bool entityclass::entitycollide( int a, int b )
     return false;
 }
 
-bool entityclass::checkdamage()
+bool entityclass::checkdamage(bool scm /*= false*/)
 {
-    //Returns true if player entity (rule 0) collides with a damagepoint
+    //Returns true if player (or supercrewmate) collides with a damagepoint
     for(size_t i=0; i < entities.size(); i++)
     {
-        if(entities[i].rule==0)
-        {
-            tempx = entities[i].xp + entities[i].cx;
-            tempy = entities[i].yp + entities[i].cy;
-            tempw = entities[i].w;
-            temph = entities[i].h;
-            rectset(tempx, tempy, tempw, temph);
-
-            for (size_t j=0; j<blocks.size(); j++)
-            {
-                if (blocks[j].type == DAMAGE && help.intersects(blocks[j].rect, temprect))
-                {
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
-}
-
-bool entityclass::scmcheckdamage()
-{
-    //Returns true if supercrewmate collides with a damagepoint
-    for(size_t i=0; i < entities.size(); i++)
-    {
-        if(entities[i].type==14)
+        if((scm && entities[i].type == 14) || (!scm && entities[i].rule == 0))
         {
             tempx = entities[i].xp + entities[i].cx;
             tempy = entities[i].yp + entities[i].cy;
@@ -4880,7 +4855,7 @@ void entityclass::entitycollisioncheck()
     //how about the supercrewmate?
     if (game.supercrewmate)
     {
-        if (scmcheckdamage() && !map.invincibility)
+        if (checkdamage(true) && !map.invincibility)
         {
             //usual player dead stuff
             game.scmhurt = true;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4689,8 +4689,14 @@ void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
         return;
     }
 
-    if (entities[j].rule == 1 && entities[j].harmful)
+    switch (entities[j].rule)
     {
+    case 1:
+        if (!entities[j].harmful)
+        {
+            break;
+        }
+
         //person i hits enemy or enemy bullet j
         if (entitycollide(i, j) && !map.invincibility)
         {
@@ -4720,20 +4726,17 @@ void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
                 game.scmhurt = scm;
             }
         }
-    }
-    if (entities[j].rule == 2)   //Moving platforms
-    {
+        break;
+    case 2:   //Moving platforms
         if (entitycollide(i, j)) removeblockat(entities[j].xp, entities[j].yp);
-    }
-    if (entities[j].rule == 3)   //Entity to entity
-    {
+        break;
+    case 3:   //Entity to entity
         if(entities[j].onentity>0)
         {
             if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
         }
-    }
-    if (entities[j].rule == 4)   //Person vs horizontal line!
-    {
+        break;
+    case 4:   //Person vs horizontal line!
         if(game.deathseq==-1)
         {
             //Here we compare the person's old position versus his new one versus the line.
@@ -4759,9 +4762,8 @@ void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
                 }
             }
         }
-    }
-    if (entities[j].rule == 5)   //Person vs vertical gravity/warp line!
-    {
+        break;
+    case 5:   //Person vs vertical gravity/warp line!
         if(game.deathseq==-1)
         {
             if(entities[j].onentity>0)
@@ -4773,9 +4775,8 @@ void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
                 }
             }
         }
-    }
-    if (entities[j].rule == 6)   //Person versus crumbly blocks! Special case
-    {
+        break;
+    case 6:   //Person versus crumbly blocks! Special case
         if (entities[j].onentity > 0)
         {
             //ok; only check the actual collision if they're in a close proximity
@@ -4789,9 +4790,8 @@ void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
                 }
             }
         }
-    }
-    if (entities[j].rule == 7) // Person versus horizontal warp line, pre-2.1
-    {
+        break;
+    case 7: // Person versus horizontal warp line, pre-2.1
         if (game.glitchrunnermode
         && game.deathseq == -1
         && entities[j].onentity > 0
@@ -4799,5 +4799,6 @@ void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
         {
             entities[j].state = entities[j].onentity;
         }
+        break;
     }
 }

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4581,186 +4581,24 @@ void entityclass::customwarplinecheck(int i) {
 
 void entityclass::entitycollisioncheck()
 {
-    std::vector<SDL_Surface*>& spritesvec = graphics.flipmode ? graphics.flipsprites : graphics.sprites;
-
     for (size_t i = 0; i < entities.size(); i++)
     {
-        if (entities[i].rule != 0)
+        bool player = entities[i].rule == 0;
+        bool scm = game.supercrewmate && entities[i].type == 14;
+        if (!player && !scm)
         {
             continue;
         }
+
         //We test entity to entity
         for (size_t j = 0; j < entities.size(); j++)
         {
-            if (i!=j)
+            if (i == j)
             {
-                if (entities[j].rule == 1 && entities[j].harmful)
-                {
-                    //player i hits enemy or enemy bullet j
-                    if (entitycollide(i, j) && !map.invincibility)
-                    {
-                        if (entities[i].size == 0 && (entities[j].size == 0 || entities[j].size == 12))
-                        {
-                            //They're both sprites, so do a per pixel collision
-                            colpoint1.x = entities[i].xp;
-                            colpoint1.y = entities[i].yp;
-                            colpoint2.x = entities[j].xp;
-                            colpoint2.y = entities[j].yp;
-                            int drawframe1 = entities[i].drawframe;
-                            int drawframe2 = entities[j].drawframe;
-                            if (INBOUNDS(drawframe1, spritesvec) && INBOUNDS(drawframe2, spritesvec)
-                            && graphics.Hitest(spritesvec[drawframe1],
-                                             colpoint1, spritesvec[drawframe2], colpoint2))
-                            {
-                                //Do the collision stuff
-                                game.deathseq = 30;
-                            }
-                        }
-                        else
-                        {
-                            //Ok, then we just assume a normal bounding box collision
-                            game.deathseq = 30;
-                        }
-                    }
-                }
-                if (entities[j].rule == 2)   //Moving platforms
-                {
-                    if (entitycollide(i, j)) removeblockat(entities[j].xp, entities[j].yp);
-                }
-                if (entities[j].rule == 3)   //Entity to entity
-                {
-                    if(entities[j].onentity>0)
-                    {
-                        if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
-                    }
-                }
-                if (entities[j].rule == 4)   //Player vs horizontal line!
-                {
-                    if(game.deathseq==-1)
-                    {
-                        //Here we compare the player's old position versus his new one versus the line.
-                        //All points either be above or below it. Otherwise, there was a collision this frame.
-                        if (entities[j].onentity > 0)
-                        {
-                            if (entityhlinecollide(i, j))
-                            {
-                                music.playef(8);
-                                game.gravitycontrol = (game.gravitycontrol + 1) % 2;
-                                game.totalflips++;
-                                if (game.gravitycontrol == 0)
-                                {
-                                    if (entities[i].vy < 1) entities[i].vy = 1;
-                                }
-                                else
-                                {
-                                    if (entities[i].vy > -1) entities[i].vy = -1;
-                                }
+                continue;
+            }
 
-                                entities[j].state = entities[j].onentity;
-                                entities[j].life = 6;
-                            }
-                        }
-                    }
-                }
-                if (entities[j].rule == 5)   //Player vs vertical gravity/warp line!
-                {
-                    if(game.deathseq==-1)
-                    {
-                        if(entities[j].onentity>0)
-                        {
-                            if (entityvlinecollide(i, j))
-                            {
-                                entities[j].state = entities[j].onentity;
-                                entities[j].life = 4;
-                            }
-                        }
-                    }
-                }
-                if (entities[j].rule == 6)   //Player versus crumbly blocks! Special case
-                {
-                    if (entities[j].onentity > 0)
-                    {
-                        //ok; only check the actual collision if they're in a close proximity
-                        temp = entities[i].yp - entities[j].yp;
-                        if (temp > -30 && temp < 30)
-                        {
-                            temp = entities[i].xp - entities[j].xp;
-                            if (temp > -30 && temp < 30)
-                            {
-                                if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
-                            }
-                        }
-                    }
-                }
-                if (entities[j].rule == 7) // Player versus horizontal warp line, pre-2.1
-                {
-                    if (game.glitchrunnermode
-                    && game.deathseq == -1
-                    && entities[j].onentity > 0
-                    && entityhlinecollide(i, j))
-                    {
-                        entities[j].state = entities[j].onentity;
-                    }
-                }
-            }
-        }
-    }
-    if (game.supercrewmate)
-    {
-        for (size_t i = 0; i < entities.size(); i++)
-        {
-            //some extra collisions
-            if (entities[i].type == 14)   //i is the supercrewmate
-            {
-                for (size_t j = 0; j < entities.size(); j++)
-                {
-                    if (i != j)
-                    {
-                        if (entities[j].rule == 1 && entities[j].harmful)  //j is a harmful enemy
-                        {
-                            //player i hits enemy or enemy bullet j
-                            if (entitycollide(i, j) && !map.invincibility)
-                            {
-                                if (entities[i].size == 0 && entities[j].size == 0)
-                                {
-                                    //They're both sprites, so do a per pixel collision
-                                    colpoint1.x = entities[i].xp;
-                                    colpoint1.y = entities[i].yp;
-                                    colpoint2.x = entities[j].xp;
-                                    colpoint2.y = entities[j].yp;
-                                    int drawframe1 = entities[i].drawframe;
-                                    int drawframe2 = entities[j].drawframe;
-                                    if (INBOUNDS(drawframe1, spritesvec) && INBOUNDS(drawframe2, spritesvec)
-                                    && graphics.Hitest(spritesvec[drawframe1],
-                                                     colpoint1, spritesvec[drawframe2], colpoint2))
-                                    {
-                                        //Do the collision stuff
-                                        game.deathseq = 30;
-                                        game.scmhurt = true;
-                                    }
-                                }
-                                else
-                                {
-                                    //Ok, then we just assume a normal bounding box collision
-                                    game.deathseq = 30;
-                                    game.scmhurt = true;
-                                }
-                            }
-                        }
-                        if (entities[j].rule == 2)   //Moving platforms
-                        {
-                            if (entitycollide(i, j)) removeblockat(entities[j].xp, entities[j].yp);
-                        }
-                        if (entities[j].type == 8 && entities[j].rule == 3)   //Entity to entity (well, checkpoints anyway!)
-                        {
-                            if(entities[j].onentity>0)
-                            {
-                                if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
-                            }
-                        }
-                    }
-                }
-            }
+            collisioncheck(i, j, scm);
         }
     }
 
@@ -4840,5 +4678,126 @@ void entityclass::entitycollisioncheck()
             game.state = activetrigger;
         }
         game.statedelay = 0;
+    }
+}
+
+void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
+{
+    if (!INBOUNDS(i, entities) || !INBOUNDS(j, entities))
+    {
+        puts("collisioncheck() out-of-bounds!");
+        return;
+    }
+
+    if (entities[j].rule == 1 && entities[j].harmful)
+    {
+        //person i hits enemy or enemy bullet j
+        if (entitycollide(i, j) && !map.invincibility)
+        {
+            if (entities[i].size == 0 && (entities[j].size == 0 || entities[j].size == 12))
+            {
+                //They're both sprites, so do a per pixel collision
+                colpoint1.x = entities[i].xp;
+                colpoint1.y = entities[i].yp;
+                colpoint2.x = entities[j].xp;
+                colpoint2.y = entities[j].yp;
+                int drawframe1 = entities[i].drawframe;
+                int drawframe2 = entities[j].drawframe;
+                std::vector<SDL_Surface*>& spritesvec = graphics.flipmode ? graphics.flipsprites : graphics.sprites;
+                if (INBOUNDS(drawframe1, spritesvec) && INBOUNDS(drawframe2, spritesvec)
+                && graphics.Hitest(spritesvec[drawframe1],
+                                 colpoint1, spritesvec[drawframe2], colpoint2))
+                {
+                    //Do the collision stuff
+                    game.deathseq = 30;
+                    game.scmhurt = scm;
+                }
+            }
+            else
+            {
+                //Ok, then we just assume a normal bounding box collision
+                game.deathseq = 30;
+                game.scmhurt = scm;
+            }
+        }
+    }
+    if (entities[j].rule == 2)   //Moving platforms
+    {
+        if (entitycollide(i, j)) removeblockat(entities[j].xp, entities[j].yp);
+    }
+    if (entities[j].rule == 3)   //Entity to entity
+    {
+        if(entities[j].onentity>0)
+        {
+            if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
+        }
+    }
+    if (entities[j].rule == 4)   //Person vs horizontal line!
+    {
+        if(game.deathseq==-1)
+        {
+            //Here we compare the person's old position versus his new one versus the line.
+            //All points either be above or below it. Otherwise, there was a collision this frame.
+            if (entities[j].onentity > 0)
+            {
+                if (entityhlinecollide(i, j))
+                {
+                    music.playef(8);
+                    game.gravitycontrol = (game.gravitycontrol + 1) % 2;
+                    game.totalflips++;
+                    if (game.gravitycontrol == 0)
+                    {
+                        if (entities[i].vy < 1) entities[i].vy = 1;
+                    }
+                    else
+                    {
+                        if (entities[i].vy > -1) entities[i].vy = -1;
+                    }
+
+                    entities[j].state = entities[j].onentity;
+                    entities[j].life = 6;
+                }
+            }
+        }
+    }
+    if (entities[j].rule == 5)   //Person vs vertical gravity/warp line!
+    {
+        if(game.deathseq==-1)
+        {
+            if(entities[j].onentity>0)
+            {
+                if (entityvlinecollide(i, j))
+                {
+                    entities[j].state = entities[j].onentity;
+                    entities[j].life = 4;
+                }
+            }
+        }
+    }
+    if (entities[j].rule == 6)   //Person versus crumbly blocks! Special case
+    {
+        if (entities[j].onentity > 0)
+        {
+            //ok; only check the actual collision if they're in a close proximity
+            temp = entities[i].yp - entities[j].yp;
+            if (temp > -30 && temp < 30)
+            {
+                temp = entities[i].xp - entities[j].xp;
+                if (temp > -30 && temp < 30)
+                {
+                    if (entitycollide(i, j)) entities[j].state = entities[j].onentity;
+                }
+            }
+        }
+    }
+    if (entities[j].rule == 7) // Person versus horizontal warp line, pre-2.1
+    {
+        if (game.glitchrunnermode
+        && game.deathseq == -1
+        && entities[j].onentity > 0
+        && entityhlinecollide(i, j))
+        {
+            entities[j].state = entities[j].onentity;
+        }
     }
 }

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -152,9 +152,7 @@ public:
 
     void entitymapcollision(int t);
 
-    void movingplatformfix(int t);
-
-    void scmmovingplatformfix(int t);
+    void movingplatformfix(int t, int j);
 
     void hormovingplatformfix(int t);
 

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -158,6 +158,8 @@ public:
 
     void entitycollisioncheck();
 
+    void collisioncheck(int i, int j, bool scm = false);
+
 
     std::vector<entclass> entities;
 

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -160,6 +160,8 @@ public:
 
     void collisioncheck(int i, int j, bool scm = false);
 
+    void stuckprevention(int t);
+
 
     std::vector<entclass> entities;
 

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -100,9 +100,7 @@ public:
 
     bool entitycollide(int a, int b);
 
-    bool checkdamage();
-
-    bool scmcheckdamage();
+    bool checkdamage(bool scm = false);
 
     void settemprect(int t);
 

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -892,14 +892,10 @@ void gamelogic()
                             obj.entitymapcollision(i);            // Collisions with walls
 
                             obj.createblock(0, obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
+                            obj.movingplatformfix(i, obj.getplayer());
                             if (game.supercrewmate)
                             {
-                                obj.movingplatformfix(i);
-                                obj.scmmovingplatformfix(i);
-                            }
-                            else
-                            {
-                                obj.movingplatformfix(i);
+                                obj.movingplatformfix(i, obj.getscm());
                             }
                         }
                     }


### PR DESCRIPTION
This is a PR to primarily improve code maintainability.

Supercrewmate collision detection has been copy-pasted from player collision detection and tweaked slightly, instead of abstracting the collision detection routines to proper generalized functions. This copy-pasting makes the codebase less maintainable, because if you fix a problem in one routine, you'd have to remember to fix it in the other routine, or otherwise the other routine could have the same issue.

So that's what I do here. Supercrewmate and player collision detection functions are now more-or-less the same thing.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
