### PR TITLE
Fix flipgravity() rule conversion being inverted

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1001,15 +1001,15 @@ void scriptclass::run()
 						i=obj.getcrewman(1);
 					}
 
-					if (obj.entities[i].rule == 6)
-					{
-						obj.entities[i].rule = 7;
-						obj.entities[i].tile = 6;
-					}
-					else if (obj.getplayer() != i) // Don't destroy player entity
+					if (obj.entities[i].rule == 7)
 					{
 						obj.entities[i].rule = 6;
 						obj.entities[i].tile = 0;
+					}
+					else if (obj.getplayer() != i) // Don't destroy player entity
+					{
+						obj.entities[i].rule = 7;
+						obj.entities[i].tile = 6;
 					}
 				}
 			}


### PR DESCRIPTION
In 2.0, 2.1, and 2.2, calling `flipgravity()` on an entity that wasn't rule 6 would change it to rule 7. In 2.3 currently, doing this will only change it to rule 7 if it's already rule 6, starting with the introduction of the change where if an entity was rule 7 it would be changed to rule 6.

The crewmate conversion trick has been restored, but converting an entity to a crewmate will change its rule to 6, not 7 like in pre-2.3. If you want it to be changed to rule 7 instead of 6, you'd have to call `flipgravity()` twice in 2.3 and only once in pre-2.3, which would make maintaining compatibility between versions a bit harder.

So to fix this, I'm inverting it so that if you call `flipgravity()` on an entity that isn't rule 7, it will be converted to rule 7, and only if it's rule 7 will it be converted to rule 6.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
