### PR TITLE
Fix "name lookup of ‘i’ changed" warning in editor.cpp

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2688,7 +2688,7 @@ void editorrender()
                 drawRect = graphics.tiles_rect;
                 drawRect.x += tpoint.x;
                 drawRect.y += tpoint.y;
-                for (int i = 0; i < 4; i++) {
+                for (int j = 0; j < 4; j++) {
                     if (custom_gray) BlitSurfaceTinted(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect, gray_ct);
                     else BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                     drawRect.x += 8;
@@ -2721,7 +2721,7 @@ void editorrender()
                     drawRect = graphics.tiles_rect;
                     drawRect.x += tpoint.x;
                     drawRect.y += tpoint.y;
-                    for (int i = 0; i < 4; i++) {
+                    for (int j = 0; j < 4; j++) {
                         if (custom_gray) BlitSurfaceTinted(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect, gray_ct);
                         else BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                         drawRect.x += 8;
@@ -2749,7 +2749,7 @@ void editorrender()
                 drawRect = graphics.tiles_rect;
                 drawRect.x += tpoint.x;
                 drawRect.y += tpoint.y;
-                for (int i = 0; i < 4; i++) {
+                for (int j = 0; j < 4; j++) {
                     if (custom_gray) BlitSurfaceTinted(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect, gray_ct);
                     else BlitSurfaceStandard(graphics.entcolours[obj.customplatformtile],NULL, graphics.backBuffer, &drawRect);
                     drawRect.x += 8;


### PR DESCRIPTION
## Changes:

I got this warning when compiling VVVVVV again after a while:
```
/home/david/g/github_vvvvvv/dav999fork/VVVVVV/desktop_version/src/editor.cpp: In function ‘void editorrender()’:
/home/david/g/github_vvvvvv/dav999fork/VVVVVV/desktop_version/src/editor.cpp:2697:29: warning: name lookup of ‘i’ changed
                 if(edentity[i].p1<=4)
                             ^
/home/david/g/github_vvvvvv/dav999fork/VVVVVV/desktop_version/src/editor.cpp:2656:14: warning:   matches this ‘i’ under ISO standard rules
     for (int i = edentity.size() - 1; i >= 0; i--)
              ^
/home/david/g/github_vvvvvv/dav999fork/VVVVVV/desktop_version/src/editor.cpp:2691:26: warning:   matches this ‘i’ under old rules
                 for (int i = 0; i < 4; i++) {
                          ^
```

It points out there are two nested for loops both defining `i` in what looks to be the code that draws entities in the editor. I thought it was kind of a worrying warning because it implies that whenever the game is compiled by a compiler using the "old rules" for name lookups, the ID of the entity that is currently being checked would silently be overwritten by `4` somewhere in the loop. To prevent this, I just renamed the inner instances of `i` to `j`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
