### PR TITLE
Make 'custom_' check more readable

### DIFF
--- a/desktop_version/src/Scripts.cpp
+++ b/desktop_version/src/Scripts.cpp
@@ -11,10 +11,7 @@ void scriptclass::load(const std::string& name)
 
     const char* t = name.c_str();
 
-    char customstring[8] = {'\0'};
-    SDL_strlcpy(customstring, t, sizeof(customstring));
-
-    if (strcmp(customstring, "custom_") == 0)
+    if (SDL_strncmp(t, "custom_", 7) == 0)
     {
         loadcustom(name);
     }


### PR DESCRIPTION
Instead of copying to a temporary string, just use `SDL_strncmp()`. Also, I checked the blame, and apparently I committed the line that used `strcmp()` instead of `SDL_strcmp()`, for whatever reason. But that's fixed now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
