### PR TITLE
Fix crewmates being drawn behind other entities

### DIFF
--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -644,3 +644,11 @@ void entclass::updatecolour()
 		break;
 	}
 }
+
+bool entclass::ishumanoid()
+{
+	return type == 0
+		|| type == 12
+		|| type == 14
+		|| type == 55;
+}

--- a/desktop_version/src/Ent.h
+++ b/desktop_version/src/Ent.h
@@ -20,6 +20,8 @@ public:
 
     void updatecolour();
 
+    bool ishumanoid();
+
 public:
     //Fundamentals
     bool invis;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1591,26 +1591,18 @@ void Graphics::drawentities()
 
 #if !defined(NO_CUSTOM_LEVELS)
     // Special case for gray Warp Zone tileset!
-    int room = game.roomx-100 + (game.roomy-100) * ed.maxwidth;
-    bool custom_gray = INBOUNDS_ARR(room, ed.level)
+    const int room = game.roomx-100 + (game.roomy-100) * ed.maxwidth;
+    const bool custom_gray = INBOUNDS_ARR(room, ed.level)
     && ed.level[room].tileset == 3 && ed.level[room].tilecol == 6;
 #else
-    bool custom_gray = false;
+    const bool custom_gray = false;
 #endif
 
     std::vector<SDL_Surface*>& tilesvec = (map.custommode && !map.finalmode) ? entcolours : tiles;
 
     std::vector<SDL_Surface*>& spritesvec = flipmode ? flipsprites : sprites;
 
-    int yoff;
-    if (map.towermode)
-    {
-        yoff = lerp(map.oldypos, map.ypos);
-    }
-    else
-    {
-        yoff = 0;
-    }
+    const int yoff = map.towermode ? lerp(map.oldypos, map.ypos) : 0;
 
     for (int i = obj.entities.size() - 1; i >= 0; i--)
     {
@@ -1619,8 +1611,8 @@ void Graphics::drawentities()
             continue;
         }
 
-        int xp = lerp(obj.entities[i].lerpoldxp, obj.entities[i].xp);
-        int yp = lerp(obj.entities[i].lerpoldyp, obj.entities[i].yp);
+        const int xp = lerp(obj.entities[i].lerpoldxp, obj.entities[i].xp);
+        const int yp = lerp(obj.entities[i].lerpoldyp, obj.entities[i].yp);
 
         switch (obj.entities[i].size)
         {
@@ -1669,7 +1661,7 @@ void Graphics::drawentities()
                 wrappedPoint.y -= 230;
             }
 
-            bool isInWrappingAreaOfTower = map.towermode && !map.minitowermode && map.ypos >= 500 && map.ypos <= 5000;
+            const bool isInWrappingAreaOfTower = map.towermode && !map.minitowermode && map.ypos >= 500 && map.ypos <= 5000;
             if (wrapX && (map.warpx || isInWrappingAreaOfTower))
             {
                 drawRect = sprites_rect;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1598,25 +1598,9 @@ void Graphics::drawentities()
     bool custom_gray = false;
 #endif
 
-    std::vector<SDL_Surface*> *tilesvec;
-    if (map.custommode && !map.finalmode)
-    {
-        tilesvec = &entcolours;
-    }
-    else
-    {
-        tilesvec = &tiles;
-    }
+    std::vector<SDL_Surface*>& tilesvec = (map.custommode && !map.finalmode) ? entcolours : tiles;
 
-    std::vector<SDL_Surface*> *spritesvec;
-    if (flipmode)
-    {
-        spritesvec = &flipsprites;
-    }
-    else
-    {
-        spritesvec = &sprites;
-    }
+    std::vector<SDL_Surface*>& spritesvec = flipmode ? flipsprites : sprites;
 
     int yoff;
     if (map.towermode)
@@ -1643,7 +1627,7 @@ void Graphics::drawentities()
         case 0:
         {
             // Sprites
-            if (!INBOUNDS_VEC(obj.entities[i].drawframe, (*spritesvec)))
+            if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
             {
                 continue;
             }
@@ -1654,7 +1638,7 @@ void Graphics::drawentities()
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
-            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
 
             //screenwrapping!
             point wrappedPoint;
@@ -1691,21 +1675,21 @@ void Graphics::drawentities()
                 drawRect = sprites_rect;
                 drawRect.x += wrappedPoint.x;
                 drawRect.y += tpoint.y;
-                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
+                BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
             }
             if (wrapY && map.warpy)
             {
                 drawRect = sprites_rect;
                 drawRect.x += tpoint.x;
                 drawRect.y += wrappedPoint.y;
-                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
+                BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
             }
             if (wrapX && wrapY && map.warpx && map.warpy)
             {
                 drawRect = sprites_rect;
                 drawRect.x += wrappedPoint.x;
                 drawRect.y += wrappedPoint.y;
-                BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
+                BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
             }
             break;
         }
