### PR TITLE
Don't use bounds check for checktrigger() in twoframedelayfix()

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -2101,7 +2101,7 @@ void mapclass::twoframedelayfix()
 	|| !custommode
 	|| game.deathseq != -1
 	// obj.checktrigger() sets obj.activetrigger and block_idx
-	|| !INBOUNDS_VEC(obj.checktrigger(&block_idx), obj.entities)
+	|| obj.checktrigger(&block_idx) <= -1
 	|| !INBOUNDS_VEC(block_idx, obj.blocks)
 	|| obj.activetrigger < 300)
 	{


### PR DESCRIPTION
This is like the previous patch, but for `twoframedelayfix()`, because I forgot to read the comment that talked about `twoframedelayfix()`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
