### PR TITLE
Fix conveyor check in entityclass::collisioncheck() always being true

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4674,7 +4674,7 @@ void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
         }
         break;
     case 2:   //Moving platforms
-        if (entities[j].behave >= 8 || entities[j].behave < 10)
+        if (entities[j].behave >= 8 && entities[j].behave < 10)
         {
             //We don't want conveyors, moving platforms only
             break;


### PR DESCRIPTION
`cppcheck` said: "Logical disjunction always evaluates to true".

Yes. Yes it does. Whoops. I learned how to specify ranges like this in high school math and still screw it up...

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
