### PR TITLE
Separate the tower background, title screen background, and horizontal and vertical warp backgrounds into separate buffers

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1373,7 +1373,7 @@ void Game::updatestate()
             gamestate = TITLEMODE;
             graphics.fademode = 4;
             graphics.backgrounddrawn = true;
-            graphics.towerbg.tdrawback = true;
+            graphics.titlebg.tdrawback = true;
             createmenu(Menu::timetrialcomplete);
             state = 0;
             break;
@@ -2942,7 +2942,7 @@ void Game::updatestate()
             gamestate = TITLEMODE;
             graphics.fademode = 4;
             graphics.backgrounddrawn = true;
-            graphics.towerbg.tdrawback = true;
+            graphics.titlebg.tdrawback = true;
             music.play(6);
             state = 0;
             break;
@@ -3278,7 +3278,7 @@ void Game::updatestate()
             gamestate = TITLEMODE;
             graphics.fademode = 4;
             graphics.backgrounddrawn = true;
-            graphics.towerbg.tdrawback = true;
+            graphics.titlebg.tdrawback = true;
             createmenu(Menu::nodeathmodecomplete);
             state = 0;
             break;
@@ -7129,7 +7129,7 @@ void Game::quittomenu()
     FILESYSTEM_unmountassets(); // should be before music.play(6)
     music.play(6);
     graphics.backgrounddrawn = false;
-    graphics.towerbg.tdrawback = true;
+    graphics.titlebg.tdrawback = true;
     graphics.flipmode = false;
     //Don't be stuck on the summary screen,
     //or "who do you want to play the level with?"
@@ -7223,7 +7223,7 @@ void Game::returntoeditor()
            ed.level[i+(j*ed.maxwidth)].warpdir=ed.kludgewarpdir[i+(j*ed.maxwidth)];
         }
     }
-    graphics.towerbg.scrolldir = 0;
+    graphics.titlebg.scrolldir = 0;
 }
 #endif
 
@@ -7233,7 +7233,7 @@ void Game::returntopausemenu()
     returntomenu(kludge_ingametemp);
     gamestate = MAPMODE;
     map.kludge_to_bg();
-    graphics.towerbg.tdrawback = true;
+    graphics.titlebg.tdrawback = true;
     graphics.backgrounddrawn = false;
     mapheld = true;
     graphics.flipmode = graphics.setflipmode;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7232,7 +7232,6 @@ void Game::returntopausemenu()
     ingame_titlemode = false;
     returntomenu(kludge_ingametemp);
     gamestate = MAPMODE;
-    map.kludge_to_bg();
     graphics.titlebg.tdrawback = true;
     graphics.backgrounddrawn = false;
     mapheld = true;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1373,7 +1373,7 @@ void Game::updatestate()
             gamestate = TITLEMODE;
             graphics.fademode = 4;
             graphics.backgrounddrawn = true;
-            map.tdrawback = true;
+            graphics.towerbg.tdrawback = true;
             createmenu(Menu::timetrialcomplete);
             state = 0;
             break;
@@ -2942,7 +2942,7 @@ void Game::updatestate()
             gamestate = TITLEMODE;
             graphics.fademode = 4;
             graphics.backgrounddrawn = true;
-            map.tdrawback = true;
+            graphics.towerbg.tdrawback = true;
             music.play(6);
             state = 0;
             break;
@@ -3278,7 +3278,7 @@ void Game::updatestate()
             gamestate = TITLEMODE;
             graphics.fademode = 4;
             graphics.backgrounddrawn = true;
-            map.tdrawback = true;
+            graphics.towerbg.tdrawback = true;
             createmenu(Menu::nodeathmodecomplete);
             state = 0;
             break;
@@ -7129,7 +7129,7 @@ void Game::quittomenu()
     FILESYSTEM_unmountassets(); // should be before music.play(6)
     music.play(6);
     graphics.backgrounddrawn = false;
-    map.tdrawback = true;
+    graphics.towerbg.tdrawback = true;
     graphics.flipmode = false;
     //Don't be stuck on the summary screen,
     //or "who do you want to play the level with?"
@@ -7223,7 +7223,7 @@ void Game::returntoeditor()
            ed.level[i+(j*ed.maxwidth)].warpdir=ed.kludgewarpdir[i+(j*ed.maxwidth)];
         }
     }
-    map.scrolldir = 0;
+    graphics.towerbg.scrolldir = 0;
 }
 #endif
 
@@ -7233,7 +7233,7 @@ void Game::returntopausemenu()
     returntomenu(kludge_ingametemp);
     gamestate = MAPMODE;
     map.kludge_to_bg();
-    map.tdrawback = true;
+    graphics.towerbg.tdrawback = true;
     graphics.backgrounddrawn = false;
     mapheld = true;
     graphics.flipmode = graphics.setflipmode;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -115,6 +115,8 @@ void Graphics::init()
     menubuffer = NULL;
     screenbuffer = NULL;
     tempBuffer = NULL;
+    warpbuffer = NULL;
+    warpbuffer_lerp = NULL;
     footerbuffer = NULL;
     ghostbuffer = NULL;
     towerbg = TowerBG();
@@ -736,7 +738,7 @@ void Graphics::drawtowertile( int x, int y, int t )
     x += 8;
     y += 8;
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
-    BlitSurfaceStandard(tiles2[t], NULL, towerbg.buffer, &rect);
+    BlitSurfaceStandard(tiles2[t], NULL, warpbuffer, &rect);
 }
 
 
@@ -2116,15 +2118,15 @@ void Graphics::drawbackground( int t )
     }
     case 3: //Warp zone (horizontal)
         FillRect(backBuffer, 0x000000);
-        BlitSurfaceStandard(towerbg.buffer, NULL, towerbg.buffer_lerp, NULL);
-        ScrollSurface(towerbg.buffer_lerp, lerp(0, -3), 0);
-        BlitSurfaceStandard(towerbg.buffer_lerp, &towerbuffer_rect, backBuffer, NULL);
+        BlitSurfaceStandard(warpbuffer, NULL, warpbuffer_lerp, NULL);
+        ScrollSurface(warpbuffer_lerp, lerp(0, -3), 0);
+        BlitSurfaceStandard(warpbuffer_lerp, &towerbuffer_rect, backBuffer, NULL);
         break;
     case 4: //Warp zone (vertical)
         FillRect(backBuffer, 0x000000);
