### PR TITLE
Clear font_positions if there is no font.txt

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -257,25 +257,33 @@ void Graphics::Makebfont()
     unsigned char* charmap = NULL;
     size_t length;
     FILESYSTEM_loadFileToMemory("graphics/font.txt", &charmap, &length);
-    if (charmap != NULL) {
+    if (charmap != NULL)
+    {
         unsigned char* current = charmap;
         unsigned char* end = charmap + length;
         int pos = 0;
-        while (current != end) {
+        while (current != end)
+        {
             int codepoint = utf8::unchecked::next(current);
             font_positions[codepoint] = pos;
             ++pos;
         }
         FILESYSTEM_freeMemory(&charmap);
-    } else {
+    }
+    else
+    {
         font_positions.clear();
     }
 }
 
-int Graphics::bfontlen(uint32_t ch) {
-    if (ch < 32) {
+int Graphics::bfontlen(uint32_t ch)
+{
+    if (ch < 32)
+    {
         return 6;
-    } else {
+    }
+    else
+    {
         return 8;
     }
 }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -267,6 +267,8 @@ void Graphics::Makebfont()
             ++pos;
         }
         FILESYSTEM_freeMemory(&charmap);
+    } else {
+        font_positions.clear();
     }
 }
 


### PR DESCRIPTION
This fixes a bug where `font_positions` wouldn't get cleared after exiting a custom level that had a `font.txt` if it didn't exist in the default graphics, leading to messed-up-looking font rendering.

This is what the bug looks like:
![font.txt not being reset properly](https://user-images.githubusercontent.com/59748578/94310621-c6f8e400-ff2e-11ea-9dcc-9c2a6cf12ff4.png)

And here's a test level so you can see for yourself:

* [charmap_test_level.zip](https://github.com/TerryCavanagh/VVVVVV/files/5285069/charmap_test_level.zip)

This bug was originally discovered by @AllyTally.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
