### PR TITLE
Allow the character separating script lines to be customizable

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1960,11 +1960,11 @@ bool editorclass::load(std::string& _path)
         if (pKey == "script")
         {
             // load in the linebreak attribute
-            linebreak = "default";
+            linebreak = "";
             pElem->QueryStringAttribute("linebreak", &linebreak);
             char splitvalue = linebreak[0];
-            // "default" is the only value where splitvalue and linebreak are different
-            if (std::strcmp(linebreak, "default") == 0)
+            // "" is the only value where splitvalue and linebreak are different
+            if (std::strcmp(linebreak, "") == 0)
             {
                 splitvalue = '|'; // To keep compatibility with older levels
                 linebreak = "\n"; // So this conversion only happens once

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1959,10 +1959,21 @@ bool editorclass::load(std::string& _path)
 
         if (pKey == "script")
         {
+            // load in the linebreak attribute
+            linebreak = "default";
+            pElem->QueryStringAttribute("linebreak", &linebreak);
+            char splitvalue = linebreak[0];
+            // "default" is the only value where splitvalue and linebreak are different
+            if (std::strcmp(linebreak, "default") == 0)
+            {
+                splitvalue = '|'; // To keep compatibility with older levels
+                linebreak = "\n"; // So this conversion only happens once
+            }
+
             std::string TextString = (pText);
             if(TextString.length())
             {
-                std::vector<std::string> values = split(TextString,'|');
+                std::vector<std::string> values = split(TextString, splitvalue);
                 script.clearcustom();
                 Script script_;
                 bool headerfound = false;
@@ -2152,7 +2163,7 @@ bool editorclass::save(std::string& _path)
     {
         Script& script_ = script.customscripts[i];
 
-        scriptString += script_.name + ":|";
+        scriptString += script_.name + ":" + linebreak[0];
         for (size_t i = 0; i < script_.contents.size(); i++)
         {
             scriptString += script_.contents[i];
@@ -2163,11 +2174,12 @@ bool editorclass::save(std::string& _path)
                 scriptString += " ";
             }
 
-            scriptString += "|";
+            scriptString += linebreak[0];
         }
     }
     msg = doc.NewElement( "script" );
     msg->LinkEndChild( doc.NewText( scriptString.c_str() ));
+    msg->SetAttribute( "linebreak", linebreak );
     data->LinkEndChild( msg );
 
     return FILESYSTEM_saveTiXml2Document(("levels/" + _path).c_str(), doc);

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -113,6 +113,8 @@ class editorclass{
   std::vector<std::string> directoryList;
   std::vector<LevelMetaData> ListOfMetaData;
 
+  const char *linebreak;
+
   void loadZips();
   void getDirectoryData();
   bool getLevelMetaData(std::string& filename, LevelMetaData& _data );


### PR DESCRIPTION
## Changes:

In order to allow the typing of the pipe character to fix the second part of #379, an attribute to the `<script>` tag of a level was added. The attribute is titled `linebreak`, and in order to preserve backwards compatibility, the abscense of this attribute (or a value of `""`) tells the game to still parse the level using a pipe as a line separator. However, if the attribute is not present (or, again, has a value of `""`), the save will be written with a `linebreak` value of `\n`.

This PR does change the format of the custom level XML file, but the code handles both the old and new formats.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
