### PR TITLE
Fix onground/onroof taking 1 frame to apply after landing on a vertical moving platform

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4473,11 +4473,13 @@ void entityclass::movingplatformfix( int t, int j )
                 {
                     entities[j].yp = entities[t].yp + entities[t].h;
                     entities[j].vy = 0;
+                    entities[j].onroof = 2;
                 }
                 else
                 {
                     entities[j].yp = entities[t].yp - entities[j].h-entities[j].cy;
                     entities[j].vy = 0;
+                    entities[j].onground = 2;
                 }
             }
             else


### PR DESCRIPTION
So, 77a636509bf3b2a429f18bcae0615b898aa7321b fixed the fact that you only got 1 frame of onground/onroof when standing on a vertical moving platform, but removing those lines entirely means that it takes 1 frame before the onground/onroof of 2 actually takes effect. This desyncs my Nova TAS, so it seems important to fix.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