-        SDL_BlitSurface(towerbg.buffer, NULL, towerbg.buffer_lerp, NULL);
-        ScrollSurface(towerbg.buffer_lerp, 0, lerp(0, -3));
-        SDL_BlitSurface(towerbg.buffer_lerp, &towerbuffer_rect, backBuffer, NULL);
+        SDL_BlitSurface(warpbuffer, NULL, warpbuffer_lerp, NULL);
+        ScrollSurface(warpbuffer_lerp, 0, lerp(0, -3));
+        SDL_BlitSurface(warpbuffer_lerp, &towerbuffer_rect, backBuffer, NULL);
         break;
     case 5:
         //Warp zone, central
@@ -2301,7 +2303,7 @@ void Graphics::updatebackground(int t)
 
         if (backgrounddrawn)
         {
-            ScrollSurface(towerbg.buffer, -3, 0 );
+            ScrollSurface(warpbuffer, -3, 0 );
             for (int j = 0; j < 15; j++)
             {
                 for (int i = 0; i < 2; i++)
@@ -2317,7 +2319,7 @@ void Graphics::updatebackground(int t)
         {
             //draw the whole thing for the first time!
             backoffset = 0;
-            FillRect(towerbg.buffer, 0x000000);
+            FillRect(warpbuffer, 0x000000);
             for (int j = 0; j < 15; j++)
             {
                 for (int i = 0; i < 21; i++)
@@ -2340,7 +2342,7 @@ void Graphics::updatebackground(int t)
 
         if (backgrounddrawn)
         {
-            ScrollSurface(towerbg.buffer,0,-3);
+            ScrollSurface(warpbuffer,0,-3);
             for (int j = 0; j < 2; j++)
             {
                 for (int i = 0; i < 21; i++)
@@ -2356,7 +2358,7 @@ void Graphics::updatebackground(int t)
         {
             //draw the whole thing for the first time!
             backoffset = 0;
-            FillRect(towerbg.buffer,0x000000 );
+            FillRect(warpbuffer,0x000000 );
             for (int j = 0; j < 16; j++)
             {
                 for (int i = 0; i < 21; i++)

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -118,6 +118,7 @@ void Graphics::init()
     footerbuffer = NULL;
     ghostbuffer = NULL;
     towerbg = TowerBG();
+    titlebg = TowerBG();
     trinketr = 0;
     trinketg = 0;
     trinketb = 0;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -11,6 +11,7 @@
 #include "Maths.h"
 #include "Screen.h"
 #include "Textbox.h"
+#include "TowerBG.h"
 
 class Graphics
 {
@@ -168,7 +169,7 @@ public:
 	void drawtile2( int x, int y, int t );
 	void drawtile( int x, int y, int t );
 	void drawtowertile( int x, int y, int t );
-	void drawtowertile3( int x, int y, int t, int off );
+	void drawtowertile3( int x, int y, int t, TowerBG& bg_obj );
 
 	void drawmap();
 
@@ -192,8 +193,8 @@ public:
 
 	void menuoffrender();
 
-	void drawtowerbackground();
-	void updatetowerbackground();
+	void drawtowerbackground(const TowerBG& bg_obj);
+	void updatetowerbackground(TowerBG& bg_obj);
 
 	void setcol(int t);
 	void drawfinalmap();
@@ -225,10 +226,10 @@ public:
 	SDL_Surface* backBuffer;
 	Screen* screenbuffer;
 	SDL_Surface* menubuffer;
-	SDL_Surface* towerbuffer;
-	SDL_Surface* towerbuffer_lerp;
 	SDL_Surface* foregroundBuffer;
 	SDL_Surface* tempBuffer;
+
+	TowerBG towerbg;
 
 	SDL_Rect bfont_rect;
 	SDL_Rect tiles_rect;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -230,6 +230,7 @@ public:
 	SDL_Surface* tempBuffer;
 
 	TowerBG towerbg;
+	TowerBG titlebg;
 
 	SDL_Rect bfont_rect;
 	SDL_Rect tiles_rect;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -228,6 +228,8 @@ public:
 	SDL_Surface* menubuffer;
 	SDL_Surface* foregroundBuffer;
 	SDL_Surface* tempBuffer;
+	SDL_Surface* warpbuffer;
+	SDL_Surface* warpbuffer_lerp;
 
 	TowerBG towerbg;
 	TowerBG titlebg;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -580,6 +580,7 @@ void menuactionpress()
             game.colourblindmode = !game.colourblindmode;
             game.savestats();
             graphics.towerbg.tdrawback = true;
+            graphics.titlebg.tdrawback = true;
             music.playef(11);
             break;
         case 1:
@@ -1683,7 +1684,7 @@ void titleinput()
                 music.playef(18);
                 game.screenshake = 10;
                 game.flashlight = 5;
-                graphics.towerbg.colstate = 10;
+                graphics.titlebg.colstate = 10;
                 map.nexttowercolour();
             }
             else
@@ -2381,13 +2382,13 @@ void mapmenuactionpress()
         map.bg_to_kludge();
         game.kludge_ingametemp = game.currentmenuname;
 
-        graphics.towerbg.scrolldir = 0;
-        graphics.towerbg.colstate = ((int) (graphics.towerbg.colstate / 5)) * 5;
-        graphics.towerbg.bypos = 0;
+        graphics.titlebg.scrolldir = 0;
+        graphics.titlebg.colstate = ((int) (graphics.titlebg.colstate / 5)) * 5;
+        graphics.titlebg.bypos = 0;
         map.nexttowercolour();
 
         // Fix delta rendering glitch
-        graphics.updatetowerbackground(graphics.towerbg);
+        graphics.updatetowerbackground(graphics.titlebg);
         titleupdatetextcol();
         break;
     }
@@ -2536,11 +2537,11 @@ void gamecompleteinput()
     //Do this before we update map.bypos
     if (!game.colourblindmode)
     {
-        graphics.updatetowerbackground(graphics.towerbg);
+        graphics.updatetowerbackground(graphics.titlebg);
     }
 
     //Do these here because input comes first
-    graphics.towerbg.bypos += graphics.towerbg.bscroll;
+    graphics.titlebg.bypos += graphics.titlebg.bscroll;
     game.oldcreditposition = game.creditposition;
 
     if (key.isDown(KEYBOARD_z) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v) || key.isDown(game.controllerButton_flip))
@@ -2556,7 +2557,7 @@ void gamecompleteinput()
         }
         else
         {
-            graphics.towerbg.bscroll = +7;
+            graphics.titlebg.bscroll = +7;
         }
         game.press_action = true;
     }

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2379,7 +2379,6 @@ void mapmenuactionpress()
         {
             game.createmenu(Menu::options);
         }
-        map.bg_to_kludge();
         game.kludge_ingametemp = game.currentmenuname;
 
         graphics.titlebg.scrolldir = 0;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -579,7 +579,7 @@ void menuactionpress()
             //disable animated backgrounds
             game.colourblindmode = !game.colourblindmode;
             game.savestats();
-            map.tdrawback = true;
+            graphics.towerbg.tdrawback = true;
             music.playef(11);
             break;
         case 1:
@@ -1683,7 +1683,7 @@ void titleinput()
                 music.playef(18);
                 game.screenshake = 10;
                 game.flashlight = 5;
-                map.colstate = 10;
+                graphics.towerbg.colstate = 10;
                 map.nexttowercolour();
             }
             else
@@ -2381,13 +2381,13 @@ void mapmenuactionpress()
         map.bg_to_kludge();
         game.kludge_ingametemp = game.currentmenuname;
 
-        map.scrolldir = 0;
-        map.colstate = ((int) (map.colstate / 5)) * 5;
-        map.bypos = 0;
+        graphics.towerbg.scrolldir = 0;
+        graphics.towerbg.colstate = ((int) (graphics.towerbg.colstate / 5)) * 5;
+        graphics.towerbg.bypos = 0;
         map.nexttowercolour();
 
         // Fix delta rendering glitch
-        graphics.updatetowerbackground();
+        graphics.updatetowerbackground(graphics.towerbg);
         titleupdatetextcol();
         break;
     }
@@ -2536,11 +2536,11 @@ void gamecompleteinput()
     //Do this before we update map.bypos
     if (!game.colourblindmode)
     {
-        graphics.updatetowerbackground();
+        graphics.updatetowerbackground(graphics.towerbg);
     }
 
     //Do these here because input comes first
-    map.bypos += map.bscroll;
+    graphics.towerbg.bypos += graphics.towerbg.bscroll;
     game.oldcreditposition = game.creditposition;
 
     if (key.isDown(KEYBOARD_z) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v) || key.isDown(game.controllerButton_flip))
@@ -2556,7 +2556,7 @@ void gamecompleteinput()
         }
         else
         {
-            map.bscroll = +7;
+            graphics.towerbg.bscroll = +7;
         }
         game.press_action = true;
     }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -27,15 +27,15 @@ void titleupdatetextcol()
 void titlelogic()
 {
     //Misc
-    //map.updatetowerglow(graphics.towerbg);
+    //map.updatetowerglow(graphics.titlebg);
     help.updateglow();
 
-    graphics.towerbg.bypos -= 2;
-    graphics.towerbg.bscroll = -2;
+    graphics.titlebg.bypos -= 2;
+    graphics.titlebg.bscroll = -2;
 
     if (!game.colourblindmode)
     {
-        graphics.updatetowerbackground(graphics.towerbg);
+        graphics.updatetowerbackground(graphics.titlebg);
     }
 
     if (!game.menustart)
@@ -149,10 +149,10 @@ void maplogic()
 void gamecompletelogic()
 {
     //Misc
-    map.updatetowerglow(graphics.towerbg);
+    map.updatetowerglow(graphics.titlebg);
     help.updateglow();
     graphics.crewframe = 0;
-    graphics.towerbg.scrolldir = 1;
+    graphics.titlebg.scrolldir = 1;
     graphics.updatetitlecolours();
 
     graphics.col_tr = map.r - (help.glow / 4) - fRandom() * 4;
@@ -169,11 +169,11 @@ void gamecompletelogic()
     if (game.creditposition <= -Credits::creditmaxposition)
     {
         game.creditposition = -Credits::creditmaxposition;
-        graphics.towerbg.bscroll = 0;
+        graphics.titlebg.bscroll = 0;
     }
     else if (!game.press_action)
     {
-        graphics.towerbg.bscroll = +1;
+        graphics.titlebg.bscroll = +1;
     }
 
     if (graphics.fademode == 1)
@@ -182,8 +182,8 @@ void gamecompletelogic()
         graphics.showcutscenebars = false;
         graphics.cutscenebarspos = 0;
         graphics.oldcutscenebarspos = 0;
-        graphics.towerbg.scrolldir = 0;
-        graphics.towerbg.bypos = 0;
+        graphics.titlebg.scrolldir = 0;
+        graphics.titlebg.bypos = 0;
         //Return to game
         game.gamestate = GAMECOMPLETE2;
         graphics.fademode = 4;
@@ -193,7 +193,7 @@ void gamecompletelogic()
 void gamecompletelogic2()
 {
     //Misc
-    map.updatetowerglow(graphics.towerbg);
+    map.updatetowerglow(graphics.titlebg);
     help.updateglow();
 
     game.creditposdelay--;
@@ -222,7 +222,7 @@ void gamecompletelogic2()
         game.savetele();
         music.currentsong=tmp;
         //Return to game
-        graphics.towerbg.colstate = 10;
+        graphics.titlebg.colstate = 10;
         game.gamestate = TITLEMODE;
         graphics.fademode = 4;
         FILESYSTEM_unmountassets(); // should be before music.playef(18)

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -27,15 +27,15 @@ void titleupdatetextcol()
 void titlelogic()
 {
     //Misc
-    //map.updatetowerglow();
+    //map.updatetowerglow(graphics.towerbg);
     help.updateglow();
 
-    map.bypos -= 2;
-    map.bscroll = -2;
+    graphics.towerbg.bypos -= 2;
+    graphics.towerbg.bscroll = -2;
 
     if (!game.colourblindmode)
     {
-        graphics.updatetowerbackground();
+        graphics.updatetowerbackground(graphics.towerbg);
     }
 
     if (!game.menustart)
@@ -149,10 +149,10 @@ void maplogic()
 void gamecompletelogic()
 {
     //Misc
-    map.updatetowerglow();
+    map.updatetowerglow(graphics.towerbg);
     help.updateglow();
     graphics.crewframe = 0;
-    map.scrolldir = 1;
+    graphics.towerbg.scrolldir = 1;
     graphics.updatetitlecolours();
 
     graphics.col_tr = map.r - (help.glow / 4) - fRandom() * 4;
@@ -169,11 +169,11 @@ void gamecompletelogic()
     if (game.creditposition <= -Credits::creditmaxposition)
     {
         game.creditposition = -Credits::creditmaxposition;
-        map.bscroll = 0;
+        graphics.towerbg.bscroll = 0;
     }
     else if (!game.press_action)
     {
-        map.bscroll = +1;
+        graphics.towerbg.bscroll = +1;
     }
 
     if (graphics.fademode == 1)
@@ -182,8 +182,8 @@ void gamecompletelogic()
         graphics.showcutscenebars = false;
         graphics.cutscenebarspos = 0;
         graphics.oldcutscenebarspos = 0;
-        map.scrolldir = 0;
-        map.bypos = 0;
+        graphics.towerbg.scrolldir = 0;
+        graphics.towerbg.bypos = 0;
         //Return to game
         game.gamestate = GAMECOMPLETE2;
         graphics.fademode = 4;
@@ -193,7 +193,7 @@ void gamecompletelogic()
 void gamecompletelogic2()
 {
     //Misc
-    map.updatetowerglow();
+    map.updatetowerglow(graphics.towerbg);
     help.updateglow();
 
     game.creditposdelay--;
@@ -222,7 +222,7 @@ void gamecompletelogic2()
         game.savetele();
         music.currentsong=tmp;
         //Return to game
-        map.colstate = 10;
+        graphics.towerbg.colstate = 10;
         game.gamestate = TITLEMODE;
         graphics.fademode = 4;
         FILESYSTEM_unmountassets(); // should be before music.playef(18)
@@ -267,7 +267,7 @@ void gamelogic()
     //Misc
     if (map.towermode)
     {
-        map.updatetowerglow();
+        map.updatetowerglow(graphics.towerbg);
     }
     help.updateglow();
 
@@ -331,28 +331,28 @@ void gamelogic()
                 //do nothing!
                 //a trigger will set this off in the game
                 map.cameramode = 1;
-                map.bscroll = 0;
+                graphics.towerbg.bscroll = 0;
             }
             else if (map.cameramode == 1)
             {
                 //move normally
-                if(map.scrolldir==0)
+                if(graphics.towerbg.scrolldir==0)
                 {
                     map.ypos -= 2;
-                    map.bypos -= 1;
-                    map.bscroll = -1;
+                    graphics.towerbg.bypos -= 1;
+                    graphics.towerbg.bscroll = -1;
                 }
                 else
                 {
                     map.ypos += 2;
-                    map.bypos += 1;
-                    map.bscroll = 1;
+                    graphics.towerbg.bypos += 1;
+                    graphics.towerbg.bscroll = 1;
                 }
             }
             else if (map.cameramode == 2)
             {
                 //do nothing, but cycle colours (for taking damage)
-                map.bscroll = 0;
+                graphics.towerbg.bscroll = 0;
             }
             else if (map.cameramode == 4)
             {
@@ -367,7 +367,7 @@ void gamelogic()
 
                 map.cameramode = 5;
 
-                map.bscroll = map.cameraseek/2;
+                graphics.towerbg.bscroll = map.cameraseek/2;
             }
             else if (map.cameramode == 5)
             {
@@ -393,7 +393,7 @@ void gamelogic()
                         }
                     }
                     map.cameraseekframe--;
-                    map.bypos = map.ypos / 2;
+                    graphics.towerbg.bypos = map.ypos / 2;
                 }
                 else
                 {
@@ -402,7 +402,7 @@ void gamelogic()
                     {
                         map.ypos = obj.entities[i].yp - 120;
                     }
-                    map.bypos = map.ypos / 2;
+                    graphics.towerbg.bypos = map.ypos / 2;
                     map.cameramode = 0;
                     map.colsuperstate = 0;
                 }
@@ -410,22 +410,22 @@ void gamelogic()
         }
         else
         {
-            map.bscroll = 0;
+            graphics.towerbg.bscroll = 0;
         }
 
         if (map.ypos <= 0)
         {
             map.ypos = 0;
-            map.bypos = 0;
-            map.bscroll = 0;
+            graphics.towerbg.bypos = 0;
+            graphics.towerbg.bscroll = 0;
         }
         if (map.towermode && map.minitowermode)
         {
             if (map.ypos >= 568)
             {
                 map.ypos = 568;
-                map.bypos = map.ypos / 2;
-                map.bscroll = 0;
+                graphics.towerbg.bypos = map.ypos / 2;
+                graphics.towerbg.bscroll = 0;
             } //100-29 * 8 = 568
         }
         else
@@ -433,7 +433,7 @@ void gamelogic()
             if (map.ypos >= 5368)
             {
                 map.ypos = 5368;    //700-29 * 8 = 5368
-                map.bypos = map.ypos / 2.0;
+                graphics.towerbg.bypos = map.ypos / 2.0;
             }
         }
 
@@ -998,14 +998,14 @@ void gamelogic()
                     if (obj.entities[player].yp-map.ypos <= 0)
                     {
                         map.ypos-=10;
-                        map.bypos = map.ypos / 2;
-                        map.bscroll = 0;
+                        graphics.towerbg.bypos = map.ypos / 2;
+                        graphics.towerbg.bscroll = 0;
                     }
                     else if (obj.entities[player].yp-map.ypos >= 208)
                     {
                         map.ypos+=2;
-                        map.bypos = map.ypos / 2;
-                        map.bscroll = 0;
+                        graphics.towerbg.bypos = map.ypos / 2;
+                        graphics.towerbg.bscroll = 0;
                     }
                 }
 
