### PR TITLE
Fix up bounds checks

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1434,7 +1434,7 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
 
         //Check if it's already been collected
         entity.para = vx;
-        if (collect[(int) vx]) return;
+        if (!INBOUNDS_ARR(vx, collect) || collect[(int) vx]) return;
         break;
     case 10: //Savepoint
         entity.rule = 3;
@@ -2581,7 +2581,10 @@ bool entityclass::updateentities( int i )
             if (entities[i].state == 1)
             {
                 music.playef(4);
-                collect[(int) entities[i].para] = true;
+                if (INBOUNDS_ARR(entities[i].para, customcollect))
+                {
+                    collect[(int) entities[i].para] = true;
+                }
 
                 return removeentity(i);
             }

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1190,7 +1190,7 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
 #if !defined(NO_CUSTOM_LEVELS)
     // Special case for gray Warp Zone tileset!
     int room = game.roomx-100 + (game.roomy-100) * ed.maxwidth;
-    bool custom_gray = room >= 0 && room < 400
+    bool custom_gray = INBOUNDS_ARR(room, ed.level)
     && ed.level[room].tileset == 3 && ed.level[room].tilecol == 6;
 #else
     bool custom_gray = false;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4499,7 +4499,7 @@ void entityclass::entitymapcollision( int t )
 
 void entityclass::movingplatformfix( int t, int j )
 {
-    if (!INBOUNDS(t, entities) || !INBOUNDS(j, entities))
+    if (!INBOUNDS_VEC(t, entities) || !INBOUNDS_VEC(j, entities))
     {
         puts("movingplatformfix() out-of-bounds!");
         return;
@@ -4652,7 +4652,7 @@ void entityclass::entitycollisioncheck()
 
 void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
 {
-    if (!INBOUNDS(i, entities) || !INBOUNDS(j, entities))
+    if (!INBOUNDS_VEC(i, entities) || !INBOUNDS_VEC(j, entities))
     {
         puts("collisioncheck() out-of-bounds!");
         return;
@@ -4679,7 +4679,7 @@ void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
                 int drawframe1 = entities[i].drawframe;
                 int drawframe2 = entities[j].drawframe;
                 std::vector<SDL_Surface*>& spritesvec = graphics.flipmode ? graphics.flipsprites : graphics.sprites;
-                if (INBOUNDS(drawframe1, spritesvec) && INBOUNDS(drawframe2, spritesvec)
+                if (INBOUNDS_VEC(drawframe1, spritesvec) && INBOUNDS_VEC(drawframe2, spritesvec)
                 && graphics.Hitest(spritesvec[drawframe1],
                                  colpoint1, spritesvec[drawframe2], colpoint2))
                 {
@@ -4774,7 +4774,7 @@ void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
 
 void entityclass::stuckprevention(int t)
 {
-    if (!INBOUNDS(t, entities))
+    if (!INBOUNDS_VEC(t, entities))
     {
         puts("stuckprevention() out-of-bounds!");
         return;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2813,110 +2813,125 @@ bool entityclass::updateentities( int i )
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
                 int j=getcrewman(1); //purple
-                if (entities[j].xp > entities[i].xp + 5)
+                if (INBOUNDS_VEC(j, entities))
                 {
-                    entities[i].dir = 1;
-                }
-                else if (entities[j].xp < entities[i].xp - 5)
-                {
-                    entities[i].dir = 0;
-                }
+                    if (entities[j].xp > entities[i].xp + 5)
+                    {
+                        entities[i].dir = 1;
+                    }
+                    else if (entities[j].xp < entities[i].xp - 5)
+                    {
+                        entities[i].dir = 0;
+                    }
 
-                if (entities[j].xp > entities[i].xp + 45)
-                {
-                    entities[i].ax = 3;
-                }
-                else if (entities[j].xp < entities[i].xp - 45)
-                {
-                    entities[i].ax = -3;
+                    if (entities[j].xp > entities[i].xp + 45)
+                    {
+                        entities[i].ax = 3;
+                    }
+                    else if (entities[j].xp < entities[i].xp - 45)
+                    {
+                        entities[i].ax = -3;
+                    }
                 }
             }
             else if (entities[i].state == 12)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
                 int j=getcrewman(2); //yellow
-                if (entities[j].xp > entities[i].xp + 5)
+                if (INBOUNDS_VEC(j, entities))
                 {
-                    entities[i].dir = 1;
-                }
-                else if (entities[j].xp < entities[i].xp - 5)
-                {
-                    entities[i].dir = 0;
-                }
+                    if (entities[j].xp > entities[i].xp + 5)
+                    {
+                        entities[i].dir = 1;
+                    }
+                    else if (entities[j].xp < entities[i].xp - 5)
+                    {
+                        entities[i].dir = 0;
+                    }
 
-                if (entities[j].xp > entities[i].xp + 45)
-                {
-                    entities[i].ax = 3;
-                }
-                else if (entities[j].xp < entities[i].xp - 45)
-                {
-                    entities[i].ax = -3;
+                    if (entities[j].xp > entities[i].xp + 45)
+                    {
+                        entities[i].ax = 3;
+                    }
+                    else if (entities[j].xp < entities[i].xp - 45)
+                    {
+                        entities[i].ax = -3;
+                    }
                 }
             }
             else if (entities[i].state == 13)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
                 int j=getcrewman(3); //red
-                if (entities[j].xp > entities[i].xp + 5)
+                if (INBOUNDS_VEC(j, entities))
                 {
-                    entities[i].dir = 1;
-                }
-                else if (entities[j].xp < entities[i].xp - 5)
-                {
-                    entities[i].dir = 0;
-                }
+                    if (entities[j].xp > entities[i].xp + 5)
+                    {
+                        entities[i].dir = 1;
+                    }
+                    else if (entities[j].xp < entities[i].xp - 5)
+                    {
+                        entities[i].dir = 0;
+                    }
 
-                if (entities[j].xp > entities[i].xp + 45)
-                {
-                    entities[i].ax = 3;
-                }
-                else if (entities[j].xp < entities[i].xp - 45)
-                {
-                    entities[i].ax = -3;
+                    if (entities[j].xp > entities[i].xp + 45)
+                    {
+                        entities[i].ax = 3;
+                    }
+                    else if (entities[j].xp < entities[i].xp - 45)
+                    {
+                        entities[i].ax = -3;
+                    }
                 }
             }
             else if (entities[i].state == 14)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
                 int j=getcrewman(4); //green
-                if (entities[j].xp > entities[i].xp + 5)
+                if (INBOUNDS_VEC(j, entities))
                 {
-                    entities[i].dir = 1;
-                }
-                else if (entities[j].xp < entities[i].xp - 5)
-                {
-                    entities[i].dir = 0;
-                }
+                    if (entities[j].xp > entities[i].xp + 5)
+                    {
+                        entities[i].dir = 1;
+                    }
+                    else if (entities[j].xp < entities[i].xp - 5)
+                    {
+                        entities[i].dir = 0;
+                    }
 
-                if (entities[j].xp > entities[i].xp + 45)
-                {
-                    entities[i].ax = 3;
-                }
-                else if (entities[j].xp < entities[i].xp - 45)
-                {
-                    entities[i].ax = -3;
+                    if (entities[j].xp > entities[i].xp + 45)
+                    {
+                        entities[i].ax = 3;
+                    }
+                    else if (entities[j].xp < entities[i].xp - 45)
+                    {
+                        entities[i].ax = -3;
+                    }
                 }
             }
             else if (entities[i].state == 15)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
                 int j=getcrewman(5); //blue
-                if (entities[j].xp > entities[i].xp + 5)
+                if (INBOUNDS_VEC(j, entities))
                 {
-                    entities[i].dir = 1;
-                }
-                else if (entities[j].xp < entities[i].xp - 5)
-                {
-                    entities[i].dir = 0;
-                }
+                    if (entities[j].xp > entities[i].xp + 5)
+                    {
+                        entities[i].dir = 1;
+                    }
+                    else if (entities[j].xp < entities[i].xp - 5)
+                    {
+                        entities[i].dir = 0;
+                    }
 
-                if (entities[j].xp > entities[i].xp + 45)
-                {
-                    entities[i].ax = 3;
-                }
-                else if (entities[j].xp < entities[i].xp - 45)
-                {
-                    entities[i].ax = -3;
+                    if (entities[j].xp > entities[i].xp + 45)
+                    {
+                        entities[i].ax = 3;
+                    }
+                    else if (entities[j].xp < entities[i].xp - 45)
+                    {
+                        entities[i].ax = -3;
+                    }
                 }
             }
             else if (entities[i].state == 16)

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -10,7 +10,7 @@
 
 bool entityclass::checktowerspikes(int t)
 {
-    if (t < 0 || t >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities))
     {
         puts("checktowerspikes() out-of-bounds!");
         return false;
@@ -1063,7 +1063,7 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
 // Remove entity, and return true if entity was successfully removed
 bool entityclass::removeentity(int t)
 {
-    if (t < 0 || t > (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities))
     {
         puts("removeentity() out-of-bounds!");
         return true;
@@ -1084,7 +1084,7 @@ void entityclass::removeallblocks()
 
 void entityclass::removeblock( int t )
 {
-    if (t < 0 || t > (int) blocks.size())
+    if (!INBOUNDS_VEC(t, blocks))
     {
         puts("removeblock() out-of-bounds!");
         return;
@@ -1113,7 +1113,7 @@ void entityclass::removetrigger( int t )
 
 void entityclass::copylinecross( int t )
 {
-    if (t < 0 || t > (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities))
     {
         puts("copylinecross() out-of-bounds!");
         return;
@@ -1124,7 +1124,7 @@ void entityclass::copylinecross( int t )
 
 void entityclass::revertlinecross( int t, int s )
 {
-    if (t < 0 || t > (int) entities.size() || s < 0 || s > (int) linecrosskludge.size())
+    if (!INBOUNDS_VEC(t, entities) || !INBOUNDS_VEC(s, linecrosskludge))
     {
         puts("revertlinecross() out-of-bounds!");
         return;
@@ -2120,7 +2120,7 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
 //Returns true if entity is removed
 bool entityclass::updateentities( int i )
 {
-    if (i < 0 || i >= (int) entities.size())
+    if (!INBOUNDS_VEC(i, entities))
     {
         puts("updateentities() out-of-bounds!");
         return true;
@@ -3325,7 +3325,7 @@ bool entityclass::updateentities( int i )
 
 void entityclass::animateentities( int _i )
 {
-    if (_i < 0 || _i >= (int) entities.size())
+    if (!INBOUNDS_VEC(_i, entities))
     {
         puts("animateentities() out-of-bounds!");
         return;
@@ -3836,7 +3836,7 @@ void entityclass::rect2set( int xi, int yi, int wi, int hi )
 
 bool entityclass::entitycollide( int a, int b )
 {
-    if (a < 0 || a > (int) entities.size() || b < 0 || b > (int) entities.size())
+    if (!INBOUNDS_VEC(a, entities) || !INBOUNDS_VEC(b, entities))
     {
         puts("entitycollide() out-of-bounds!");
         return false;
@@ -3886,7 +3886,7 @@ bool entityclass::checkdamage(bool scm /*= false*/)
 
 void entityclass::settemprect( int t )
 {
-    if (t < 0 || t >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities))
     {
         return;
     }
@@ -4077,7 +4077,7 @@ int entityclass::yline( int a, int b )
 
 bool entityclass::entityhlinecollide( int t, int l )
 {
-    if (t < 0 || t >= (int) entities.size() || l < 0 || l >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities) || !INBOUNDS_VEC(l, entities))
     {
         puts("entityhlinecollide() out-of-bounds!");
         return false;
@@ -4104,7 +4104,7 @@ bool entityclass::entityhlinecollide( int t, int l )
 
 bool entityclass::entityvlinecollide( int t, int l )
 {
-    if (t < 0 || t >= (int) entities.size() || l < 0 || l >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities) || !INBOUNDS_VEC(l, entities))
     {
         puts("entityvlinecollide() out-of-bounds!");
         return false;
@@ -4128,7 +4128,7 @@ bool entityclass::entityvlinecollide( int t, int l )
 }
 
 bool entityclass::entitywarphlinecollide(int t, int l) {
-    if (t < 0 || t >= (int) entities.size() || l < 0 || l >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities) || !INBOUNDS_VEC(l, entities))
     {
         puts("entitywarphlinecollide() out-of-bounds!");
         return false;
@@ -4166,7 +4166,7 @@ bool entityclass::entitywarphlinecollide(int t, int l) {
 }
 
 bool entityclass::entitywarpvlinecollide(int t, int l) {
-    if (t < 0 || t >= (int) entities.size() || l < 0 || l >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities) || !INBOUNDS_VEC(l, entities))
     {
         puts("entitywarpvlinecollide() out-of-bounds!");
         return false;
@@ -4201,7 +4201,7 @@ bool entityclass::entitywarpvlinecollide(int t, int l) {
 
 float entityclass::entitycollideplatformroof( int t )
 {
-    if (t < 0 || t >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities))
     {
         puts("entitycollideplatformroof() out-of-bounds!");
         return -1000;
@@ -4223,7 +4223,7 @@ float entityclass::entitycollideplatformroof( int t )
 
 float entityclass::entitycollideplatformfloor( int t )
 {
-    if (t < 0 || t >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities))
     {
         puts("entitycollideplatformfloor() out-of-bounds!");
         return -1000;
@@ -4245,7 +4245,7 @@ float entityclass::entitycollideplatformfloor( int t )
 
 bool entityclass::entitycollidefloor( int t )
 {
-    if (t < 0 || t >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities))
     {
         puts("entitycollidefloor() out-of-bounds!");
         return false;
@@ -4264,7 +4264,7 @@ bool entityclass::entitycollidefloor( int t )
 
 bool entityclass::entitycollideroof( int t )
 {
-    if (t < 0 || t >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities))
     {
         puts("entitycollideroof() out-of-bounds!");
         return false;
@@ -4283,7 +4283,7 @@ bool entityclass::entitycollideroof( int t )
 
 bool entityclass::testwallsx( int t, int tx, int ty )
 {
-    if (t < 0 || t >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities))
     {
         puts("testwallsx() out-of-bounds!");
         return false;
@@ -4335,7 +4335,7 @@ bool entityclass::testwallsx( int t, int tx, int ty )
 
 bool entityclass::testwallsy( int t, float tx, float ty )
 {
-    if (t < 0 || t >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities))
     {
         puts("testwallsy() out-of-bounds!");
         return false;
@@ -4388,7 +4388,7 @@ bool entityclass::testwallsy( int t, float tx, float ty )
 
 void entityclass::fixfriction( int t, float xfix, float xrate, float yrate )
 {
-    if (t < 0 || t >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities))
     {
         puts("fixfriction() out-of-bounds!");
         return;
@@ -4409,7 +4409,7 @@ void entityclass::fixfriction( int t, float xfix, float xrate, float yrate )
 
 void entityclass::applyfriction( int t, float xrate, float yrate )
 {
-    if (t < 0 || t >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities))
     {
         puts("applyfriction() out-of-bounds!");
         return;
@@ -4430,7 +4430,7 @@ void entityclass::applyfriction( int t, float xrate, float yrate )
 
 void entityclass::updateentitylogic( int t )
 {
-    if (t < 0 || t >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities))
     {
         puts("updateentitylogic() out-of-bounds!");
         return;
@@ -4470,7 +4470,7 @@ void entityclass::updateentitylogic( int t )
 
 void entityclass::entitymapcollision( int t )
 {
-    if (t < 0 || t >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities))
     {
         puts("entitymapcollision() out-of-bounds!");
         return;
@@ -4540,7 +4540,7 @@ void entityclass::movingplatformfix( int t, int j )
 
 void entityclass::hormovingplatformfix( int t )
 {
-    if (t < 0 || t >= (int) entities.size())
+    if (!INBOUNDS_VEC(t, entities))
     {
         puts("hormovingplatformfix() out-of-bounds!");
         return;
@@ -4552,7 +4552,7 @@ void entityclass::hormovingplatformfix( int t )
 }
 
 void entityclass::customwarplinecheck(int i) {
-    if (i < 0 || i >= (int) entities.size())
+    if (!INBOUNDS_VEC(i, entities))
     {
         puts("customwarplinecheck() out-of-bounds!");
         return;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2093,11 +2093,11 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
             // Face the player
             // FIXME: Duplicated from updateentities!
             int j = getplayer();
-            if (j > -1 && entities[j].xp > entity.xp + 5)
+            if (INBOUNDS_VEC(j, entities) && entities[j].xp > entity.xp + 5)
             {
                 entity.dir = 1;
             }
-            else if (j > -1 && entities[j].xp < entity.xp - 5)
+            else if (INBOUNDS_VEC(j, entities) && entities[j].xp < entity.xp - 5)
             {
                 entity.dir = 0;
             }
@@ -2422,7 +2422,7 @@ bool entityclass::updateentities( int i )
                 {
                     int player = getplayer();
                     //first, y position
-                    if (player > -1 && entities[player].yp > 14 * 8)
+                    if (INBOUNDS_VEC(player, entities) && entities[player].yp > 14 * 8)
                     {
                         entities[i].tile = 120;
                         entities[i].yp = (28*8)-62;
@@ -2435,7 +2435,7 @@ bool entityclass::updateentities( int i )
                         entities[i].oldyp = 24;
                     }
                     //now, x position
-                    if (player > -1 && entities[player].xp > 20 * 8)
+                    if (INBOUNDS_VEC(player, entities) && entities[player].xp > 20 * 8)
                     {
                         //approach from the left
                         entities[i].xp = -64;
@@ -2647,7 +2647,7 @@ bool entityclass::updateentities( int i )
                 game.saverx = game.roomx;
                 game.savery = game.roomy;
                 int player = getplayer();
-                if (player > -1)
+                if (INBOUNDS_VEC(player, entities))
                 {
                     game.savedir = entities[player].dir;
                 }
@@ -2680,11 +2680,11 @@ bool entityclass::updateentities( int i )
                 temp = getplayer();
                 if (game.gravitycontrol == 0)
                 {
-                    if (temp > -1 && entities[temp].vy < 3) entities[temp].vy = 3;
+                    if (INBOUNDS_VEC(temp, entities) && entities[temp].vy < 3) entities[temp].vy = 3;
                 }
                 else
                 {
-                    if (temp > -1 && entities[temp].vy > -3) entities[temp].vy = -3;
+                    if (INBOUNDS_VEC(temp, entities) && entities[temp].vy > -3) entities[temp].vy = -3;
                 }
             }
             else if (entities[i].state == 2)
@@ -2737,20 +2737,20 @@ bool entityclass::updateentities( int i )
                 if (entities[k].rule == 7)	entities[k].tile = 6;
                 //Stay close to the hero!
                 int j = getplayer();
-                if (j > -1 && entities[j].xp > entities[i].xp + 5)
+                if (INBOUNDS_VEC(j, entities) && entities[j].xp > entities[i].xp + 5)
                 {
                     entities[i].dir = 1;
                 }
-                else if (j > -1 && entities[j].xp < entities[i].xp - 5)
+                else if (INBOUNDS_VEC(j, entities) && entities[j].xp < entities[i].xp - 5)
                 {
                     entities[i].dir = 0;
                 }
 
-                if (j > -1 && entities[j].xp > entities[i].xp + 45)
+                if (INBOUNDS_VEC(j, entities) && entities[j].xp > entities[i].xp + 45)
                 {
                     entities[i].ax = 3;
                 }
-                else if (j > -1 && entities[j].xp < entities[i].xp - 45)
+                else if (INBOUNDS_VEC(j, entities) && entities[j].xp < entities[i].xp - 45)
                 {
                     entities[i].ax = -3;
                 }
@@ -2768,20 +2768,20 @@ bool entityclass::updateentities( int i )
             {
                 //Basic rules, don't change expression
                 int j = getplayer();
-                if (j > -1 && entities[j].xp > entities[i].xp + 5)
+                if (INBOUNDS_VEC(j, entities) && entities[j].xp > entities[i].xp + 5)
                 {
                     entities[i].dir = 1;
                 }
-                else if (j > -1 && entities[j].xp < entities[i].xp - 5)
+                else if (INBOUNDS_VEC(j, entities) && entities[j].xp < entities[i].xp - 5)
                 {
                     entities[i].dir = 0;
                 }
 
-                if (j > -1 && entities[j].xp > entities[i].xp + 45)
+                if (INBOUNDS_VEC(j, entities) && entities[j].xp > entities[i].xp + 45)
                 {
                     entities[i].ax = 3;
                 }
-                else if (j > -1 && entities[j].xp < entities[i].xp - 45)
+                else if (INBOUNDS_VEC(j, entities) && entities[j].xp < entities[i].xp - 45)
                 {
                     entities[i].ax = -3;
                 }
@@ -2791,20 +2791,20 @@ bool entityclass::updateentities( int i )
                 //Everything from 10 on is for cutscenes
                 //Basic rules, don't change expression
                 int j = getplayer();
-                if (j > -1 && entities[j].xp > entities[i].xp + 5)
+                if (INBOUNDS_VEC(j, entities) && entities[j].xp > entities[i].xp + 5)
                 {
                     entities[i].dir = 1;
                 }
-                else if (j > -1 && entities[j].xp < entities[i].xp - 5)
+                else if (INBOUNDS_VEC(j, entities) && entities[j].xp < entities[i].xp - 5)
                 {
                     entities[i].dir = 0;
                 }
 
-                if (j > -1 && entities[j].xp > entities[i].xp + 45)
+                if (INBOUNDS_VEC(j, entities) && entities[j].xp > entities[i].xp + 45)
                 {
                     entities[i].ax = 3;
                 }
-                else if (j > -1 && entities[j].xp < entities[i].xp - 45)
+                else if (INBOUNDS_VEC(j, entities) && entities[j].xp < entities[i].xp - 45)
                 {
                     entities[i].ax = -3;
                 }
@@ -2949,11 +2949,11 @@ bool entityclass::updateentities( int i )
                 //Stand still and face the player
                 //FIXME: Duplicated in createentity!
                 int j = getplayer();
-                if (j > -1 && entities[j].xp > entities[i].xp + 5)
+                if (INBOUNDS_VEC(j, entities) && entities[j].xp > entities[i].xp + 5)
                 {
                     entities[i].dir = 1;
                 }
-                else if (j > -1 && entities[j].xp < entities[i].xp - 5)
+                else if (INBOUNDS_VEC(j, entities) && entities[j].xp < entities[i].xp - 5)
                 {
                     entities[i].dir = 0;
                 }
@@ -3065,7 +3065,7 @@ bool entityclass::updateentities( int i )
             {
                 //follow player, but only if he's on the floor!
                 int j = getplayer();
-                if(j > -1 && entities[j].onground>0)
+                if(INBOUNDS_VEC(j, entities) && entities[j].onground>0)
                 {
                     if (entities[j].xp > entities[i].xp + 5)
                     {
@@ -3091,11 +3091,11 @@ bool entityclass::updateentities( int i )
                 }
                 else
                 {
-                    if (j > -1 && entities[j].xp > entities[i].xp + 5)
+                    if (INBOUNDS_VEC(j, entities) && entities[j].xp > entities[i].xp + 5)
                     {
                         entities[i].dir = 1;
                     }
-                    else if (j > -1 && entities[j].xp < entities[i].xp - 5)
+                    else if (INBOUNDS_VEC(j, entities) && entities[j].xp < entities[i].xp - 5)
                     {
                         entities[i].dir = 0;
                     }
@@ -3156,7 +3156,7 @@ bool entityclass::updateentities( int i )
         case 51: //Vertical warp line
             if (entities[i].state == 2){
               int j=getplayer();
-              if(j > -1 && entities[j].xp<=307){
+              if(INBOUNDS_VEC(j, entities) && entities[j].xp<=307){
                 customwarpmodevon=false;
                 entities[i].state = 0;
               }
@@ -3171,7 +3171,7 @@ bool entityclass::updateentities( int i )
         case 52: //Vertical warp line
             if (entities[i].state == 2){
               int j=getplayer();
-              if(j > -1 && entities[j].xp<=307){
+              if(INBOUNDS_VEC(j, entities) && entities[j].xp<=307){
                 customwarpmodevon=false;
                 entities[i].state = 0;
               }
@@ -3213,11 +3213,11 @@ bool entityclass::updateentities( int i )
             {
                 //Basic rules, don't change expression
                 int j = getplayer();
-                if (j > -1 && entities[j].xp > entities[i].xp + 5)
+                if (INBOUNDS_VEC(j, entities) && entities[j].xp > entities[i].xp + 5)
                 {
                     entities[i].dir = 1;
                 }
-                else if (j > -1 && entities[j].xp < entities[i].xp - 5)
+                else if (INBOUNDS_VEC(j, entities) && entities[j].xp < entities[i].xp - 5)
                 {
                     entities[i].dir = 0;
                 }
@@ -3284,7 +3284,7 @@ bool entityclass::updateentities( int i )
                     game.saverx = game.roomx;
                     game.savery = game.roomy;
                     int player = getplayer();
-                    if (player > -1)
+                    if (INBOUNDS_VEC(player, entities))
                     {
                         game.savedir = entities[player].dir;
                     }
@@ -4632,7 +4632,7 @@ void entityclass::entitycollisioncheck()
     // WARNING: If updating this code, don't forget to update Map.cpp mapclass::twoframedelayfix()
     activetrigger = -1;
     int block_idx = -1;
-    if (checktrigger(&block_idx) > -1 && block_idx > -1)
+    if (INBOUNDS_VEC(checktrigger(&block_idx), entities) && INBOUNDS_VEC(block_idx, blocks))
     {
         // Load the block's script if its gamestate is out of range
         if (blocks[block_idx].script != "" && (activetrigger < 300 || activetrigger > 336))

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -397,7 +397,7 @@ void Game::lifesequence()
     if (lifeseq > 0)
     {
         int i = obj.getplayer();
-        if (i > -1)
+        if (INBOUNDS_VEC(i, obj.entities))
         {
             obj.entities[i].invis = false;
             if (lifeseq == 2) obj.entities[i].invis = true;
@@ -407,7 +407,7 @@ void Game::lifesequence()
         if (lifeseq > 5) gravitycontrol = savegc;
 
         lifeseq--;
-        if (i > -1 && lifeseq <= 0)
+        if (INBOUNDS_VEC(i, obj.entities) && lifeseq <= 0)
         {
             obj.entities[i].invis = false;
         }
@@ -862,7 +862,7 @@ void Game::updatestate()
         {
             //leaving the naughty corner
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[obj.getplayer()].tile = 0;
             }
@@ -873,7 +873,7 @@ void Game::updatestate()
         {
             //entering the naughty corner
             int i = obj.getplayer();
-            if(i > -1 && obj.entities[i].tile == 0)
+            if(INBOUNDS_VEC(i, obj.entities) && obj.entities[i].tile == 0)
             {
                 obj.entities[i].tile = 144;
                 music.playef(2);
@@ -1470,12 +1470,12 @@ void Game::updatestate()
 
             int i = obj.getplayer();
             hascontrol = false;
-            if (i > -1 && obj.entities[i].onroof > 0 && gravitycontrol == 1)
+            if (INBOUNDS_VEC(i, obj.entities) && obj.entities[i].onroof > 0 && gravitycontrol == 1)
             {
                 gravitycontrol = 0;
                 music.playef(1);
             }
-            if (i > -1 && obj.entities[i].onground > 0)
+            if (INBOUNDS_VEC(i, obj.entities) && obj.entities[i].onground > 0)
             {
                 state++;
             }
@@ -1487,7 +1487,7 @@ void Game::updatestate()
 
             companion = 6;
             int i = obj.getcompanion();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].tile = 0;
                 obj.entities[i].state = 1;
@@ -1516,7 +1516,7 @@ void Game::updatestate()
             music.playef(2);
             graphics.textboxactive();
             int i = obj.getcompanion();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].tile = 54;
                 obj.entities[i].state = 0;
@@ -1534,7 +1534,7 @@ void Game::updatestate()
         {
 
             int i = obj.getcompanion();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].tile = 0;
                 obj.entities[i].state = 1;
@@ -1594,12 +1594,12 @@ void Game::updatestate()
 
             int i = obj.getplayer();
             hascontrol = false;
-            if (i > -1 && obj.entities[i].onground > 0 && gravitycontrol == 0)
+            if (INBOUNDS_VEC(i, obj.entities) && obj.entities[i].onground > 0 && gravitycontrol == 0)
             {
                 gravitycontrol = 1;
                 music.playef(1);
             }
-            if (i > -1 && obj.entities[i].onroof > 0)
+            if (INBOUNDS_VEC(i, obj.entities) && obj.entities[i].onroof > 0)
             {
                 state++;
             }
@@ -1610,7 +1610,7 @@ void Game::updatestate()
         {
             companion = 7;
             int i = obj.getcompanion();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].tile = 6;
                 obj.entities[i].state = 1;
@@ -1631,7 +1631,7 @@ void Game::updatestate()
             state++;
             music.playef(2);
             graphics.textboxactive();
-            int i = obj.getcompanion(); if (i > -1) {	/*obj.entities[i].tile = 66;	obj.entities[i].state = 0;*/	}
+            int i = obj.getcompanion(); if (INBOUNDS_VEC(i, obj.entities)) {	/*obj.entities[i].tile = 66;	obj.entities[i].state = 0;*/	}
             break;
         }
         case 126:
@@ -1655,7 +1655,7 @@ void Game::updatestate()
             music.playef(14);
             graphics.textboxactive();
             int i = obj.getcompanion();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].tile = 6;
                 obj.entities[i].state = 1;
@@ -1976,13 +1976,13 @@ void Game::updatestate()
             statedelay = 5;
 
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].colour = 0;
                 obj.entities[i].invis = false;
 
                 int j = obj.getteleporter();
-                if (j > -1)
+                if (INBOUNDS_VEC(j, obj.entities))
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
@@ -1996,7 +1996,7 @@ void Game::updatestate()
             }
 
             i = obj.getteleporter();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].tile = 1;
                 obj.entities[i].colour = 101;
@@ -2007,7 +2007,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 10;
             }
@@ -2017,7 +2017,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 //obj.entities[i].xp += 10;
             }
@@ -2027,7 +2027,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 8;
             }
@@ -2037,7 +2037,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 6;
             }
@@ -2047,7 +2047,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 //obj.entities[i].xp += 4;
             }
@@ -2057,7 +2057,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 2;
             }
@@ -2068,7 +2068,7 @@ void Game::updatestate()
             state++;
             statedelay = 15;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 1;
             }
@@ -2169,20 +2169,20 @@ void Game::updatestate()
             }
 
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].colour = 0;
                 obj.entities[i].invis = true;
             }
 
             i = obj.getcompanion();
-            if(i>-1)
+            if(INBOUNDS_VEC(i, obj.entities))
             {
                 obj.removeentity(i);
             }
 
             i = obj.getteleporter();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].tile = 1;
                 obj.entities[i].colour = 100;
@@ -3169,7 +3169,7 @@ void Game::updatestate()
         {
             //Activating a teleporter (long version for level complete)
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].colour = 102;
             }
@@ -3211,7 +3211,7 @@ void Game::updatestate()
             screenshake = 0;
 
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].colour = 0;
                 obj.entities[i].invis = true;
@@ -3304,14 +3304,14 @@ void Game::updatestate()
             //state = 3040; //Lab
 
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].colour = 0;
                 obj.entities[i].invis = true;
             }
 
             i = obj.getteleporter();
-            if(i>-1)
+            if(INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].tile = 1;
                 obj.entities[i].colour = 100;
@@ -3348,9 +3348,9 @@ void Game::updatestate()
 
             int i = obj.getplayer();
             int j = obj.getteleporter();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
-                if (j != -1)
+                if (INBOUNDS_VEC(j, obj.entities))
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
@@ -3374,7 +3374,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 10;
             }
@@ -3384,7 +3384,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 10;
             }
@@ -3394,7 +3394,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 8;
             }
@@ -3404,7 +3404,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 6;
             }
@@ -3414,7 +3414,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 3;
             }
@@ -3425,7 +3425,7 @@ void Game::updatestate()
             state++;
             statedelay = 15;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 1;
             }
@@ -3442,7 +3442,7 @@ void Game::updatestate()
             }
             int i = obj.getteleporter();
             activetele = true;
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 teleblock.x = obj.entities[i].xp - 32;
                 teleblock.y = obj.entities[i].yp - 32;
@@ -3479,9 +3479,9 @@ void Game::updatestate()
 
             int i = obj.getplayer();
             int j = obj.getteleporter();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
-                if (j != -1)
+                if (INBOUNDS_VEC(j, obj.entities))
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
@@ -3505,7 +3505,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 12;
             }
@@ -3515,7 +3515,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 12;
             }
@@ -3525,7 +3525,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 10;
             }
@@ -3535,7 +3535,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 8;
             }
@@ -3545,7 +3545,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 5;
             }
@@ -3556,7 +3556,7 @@ void Game::updatestate()
             state++;
             statedelay = 15;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 2;
             }
@@ -3592,9 +3592,9 @@ void Game::updatestate()
 
             int i = obj.getplayer();
             int j = obj.getteleporter();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
-                if (j != -1)
+                if (INBOUNDS_VEC(j, obj.entities))
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
@@ -3618,7 +3618,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp -= 12;
             }
@@ -3628,7 +3628,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp -= 12;
             }
@@ -3638,7 +3638,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp -= 10;
             }
@@ -3648,7 +3648,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp -= 8;
             }
@@ -3658,7 +3658,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp -= 5;
             }
@@ -3669,7 +3669,7 @@ void Game::updatestate()
             state++;
             statedelay = 15;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp -= 2;
             }
@@ -3705,9 +3705,9 @@ void Game::updatestate()
 
             int i = obj.getplayer();
             int j = obj.getteleporter();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
-                if (j != -1)
+                if (INBOUNDS_VEC(j, obj.entities))
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
@@ -3731,7 +3731,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 12;
                 obj.entities[i].yp -= 15;
@@ -3742,7 +3742,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 12;
                 obj.entities[i].yp -= 10;
@@ -3753,7 +3753,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 12;
                 obj.entities[i].yp -= 10;
@@ -3764,7 +3764,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 8;
                 obj.entities[i].yp -= 8;
@@ -3775,7 +3775,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 6;
                 obj.entities[i].yp -= 8;
@@ -3787,7 +3787,7 @@ void Game::updatestate()
             state++;
             statedelay = 15;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 3;
             }
@@ -3823,9 +3823,9 @@ void Game::updatestate()
 
             int i = obj.getplayer();
             int j = obj.getteleporter();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
-                if (j != -1)
+                if (INBOUNDS_VEC(j, obj.entities))
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
@@ -3849,7 +3849,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 4;
                 obj.entities[i].yp -= 15;
@@ -3860,7 +3860,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 4;
                 obj.entities[i].yp -= 10;
@@ -3871,7 +3871,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 4;
                 obj.entities[i].yp -= 10;
@@ -3882,7 +3882,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 4;
                 obj.entities[i].yp -= 8;
@@ -3893,7 +3893,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 2;
                 obj.entities[i].yp -= 8;
@@ -3905,7 +3905,7 @@ void Game::updatestate()
             state++;
             statedelay = 15;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 1;
             }
@@ -3941,9 +3941,9 @@ void Game::updatestate()
 
             int i = obj.getplayer();
             int j = obj.getteleporter();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
-                if (j != -1)
+                if (INBOUNDS_VEC(j, obj.entities))
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
@@ -3967,7 +3967,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp -= 28;
                 obj.entities[i].yp -= 8;
@@ -3978,7 +3978,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp -= 28;
                 obj.entities[i].yp -= 8;
@@ -3989,7 +3989,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp -= 25;
             }
@@ -3999,7 +3999,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp -= 25;
             }
@@ -4009,7 +4009,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp -= 20;
             }
@@ -4020,7 +4020,7 @@ void Game::updatestate()
             state++;
             statedelay = 15;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp -= 16;
             }
@@ -4057,9 +4057,9 @@ void Game::updatestate()
 
             int i = obj.getplayer();
             int j = obj.getteleporter();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
-                if (j != -1)
+                if (INBOUNDS_VEC(j, obj.entities))
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
@@ -4083,7 +4083,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 10;
             }
@@ -4093,7 +4093,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 10;
             }
@@ -4103,7 +4103,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 8;
             }
