### PR TITLE
Fix teleporter sprites sometimes being solid colors

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3082,7 +3082,7 @@ void Graphics::drawtele(int x, int y, int t, Uint32 c)
 
 	setcolreal(c);
 	if (t > 9) t = 8;
-	if (t < 0) t = 0;
+	if (t < 1) t = 1;
 
 	setRect(telerect, x , y, tele_rect.w, tele_rect.h );
 	if (INBOUNDS_VEC(t, tele))


### PR DESCRIPTION
This commit fixes a bug that also sometimes occurred in 2.2, where the teleporter sprite would randomly turn into a solid color and just be a solid circle with no detail.

![Solid teleporter sprite](https://user-images.githubusercontent.com/59748578/98053690-03511700-1dee-11eb-8ab1-d018ad1c5ff4.png)

Why did this happen? The short answer is an incorrect lower bound when clamping the teleporter sprite index in `Graphics::drawtele()`. The long answer is bad RNG with the teleporter animation code. This commit fixes the short answer, because I do not want to mess with the long answer.

So, here is what would happen: the teleporter's `tile` would be 6. The teleporter code decrements its `framedelay` each frame. Then when it reached a `framedelay` of 0, it would call `fRandom()` and essentially ask for a random number between 0 and 6. If the RNG ended up being greater than or equal to 4, then it would set its `walkingframe` to -5. At the end of the routine, the teleporter's `drawframe` ends up being its `tile` plus its `walkingframe`. So having a `walkingframe` of -5 here is fine, because its `tile` is 6.

Until it isn't. When its `tile` becomes 2, it still keeps its `walkingframe` around. The code that runs when its `tile` is 2 does have the possibility of completely resetting its `walkingframe` to be in bounds (in bounds after its `tile` is added), but that only runs when its `framedelay` is 0, and in the meantime it'll just use the previous `walkingframe`.

So you could have a `walkingframe` of -5, plus a `tile` of 2, which produces a `drawframe` of -3. Then `Graphics::drawtele()` will clamp that to 0, which just means it'll draw the teleporter backing, and the teleporter backing is a simple solid color, so the teleporter will end up being completely and fully solid.

To fix this, I just made `Graphics::drawtele()` clamp to 1 on the lower bound, instead of 0. So if it ever gets passed a negative teleporter index, it'll just draw the normal teleporter sprite instead, which is better.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
