### PR TITLE
Clean up music handling and put it in one place

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -177,7 +177,7 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 		t += num_mmmmmm_tracks;
 	}
 	safeToProcessMusic = true;
-	Mix_VolumeMusic(MIX_MAX_VOLUME);
+	musicVolume = MIX_MAX_VOLUME;
 	if (currentsong !=t)
 	{
 		if (t != -1)
@@ -246,7 +246,6 @@ void musicclass::haltdasmusik()
 
 void musicclass::silencedasmusik()
 {
-	Mix_VolumeMusic(0) ;
 	musicVolume = 0;
 }
 
@@ -265,7 +264,6 @@ void musicclass::fadeout()
 void musicclass::processmusicfadein()
 {
 	musicVolume += FadeVolAmountPerFrame;
-	Mix_VolumeMusic(musicVolume);
 	if (musicVolume >= MIX_MAX_VOLUME)
 	{
 		m_doFadeInVol = false;

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -132,7 +132,7 @@ void musicclass::init()
 
 	safeToProcessMusic= false;
 	m_doFadeInVol = false;
-	musicVolume = 128;
+	musicVolume = MIX_MAX_VOLUME;
 	FadeVolAmountPerFrame = 0;
 
 	currentsong = 0;
@@ -177,7 +177,7 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 		t += num_mmmmmm_tracks;
 	}
 	safeToProcessMusic = true;
-	Mix_VolumeMusic(128);
+	Mix_VolumeMusic(MIX_MAX_VOLUME);
 	if (currentsong !=t)
 	{
 		if (t != -1)

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -5,7 +5,6 @@
 #include <stdio.h>
 
 #include "BinaryBlob.h"
-#include "Game.h"
 #include "Map.h"
 #include "UtilityClass.h"
 
@@ -265,11 +264,8 @@ void musicclass::fadeout()
 
 void musicclass::processmusicfadein()
 {
-	// Instead of returning early if music is muted, this should still increase `musicVolume`
-	// so that anything that relies on this won't break. We'll simply just not set the volume
-	// if the music is muted
 	musicVolume += FadeVolAmountPerFrame;
-	if (!game.musicmuted) Mix_VolumeMusic(musicVolume);
+	Mix_VolumeMusic(musicVolume);
 	if (musicVolume >= MIX_MAX_VOLUME)
 	{
 		m_doFadeInVol = false;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -657,13 +657,13 @@ void inline fixedloop()
     {
         Mix_Volume(-1,MIX_MAX_VOLUME);
 
-        if (game.musicmuted || game.completestop)
+        if (game.musicmuted)
         {
             Mix_VolumeMusic(0);
         }
         else
         {
-            Mix_VolumeMusic(MIX_MAX_VOLUME);
+            Mix_VolumeMusic(music.musicVolume);
         }
     }
 


### PR DESCRIPTION
Previously, setting the actual volume of the music was all over the place. Which isn't bad, but when I added being able to press N to mute the music specifically, I should've made it so that there would be a volume variable somewhere that the game looks at if the music is unmuted, and otherwise sets the actual volume to 0 if the game is muted.

This resulted in things like #400 and #505 and having to add a bunch of special-cased checks like `game.musicmuted` and `game.completestop`. But instead of adding a bunch of special-case code, just make it so there's a central place where `Mix_VolumeMusic()` actually gets called, and if some piece of code wants to set the music volume, they can set `music.musicVolume`. But the music handling logic in `main.cpp` gets the final say on whether to listen to `music.musicVolume`, or to mute the game entirely.

This is how the music handling code should have been from the start (when pressing N to mute the music was added).

Fixes #505.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
