### PR TITLE
Remove unused attributes from entclass

### DIFF
--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -38,11 +38,9 @@ entclass::entclass()
 	x2 = 320;
 	y2 = 240;
 
-	jumping = false;
 	gravity = false;
 	onground = 0;
 	onroof = 0;
-	jumpframe = 0;
 
 	onentity = 0;
 	harmful = false;

--- a/desktop_version/src/Ent.h
+++ b/desktop_version/src/Ent.h
@@ -42,10 +42,8 @@ public:
     int onwall, onxwall, onywall;
 
     //Platforming specific
-    bool jumping;
     bool gravity;
     int onground, onroof;
-    int jumpframe;
     //Animation
     int framedelay, drawframe, walkingframe, dir, actionframe;
     int yp;int xp;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4446,7 +4446,6 @@ void entityclass::entitymapcollision( int t )
     {
         if (entities[t].onwall > 0) entities[t].state = entities[t].onwall;
         if (entities[t].onywall > 0) entities[t].state = entities[t].onywall;
-        entities[t].jumpframe = 0;
     }
 }
 


### PR DESCRIPTION
These attributes were `jumping` and `jumpframe`. Removal of unused attributes makes reading the code easier.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
