### PR TITLE
Fix variables shadowing other variables

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1942,7 +1942,7 @@ void Graphics::drawentity(const int i, const int yoff)
 
         tpoint.x = xp; tpoint.y = yp - yoff;
         setcolreal(obj.entities[i].realcol);
-        SDL_Rect drawRect = {Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp - yoff), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) };
+        setRect(drawRect, Sint16(obj.entities[i].xp ), Sint16(obj.entities[i].yp - yoff), Sint16(sprites_rect.x * 6), Sint16(sprites_rect.y * 6 ) );
         SDL_Surface* TempSurface = ScaleSurface( spritesvec[obj.entities[i].drawframe], 6 * sprites_rect.w,6* sprites_rect.h );
         BlitSurfaceColoured(TempSurface, NULL , backBuffer,  &drawRect, ct );
         SDL_FreeSurface(TempSurface);

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -100,8 +100,8 @@ void musicclass::init()
 		const std::vector<int> extra = musicReadBlob.getExtra();
 		for (size_t i = 0; i < extra.size(); i++)
 		{
-			const int& index = extra[i];
-			rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
+			const int& index_ = extra[i];
+			rw = SDL_RWFromMem(musicReadBlob.getAddress(index_), musicReadBlob.getSize(index_));
 			musicTracks.push_back(MusicTrack( rw ));
 
 			num_mmmmmm_tracks++;
@@ -123,8 +123,8 @@ void musicclass::init()
 	const std::vector<int> extra = musicReadBlob.getExtra();
 	for (size_t i = 0; i < extra.size(); i++)
 	{
-		const int& index = extra[i];
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index));
+		const int& index_ = extra[i];
+		rw = SDL_RWFromMem(musicReadBlob.getAddress(index_), musicReadBlob.getSize(index_));
 		musicTracks.push_back(MusicTrack( rw ));
 
 		num_pppppp_tracks++;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2503,10 +2503,10 @@ void teleporterrender()
         //Draw the chosen destination coordinate!
         //TODO
         //draw the coordinates //destination
-        int tempx = map.teleporters[game.teleport_to_teleporter].x;
-        int tempy = map.teleporters[game.teleport_to_teleporter].y;
-        graphics.drawrect(40 + (tempx * 12) + 1, 21 + (tempy * 9) + 1, 12 - 2, 9 - 2, 245 - (help.glow * 2), 16, 16);
-        graphics.drawrect(40 + (tempx * 12) + 3, 21 + (tempy * 9) + 3, 12 - 6, 9 - 6, 245 - (help.glow * 2), 16, 16);
+        int tempx_ = map.teleporters[game.teleport_to_teleporter].x;
+        int tempy_ = map.teleporters[game.teleport_to_teleporter].y;
+        graphics.drawrect(40 + (tempx_ * 12) + 1, 21 + (tempy_ * 9) + 1, 12 - 2, 9 - 2, 245 - (help.glow * 2), 16, 16);
+        graphics.drawrect(40 + (tempx_ * 12) + 3, 21 + (tempy_ * 9) + 3, 12 - 6, 9 - 6, 245 - (help.glow * 2), 16, 16);
     }
 
     //draw legend details

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1766,46 +1766,46 @@ bool editorclass::load(std::string& _path)
 
             for( tinyxml2::XMLElement* subElem = pElem->FirstChildElement(); subElem; subElem= subElem->NextSiblingElement())
             {
-                std::string pKey(subElem->Value());
-                const char* pText = subElem->GetText() ;
-                if(pText == NULL)
+                std::string pKey_(subElem->Value());
+                const char* pText_ = subElem->GetText() ;
+                if(pText_ == NULL)
                 {
-                    pText = "";
+                    pText_ = "";
                 }
 
-                if(pKey == "Creator")
+                if(pKey_ == "Creator")
                 {
-                    EditorData::GetInstance().creator = pText;
+                    EditorData::GetInstance().creator = pText_;
                 }
 
-                if(pKey == "Title")
+                if(pKey_ == "Title")
                 {
-                    EditorData::GetInstance().title = pText;
+                    EditorData::GetInstance().title = pText_;
                 }
 
-                if(pKey == "Desc1")
+                if(pKey_ == "Desc1")
                 {
-                    Desc1 = pText;
+                    Desc1 = pText_;
                 }
 
-                if(pKey == "Desc2")
+                if(pKey_ == "Desc2")
                 {
-                    Desc2 = pText;
+                    Desc2 = pText_;
                 }
 
-                if(pKey == "Desc3")
+                if(pKey_ == "Desc3")
                 {
-                    Desc3 = pText;
+                    Desc3 = pText_;
                 }
 
-                if(pKey == "website")
+                if(pKey_ == "website")
                 {
-                    website = pText;
+                    website = pText_;
                 }
 
-                if(pKey == "onewaycol_override")
+                if(pKey_ == "onewaycol_override")
                 {
-                    onewaycol_override = help.Int(pText);
+                    onewaycol_override = help.Int(pText_);
                 }
             }
         }