@@ -1726,7 +1710,7 @@ void Graphics::drawentities()
         case 8:
         {
             // Special: Moving platform, 4 tiles or 8 tiles
-            if (!INBOUNDS_VEC(obj.entities[i].drawframe, (*tilesvec)))
+            if (!INBOUNDS_VEC(obj.entities[i].drawframe, tilesvec))
             {
                 continue;
             }
@@ -1747,11 +1731,11 @@ void Graphics::drawentities()
                 {
                     colourTransform temp_ct;
                     temp_ct.colour = 0xFFFFFFFF;
-                    BlitSurfaceTinted((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, temp_ct);
+                    BlitSurfaceTinted(tilesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, temp_ct);
                 }
                 else
                 {
-                    BlitSurfaceStandard((*tilesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+                    BlitSurfaceStandard(tilesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
                 }
             }
             break;
@@ -1793,7 +1777,7 @@ void Graphics::drawentities()
             // Note: This code is in the 4-tile code
             break;
         case 9:         // Really Big Sprite! (2x2)
-            if (!INBOUNDS_VEC(obj.entities[i].drawframe, (*spritesvec)))
+            if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
             {
                 continue;
             }
@@ -1805,7 +1789,7 @@ void Graphics::drawentities()
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
-            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
 
             tpoint.x = xp+32;
             tpoint.y = yp - yoff;
@@ -1813,7 +1797,7 @@ void Graphics::drawentities()
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
-            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
 
             tpoint.x = xp;
             tpoint.y = yp+32 - yoff;
@@ -1821,7 +1805,7 @@ void Graphics::drawentities()
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
-            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+12],NULL, backBuffer, &drawRect, ct);
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe+12],NULL, backBuffer, &drawRect, ct);
 
             tpoint.x = xp+32;
             tpoint.y = yp+32 - yoff;
@@ -1829,10 +1813,10 @@ void Graphics::drawentities()
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
-            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe + 13],NULL, backBuffer, &drawRect, ct);
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe + 13],NULL, backBuffer, &drawRect, ct);
             break;
         case 10:         // 2x1 Sprite
-            if (!INBOUNDS_VEC(obj.entities[i].drawframe, (*spritesvec)))
+            if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
             {
                 continue;
             }
@@ -1844,7 +1828,7 @@ void Graphics::drawentities()
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
-            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
 
             tpoint.x = xp+32;
             tpoint.y = yp - yoff;
@@ -1852,14 +1836,14 @@ void Graphics::drawentities()
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
-            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
             break;
         case 11:    //The fucking elephant
             setcolreal(obj.entities[i].realcol);
             drawimagecol(3, xp, yp - yoff);
             break;
         case 12:         // Regular sprites that don't wrap
-            if (!INBOUNDS_VEC(obj.entities[i].drawframe, (*spritesvec)))
+            if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
             {
                 continue;
             }
