### PR TITLE
Move check/cmode temporary variables off of mapclass

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -89,8 +89,6 @@ mapclass::mapclass()
 	cameraseek = 0;
 	minitowermode = false;
 	scrolldir = 0;
-	check = 0;
-	cmode = 0;
 	tdrawback = false;
 	bscroll = 0;
 	roomtexton = false;
@@ -590,8 +588,8 @@ void mapclass::updatetowerglow()
 		if (colsuperstate > 0) colstate--;
 		colstate++;
 		if (colstate >= 30) colstate = 0;
-		check = colstate % 5; //current state of phase
-		cmode = (colstate - check) / 5; // current colour transition
+		int check = colstate % 5; //current state of phase
+		int cmode = (colstate - check) / 5; // current colour transition
 
 		switch(cmode)
 		{
@@ -637,8 +635,8 @@ void mapclass::nexttowercolour()
 {
 	colstate+=5;
 	if (colstate >= 30) colstate = 0;
-	check = colstate % 5; //current state of phase
-	cmode = (colstate - check) / 5; // current colour transition
+	int check = colstate % 5; //current state of phase
+	int cmode = (colstate - check) / 5; // current colour transition
 
 	switch(cmode)
 	{
@@ -669,8 +667,8 @@ void mapclass::settowercolour(int t)
 {
 	colstate=t*5;
 	if (colstate >= 30) colstate = 0;
-	check = colstate % 5; //current state of phase
-	cmode = (colstate - check) / 5; // current colour transition
+	int check = colstate % 5; //current state of phase
+	int cmode = (colstate - check) / 5; // current colour transition
 
 	switch(cmode)
 	{

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -111,7 +111,6 @@ public:
 
     //This is the old colour cycle
     int r, g,b;
-    int check, cmode;
     int colstate, colstatedelay;
     int colsuperstate;
     int spikeleveltop, spikelevelbottom;


### PR DESCRIPTION
Yet another set of temporary variables is on a global class when they shouldn't be. These two are only used in tower background functions and are never used anywhere else, so they're clearly temporaries.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
