### PR TITLE
Disable hardcoded (10,5) no-follow rule of scripting crewmates in custom levels

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2773,7 +2773,7 @@ bool entityclass::updateentities( int i )
                 }
 
                 //Special rules:
-                if (game.roomx == 110 && game.roomy == 105)
+                if (game.roomx == 110 && game.roomy == 105 && !map.custommode)
                 {
                     if (entities[i].xp < 155)
                     {


### PR DESCRIPTION
Scripting crewmates apparently have a specific hardcoded rule in their follow-player code that makes it so if they're in (10,5) and are to the left of the line x=155, they will refuse to continue following the player. This was clearly done to make it so Vitellary in the main game wouldn't overlap the teleporter, and that was clearly done to make it so it wouldn't look like he would go behind the teleporter, which would look weird (I also noticed this in #513).

I stumbled across this code and thought that just like other weird main-game code that shouldn't apply in custom levels (#136, #137, #144), this should be fixed, too.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
