### PR TITLE
Restore entity-to-crewmate conversion trick

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1006,7 +1006,7 @@ void scriptclass::run()
 						obj.entities[i].rule = 7;
 						obj.entities[i].tile = 6;
 					}
-					else if (obj.entities[i].rule == 7)
+					else if (obj.entities[i].rule != 0) // Don't destroy player entity (rule 0)
 					{
 						obj.entities[i].rule = 6;
 						obj.entities[i].tile = 0;


### PR DESCRIPTION
So there's this trick that I recently discovered, since many script commands don't initialize `i` it's possible to use them to manipulate arbitrary entities by specifying their indice.

This means in 2.2 you can convert entities to pseudo-crewmates by changing their rule to 6. Except in 2.3, this was fixed when I fixed the command to work on flipped crewmates as well. So I'm restoring this functionality, but I recognize the protection that my previous change to the command did in preventing levels from destroying the player entity by changing the player's rule to something nonzero, so instead of removing the if-conditional entirely, I'm making it so that it will only set the rule if the entity's rule isn't 0.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
