### PR TITLE
Fix conveyor/platform collisions with newyp, and getting stuck inside certain conveyors

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4674,6 +4674,11 @@ void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
         }
         break;
     case 2:   //Moving platforms
+        if (entities[j].behave >= 8 || entities[j].behave < 10)
+        {
+            //We don't want conveyors, moving platforms only
+            break;
+        }
         if (entitycollide(i, j))
         {
             //Disable collision temporarily so we don't push the person out!

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -939,6 +939,7 @@ void gamelogic()
                 if (INBOUNDS_VEC(i, obj.entities) && j > -1000)
                 {
                     obj.entities[i].newxp = obj.entities[i].xp + j;
+                    obj.entities[i].newyp = obj.entities[i].yp;
                     obj.entitymapcollision(i);
                 }
                 else
@@ -947,6 +948,7 @@ void gamelogic()
                     if (INBOUNDS_VEC(i, obj.entities) && j > -1000)
                     {
                         obj.entities[i].newxp = obj.entities[i].xp + j;
+                        obj.entities[i].newyp = obj.entities[i].yp;
                         obj.entitymapcollision(i);
                     }
                 }


### PR DESCRIPTION
There is this issue with conveyors where if you collide with them, your intended next y-position doesn't get updated to the position of the conveyor, and then your y-position gets set to your intended next y-position. This also applies to horizontally moving platforms.

This bug used to not produce any problems, if at all, until #502 got merged. Since then, respawning from checkpoints that are on conveyors would sometimes not update your y-position at all, making it possible to get stuck inside a death loop that would require you to exit the game and re-enter it.

But you can always reliably create this bug simply by going into the editor and placing down a conveyor and checkpoint on top of each other. Then enter and exit playtesting a bunch of times, and you'll notice the glitchy y-position Viridian keeps taking on.

The root cause of this is how the game moves the player whenever they stand on the top or bottom of a conveyor (or a horizontally moving platform). The game sets their intended next x-position (`newxp`), then calls `obj.entitymapcollision()` on them. This would be okay, except their intended next y-position (`newyp`) doesn't get set along with their `newxp`, so `entitymapcollision()` will use the wrong `newyp`, then find that there is nothing that will collide with the player at that given `newyp`, then update the `yp` of the player to the wrong `newyp`.

So, the platform logic simply doesn't set the player's `newyp`. Why does the player have the wrong `newyp`? It's because moving platforms (and conveyors) are updated first before all other entities are, and this includes the code that checks the player for collisions with moving platforms. That's right: the moving platform collision code gets ran before the player properly gets updated. This means that the game will use the `newyp` of the previous frame, which could be anything, really, but it most likely just means the intended next y-position of the player gets canceled, leaving the player with the same y-position they had before.

Okay, but this bug only seems to happen when you put a checkpoint inside a conveyor (or a moving platform that hasn't started moving yet) and start playtesting from it, so why doesn't this bug happen more often, then? Well, it's probably because of luck and coincidence. Most of the time, if you're colliding with a conveyor or horizontally moving platform, you probably have a correct `newyp` from the previous frame of the game, so there'd be no problems. And before #502 got merged, this previous frame would be provided by the player having to fall to the surface due to the y-offset of their savepoint. However, if you make it so that you immediately teleport on to a conveyor (because you died), then this bug will rear its ugly head.

I also noticed that getting inside a conveyor seems to always push the player out, despite conveyors sharing the same code with moving platforms, which has code to temporarily disable their own collision when the player gets stuck inside them, so that the player *doesn't* get pushed out.

Well, it turns out that the reason this happens is because conveyors in a room that get placed during `mapclass::loadlevel()` get tile 1 placed underneath them. This is mostly so moving platforms will collide with them, because otherwise platforms don't collide with other platforms, and a conveyor is considered a platform.

This means that a conveyor without any tiles behind it will simply get the player stuck if they get inside it, and the player won't be pushed out. This is bad, because conveyors don't move, so they'll be stuck there forever until they press R (or save, quit, and load). This situation doesn't come up in the main game, but it *could* come up in custom levels that use the internal `createentity()` command to create conveyors that don't have any tiles behind them.

It seems good to fix this as well, while we're at it fixing conveyor physics, so I'm fixing this as well.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