@@ -1207,7 +1207,7 @@ void gamelogic()
         //Right so! Screenwraping for tower:
         if (map.towermode && map.minitowermode)
         {
-            if (map.scrolldir == 1)
+            if (graphics.towerbg.scrolldir == 1)
             {
                 //This is minitower 1!
                 int player = obj.getplayer();
@@ -1712,7 +1712,7 @@ void gamelogic()
     {
         if (map.towermode)
         {
-            graphics.updatetowerbackground();
+            graphics.updatetowerbackground(graphics.towerbg);
         }
         else
         {

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -628,10 +628,10 @@ void mapclass::updatetowerglow(TowerBG& bg_obj)
 
 void mapclass::nexttowercolour()
 {
-	graphics.towerbg.colstate+=5;
-	if (graphics.towerbg.colstate >= 30) graphics.towerbg.colstate = 0;
-	int check = graphics.towerbg.colstate % 5; //current state of phase
-	int cmode = (graphics.towerbg.colstate - check) / 5; // current colour transition
+	graphics.titlebg.colstate+=5;
+	if (graphics.titlebg.colstate >= 30) graphics.titlebg.colstate = 0;
+	int check = graphics.titlebg.colstate % 5; //current state of phase
+	int cmode = (graphics.titlebg.colstate - check) / 5; // current colour transition
 
 	switch(cmode)
 	{
@@ -655,15 +655,15 @@ void mapclass::nexttowercolour()
 		break;
 	}
 
-	graphics.towerbg.tdrawback = true;
+	graphics.titlebg.tdrawback = true;
 }
 
 void mapclass::settowercolour(int t)
 {
-	graphics.towerbg.colstate=t*5;
-	if (graphics.towerbg.colstate >= 30) graphics.towerbg.colstate = 0;
-	int check = graphics.towerbg.colstate % 5; //current state of phase
-	int cmode = (graphics.towerbg.colstate - check) / 5; // current colour transition
+	graphics.titlebg.colstate=t*5;
+	if (graphics.titlebg.colstate >= 30) graphics.titlebg.colstate = 0;
+	int check = graphics.titlebg.colstate % 5; //current state of phase
+	int cmode = (graphics.titlebg.colstate - check) / 5; // current colour transition
 
 	switch(cmode)
 	{
@@ -687,7 +687,7 @@ void mapclass::settowercolour(int t)
 		break;
 	}
 
-	graphics.towerbg.tdrawback = true;
+	graphics.titlebg.tdrawback = true;
 }
 
 bool mapclass::spikecollide(int x, int y)

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -16,7 +16,6 @@ mapclass::mapclass()
 	r = 196;
 	g = 196;
 	b = 196;
-	colstate = 0;
 	colstatedelay = 0;
 	colsuperstate = 0;
 	spikeleveltop = 0;
@@ -82,15 +81,11 @@ mapclass::mapclass()
 
 	ypos = 0;
 	oldypos = 0;
-	bypos = 0;
 
 	background = 0;
 	cameramode = 0;
 	cameraseek = 0;
 	minitowermode = false;
-	scrolldir = 0;
-	tdrawback = false;
-	bscroll = 0;
 	roomtexton = false;
 	kludge_bypos = 0;
 	kludge_colstate = 0;
@@ -581,15 +576,15 @@ void mapclass::setcol(const int r1, const int g1, const int b1 , const int r2, c
 	b = intpol(b1, b2, c / 5);
 }
 
-void mapclass::updatetowerglow()
+void mapclass::updatetowerglow(TowerBG& bg_obj)
 {
 	if (colstatedelay <= 0 || colsuperstate > 0)
 	{
-		if (colsuperstate > 0) colstate--;
-		colstate++;
-		if (colstate >= 30) colstate = 0;
-		int check = colstate % 5; //current state of phase
-		int cmode = (colstate - check) / 5; // current colour transition
+		if (colsuperstate > 0) bg_obj.colstate--;
+		bg_obj.colstate++;
+		if (bg_obj.colstate >= 30) bg_obj.colstate = 0;
+		int check = bg_obj.colstate % 5; //current state of phase
+		int cmode = (bg_obj.colstate - check) / 5; // current colour transition
 
 		switch(cmode)
 		{
@@ -623,7 +618,7 @@ void mapclass::updatetowerglow()
 		}
 		if (colsuperstate > 0) colstatedelay = 0;
 
-		tdrawback = true;
+		bg_obj.tdrawback = true;
 	}
 	else
 	{
@@ -633,10 +628,10 @@ void mapclass::updatetowerglow()
 
 void mapclass::nexttowercolour()
 {
-	colstate+=5;
-	if (colstate >= 30) colstate = 0;
-	int check = colstate % 5; //current state of phase
-	int cmode = (colstate - check) / 5; // current colour transition
+	graphics.towerbg.colstate+=5;
+	if (graphics.towerbg.colstate >= 30) graphics.towerbg.colstate = 0;
+	int check = graphics.towerbg.colstate % 5; //current state of phase
+	int cmode = (graphics.towerbg.colstate - check) / 5; // current colour transition
 
 	switch(cmode)
 	{
@@ -660,15 +655,15 @@ void mapclass::nexttowercolour()
 		break;
 	}
 
-	tdrawback = true;
+	graphics.towerbg.tdrawback = true;
 }
 
 void mapclass::settowercolour(int t)
 {
-	colstate=t*5;
-	if (colstate >= 30) colstate = 0;
-	int check = colstate % 5; //current state of phase
-	int cmode = (colstate - check) / 5; // current colour transition
+	graphics.towerbg.colstate=t*5;
+	if (graphics.towerbg.colstate >= 30) graphics.towerbg.colstate = 0;
+	int check = graphics.towerbg.colstate % 5; //current state of phase
+	int cmode = (graphics.towerbg.colstate - check) / 5; // current colour transition
 
 	switch(cmode)
 	{
@@ -692,7 +687,7 @@ void mapclass::settowercolour(int t)
 		break;
 	}
 
-	tdrawback = true;
+	graphics.towerbg.tdrawback = true;
 }
 
 bool mapclass::spikecollide(int x, int y)
@@ -849,7 +844,7 @@ void mapclass::resetplayer()
 				ypos = 0;
 			}
 			oldypos = ypos;
-			bypos = ypos / 2;
+			graphics.towerbg.bypos = ypos / 2;
 		}
 	}
 
@@ -1261,9 +1256,9 @@ void mapclass::loadlevel(int rx, int ry)
 
 				ypos = (700-29) * 8;
 				oldypos = ypos;
-				bypos = ypos / 2;
+				graphics.towerbg.bypos = ypos / 2;
 				cameramode = 0;
-				colstate = 0;
+				graphics.towerbg.colstate = 0;
 				colsuperstate = 0;
 			}
 			else if (ry == 104)
@@ -1271,9 +1266,9 @@ void mapclass::loadlevel(int rx, int ry)
 				//you've entered from the top floor
 				ypos = 0;
 				oldypos = ypos;
-				bypos = 0;
+				graphics.towerbg.bypos = 0;
 				cameramode = 0;
-				colstate = 0;
+				graphics.towerbg.colstate = 0;
 				colsuperstate = 0;
 			}
 		}
