### PR TITLE
Remove unused Graphics::tl and move bcol and bcol2 temporary variables off of Graphics

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -104,8 +104,6 @@ void Graphics::init()
 
     // initialize everything else to zero
     backBuffer = NULL;
-    bcol = 0;
-    bcol2 = 0;
     ct = colourTransform();
     foot_rect = SDL_Rect();
     foregrounddrawn = false;
@@ -1966,6 +1964,9 @@ void Graphics::drawbackground( int t )
         }
         break;
     case 2:
+    {
+        int bcol, bcol2;
+
             //Lab
             switch(rcol)
             {
@@ -2112,6 +2113,7 @@ void Graphics::drawbackground( int t )
             FillRect(backBuffer,backboxrect, bcol2);
         }
         break;
+    }
     case 3: //Warp zone (horizontal)
         FillRect(backBuffer, 0x000000);
         BlitSurfaceStandard(towerbuffer, NULL, towerbuffer_lerp, NULL);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -117,7 +117,6 @@ void Graphics::init()
     menubuffer = NULL;
     screenbuffer = NULL;
     tempBuffer = NULL;
-    tl = point();
     towerbuffer = NULL;
     towerbuffer_lerp = NULL;
     footerbuffer = NULL;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -221,7 +221,6 @@ public:
 	bool flipmode;
 	bool setflipmode;
 	bool notextoutline;
-	point tl;
 	//buffer objects. //TODO refactor buffer objects
 	SDL_Surface* backBuffer;
 	Screen* screenbuffer;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -200,7 +200,7 @@ public:
 
 	colourTransform ct;
 
-	int bcol, bcol2, rcol;
+	int rcol;
 
 
 


### PR DESCRIPTION
`Graphics::tl` is unused. `Graphics::bcol` and `Graphics::bcol2` are temporary variables that shouldn't be on a global class.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
