### PR TITLE
Add XML forwards compatibility

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -105,6 +105,7 @@ SET(VVV_SRC
 	src/Tower.cpp
 	src/UtilityClass.cpp
 	src/WarpClass.cpp
+	src/XMLUtils.cpp
 	src/main.cpp
 	src/Network.c
 )

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4747,100 +4747,78 @@ void Game::loadstats(int *width, int *height, bool *vsync)
 void Game::savestats()
 {
     tinyxml2::XMLDocument doc;
-    tinyxml2::XMLElement * msg;
-    tinyxml2::XMLDeclaration * decl = doc.NewDeclaration();
-    doc.LinkEndChild( decl );
+    bool already_exists = FILESYSTEM_loadTiXml2Document("saves/unlock.vvv", doc);
+    if (!already_exists)
+    {
+        puts("No unlock.vvv found. Creating new file");
+    }
 
-    tinyxml2::XMLElement * root = doc.NewElement( "Save" );
-    doc.LinkEndChild( root );
+    xml::update_declaration(doc);
 
-    tinyxml2::XMLComment * comment = doc.NewComment(" Save file " );
-    root->LinkEndChild( comment );
+    tinyxml2::XMLElement * root = xml::update_element(doc, "Save");
 
-    tinyxml2::XMLElement * dataNode = doc.NewElement( "Data" );
-    root->LinkEndChild( dataNode );
+    xml::update_comment(root, " Save file " );
+
+    tinyxml2::XMLElement * dataNode = xml::update_element(root, "Data");
 
     std::string s_unlock;
     for(size_t i = 0; i < SDL_arraysize(unlock); i++ )
     {
         s_unlock += help.String(unlock[i]) + ",";
     }
-    msg = doc.NewElement( "unlock" );
-    msg->LinkEndChild( doc.NewText( s_unlock.c_str() ));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "unlock", s_unlock.c_str());
 
     std::string s_unlocknotify;
     for(size_t i = 0; i < SDL_arraysize(unlocknotify); i++ )
     {
         s_unlocknotify += help.String(unlocknotify[i]) + ",";
     }
-    msg = doc.NewElement( "unlocknotify" );
-    msg->LinkEndChild( doc.NewText( s_unlocknotify.c_str() ));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "unlocknotify", s_unlocknotify.c_str());
 
     std::string s_besttimes;
     for(size_t i = 0; i < SDL_arraysize(besttimes); i++ )
     {
         s_besttimes += help.String(besttimes[i]) + ",";
     }
-    msg = doc.NewElement( "besttimes" );
-    msg->LinkEndChild( doc.NewText( s_besttimes.c_str() ));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "besttimes", s_besttimes.c_str());
 
     std::string s_bestframes;
     for (size_t i = 0; i < SDL_arraysize(bestframes); i++)
     {
         s_bestframes += help.String(bestframes[i]) + ",";
     }
-    msg = doc.NewElement( "bestframes" );
-    msg->LinkEndChild( doc.NewText( s_bestframes.c_str() ) );
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "bestframes", s_bestframes.c_str());
 
     std::string s_besttrinkets;
     for(size_t i = 0; i < SDL_arraysize(besttrinkets); i++ )
     {
         s_besttrinkets += help.String(besttrinkets[i]) + ",";
     }
-    msg = doc.NewElement( "besttrinkets" );
-    msg->LinkEndChild( doc.NewText( s_besttrinkets.c_str() ));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "besttrinkets", s_besttrinkets.c_str());
 
     std::string s_bestlives;
     for(size_t i = 0; i < SDL_arraysize(bestlives); i++ )
     {
         s_bestlives += help.String(bestlives[i]) + ",";
     }
-    msg = doc.NewElement( "bestlives" );
-    msg->LinkEndChild( doc.NewText( s_bestlives.c_str() ));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "bestlives", s_bestlives.c_str());
 
     std::string s_bestrank;
     for(size_t i = 0; i < SDL_arraysize(bestrank); i++ )
     {
         s_bestrank += help.String(bestrank[i]) + ",";
     }
-    msg = doc.NewElement( "bestrank" );
-    msg->LinkEndChild( doc.NewText( s_bestrank.c_str() ));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "bestrank", s_bestrank.c_str());
 
-    msg = doc.NewElement( "bestgamedeaths" );
-    msg->LinkEndChild( doc.NewText( help.String(bestgamedeaths).c_str() ));
-    dataNode->LinkEndChild( msg );
-    msg = doc.NewElement( "stat_trinkets" );
-    msg->LinkEndChild( doc.NewText( help.String(stat_trinkets).c_str()));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "bestgamedeaths", bestgamedeaths);
 
-    msg = doc.NewElement( "fullscreen" );
-    msg->LinkEndChild( doc.NewText( help.String(fullscreen).c_str()));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "stat_trinkets", stat_trinkets);
 
-    msg = doc.NewElement( "stretch" );
-    msg->LinkEndChild( doc.NewText( help.String(stretchMode).c_str()));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "fullscreen", fullscreen);
 
-    msg = doc.NewElement( "useLinearFilter" );
-    msg->LinkEndChild( doc.NewText( help.String(useLinearFilter).c_str()));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "stretch", stretchMode);
+
+    xml::update_tag(dataNode, "useLinearFilter", useLinearFilter);
 
     int width, height;
     if (graphics.screenbuffer != NULL)
@@ -4852,85 +4830,47 @@ void Game::savestats()
         width = 320;
         height = 240;
     }
