### PR TITLE
Fix the interpolation of the tower background when it scrolls from the top

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2507,7 +2507,7 @@ void Graphics::updatetowerbackground()
     {
         int off = map.scrolldir == 0 ? 0 : map.bscroll;
         //Draw the whole thing; needed for every colour cycle!
-        for (int j = 0; j < 32; j++)
+        for (int j = -1; j < 32; j++)
         {
             for (int i = 0; i < 40; i++)
             {
@@ -2526,6 +2526,8 @@ void Graphics::updatetowerbackground()
         {
             for (int i = 0; i < 40; i++)
             {
+                temp = map.tower.backat(i, -1, map.bypos);
+                drawtowertile3(i * 8, -1*8 - (map.bypos % 8), temp, map.colstate);
                 temp = map.tower.backat(i, 0, map.bypos);
                 drawtowertile3(i * 8, -(map.bypos % 8), temp, map.colstate);
             }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -26,6 +26,7 @@ void Graphics::init()
     setRect(prect, 0, 0, 4, 4);
     setRect(line_rect, 0,0,0,0);
     setRect(tele_rect,0,0,96,96);
+    setRect(towerbuffer_rect, 8, 8, 320, 240);
 
 
     //We initialise a few things
@@ -735,6 +736,8 @@ void Graphics::drawtowertile( int x, int y, int t )
         WHINE_ONCE("drawtowertile() out-of-bounds!")
         return;
     }
+    x += 8;
+    y += 8;
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
     BlitSurfaceStandard(tiles2[t], NULL, towerbuffer, &rect);
 }
@@ -748,6 +751,8 @@ void Graphics::drawtowertile3( int x, int y, int t, int off )
         WHINE_ONCE("drawtowertile3() out-of-bounds!")
         return;
     }
+    x += 8;
+    y += 8;
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
     BlitSurfaceStandard(tiles3[t], NULL, towerbuffer, &rect);
 }
@@ -2112,13 +2117,13 @@ void Graphics::drawbackground( int t )
         FillRect(backBuffer, 0x000000);
         BlitSurfaceStandard(towerbuffer, NULL, towerbuffer_lerp, NULL);
         ScrollSurface(towerbuffer_lerp, lerp(0, -3), 0);
-        BlitSurfaceStandard(towerbuffer_lerp, NULL, backBuffer, NULL);
+        BlitSurfaceStandard(towerbuffer_lerp, &towerbuffer_rect, backBuffer, NULL);
         break;
     case 4: //Warp zone (vertical)
         FillRect(backBuffer, 0x000000);
         SDL_BlitSurface(towerbuffer, NULL, towerbuffer_lerp, NULL);
         ScrollSurface(towerbuffer_lerp, 0, lerp(0, -3));
-        SDL_BlitSurface(towerbuffer_lerp,NULL, backBuffer,NULL);
+        SDL_BlitSurface(towerbuffer_lerp, &towerbuffer_rect, backBuffer, NULL);
         break;
     case 5:
         //Warp zone, central
@@ -2489,7 +2494,7 @@ void Graphics::drawtowerbackground()
     FillRect(backBuffer, 0x000000);
     SDL_BlitSurface(towerbuffer, NULL, towerbuffer_lerp, NULL);
     ScrollSurface(towerbuffer_lerp, 0, lerp(0, -map.bscroll));
-    SDL_BlitSurface(towerbuffer_lerp,NULL, backBuffer,NULL);
+    SDL_BlitSurface(towerbuffer_lerp, &towerbuffer_rect, backBuffer, NULL);
 }
 
 void Graphics::updatetowerbackground()

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -238,6 +238,7 @@ public:
 	SDL_Rect bg_rect;
 	SDL_Rect line_rect;
 	SDL_Rect tele_rect;
+	SDL_Rect towerbuffer_rect;
 
 	SDL_Rect foot_rect;
 	SDL_Rect prect;


### PR DESCRIPTION
On the deltaframes of the tower background, there would be "pixel bleed" if the tower background would be scrolling from the top. This is because there wouldn't be any more pixels from above the screen to grab, because the background rendering functions didn't draw any pixels above the screen. But they couldn't draw any pixels above the screen, because that was simply the end of the buffer. So this PR expands the buffer, and then draws above the screen to fix this glitchy interpolation rendering.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