@@ -4113,7 +4113,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 6;
             }
@@ -4123,7 +4123,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 3;
             }
@@ -4134,7 +4134,7 @@ void Game::updatestate()
             state++;
             statedelay = 15;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 1;
             }
@@ -4170,9 +4170,9 @@ void Game::updatestate()
 
             int i = obj.getplayer();
             int j = obj.getteleporter();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
-                if (j != -1)
+                if (INBOUNDS_VEC(j, obj.entities))
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
@@ -4196,7 +4196,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 10;
             }
@@ -4206,7 +4206,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 10;
             }
@@ -4216,7 +4216,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 8;
             }
@@ -4226,7 +4226,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 6;
             }
@@ -4236,7 +4236,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 3;
             }
@@ -4247,7 +4247,7 @@ void Game::updatestate()
             state++;
             statedelay = 15;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 1;
             }
@@ -4283,9 +4283,9 @@ void Game::updatestate()
 
             int i = obj.getplayer();
             int j = obj.getteleporter();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
-                if (j != -1)
+                if (INBOUNDS_VEC(j, obj.entities))
                 {
                     obj.entities[i].xp = obj.entities[j].xp+44;
                     obj.entities[i].yp = obj.entities[j].yp+44;
@@ -4309,7 +4309,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 10;
             }