-    msg = doc.NewElement( "window_width" );
-    msg->LinkEndChild( doc.NewText( help.String(width).c_str()));
-    dataNode->LinkEndChild( msg );
-    msg = doc.NewElement( "window_height" );
-    msg->LinkEndChild( doc.NewText( help.String(height).c_str()));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "window_width", width);
 
-    msg = doc.NewElement( "noflashingmode" );
-    msg->LinkEndChild( doc.NewText( help.String(noflashingmode).c_str()));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "window_height", height);
 
-    msg = doc.NewElement( "colourblindmode" );
-    msg->LinkEndChild( doc.NewText( help.String(colourblindmode).c_str()));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "noflashingmode", noflashingmode);
 
-    msg = doc.NewElement( "setflipmode" );
-    msg->LinkEndChild( doc.NewText( help.String(graphics.setflipmode).c_str()));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "colourblindmode", colourblindmode);
 
-    msg = doc.NewElement( "invincibility" );
-    msg->LinkEndChild( doc.NewText( help.String(map.invincibility).c_str()));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "setflipmode", graphics.setflipmode);
 
-    msg = doc.NewElement( "slowdown" );
-    msg->LinkEndChild( doc.NewText( help.String(slowdown).c_str()));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "invincibility", map.invincibility);
 
-    msg = doc.NewElement( "swnbestrank" );
-    msg->LinkEndChild( doc.NewText( help.String(swnbestrank).c_str()));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "slowdown", slowdown);
 
-    msg = doc.NewElement( "swnrecord" );
-    msg->LinkEndChild( doc.NewText( help.String(swnrecord).c_str()));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "swnbestrank", swnbestrank);
+
+    xml::update_tag(dataNode, "swnrecord", swnrecord);
 
 
-    msg = doc.NewElement( "advanced_smoothing" );
-    msg->LinkEndChild( doc.NewText( help.String(fullScreenEffect_badSignal).c_str()));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "advanced_smoothing", fullScreenEffect_badSignal);
 
 
-    msg = doc.NewElement( "usingmmmmmm" );
-    msg->LinkEndChild( doc.NewText( help.String(usingmmmmmm).c_str()));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "usingmmmmmm", usingmmmmmm);
 
-    msg = doc.NewElement("ghostsenabled");
-    msg->LinkEndChild(doc.NewText(help.String((int) ghostsenabled).c_str()));
-    dataNode->LinkEndChild(msg);
+    xml::update_tag(dataNode, "ghostsenabled", (int) ghostsenabled);
 
-    msg = doc.NewElement("skipfakeload");
-    msg->LinkEndChild(doc.NewText(help.String((int) skipfakeload).c_str()));
-    dataNode->LinkEndChild(msg);
+    xml::update_tag(dataNode, "skipfakeload", (int) skipfakeload);
 
-    msg = doc.NewElement("disablepause");
-    msg->LinkEndChild(doc.NewText(help.String((int) disablepause).c_str()));
-    dataNode->LinkEndChild(msg);
+    xml::update_tag(dataNode, "disablepause", (int) disablepause);
 
-    msg = doc.NewElement("notextoutline");
-    msg->LinkEndChild(doc.NewText(help.String((int) graphics.notextoutline).c_str()));
-    dataNode->LinkEndChild(msg);
+    xml::update_tag(dataNode, "notextoutline", (int) graphics.notextoutline);
 
-    msg = doc.NewElement("translucentroomname");
-    msg->LinkEndChild(doc.NewText(help.String((int) graphics.translucentroomname).c_str()));
-    dataNode->LinkEndChild(msg);
+    xml::update_tag(dataNode, "translucentroomname", (int) graphics.translucentroomname);
 
-    msg = doc.NewElement("showmousecursor");
-    msg->LinkEndChild(doc.NewText(help.String((int)graphics.showmousecursor).c_str()));
-    dataNode->LinkEndChild(msg);
+    xml::update_tag(dataNode, "showmousecursor", (int) graphics.showmousecursor);
 
-    msg = doc.NewElement("over30mode");
-    msg->LinkEndChild(doc.NewText(help.String((int) over30mode).c_str()));
-    dataNode->LinkEndChild(msg);
+    xml::update_tag(dataNode, "over30mode", (int) over30mode);
 
-    msg = doc.NewElement("glitchrunnermode");
-    msg->LinkEndChild(doc.NewText(help.String((int) glitchrunnermode).c_str()));
-    dataNode->LinkEndChild(msg);
+    xml::update_tag(dataNode, "glitchrunnermode", (int) glitchrunnermode);
 
     int vsyncOption;
