### PR TITLE
Re-add original oldxp/oldyp assignments of player in mapclass::gotoroom()

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1100,6 +1100,8 @@ void mapclass::gotoroom(int rx, int ry)
 	temp = obj.getplayer();
 	if(INBOUNDS_VEC(temp, obj.entities))
 	{
+		obj.entities[temp].oldxp = obj.entities[temp].xp;
+		obj.entities[temp].oldyp = obj.entities[temp].yp;
 		obj.entities[temp].lerpoldxp = obj.entities[temp].xp - int(obj.entities[temp].vx);
 		obj.entities[temp].lerpoldyp = obj.entities[temp].yp - int(obj.entities[temp].vy);
 	}


### PR DESCRIPTION
The intent of #504 was to make it so `oldxp`/`oldyp` would never be messed with for over-30-FPS stuff, but I forgot that I changed these assignments in my over-30-FPS patch when I was doing #504. So these assignments have been restored to the way they were in 2.2, and is fixed now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
