### PR TITLE
Move all settings to settings.vvv

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4707,11 +4707,12 @@ void Game::loadstats(int *width, int *height, bool *vsync)
 
     }
 
-    if (graphics.showmousecursor == true)
+    if (graphics.showmousecursor)
     {
         SDL_ShowCursor(SDL_ENABLE);
     }
-    else {
+    else
+    {
         SDL_ShowCursor(SDL_DISABLE);
     }
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -6,7 +6,11 @@
 #include <vector>
 
 // Forward decl without including all of <tinyxml2.h>
-namespace tinyxml2 { class XMLDocument; }
+namespace tinyxml2
+{
+    class XMLDocument;
+    class XMLElement;
+}
 
 struct MenuOption
 {
@@ -126,9 +130,19 @@ public:
 
     void loadstats(int *width, int *height, bool *vsync);
 
-    void  savestats();
+    void  savestats(const bool stats_only = false);
 
     void deletestats();
+
+    void deserializesettings(tinyxml2::XMLElement* dataNode, int* width, int* height, bool* vsync);
+
+    void serializesettings(tinyxml2::XMLElement* dataNode);
+
+    void loadsettings(int* width, int* height, bool* vsync);
+
+    void savesettings();
+
+    void deletesettings();
 
     void deletequick();
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1280,6 +1280,7 @@ void menuactionpress()
             game.deletequick();
             game.deletetele();
             game.deletestats();
+            game.deletesettings();
             game.flashlight = 5;
             game.screenshake = 15;
             game.createmenu(Menu::mainmenu);

--- a/desktop_version/src/XMLUtils.cpp
+++ b/desktop_version/src/XMLUtils.cpp
@@ -4,16 +4,15 @@
 namespace xml
 {
 
-// Helper functions for these utils (not exported)
-
-static inline tinyxml2::XMLDocument& get_document(tinyxml2::XMLNode* parent)
+// Just get the document, because TinyXML-2 is annoying.
+// Useful outside of this file.
+// TODO: But XML handling should really be put in a separate file (maybe this
+// one renamed?) instead of lumped in with Game.cpp, and when that happens
+// maybe this will be unexported again?
+tinyxml2::XMLDocument& get_document(tinyxml2::XMLNode* parent)
 {
     return *(parent->GetDocument());
 }
-
-
-// EXPORTED FUNCTIONS
-
 
 // Create a new element if it doesn't exist. Returns the element.
 tinyxml2::XMLElement* update_element(tinyxml2::XMLNode* parent, const char* name)

--- a/desktop_version/src/XMLUtils.h
+++ b/desktop_version/src/XMLUtils.h
@@ -11,6 +11,8 @@ namespace tinyxml2
 namespace xml
 {
 
+tinyxml2::XMLDocument& get_document(tinyxml2::XMLNode* parent);
+
 tinyxml2::XMLElement* update_element(tinyxml2::XMLNode* parent, const char* name);
 // Same thing as above, but takes &parent instead of *parent
 tinyxml2::XMLElement* update_element(tinyxml2::XMLNode& parent, const char* name);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -217,7 +217,12 @@ int main(int argc, char *argv[])
     int width = 320;
     int height = 240;
     bool vsync = false;
+
+    // Prioritize unlock.vvv first (2.2 and below),
+    // but settings have been migrated to settings.vvv (2.3 and up)
     game.loadstats(&width, &height, &vsync);
+    game.loadsettings(&width, &height, &vsync);
+
     gameScreen.init(
         width,
         height,


### PR DESCRIPTION
The game previously did this dumb thing where it lumped in all its settings with its file that tracked your records and unlocks, `unlock.vvv`. It wasn't really an issue, until 2.3 came along and added a few settings, suddenly making a problem where 2.3 settings would be reset by chance if you decided to touch 2.2.

The solution to this is to move all settings to a new file, `settings.vvv`. However, for compatibility with 2.2, settings will still be written to `unlock.vvv`.

The game will prioritize reading from `settings.vvv` instead of `unlock.vvv`, so if there's a setting that's missing from `unlock.vvv`, no worries there. But if `settings.vvv` is missing, then it'll read settings from `unlock.vvv`. As well, if `unlock.vvv` is missing, then `settings.vvv` will be read from instead (I explicitly tested for this, and found that I had to write special code to handle this case, otherwise the game would overwrite the existing `settings.vvv` before reading from it; kids, make sure to always test your code!).

Closes #373 fully.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