-    msg = doc.NewElement("vsync");
     if (graphics.screenbuffer != NULL)
     {
         vsyncOption = (int) graphics.screenbuffer->vsync;
@@ -4939,37 +4879,64 @@ void Game::savestats()
     {
         vsyncOption = 0;
     }
-    msg->LinkEndChild(doc.NewText(help.String(vsyncOption).c_str()));
-    dataNode->LinkEndChild(msg);
+    xml::update_tag(dataNode, "vsync", vsyncOption);
 
+    // Delete all controller buttons we had previously.
+    // dataNode->FirstChildElement() shouldn't be NULL at this point...
+    // we've already added a bunch of elements
+    for (tinyxml2::XMLElement* element = dataNode->FirstChildElement();
+    element != NULL;
+    /* Increment code handled separately */)
+    {
+        const char* name = element->Name();
+
+        if (SDL_strcmp(name, "flipButton") == 0
+        || SDL_strcmp(name, "enterButton") == 0
+        || SDL_strcmp(name, "escButton") == 0
+        || SDL_strcmp(name, "restartButton") == 0)
+        {
+            // Can't just doc.DeleteNode(element) and then go to next,
+            // element->NextSiblingElement() will be NULL.
+            // Instead, store pointer of element we want to delete. Then
+            // increment `element`. And THEN delete the element.
+            tinyxml2::XMLElement* delete_this = element;
+
+            element = element->NextSiblingElement();
+
+            doc.DeleteNode(delete_this);
+            continue;
+        }
+
+        element = element->NextSiblingElement();
+    }
+
+    // Now add them
     for (size_t i = 0; i < controllerButton_flip.size(); i += 1)
     {
-        msg = doc.NewElement("flipButton");
+        tinyxml2::XMLElement* msg = doc.NewElement("flipButton");
         msg->LinkEndChild(doc.NewText(help.String((int) controllerButton_flip[i]).c_str()));
         dataNode->LinkEndChild(msg);
     }
     for (size_t i = 0; i < controllerButton_map.size(); i += 1)
     {
-        msg = doc.NewElement("enterButton");
+        tinyxml2::XMLElement* msg = doc.NewElement("enterButton");
         msg->LinkEndChild(doc.NewText(help.String((int) controllerButton_map[i]).c_str()));
         dataNode->LinkEndChild(msg);
     }
     for (size_t i = 0; i < controllerButton_esc.size(); i += 1)
     {
-        msg = doc.NewElement("escButton");
+        tinyxml2::XMLElement* msg = doc.NewElement("escButton");
         msg->LinkEndChild(doc.NewText(help.String((int) controllerButton_esc[i]).c_str()));
         dataNode->LinkEndChild(msg);
     }
     for (size_t i = 0; i < controllerButton_restart.size(); i += 1)
     {
-        msg = doc.NewElement("restartButton");
+        tinyxml2::XMLElement* msg = doc.NewElement("restartButton");
         msg->LinkEndChild(doc.NewText(help.String((int) controllerButton_restart[i]).c_str()));
         dataNode->LinkEndChild(msg);
     }
 
-    msg = doc.NewElement( "controllerSensitivity" );
-    msg->LinkEndChild( doc.NewText( help.String(controllerSensitivity).c_str()));
-    dataNode->LinkEndChild( msg );
+    xml::update_tag(dataNode, "controllerSensitivity", controllerSensitivity);
 
     FILESYSTEM_saveTiXml2Document("saves/unlock.vvv", doc);
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5886,19 +5886,22 @@ std::string Game::writemaingamesave(tinyxml2::XMLDocument& doc)
 
 void Game::customsavequick(std::string savfile)
 {
+    const std::string levelfile = savfile.substr(7);
+
     tinyxml2::XMLDocument doc;
-    tinyxml2::XMLElement* msg;
-    tinyxml2::XMLDeclaration* decl = doc.NewDeclaration();
-    doc.LinkEndChild( decl );
+    bool already_exists = FILESYSTEM_loadTiXml2Document(("saves/" + levelfile + ".vvv").c_str(), doc);
+    if (!already_exists)
+    {
+        printf("No %s.vvv found. Creating new file\n", levelfile.c_str());
+    }
 
-    tinyxml2::XMLElement * root = doc.NewElement( "Save" );
-    doc.LinkEndChild( root );
+    xml::update_declaration(doc);
 
-    tinyxml2::XMLComment * comment = doc.NewComment(" Save file " );
-    root->LinkEndChild( comment );
+    tinyxml2::XMLElement * root = xml::update_element(doc, "Save");
 
-    tinyxml2::XMLElement * msgs = doc.NewElement( "Data" );
-    root->LinkEndChild( msgs );
+    xml::update_comment(root, " Save file ");
+
+    tinyxml2::XMLElement * msgs = xml::update_element(root, "Data");
 
 
     //Flags, map and stats
@@ -5908,179 +5911,108 @@ void Game::customsavequick(std::string savfile)
     {
         mapExplored += help.String(map.explored[i]) + ",";
     }
-    msg = doc.NewElement( "worldmap" );
-    msg->LinkEndChild( doc.NewText( mapExplored.c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "worldmap", mapExplored.c_str());
 
     std::string flags;
     for(size_t i = 0; i < SDL_arraysize(obj.flags); i++ )
     {
         flags += help.String((int) obj.flags[i]) + ",";
     }
-    msg = doc.NewElement( "flags" );
-    msg->LinkEndChild( doc.NewText( flags.c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "flags", flags.c_str());
 
     std::string moods;
     for(size_t i = 0; i < SDL_arraysize(obj.customcrewmoods); i++ )
     {
         moods += help.String(obj.customcrewmoods[i]) + ",";
     }
-    msg = doc.NewElement( "moods" );
-    msg->LinkEndChild( doc.NewText( moods.c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "moods", moods.c_str());
 
     std::string crewstatsString;
     for(size_t i = 0; i < SDL_arraysize(crewstats); i++ )
     {
         crewstatsString += help.String(crewstats[i]) + ",";
     }
-    msg = doc.NewElement( "crewstats" );
-    msg->LinkEndChild( doc.NewText( crewstatsString.c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "crewstats", crewstatsString.c_str());
 
     std::string collect;
     for(size_t i = 0; i < SDL_arraysize(obj.collect); i++ )
     {
         collect += help.String((int) obj.collect[i]) + ",";
     }
-    msg = doc.NewElement( "collect" );
-    msg->LinkEndChild( doc.NewText( collect.c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "collect", collect.c_str());
 
     std::string customcollect;
     for(size_t i = 0; i < SDL_arraysize(obj.customcollect); i++ )
     {
         customcollect += help.String((int) obj.customcollect[i]) + ",";
     }
-    msg = doc.NewElement( "customcollect" );
-    msg->LinkEndChild( doc.NewText( customcollect.c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "customcollect", customcollect.c_str());
 
     //Position
 
-    msg = doc.NewElement( "finalx" );
-    msg->LinkEndChild( doc.NewText( help.String(map.finalx).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "finalx", map.finalx);
 
-    msg = doc.NewElement( "finaly" );
-    msg->LinkEndChild( doc.NewText( help.String(map.finaly).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "finaly", map.finaly);
 
-    msg = doc.NewElement( "savex" );
-    msg->LinkEndChild( doc.NewText( help.String(savex).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "savex", savex);
 
-    msg = doc.NewElement( "savey" );
-    msg->LinkEndChild( doc.NewText( help.String(savey).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "savey", savey);
 
-    msg = doc.NewElement( "saverx" );
-    msg->LinkEndChild( doc.NewText( help.String(saverx).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "saverx", saverx);
 
-    msg = doc.NewElement( "savery" );
-    msg->LinkEndChild( doc.NewText( help.String(savery).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "savery", savery);
 
-    msg = doc.NewElement( "savegc" );
-    msg->LinkEndChild( doc.NewText( help.String(savegc).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "savegc", savegc);
 
-    msg = doc.NewElement( "savedir" );
-    msg->LinkEndChild( doc.NewText( help.String(savedir).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "savedir", savedir);
 
-    msg = doc.NewElement( "savepoint" );
-    msg->LinkEndChild( doc.NewText( help.String(savepoint).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "savepoint", savepoint);
 
-    msg = doc.NewElement( "trinkets" );
-    msg->LinkEndChild( doc.NewText( help.String(trinkets()).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "trinkets", trinkets());
 
-    msg = doc.NewElement( "crewmates" );
-    msg->LinkEndChild( doc.NewText( help.String(crewmates()).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "crewmates", crewmates());
 
 
     //Special stats
 
     if(music.nicefade==1)
     {
-        msg = doc.NewElement( "currentsong" );
-        msg->LinkEndChild( doc.NewText( help.String(music.nicechange).c_str() ));
-        msgs->LinkEndChild( msg );
+        xml::update_tag(msgs, "currentsong", music.nicechange );
     }
     else
     {
-        msg = doc.NewElement( "currentsong" );
-        msg->LinkEndChild( doc.NewText( help.String(music.currentsong).c_str() ));
-        msgs->LinkEndChild( msg );
+        xml::update_tag(msgs, "currentsong", music.currentsong);
     }
 
-    msg = doc.NewElement( "teleportscript" );
-    msg->LinkEndChild( doc.NewText( teleportscript.c_str() ));
-    msgs->LinkEndChild( msg );
-    msg = doc.NewElement( "companion" );
-    msg->LinkEndChild( doc.NewText( help.String(companion).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "teleportscript", teleportscript.c_str());
+    xml::update_tag(msgs, "companion", companion);
 
-    msg = doc.NewElement( "lastsaved" );
-    msg->LinkEndChild( doc.NewText( help.String(lastsaved).c_str() ));
-    msgs->LinkEndChild( msg );
-    msg = doc.NewElement( "supercrewmate" );
-    msg->LinkEndChild( doc.NewText( BoolToString(supercrewmate) ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "lastsaved", lastsaved);
+    xml::update_tag(msgs, "supercrewmate", BoolToString(supercrewmate));
 
-    msg = doc.NewElement( "scmprogress" );
-    msg->LinkEndChild( doc.NewText( help.String(scmprogress).c_str() ));
-    msgs->LinkEndChild( msg );
-    msg = doc.NewElement( "scmmoveme" );
-    msg->LinkEndChild( doc.NewText( BoolToString(scmmoveme) ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "scmprogress", scmprogress);
+    xml::update_tag(msgs, "scmmoveme", BoolToString(scmmoveme));
 
 
-    msg = doc.NewElement( "frames" );
-    msg->LinkEndChild( doc.NewText( help.String(frames).c_str() ));
-    msgs->LinkEndChild( msg );
-    msg = doc.NewElement( "seconds" );
-    msg->LinkEndChild( doc.NewText( help.String(seconds).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "frames", frames);
+    xml::update_tag(msgs, "seconds", seconds);
 
-    msg = doc.NewElement( "minutes" );
-    msg->LinkEndChild( doc.NewText( help.String(minutes).c_str()) );
-    msgs->LinkEndChild( msg );
-    msg = doc.NewElement( "hours" );
-    msg->LinkEndChild( doc.NewText( help.String(hours).c_str()) );
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "minutes", minutes);
+    xml::update_tag(msgs, "hours", hours);
 
-    msg = doc.NewElement( "deathcounts" );
-    msg->LinkEndChild( doc.NewText( help.String(deathcounts).c_str() ));
-    msgs->LinkEndChild( msg );
-    msg = doc.NewElement( "totalflips" );
-    msg->LinkEndChild( doc.NewText( help.String(totalflips).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "deathcounts", deathcounts);
+    xml::update_tag(msgs, "totalflips", totalflips);
 
-    msg = doc.NewElement( "hardestroom" );
-    msg->LinkEndChild( doc.NewText( hardestroom.c_str() ));
-    msgs->LinkEndChild( msg );
-    msg = doc.NewElement( "hardestroomdeaths" );
-    msg->LinkEndChild( doc.NewText( help.String(hardestroomdeaths).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "hardestroom", hardestroom.c_str());
+    xml::update_tag(msgs, "hardestroomdeaths", hardestroomdeaths);
 
-    msg = doc.NewElement( "showminimap" );
-    msg->LinkEndChild( doc.NewText( BoolToString(map.customshowmm) ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "showminimap", BoolToString(map.customshowmm));
 
-    msg = doc.NewElement( "summary" );
     std::string summary = savearea + ", " + timestring();
-    msg->LinkEndChild( doc.NewText( summary.c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "summary", summary.c_str());
 
     customquicksummary = summary;
 
-    std::string levelfile = savfile.substr(7);
     if(FILESYSTEM_saveTiXml2Document(("saves/"+levelfile+".vvv").c_str(), doc))
     {
         printf("Game saved\n");

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5720,6 +5720,11 @@ void Game::savetele()
     }
 
     tinyxml2::XMLDocument doc;
+    bool already_exists = FILESYSTEM_loadTiXml2Document("saves/tsave.vvv", doc);
+    if (!already_exists)
+    {
+        puts("No tsave.vvv found. Creating new file");
+    }
     telesummary = writemaingamesave(doc);
 
     if(FILESYSTEM_saveTiXml2Document("saves/tsave.vvv", doc))
@@ -5743,6 +5748,11 @@ void Game::savequick()
     }
 
     tinyxml2::XMLDocument doc;
+    bool already_exists = FILESYSTEM_loadTiXml2Document("saves/qsave.vvv", doc);
+    if (!already_exists)
+    {
+        puts("No qsave.vvv found. Creating new file");
+    }
     quicksummary = writemaingamesave(doc);
 
     if(FILESYSTEM_saveTiXml2Document("saves/qsave.vvv", doc))
@@ -5768,18 +5778,13 @@ std::string Game::writemaingamesave(tinyxml2::XMLDocument& doc)
         return "";
     }
 
-    tinyxml2::XMLElement* msg;
-    tinyxml2::XMLDeclaration* decl = doc.NewDeclaration();
-    doc.LinkEndChild( decl );
+    xml::update_declaration(doc);
 
-    tinyxml2::XMLElement * root = doc.NewElement( "Save" );
-    doc.LinkEndChild( root );
+    tinyxml2::XMLElement * root = xml::update_element(doc, "Save");
 
-    tinyxml2::XMLComment * comment = doc.NewComment(" Save file " );
-    root->LinkEndChild( comment );
+    xml::update_comment(root, " Save file " );
 
-    tinyxml2::XMLElement * msgs = doc.NewElement( "Data" );
-    root->LinkEndChild( msgs );
+    tinyxml2::XMLElement * msgs = xml::update_element(root, "Data");
 
 
     //Flags, map and stats
@@ -5789,157 +5794,91 @@ std::string Game::writemaingamesave(tinyxml2::XMLDocument& doc)
     {
         mapExplored += help.String(map.explored[i]) + ",";
     }
-    msg = doc.NewElement( "worldmap" );
-    msg->LinkEndChild( doc.NewText( mapExplored.c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "worldmap", mapExplored.c_str());
 
     std::string flags;
     for(size_t i = 0; i < SDL_arraysize(obj.flags); i++ )
     {
         flags += help.String((int) obj.flags[i]) + ",";
     }
-    msg = doc.NewElement( "flags" );
-    msg->LinkEndChild( doc.NewText( flags.c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "flags", flags.c_str());
 
     std::string crewstatsString;
     for(size_t i = 0; i < SDL_arraysize(crewstats); i++ )
     {
         crewstatsString += help.String(crewstats[i]) + ",";
     }
-    msg = doc.NewElement( "crewstats" );
-    msg->LinkEndChild( doc.NewText( crewstatsString.c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "crewstats", crewstatsString.c_str());
 
     std::string collect;
     for(size_t i = 0; i < SDL_arraysize(obj.collect); i++ )
     {
         collect += help.String((int) obj.collect[i]) + ",";
     }
-    msg = doc.NewElement( "collect" );
-    msg->LinkEndChild( doc.NewText( collect.c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "collect", collect.c_str());
 
     //Position
 
-    msg = doc.NewElement( "finalx" );
-    msg->LinkEndChild( doc.NewText( help.String(map.finalx).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "finalx", map.finalx);
 
-    msg = doc.NewElement( "finaly" );
-    msg->LinkEndChild( doc.NewText( help.String(map.finaly).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "finaly", map.finaly);
 
-    msg = doc.NewElement( "savex" );
-    msg->LinkEndChild( doc.NewText( help.String(savex).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "savex", savex);
 
-    msg = doc.NewElement( "savey" );
-    msg->LinkEndChild( doc.NewText( help.String(savey).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "savey", savey);
 
-    msg = doc.NewElement( "saverx" );
-    msg->LinkEndChild( doc.NewText( help.String(saverx).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "saverx", saverx);
 
-    msg = doc.NewElement( "savery" );
-    msg->LinkEndChild( doc.NewText( help.String(savery).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "savery", savery);
 
-    msg = doc.NewElement( "savegc" );
-    msg->LinkEndChild( doc.NewText( help.String(savegc).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "savegc", savegc);
 
-    msg = doc.NewElement( "savedir" );
-    msg->LinkEndChild( doc.NewText( help.String(savedir).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "savedir", savedir);
 
-    msg = doc.NewElement( "savepoint" );
-    msg->LinkEndChild( doc.NewText( help.String(savepoint).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "savepoint", savepoint);
 
-    msg = doc.NewElement( "trinkets" );
-    msg->LinkEndChild( doc.NewText( help.String(trinkets()).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "trinkets", trinkets());
 
 
     //Special stats
 
     if(music.nicefade==1)
     {
-        msg = doc.NewElement( "currentsong" );
-        msg->LinkEndChild( doc.NewText( help.String(music.nicechange).c_str() ));
-        msgs->LinkEndChild( msg );
+        xml::update_tag(msgs, "currentsong", music.nicechange);
     }
     else
     {
-        msg = doc.NewElement( "currentsong" );
-        msg->LinkEndChild( doc.NewText( help.String(music.currentsong).c_str() ));
-        msgs->LinkEndChild( msg );
+        xml::update_tag(msgs, "currentsong", music.currentsong);
     }
 
-    msg = doc.NewElement( "teleportscript" );
-    msg->LinkEndChild( doc.NewText( teleportscript.c_str() ));
-    msgs->LinkEndChild( msg );
-    msg = doc.NewElement( "companion" );
-    msg->LinkEndChild( doc.NewText( help.String(companion).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "teleportscript", teleportscript.c_str());
+    xml::update_tag(msgs, "companion", companion);
 
-    msg = doc.NewElement( "lastsaved" );
-    msg->LinkEndChild( doc.NewText( help.String(lastsaved).c_str() ));
-    msgs->LinkEndChild( msg );
-    msg = doc.NewElement( "supercrewmate" );
-    msg->LinkEndChild( doc.NewText( BoolToString(supercrewmate) ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "lastsaved", lastsaved);
+    xml::update_tag(msgs, "supercrewmate", BoolToString(supercrewmate));
 
-    msg = doc.NewElement( "scmprogress" );
-    msg->LinkEndChild( doc.NewText( help.String(scmprogress).c_str() ));
-    msgs->LinkEndChild( msg );
-    msg = doc.NewElement( "scmmoveme" );
-    msg->LinkEndChild( doc.NewText( BoolToString(scmmoveme) ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "scmprogress", scmprogress);
+    xml::update_tag(msgs, "scmmoveme", BoolToString(scmmoveme));
 
 
-    msg = doc.NewElement( "frames" );
-    msg->LinkEndChild( doc.NewText( help.String(frames).c_str() ));
-    msgs->LinkEndChild( msg );
-    msg = doc.NewElement( "seconds" );
-    msg->LinkEndChild( doc.NewText( help.String(seconds).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "frames", frames);
+    xml::update_tag(msgs, "seconds", seconds);
 
-    msg = doc.NewElement( "minutes" );
-    msg->LinkEndChild( doc.NewText( help.String(minutes).c_str()) );
-    msgs->LinkEndChild( msg );
-    msg = doc.NewElement( "hours" );
-    msg->LinkEndChild( doc.NewText( help.String(hours).c_str()) );
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "minutes", minutes);
+    xml::update_tag(msgs, "hours", hours);
 
-    msg = doc.NewElement( "deathcounts" );
-    msg->LinkEndChild( doc.NewText( help.String(deathcounts).c_str() ));
-    msgs->LinkEndChild( msg );
-    msg = doc.NewElement( "totalflips" );
-    msg->LinkEndChild( doc.NewText( help.String(totalflips).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "deathcounts", deathcounts);
+    xml::update_tag(msgs, "totalflips", totalflips);
 
-    msg = doc.NewElement( "hardestroom" );
-    msg->LinkEndChild( doc.NewText( hardestroom.c_str() ));
-    msgs->LinkEndChild( msg );
-    msg = doc.NewElement( "hardestroomdeaths" );
-    msg->LinkEndChild( doc.NewText( help.String(hardestroomdeaths).c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "hardestroom", hardestroom.c_str());
+    xml::update_tag(msgs, "hardestroomdeaths", hardestroomdeaths);
 
-    msg = doc.NewElement( "finalmode" );
-    msg->LinkEndChild( doc.NewText( BoolToString(map.finalmode)));
-    msgs->LinkEndChild( msg );
-    msg = doc.NewElement( "finalstretch" );
-    msg->LinkEndChild( doc.NewText( BoolToString(map.finalstretch) ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "finalmode", BoolToString(map.finalmode));
+    xml::update_tag(msgs, "finalstretch", BoolToString(map.finalstretch));
 
 
-    msg = doc.NewElement( "summary" );
     std::string summary = savearea + ", " + timestring();
-    msg->LinkEndChild( doc.NewText( summary.c_str() ));
-    msgs->LinkEndChild( msg );
+    xml::update_tag(msgs, "summary", summary.c_str());
 
     return summary;
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -25,19 +25,6 @@
 #define strcasecmp stricmp
 #endif
 
-//TODO: Non Urgent code cleanup
-const char* BoolToString(bool _b)
-{
-    if(_b)
-    {
-        return "1";
-    }
-    else
-    {
-        return "0";
-    }
-}
-
 bool GetButtonFromString(const char *pText, SDL_GameControllerButton *button)
 {
     if (*pText == '0' ||
@@ -5855,10 +5842,10 @@ std::string Game::writemaingamesave(tinyxml2::XMLDocument& doc)
     xml::update_tag(msgs, "companion", companion);
 
     xml::update_tag(msgs, "lastsaved", lastsaved);
-    xml::update_tag(msgs, "supercrewmate", BoolToString(supercrewmate));
+    xml::update_tag(msgs, "supercrewmate", (int) supercrewmate);
 
     xml::update_tag(msgs, "scmprogress", scmprogress);
-    xml::update_tag(msgs, "scmmoveme", BoolToString(scmmoveme));
+    xml::update_tag(msgs, "scmmoveme", (int) scmmoveme);
 
 
     xml::update_tag(msgs, "frames", frames);
@@ -5873,8 +5860,8 @@ std::string Game::writemaingamesave(tinyxml2::XMLDocument& doc)
     xml::update_tag(msgs, "hardestroom", hardestroom.c_str());
     xml::update_tag(msgs, "hardestroomdeaths", hardestroomdeaths);
 
-    xml::update_tag(msgs, "finalmode", BoolToString(map.finalmode));
-    xml::update_tag(msgs, "finalstretch", BoolToString(map.finalstretch));
+    xml::update_tag(msgs, "finalmode", (int) map.finalmode);
+    xml::update_tag(msgs, "finalstretch", (int) map.finalstretch);
 
 
     std::string summary = savearea + ", " + timestring();
@@ -5988,10 +5975,10 @@ void Game::customsavequick(std::string savfile)
     xml::update_tag(msgs, "companion", companion);
 
     xml::update_tag(msgs, "lastsaved", lastsaved);
-    xml::update_tag(msgs, "supercrewmate", BoolToString(supercrewmate));
+    xml::update_tag(msgs, "supercrewmate", (int) supercrewmate);
 
     xml::update_tag(msgs, "scmprogress", scmprogress);
-    xml::update_tag(msgs, "scmmoveme", BoolToString(scmmoveme));
+    xml::update_tag(msgs, "scmmoveme", (int) scmmoveme);
 
 
     xml::update_tag(msgs, "frames", frames);
@@ -6006,7 +5993,7 @@ void Game::customsavequick(std::string savfile)
     xml::update_tag(msgs, "hardestroom", hardestroom.c_str());
     xml::update_tag(msgs, "hardestroomdeaths", hardestroomdeaths);
 
-    xml::update_tag(msgs, "showminimap", BoolToString(map.customshowmm));
+    xml::update_tag(msgs, "showminimap", (int) map.customshowmm);
 
     std::string summary = savearea + ", " + timestring();
     xml::update_tag(msgs, "summary", summary.c_str());

--- a/desktop_version/src/XMLUtils.cpp
+++ b/desktop_version/src/XMLUtils.cpp
@@ -1,0 +1,142 @@
+#include <SDL.h>
+#include <tinyxml2.h>
+
+namespace xml
+{
+
+// Helper functions for these utils (not exported)
+
+static inline tinyxml2::XMLDocument& get_document(tinyxml2::XMLNode* parent)
+{
+    return *(parent->GetDocument());
+}
+
+
+// EXPORTED FUNCTIONS
+
+
+// Create a new element if it doesn't exist. Returns the element.
+tinyxml2::XMLElement* update_element(tinyxml2::XMLNode* parent, const char* name)
+{
+    if (parent == NULL)
+    {
+        return NULL;
+    }
+
+    tinyxml2::XMLDocument& doc = get_document(parent);
+
+    tinyxml2::XMLElement* element = parent->FirstChildElement(name);
+    if (element == NULL)
+    {
+        // It doesn't exist, so create a new one
+        element = doc.NewElement(name);
+        parent->LinkEndChild(element);
+    }
+
+    return element;
+}
+
+// Same thing as above, but takes &parent instead of *parent
+tinyxml2::XMLElement* update_element(tinyxml2::XMLNode& parent, const char* name)
+{
+    return update_element(&parent, name);
+}
+
+// Same thing as above, but deletes the content inside the element, too.
+tinyxml2::XMLElement* update_element_delete_contents(tinyxml2::XMLNode* parent, const char* name)
+{
+    tinyxml2::XMLDocument& doc = get_document(parent);
+
+    tinyxml2::XMLElement* element = update_element(parent, name);
+
+    for (tinyxml2::XMLNode* node = element->FirstChild();
+    node != NULL;
+    /* Increment code handled separately */)
+    {
+        // Unfortunately, element->DeleteNode() is private
+        // Can't just doc.DeleteNode(node) and then go to next,
+        // node->NextSiblingElement() will be NULL.
+        // Instead, store pointer of node we want to delete. Then increment
+        // `node`. And THEN delete the node.
+        tinyxml2::XMLNode* delete_this = node;
+
+        node = node->NextSiblingElement();
+
+        doc.DeleteNode(delete_this);
+    }
+
+    return element;
+}
+
+// Call update_element_delete_contents(), then immediately set its value to a
+// string. Returns the element.
+tinyxml2::XMLElement* update_tag(tinyxml2::XMLNode* parent, const char* name, const char* value)
+{
+    tinyxml2::XMLElement* element = update_element_delete_contents(parent, name);
+
+    element->InsertNewText(value);
+
+    return element;
+}
+
+// Same as above, but takes an int instead, and automatically converts it to a
+// string.
+tinyxml2::XMLElement* update_tag(tinyxml2::XMLNode* parent, const char* name, const int value)
+{
+    char string[16];
+    SDL_snprintf(string, sizeof(string), "%i", value);
+
+    return update_tag(parent, name, string);
+}
+
+// Delete the declaration, if it exists. Then create a new declaration.
+// Returns the declaration.
+tinyxml2::XMLDeclaration* update_declaration(tinyxml2::XMLDocument& doc)
+{
+    if (doc.FirstChild() != NULL)
+    {
+        tinyxml2::XMLDeclaration* decl = doc.FirstChild()->ToDeclaration();
+
+        if (decl != NULL)
+        {
+            doc.DeleteNode(decl);
+        }
+    }
+
+    tinyxml2::XMLDeclaration* decl = doc.NewDeclaration();
+    doc.InsertFirstChild(decl);
+
+    return decl;
+}
+
+// Create a new comment if the first child of the node isn't a comment.
+// Returns the comment.
+tinyxml2::XMLComment* update_comment(tinyxml2::XMLNode* parent, const char* text)
+{
+    if (parent == NULL)
+    {
+        return NULL;
+    }
+
+    tinyxml2::XMLDocument& doc = get_document(parent);
+
+    if (parent->FirstChild() == NULL)
+    {
+        return NULL;
+    }
+
+    tinyxml2::XMLComment* comment = parent->FirstChild()->ToComment();
+
+    if (comment == NULL)
+    {
+        // It doesn't exist, so create a new one
+        comment = doc.NewComment(text);
+        parent->InsertFirstChild(comment);
+    }
+
+    return comment;
+}
+
+
+
+} // namespace xml

--- a/desktop_version/src/XMLUtils.h
+++ b/desktop_version/src/XMLUtils.h
@@ -1,0 +1,27 @@
+// Forward decl, avoid including tinyxml2.h
+namespace tinyxml2
+{
+    class XMLComment;
+    class XMLDocument;
+    class XMLDeclaration;
+    class XMLElement;
+    class XMLNode;
+}
+
+namespace xml
+{
+
+tinyxml2::XMLElement* update_element(tinyxml2::XMLNode* parent, const char* name);
+// Same thing as above, but takes &parent instead of *parent
+tinyxml2::XMLElement* update_element(tinyxml2::XMLNode& parent, const char* name);
+
+tinyxml2::XMLElement* update_element_delete_contents(tinyxml2::XMLNode* parent, const char* name);
+
+tinyxml2::XMLElement* update_tag(tinyxml2::XMLNode* parent, const char* name, const char* value);
+tinyxml2::XMLElement* update_tag(tinyxml2::XMLNode* parent, const char* name, const int value);
+
+tinyxml2::XMLDeclaration* update_declaration(tinyxml2::XMLDocument& doc);
+
+tinyxml2::XMLComment* update_comment(tinyxml2::XMLNode* parent, const char* text);
+
+} // namespace xml

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -383,6 +383,8 @@ void editorclass::reset()
     currentghosts = 0;
 
     onewaycol_override = false;
+
+    loaded_filepath = "";
 }
 
 void editorclass::gethooks()
@@ -1730,6 +1732,7 @@ bool editorclass::load(std::string& _path)
         return false;
     }
 
+    loaded_filepath = _path;
 
     tinyxml2::XMLHandle hDoc(&doc);
     tinyxml2::XMLElement* pElem;
@@ -2018,11 +2021,18 @@ bool editorclass::load(std::string& _path)
 bool editorclass::save(std::string& _path)
 {
     tinyxml2::XMLDocument doc;
-    bool already_exists = FILESYSTEM_loadTiXml2Document(("levels/" + _path).c_str(), doc);
-    if (!already_exists)
+
+    std::string newpath("levels/" + _path);
+
+    // Try to preserve the XML of the currently-loaded one
+    bool already_exists = !loaded_filepath.empty() && FILESYSTEM_loadTiXml2Document(loaded_filepath.c_str(), doc);
+    if (!already_exists && !loaded_filepath.empty())
     {
-        printf("No %s found. Creating new file\n", _path.c_str());
+        printf("Currently-loaded %s not found\n", loaded_filepath.c_str());
     }
+
+    loaded_filepath = newpath;
+
     tinyxml2::XMLElement* msg;
 
     xml::update_declaration(doc);
@@ -2150,7 +2160,7 @@ bool editorclass::save(std::string& _path)
     }
     xml::update_tag(data, "script", scriptString.c_str());
 
-    return FILESYSTEM_saveTiXml2Document(("levels/" + _path).c_str(), doc);
+    return FILESYSTEM_saveTiXml2Document(newpath.c_str(), doc);
 }
 
 

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -191,6 +191,7 @@ class editorclass{
   std::string note;
   std::string keybuffer;
   std::string filename;
+  std::string loaded_filepath;
 
   int drawmode;
   int tilex, tiley;


### PR DESCRIPTION
This PR adds XML forwards compatibility, meaning extra XML data will be preserved if the game encounters it while writing an XML file. It assumes that the XML data is from some future version of the game and tries very hard not to throw it away. It does this by loading in the current XML when it saves it, and instead of creating a new XML document from scratch, it takes the existing document and updates it in place.

There are exceptions, of course. The most notable ones are that unknown attributes of `<edLevelClass>` and `<edEntity>` are *not* preserved. This is because they would take extra work to support (you can't just blindly keep the attributes for the same indice between reading and writing, in the meantime the user could have changed the order around or deleted edentities, so then you have to keep the entire XML object attached to the internal edentity object, which just opens up a whole can of worms), and also because the level format, where every single thing is shoved into one file, instead of being made up of multiple files, is terrible, and should be abandoned in the future, and when that happens there won't be any need for preserving attributes on objects like these.

This PR only closes one part of #373.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
