### PR TITLE
Fix destroy(platforms), implement under different names

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -169,9 +169,18 @@ void scriptclass::run()
 					for(size_t edi=0; edi<obj.entities.size(); edi++){
 						if(obj.entities[edi].type==11) removeentity_iter(edi);
 					}
-				}else if(words[1]=="platforms"){
+				}else if(words[1]=="platforms"||words[1]=="moving"){
+					bool fixed=words[1]=="moving";
 					for(size_t edi=0; edi<obj.entities.size(); edi++){
+						//Destroy the block first, otherwise we can't get entity position
+						if(fixed) obj.removeblockat(obj.entities[edi].xp, obj.entities[edi].yp);
 						if(obj.entities[edi].rule==2 && obj.entities[edi].animate==100) removeentity_iter(edi);
+					}
+				}else if(words[1]=="disappear"){
+					for(size_t edi=0; edi<obj.entities.size(); edi++){
+						//Destroy the block first, otherwise we can't get entity position
+						obj.removeblockat(obj.entities[edi].xp, obj.entities[edi].yp);
+						if(obj.entities[edi].type==2 && obj.entities[edi].rule==3) removeentity_iter(edi);
 					}
 				}
 			}

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3951,13 +3951,7 @@ void scriptclass::loadcustom(const std::string& t)
 			add("custom"+lines[i]);
 		}else if(words[0] == "destroy"){
 			if(customtextmode==1){ add("endtext"); customtextmode=0;}
-			if(words[1]=="gravitylines"){
-				add("destroy(gravitylines)");
-			}else if(words[1]=="warptokens"){
-				add("destroy(warptokens)");
-			}else if(words[1]=="platforms"){
-				add("destroy(platforms)");
-			}
+			add(lines[i]);
 		}else if(words[0] == "speaker"){
 			speakermode=0;
 			if(words[1]=="gray" || words[1]=="grey" || words[1]=="terminal" || words[1]=="0") speakermode=0;


### PR DESCRIPTION
`destroy(platforms)` has been bugged since 2.0. The problem with it is that it removes the platform entity, but doesn't remove its block. This results in essentially turning the platorm invisible and stopping it from moving.

This error should be fixed, but some levels (including my own) rely on the invisible platform trick. So instead, the fixed version will be implemented under a different name, `destroy(moving)`.

There's also another problem with `destroy(platforms)`, which is that the name is misleading and it doesn't additionally destroy disappearing platforms. I would also fix this, but in order to not run the risk of breakage, it will have to be implemented under a different name, too. So this will be `destroy(disappear)`. As an added benefit, it's also more granular to have platform-destroying functions under different names than it is to consolidate them under the same name.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
