### PR TITLE
Add error messages for game save failure

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -225,6 +225,7 @@ void Game::init(void)
     minutes = 0;
     hours = 0;
     gamesaved = false;
+    gamesavefailed = false;
     savetime = "00:00";
     savearea = "nowhere";
     savetrinkets = 0;
@@ -5724,12 +5725,12 @@ bool Game::savetele()
 }
 
 
-void Game::savequick()
+bool Game::savequick()
 {
     if (map.custommode || inspecial())
     {
         //Don't trash save data!
-        return;
+        return false;
     }
 
     tinyxml2::XMLDocument doc;
@@ -5740,16 +5741,14 @@ void Game::savequick()
     }
     quicksummary = writemaingamesave(doc);
 
-    if(FILESYSTEM_saveTiXml2Document("saves/qsave.vvv", doc))
-    {
-        printf("Game saved\n");
-    }
-    else
+    if(!FILESYSTEM_saveTiXml2Document("saves/qsave.vvv", doc))
     {
         printf("Could Not Save game!\n");
         printf("Failed: %s%s\n", saveFilePath.c_str(), "qsave.vvv");
+        return false;
     }
-
+    printf("Game saved\n");
+    return true;
 }
 
 // Returns summary of save
@@ -5869,7 +5868,7 @@ std::string Game::writemaingamesave(tinyxml2::XMLDocument& doc)
 }
 
 
-void Game::customsavequick(std::string savfile)
+bool Game::customsavequick(std::string savfile)
 {
     const std::string levelfile = savfile.substr(7);
 
@@ -5998,15 +5997,14 @@ void Game::customsavequick(std::string savfile)
 
     customquicksummary = summary;
 
-    if(FILESYSTEM_saveTiXml2Document(("saves/"+levelfile+".vvv").c_str(), doc))
-    {
-        printf("Game saved\n");
-    }
-    else
+    if(!FILESYSTEM_saveTiXml2Document(("saves/"+levelfile+".vvv").c_str(), doc))
     {
         printf("Could Not Save game!\n");
         printf("Failed: %s%s%s\n", saveFilePath.c_str(), levelfile.c_str(), ".vvv");
+        return false;
     }
+    printf("Game saved\n");
+    return true;
 }
 
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1918,16 +1918,15 @@ void Game::updatestate()
             }
             else
             {
-                savetele();
-                if (graphics.flipmode)
+                if (savetele())
                 {
-                    graphics.createtextbox("    Game Saved    ", -1, 202, 174, 174, 174);
+                    graphics.createtextbox("    Game Saved    ", -1, graphics.flipmode ? 202 : 12, 174, 174, 174);
                     graphics.textboxtimer(25);
                 }
                 else
                 {
-                    graphics.createtextbox("    Game Saved    ", -1, 12, 174, 174, 174);
-                    graphics.textboxtimer(25);
+                    graphics.createtextbox("  ERROR: Could not save game!  ", -1, graphics.flipmode ? 202 : 12, 255, 60, 60);
+                    graphics.textboxtimer(50);
                 }
                 state = 0;
             }
@@ -5698,12 +5697,12 @@ void Game::initteleportermode()
     }
 }
 
-void Game::savetele()
+bool Game::savetele()
 {
     if (map.custommode || inspecial())
     {
         //Don't trash save data!
-        return;
+        return false;
     }
 
     tinyxml2::XMLDocument doc;
@@ -5714,15 +5713,14 @@ void Game::savetele()
     }
     telesummary = writemaingamesave(doc);
 
-    if(FILESYSTEM_saveTiXml2Document("saves/tsave.vvv", doc))
-    {
-        printf("Game saved\n");
-    }
-    else
+    if(!FILESYSTEM_saveTiXml2Document("saves/tsave.vvv", doc))
     {
         printf("Could Not Save game!\n");
         printf("Failed: %s%s\n", saveFilePath.c_str(), "tsave.vvv");
+        return false;
     }
+    printf("Game saved\n");
+    return true;
 }
 
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -132,7 +132,7 @@ public:
 
     void deletequick();
 
-    void savetele();
+    bool savetele();
 
     void loadtele();
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -97,8 +97,8 @@ public:
 
     void resetgameclock();
 
-    void customsavequick(std::string savfile);
-    void savequick();
+    bool customsavequick(std::string savfile);
+    bool savequick();
 
     void gameclock();
 
