### PR TITLE
Clean up and prevent unnecessary qualifiers to self

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1,3 +1,4 @@
+#define OBJ_DEFINITION
 #include "Entity.h"
 
 #include <SDL.h>

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -10,8 +10,22 @@
 #include "BlockV.h"
 #include "Game.h"
 
-#define removeentity_iter(index) { if (obj.removeentity(index)) index--; }
-#define removeblock_iter(index) { obj.removeblock(index); index--; }
+#define removeentity_iter(index) \
+    do \
+    { \
+        extern entityclass obj; \
+        if (obj.removeentity(index)) \
+        { \
+            index--; \
+        } \
+    } while (false)
+#define removeblock_iter(index) \
+    do \
+    { \
+        extern entityclass obj; \
+        obj.removeblock(index); \
+        index--; \
+    } while (false)
 
 enum
 {
@@ -193,6 +207,8 @@ public:
     bool customcrewmoods[Game::numcrew];
 };
 
+#ifndef OBJ_DEFINITION
 extern entityclass obj;
+#endif
 
 #endif /* ENTITY_H */

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1,3 +1,4 @@
+#define GAME_DEFINITION
 #include "Game.h"
 
 #include <sstream>
@@ -6619,8 +6620,8 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("animated backgrounds");
         option("screen effects");
         option("text outline");
-        option("invincibility", !ingame_titlemode || (!game.insecretlab && !game.intimetrial && !game.nodeathmode));
-        option("slowdown", !ingame_titlemode || (!game.insecretlab && !game.intimetrial && !game.nodeathmode));
+        option("invincibility", !ingame_titlemode || (!insecretlab && !intimetrial && !nodeathmode));
+        option("slowdown", !ingame_titlemode || (!insecretlab && !intimetrial && !nodeathmode));
         option("return");
         menuyoff = 0;
         break;
@@ -7196,13 +7197,13 @@ void Game::returntolab()
 #if !defined(NO_CUSTOM_LEVELS)
 void Game::returntoeditor()
 {
-    game.gamestate = EDITORMODE;
+    gamestate = EDITORMODE;
 
     graphics.textbox.clear();
-    game.hascontrol = true;
-    game.advancetext = false;
-    game.completestop = false;
-    game.state = 0;
+    hascontrol = true;
+    advancetext = false;
+    completestop = false;
+    state = 0;
     graphics.showcutscenebars = false;
     graphics.fademode = 0;
 
@@ -7234,13 +7235,13 @@ void Game::returntopausemenu()
     map.kludge_to_bg();
     map.tdrawback = true;
     graphics.backgrounddrawn = false;
-    game.mapheld = true;
+    mapheld = true;
     graphics.flipmode = graphics.setflipmode;
     if (!map.custommode && !graphics.flipmode)
     {
         obj.flags[73] = true;
     }
-    game.shouldreturntopausemenu = true;
+    shouldreturntopausemenu = true;
 }
 
 void Game::unlockAchievement(const char *name) {

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -425,6 +425,8 @@ public:
     bool disablepause;
 };
 
+#ifndef GAME_DEFINITION
 extern Game game;
+#endif
 
 #endif /* GAME_H */

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1,3 +1,4 @@
+#define GRAPHICS_DEFINITION
 #include "Graphics.h"
 
 #include <stdio.h>
@@ -2991,16 +2992,16 @@ void Graphics::renderwithscreeneffects()
 {
 	if (game.flashlight > 0 && !game.noflashingmode)
 	{
-		graphics.flashlight();
+		flashlight();
 	}
 
 	if (game.screenshake > 0 && !game.noflashingmode)
 	{
-		graphics.screenshake();
+		screenshake();
 	}
 	else
 	{
-		graphics.render();
+		render();
 	}
 }
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -317,6 +317,8 @@ public:
 	Uint32 crewcolourreal(int t);
 };
 
+#ifndef GRAPHICS_DEFINITION
 extern Graphics graphics;
+#endif
 
 #endif /* GRAPHICS_H */

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -1,3 +1,4 @@
+#define KEY_DEFINITION
 #include "KeyPoll.h"
 
 #include <stdio.h>

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -81,6 +81,8 @@ private:
 	Uint32 wasFullscreen;
 };
 
+#ifndef KEY_DEFINITION
 extern KeyPoll key;
