### PR TITLE
Allow calling flipgravity() on duplicate player entities

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1006,7 +1006,7 @@ void scriptclass::run()
 						obj.entities[i].rule = 7;
 						obj.entities[i].tile = 6;
 					}
-					else if (obj.entities[i].rule != 0) // Don't destroy player entity (rule 0)
+					else if (obj.getplayer() != i) // Don't destroy player entity
 					{
 						obj.entities[i].rule = 6;
 						obj.entities[i].tile = 0;


### PR DESCRIPTION
This is a followup to b7cf6855b0ad1e30ac33bc9a53ef4268fdf686cf and 10ed0058fd760f764cc7b849e6f0e22f1e4dc6bb.

In 2.2, if you had a duplicate player entity, there'd be no way to get rid of it. Except for the recently-discovered Arbitrary Entity
Manipulation glitch, where you set `i` to the indice of the entity and call `flipgravity()` on it, turning its rule to 7 and making it no longer a player entity.

However, I patched this useful mechanic out when I made it so that you'd no longer be able to convert entities with rule 0 to rule 6 (10ed0058fd760f764cc7b849e6f0e22f1e4dc6bb, upheld in b7cf6855b0ad1e30ac33bc9a53ef4268fdf686cf), because doing so would mean being able to softlock the game by not having any player entity.

So, in this patch, I'm making it so that you *can* convert duplicate player entities to crewmates (and thus basically destroy them), but you can't do that to the *true* player entity (i.e. the first entity indice that has rule 0, which is basically always indice 0).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
