### PR TITLE
Remove duplicate onroof and onground assignments for vertically-moving platforms

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4474,13 +4474,11 @@ void entityclass::movingplatformfix( int t, int j )
                 {
                     entities[j].yp = entities[t].yp + entities[t].h;
                     entities[j].vy = 0;
-                    entities[j].onroof = true;
                 }
                 else
                 {
                     entities[j].yp = entities[t].yp - entities[j].h-entities[j].cy;
                     entities[j].vy = 0;
-                    entities[j].onground = true;
                 }
             }
             else


### PR DESCRIPTION
The `onroof`/`onground` attributes are used to determine if the player is standing on a surface and is eligible to flip. Most notably, it is an integer and not a boolean, and it starts at 2, giving the player 2 frames to edge-flip, i.e. they can still flip 2 frames after walking off an edge.

However, these attributes are unnecessarily reassigned in `movingplatformfix()` (which is the function that deals exclusively with vertically-moving platforms; horizontal moving platforms get their own `hormovingplatformfix()`). Whoever wrote this misunderstood what `onroof`/`onground` meant; they thought that they were booleans, and so set them to true, instead of the proper value of 2. This ends up setting `onroof`/`onground` to 1 instead of 2, causing a discrepancy with vertical moving platforms and the rest of the surfaces in the game.

The bigger mistake here is duplicating code that never needed to be duplicated. The `onroof`/`onground` assignment in `gamelogic()` works perfectly fine for vertical moving platforms. Indeed, after testing it with libTAS, I can confirm that removing the duplicate assignments restores being able to edge-flip off of moving platforms with 2 frames of leeway, instead of only 1 frame. It also doesn't change how long it takes for the `onroof`/`onground` to get set when the player is recognized as standing on a vertically-moving platform, either.

And so, it's better to not duplicate this code, because when you duplicate it you run the risk of making a mistake, as I just demonstrated.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
