### PR TITLE
Clean up color-clamping code in Graphics::bigrprint()

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2988,12 +2988,9 @@ void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool
 {
 	std::vector<SDL_Surface*>& font = flipmode ? flipbfont : bfont;
 
-	if (r < 0) r = 0;
-	if (g < 0) g = 0;
-	if (b < 0) b = 0;
-	if (r > 255) r = 255;
-	if (g > 255) g = 255;
-	if (b > 255) b = 255;
+	r = clamp(r, 0, 255);
+	g = clamp(g, 0, 255);
+	b = clamp(b, 0, 255);
 	ct.colour = getRGB(r, g, b);
 
 	x = x /  (sc);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3000,14 +3000,6 @@ void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool
 
 	x -= (len(t));
 
-	if (r < -1) r = -1;
-	if (g < 0) g = 0;
-	if (b < 0) b = 0;
-	if (r > 255) r = 255;
-	if (g > 255) g = 255;
-	if (b > 255) b = 255;
-	ct.colour = getRGB(r, g, b);
-
 	if (cen)
 	{
 		x = std::max(160 - (int((len(t)/ 2.0)*sc)), 0 );


### PR DESCRIPTION
For some reason, there's some color-clamping code in this function directly after already-existing color-clamping code. This code dates back to 2.2. And also, there's a smaller lower-bound of -1 for the red channel, despite the fact that this smaller value doesn't matter because the red would get clamped to 0 by the first code anyway.

So even if this was put here for some strange reason, it doesn't matter because it doesn't do anything anyway.

Also, all other graphics functions use the `clamp()` macro instead of writing out the clamping manually, so this one should, too.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