@@ -1351,17 +1346,17 @@ void mapclass::loadlevel(int rx, int ry)
 		break;
 	}
 	case 3: //The Tower
-		tdrawback = true;
+		graphics.towerbg.tdrawback = true;
 		minitowermode = false;
 		tower.minitowermode = false;
-		bscroll = 0;
-		scrolldir = 0;
+		graphics.towerbg.bscroll = 0;
+		graphics.towerbg.scrolldir = 0;
 
 		roomname = "The Tower";
 		tileset = 1;
 		background = 3;
 		towermode = true;
-		//bypos = 0; ypos = 0; cameramode = 0;
+		//graphics.towerbg.bypos = 0; ypos = 0; cameramode = 0;
 
 		//All the entities for here are just loaded here; it's essentially one room after all
 
@@ -1450,11 +1445,11 @@ void mapclass::loadlevel(int rx, int ry)
 		break;
 	}
 	case 7: //Final Level, Tower 1
-		tdrawback = true;
+		graphics.towerbg.tdrawback = true;
 		minitowermode = true;
 		tower.minitowermode = true;
-		bscroll = 0;
-		scrolldir = 1;
+		graphics.towerbg.bscroll = 0;
+		graphics.towerbg.scrolldir = 1;
 
 		roomname = "Panic Room";
 		tileset = 1;