@@ -204,6 +204,7 @@ public:
 
     int frames, seconds, minutes, hours;
     bool gamesaved;
+    bool gamesavefailed;
     std::string savetime;
     std::string savearea;
     int savetrinkets;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2010,6 +2010,7 @@ void gameinput()
         //Quit menu, same conditions as in game menu
         game.gamestate = MAPMODE;
         game.gamesaved = false;
+        game.gamesavefailed = false;
         graphics.resumegamemode = false;
         game.menupage = 20; // The Map Page
         BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
@@ -2040,6 +2041,7 @@ void gameinput()
         map.cursordelay = 0;
         map.cursorstate = 0;
         game.gamesaved = false;
+        game.gamesavefailed = false;
         graphics.resumegamemode = false;
         game.menupage = 0; // The Map Page
         BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
@@ -2058,6 +2060,7 @@ void gameinput()
         //Quit menu, same conditions as in game menu
         game.gamestate = MAPMODE;
         game.gamesaved = false;
+        game.gamesavefailed = false;
         graphics.resumegamemode = false;
         game.menupage = 30; // Pause screen
 
@@ -2291,12 +2294,11 @@ void mapmenuactionpress()
     }
         break;
     case 3:
-    if (!game.gamesaved && !game.inspecial())
+    if (!game.gamesaved && !game.gamesavefailed && !game.inspecial())
     {
         game.flashlight = 5;
         game.screenshake = 10;
         music.playef(18);
-        game.gamesaved = true;
 
         game.savetime = game.timestring();
         game.savearea = map.currentarea(map.area(game.roomx, game.roomy));
@@ -2304,16 +2306,19 @@ void mapmenuactionpress()
 
         if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111) game.savearea = "The Ship";
 
+        bool success;
 #if !defined(NO_CUSTOM_LEVELS)
         if(map.custommodeforreal)
         {
-            game.customsavequick(ed.ListOfMetaData[game.playcustomlevel].filename);
+            success = game.customsavequick(ed.ListOfMetaData[game.playcustomlevel].filename);
         }
         else
 #endif
         {
-            game.savequick();
+            success = game.savequick();
         }
+        game.gamesaved = success;
+        game.gamesavefailed = !success;
     }
         break;
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2215,6 +2215,10 @@ void maprender()
         {
             graphics.Print(0, 115, "Cannot Save in Secret Lab", 146, 146, 180, true);
         }
+        else if (game.gamesavefailed)
+        {
+            graphics.Print(0, 115, "ERROR: Could not save game!", 146, 146, 180, true);
+        }
         else if (map.custommode)
         {
             if (game.gamesaved)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3552,17 +3552,16 @@ void scriptclass::teleport()
 		}
 		if (!game.intimetrial && !game.nodeathmode && !game.inintermission)
 		{
-			if (graphics.flipmode)
+			if (game.savetele())
 			{
-				graphics.createtextbox("    Game Saved    ", -1, 202, 174, 174, 174);
+				graphics.createtextbox("    Game Saved    ", -1, graphics.flipmode ? 202 : 12, 174, 174, 174);
 				graphics.textboxtimer(25);
 			}
 			else
 			{
-				graphics.createtextbox("    Game Saved    ", -1, 12, 174, 174, 174);
-				graphics.textboxtimer(25);
+				graphics.createtextbox("  ERROR: Could not save game!  ", -1, graphics.flipmode ? 202 : 12, 255, 60, 60);
+				graphics.textboxtimer(50);
 			}
-			game.savetele();
 		}
 	}
 }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3614,6 +3614,7 @@ void scriptclass::hardreset()
 	game.minutes = 0;
 	game.hours = 0;
 	game.gamesaved = false;
+	game.gamesavefailed = false;
 	game.savetime = "00:00";
 	game.savearea = "nowhere";
 	game.savetrinkets = 0;


### PR DESCRIPTION
## Changes:

When touching a teleporter or quicksaving the game, the game would always explicitly say saving was successful, even if the save actually failed. Now both telesaving and quicksaving can alternatively show an error message:

![could_not_telesave](https://user-images.githubusercontent.com/44736680/98063838-dbdb6800-1e48-11eb-9ed9-2db9ecbeb9df.png) ![could_not_quicksave](https://user-images.githubusercontent.com/44736680/98063847-e0078580-1e48-11eb-8d79-0de426c8aeff.png)

This partially covers #377.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