@@ -2145,12 +2145,12 @@ bool editorclass::save(std::string& _path)
         Script& script_ = script.customscripts[i];
 
         scriptString += script_.name + ":|";
-        for (size_t i = 0; i < script_.contents.size(); i++)
+        for (size_t ii = 0; ii < script_.contents.size(); i++)
         {
-            scriptString += script_.contents[i];
+            scriptString += script_.contents[ii];
 
             // Inserts a space if the line ends with a :
-            if (script_.contents[i].length() && *script_.contents[i].rbegin() == ':')
+            if (script_.contents[ii].length() && *script_.contents[ii].rbegin() == ':')
             {
                 scriptString += " ";
             }
@@ -2644,14 +2644,11 @@ void editorrender()
     // Draw entities backward to remain accurate with ingame
     for (int i = edentity.size() - 1; i >= 0; i--)
     {
-        //if() on screen
-        int tx=(edentity[i].x-(edentity[i].x%40))/40;
-        int ty=(edentity[i].y-(edentity[i].y%30))/30;
-
         point tpoint;
         SDL_Rect drawRect;
 
-        if(tx==ed.levx && ty==ed.levy)
+        //if() on screen
+        if(edentity[i].x % 40 == ed.levx && edentity[i].y % 30 == ed.levy)
         {
             switch(edentity[i].t)
             {
@@ -2928,9 +2925,7 @@ void editorrender()
         //Need to also check warp point destinations
         if(edentity[i].t==13 && ed.warpent!=i)
         {
-            tx=(edentity[i].p1-(edentity[i].p1%40))/40;
-            ty=(edentity[i].p2-(edentity[i].p2%30))/30;
-            if(tx==ed.levx && ty==ed.levy)
+            if (edentity[i].p1 % 40 == ed.levx && edentity[i].p2 % 30 == ed.levy)
             {
                 graphics.drawsprite((edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8),18+(ed.entframe%2),64,64,64);
                 fillboxabs((edentity[i].p1*8)- (ed.levx*40*8),(edentity[i].p2*8)- (ed.levy*30*8),16,16,graphics.getRGB(64,64,96));


### PR DESCRIPTION
In C++, when you have two variables in different scopes with the same name, the inner scope wins. Except you have to be really careful because sometimes they're not (#507). So it's better to just always have unique variable names and make sure to never clash a name with a variable in an outer scope - after all, the C++ compiler and standard might be fine with it, but that doesn't mean humans can't make mistakes reading or writing it.

Usually I just renamed the inner variables, but for `tx`/`ty` in `editor.cpp`, I just got rid of the ridiculous overcomplicated modulo calculations and replaced them with actual simple modulo calculations, because the existing ones were just ridiculous. Actually, somebody ought to find every instance of the overcomplicated modulos and replace them with the actual good ones, because it's really stupid, quite frankly...

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