@@ -1465,18 +1460,18 @@ void mapclass::loadlevel(int rx, int ry)
 
 		ypos = 0;
 		oldypos = 0;
-		bypos = 0;
+		graphics.towerbg.bypos = 0;
 		cameramode = 0;
-		colstate = 0;
+		graphics.towerbg.colstate = 0;
 		colsuperstate = 0;
 		break;
 	case 8: //Final Level, Tower 1 (reentered from below)
 	{
-		tdrawback = true;
+		graphics.towerbg.tdrawback = true;
 		minitowermode = true;
 		tower.minitowermode = true;
-		bscroll = 0;
-		scrolldir = 1;
+		graphics.towerbg.bscroll = 0;
+		graphics.towerbg.scrolldir = 1;
 
 		roomname = "Panic Room";
 		tileset = 1;
@@ -1495,18 +1490,18 @@ void mapclass::loadlevel(int rx, int ry)
 
 		ypos = (100-29) * 8;
 		oldypos = ypos;
-		bypos = ypos/2;
+		graphics.towerbg.bypos = ypos/2;
 		cameramode = 0;
-		colstate = 0;
+		graphics.towerbg.colstate = 0;
 		colsuperstate = 0;}
 		break;
 	case 9: //Final Level, Tower 2
 	{
-		tdrawback = true;
+		graphics.towerbg.tdrawback = true;
 		minitowermode = true;
 		tower.minitowermode = true;
-		bscroll = 0;
-		scrolldir = 0;
+		graphics.towerbg.bscroll = 0;
+		graphics.towerbg.scrolldir = 0;
 		final_colorframe = 2;
 
 		roomname = "The Final Challenge";
@@ -1540,20 +1535,20 @@ void mapclass::loadlevel(int rx, int ry)
 
 		ypos = (100-29) * 8;
 		oldypos = ypos;
-		bypos = ypos/2;
+		graphics.towerbg.bypos = ypos/2;
 		cameramode = 0;
-		colstate = 0;
+		graphics.towerbg.colstate = 0;
 		colsuperstate = 0;
 		break;
 	}
 	case 10: //Final Level, Tower 2
 	{
 
-		tdrawback = true;
+		graphics.towerbg.tdrawback = true;
 		minitowermode = true;
 		tower.minitowermode = true;
-		bscroll = 0;
-		scrolldir = 0;
+		graphics.towerbg.bscroll = 0;
+		graphics.towerbg.scrolldir = 0;
 		final_colorframe = 2;
 
 		roomname = "The Final Challenge";
@@ -1579,9 +1574,9 @@ void mapclass::loadlevel(int rx, int ry)
 
 		ypos = 0;
 		oldypos = 0;
-		bypos = 0;
+		graphics.towerbg.bypos = 0;
 		cameramode = 0;
-		colstate = 0;
+		graphics.towerbg.colstate = 0;
 		colsuperstate = 0;
 		break;
 	}
