### PR TITLE
Add bounds checks to indexing of global "temporary" variable `k`

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2736,8 +2736,8 @@ bool entityclass::updateentities( int i )
             if (entities[i].state == 1)
             {
                 //happy!
-                if (entities[k].rule == 6)	entities[k].tile = 0;
-                if (entities[k].rule == 7)	entities[k].tile = 6;
+                if (INBOUNDS_VEC(k, entities) && entities[k].rule == 6)	entities[k].tile = 0;
+                if (INBOUNDS_VEC(k, entities) && entities[k].rule == 7)	entities[k].tile = 6;
                 //Stay close to the hero!
                 int j = getplayer();
                 if (INBOUNDS_VEC(j, entities) && entities[j].xp > entities[i].xp + 5)


### PR DESCRIPTION
For some reason, the variable `k` is on `entityclass` and gets mutated in `createentity()` and `createblock()`. Then `updateentities()` uses it without checking if it's valid, because either `k` or the size of `entities` could have changed in the meantime. To fix any potential undefined behavior, these bounds checks should be added.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