+#endif
 
 #endif /* KEYPOLL_H */

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1,3 +1,4 @@
+#define MAP_DEFINITION
 #include "Map.h"
 
 #include "editor.h"

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -190,6 +190,8 @@ public:
     }
 };
 
+#ifndef MAP_DEFINITION
 extern mapclass map;
+#endif
 
 #endif /* MAPGAME_H */

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -1,3 +1,4 @@
+#define MUSIC_DEFINITION
 #include "Music.h"
 
 #include <SDL.h>
@@ -152,6 +153,7 @@ void musicclass::init()
 
 void songend()
 {
+	extern musicclass music;
 	music.songEnd = SDL_GetPerformanceCounter();
 	music.currentsong = -1;
 }

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -58,6 +58,8 @@ public:
 	Uint64 songEnd;
 };
 
+#ifndef MUSIC_DEFINITION
 extern musicclass music;
+#endif
 
 #endif /* MUSIC_H */

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1,3 +1,4 @@
+#define SCRIPT_DEFINITION
 #include "Script.h"
 
 #include "editor.h"

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -68,6 +68,8 @@ public:
     std::vector<Script> customscripts;
 };
 
+#ifndef SCRIPT_DEFINITION
 extern scriptclass script;
+#endif
 
 #endif /* SCRIPT_H */

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -1,3 +1,4 @@
+#define HELP_DEFINITION
 #include "UtilityClass.h"
 
 #include <cctype>

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -58,6 +58,8 @@ public:
     int splitseconds[30];
 };
 
+#ifndef HELP_DEFINITION
 extern UtilityClass help;
+#endif
 
 #endif /* UTILITYCLASS_H */

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1,5 +1,6 @@
 #if !defined(NO_CUSTOM_LEVELS)
 
+#define ED_DEFINITION
 #include "editor.h"
 
 #include <physfs.h>
