### PR TITLE
Split flip logic from player input logic

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1909,95 +1909,95 @@ void gameinput()
                 }
             }
         }
+    }
 
-        if (game.press_left)
+    if (game.press_left)
+    {
+        game.tapleft++;
+    }
+    else
+    {
+        if (game.tapleft <= 4 && game.tapleft > 0)
         {
-            game.tapleft++;
-        }
-        else
-        {
-            if (game.tapleft <= 4 && game.tapleft > 0)
+            for (size_t ie = 0; ie < obj.entities.size(); ++ie)
             {
-                for (size_t ie = 0; ie < obj.entities.size(); ++ie)
+                if (obj.entities[ie].rule == 0)
                 {
-                    if (obj.entities[ie].rule == 0)
+                    if (obj.entities[ie].vx < 0.0f)
                     {
-                        if (obj.entities[ie].vx < 0.0f)
-                        {
-                            obj.entities[ie].vx = 0.0f;
-                        }
+                        obj.entities[ie].vx = 0.0f;
                     }
                 }
             }
-            game.tapleft = 0;
         }
-        if (game.press_right)
+        game.tapleft = 0;
+    }
+    if (game.press_right)
+    {
+        game.tapright++;
+    }
+    else
+    {
+        if (game.tapright <= 4 && game.tapright > 0)
         {
-            game.tapright++;
-        }
-        else
-        {
-            if (game.tapright <= 4 && game.tapright > 0)
+            for (size_t ie = 0; ie < obj.entities.size(); ++ie)
             {
-                for (size_t ie = 0; ie < obj.entities.size(); ++ie)
+                if (obj.entities[ie].rule == 0)
                 {
-                    if (obj.entities[ie].rule == 0)
+                    if (obj.entities[ie].vx > 0.0f)
                     {
-                        if (obj.entities[ie].vx > 0.0f)
-                        {
-                            obj.entities[ie].vx = 0.0f;
-                        }
+                        obj.entities[ie].vx = 0.0f;
                     }
                 }
             }
-            game.tapright = 0;
         }
+        game.tapright = 0;
+    }
 
-        if (!game.press_action)
+    if (!game.press_action)
+    {
+        game.jumppressed = 0;
+        game.jumpheld = false;
+    }
+
+    if (game.press_action && !game.jumpheld)
+    {
+        game.jumppressed = 5;
+        game.jumpheld = true;
+    }
+
+    if (game.jumppressed > 0)
+    {
+        game.jumppressed--;
+        if (obj.entities[obj.getplayer()].onground>0 && game.gravitycontrol == 0)
         {
+            game.gravitycontrol = 1;
+            for (size_t ie = 0; ie < obj.entities.size(); ++ie)
+            {
+                if (obj.entities[ie].rule == 0)
+                {
+                    obj.entities[ie].vy = -4;
+                    obj.entities[ie].ay = -3;
+                }
+            }
+            music.playef(0);
             game.jumppressed = 0;
-            game.jumpheld = false;
+            game.totalflips++;
         }
-
-        if (game.press_action && !game.jumpheld)
+        if (obj.entities[obj.getplayer()].onroof>0 && game.gravitycontrol == 1)
         {
-            game.jumppressed = 5;
-            game.jumpheld = true;
-        }
-
-        if (game.jumppressed > 0)
-        {
-            game.jumppressed--;
-            if (obj.entities[obj.getplayer()].onground>0 && game.gravitycontrol == 0)
+            game.gravitycontrol = 0;
+            for (size_t ie = 0; ie < obj.entities.size(); ++ie)
             {
-                game.gravitycontrol = 1;
-                for (size_t ie = 0; ie < obj.entities.size(); ++ie)
+                if (obj.entities[ie].rule == 0)
                 {
-                    if (obj.entities[ie].rule == 0)
-                    {
-                        obj.entities[ie].vy = -4;
-                        obj.entities[ie].ay = -3;
-                    }
+                    obj.entities[ie].vy = 4;
+                    obj.entities[ie].ay = 3;
                 }
-                music.playef(0);
-                game.jumppressed = 0;
-                game.totalflips++;
             }
-            if (obj.entities[obj.getplayer()].onroof>0 && game.gravitycontrol == 1)
-            {
-                game.gravitycontrol = 0;
-                for (size_t ie = 0; ie < obj.entities.size(); ++ie)
-                {
-                    if (obj.entities[ie].rule == 0)
-                    {
-                        obj.entities[ie].vy = 4;
-                        obj.entities[ie].ay = 3;
-                    }
-                }
-                music.playef(1);
-                game.jumppressed = 0;
-                game.totalflips++;
-            }
+            music.playef(1);
+            game.jumppressed = 0;
+            game.totalflips++;
         }
     }
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1897,38 +1897,6 @@ void gameinput()
                     }
                 }
 
-                if (game.press_left)
-                {
-                    game.tapleft++;
-                }
-                else
-                {
-                    if (game.tapleft <= 4 && game.tapleft > 0)
-                    {
-                        if (obj.entities[ie].vx < 0.0f)
-                        {
-                            obj.entities[ie].vx = 0.0f;
-                        }
-                    }
-                    game.tapleft = 0;
-                }
-                if (game.press_right)
-                {
-                    game.tapright++;
-                }
-                else
-                {
-                    if (game.tapright <= 4 && game.tapright > 0)
-                    {
-                        if (obj.entities[ie].vx > 0.0f)
-                        {
-                            obj.entities[ie].vx = 0.0f;
-                        }
-                    }
-                    game.tapright = 0;
-                }
-
-
                 if(game.press_left)
                 {
                     obj.entities[ie].ax = -3;
@@ -1940,6 +1908,49 @@ void gameinput()
                     obj.entities[ie].dir = 1;
                 }
             }