@@ -4319,7 +4319,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 10;
             }
@@ -4329,7 +4329,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 8;
             }
@@ -4339,7 +4339,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 6;
             }
@@ -4349,7 +4349,7 @@ void Game::updatestate()
         {
             state++;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 3;
             }
@@ -4360,7 +4360,7 @@ void Game::updatestate()
             state++;
             statedelay = 15;
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].xp += 1;
             }
@@ -5032,7 +5032,7 @@ void Game::deathsequence()
     {
         i = obj.getplayer();
     }
-    if (i > -1)
+    if (INBOUNDS_VEC(i, obj.entities))
     {
         obj.entities[i].colour = 1;
 
@@ -5047,7 +5047,7 @@ void Game::deathsequence()
         }
         deathcounts++;
         music.playef(2);
-        if (i > -1)
+        if (INBOUNDS_VEC(i, obj.entities))
         {
             obj.entities[i].invis = true;
         }
@@ -5068,7 +5068,7 @@ void Game::deathsequence()
             }
         }
     }
-    if (i > -1)
+    if (INBOUNDS_VEC(i, obj.entities))
     {
         if (deathseq == 25) obj.entities[i].invis = true;
         if (deathseq == 20) obj.entities[i].invis = true;
@@ -5079,7 +5079,7 @@ void Game::deathsequence()
     }
     if (!nodeathmode)
     {
-        if (i > -1 && deathseq <= 1) obj.entities[i].invis = false;
+        if (INBOUNDS_VEC(i, obj.entities) && deathseq <= 1) obj.entities[i].invis = false;
     }
     else
     {
@@ -7166,7 +7166,7 @@ void Game::returntolab()
     graphics.fademode = 4;
     map.gotoroom(119, 107);
     int player = obj.getplayer();
-    if (player > -1)
+    if (INBOUNDS_VEC(player, obj.entities))
     {
         obj.entities[player].xp = 132;
         obj.entities[player].yp = 137;
@@ -7179,7 +7179,7 @@ void Game::returntolab()
     savex = 132;
     savey = 137;
     savegc = 0;
-    if (player > -1)
+    if (INBOUNDS_VEC(player, obj.entities))
     {
         savedir = obj.entities[player].dir;
     }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -641,7 +641,6 @@ void Game::savecustomlevelstats()
 
 void Game::updatestate()
 {
-    int i, j;
     statedelay--;
     if(statedelay<=0){
         statedelay=0;
@@ -1469,7 +1468,7 @@ void Game::updatestate()
         {
 
 
-            i = obj.getplayer();
+            int i = obj.getplayer();
             hascontrol = false;
             if (i > -1 && obj.entities[i].onroof > 0 && gravitycontrol == 1)
             {
@@ -1487,7 +1486,7 @@ void Game::updatestate()
 
 
             companion = 6;
-            i = obj.getcompanion();
+            int i = obj.getcompanion();
             if (i > -1)
             {
                 obj.entities[i].tile = 0;
@@ -1516,7 +1515,7 @@ void Game::updatestate()
             state++;
             music.playef(2);
             graphics.textboxactive();
-            i = obj.getcompanion();
+            int i = obj.getcompanion();
             if (i > -1)
             {
                 obj.entities[i].tile = 54;
@@ -1534,7 +1533,7 @@ void Game::updatestate()
         case 110:
         {
 
-            i = obj.getcompanion();
+            int i = obj.getcompanion();
             if (i > -1)
             {
                 obj.entities[i].tile = 0;
@@ -1560,7 +1559,7 @@ void Game::updatestate()
             //                       Test script for space station, totally delete me!
             //
         {
-            i = obj.getplayer();
+            int i = obj.getplayer();
             hascontrol = false;
             state++;
         }
@@ -1596,7 +1595,7 @@ void Game::updatestate()
         case 121:
         {
 
-            i = obj.getplayer();
+            int i = obj.getplayer();
             hascontrol = false;
             if (i > -1 && obj.entities[i].onground > 0 && gravitycontrol == 0)
             {
@@ -1611,8 +1610,9 @@ void Game::updatestate()
         }
         break;
         case 122:
+        {
             companion = 7;
-            i = obj.getcompanion();
+            int i = obj.getcompanion();
             if (i > -1)
             {
                 obj.entities[i].tile = 6;
@@ -1626,14 +1626,17 @@ void Game::updatestate()
             state++;
             music.playef(14);
             break;
+        }
         case 124:
+        {
             graphics.createtextbox("I've found a teleporter, but", 60-20, 90 - 40, 255, 255, 134);
             graphics.addline("I can't get it to go anywhere...");
             state++;
             music.playef(2);
             graphics.textboxactive();
-            i = obj.getcompanion(); if (i > -1) {	/*obj.entities[i].tile = 66;	obj.entities[i].state = 0;*/	}
+            int i = obj.getcompanion(); if (i > -1) {	/*obj.entities[i].tile = 66;	obj.entities[i].state = 0;*/	}
             break;
+        }
         case 126:
             graphics.createtextbox("I can help with that!", 125, 152-40, 164, 164, 255);
             state++;
@@ -1649,17 +1652,19 @@ void Game::updatestate()
             break;
 
         case 130:
+        {
             graphics.createtextbox("Yey! Let's go home!", 60-30, 90-35, 255, 255, 134);
             state++;
             music.playef(14);
             graphics.textboxactive();
-            i = obj.getcompanion();
+            int i = obj.getcompanion();
             if (i > -1)
             {
                 obj.entities[i].tile = 6;
                 obj.entities[i].state = 1;
             }
             break;
+        }
         case 132:
             graphics.textboxremove();
             hascontrol = true;
@@ -1973,7 +1978,7 @@ void Game::updatestate()
             state++;
             statedelay = 5;
 
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].colour = 0;
@@ -2002,62 +2007,76 @@ void Game::updatestate()
             break;
         }
         case 2503:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 10;
             }
             break;
+        }
         case 2504:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 //obj.entities[i].xp += 10;
             }
             break;
+        }
         case 2505:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 8;
             }
             break;
+        }
         case 2506:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 6;
             }
             break;
+        }
         case 2507:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 //obj.entities[i].xp += 4;
             }
             break;
+        }
         case 2508:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 2;
             }
             break;
+        }
         case 2509:
+        {
             state++;
             statedelay = 15;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 1;
             }
             break;
+        }
         case 2510:
             advancetext = true;
             hascontrol = false;
@@ -2123,6 +2142,7 @@ void Game::updatestate()
             music.playef(10);
             break;
         case 3005:
+        {
             //Activating a teleporter 2
             state++;
             statedelay = 50;
@@ -2151,7 +2171,7 @@ void Game::updatestate()
                 break; //Intermission 1
             }
 
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].colour = 0;
@@ -2171,6 +2191,7 @@ void Game::updatestate()
                 obj.entities[i].colour = 100;
             }
             break;
+        }
 
         case 3006:
             //Level complete! (warp zone)
@@ -3148,8 +3169,9 @@ void Game::updatestate()
             }
             break;
         case 3511:
+        {
             //Activating a teleporter (long version for level complete)
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].colour = 102;
@@ -3161,6 +3183,7 @@ void Game::updatestate()
             screenshake = 90;
             music.playef(9);
             break;
+        }
         case 3512:
             //Activating a teleporter 2
             state++;
@@ -3183,13 +3206,14 @@ void Game::updatestate()
             music.playef(9);
             break;
         case 3515:
+        {
             //Activating a teleporter 2
             state++;
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
 
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].colour = 0;
@@ -3200,6 +3224,7 @@ void Game::updatestate()
             music.playef(10);
             statedelay = 60;
             break;
+        }
         case 3516:
             graphics.fademode = 2;
             state++;
@@ -3272,6 +3297,7 @@ void Game::updatestate()
             music.playef(10);
             break;
         case 4002:
+        {
             //Activating a teleporter 2
             state++;
             statedelay = 10;
@@ -3280,7 +3306,7 @@ void Game::updatestate()
             //state = 3020; //Space Station
             //state = 3040; //Lab
 
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].colour = 0;
@@ -3294,6 +3320,7 @@ void Game::updatestate()
                 obj.entities[i].colour = 100;
             }
             break;
+        }
         case 4003:
             state = 0;
             statedelay = 0;
@@ -3317,12 +3344,13 @@ void Game::updatestate()
             music.playef(10);
             break;
         case 4012:
+        {
             //Activating a teleporter 2
             state++;
             statedelay = 5;
 
-            i = obj.getplayer();
-            j = obj.getteleporter();
+            int i = obj.getplayer();
+            int j = obj.getteleporter();
             if (i > -1)
             {
                 if (j != -1)
@@ -3344,56 +3372,70 @@ void Game::updatestate()
                 obj.entities[i].vx = 6;
             }
             break;
+        }
         case 4013:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 10;
             }
             break;
+        }
         case 4014:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 10;
             }
             break;