@@ -2113,4 +2108,18 @@ void mapclass::twoframedelayfix()
 		script.run();
 		script.dontrunnextframe = true;
 	}
+}
+
+void mapclass::bg_to_kludge()
+{
+	kludge_bypos = graphics.towerbg.bypos;
+	kludge_colstate = graphics.towerbg.colstate;
+	kludge_scrolldir = graphics.towerbg.scrolldir;
+}
+
+void mapclass::kludge_to_bg()
+{
+	graphics.towerbg.bypos = kludge_bypos;
+	graphics.towerbg.colstate = kludge_colstate;
+	graphics.towerbg.scrolldir = kludge_scrolldir;
 }

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -87,9 +87,6 @@ mapclass::mapclass()
 	cameraseek = 0;
 	minitowermode = false;
 	roomtexton = false;
-	kludge_bypos = 0;
-	kludge_colstate = 0;
-	kludge_scrolldir = 0;
 }
 
 //Areamap starts at 100,100 and extends 20x20
@@ -2108,18 +2105,4 @@ void mapclass::twoframedelayfix()
 		script.run();
 		script.dontrunnextframe = true;
 	}
-}
-
-void mapclass::bg_to_kludge()
-{
-	kludge_bypos = graphics.towerbg.bypos;
-	kludge_colstate = graphics.towerbg.colstate;
-	kludge_scrolldir = graphics.towerbg.scrolldir;
-}
-
-void mapclass::kludge_to_bg()
-{
-	graphics.towerbg.bypos = kludge_bypos;
-	graphics.towerbg.colstate = kludge_colstate;
-	graphics.towerbg.scrolldir = kludge_scrolldir;
 }

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -9,6 +9,7 @@
 #include "Otherlevel.h"
 #include "Spacestation2.h"
 #include "Tower.h"