+        }
+
+        if (game.press_left)
+        {
+            game.tapleft++;
+        }
+        else
+        {
+            if (game.tapleft <= 4 && game.tapleft > 0)
+            {
+                for (size_t ie = 0; ie < obj.entities.size(); ++ie)
+                {
+                    if (obj.entities[ie].rule == 0)
+                    {
+                        if (obj.entities[ie].vx < 0.0f)
+                        {
+                            obj.entities[ie].vx = 0.0f;
+                        }
+                    }
+                }
+            }
+            game.tapleft = 0;
+        }
+        if (game.press_right)
+        {
+            game.tapright++;
+        }
+        else
+        {
+            if (game.tapright <= 4 && game.tapright > 0)
+            {
+                for (size_t ie = 0; ie < obj.entities.size(); ++ie)
+                {
+                    if (obj.entities[ie].rule == 0)
+                    {
+                        if (obj.entities[ie].vx > 0.0f)
+                        {
+                            obj.entities[ie].vx = 0.0f;
+                        }
+                    }
+                }
+            }
+            game.tapright = 0;
         }
 
         if (!game.press_action)

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1797,6 +1797,8 @@ void gameinput()
     bool has_control = false;
     bool enter_pressed = game.press_map && !game.mapheld;
     bool enter_already_processed = false;
+    bool any_onground = false;
+    bool any_onroof = false;
     for (size_t ie = 0; ie < obj.entities.size(); ++ie)
     {
         if (obj.entities[ie].rule == 0)
@@ -1908,6 +1910,12 @@ void gameinput()
                     obj.entities[ie].dir = 1;
                 }
             }
+
+            if (obj.entities[ie].onground > 0) {
+              any_onground = true;
+            } else if (obj.entities[ie].onroof > 0) {
+              any_onroof = true;
+            }
         }
     }
 
@@ -1969,7 +1977,7 @@ void gameinput()
     if (game.jumppressed > 0)
     {
         game.jumppressed--;
-        if (obj.entities[obj.getplayer()].onground>0 && game.gravitycontrol == 0)
+        if (any_onground && game.gravitycontrol == 0)
         {
             game.gravitycontrol = 1;
             for (size_t ie = 0; ie < obj.entities.size(); ++ie)
@@ -1984,7 +1992,7 @@ void gameinput()
             game.jumppressed = 0;
             game.totalflips++;
         }
-        if (obj.entities[obj.getplayer()].onroof>0 && game.gravitycontrol == 1)
+        if (any_onroof && game.gravitycontrol == 1)
         {
             game.gravitycontrol = 0;
             for (size_t ie = 0; ie < obj.entities.size(); ++ie)

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1939,41 +1939,53 @@ void gameinput()
                     obj.entities[ie].ax = 3;
                     obj.entities[ie].dir = 1;
                 }
+            }
+        }
 
-                if (!game.press_action)
-                {
-                    game.jumppressed = 0;
-                    game.jumpheld = false;
-                }
+        if (!game.press_action)
+        {
+            game.jumppressed = 0;
+            game.jumpheld = false;
+        }
 
-                if (game.press_action && !game.jumpheld)
-                {
-                    game.jumppressed = 5;
-                    game.jumpheld = true;
-                }
+        if (game.press_action && !game.jumpheld)
+        {
+            game.jumppressed = 5;
+            game.jumpheld = true;
+        }
 
-                if (game.jumppressed > 0)
+        if (game.jumppressed > 0)
+        {
+            game.jumppressed--;
+            if (obj.entities[obj.getplayer()].onground>0 && game.gravitycontrol == 0)
+            {
+                game.gravitycontrol = 1;
+                for (size_t ie = 0; ie < obj.entities.size(); ++ie)
                 {
-                    game.jumppressed--;
-                    if (obj.entities[ie].onground>0 && game.gravitycontrol == 0)
+                    if (obj.entities[ie].rule == 0)
                     {
-                        game.gravitycontrol = 1;
                         obj.entities[ie].vy = -4;
                         obj.entities[ie].ay = -3;
-                        music.playef(0);
-                        game.jumppressed = 0;
-                        game.totalflips++;
-                    }
-                    if (obj.entities[ie].onroof>0 && game.gravitycontrol == 1)
-                    {
-                        game.gravitycontrol = 0;
-                        obj.entities[ie].vy = 4;
-                        obj.entities[ie].ay = 3;
-                        music.playef(1);
-                        game.jumppressed = 0;
-                        game.totalflips++;
                     }
                 }
+                music.playef(0);
+                game.jumppressed = 0;
+                game.totalflips++;
+            }
+            if (obj.entities[obj.getplayer()].onroof>0 && game.gravitycontrol == 1)
+            {
+                game.gravitycontrol = 0;
+                for (size_t ie = 0; ie < obj.entities.size(); ++ie)
+                {
+                    if (obj.entities[ie].rule == 0)
+                    {
+                        obj.entities[ie].vy = 4;
+                        obj.entities[ie].ay = 3;
+                    }
+                }
+                music.playef(1);
+                game.jumppressed = 0;
+                game.totalflips++;
             }
         }
     }


### PR DESCRIPTION
Closes #484

## Changes:
Flipping only applies momentum to the player entity currently being processed. This normally wouldn't be a problem. However, flipping involves global state, and only one flip can occur per frame. This means that additional player entities don't get this boost of momentum, which feels somewhat unnatural during gameplay.
This commit fixes this by splitting flip logic out of the loop over player entities, and applying the flip momentum to all player entities.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
