### PR TITLE
Don't use bounds check for result of checktrigger(), it's a gamestate

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4650,7 +4650,7 @@ void entityclass::entitycollisioncheck()
     // WARNING: If updating this code, don't forget to update Map.cpp mapclass::twoframedelayfix()
     activetrigger = -1;
     int block_idx = -1;
-    if (INBOUNDS_VEC(checktrigger(&block_idx), entities) && INBOUNDS_VEC(block_idx, blocks))
+    if (checktrigger(&block_idx) > -1 && INBOUNDS_VEC(block_idx, blocks))
     {
         // Load the block's script if its gamestate is out of range
         if (blocks[block_idx].script != "" && (activetrigger < 300 || activetrigger > 336))


### PR DESCRIPTION
`checktrigger()` returns a gamestate number, not the index of an entity.

Whoops.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
