### PR TITLE
Fix duplicate levels in levelstats if you don't have a higher score

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -438,10 +438,14 @@ void Game::updatecustomlevelstats(std::string clevel, int cscore)
             break;
         }
     }
-    if(tvar>=0 && cscore > customlevelstats[tvar].score)
+    if(tvar>=0)
     {
-        //update existing entry
-        customlevelstats[tvar].score=cscore;
+        // We have an existing entry
+        // Don't update it unless it's a higher score
+        if (cscore > customlevelstats[tvar].score)
+        {
+            customlevelstats[tvar].score=cscore;
+        }
     }
     else
     {


### PR DESCRIPTION
This is a regression from 25779606b499819de50151cd20aab406256315f5 (PR #74).

On the one hand, I should've thought this through carefully when implementing the fix for the lower-score overwrite bug. On the other hand, flibit didn't seem to notice either. And on the third hand, no one else seems to have noticed, when they have had over 8 months to do so. Not even the person who originally reported the lower-score overwrite bug and also reported other bugs I hadn't noticed (e.g. the "You have rescued a crewmate!" in Flip Mode) noticed, which I believe was weee50. But to be fair, he does seem to be less active nowadays.

On the fourth hand, I only realized the cause of the duplicate bug after stepping through it in GDB, instead of just looking at it and going "hey wait a minute" earlier. I'm surprised it didn't take me longer to realize the problem.

I'm not sure what all these hands mean anymore, or where I'm getting extra hands from. Whatever. This regression is fixed now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