+#include "TowerBG.h"
 #include "WarpClass.h"
 
 struct Roomtext
@@ -47,7 +48,7 @@ public:
 
     void setcol(const int r1, const int g1, const int b1 , const int r2, const  int g2, const int b2, const int c);
 
-    void updatetowerglow();
+    void updatetowerglow(TowerBG& bg_obj);
 
     void nexttowercolour();
 
@@ -102,21 +103,17 @@ public:
     bool towermode;
     float ypos;
     float oldypos;
-    int bypos;
     int cameramode;
     int cameraseek, cameraseekframe;
     int resumedelay;
     bool minitowermode;
-    int scrolldir;
 
     //This is the old colour cycle
     int r, g,b;
-    int colstate, colstatedelay;
+    int colstatedelay;
     int colsuperstate;
     int spikeleveltop, spikelevelbottom;
     int oldspikeleveltop, oldspikelevelbottom;
-    bool tdrawback;
-    int bscroll;
     //final level navigation
     int finalx;
     int finaly;
@@ -172,18 +169,8 @@ public:
     int kludge_bypos;
     int kludge_colstate;
     int kludge_scrolldir;
-    void inline bg_to_kludge()
-    {
-        kludge_bypos = bypos;
-        kludge_colstate = colstate;
-        kludge_scrolldir = scrolldir;
-    }
-    void inline kludge_to_bg()
-    {
-        bypos = kludge_bypos;
-        colstate = kludge_colstate;
-        scrolldir = kludge_scrolldir;
-    }
+    void bg_to_kludge();
+    void kludge_to_bg();
 };
 
 #ifndef MAP_DEFINITION

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -165,12 +165,6 @@ public:
 
     //Map cursor
     int cursorstate, cursordelay;
