### PR TITLE
Move crewmate drawframe fix to entityclass::createentity() instead of mapclass::loadlevel()

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2079,6 +2079,40 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
     {
         entity.drawframe++;
     }
+    // Make sure our crewmates are facing the player if applicable
+    // Also make sure they're flipped if they're flipped
+    // FIXME: Duplicated from updateentities!
+    if (entity.rule == 6 || entity.rule == 7)
+    {
+        if (entity.tile == 144 || entity.tile == 144+6)
+        {
+            entity.drawframe = 144;
+        }
+        if (entity.state == 18)
+        {
+            // Face the player
+            // FIXME: Duplicated from updateentities!
+            int j = getplayer();
+            if (j > -1 && entities[j].xp > entity.xp + 5)
+            {
+                entity.dir = 1;
+            }
+            else if (j > -1 && entities[j].xp < entity.xp - 5)
+            {
+                entity.dir = 0;
+            }
+        }
+        // Fix drawframe
+        // FIXME: Duplicated from animateentities!
+        if (entity.rule == 7)
+        {
+            entity.drawframe += 6;
+        }
+        if (entity.dir == 0)
+        {
+            entity.drawframe += 3;
+        }
+    }
 
     entities.push_back(entity);
 }
@@ -2913,6 +2947,7 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 18)
             {
                 //Stand still and face the player
+                //FIXME: Duplicated in createentity!
                 int j = getplayer();
                 if (j > -1 && entities[j].xp > entities[i].xp + 5)
                 {
@@ -3561,6 +3596,7 @@ void entityclass::animateentities( int _i )
         case 12:
         case 55:
         case 14: //Crew member! Very similar to hero
+            //FIXME: Duplicated in createentity!
             entities[_i].framedelay--;
             if(entities[_i].dir==1)
             {

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -2084,37 +2084,6 @@ void mapclass::loadlevel(int rx, int ry)
 			}
 		}
 	}
-
-	//Make sure our crewmates are facing the player if appliciable
-	//Also make sure they're flipped if they're flipped
-	for (size_t i = 0; i < obj.entities.size(); i++)
-	{
-		if (obj.entities[i].rule == 6 || obj.entities[i].rule == 7)
-		{
-			if (obj.entities[i].tile == 144 || obj.entities[i].tile == 144+6)
-			{
-				obj.entities[i].drawframe = 144;
-			}
-			if (obj.entities[i].state == 18)
-			{
-				//face the player
-				int j = obj.getplayer();
-				if (j > -1 && obj.entities[j].xp > obj.entities[i].xp + 5)
-				{
-					obj.entities[i].dir = 1;
-				}
-				else if (j > -1 && obj.entities[j].xp < obj.entities[i].xp - 5)
-				{
-					obj.entities[i].dir = 0;
-					obj.entities[i].drawframe += 3;
-				}
-			}
-		}
-		if (obj.entities[i].rule == 7)
-		{
-			obj.entities[i].drawframe += 6;
-		}
-	}
 }
 
 void mapclass::twoframedelayfix()


### PR DESCRIPTION
This makes it so the fix for crewmates' drawframes being wrong for 1-frame is fixed for all crewmates regardless of when they get created. Sure, crewmates created in `mapclass::loadlevel()` have their drawframes fixed there, but for crewmates that get created from scripting (such as Violet when gotorooming to the Ship teleporter room after Space Station 1), this fix doesn't apply to them. But now it does, and Violet will no longer be facing the wrong way for 1 frame when teleporting to the Ship teleporter room in the Space Station 1 Level Complete cutscene.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
