### PR TITLE
Prevent potential undefined behavior with integer underflow/overflow with help.Int()

### DIFF
--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -106,7 +106,7 @@ int UtilityClass::Int(const char* str, int fallback /*= 0*/)
 		return fallback;
 	}
 
-	return SDL_atoi(str);
+	return (int) SDL_strtol(str, NULL, 0);
 }
 
 std::string UtilityClass::GCString(std::vector<SDL_GameControllerButton> buttons)


### PR DESCRIPTION
It's possible that `SDL_atoi()` could call the libc `atoi()`, and if a string is provided that's too large to fit into an integer, then that would result in undefined behavior. To avoid this, use `SDL_strtol()` instead.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
