### PR TITLE
Remove unused attributes author/description/title from editorclass

### DIFF
--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -240,10 +240,6 @@ class editorclass{
   int sbx, sby;
   int pagey;
 
-  std::string author;
-  std::string description;
-  std::string title;
-
   //Functions for interfacing with the script:
   void addhook(std::string t);
   void removehook(std::string t);


### PR DESCRIPTION
The author, description, and title of the level are actually stored on the `EditorData` instance. These attributes do nothing and should be removed.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
