### PR TITLE
Add space after lines terminated by a colon in scripts

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -14,6 +14,7 @@ Contributors
 * Fredrik Ljungdahl (@FredrIQ)
 * Nichole Mattera (@NicholeMattera)
 * Matt Penny (@mwpenny)
+* MAO3J1m0Op (@MAO3J1m0Op)
 * Tynan Richards (@tzann)
 * Elliott Saltar (@eboyblue3)
 * Marvin Scholz (@ePirat)

--- a/desktop_version/src/Credits.h
+++ b/desktop_version/src/Credits.h
@@ -93,6 +93,7 @@ static const char* githubfriends[] = {
     "Allison Fleischer",
     "Daniel Lee",
     "Fredrik Ljungdahl",
+    "MAO3J1m0Op",
     "Nichole Mattera",
     "Matt Penny",
     "Tynan Richards",

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2158,7 +2158,7 @@ bool editorclass::save(std::string& _path)
             scriptString += script_.contents[i]
 
             // Inserts a space if the line ends with a :
-            + (script_.contents[i].back() == ':'? " " : "")
+            + (script_.contents[i].length() != 0 && *script_.contents[i].rbegin() == ':' ? " " : "")
 
             + "|";
         }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2155,7 +2155,12 @@ bool editorclass::save(std::string& _path)
         scriptString += script_.name + ":|";
         for (size_t i = 0; i < script_.contents.size(); i++)
         {
-            scriptString += script_.contents[i] + "|";
+            scriptString += script_.contents[i]
+
+            // Inserts a space if the line ends with a :
+            + (script_.contents[i].back() == ':'? " " : "")
+
+            + "|";
         }
     }
     msg = doc.NewElement( "script" );

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2155,12 +2155,15 @@ bool editorclass::save(std::string& _path)
         scriptString += script_.name + ":|";
         for (size_t i = 0; i < script_.contents.size(); i++)
         {
-            scriptString += script_.contents[i]
+            scriptString += script_.contents[i];
 
             // Inserts a space if the line ends with a :
-            + (script_.contents[i].length() != 0 && *script_.contents[i].rbegin() == ':' ? " " : "")
+            if (script_.contents[i].length() && *script_.contents[i].rbegin() == ':')
+            {
+                scriptString += " ";
+            }
 
-            + "|";
+            scriptString += "|";
         }
     }
     msg = doc.NewElement( "script" );


### PR DESCRIPTION
## Changes:

This is a small fix that partially addresses #379 by inserting a space after a colon followed by a new line when a script is saved.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
