### PR TITLE
Fix default Graphics::setcol() value having no alpha

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2717,7 +2717,7 @@ void Graphics::setcol( int t )
 		break;
 
 	default:
-		ct.colour = 0xFFFFFF;
+		ct.colour = getRGB(255, 255, 255);
 		break;
 	}
 }


### PR DESCRIPTION
This patch fixes a regression caused by commit 6b1a7ebce6fa77ec54c881bec95081b1a2826646.

When you spawn a crewmate with an invalid color, by doing something like `createentity(100,100,18,-1,0)` (here the color is -1, which is invalid), a white crewmate with the color of solid white (255, 255, 255) would appear.

That is, until @AllyTally came along and committed commit 6b1a7ebce6fa77ec54c881bec95081b1a2826646 (Make "[Press ENTER to return to editor]" fade out after a bit) (PR #158). Then after that commit, it would seem like the crewmate didn't appear, but in reality they were just invisible, because they had an invisible color.

As part of Ally's changes, to properly support drawing text with a certain amount of alpha, she made `BlitSurfaceColoured()` account for the alpha of the color given instead of only caring about the RGB of the color, discarding the alpha, and using the alpha of the surface it was drawing instead. This effectively made it so the alpha of whatever it was drawing would be 255 all the time, except for if you had custom textures and your custom textures had translucent pixels.

However, the default color set by `Graphics::setcol()` if you didn't provide a valid color index was `0xFFFFFF`. Which is only (255, 255, 255) but ends up having an alpha value of 0 (because it's actually `0x00FFFFFF`). And all colors drawn with alpha 0 end up being drawn with alpha 0 after 6b1a7ebce6fa77ec54c881bec95081b1a2826646. So invalid-colored entities will end up being invisible.

To fix this, I just decided to add alpha to the default value instead. In addition, I used `getRGB()` to be consistent with all the other colors in the function.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
