### PR TITLE
Clean up bounds checks and style for customifflag/flag/ifflag/ifcrewlost

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -194,8 +194,8 @@ void scriptclass::run()
 			}
 			else if (words[0] == "customifflag")
 			{
-				size_t flag = ss_toi(words[1]);
-				if (flag < SDL_arraysize(obj.flags) && obj.flags[flag])
+				int flag = ss_toi(words[1]);
+				if (INBOUNDS_ARR(flag, obj.flags) && obj.flags[flag])
 				{
 					load("custom_"+words[2]);
 					position--;
@@ -216,11 +216,16 @@ void scriptclass::run()
 			}
 			if (words[0] == "flag")
 			{
-				if(ss_toi(words[1])>=0 && ss_toi(words[1])<100){
-					if(words[2]=="on"){
-						obj.flags[ss_toi(words[1])] = true;
-					}else if(words[2]=="off"){
-						obj.flags[ss_toi(words[1])] = false;
+				int flag = ss_toi(words[1]);
+				if (INBOUNDS_ARR(flag, obj.flags))
+				{
+					if (words[2] == "on")
+					{
+						obj.flags[flag] = true;
+					}
+					else if (words[2] == "off")
+					{
+						obj.flags[flag] = false;
 					}
 				}
 			}
@@ -1359,8 +1364,8 @@ void scriptclass::run()
 			}
 			else if (words[0] == "ifflag")
 			{
-				size_t flag = ss_toi(words[1]);
-				if (flag < SDL_arraysize(obj.flags) && obj.flags[flag])
+				int flag = ss_toi(words[1]);
+				if (INBOUNDS_ARR(flag, obj.flags) && obj.flags[flag])
 				{
 					load(words[2]);
 					position--;
@@ -1368,8 +1373,8 @@ void scriptclass::run()
 			}
 			else if (words[0] == "ifcrewlost")
 			{
-				size_t crewmate = ss_toi(words[1]);
-				if (crewmate < SDL_arraysize(game.crewstats) && game.crewstats[crewmate]==false)
+				int crewmate = ss_toi(words[1]);
+				if (INBOUNDS_ARR(crewmate, game.crewstats) && !game.crewstats[crewmate])
 				{
 					load(words[2]);
 					position--;


### PR DESCRIPTION
These commands now use the `INBOUNDS_ARR()` macro to convey intent, and to make sure that if the size of the array changes in the future, that the bounds check wouldn't end up being wrong. Also fixed some code style for the `flag()` and `ifcrewlost()` commands.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
