### PR TITLE
Don't unset Flip Mode when deleting all data in M&P

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4429,7 +4429,9 @@ void Game::deletestats()
             bestlives[i] = -1;
             bestrank[i] = -1;
         }
+#ifndef MAKEANDPLAY
         graphics.setflipmode = false;
+#endif
         stat_trinkets = 0;
     }
 }


### PR DESCRIPTION
Whenever you delete all your save data, your settings aren't changed at all, and you could resave them if you fiddled with a setting somewhere. But the full game doesn't count Flip Mode as a setting, instead it counts it as an unlock. This means deleting your save data would unset Flip Mode in M&P, which would seem weird because in M&P it's just a simple setting.

For consistency, Flip Mode shouldn't be unset when deleting save data in M&P.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