@@ -1870,7 +1854,7 @@ void Graphics::drawentities()
             drawRect = sprites_rect;
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
-            BlitSurfaceColoured((*spritesvec)[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
 
 
             //if we're outside the screen, we need to draw indicators
@@ -1918,7 +1902,7 @@ void Graphics::drawentities()
         case 13:
         {
             //Special for epilogue: huge hero!
-            if (!INBOUNDS_VEC(obj.entities[i].drawframe, (*spritesvec)))
+            if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
             {
                 continue;
             }
@@ -1926,7 +1910,7 @@ void Graphics::drawentities()
             tpoint.x = xp; tpoint.y = yp - yoff;
             setcolreal(obj.entities[i].realcol);
             SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp - yoff), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
-            SDL_Surface* TempSurface = ScaleSurface( (*spritesvec)[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
+            SDL_Surface* TempSurface = ScaleSurface( spritesvec[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
             BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
             SDL_FreeSurface(TempSurface);
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1453,6 +1453,12 @@ bool Graphics::Hitest(SDL_Surface* surface1, point p1, SDL_Surface* surface2, po
 
 void Graphics::drawgravityline( int t )
 {
+    if (!INBOUNDS_VEC(t, obj.entities))
+    {
+        WHINE_ONCE("drawgravityline() out-of-bounds!");
+        return;
+    }
+
     if (obj.entities[t].life == 0 || obj.entities[t].onentity == 1) // FIXME: Remove 'onentity == 1' when game loop order is fixed!
     {
         switch(linestate)

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1591,6 +1591,27 @@ void Graphics::drawtrophytext()
 
 void Graphics::drawentities()
 {
+    const int yoff = map.towermode ? lerp(map.oldypos, map.ypos) : 0;
+
+    for (int i = obj.entities.size() - 1; i >= 0; i--)
+    {
+        drawentity(i, yoff);
+    }
+}
+
+void Graphics::drawentity(const int i, const int yoff)
+{
+    if (!INBOUNDS_VEC(i, obj.entities))
+    {
+        WHINE_ONCE("drawentity() out-of-bounds!");
+        return;
+    }
+
+        if (obj.entities[i].invis)
+        {
+            return;
+        }
+
     point tpoint;
 
     SDL_Rect drawRect;
@@ -1608,15 +1629,6 @@ void Graphics::drawentities()
 
     std::vector<SDL_Surface*>& spritesvec = flipmode ? flipsprites : sprites;
 
-    const int yoff = map.towermode ? lerp(map.oldypos, map.ypos) : 0;
-
-    for (int i = obj.entities.size() - 1; i >= 0; i--)
-    {
-        if (obj.entities[i].invis)
-        {
-            continue;
-        }
-
         const int xp = lerp(obj.entities[i].lerpoldxp, obj.entities[i].xp);
         const int yp = lerp(obj.entities[i].lerpoldyp, obj.entities[i].yp);
 
@@ -1627,7 +1639,7 @@ void Graphics::drawentities()
             // Sprites
             if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
             {
-                continue;
+                return;
             }
             tpoint.x = xp;
             tpoint.y = yp - yoff;
@@ -1695,7 +1707,7 @@ void Graphics::drawentities()
             // Tiles
             if (!INBOUNDS_VEC(obj.entities[i].drawframe, tiles))
             {
-                continue;
+                return;
             }
             tpoint.x = xp;
             tpoint.y = yp - yoff;
@@ -1710,7 +1722,7 @@ void Graphics::drawentities()
             // Special: Moving platform, 4 tiles or 8 tiles
             if (!INBOUNDS_VEC(obj.entities[i].drawframe, tilesvec))
             {
-                continue;
+                return;
             }
             tpoint.x = xp;
             tpoint.y = yp - yoff;
@@ -1777,7 +1789,7 @@ void Graphics::drawentities()
         case 9:         // Really Big Sprite! (2x2)
             if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
             {
-                continue;
+                return;
             }
             setcolreal(obj.entities[i].realcol);
 
@@ -1816,7 +1828,7 @@ void Graphics::drawentities()
         case 10:         // 2x1 Sprite
             if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
             {
-                continue;
+                return;
             }
             setcolreal(obj.entities[i].realcol);
 
@@ -1843,7 +1855,7 @@ void Graphics::drawentities()
         case 12:         // Regular sprites that don't wrap
             if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
             {
-                continue;
+                return;
             }
             tpoint.x = xp;
             tpoint.y = yp - yoff;
@@ -1902,7 +1914,7 @@ void Graphics::drawentities()
             //Special for epilogue: huge hero!
             if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
             {
-                continue;
+                return;
             }
 
             tpoint.x = xp; tpoint.y = yp - yoff;
@@ -1917,7 +1929,6 @@ void Graphics::drawentities()
             break;
         }
         }
-    }
 }
 
 void Graphics::drawbackground( int t )

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1607,10 +1607,10 @@ void Graphics::drawentity(const int i, const int yoff)
         return;
     }
 
-        if (obj.entities[i].invis)
-        {
-            return;
-        }
+    if (obj.entities[i].invis)
+    {
+        return;
+    }
 
     point tpoint;
 
@@ -1629,306 +1629,306 @@ void Graphics::drawentity(const int i, const int yoff)
 
     std::vector<SDL_Surface*>& spritesvec = flipmode ? flipsprites : sprites;
 
-        const int xp = lerp(obj.entities[i].lerpoldxp, obj.entities[i].xp);
-        const int yp = lerp(obj.entities[i].lerpoldyp, obj.entities[i].yp);
+    const int xp = lerp(obj.entities[i].lerpoldxp, obj.entities[i].xp);
+    const int yp = lerp(obj.entities[i].lerpoldyp, obj.entities[i].yp);
 
-        switch (obj.entities[i].size)
+    switch (obj.entities[i].size)
+    {
+    case 0:
+    {
+        // Sprites
+        if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
         {
-        case 0:
-        {
-            // Sprites
-            if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
-            {
-                return;
-            }
-            tpoint.x = xp;
-            tpoint.y = yp - yoff;
-            setcolreal(obj.entities[i].realcol);
+            return;
+        }
+        tpoint.x = xp;
+        tpoint.y = yp - yoff;
+        setcolreal(obj.entities[i].realcol);
 
+        drawRect = sprites_rect;
+        drawRect.x += tpoint.x;
+        drawRect.y += tpoint.y;
+        BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
+
+        //screenwrapping!
+        point wrappedPoint;
+        bool wrapX = false;
+        bool wrapY = false;
+
+        wrappedPoint.x = tpoint.x;
+        if (tpoint.x < 0)
+        {
+            wrapX = true;
+            wrappedPoint.x += 320;
+        }
+        else if (tpoint.x > 300)
+        {
+            wrapX = true;
+            wrappedPoint.x -= 320;
+        }
+
+        wrappedPoint.y = tpoint.y;
+        if (tpoint.y < 0)
+        {
+            wrapY = true;
+            wrappedPoint.y += 230;
+        }
+        else if (tpoint.y > 210)
+        {
+            wrapY = true;
+            wrappedPoint.y -= 230;
+        }
+
+        const bool isInWrappingAreaOfTower = map.towermode && !map.minitowermode && map.ypos >= 500 && map.ypos <= 5000;
+        if (wrapX && (map.warpx || isInWrappingAreaOfTower))
+        {
             drawRect = sprites_rect;
-            drawRect.x += tpoint.x;
+            drawRect.x += wrappedPoint.x;
             drawRect.y += tpoint.y;
             BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
-
-            //screenwrapping!
-            point wrappedPoint;
-            bool wrapX = false;
-            bool wrapY = false;
-
-            wrappedPoint.x = tpoint.x;
-            if (tpoint.x < 0)
-            {
-                wrapX = true;
-                wrappedPoint.x += 320;
-            }
-            else if (tpoint.x > 300)
-            {
-                wrapX = true;
-                wrappedPoint.x -= 320;
-            }
-
-            wrappedPoint.y = tpoint.y;
-            if (tpoint.y < 0)
-            {
-                wrapY = true;
-                wrappedPoint.y += 230;
-            }
-            else if (tpoint.y > 210)
-            {
-                wrapY = true;
-                wrappedPoint.y -= 230;
-            }
-
-            const bool isInWrappingAreaOfTower = map.towermode && !map.minitowermode && map.ypos >= 500 && map.ypos <= 5000;
-            if (wrapX && (map.warpx || isInWrappingAreaOfTower))
-            {
-                drawRect = sprites_rect;
-                drawRect.x += wrappedPoint.x;
-                drawRect.y += tpoint.y;
-                BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
-            }
-            if (wrapY && map.warpy)
-            {
-                drawRect = sprites_rect;
-                drawRect.x += tpoint.x;
-                drawRect.y += wrappedPoint.y;
-                BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
-            }
-            if (wrapX && wrapY && map.warpx && map.warpy)
-            {
-                drawRect = sprites_rect;
-                drawRect.x += wrappedPoint.x;
-                drawRect.y += wrappedPoint.y;
-                BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
-            }
-            break;
         }
-        case 1:
-            // Tiles
-            if (!INBOUNDS_VEC(obj.entities[i].drawframe, tiles))
-            {
-                return;
-            }
-            tpoint.x = xp;
-            tpoint.y = yp - yoff;
+        if (wrapY && map.warpy)
+        {
+            drawRect = sprites_rect;
+            drawRect.x += tpoint.x;
+            drawRect.y += wrappedPoint.y;
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
+        }
+        if (wrapX && wrapY && map.warpx && map.warpy)
+        {
+            drawRect = sprites_rect;
+            drawRect.x += wrappedPoint.x;
+            drawRect.y += wrappedPoint.y;
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe], NULL, backBuffer, &drawRect, ct);
+        }
+        break;
+    }
+    case 1:
+        // Tiles
+        if (!INBOUNDS_VEC(obj.entities[i].drawframe, tiles))
+        {
+            return;
+        }
+        tpoint.x = xp;
+        tpoint.y = yp - yoff;
+        drawRect = tiles_rect;
+        drawRect.x += tpoint.x;
+        drawRect.y += tpoint.y;
+        BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+        break;
+    case 2:
+    case 8:
+    {
+        // Special: Moving platform, 4 tiles or 8 tiles
+        if (!INBOUNDS_VEC(obj.entities[i].drawframe, tilesvec))
+        {
+            return;
+        }
+        tpoint.x = xp;
+        tpoint.y = yp - yoff;
+        int thiswidth = 4;
+        if (obj.entities[i].size == 8)
+        {
+            thiswidth = 8;
+        }
+        for (int ii = 0; ii < thiswidth; ii++)
+        {
             drawRect = tiles_rect;
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
-            BlitSurfaceStandard(tiles[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-            break;
-        case 2:
-        case 8:
+            drawRect.x += 8 * ii;
+            if (custom_gray)
+            {
+                colourTransform temp_ct;
+                temp_ct.colour = 0xFFFFFFFF;
+                BlitSurfaceTinted(tilesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, temp_ct);
+            }
+            else
+            {
+                BlitSurfaceStandard(tilesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
+            }
+        }
+        break;
+    }
+    case 3:    // Big chunky pixels!
+        prect.x = xp;
+        prect.y = yp - yoff;
+        FillRect(backBuffer, prect, obj.entities[i].realcol);
+        break;
+    case 4:    // Small pickups
+        setcolreal(obj.entities[i].realcol);
+        drawhuetile(xp, yp - yoff, obj.entities[i].tile);
+        break;
+    case 5:    //Horizontal Line
+    {
+        int oldw = obj.entities[i].w;
+        if ((game.swngame == 3 || kludgeswnlinewidth) && obj.getlineat(84 - 32) == i)
         {
-            // Special: Moving platform, 4 tiles or 8 tiles
-            if (!INBOUNDS_VEC(obj.entities[i].drawframe, tilesvec))
-            {
-                return;
-            }
-            tpoint.x = xp;
-            tpoint.y = yp - yoff;
-            int thiswidth = 4;
-            if (obj.entities[i].size == 8)
-            {
-                thiswidth = 8;
-            }
-            for (int ii = 0; ii < thiswidth; ii++)
-            {
-                drawRect = tiles_rect;
-                drawRect.x += tpoint.x;
-                drawRect.y += tpoint.y;
-                drawRect.x += 8 * ii;
-                if (custom_gray)
-                {
-                    colourTransform temp_ct;
-                    temp_ct.colour = 0xFFFFFFFF;
-                    BlitSurfaceTinted(tilesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, temp_ct);
-                }
-                else
-                {
-                    BlitSurfaceStandard(tilesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect);
-                }
-            }
-            break;
+            oldw -= 24;
         }
-        case 3:    // Big chunky pixels!
-            prect.x = xp;
-            prect.y = yp - yoff;
-            FillRect(backBuffer, prect, obj.entities[i].realcol);
-            break;
-        case 4:    // Small pickups
-            setcolreal(obj.entities[i].realcol);
-            drawhuetile(xp, yp - yoff, obj.entities[i].tile);
-            break;
-        case 5:    //Horizontal Line
+        line_rect.x = xp;
+        line_rect.y = yp - yoff;
+        line_rect.w = lerp(oldw, obj.entities[i].w);
+        line_rect.h = 1;
+        drawgravityline(i);
+        break;
+    }
+    case 6:    //Vertical Line
+        line_rect.x = xp;
+        line_rect.y = yp - yoff;
+        line_rect.w = 1;
+        line_rect.h = obj.entities[i].h;
+        drawgravityline(i);
+        break;
+    case 7:    //Teleporter
+        drawtele(xp, yp - yoff, obj.entities[i].drawframe, obj.entities[i].realcol);
+        break;
+    //case 8:    // Special: Moving platform, 8 tiles
+        // Note: This code is in the 4-tile code
+        break;
+    case 9:         // Really Big Sprite! (2x2)
+        if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
         {
-            int oldw = obj.entities[i].w;
-            if ((game.swngame == 3 || kludgeswnlinewidth) && obj.getlineat(84 - 32) == i)
-            {
-                oldw -= 24;
-            }
-            line_rect.x = xp;
-            line_rect.y = yp - yoff;
-            line_rect.w = lerp(oldw, obj.entities[i].w);
-            line_rect.h = 1;
-            drawgravityline(i);
-            break;
+            return;
         }
-        case 6:    //Vertical Line
-            line_rect.x = xp;
-            line_rect.y = yp - yoff;
-            line_rect.w = 1;
-            line_rect.h = obj.entities[i].h;
-            drawgravityline(i);
-            break;
-        case 7:    //Teleporter
-            drawtele(xp, yp - yoff, obj.entities[i].drawframe, obj.entities[i].realcol);
-            break;
-        //case 8:    // Special: Moving platform, 8 tiles
-            // Note: This code is in the 4-tile code
-            break;
-        case 9:         // Really Big Sprite! (2x2)
-            if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
-            {
-                return;
-            }
-            setcolreal(obj.entities[i].realcol);
+        setcolreal(obj.entities[i].realcol);
 
-            tpoint.x = xp;
-            tpoint.y = yp - yoff;
+        tpoint.x = xp;
+        tpoint.y = yp - yoff;
 
-            drawRect = sprites_rect;
-            drawRect.x += tpoint.x;
-            drawRect.y += tpoint.y;
-            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+        drawRect = sprites_rect;
+        drawRect.x += tpoint.x;
+        drawRect.y += tpoint.y;
+        BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
 
-            tpoint.x = xp+32;
-            tpoint.y = yp - yoff;
-            //
-            drawRect = sprites_rect;
-            drawRect.x += tpoint.x;
-            drawRect.y += tpoint.y;
-            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
+        tpoint.x = xp+32;
+        tpoint.y = yp - yoff;
+        //
+        drawRect = sprites_rect;
+        drawRect.x += tpoint.x;
+        drawRect.y += tpoint.y;
+        BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
 
-            tpoint.x = xp;
-            tpoint.y = yp+32 - yoff;
-            //
-            drawRect = sprites_rect;
-            drawRect.x += tpoint.x;
-            drawRect.y += tpoint.y;
-            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe+12],NULL, backBuffer, &drawRect, ct);
+        tpoint.x = xp;
+        tpoint.y = yp+32 - yoff;
+        //
+        drawRect = sprites_rect;
+        drawRect.x += tpoint.x;
+        drawRect.y += tpoint.y;
+        BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe+12],NULL, backBuffer, &drawRect, ct);
 
-            tpoint.x = xp+32;
-            tpoint.y = yp+32 - yoff;
-            //
-            drawRect = sprites_rect;
-            drawRect.x += tpoint.x;
-            drawRect.y += tpoint.y;
-            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe + 13],NULL, backBuffer, &drawRect, ct);
-            break;
-        case 10:         // 2x1 Sprite
-            if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
-            {
-                return;
-            }
-            setcolreal(obj.entities[i].realcol);
-
-            tpoint.x = xp;
-            tpoint.y = yp - yoff;
-            //
-            drawRect = sprites_rect;
-            drawRect.x += tpoint.x;
-            drawRect.y += tpoint.y;
-            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-
-            tpoint.x = xp+32;
-            tpoint.y = yp - yoff;
-            //
-            drawRect = sprites_rect;
-            drawRect.x += tpoint.x;
-            drawRect.y += tpoint.y;
-            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
-            break;
-        case 11:    //The fucking elephant
-            setcolreal(obj.entities[i].realcol);
-            drawimagecol(3, xp, yp - yoff);
-            break;
-        case 12:         // Regular sprites that don't wrap
-            if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
-            {
-                return;
-            }
-            tpoint.x = xp;
-            tpoint.y = yp - yoff;
-            setcolreal(obj.entities[i].realcol);
-            //
-            drawRect = sprites_rect;
-            drawRect.x += tpoint.x;
-            drawRect.y += tpoint.y;
-            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
-
-
-            //if we're outside the screen, we need to draw indicators
-
-            if (obj.entities[i].xp < -20 && obj.entities[i].vx > 0)
-            {
-                if (obj.entities[i].xp < -100)
-                {
-                    tpoint.x = -5 + (int(( -obj.entities[i].xp) / 10));
-                }
-                else
-                {
-                    tpoint.x = 5;
-                }
-
-                tpoint.y = tpoint.y+4;
-
-
-                drawRect = tiles_rect;
-                drawRect.x += tpoint.x;
-                drawRect.y += tpoint.y;
-                BlitSurfaceColoured(tiles[1167],NULL, backBuffer, &drawRect, ct);
-
-            }
-            else if (obj.entities[i].xp > 340 && obj.entities[i].vx < 0)
-            {
-                if (obj.entities[i].xp > 420)
-                {
-                    tpoint.x = 320 - (int(( obj.entities[i].xp-320) / 10));
-                }
-                else
-                {
-                    tpoint.x = 310;
-                }
-
-                tpoint.y = tpoint.y+4;
-                //
-
-                drawRect = tiles_rect;
-                drawRect.x += tpoint.x;
-                drawRect.y += tpoint.y;
-                BlitSurfaceColoured(tiles[1166],NULL, backBuffer, &drawRect, ct);
-            }
-            break;
-        case 13:
+        tpoint.x = xp+32;
+        tpoint.y = yp+32 - yoff;
+        //
+        drawRect = sprites_rect;
+        drawRect.x += tpoint.x;
+        drawRect.y += tpoint.y;
+        BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe + 13],NULL, backBuffer, &drawRect, ct);
+        break;
+    case 10:         // 2x1 Sprite
+        if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
         {
-            //Special for epilogue: huge hero!
-            if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
+            return;
+        }
+        setcolreal(obj.entities[i].realcol);
+
+        tpoint.x = xp;
+        tpoint.y = yp - yoff;
+        //
+        drawRect = sprites_rect;
+        drawRect.x += tpoint.x;
+        drawRect.y += tpoint.y;
+        BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+
+        tpoint.x = xp+32;
+        tpoint.y = yp - yoff;
+        //
+        drawRect = sprites_rect;
+        drawRect.x += tpoint.x;
+        drawRect.y += tpoint.y;
+        BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
+        break;
+    case 11:    //The fucking elephant
+        setcolreal(obj.entities[i].realcol);
+        drawimagecol(3, xp, yp - yoff);
+        break;
+    case 12:         // Regular sprites that don't wrap
+        if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
+        {
+            return;
+        }
+        tpoint.x = xp;
+        tpoint.y = yp - yoff;
+        setcolreal(obj.entities[i].realcol);
+        //
+        drawRect = sprites_rect;
+        drawRect.x += tpoint.x;
+        drawRect.y += tpoint.y;
+        BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+
+
+        //if we're outside the screen, we need to draw indicators
+
+        if (obj.entities[i].xp < -20 && obj.entities[i].vx > 0)
+        {
+            if (obj.entities[i].xp < -100)
             {
-                return;
+                tpoint.x = -5 + (int(( -obj.entities[i].xp) / 10));
+            }
+            else
+            {
+                tpoint.x = 5;
             }
 
-            tpoint.x = xp; tpoint.y = yp - yoff;
-            setcolreal(obj.entities[i].realcol);
-            SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp - yoff), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
-            SDL_Surface* TempSurface = ScaleSurface( spritesvec[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
-            BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
-            SDL_FreeSurface(TempSurface);
+            tpoint.y = tpoint.y+4;
 
 
+            drawRect = tiles_rect;
+            drawRect.x += tpoint.x;
+            drawRect.y += tpoint.y;
+            BlitSurfaceColoured(tiles[1167],NULL, backBuffer, &drawRect, ct);
 
-            break;
         }
+        else if (obj.entities[i].xp > 340 && obj.entities[i].vx < 0)
+        {
+            if (obj.entities[i].xp > 420)
+            {
+                tpoint.x = 320 - (int(( obj.entities[i].xp-320) / 10));
+            }
+            else
+            {
+                tpoint.x = 310;
+            }
+
+            tpoint.y = tpoint.y+4;
+            //
+
+            drawRect = tiles_rect;
+            drawRect.x += tpoint.x;
+            drawRect.y += tpoint.y;
+            BlitSurfaceColoured(tiles[1166],NULL, backBuffer, &drawRect, ct);
         }
+        break;
+    case 13:
+    {
+        //Special for epilogue: huge hero!
+        if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
+        {
+            return;
+        }
+
+        tpoint.x = xp; tpoint.y = yp - yoff;
+        setcolreal(obj.entities[i].realcol);
+        SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp - yoff), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
+        SDL_Surface* TempSurface = ScaleSurface( spritesvec[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
+        BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
+        SDL_FreeSurface(TempSurface);
+
+
+
+        break;
+    }
+    }
 }
 
 void Graphics::drawbackground( int t )

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1593,9 +1593,30 @@ void Graphics::drawentities()
 {
     const int yoff = map.towermode ? lerp(map.oldypos, map.ypos) : 0;
 
-    for (int i = obj.entities.size() - 1; i >= 0; i--)
+    if (!map.custommode)
     {
-        drawentity(i, yoff);
+        for (int i = obj.entities.size() - 1; i >= 0; i--)
+        {
+            if (!obj.entities[i].ishumanoid())
+            {
+                drawentity(i, yoff);
+            }
+        }
+
+        for (int i = obj.entities.size() - 1; i >= 0; i--)
+        {
+            if (obj.entities[i].ishumanoid())
+            {
+                drawentity(i, yoff);
+            }
+        }
+    }
+    else
+    {
+        for (int i = obj.entities.size() - 1; i >= 0; i--)
+        {
+            drawentity(i, yoff);
+        }
     }
 }
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -139,6 +139,8 @@ public:
 
 	void drawentities();
 
+	void drawentity(const int i, const int yoff);
+
 	void drawtrophytext();
 
 	void bigrprint(int x, int y, std::string& t, int r, int g, int b, bool cen = false, float sc = 2);


### PR DESCRIPTION
This fixes the draw order by drawing all other entities first, before then drawing all humanoids[1] after, including the player afterwards.

This is actually a regression fix from #191. When I was testing this, I was thinking about where get a crewmate in front of another entity in the main game, other than the checkpoints in Intermission 1. And then I thought about the teleporters, because I remember the pre-Deep Space cutscene in Dimension Open looking funny because Vita ended up being behind the teleporter. (Actually, a lot of the cutscenes of Dimension Open look funny because of crewmates standing behind terminals.)

So then I tried to get crewmates in front of teleporters. It actually turns out that you can't do it for most of them... except for Verdigris. And then that's what I realized why there was an oddity in `WarpClass.cpp` when I was removing the `active` system from the game - for some reason, the game put a hole in `obj.entities` between the teleporter and the player when loading the room Murdering Twinmaker. In a violation of Chesterton's Fence (the principle that you should understand something before removing it), I shrugged it off and decided "there's no way to support having holes with my new system, and having holes is probably bad anyway, so I'm going to remove this and move on". The fact that there wasn't any comments clarifying the mysterious code didn't help (but, this *was* 2.2 code after all; have you *seen* 2.2 code?!).

And it turns out that this maneuver was done so Verdigris would fill that hole when he got created, and Verdigris being first before the teleporter would mean he would be drawn in front of the teleporter, instead of being behind it. So ever since b1b1474b7bbc3ceddea24f689a7ddb050cfe4490 got merged, there has actually been a regression from 2.2 where Verdigris got drawn behind the teleporter in Murdering Twinmaker, instead of properly being in front of it like in 2.2 and previous.

This patch fixes that regression, but it actually properly fixes it instead of hacking around with the `active` system.

Closes #426.

[1]: I'm going to go on a rant here, so hear me out. It's not explicitly stated that the characters in VVVVVV are human. So, given this information, what do we call them? Well, the VVVVVV community (at least the custom levels one, I don't think the speedrunning community does this or is preoccupied with lore in the first place) decided to call them "villis", because of the roomname "The Villi People" - which is only one blunder in a series of awful headcanons based off of the assumption that the intent of Bennett Foddy (who named the roomnames) was to decree some sort of lore to the game. Another one being "Verdigris can't flip" because of "Green Dudes Can't Flip". Then an OC (original character) got named based off of "The Voon Show" too. And  so on and so forth.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
