### PR TITLE
Removed unused attributes towercol and RGB() from mapclass

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -123,11 +123,6 @@ const int mapclass::areamap[] = {
 	2,2,2,2,2,0,0,2,0,3,0,0,0,0,0,0,0,0,0,0,
 };
 
-int mapclass::RGB(int red,int green,int blue)
-{
-	return (blue | (green << 8) | (red << 16));
-}
-
 int mapclass::intpol(int a, int b, float c)
 {
 	return static_cast<int>(a + ((b - a) * c));

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -91,7 +91,6 @@ mapclass::mapclass()
 	scrolldir = 0;
 	check = 0;
 	cmode = 0;
-	towercol = 0;
 	tdrawback = false;
 	bscroll = 0;
 	roomtexton = false;
@@ -632,7 +631,6 @@ void mapclass::updatetowerglow()
 		if (colsuperstate > 0) colstatedelay = 0;
 
 		tdrawback = true;
-		towercol = RGB(r*0.04f, g*0.04f, b*0.04f);
 	}
 	else
 	{
@@ -670,7 +668,6 @@ void mapclass::nexttowercolour()
 	}
 
 	tdrawback = true;
-	towercol = RGB(r*0.04, g*0.04, b*0.04);
 }
 
 void mapclass::settowercolour(int t)
@@ -703,7 +700,6 @@ void mapclass::settowercolour(int t)
 	}
 
 	tdrawback = true;
-	towercol = RGB(r*0.04, g*0.04, b*0.04);
 }
 
 bool mapclass::spikecollide(int x, int y)

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -22,8 +22,6 @@ class mapclass
 public:
     mapclass();
 
-    int RGB(int red,int green,int blue);
-
     int intpol(int a, int b, float c);
 
     void setteleporter(int x, int y);

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -114,7 +114,6 @@ public:
     //This is the old colour cycle
     int r, g,b;
     int check, cmode;
-    int towercol;
     int colstate, colstatedelay;
     int colsuperstate;
     int spikeleveltop, spikelevelbottom;


### PR DESCRIPTION
I was working on fixing #369, when I noticed these attributes and wondered what they were for, because I had never really seen them before. It turns out that they aren't used for anything, so they can be safely removed and I don't have to worry about analyzing them.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
