### PR TITLE
Reload window icon when mounting and unmounting assets

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3242,6 +3242,11 @@ void Graphics::reloadresources() {
 	images.push_back(grphx.im_image11);
 	images.push_back(grphx.im_image12);
 
+	if (screenbuffer != NULL)
+	{
+		screenbuffer->LoadIcon();
+	}
+
 	music.init();
 }
 

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -62,27 +62,7 @@ void Screen::init(
 	);
 	SDL_SetWindowTitle(m_window, "VVVVVV");
 
-	unsigned char *fileIn = NULL;
-	size_t length = 0;
-	unsigned char *data;
-	unsigned int width, height;
-	FILESYSTEM_loadFileToMemory("VVVVVV.png", &fileIn, &length);
-	lodepng_decode24(&data, &width, &height, fileIn, length);
-	FILESYSTEM_freeMemory(&fileIn);
-	SDL_Surface *icon = SDL_CreateRGBSurfaceFrom(
-		data,
-		width,
-		height,
-		24,
-		width * 3,
-		0x000000FF,
-		0x0000FF00,
-		0x00FF0000,
-		0x00000000
-	);
-	SDL_SetWindowIcon(m_window, icon);
-	SDL_FreeSurface(icon);
-	free(data);
+	LoadIcon();
 
 	// FIXME: This surface should be the actual backbuffer! -flibit
 	m_screen = SDL_CreateRGBSurface(
@@ -107,6 +87,31 @@ void Screen::init(
 	badSignalEffect = badSignal;
 
 	ResizeScreen(windowWidth, windowHeight);
+}
+
+void Screen::LoadIcon()
+{
+	unsigned char *fileIn = NULL;
+	size_t length = 0;
+	unsigned char *data;
+	unsigned int width, height;
+	FILESYSTEM_loadFileToMemory("VVVVVV.png", &fileIn, &length);
+	lodepng_decode24(&data, &width, &height, fileIn, length);
+	FILESYSTEM_freeMemory(&fileIn);
+	SDL_Surface *icon = SDL_CreateRGBSurfaceFrom(
+		data,
+		width,
+		height,
+		24,
+		width * 3,
+		0x000000FF,
+		0x0000FF00,
+		0x00FF0000,
+		0x00000000
+	);
+	SDL_SetWindowIcon(m_window, icon);
+	SDL_FreeSurface(icon);
+	free(data);
 }
 
 void Screen::ResizeScreen(int x, int y)

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -16,6 +16,8 @@ public:
 		bool badSignal
 	);
 
+	void LoadIcon();
+
 	void ResizeScreen(int x, int y);
 	void ResizeToNearestMultiple();
 	void GetWindowSize(int* x, int* y);


### PR DESCRIPTION
The window icon is simply another asset that can be customized by level makers. And in fact, one of my levels changes the window icon. It's simply named `VVVVVV.png`, but it doesn't sit in the `graphics` folder, rather it sits in the root VVVVVV directory.

I noticed that this asset was missed when per-level assets loading was added, so I decided to add it in.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
