### PR TITLE
Add kludge to fix rendering of gravity lines in a gotoroom

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1632,7 +1632,7 @@ void Graphics::drawentities()
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
             BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
-            
+
             //screenwrapping!
             point wrappedPoint;
             bool wrapX = false;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1430,7 +1430,7 @@ bool Graphics::Hitest(SDL_Surface* surface1, point p1, SDL_Surface* surface2, po
 
 void Graphics::drawgravityline( int t )
 {
-    if (obj.entities[t].life == 0)
+    if (obj.entities[t].life == 0 || obj.entities[t].onentity == 1) // FIXME: Remove 'onentity == 1' when game loop order is fixed!
     {
         switch(linestate)
         {


### PR DESCRIPTION
Due to #464, standing inside a gravity line during a gotoroom that occurs every frame will end up with the gravity line being gray instead of being white. To temporarily fix this (until #464 is properly fixed), I decided to add some kludge that colors it white if its onentity is 1. I tested this patch with gravity lines in both constant-gotoroom and normal environments, and it seems to be fine for both.

Attached is a level where you can test this for yourself.

* [gravity_lines_gotoroom_test.zip](https://github.com/TerryCavanagh/VVVVVV/files/5284326/gravity_lines_gotoroom_test.zip)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