-
-    int kludge_bypos;
-    int kludge_colstate;
-    int kludge_scrolldir;
-    void bg_to_kludge();
-    void kludge_to_bg();
 };
 
 #ifndef MAP_DEFINITION

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1182,7 +1182,7 @@ void titlerender()
     }
     else
     {
-        if(!game.colourblindmode) graphics.drawtowerbackground();
+        if(!game.colourblindmode) graphics.drawtowerbackground(graphics.towerbg);
 
         tr = graphics.col_tr;
         tg = graphics.col_tg;
@@ -1211,7 +1211,7 @@ void gamecompleterender()
 {
     FillRect(graphics.backBuffer, 0x000000);
 
-    if(!game.colourblindmode) graphics.drawtowerbackground();
+    if(!game.colourblindmode) graphics.drawtowerbackground(graphics.towerbg);
 
     tr = graphics.col_tr;
     tg = graphics.col_tg;
@@ -1397,7 +1397,7 @@ void gamerender()
         {
             if (!game.colourblindmode)
             {
-                graphics.drawtowerbackground();
+                graphics.drawtowerbackground(graphics.towerbg);
             }
             else
             {

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1182,7 +1182,7 @@ void titlerender()
     }
     else
     {
-        if(!game.colourblindmode) graphics.drawtowerbackground(graphics.towerbg);
+        if(!game.colourblindmode) graphics.drawtowerbackground(graphics.titlebg);
 
         tr = graphics.col_tr;
         tg = graphics.col_tg;
@@ -1211,7 +1211,7 @@ void gamecompleterender()
 {
     FillRect(graphics.backBuffer, 0x000000);
 
-    if(!game.colourblindmode) graphics.drawtowerbackground(graphics.towerbg);
+    if(!game.colourblindmode) graphics.drawtowerbackground(graphics.titlebg);
 
     tr = graphics.col_tr;
     tg = graphics.col_tg;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2642,7 +2642,7 @@ void scriptclass::resetgametomenu()
 	graphics.flipmode = false;
 	obj.entities.clear();
 	graphics.fademode = 4;
-	graphics.towerbg.tdrawback = true;
+	graphics.titlebg.tdrawback = true;
 	game.createmenu(Menu::gameover);
 }
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1537,7 +1537,7 @@ void scriptclass::run()
 				map.resetnames();
 				map.resetmap();
 				map.resetplayer();
-				map.tdrawback = true;
+				graphics.towerbg.tdrawback = true;
 
 				obj.resetallflags();
 				i = obj.getplayer();
@@ -2642,7 +2642,7 @@ void scriptclass::resetgametomenu()
 	graphics.flipmode = false;
 	obj.entities.clear();
 	graphics.fademode = 4;
-	map.tdrawback = true;
+	graphics.towerbg.tdrawback = true;
 	game.createmenu(Menu::gameover);
 }
 
@@ -2732,7 +2732,7 @@ void scriptclass::startgamemode( int t )
 			{
 				map.ypos = obj.entities[i].yp - 120;
 			}
-			map.bypos = map.ypos / 2;
+			graphics.towerbg.bypos = map.ypos / 2;
 			map.cameramode = 0;
 			map.colsuperstate = 0;
 		}
@@ -3714,7 +3714,7 @@ void scriptclass::hardreset()
 	}
 	map.cameraseekframe = 0;
 	map.resumedelay = 0;
-	map.scrolldir = 0;
+	graphics.towerbg.scrolldir = 0;
 	map.customshowmm=true;
 
 	SDL_memset(map.roomdeaths, 0, sizeof(map.roomdeaths));

--- a/desktop_version/src/TowerBG.h
+++ b/desktop_version/src/TowerBG.h
@@ -1,0 +1,17 @@
+#ifndef TOWERBG_H
+#define TOWERBG_H
+
+#include <SDL.h>
+
+struct TowerBG
+{
+	SDL_Surface* buffer;
+	SDL_Surface* buffer_lerp;
+	bool tdrawback;
+	int bypos;
+	int bscroll;
+	int colstate;
+	int scrolldir;
+};
+
+#endif /* TOWERBG_H */

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3292,7 +3292,7 @@ void editorrender()
     {
         if(!game.colourblindmode)
         {
-            graphics.drawtowerbackground(graphics.towerbg);
+            graphics.drawtowerbackground(graphics.titlebg);
         }
         else
         {
@@ -3679,8 +3679,8 @@ void editorlogic()
         game.shouldreturntoeditor = false;
     }
 
-    graphics.towerbg.bypos -= 2;
-    graphics.towerbg.bscroll = -2;
+    graphics.titlebg.bypos -= 2;
+    graphics.titlebg.bscroll = -2;
 
     ed.entframedelay--;
     if(ed.entframedelay<=0)
@@ -3740,14 +3740,14 @@ void editorlogic()
     }
     else if (!game.colourblindmode)
     {
-        graphics.updatetowerbackground(graphics.towerbg);
+        graphics.updatetowerbackground(graphics.titlebg);
     }
 
     if (graphics.fademode == 1)
     {
         //Return to game
         map.nexttowercolour();
-        graphics.towerbg.colstate = 10;
+        graphics.titlebg.colstate = 10;
         game.gamestate = TITLEMODE;
         script.hardreset();
         graphics.fademode = 4;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3292,7 +3292,7 @@ void editorrender()
     {
         if(!game.colourblindmode)
         {
-            graphics.drawtowerbackground();
+            graphics.drawtowerbackground(graphics.towerbg);
         }
         else
         {
@@ -3679,8 +3679,8 @@ void editorlogic()
         game.shouldreturntoeditor = false;
     }
 
-    map.bypos -= 2;
-    map.bscroll = -2;
+    graphics.towerbg.bypos -= 2;
+    graphics.towerbg.bscroll = -2;
 
     ed.entframedelay--;
     if(ed.entframedelay<=0)
@@ -3740,14 +3740,14 @@ void editorlogic()
     }
     else if (!game.colourblindmode)
     {
-        graphics.updatetowerbackground();
+        graphics.updatetowerbackground(graphics.towerbg);
     }
 
     if (graphics.fademode == 1)
     {
         //Return to game
         map.nexttowercolour();
-        map.colstate = 10;
+        graphics.towerbg.colstate = 10;
         game.gamestate = TITLEMODE;
         script.hardreset();
         graphics.fademode = 4;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -210,7 +210,7 @@ int main(int argc, char *argv[])
     game.mainmenu = 0;
 
     map.ypos = (700-29) * 8;
-    map.bypos = map.ypos / 2;
+    graphics.towerbg.bypos = map.ypos / 2;
 
     //Moved screensetting init here from main menu V2.1
     int width = 320;
@@ -256,11 +256,11 @@ int main(int argc, char *argv[])
     graphics.menubuffer = CREATE_SURFACE(320, 240);
     SDL_SetSurfaceBlendMode(graphics.menubuffer, SDL_BLENDMODE_NONE);
 
-    graphics.towerbuffer =  CREATE_SURFACE(320 + 16, 240 + 16);
-    SDL_SetSurfaceBlendMode(graphics.towerbuffer, SDL_BLENDMODE_NONE);
+    graphics.towerbg.buffer =  CREATE_SURFACE(320 + 16, 240 + 16);
+    SDL_SetSurfaceBlendMode(graphics.towerbg.buffer, SDL_BLENDMODE_NONE);
 
-    graphics.towerbuffer_lerp = CREATE_SURFACE(320 + 16, 240 + 16);
-    SDL_SetSurfaceBlendMode(graphics.towerbuffer_lerp, SDL_BLENDMODE_NONE);
+    graphics.towerbg.buffer_lerp = CREATE_SURFACE(320 + 16, 240 + 16);
+    SDL_SetSurfaceBlendMode(graphics.towerbg.buffer_lerp, SDL_BLENDMODE_NONE);
 
     graphics.tempBuffer = CREATE_SURFACE(320, 240);
     SDL_SetSurfaceBlendMode(graphics.tempBuffer, SDL_BLENDMODE_NONE);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -211,6 +211,7 @@ int main(int argc, char *argv[])
 
     map.ypos = (700-29) * 8;
     graphics.towerbg.bypos = map.ypos / 2;
+    graphics.titlebg.bypos = map.ypos / 2;
 
     //Moved screensetting init here from main menu V2.1
     int width = 320;
@@ -261,6 +262,12 @@ int main(int argc, char *argv[])
 
     graphics.towerbg.buffer_lerp = CREATE_SURFACE(320 + 16, 240 + 16);
     SDL_SetSurfaceBlendMode(graphics.towerbg.buffer_lerp, SDL_BLENDMODE_NONE);
+
+    graphics.titlebg.buffer = CREATE_SURFACE(320 + 16, 240 + 16);
+    SDL_SetSurfaceBlendMode(graphics.titlebg.buffer, SDL_BLENDMODE_NONE);
+
+    graphics.titlebg.buffer_lerp = CREATE_SURFACE(320 + 16, 240 + 16);
+    SDL_SetSurfaceBlendMode(graphics.titlebg.buffer_lerp, SDL_BLENDMODE_NONE);
 
     graphics.tempBuffer = CREATE_SURFACE(320, 240);
     SDL_SetSurfaceBlendMode(graphics.tempBuffer, SDL_BLENDMODE_NONE);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -257,6 +257,12 @@ int main(int argc, char *argv[])
     graphics.menubuffer = CREATE_SURFACE(320, 240);
     SDL_SetSurfaceBlendMode(graphics.menubuffer, SDL_BLENDMODE_NONE);
 
+    graphics.warpbuffer = CREATE_SURFACE(320 + 16, 240 + 16);
+    SDL_SetSurfaceBlendMode(graphics.warpbuffer, SDL_BLENDMODE_NONE);
+
+    graphics.warpbuffer_lerp = CREATE_SURFACE(320 + 16, 240 + 16);
+    SDL_SetSurfaceBlendMode(graphics.warpbuffer_lerp, SDL_BLENDMODE_NONE);
+
     graphics.towerbg.buffer =  CREATE_SURFACE(320 + 16, 240 + 16);
     SDL_SetSurfaceBlendMode(graphics.towerbg.buffer, SDL_BLENDMODE_NONE);
 


### PR DESCRIPTION
This PR fixes #369 by doing what I suggested - splitting the three usages of one buffer into three separate buffers. Well, technically, it was one buffer plus its lerp buffer, and there needs to be a lerp buffer for each buffer; so now we have six buffers, three of which are the "main" ones, plus three lerp ones. I just threw out a bunch of numbers. Oh, also, the tower and title screen backgrounds have a bunch of other variables associated with them, so I put them in an object, but you can always just read the diffs for details like that.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