@@ -491,9 +492,9 @@ void editorclass::insertline(int t)
 
 void editorclass::getlin(const enum textmode mode, const std::string& prompt, std::string* ptr)
 {
-    ed.textmod = mode;
-    ed.textptr = ptr;
-    ed.textdesc = prompt;
+    textmod = mode;
+    textptr = ptr;
+    textdesc = prompt;
     key.enabletextentry();
     if (ptr)
     {
@@ -502,10 +503,10 @@ void editorclass::getlin(const enum textmode mode, const std::string& prompt, st
     else
     {
         key.keybuffer = "";
-        ed.textptr = &(key.keybuffer);
+        textptr = &(key.keybuffer);
     }
 
-    ed.oldenttext = key.keybuffer;
+    oldenttext = key.keybuffer;
 }
 
 const short* editorclass::loadlevel( int rxi, int ryi )
@@ -2272,22 +2273,22 @@ void editorclass::generatecustomminimap()
     int tm=0;
     int temp=0;
     //Scan over the map size
-    if(ed.mapheight<=5 && ed.mapwidth<=5)
+    if(mapheight<=5 && mapwidth<=5)
     {
         //4x map
-        for(int j2=0; j2<ed.mapheight; j2++)
+        for(int j2=0; j2<mapheight; j2++)
         {
-            for(int i2=0; i2<ed.mapwidth; i2++)
+            for(int i2=0; i2<mapwidth; i2++)
             {
                 //Ok, now scan over each square
                 tm=196;
-                if(ed.level[i2 + (j2*ed.maxwidth)].tileset==1) tm=96;
+                if(level[i2 + (j2*maxwidth)].tileset==1) tm=96;
 
                 for(int j=0; j<36; j++)
                 {
                     for(int i=0; i<48; i++)
                     {
-                        temp=ed.absfree(int(i*0.83) + (i2*40),int(j*0.83)+(j2*30));
+                        temp=absfree(int(i*0.83) + (i2*40),int(j*0.83)+(j2*30));
                         if(temp>=1)
                         {
                             //Fill in this pixel
@@ -2298,22 +2299,22 @@ void editorclass::generatecustomminimap()
             }
         }
     }
-    else if(ed.mapheight<=10 && ed.mapwidth<=10)
+    else if(mapheight<=10 && mapwidth<=10)
     {
         //2x map
-        for(int j2=0; j2<ed.mapheight; j2++)
+        for(int j2=0; j2<mapheight; j2++)
         {
-            for(int i2=0; i2<ed.mapwidth; i2++)
+            for(int i2=0; i2<mapwidth; i2++)
             {
                 //Ok, now scan over each square
                 tm=196;
-                if(ed.level[i2 + (j2*ed.maxwidth)].tileset==1) tm=96;
+                if(level[i2 + (j2*maxwidth)].tileset==1) tm=96;
 
                 for(int j=0; j<18; j++)
                 {
                     for(int i=0; i<24; i++)
                     {
-                        temp=ed.absfree(int(i*1.6) + (i2*40),int(j*1.6)+(j2*30));
+                        temp=absfree(int(i*1.6) + (i2*40),int(j*1.6)+(j2*30));
                         if(temp>=1)
                         {
                             //Fill in this pixel
@@ -2326,19 +2327,19 @@ void editorclass::generatecustomminimap()
     }
     else
     {
-        for(int j2=0; j2<ed.mapheight; j2++)
+        for(int j2=0; j2<mapheight; j2++)
         {
-            for(int i2=0; i2<ed.mapwidth; i2++)
+            for(int i2=0; i2<mapwidth; i2++)
             {
                 //Ok, now scan over each square
                 tm=196;
-                if(ed.level[i2 + (j2*ed.maxwidth)].tileset==1) tm=96;
+                if(level[i2 + (j2*maxwidth)].tileset==1) tm=96;
 
                 for(int j=0; j<9; j++)
                 {
                     for(int i=0; i<12; i++)
                     {
-                        temp=ed.absfree(3+(i*3) + (i2*40),(j*3)+(j2*30));
+                        temp=absfree(3+(i*3) + (i2*40),(j*3)+(j2*30));
                         if(temp>=1)
                         {
                             //Fill in this pixel
@@ -2354,6 +2355,7 @@ void editorclass::generatecustomminimap()
 #if !defined(NO_EDITOR)
 void editormenurender(int tr, int tg, int tb)
 {
+    extern editorclass ed;
     switch (game.currentmenuname)
     {
     case Menu::ed_settings:
@@ -2532,6 +2534,7 @@ void editormenurender(int tr, int tg, int tb)
 
 void editorrender()
 {
+    extern editorclass ed;
     if (game.shouldreturntoeditor)
     {
         graphics.backgrounddrawn = false;
@@ -3660,6 +3663,7 @@ void editorrender()
 
 void editorlogic()
 {
+    extern editorclass ed;
     //Misc
     help.updateglow();
     graphics.updatetitlecolours();
@@ -3760,6 +3764,7 @@ void editorlogic()
 
 void editormenuactionpress()
 {
+    extern editorclass ed;
     switch (game.currentmenuname)
     {
     case Menu::ed_desc:
@@ -3912,6 +3917,7 @@ void editormenuactionpress()
 
 void editorinput()
 {
+    extern editorclass ed;
     game.mx = (float) key.mx;
     game.my = (float) key.my;
     ed.tilex=(game.mx - (game.mx%8))/8;
@@ -5706,7 +5712,7 @@ Uint32 editorclass::getonewaycol(const int rx, const int ry)
 Uint32 editorclass::getonewaycol()
 {
     if (game.gamestate == EDITORMODE)
-        return getonewaycol(ed.levx, ed.levy);
+        return getonewaycol(levx, levy);
     else if (map.custommode)
         return getonewaycol(game.roomx - 100, game.roomy - 100);
 

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -293,7 +293,9 @@ void editorlogic();
 void editorinput();
 #endif
 
+#ifndef ED_DEFINITION
 extern editorclass ed;
+#endif
 
 #endif /* EDITOR_H */
 


### PR DESCRIPTION
By "unnecessary qualifiers to self", I mean something like using the `game.` qualifier for a variable on the `Game` class when you're inside a function on the `Game` class itself. This patch is to enforce consistency as most of the code doesn't have these unnecessary qualifiers.

To prevent further unnecessary qualifiers to self, I made it so the extern in each header file can be omitted by using a define. That way, if someone writes something referring to `game.` on a `Game` function, there will be a compile error.

However, if you really need to have a reference to the global name, and you're within the same `.cpp` file as the implementation of that object, you can just do the extern at the function-level. A good example of this is `editorinput()`/`editorrender()`/`editorlogic()` in `editor.cpp`. In my opinion, they should probably be split off into their own separate file because `editor.cpp` is getting way too big, but this will do for now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