+        }
         case 4015:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 8;
             }
             break;
+        }
         case 4016:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 6;
             }
             break;
+        }
         case 4017:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 3;
             }
             break;
+        }
         case 4018:
+        {
             state++;
             statedelay = 15;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 1;
             }
             break;
+        }
         case 4019:
+        {
             if (intimetrial || nodeathmode || inintermission)
             {
             }
@@ -3401,7 +3443,7 @@ void Game::updatestate()
             {
                 savetele();
             }
-            i = obj.getteleporter();
+            int i = obj.getteleporter();
             activetele = true;
             if (i > -1)
             {
@@ -3414,6 +3456,7 @@ void Game::updatestate()
             advancetext = false;
             state = 0;
             break;
+        }
 
         case 4020:
             //Activating a teleporter (default appear)
@@ -3432,12 +3475,13 @@ void Game::updatestate()
             music.playef(10);
             break;
         case 4022:
+        {
             //Activating a teleporter 2
             state++;
             statedelay = 5;
 
-            i = obj.getplayer();
-            j = obj.getteleporter();
+            int i = obj.getplayer();
+            int j = obj.getteleporter();
             if (i > -1)
             {
                 if (j != -1)
@@ -3459,55 +3503,68 @@ void Game::updatestate()
                 obj.entities[i].vx = 6;
             }
             break;
+        }
         case 4023:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 12;
             }
             break;
+        }
         case 4024:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 12;
             }
             break;
+        }
         case 4025:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 10;
             }
             break;
+        }
         case 4026:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 8;
             }
             break;
+        }
         case 4027:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 5;
             }
             break;
+        }
         case 4028:
+        {
             state++;
             statedelay = 15;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 2;
             }
             break;
+        }
         case 4029:
             hascontrol = true;
             advancetext = false;
@@ -3531,12 +3588,13 @@ void Game::updatestate()
             music.playef(10);
             break;
         case 4032:
+        {
             //Activating a teleporter 2
             state++;
             statedelay = 5;
 
-            i = obj.getplayer();
-            j = obj.getteleporter();
+            int i = obj.getplayer();
+            int j = obj.getteleporter();
             if (i > -1)
             {
                 if (j != -1)
@@ -3558,55 +3616,68 @@ void Game::updatestate()
                 obj.entities[i].vx = -6;
             }
             break;
+        }
         case 4033:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp -= 12;
             }
             break;
+        }
         case 4034:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp -= 12;
             }
             break;
+        }
         case 4035:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp -= 10;
             }
             break;
+        }
         case 4036:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp -= 8;
             }
             break;
+        }
         case 4037:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp -= 5;
             }
             break;
+        }
         case 4038:
+        {
             state++;
             statedelay = 15;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp -= 2;
             }
             break;
+        }
         case 4039:
             hascontrol = true;
             advancetext = false;
@@ -3630,12 +3701,13 @@ void Game::updatestate()
             music.playef(10);
             break;
         case 4042:
+        {
             //Activating a teleporter 2
             state++;
             statedelay = 5;
 
-            i = obj.getplayer();
-            j = obj.getteleporter();
+            int i = obj.getplayer();
+            int j = obj.getteleporter();
             if (i > -1)
             {
                 if (j != -1)
@@ -3657,60 +3729,73 @@ void Game::updatestate()
                 obj.entities[i].vx = 6;
             }
             break;
+        }
         case 4043:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 12;
                 obj.entities[i].yp -= 15;
             }
             break;
+        }
         case 4044:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 12;
                 obj.entities[i].yp -= 10;
             }
             break;
+        }
         case 4045:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 12;
                 obj.entities[i].yp -= 10;
             }
             break;
+        }
         case 4046:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 8;
                 obj.entities[i].yp -= 8;
             }
             break;
+        }
         case 4047:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 6;
                 obj.entities[i].yp -= 8;
             }
             break;
+        }
         case 4048:
+        {
             state++;
             statedelay = 15;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 3;
             }
             break;
+        }
         case 4049:
             hascontrol = true;
             advancetext = false;
@@ -3734,12 +3819,13 @@ void Game::updatestate()
             music.playef(10);
             break;
         case 4052:
+        {
             //Activating a teleporter 2
             state++;
             statedelay = 5;
 
-            i = obj.getplayer();
-            j = obj.getteleporter();
+            int i = obj.getplayer();
+            int j = obj.getteleporter();
             if (i > -1)
             {
                 if (j != -1)
@@ -3761,60 +3847,73 @@ void Game::updatestate()
                 obj.entities[i].vx = 6;
             }
             break;
+        }
         case 4053:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 4;
                 obj.entities[i].yp -= 15;
             }
             break;
+        }
         case 4054:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 4;
                 obj.entities[i].yp -= 10;
             }
             break;
+        }
         case 4055:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 4;
                 obj.entities[i].yp -= 10;
             }
             break;
+        }
         case 4056:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 4;
                 obj.entities[i].yp -= 8;
             }
             break;
+        }
         case 4057:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 2;
                 obj.entities[i].yp -= 8;
             }
             break;
+        }
         case 4058:
+        {
             state++;
             statedelay = 15;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 1;
             }
             break;
+        }
         case 4059:
             hascontrol = true;
             advancetext = false;
@@ -3838,12 +3937,13 @@ void Game::updatestate()
             music.playef(10);
             break;
         case 4062:
+        {
             //Activating a teleporter 2
             state++;
             statedelay = 5;
 
-            i = obj.getplayer();
-            j = obj.getteleporter();
+            int i = obj.getplayer();
+            int j = obj.getteleporter();
             if (i > -1)
             {
                 if (j != -1)
@@ -3865,57 +3965,70 @@ void Game::updatestate()
                 obj.entities[i].vx = -6;
             }
             break;
+        }
         case 4063:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp -= 28;
                 obj.entities[i].yp -= 8;
             }
             break;
+        }
         case 4064:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp -= 28;
                 obj.entities[i].yp -= 8;
             }
             break;
+        }
         case 4065:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp -= 25;
             }
             break;
+        }
         case 4066:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp -= 25;
             }
             break;
+        }
         case 4067:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp -= 20;
             }
             break;
+        }
         case 4068:
+        {
             state++;
             statedelay = 15;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp -= 16;
             }
             break;
+        }
         case 4069:
             hascontrol = true;
             advancetext = false;
@@ -3940,12 +4053,13 @@ void Game::updatestate()
             music.playef(10);
             break;
         case 4072:
+        {
             //Activating a teleporter 2
             state++;
             statedelay = 5;
 
-            i = obj.getplayer();
-            j = obj.getteleporter();
+            int i = obj.getplayer();
+            int j = obj.getteleporter();
             if (i > -1)
             {
                 if (j != -1)
@@ -3967,55 +4081,68 @@ void Game::updatestate()
                 obj.entities[i].vx = 6;
             }
             break;
+        }
         case 4073:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 10;
             }
             break;
+        }
         case 4074:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 10;
             }
             break;
+        }
         case 4075:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 8;
             }
             break;
+        }
         case 4076:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 6;
             }
             break;
+        }
         case 4077:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 3;
             }
             break;
+        }
         case 4078:
+        {
             state++;
             statedelay = 15;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 1;
             }
             break;
+        }
         case 4079:
             state = 0;
             startscript = true;
@@ -4039,12 +4166,13 @@ void Game::updatestate()
             music.playef(10);
             break;
         case 4082:
+        {
             //Activating a teleporter 2
             state++;
             statedelay = 5;
 
-            i = obj.getplayer();
-            j = obj.getteleporter();
+            int i = obj.getplayer();
+            int j = obj.getteleporter();
             if (i > -1)
             {
                 if (j != -1)
@@ -4066,55 +4194,68 @@ void Game::updatestate()
                 obj.entities[i].vx = 6;
             }
             break;
+        }
         case 4083:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 10;
             }
             break;
+        }
         case 4084:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 10;
             }
             break;
+        }
         case 4085:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 8;
             }
             break;
+        }
         case 4086:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 6;
             }
             break;
+        }
         case 4087:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 3;
             }
             break;
+        }
         case 4088:
+        {
             state++;
             statedelay = 15;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 1;
             }
             break;
+        }
         case 4089:
             startscript = true;
             newscript = "gamecomplete_ending";
@@ -4138,12 +4279,13 @@ void Game::updatestate()
             music.playef(10);
             break;
         case 4092:
+        {
             //Activating a teleporter 2
             state++;
             statedelay = 5;
 
-            i = obj.getplayer();
-            j = obj.getteleporter();
+            int i = obj.getplayer();
+            int j = obj.getteleporter();
             if (i > -1)
             {
                 if (j != -1)
@@ -4165,55 +4307,68 @@ void Game::updatestate()
                 obj.entities[i].vx = 6;
             }
             break;
+        }
         case 4093:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 10;
             }
             break;
+        }
         case 4094:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 10;
             }
             break;
+        }
         case 4095:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 8;
             }
             break;
+        }
         case 4096:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 6;
             }
             break;
+        }
         case 4097:
+        {
             state++;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 3;
             }
             break;
+        }
         case 4098:
