### PR TITLE
Fix inconsistencies with checkpoints, spawn points, and start points

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2619,12 +2619,12 @@ bool entityclass::updateentities( int i )
 
                 if (entities[i].tile == 20)
                 {
-                    game.savey = entities[i].yp - 1;
+                    game.savey = entities[i].yp - 2;
                     game.savegc = 1;
                 }
                 else if (entities[i].tile == 21)
                 {
-                    game.savey = entities[i].yp-8;
+                    game.savey = entities[i].yp - 7;
                     game.savegc = 0;
                 }
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1526,7 +1526,7 @@ void editorclass::findstartpoint()
         game.edsaverx = 100+tx;
         game.edsavery = 100+ty;
         game.edsavegc = 0;
-        game.edsavey--;
+        game.edsavey++;
         game.edsavedir=1-edentity[testeditor].p1;
     }
 }
@@ -4719,12 +4719,13 @@ void editorinput()
                             if (edentity[testeditor].p1 == 0) // NOT a bool check!
                             {
                                 game.edsavegc = 1;
+                                game.edsavey -= 2;
                             }
                             else
                             {
                                 game.edsavegc = 0;
+                                game.edsavey -= 7;
                             }
-                            game.edsavey--;
                             game.edsavedir = 0;
                         }
                         else
@@ -4737,7 +4738,7 @@ void editorinput()
                             game.edsaverx = 100+tx;
                             game.edsavery = 100+ty;
                             game.edsavegc = 0;
-                            game.edsavey--;
+                            game.edsavey++;
                             game.edsavedir=1-edentity[testeditor].p1;
                         }
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -4716,7 +4716,14 @@ void editorinput()
                             game.edsavey = (edentity[testeditor].y%30)*8;
                             game.edsaverx = 100+tx;
                             game.edsavery = 100+ty;
-                            game.edsavegc = 1-edentity[testeditor].p1;
+                            if (edentity[testeditor].p1 == 0) // NOT a bool check!
+                            {
+                                game.edsavegc = 1;
+                            }
+                            else
+                            {
+                                game.edsavegc = 0;
+                            }
                             game.edsavey--;
                             game.edsavedir = 0;
                         }


### PR DESCRIPTION
* **Fix spawning from an exotic checkpoint setting invalid gravitycontrol**

  An exotic checkpoint is a checkpoint with a sprite that is neither the flipped checkpoint nor unflipped checkpoint. More specifically, it's a checkpoint whose edentity p1 attribute is something other than 0 or 1.

  Normally, whenever you touch an exotic checkpoint in-game, your savepoint's y-position and gravitycontrol don't get touched. However, in the editor, spawning from an exotic checkpoint means that your gravitycontrol gets set to a value that is neither 0 nor 1. In this invalid gravitycontrol state, Viridian is treated like they're flipped, but they cannot unflip.

  This is an inconsistency between the editor and in-game, so I'm fixing it. Now, spawning from an exotic checkpoint in the editor will just set your gravitycontrol to 0, i.e. unflipped.

* **Fix inconsistencies with y-positions of spawns**

  It seems like the start point of a custom level and all checkpoints in the game end up putting your spawn point one pixel away from the surface it touches, which seems like an oversight. I'm going to enforce some consistency here and make it so that all spawn points, whenever you start from a start point or a checkpoint, will always be correctly positioned flush with the surface they're standing on, and not one pixel more or less than that.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