+        {
             state++;
             statedelay = 15;
-            i = obj.getplayer();
+            int i = obj.getplayer();
             if (i > -1)
             {
                 obj.entities[i].xp += 1;
             }
             break;
+        }
         case 4099:
             if (nocutscenes)
             {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1558,11 +1558,8 @@ void Game::updatestate()
             //
             //                       Test script for space station, totally delete me!
             //
-        {
-            int i = obj.getplayer();
             hascontrol = false;
             state++;
-        }
         break;
         case 116:
             advancetext = true;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1569,7 +1569,7 @@ void Graphics::drawentities()
 #if !defined(NO_CUSTOM_LEVELS)
     // Special case for gray Warp Zone tileset!
     int room = game.roomx-100 + (game.roomy-100) * ed.maxwidth;
-    bool custom_gray = room >= 0 && room < 400
+    bool custom_gray = INBOUNDS_ARR(room, ed.level)
     && ed.level[room].tileset == 3 && ed.level[room].tilecol == 6;
 #else
     bool custom_gray = false;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -622,6 +622,11 @@ void Graphics::printcrewnamestatus( int x, int y, int t )
 
 void Graphics::drawsprite( int x, int y, int t, int r, int g,  int b )
 {
+    if (!INBOUNDS_VEC(t, sprites))
+    {
+        WHINE_ONCE("drawsprite() out-of-bounds!");
+    }
+
     SDL_Rect rect = { Sint16(x), Sint16(y), sprites_rect.w, sprites_rect.h };
     setcolreal(getRGB(r,g,b));
     BlitSurfaceColoured(sprites[t], NULL, backBuffer, &rect, ct);
@@ -629,6 +634,11 @@ void Graphics::drawsprite( int x, int y, int t, int r, int g,  int b )
 
 void Graphics::drawsprite(int x, int y, int t, Uint32 c)
 {
+    if (!INBOUNDS_VEC(t, sprites))
+    {
+        WHINE_ONCE("drawsprite() out-of-bounds!");
+    }
+
     SDL_Rect rect = { Sint16(x), Sint16(y), sprites_rect.w, sprites_rect.h };
     setcolreal(c);
     BlitSurfaceColoured(sprites[t], NULL, backBuffer, &rect, ct);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -167,7 +167,7 @@ int Graphics::font_idx(uint32_t ch) {
 
 void Graphics::drawspritesetcol(int x, int y, int t, int c)
 {
-    if (!INBOUNDS(t, sprites))
+    if (!INBOUNDS_VEC(t, sprites))
     {
         return;
     }
@@ -380,7 +380,7 @@ void Graphics::PrintAlpha( int _x, int _y, std::string _s, int r, int g, int b, 
         fontRect.y = tpoint.y ;
 
         idx = font_idx(curr);
-        if (INBOUNDS(idx, font))
+        if (INBOUNDS_VEC(idx, font))
         {
             BlitSurfaceColoured( font[idx], NULL, backBuffer, &fontRect , ct);
         }
@@ -422,7 +422,7 @@ void Graphics::bigprint(  int _x, int _y, std::string _s, int r, int g, int b, b
         */
 
         idx = font_idx(curr);
-        if (INBOUNDS(idx, font))
+        if (INBOUNDS_VEC(idx, font))
         {
             SDL_Surface* tempPrint = ScaleSurface(font[idx], font[idx]->w *sc,font[idx]->h *sc);
             SDL_Rect printrect = { static_cast<Sint16>((_x) + bfontpos), static_cast<Sint16>(_y) , static_cast<Sint16>((bfont_rect.w*sc)+1), static_cast<Sint16>((bfont_rect.h * sc)+1)};
@@ -475,7 +475,7 @@ void Graphics::PrintOffAlpha( int _x, int _y, std::string _s, int r, int g, int 
         fontRect.y = tpoint.y ;
 
         idx = font_idx(curr);
-        if (INBOUNDS(idx, font))
+        if (INBOUNDS_VEC(idx, font))
         {
             BlitSurfaceColoured( font[idx], NULL, backBuffer, &fontRect , ct);
         }
@@ -534,7 +534,7 @@ void Graphics::RPrint( int _x, int _y, std::string _s, int r, int g, int b, bool
         fontRect.y = tpoint.y ;
 
         idx = font_idx(curr);
-        if (INBOUNDS(idx, font))
+        if (INBOUNDS_VEC(idx, font))
         {
             BlitSurfaceColoured( font[idx], NULL, backBuffer, &fontRect , ct);
         }
@@ -636,7 +636,7 @@ void Graphics::drawsprite(int x, int y, int t, Uint32 c)
 
 void Graphics::drawtile( int x, int y, int t )
 {
-    if (!INBOUNDS(t, tiles))
+    if (!INBOUNDS_VEC(t, tiles))
     {
         WHINE_ONCE("drawtile() out-of-bounds!")
         return;
@@ -660,7 +660,7 @@ void Graphics::drawtile( int x, int y, int t )
 
 void Graphics::drawtile2( int x, int y, int t )
 {
-    if (!INBOUNDS(t, tiles2))
+    if (!INBOUNDS_VEC(t, tiles2))
     {
         WHINE_ONCE("drawtile2() out-of-bounds!")
         return;
@@ -686,7 +686,7 @@ void Graphics::drawtile2( int x, int y, int t )
 void Graphics::drawtile3( int x, int y, int t, int off, int height_subtract /*= 0*/ )
 {
     t += off * 30;
-    if (!INBOUNDS(t, tiles3))
+    if (!INBOUNDS_VEC(t, tiles3))
     {
         WHINE_ONCE("drawtile3() out-of-bounds!")
         return;
@@ -698,7 +698,7 @@ void Graphics::drawtile3( int x, int y, int t, int off, int height_subtract /*= 
 
 void Graphics::drawentcolours( int x, int y, int t)
 {
-    if (!INBOUNDS(t, entcolours))
+    if (!INBOUNDS_VEC(t, entcolours))
     {
         WHINE_ONCE("drawentcolours() out-of-bounds!")
         return;
@@ -709,7 +709,7 @@ void Graphics::drawentcolours( int x, int y, int t)
 
 void Graphics::drawtowertile( int x, int y, int t )
 {
-    if (!INBOUNDS(t, tiles2))
+    if (!INBOUNDS_VEC(t, tiles2))
     {
         WHINE_ONCE("drawtowertile() out-of-bounds!")
         return;
@@ -722,7 +722,7 @@ void Graphics::drawtowertile( int x, int y, int t )
 void Graphics::drawtowertile3( int x, int y, int t, int off )
 {
     t += off*30;
-    if (!INBOUNDS(t, tiles3))
+    if (!INBOUNDS_VEC(t, tiles3))
     {
         WHINE_ONCE("drawtowertile3() out-of-bounds!")
         return;
@@ -895,7 +895,7 @@ void Graphics::updatetextboxes()
 
 void Graphics::drawimagecol( int t, int xp, int yp, int r = 0, int g = 0, int b = 0, bool cent/*= false*/ )
 {
-    if (!INBOUNDS(t, images))
+    if (!INBOUNDS_VEC(t, images))
     {
         return;
     }
@@ -930,7 +930,7 @@ void Graphics::drawimagecol( int t, int xp, int yp, int r = 0, int g = 0, int b 
 
 void Graphics::drawimage( int t, int xp, int yp, bool cent/*=false*/ )
 {
-    if (!INBOUNDS(t, images))
+    if (!INBOUNDS_VEC(t, images))
     {
         return;
     }
@@ -958,7 +958,7 @@ void Graphics::drawimage( int t, int xp, int yp, bool cent/*=false*/ )
 
 void Graphics::drawpartimage( int t, int xp, int yp, int wp, int hp)
 {
-  if (!INBOUNDS(t, images))
+  if (!INBOUNDS_VEC(t, images))
   {
     return;
   }
@@ -1181,7 +1181,7 @@ void Graphics::textboxremove()
 
 void Graphics::textboxtimer( int t )
 {
-    if (!INBOUNDS(m, textbox))
+    if (!INBOUNDS_VEC(m, textbox))
     {
         puts("textboxtimer() out-of-bounds!");
         return;
@@ -1192,7 +1192,7 @@ void Graphics::textboxtimer( int t )
 
 void Graphics::addline( std::string t )
 {
-    if (!INBOUNDS(m, textbox))
+    if (!INBOUNDS_VEC(m, textbox))
     {
         puts("addline() out-of-bounds!");
         return;
@@ -1203,7 +1203,7 @@ void Graphics::addline( std::string t )
 
 void Graphics::textboxadjust()
 {
-    if (!INBOUNDS(m, textbox))
+    if (!INBOUNDS_VEC(m, textbox))
     {
         puts("textboxadjust() out-of-bounds!");
         return;
@@ -1372,7 +1372,7 @@ void Graphics::drawmenu( int cr, int cg, int cb, bool levelmenu /*= false*/ )
 
 void Graphics::drawcoloredtile( int x, int y, int t, int r, int g, int b )
 {
-    if (!INBOUNDS(t, tiles))
+    if (!INBOUNDS_VEC(t, tiles))
     {
         return;
     }
@@ -1620,7 +1620,7 @@ void Graphics::drawentities()
         case 0:
         {
             // Sprites
-            if (!INBOUNDS(obj.entities[i].drawframe, (*spritesvec)))
+            if (!INBOUNDS_VEC(obj.entities[i].drawframe, (*spritesvec)))
             {
                 continue;
             }
@@ -1688,7 +1688,7 @@ void Graphics::drawentities()
         }
         case 1:
             // Tiles
-            if (!INBOUNDS(obj.entities[i].drawframe, tiles))
+            if (!INBOUNDS_VEC(obj.entities[i].drawframe, tiles))
             {
                 continue;
             }
@@ -1703,7 +1703,7 @@ void Graphics::drawentities()
         case 8:
         {
             // Special: Moving platform, 4 tiles or 8 tiles
-            if (!INBOUNDS(obj.entities[i].drawframe, (*tilesvec)))
+            if (!INBOUNDS_VEC(obj.entities[i].drawframe, (*tilesvec)))
             {
                 continue;
             }
@@ -1770,7 +1770,7 @@ void Graphics::drawentities()
             // Note: This code is in the 4-tile code
             break;
         case 9:         // Really Big Sprite! (2x2)
-            if (!INBOUNDS(obj.entities[i].drawframe, (*spritesvec)))
+            if (!INBOUNDS_VEC(obj.entities[i].drawframe, (*spritesvec)))
             {
                 continue;
             }
@@ -1809,7 +1809,7 @@ void Graphics::drawentities()
             BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe + 13],NULL, backBuffer, &drawRect, ct);
             break;
         case 10:         // 2x1 Sprite
-            if (!INBOUNDS(obj.entities[i].drawframe, (*spritesvec)))
+            if (!INBOUNDS_VEC(obj.entities[i].drawframe, (*spritesvec)))
             {
                 continue;
             }
@@ -1836,7 +1836,7 @@ void Graphics::drawentities()
             drawimagecol(3, xp, yp - yoff);
             break;
         case 12:         // Regular sprites that don't wrap
-            if (!INBOUNDS(obj.entities[i].drawframe, (*spritesvec)))
+            if (!INBOUNDS_VEC(obj.entities[i].drawframe, (*spritesvec)))
             {
                 continue;
             }
@@ -1895,7 +1895,7 @@ void Graphics::drawentities()
         case 13:
         {
             //Special for epilogue: huge hero!
-            if (!INBOUNDS(obj.entities[i].drawframe, (*spritesvec)))
+            if (!INBOUNDS_VEC(obj.entities[i].drawframe, (*spritesvec)))
             {
                 continue;
             }
@@ -2767,7 +2767,7 @@ void Graphics::menuoffrender()
 
 void Graphics::drawhuetile( int x, int y, int t )
 {
-	if (!INBOUNDS(t, tiles))
+	if (!INBOUNDS_VEC(t, tiles))
 	{
 		return;
 	}
@@ -2820,7 +2820,7 @@ void Graphics::setwarprect( int a, int b, int c, int d )
 
 void Graphics::textboxcenter()
 {
-	if (!INBOUNDS(m, textbox))
+	if (!INBOUNDS_VEC(m, textbox))
 	{
 		puts("textboxcenter() out-of-bounds!");
 		return;
@@ -2832,7 +2832,7 @@ void Graphics::textboxcenter()
 
 void Graphics::textboxcenterx()
 {
-	if (!INBOUNDS(m, textbox))
+	if (!INBOUNDS_VEC(m, textbox))
 	{
 		puts("textboxcenterx() out-of-bounds!");
 		return;
@@ -2843,7 +2843,7 @@ void Graphics::textboxcenterx()
 
 int Graphics::textboxwidth()
 {
-	if (!INBOUNDS(m, textbox))
+	if (!INBOUNDS_VEC(m, textbox))
 	{
 		puts("textboxwidth() out-of-bounds!");
 		return 0;
@@ -2854,7 +2854,7 @@ int Graphics::textboxwidth()
 
 void Graphics::textboxmove(int xo, int yo)
 {
-	if (!INBOUNDS(m, textbox))
+	if (!INBOUNDS_VEC(m, textbox))
 	{
 		puts("textboxmove() out-of-bounds!");
 		return;
@@ -2866,7 +2866,7 @@ void Graphics::textboxmove(int xo, int yo)
 
 void Graphics::textboxmoveto(int xo)
 {
-	if (!INBOUNDS(m, textbox))
+	if (!INBOUNDS_VEC(m, textbox))
 	{
 		puts("textboxmoveto() out-of-bounds!");
 		return;
@@ -2877,7 +2877,7 @@ void Graphics::textboxmoveto(int xo)
 
 void Graphics::textboxcentery()
 {
-	if (!INBOUNDS(m, textbox))
+	if (!INBOUNDS_VEC(m, textbox))
 	{
 		puts("textboxcentery() out-of-bounds!");
 		return;
@@ -3013,7 +3013,7 @@ void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool
 	while (iter != t.end()) {
 		cur = utf8::unchecked::next(iter);
 		idx = font_idx(cur);
-		if (INBOUNDS(idx, font))
+		if (INBOUNDS_VEC(idx, font))
 		{
 			SDL_Surface* tempPrint = ScaleSurface(font[idx], font[idx]->w *sc,font[idx]->h *sc);
 			SDL_Rect printrect = { Sint16((x) + bfontpos), Sint16(y) , Sint16(bfont_rect.w*sc), Sint16(bfont_rect.h * sc)};
@@ -3030,7 +3030,7 @@ void Graphics::drawtele(int x, int y, int t, Uint32 c)
 
 	SDL_Rect telerect;
 	setRect(telerect, x , y, tele_rect.w, tele_rect.h );
-	if (INBOUNDS(0, tele))
+	if (INBOUNDS_VEC(0, tele))
 	{
 		BlitSurfaceColoured(tele[0], NULL, backBuffer, &telerect, ct);
 	}
@@ -3040,7 +3040,7 @@ void Graphics::drawtele(int x, int y, int t, Uint32 c)
 	if (t < 0) t = 0;
 
 	setRect(telerect, x , y, tele_rect.w, tele_rect.h );
-	if (INBOUNDS(t, tele))
+	if (INBOUNDS_VEC(t, tele))
 	{
 		BlitSurfaceColoured(tele[t], NULL, backBuffer, &telerect, ct);
 	}
@@ -3086,7 +3086,7 @@ void Graphics::setcolreal(Uint32 t)
 
 void Graphics::drawforetile(int x, int y, int t)
 {
-	if (!INBOUNDS(t, tiles))
+	if (!INBOUNDS_VEC(t, tiles))
 	{
 		WHINE_ONCE("drawforetile() out-of-bounds!")
 		return;
@@ -3110,7 +3110,7 @@ void Graphics::drawforetile(int x, int y, int t)
 
 void Graphics::drawforetile2(int x, int y, int t)
 {
-	if (!INBOUNDS(t, tiles2))
+	if (!INBOUNDS_VEC(t, tiles2))
 	{
 		WHINE_ONCE("drawforetile2() out-of-bounds!")
 		return;
@@ -3135,7 +3135,7 @@ void Graphics::drawforetile2(int x, int y, int t)
 void Graphics::drawforetile3(int x, int y, int t, int off)
 {
 	t += off * 30;
-	if (!INBOUNDS(t, tiles3))
+	if (!INBOUNDS_VEC(t, tiles3))
 	{
 		WHINE_ONCE("drawforetile3() out-of-bounds!")
 		return;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -13,6 +13,7 @@
 #include "Map.h"
 #include "Music.h"
 #include "Script.h"
+#include "UtilityClass.h"
 
 void updatebuttonmappings(int bind)
 {
@@ -1781,7 +1782,7 @@ void gameinput()
     if(map.custommode && !map.custommodeforreal){
         if ((game.press_map || key.isDown(27)) && !game.mapheld){
             //Return to level editor
-            if (game.activeactivity > -1 && game.press_map){
+            if (INBOUNDS_VEC(game.activeactivity, obj.blocks) && game.press_map){
                 //pass, let code block below handle it
             }else if(game.activetele && game.readytotele > 20 && game.press_map){
                 //pass, let code block below handle it
@@ -1824,13 +1825,13 @@ void gameinput()
                                 music.fadeout();
 
                                 int player = obj.getplayer();
-                                if (player > -1)
+                                if (INBOUNDS_VEC(player, obj.entities))
                                 {
                                     obj.entities[player].colour = 102;
                                 }
 
                                 int teleporter = obj.getteleporter();
-                                if (teleporter > -1)
+                                if (INBOUNDS_VEC(teleporter, obj.entities))
                                 {
                                     obj.entities[teleporter].tile = 6;
                                     obj.entities[teleporter].colour = 102;
@@ -1866,15 +1867,15 @@ void gameinput()
                                 music.fadeout();
 
                                 int player = obj.getplayer();
-                                if (player > -1)
+                                if (INBOUNDS_VEC(player, obj.entities))
                                 {
                                     obj.entities[player].colour = 102;
                                 }
                                 int companion = obj.getcompanion();
-                                if(companion>-1) obj.entities[companion].colour = 102;
+                                if(INBOUNDS_VEC(companion, obj.entities)) obj.entities[companion].colour = 102;
 
                                 int teleporter = obj.getteleporter();
-                                if (teleporter > -1)
+                                if (INBOUNDS_VEC(teleporter, obj.entities))
                                 {
                                     obj.entities[teleporter].tile = 6;
                                     obj.entities[teleporter].colour = 102;
@@ -1885,7 +1886,7 @@ void gameinput()
                             }
                         }
                     }
-                    else if (game.activeactivity > -1)
+                    else if (INBOUNDS_VEC(game.activeactivity, obj.blocks))
                     {
                         enter_already_processed = true;
                         if((int(std::abs(obj.entities[ie].vx))<=1) && (int(obj.entities[ie].vy) == 0) )
@@ -2278,7 +2279,7 @@ void mapmenuactionpress()
         game.hascontrol = false;
 
         int i = obj.getplayer();
-        if (i > -1)
+        if (INBOUNDS_VEC(i, obj.entities))
         {
             obj.entities[i].colour = 102;
         }
@@ -2506,13 +2507,13 @@ void teleporterinput()
                 game.hascontrol = false;
 
                 int i = obj.getplayer();
-                if (i > -1)
+                if (INBOUNDS_VEC(i, obj.entities))
                 {
                     obj.entities[i].colour = 102;
                 }
 
                 i = obj.getteleporter();
-                if (i > -1)
+                if (INBOUNDS_VEC(i, obj.entities))
                 {
                     obj.entities[i].tile = 6;
                     obj.entities[i].colour = 102;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -289,7 +289,7 @@ void gamelogic()
             obj.upsetmode = true;
             //change player to sad
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].tile = 144;
             }
@@ -306,7 +306,7 @@ void gamelogic()
             obj.upsetmode = false;
             //change player to happy
             int i = obj.getplayer();
-            if (i > -1)
+            if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].tile = 0;
             }
@@ -357,7 +357,7 @@ void gamelogic()
             else if (map.cameramode == 4)
             {
                 int i = obj.getplayer();
-                if (i > -1)
+                if (INBOUNDS_VEC(i, obj.entities))
                 {
                     map.cameraseek = map.ypos - (obj.entities[i].yp - 120);
                 }
@@ -378,14 +378,14 @@ void gamelogic()
                 {
                     int i = obj.getplayer();
                     map.ypos -= map.cameraseek;
-                    if (map.cameraseek > 0 && i > -1)
+                    if (map.cameraseek > 0 && INBOUNDS_VEC(i, obj.entities))
                     {
                         if (map.ypos < obj.entities[i].yp - 120)
                         {
                             map.ypos = obj.entities[i].yp - 120;
                         }
                     }
-                    else if (i > -1)
+                    else if (INBOUNDS_VEC(i, obj.entities))
                     {
                         if (map.ypos > obj.entities[i].yp - 120)
                         {
@@ -398,7 +398,7 @@ void gamelogic()
                 else
                 {
                     int i = obj.getplayer();
-                    if (i > -1)
+                    if (INBOUNDS_VEC(i, obj.entities))
                     {
                         map.ypos = obj.entities[i].yp - 120;
                     }
@@ -649,7 +649,7 @@ void gamelogic()
             if (game.roomx == 41 + game.scmprogress)   //he's in the same room
             {
                 int i = obj.getplayer();
-                if (i > -1 && obj.entities[i].ax > 0 && obj.entities[i].xp > 280)
+                if (INBOUNDS_VEC(i, obj.entities) && obj.entities[i].ax > 0 && obj.entities[i].xp > 280)
                 {
                     obj.entities[i].ax = 0;
                     obj.entities[i].dir = 0;
@@ -863,7 +863,7 @@ void gamelogic()
                 {
                     game.timetrialparlost = true;
                     int i = obj.getplayer();
-                    if (i > -1)
+                    if (INBOUNDS_VEC(i, obj.entities))
                     {
                         obj.entities[i].tile = 144;
                     }
@@ -924,7 +924,7 @@ void gamelogic()
                 //is the player standing on a moving platform?
                 int i = obj.getplayer();
                 float j = obj.entitycollideplatformfloor(i);
-                if (i > -1 && j > -1000)
+                if (INBOUNDS_VEC(i, obj.entities) && j > -1000)
                 {
                     obj.entities[i].newxp = obj.entities[i].xp + j;
                     obj.entitymapcollision(i);
@@ -932,7 +932,7 @@ void gamelogic()
                 else
                 {
                     j = obj.entitycollideplatformroof(i);
-                    if (i > -1 && j > -1000)
+                    if (INBOUNDS_VEC(i, obj.entities) && j > -1000)
                     {
                         obj.entities[i].newxp = obj.entities[i].xp + j;
                         obj.entitymapcollision(i);
@@ -957,7 +957,7 @@ void gamelogic()
             {
                 //special for tower: is the player touching any spike blocks?
                 int player = obj.getplayer();
-                if(player > -1 && obj.checktowerspikes(player) && graphics.fademode==0)
+                if(INBOUNDS_VEC(player, obj.entities) && obj.checktowerspikes(player) && graphics.fademode==0)
                 {
                     game.deathseq = 30;
                 }
@@ -966,7 +966,7 @@ void gamelogic()
             if(map.towermode && game.lifeseq==0)
             {
                 int player = obj.getplayer();
-                if(!map.invincibility && player > -1)
+                if(!map.invincibility && INBOUNDS_VEC(player, obj.entities))
                 {
                     if (obj.entities[player].yp-map.ypos <= 0)
                     {
@@ -977,7 +977,7 @@ void gamelogic()
                         game.deathseq = 30;
                     }
                 }
-                else if (player > -1)
+                else if (INBOUNDS_VEC(player, obj.entities))
                 {
                     if (obj.entities[player].yp-map.ypos <= 0)
                     {
@@ -993,7 +993,7 @@ void gamelogic()
                     }
                 }
 
-                if (player > -1 && obj.entities[player].yp - map.ypos <= 40)
+                if (INBOUNDS_VEC(player, obj.entities) && obj.entities[player].yp - map.ypos <= 40)
                 {
                     map.spikeleveltop++;
                     if (map.spikeleveltop >= 8) map.spikeleveltop = 8;
@@ -1003,7 +1003,7 @@ void gamelogic()
                     if (map.spikeleveltop > 0) map.spikeleveltop--;
                 }
 
-                if (player > -1 && obj.entities[player].yp - map.ypos >= 164)
+                if (INBOUNDS_VEC(player, obj.entities) && obj.entities[player].yp - map.ypos >= 164)
                 {
                     map.spikelevelbottom++;
                     if (map.spikelevelbottom >= 8) map.spikelevelbottom = 8;
@@ -1026,7 +1026,7 @@ void gamelogic()
                 obj.customwarpmodevon = false;
 
                 int i = obj.getplayer();
-                if (i > -1 && ((game.door_down > -2 && obj.entities[i].yp >= 226-16) || (game.door_up > -2 && obj.entities[i].yp < -2+16) ||	(game.door_left > -2 && obj.entities[i].xp < -14+16) ||	(game.door_right > -2 && obj.entities[i].xp >= 308-16))){
+                if (INBOUNDS_VEC(i, obj.entities) && ((game.door_down > -2 && obj.entities[i].yp >= 226-16) || (game.door_up > -2 && obj.entities[i].yp < -2+16) ||	(game.door_left > -2 && obj.entities[i].xp < -14+16) ||	(game.door_right > -2 && obj.entities[i].xp >= 308-16))){
                     //Player is leaving room
                     obj.customwarplinecheck(i);
                 }
@@ -1132,13 +1132,13 @@ void gamelogic()
         {
             //Normal! Just change room
             int player = obj.getplayer();
-            if (player > -1 && game.door_down > -2 && obj.entities[player].yp >= 238)
+            if (INBOUNDS_VEC(player, obj.entities) && game.door_down > -2 && obj.entities[player].yp >= 238)
             {
                 obj.entities[player].yp -= 240;
                 map.gotoroom(game.roomx, game.roomy + 1);
                 screen_transition = true;
             }
-            if (player > -1 && game.door_up > -2 && obj.entities[player].yp < -2)
+            if (INBOUNDS_VEC(player, obj.entities) && game.door_up > -2 && obj.entities[player].yp < -2)
             {
                 obj.entities[player].yp += 240;
                 map.gotoroom(game.roomx, game.roomy - 1);
@@ -1150,13 +1150,13 @@ void gamelogic()
         {
             //Normal! Just change room
             int player = obj.getplayer();
-            if (player > -1 && game.door_left > -2 && obj.entities[player].xp < -14)
+            if (INBOUNDS_VEC(player, obj.entities) && game.door_left > -2 && obj.entities[player].xp < -14)
             {
                 obj.entities[player].xp += 320;
                 map.gotoroom(game.roomx - 1, game.roomy);
                 screen_transition = true;
             }
-            if (player > -1 && game.door_right > -2 && obj.entities[player].xp >= 308)
+            if (INBOUNDS_VEC(player, obj.entities) && game.door_right > -2 && obj.entities[player].xp >= 308)
             {
                 obj.entities[player].xp -= 320;
                 map.gotoroom(game.roomx + 1, game.roomy);
@@ -1171,12 +1171,12 @@ void gamelogic()
             {
                 //This is minitower 1!
                 int player = obj.getplayer();
-                if (player > -1 && game.door_left > -2 && obj.entities[player].xp < -14)
+                if (INBOUNDS_VEC(player, obj.entities) && game.door_left > -2 && obj.entities[player].xp < -14)
                 {
                     obj.entities[player].xp += 320;
                     map.gotoroom(48, 52);
                 }
-                if (player > -1 && game.door_right > -2 && obj.entities[player].xp >= 308)
+                if (INBOUNDS_VEC(player, obj.entities) && game.door_right > -2 && obj.entities[player].xp >= 308)
                 {
                     obj.entities[player].xp -= 320;
                     obj.entities[player].yp -= (71*8);
@@ -1187,7 +1187,7 @@ void gamelogic()
             {
                 //This is minitower 2!
                 int player = obj.getplayer();
-                if (player > -1 && game.door_left > -2 && obj.entities[player].xp < -14)
+                if (INBOUNDS_VEC(player, obj.entities) && game.door_left > -2 && obj.entities[player].xp < -14)
                 {
                     if (obj.entities[player].yp > 300)
                     {
@@ -1201,7 +1201,7 @@ void gamelogic()
                         map.gotoroom(50, 53);
                     }
                 }
-                if (player > -1 && game.door_right > -2 && obj.entities[player].xp >= 308)
+                if (INBOUNDS_VEC(player, obj.entities) && game.door_right > -2 && obj.entities[player].xp >= 308)
                 {
                     obj.entities[player].xp -= 320;
                     map.gotoroom(52, 53);
@@ -1231,13 +1231,13 @@ void gamelogic()
             {
                 //Do not wrap! Instead, go to the correct room
                 int player = obj.getplayer();
-                if (player > -1 && game.door_left > -2 && obj.entities[player].xp < -14)
+                if (INBOUNDS_VEC(player, obj.entities) && game.door_left > -2 && obj.entities[player].xp < -14)
                 {
                     obj.entities[player].xp += 320;
                     obj.entities[player].yp -= (671 * 8);
                     map.gotoroom(108, 109);
                 }
-                if (player > -1 && game.door_right > -2 && obj.entities[player].xp >= 308)
+                if (INBOUNDS_VEC(player, obj.entities) && game.door_right > -2 && obj.entities[player].xp >= 308)
                 {
                     obj.entities[player].xp -= 320;
                     map.gotoroom(110, 104);
@@ -1270,7 +1270,7 @@ void gamelogic()
                 if (game.roomx == 117 && game.roomy == 102)
                 {
                     int i = obj.getplayer();
-                    if (i > -1)
+                    if (INBOUNDS_VEC(i, obj.entities))
                     {
                         obj.entities[i].yp = 225;
                     }
@@ -1280,7 +1280,7 @@ void gamelogic()
                 else if (game.roomx == 119 && game.roomy == 100)
                 {
                     int i = obj.getplayer();
-                    if (i > -1)
+                    if (INBOUNDS_VEC(i, obj.entities))
                     {
                         obj.entities[i].yp = 225;
                     }
@@ -1290,7 +1290,7 @@ void gamelogic()
                 else if (game.roomx == 119 && game.roomy == 103)
                 {
                     int i = obj.getplayer();
-                    if (i > -1)
+                    if (INBOUNDS_VEC(i, obj.entities))
                     {
                         obj.entities[i].xp = 0;
                     }
@@ -1300,7 +1300,7 @@ void gamelogic()
                 else if (game.roomx == 116 && game.roomy == 103)
                 {
                     int i = obj.getplayer();
-                    if (i > -1)
+                    if (INBOUNDS_VEC(i, obj.entities))
                     {
                         obj.entities[i].yp = 225;
                     }
@@ -1310,7 +1310,7 @@ void gamelogic()
                 else if (game.roomx == 116 && game.roomy == 100)
                 {
                     int i = obj.getplayer();
-                    if (i > -1)
+                    if (INBOUNDS_VEC(i, obj.entities))
                     {
                         obj.entities[i].xp = 0;
                     }
@@ -1320,7 +1320,7 @@ void gamelogic()
                 else if (game.roomx == 114 && game.roomy == 102)
                 {
                     int i = obj.getplayer();
-                    if (i > -1)
+                    if (INBOUNDS_VEC(i, obj.entities))
                     {
                         obj.entities[i].yp = 225;
                     }
@@ -1407,7 +1407,7 @@ void gamelogic()
         //We've changed room? Let's bring our companion along!
         game.roomchange = false;
         int i = obj.getplayer();
-        if (game.companion > 0 && i > -1)
+        if (game.companion > 0 && INBOUNDS_VEC(i, obj.entities))
         {
             //ok, we'll presume our companion has been destroyed in the room change. So:
             switch(game.companion)
@@ -1416,7 +1416,7 @@ void gamelogic()
             {
                 obj.createentity(obj.entities[i].xp, 121.0f, 15.0f,1);  //Y=121, the floor in that particular place!
                 int j = obj.getcompanion();
-                if (j > -1)
+                if (INBOUNDS_VEC(j, obj.entities))
                 {
                     obj.entities[j].vx = obj.entities[i].vx;
                     obj.entities[j].dir = obj.entities[i].dir;
@@ -1435,7 +1435,7 @@ void gamelogic()
                         obj.createentity(obj.entities[i].xp, 86.0f, 16.0f, 1);  //Y=86, the ROOF in that particular place!
                     }
                     int j = obj.getcompanion();
-                    if (j > -1)
+                    if (INBOUNDS_VEC(j, obj.entities))
                     {
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
@@ -1449,7 +1449,7 @@ void gamelogic()
                     {
                         obj.createentity(310, 177, 17, 1);
                         int j = obj.getcompanion();
-                        if (j > -1)
+                        if (INBOUNDS_VEC(j, obj.entities))
                         {
                             obj.entities[j].vx = obj.entities[i].vx;
                             obj.entities[j].dir = obj.entities[i].dir;
@@ -1459,7 +1459,7 @@ void gamelogic()
                     {
                         obj.createentity(obj.entities[i].xp, 177.0f, 17.0f, 1);
                         int j = obj.getcompanion();
-                        if (j > -1)
+                        if (INBOUNDS_VEC(j, obj.entities))
                         {
                             obj.entities[j].vx = obj.entities[i].vx;
                             obj.entities[j].dir = obj.entities[i].dir;
@@ -1479,7 +1479,7 @@ void gamelogic()
                         obj.createentity(obj.entities[i].xp, 185.0f, 18.0f, 15, 0, 1);
                     }
                     int j = obj.getcompanion();
-                    if (j > -1)
+                    if (INBOUNDS_VEC(j, obj.entities))
                     {
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
@@ -1494,7 +1494,7 @@ void gamelogic()
                     {
                         obj.createentity(225.0f, 169.0f, 18, graphics.crewcolour(game.lastsaved), 0, 10);
                         int j = obj.getcompanion();
-                        if (j > -1)
+                        if (INBOUNDS_VEC(j, obj.entities))
                         {
                             obj.entities[j].vx = obj.entities[i].vx;
                             obj.entities[j].dir = obj.entities[i].dir;
@@ -1507,7 +1507,7 @@ void gamelogic()
                     {
                         obj.createentity(160.0f, 177.0f, 18, graphics.crewcolour(game.lastsaved), 0, 18, 1);
                         int j = obj.getcompanion();
-                        if (j > -1)
+                        if (INBOUNDS_VEC(j, obj.entities))
                         {
                             obj.entities[j].vx = obj.entities[i].vx;
                             obj.entities[j].dir = obj.entities[i].dir;
@@ -1518,7 +1518,7 @@ void gamelogic()
                         obj.flags[59] = true;
                         obj.createentity(obj.entities[i].xp, -20.0f, 18.0f, graphics.crewcolour(game.lastsaved), 0, 10, 0);
                         int j = obj.getcompanion();
-                        if (j > -1)
+                        if (INBOUNDS_VEC(j, obj.entities))
                         {
                             obj.entities[j].vx = obj.entities[i].vx;
                             obj.entities[j].dir = obj.entities[i].dir;
@@ -1601,7 +1601,7 @@ void gamelogic()
     if (game.activetele && !game.advancetext && game.hascontrol && !script.running && !game.intimetrial)
     {
         int i = obj.getplayer();
-        if (i > -1)
+        if (INBOUNDS_VEC(i, obj.entities))
         {
             obj.settemprect(i);
         }
@@ -1636,7 +1636,7 @@ void gamelogic()
 #endif
 
     game.prev_act_fade = game.act_fade;
-    if (game.activeactivity > -1 && game.hascontrol && !script.running)
+    if (INBOUNDS_VEC(game.activeactivity, obj.blocks) && game.hascontrol && !script.running)
     {
         if (game.act_fade < 5)
         {
@@ -1720,7 +1720,7 @@ void gamelogic()
                 GhostInfo ghost;
                 ghost.rx = game.roomx-100;
                 ghost.ry = game.roomy-100;
-                if (i > -1)
+                if (INBOUNDS_VEC(i, obj.entities))
                 {
                     ghost.x = obj.entities[i].xp;
                     ghost.y = obj.entities[i].yp;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -769,12 +769,16 @@ void gamelogic()
             }
             else if (game.swngame == 3)    //extend line
             {
-                obj.entities[obj.getlineat(84 - 32)].w += 24;
-                if (obj.entities[obj.getlineat(84 - 32)].w > 332)
+                int line = obj.getlineat(84 - 32);
+                if (INBOUNDS_VEC(line, obj.entities))
                 {
-                    obj.entities[obj.getlineat(84 - 32)].w = 332;
-                    game.swngame = 2;
-                    graphics.kludgeswnlinewidth = true;
+                    obj.entities[line].w += 24;
+                    if (obj.entities[line].w > 332)
+                    {
+                        obj.entities[line].w = 332;
+                        game.swngame = 2;
+                        graphics.kludgeswnlinewidth = true;
+                    }
                 }
             }
             else if (game.swngame == 4)    //create top line
@@ -786,12 +790,16 @@ void gamelogic()
             }
             else if (game.swngame == 5)    //remove line
             {
-                obj.entities[obj.getlineat(148 + 32)].xp += 24;
-                if (obj.entities[obj.getlineat(148 + 32)].xp > 320)
+                int line = obj.getlineat(148 + 32);
+                if (INBOUNDS_VEC(line, obj.entities))
                 {
-                    obj.removeentity(obj.getlineat(148 + 32));
-                    game.swnmode = false;
-                    game.swngame = 6;
+                    obj.entities[line].xp += 24;
+                    if (obj.entities[line].xp > 320)
+                    {
+                        obj.removeentity(line);
+                        game.swnmode = false;
+                        game.swngame = 6;
+                    }
                 }
             }
             else if (game.swngame == 6)    //Init the super gravitron
@@ -1587,7 +1595,12 @@ void gamelogic()
 
                 if (game.scmmoveme)
                 {
-                    obj.entities[obj.getscm()].xp = obj.entities[obj.getplayer()].xp;
+                    int scm = obj.getscm();
+                    int player = obj.getplayer();
+                    if (INBOUNDS_VEC(scm, obj.entities) && INBOUNDS_VEC(player, obj.entities))
+                    {
+                        obj.entities[scm].xp = obj.entities[player].xp;
+                    }
                     game.scmmoveme = false;
                 }
                 break;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1402,7 +1402,6 @@ void gamelogic()
         }
     }
 
-    int j;
     if (game.roomchange)
     {
         //We've changed room? Let's bring our companion along!
@@ -1414,14 +1413,16 @@ void gamelogic()
             switch(game.companion)
             {
             case 6:
+            {
                 obj.createentity(obj.entities[i].xp, 121.0f, 15.0f,1);  //Y=121, the floor in that particular place!
-                j = obj.getcompanion();
+                int j = obj.getcompanion();
                 if (j > -1)
                 {
                     obj.entities[j].vx = obj.entities[i].vx;
                     obj.entities[j].dir = obj.entities[i].dir;
                 }
                 break;
+            }
             case 7:
                 if (game.roomy <= 105)   //don't jump after him!
                 {
@@ -1433,7 +1434,7 @@ void gamelogic()
                     {
                         obj.createentity(obj.entities[i].xp, 86.0f, 16.0f, 1);  //Y=86, the ROOF in that particular place!
                     }
-                    j = obj.getcompanion();
+                    int j = obj.getcompanion();
                     if (j > -1)
                     {
                         obj.entities[j].vx = obj.entities[i].vx;
@@ -1447,7 +1448,7 @@ void gamelogic()
                     if (game.roomx == 102)
                     {
                         obj.createentity(310, 177, 17, 1);
-                        j = obj.getcompanion();
+                        int j = obj.getcompanion();
                         if (j > -1)
                         {
                             obj.entities[j].vx = obj.entities[i].vx;
@@ -1457,7 +1458,7 @@ void gamelogic()
                     else
                     {
                         obj.createentity(obj.entities[i].xp, 177.0f, 17.0f, 1);
-                        j = obj.getcompanion();
+                        int j = obj.getcompanion();
                         if (j > -1)
                         {
                             obj.entities[j].vx = obj.entities[i].vx;
@@ -1477,7 +1478,7 @@ void gamelogic()
                     {
                         obj.createentity(obj.entities[i].xp, 185.0f, 18.0f, 15, 0, 1);
                     }
-                    j = obj.getcompanion();
+                    int j = obj.getcompanion();
                     if (j > -1)
                     {
                         obj.entities[j].vx = obj.entities[i].vx;
@@ -1492,7 +1493,7 @@ void gamelogic()
                     if (!obj.flags[59])
                     {
                         obj.createentity(225.0f, 169.0f, 18, graphics.crewcolour(game.lastsaved), 0, 10);
-                        j = obj.getcompanion();
+                        int j = obj.getcompanion();
                         if (j > -1)
                         {
                             obj.entities[j].vx = obj.entities[i].vx;
@@ -1505,7 +1506,7 @@ void gamelogic()
                     if (obj.flags[59])
                     {
                         obj.createentity(160.0f, 177.0f, 18, graphics.crewcolour(game.lastsaved), 0, 18, 1);
-                        j = obj.getcompanion();
+                        int j = obj.getcompanion();
                         if (j > -1)
                         {
                             obj.entities[j].vx = obj.entities[i].vx;
@@ -1516,7 +1517,7 @@ void gamelogic()
                     {
                         obj.flags[59] = true;
                         obj.createentity(obj.entities[i].xp, -20.0f, 18.0f, graphics.crewcolour(game.lastsaved), 0, 10, 0);
-                        j = obj.getcompanion();
+                        int j = obj.getcompanion();
                         if (j > -1)
                         {
                             obj.entities[j].vx = obj.entities[i].vx;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -829,7 +829,7 @@ void mapclass::resetplayer()
 
 	game.deathseq = -1;
 	int i = obj.getplayer();
-	if(i>-1)
+	if(INBOUNDS_VEC(i, obj.entities))
 	{
 		obj.entities[i].vx = 0;
 		obj.entities[i].vy = 0;
@@ -1097,7 +1097,7 @@ void mapclass::gotoroom(int rx, int ry)
 	//continuations!
 
 	temp = obj.getplayer();
-	if(temp>-1)
+	if(INBOUNDS_VEC(temp, obj.entities))
 	{
 		obj.entities[temp].oldxp = obj.entities[temp].xp - int(obj.entities[temp].vx);
 		obj.entities[temp].oldyp = obj.entities[temp].yp - int(obj.entities[temp].vy);
@@ -1262,7 +1262,7 @@ void mapclass::loadlevel(int rx, int ry)
 			{
 				//entered from ground floor
 				int player = obj.getplayer();
-				if (player > -1)
+				if (INBOUNDS_VEC(player, obj.entities))
 				{
 					obj.entities[player].yp += (671 * 8);
 				}
@@ -1494,7 +1494,7 @@ void mapclass::loadlevel(int rx, int ry)
 		tower.loadminitower1();
 
 		int i = obj.getplayer();
-		if (i > -1)
+		if (INBOUNDS_VEC(i, obj.entities))
 		{
 			obj.entities[i].yp += (71 * 8);
 		}
@@ -1539,7 +1539,7 @@ void mapclass::loadlevel(int rx, int ry)
 		obj.createentity(72, 156, 11, 200); // (horizontal gravity line)
 
 		int i = obj.getplayer();
-		if (i > -1)
+		if (INBOUNDS_VEC(i, obj.entities))
 		{
 			obj.entities[i].yp += (71 * 8);
 		}
@@ -2098,8 +2098,8 @@ void mapclass::twoframedelayfix()
 	|| !custommode
 	|| game.deathseq != -1
 	// obj.checktrigger() sets obj.activetrigger and block_idx
-	|| obj.checktrigger(&block_idx) <= -1
-	|| block_idx <= -1
+	|| !INBOUNDS_VEC(obj.checktrigger(&block_idx), obj.entities)
+	|| !INBOUNDS_VEC(block_idx, obj.blocks)
 	|| obj.activetrigger < 300)
 	{
 		return;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -2077,8 +2077,11 @@ void mapclass::loadlevel(int rx, int ry)
 				//A slight varation - she's upside down
 				obj.createentity(249, 62, 18, 16, 0, 18);
 				int j = obj.getcrewman(5);
-				obj.entities[j].rule = 7;
-				obj.entities[j].tile +=6;
+				if (INBOUNDS_VEC(j, obj.entities))
+				{
+					obj.entities[j].rule = 7;
+					obj.entities[j].tile +=6;
+				}
 				//What script do we use?
 				obj.createblock(5, 249-32, 0, 32+32+32, 240, 5);
 			}

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -889,7 +889,7 @@ void mapclass::warpto(int rx, int ry , int t, int tx, int ty)
 {
 	gotoroom(rx, ry);
 	game.teleport = false;
-	if (INBOUNDS(t, obj.entities))
+	if (INBOUNDS_VEC(t, obj.entities))
 	{
 		obj.entities[t].xp = tx * 8;
 		obj.entities[t].yp = (ty * 8) - obj.entities[t].h;

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -182,7 +182,7 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 		if (t != -1)
 		{
 			currentsong = t;
-			if (!INBOUNDS(t, musicTracks))
+			if (!INBOUNDS_VEC(t, musicTracks))
 			{
 				puts("play() out-of-bounds!");
 				currentsong = -1;

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -352,7 +352,7 @@ void musicclass::changemusicarea(int x, int y)
 
 void musicclass::playef(int t)
 {
-	if (t < 0 || t >= (int) soundTracks.size())
+	if (!INBOUNDS_VEC(t, soundTracks))
 	{
 		return;
 	}

--- a/desktop_version/src/Otherlevel.cpp
+++ b/desktop_version/src/Otherlevel.cpp
@@ -3,6 +3,7 @@
 #include "Game.h"
 #include "Entity.h"
 #include "MakeAndPlay.h"
+#include "UtilityClass.h"
 
 const short* otherlevelclass::loadlevel(int rx, int ry)
 {
@@ -8892,8 +8893,12 @@ const short* otherlevelclass::loadlevel(int rx, int ry)
 
 			//violet
 			obj.createentity(83, 126, 18, 20, 0, 18);
-			obj.entities[obj.getcrewman(1)].rule = 7;
-			obj.entities[obj.getcrewman(1)].tile +=6;
+			int crewman = obj.getcrewman(1);
+			if (INBOUNDS_VEC(crewman, obj.entities))
+			{
+				obj.entities[crewman].rule = 7;
+				obj.entities[crewman].tile +=6;
+			}
 			obj.createblock(5, 83 - 32, 0, 32 + 32 + 32, 240, 1);
 		}
 		result = contents;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -54,7 +54,7 @@ void menurender()
       graphics.Print( -1, 100, "ERROR: No levels found.", tr, tg, tb, true);
       }
       int tmp=game.currentmenuoption+(game.levelpage*8);
-      if(tmp>=0 && tmp < (int) ed.ListOfMetaData.size()){ // FIXME: size_t/int! -flibit
+      if(INBOUNDS_VEC(tmp, ed.ListOfMetaData)){
         //Don't show next/previous page or return to menu options here!
         if(game.menuoptions.size() - game.currentmenuoption<=3){
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1677,7 +1677,7 @@ void gamerender()
     }
 
     float act_alpha = graphics.lerp(game.prev_act_fade, game.act_fade) / 10.0f;
-    if (game.activeactivity > -1)
+    if (INBOUNDS_VEC(game.activeactivity, obj.entities))
     {
         game.activity_lastprompt = obj.blocks[game.activeactivity].prompt;
         game.activity_r = obj.blocks[game.activeactivity].r;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -582,7 +582,7 @@ void scriptclass::run()
 				}
 
 				//next is whether to position above or below
-				if (words[2] == "above")
+				if (INBOUNDS_VEC(i, obj.entities) && words[2] == "above")
 				{
 					if (j == 1)    //left
 					{
@@ -595,7 +595,7 @@ void scriptclass::run()
 						texty = obj.entities[i].yp - 18 - (txt.size() * 8);
 					}
 				}
-				else
+				else if (INBOUNDS_VEC(i, obj.entities))
 				{
 					if (j == 1)    //left
 					{
@@ -922,11 +922,11 @@ void scriptclass::run()
 					obj.customcrewmoods[1]=ss_toi(words[2]);
 				}
 
-				if (ss_toi(words[2]) == 0)
+				if (INBOUNDS_VEC(i, obj.entities) && ss_toi(words[2]) == 0)
 				{
 					obj.entities[i].tile = 0;
 				}
-				else
+				else if (INBOUNDS_VEC(i, obj.entities))
 				{
 					obj.entities[i].tile = 144;
 				}
@@ -1001,12 +1001,12 @@ void scriptclass::run()
 						i=obj.getcrewman(1);
 					}
 
-					if (obj.entities[i].rule == 7)
+					if (INBOUNDS_VEC(i, obj.entities) && obj.entities[i].rule == 7)
 					{
 						obj.entities[i].rule = 6;
 						obj.entities[i].tile = 0;
 					}
-					else if (obj.getplayer() != i) // Don't destroy player entity
+					else if (INBOUNDS_VEC(i, obj.entities) && obj.getplayer() != i) // Don't destroy player entity
 					{
 						obj.entities[i].rule = 7;
 						obj.entities[i].tile = 6;
@@ -1863,13 +1863,14 @@ void scriptclass::run()
 					i=1;
 				}
 
-				if (i == 4)
+				int crewman = obj.getcrewman(i);
+				if (INBOUNDS_VEC(crewman, obj.entities) && i == 4)
 				{
-					obj.createblock(5, obj.entities[obj.getcrewman(i)].xp - 32, obj.entities[obj.getcrewman(i)].yp-20, 96, 60, i);
+					obj.createblock(5, obj.entities[crewman].xp - 32, obj.entities[crewman].yp-20, 96, 60, i);
 				}
-				else
+				else if (INBOUNDS_VEC(crewman, obj.entities))
 				{
-					obj.createblock(5, obj.entities[obj.getcrewman(i)].xp - 32, 0, 96, 240, i);
+					obj.createblock(5, obj.entities[crewman].xp - 32, 0, 96, 240, i);
 				}
 			}
 			else if (words[0] == "createrescuedcrew")
@@ -2097,7 +2098,10 @@ void scriptclass::run()
 
 				obj.createentity(200, 153, 18, r, 0, 19, 30);
 				i = obj.getcrewman(game.lastsaved);
-				obj.entities[i].dir = 1;
+				if (INBOUNDS_VEC(i, obj.entities))
+				{
+					obj.entities[i].dir = 1;
+				}
 			}
 			else if (words[0] == "specialline")
 			{

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -111,7 +111,7 @@ void scriptclass::run()
 				int temprx=ss_toi(words[1])-1;
 				int tempry=ss_toi(words[2])-1;
 				int curlevel=temprx+(ed.maxwidth*(tempry));
-				bool inbounds = curlevel >= 0 && curlevel < 400;
+				bool inbounds = INBOUNDS_ARR(curlevel, ed.level);
 				if (inbounds)
 				{
 					ed.level[curlevel].warpdir=ss_toi(words[3]);
@@ -151,7 +151,7 @@ void scriptclass::run()
 			if (words[0] == "ifwarp")
 			{
 				int room = ss_toi(words[1])-1+(ed.maxwidth*(ss_toi(words[2])-1));
-				if (room >= 0 && room < 400 && ed.level[room].warpdir == ss_toi(words[3]))
+				if (INBOUNDS_ARR(room, ed.level) && ed.level[room].warpdir == ss_toi(words[3]))
 				{
 					load("custom_"+words[4]);
 					position--;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -98,7 +98,7 @@ void scriptclass::run()
 			{
 				//USAGE: moveplayer(x offset, y offset)
 				int player = obj.getplayer();
-				if (player > -1)
+				if (INBOUNDS_VEC(player, obj.entities))
 				{
 					obj.entities[player].xp += ss_toi(words[1]);
 					obj.entities[player].yp += ss_toi(words[2]);
@@ -254,7 +254,7 @@ void scriptclass::run()
 			if (words[0] == "tofloor")
 			{
 				int player = obj.getplayer();
-				if(player > -1 && obj.entities[player].onroof>0)
+				if(INBOUNDS_VEC(player, obj.entities) && obj.entities[player].onroof>0)
 				{
 					game.press_action = true;
 					scriptdelay = 1;
@@ -293,7 +293,7 @@ void scriptclass::run()
 			{
 				//USAGE: gotoposition(x position, y position, gravity position)
 				int player = obj.getplayer();
-				if (player > -1)
+				if (INBOUNDS_VEC(player, obj.entities))
 				{
 					obj.entities[player].xp = ss_toi(words[1]);
 					obj.entities[player].yp = ss_toi(words[2]);
@@ -429,7 +429,7 @@ void scriptclass::run()
 				if (words[1] == "player")
 				{
 					i = obj.getplayer();
-					if (i > -1)
+					if (INBOUNDS_VEC(i, obj.entities))
 					{
 						j = obj.entities[i].dir;
 					}
@@ -485,7 +485,7 @@ void scriptclass::run()
 				}
 
 				//next is whether to position above or below
-				if (i > -1 && words[2] == "above")
+				if (INBOUNDS_VEC(i, obj.entities) && words[2] == "above")
 				{
 					if (j == 1)    //left
 					{
@@ -498,7 +498,7 @@ void scriptclass::run()
 						texty = obj.entities[i].yp - 18 - (txt.size() * 8);
 					}
 				}
-				else if (i > -1)
+				else if (INBOUNDS_VEC(i, obj.entities))
 				{
 					if (j == 1)    //left
 					{
@@ -701,7 +701,7 @@ void scriptclass::run()
 			{
 				//Create the super VVVVVV combo!
 				i = obj.getplayer();
-				if (i > -1)
+				if (INBOUNDS_VEC(i, obj.entities))
 				{
 					obj.entities[i].xp = 30;
 					obj.entities[i].yp = 46;
@@ -716,7 +716,7 @@ void scriptclass::run()
 			{
 				//Create the super VVVVVV combo!
 				i = obj.getplayer();
-				if (i > -1)
+				if (INBOUNDS_VEC(i, obj.entities))
 				{
 					obj.entities[i].xp = 100;
 					obj.entities[i].size = 0;
@@ -865,11 +865,11 @@ void scriptclass::run()
 					i=obj.getcrewman(1);
 				}
 
-				if (i > -1 && ss_toi(words[2]) == 0)
+				if (INBOUNDS_VEC(i, obj.entities) && ss_toi(words[2]) == 0)
 				{
 					obj.entities[i].tile = 0;
 				}
-				else if (i > -1)
+				else if (INBOUNDS_VEC(i, obj.entities))
 				{
 					obj.entities[i].tile = 144;
 				}
@@ -962,7 +962,7 @@ void scriptclass::run()
 					i=obj.getcrewman(1);
 				}
 
-				if (i > -1)
+				if (INBOUNDS_VEC(i, obj.entities))
 				{
 					obj.entities[i].tile = ss_toi(words[2]);
 				}
@@ -1045,7 +1045,7 @@ void scriptclass::run()
 					i=obj.getcrewman(1);
 				}
 
-				if (i > -1)
+				if (INBOUNDS_VEC(i, obj.entities))
 				{
 					obj.entities[i].tile +=12;
 				}
@@ -1081,11 +1081,11 @@ void scriptclass::run()
 					i=obj.getcrewman(1);
 				}
 
-				if (i > -1 && ss_toi(words[2]) == 0)
+				if (INBOUNDS_VEC(i, obj.entities) && ss_toi(words[2]) == 0)
 				{
 					obj.entities[i].dir = 0;
 				}
-				else if (i > -1)
+				else if (INBOUNDS_VEC(i, obj.entities))
 				{
 					obj.entities[i].dir = 1;
 				}
@@ -1150,7 +1150,7 @@ void scriptclass::run()
 				}
 
 
-				if (i > -1)
+				if (INBOUNDS_VEC(i, obj.entities))
 				{
 					obj.entities[i].state = ss_toi(words[2]);
 					if (obj.entities[i].state == 16)
@@ -1166,7 +1166,7 @@ void scriptclass::run()
 			else if (words[0] == "activateteleporter")
 			{
 				i = obj.getteleporter();
-				if (i > -1)
+				if (INBOUNDS_VEC(i, obj.entities))
 				{
 					obj.entities[i].tile = 6;
 					obj.entities[i].colour = 102;
@@ -1203,7 +1203,7 @@ void scriptclass::run()
 					i=obj.getcrewman(1);
 				}
 
-				if (i > -1)
+				if (INBOUNDS_VEC(i, obj.entities))
 				{
 					if (words[2] == "cyan")
 					{
@@ -1286,7 +1286,7 @@ void scriptclass::run()
 			{
 				i = obj.getplayer();
 				game.savepoint = 0;
-				if (i > -1)
+				if (INBOUNDS_VEC(i, obj.entities))
 				{
 					game.savex = obj.entities[i].xp ;
 					game.savey = obj.entities[i].yp;
@@ -1294,7 +1294,7 @@ void scriptclass::run()
 				game.savegc = game.gravitycontrol;
 				game.saverx = game.roomx;
 				game.savery = game.roomy;
-				if (i > -1)
+				if (INBOUNDS_VEC(i, obj.entities))
 				{
 					game.savedir = obj.entities[i].dir;
 				}
@@ -1463,7 +1463,7 @@ void scriptclass::run()
 			else if (words[0] == "hideplayer")
 			{
 				int player = obj.getplayer();
-				if (player > -1)
+				if (INBOUNDS_VEC(player, obj.entities))
 				{
 					obj.entities[player].invis = true;
 				}
@@ -1471,7 +1471,7 @@ void scriptclass::run()
 			else if (words[0] == "showplayer")
 			{
 				int player = obj.getplayer();
-				if (player > -1)
+				if (INBOUNDS_VEC(player, obj.entities))
 				{
 					obj.entities[player].invis = false;
 				}
@@ -1535,7 +1535,7 @@ void scriptclass::run()
 
 				obj.resetallflags();
 				i = obj.getplayer();
-				if (i > -1)
+				if (INBOUNDS_VEC(i, obj.entities))
 				{
 					obj.entities[i].tile = 0;
 				}
@@ -1711,11 +1711,11 @@ void scriptclass::run()
 					j=obj.getcrewman(1);
 				}
 
-				if (i > -1 && j > -1 && obj.entities[j].xp > obj.entities[i].xp + 5)
+				if (INBOUNDS_VEC(i, obj.entities) && INBOUNDS_VEC(j, obj.entities) && obj.entities[j].xp > obj.entities[i].xp + 5)
 				{
 					obj.entities[i].dir = 1;
 				}
-				else if (i > -1 && j > -1 && obj.entities[j].xp < obj.entities[i].xp - 5)
+				else if (INBOUNDS_VEC(i, obj.entities) && INBOUNDS_VEC(j, obj.entities) && obj.entities[j].xp < obj.entities[i].xp - 5)
 				{
 					obj.entities[i].dir = 0;
 				}
@@ -1901,7 +1901,7 @@ void scriptclass::run()
 			else if (words[0] == "restoreplayercolour")
 			{
 				i = obj.getplayer();
-				if (i > -1)
+				if (INBOUNDS_VEC(i, obj.entities))
 				{
 					obj.entities[i].colour = 0;
 				}
@@ -1910,7 +1910,7 @@ void scriptclass::run()
 			{
 				i = obj.getplayer();
 
-				if (i > -1)
+				if (INBOUNDS_VEC(i, obj.entities))
 				{
 					if (words[1] == "cyan")
 					{
@@ -1949,7 +1949,7 @@ void scriptclass::run()
 			else if (words[0] == "activeteleporter")
 			{
 				i = obj.getteleporter();
-				if (i > -1)
+				if (INBOUNDS_VEC(i, obj.entities))
 				{
 					obj.entities[i].colour = 101;
 				}
@@ -2718,7 +2718,7 @@ void scriptclass::startgamemode( int t )
 			map.resetplayer();
 
 			i = obj.getplayer();
-			if (i > -1)
+			if (INBOUNDS_VEC(i, obj.entities))
 			{
 				map.ypos = obj.entities[i].yp - 120;
 			}
@@ -3437,7 +3437,7 @@ void scriptclass::teleport()
 	game.companion = 0;
 
 	i = obj.getplayer(); //less likely to have a serious collision error if the player is centered
-	if (i > -1)
+	if (INBOUNDS_VEC(i, obj.entities))
 	{
 		obj.entities[i].xp = 150;
 		obj.entities[i].yp = 110;
@@ -3460,13 +3460,13 @@ void scriptclass::teleport()
 	game.gravitycontrol = 0;
 	map.gotoroom(100+game.teleport_to_x, 100+game.teleport_to_y);
 	j = obj.getteleporter();
-	if (j > -1)
+	if (INBOUNDS_VEC(j, obj.entities))
 	{
 		obj.entities[j].state = 2;
 	}
 	game.teleport_to_new_area = false;
 
-	if (j > -1)
+	if (INBOUNDS_VEC(j, obj.entities))
 	{
 		game.savepoint = obj.entities[j].para;
 		game.savex = obj.entities[j].xp + 44;
@@ -3477,7 +3477,7 @@ void scriptclass::teleport()
 	game.saverx = game.roomx;
 	game.savery = game.roomy;
 	int player = obj.getplayer();
-	if (player > -1)
+	if (INBOUNDS_VEC(player, obj.entities))
 	{
 		game.savedir = obj.entities[player].dir;
 	}
@@ -3730,7 +3730,7 @@ void scriptclass::hardreset()
 	i = 100; //previously a for-loop iterating over collect/customcollect set this to 100
 
 	int theplayer = obj.getplayer();
-	if (theplayer > -1){
+	if (INBOUNDS_VEC(theplayer, obj.entities)){
 		obj.entities[theplayer].tile = 0;
 	}
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -82,7 +82,7 @@ void scriptclass::run()
 	short execution_counter = 0;
 	while(running && scriptdelay<=0 && !game.pausescript)
 	{
-		if (position < (int) commands.size())
+		if (INBOUNDS_VEC(position, commands))
 		{
 			//Let's split or command in an array of words
 			tokenize(commands[position]);
@@ -414,7 +414,7 @@ void scriptclass::run()
 				for (int i = 0; i < ss_toi(words[4]); i++)
 				{
 					position++;
-					if (position < (int) commands.size())
+					if (INBOUNDS_VEC(position, commands))
 					{
 						txt.push_back(commands[position]);
 					}
@@ -3997,7 +3997,7 @@ void scriptclass::loadcustom(const std::string& t)
 			int nti = ti>=0 && ti<=50 ? ti : 1;
 			for(int ti2=0; ti2<nti; ti2++){
 				i++;
-				if(i < lines.size()){
+				if(INBOUNDS_VEC(i, lines)){
 					add(lines[i]);
 				}
 			}
@@ -4022,7 +4022,7 @@ void scriptclass::loadcustom(const std::string& t)
 			int nti = ti>=0 && ti<=50 ? ti : 1;
 			for(int ti2=0; ti2<nti; ti2++){
 				i++;
-				if(i < lines.size()){
+				if(INBOUNDS_VEC(i, lines)){
 					add(lines[i]);
 				}
 			}

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -4,7 +4,9 @@
 #include <string>
 #include <vector>
 
-#define filllines(lines) commands.insert(commands.end(), lines, lines + sizeof(lines)/sizeof(lines[0]))
+#include <SDL.h>
+
+#define filllines(lines) commands.insert(commands.end(), lines, lines + SDL_arraysize(lines))
 
 
 struct Script

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -17,7 +17,7 @@ bool is_positive_num(const std::string& str, bool hex);
 
 bool endsWith(const std::string& str, const std::string& suffix);
 
-#define INBOUNDS(index, vector) ((int) index >= 0 && (int) index < (int) vector.size())
+#define INBOUNDS_VEC(index, vector) ((int) index >= 0 && (int) index < (int) vector.size())
 #define INBOUNDS_ARR(index, array) ((int) index >= 0 && (int) index < (int) SDL_arraysize(array))
 
 #define WHINE_ONCE(message) \

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2676,6 +2676,10 @@ void editorrender()
                 fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),16,16,graphics.getBGR(255,164,255));
                 break;
             case 2: //Threadmills & platforms
+                if (!INBOUNDS_VEC(obj.customplatformtile, graphics.entcolours))
+                {
+                    continue;
+                }
                 tpoint.x = (edentity[i].x*8)- (ed.levx*40*8);
                 tpoint.y = (edentity[i].y*8)- (ed.levy*30*8);
                 drawRect = graphics.tiles_rect;
@@ -2733,6 +2737,10 @@ void editorrender()
                 }
                 break;
             case 3: //Disappearing Platform
+                if (!INBOUNDS_VEC(obj.customplatformtile, graphics.entcolours))
+                {
+                    continue;
+                }
                 tpoint.x = (edentity[i].x*8)- (ed.levx*40*8);
                 tpoint.y = (edentity[i].y*8)- (ed.levy*30*8);
                 drawRect = graphics.tiles_rect;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1567,7 +1567,7 @@ void editorclass::switch_tileset(const bool reversed /*= false*/)
 {
     const char* tilesets[] = {"Space Station", "Outside", "Lab", "Warp Zone", "Ship"};
     const size_t roomnum = levx + levy*maxwidth;
-    if (roomnum >= SDL_arraysize(level))
+    if (!INBOUNDS_ARR(roomnum, level))
     {
         return;
     }
@@ -1601,7 +1601,7 @@ void editorclass::switch_tileset(const bool reversed /*= false*/)
 void editorclass::switch_tilecol(const bool reversed /*= false*/)
 {
     const size_t roomnum = levx + levy*maxwidth;
-    if (roomnum >= SDL_arraysize(level))
+    if (!INBOUNDS_ARR(roomnum, level))
     {
         return;
     }
@@ -1626,7 +1626,7 @@ void editorclass::switch_tilecol(const bool reversed /*= false*/)
 void editorclass::clamp_tilecol(const int rx, const int ry, const bool wrap /*= false*/)
 {
     const size_t roomnum = rx + ry*maxwidth;
-    if (roomnum >= SDL_arraysize(level))
+    if (!INBOUNDS_ARR(roomnum, level))
     {
         return;
     }
@@ -1676,7 +1676,7 @@ void editorclass::clamp_tilecol(const int rx, const int ry, const bool wrap /*= 
 void editorclass::switch_enemy(const bool reversed /*= false*/)
 {
     const size_t roomnum = levx + levy*maxwidth;
-    if (roomnum >= SDL_arraysize(level))
+    if (!INBOUNDS_ARR(roomnum, level))
     {
         return;
     }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2124,7 +2124,7 @@ bool editorclass::save(std::string& _path)
     data->LinkEndChild( msg );
 
     msg = doc.NewElement( "levelMetaData" );
-    for(int i = 0; i < 400; i++)
+    for(size_t i = 0; i < SDL_arraysize(level); i++)
     {
         tinyxml2::XMLElement *edlevelclassElement = doc.NewElement( "edLevelClass" );
         edlevelclassElement->SetAttribute( "tileset", level[i].tileset);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2997,7 +2997,7 @@ void editorrender()
         for (int i = 0; i < (int)ed.ghosts.size(); i++) {
             if (i <= ed.currentghosts) { // We don't want all of them to show up at once :)
                 if (ed.ghosts[i].rx != ed.levx || ed.ghosts[i].ry != ed.levy
-                || !INBOUNDS(ed.ghosts[i].frame, graphics.sprites))
+                || !INBOUNDS_VEC(ed.ghosts[i].frame, graphics.sprites))
                     continue;
                 point tpoint;
                 tpoint.x = ed.ghosts[i].x;


### PR DESCRIPTION
The game currently has these problems with its bounds checks, all of which this PR fixes:

- It was sometimes using manually-typed bounds checks instead of the macros, which is inconsistent. Also, some of these manually-typed bounds checks are wrong!
- It was falsely assuming it would be sufficient to check `i > -1` and not the other end, *especially* in script commands, where the lack of checking of the other end could lead to potential out-of-bounds indexing given a fuzzer!
- In the same vein, it was also falsely assuming entity getters that returned a default value of 0 would also be fine to not check, leading to the same situation with certain script commands as above.
- And sometimes it just plain flat-out didn't bounds-check certain things.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
