### PR TITLE
Merge music.fadeoutqueuesong system into music.nicechange system, fix more music code not accounting for dynamic number of MMMMMM tracks

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5925,7 +5925,7 @@ std::string Game::writemaingamesave(tinyxml2::XMLDocument& doc)
 
     //Special stats
 
-    if(music.nicefade==1)
+    if (music.nicefade)
     {
         xml::update_tag(msgs, "currentsong", music.nicechange);
     }
@@ -6058,7 +6058,7 @@ bool Game::customsavequick(std::string savfile)
 
     //Special stats
 
-    if(music.nicefade==1)
+    if (music.nicefade)
     {
         xml::update_tag(msgs, "currentsong", music.nicechange );
     }

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -298,7 +298,7 @@ void musicclass::processmusic()
 void musicclass::niceplay(int t)
 {
 	// important: do nothing if the correct song is playing!
-	if((!mmmmmm && currentsong!=t) || (mmmmmm && usingmmmmmm && currentsong!=t) || (mmmmmm && !usingmmmmmm && currentsong!=t+16))
+	if((!mmmmmm && currentsong!=t) || (mmmmmm && usingmmmmmm && currentsong!=t) || (mmmmmm && !usingmmmmmm && currentsong!=t+num_mmmmmm_tracks))
 	{
 		if(currentsong!=-1)
 		{

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -139,7 +139,7 @@ void musicclass::init()
 	nicechange = -1;
 	nicefade = false;
 	resumesong = 0;
-	dontquickfade = false;
+	quick_fade = true;
 
 	songStart = 0;
 	songEnd = 0;
@@ -204,13 +204,13 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 					nicechange = t;
 					nicefade = true;
 					currentsong = -1;
-					if (!dontquickfade)
+					if (quick_fade)
 					{
 						Mix_FadeOutMusic(500); // fade out quicker
 					}
 					else
 					{
-						dontquickfade = false;
+						quick_fade = true;
 					}
 				}
 				else if(Mix_FadeInMusicPos(musicTracks[t].m_music, -1, fadein_ms, position_sec)==-1)
@@ -260,10 +260,11 @@ void musicclass::fadeMusicVolumeIn(int ms)
 	FadeVolAmountPerFrame =  MIX_MAX_VOLUME / (ms / 33);
 }
 
-void musicclass::fadeout()
+void musicclass::fadeout(const bool quick_fade_ /*= true*/)
 {
 	Mix_FadeOutMusic(2000);
 	resumesong = currentsong;
+	quick_fade = quick_fade_;
 }
 
 void musicclass::processmusicfadein()
@@ -303,8 +304,7 @@ void musicclass::niceplay(int t)
 	{
 		if(currentsong!=-1)
 		{
-			dontquickfade = true;
-			fadeout();
+			fadeout(false);
 		}
 		nicefade = true;
 		nicechange = t;

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -189,7 +189,7 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 				currentsong = -1;
 				return;
 			}
-			if (currentsong == 0 || currentsong == 7 || (!map.custommode && (currentsong == 0+num_pppppp_tracks || currentsong == 7+num_pppppp_tracks)))
+			if (currentsong == 0 || currentsong == 7 || (!map.custommode && (currentsong == 0+num_mmmmmm_tracks || currentsong == 7+num_mmmmmm_tracks)))
 			{
 				// Level Complete theme, no fade in or repeat
 				if(Mix_FadeInMusicPos(musicTracks[t].m_music, 0, 0, position_sec)==-1)

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -139,7 +139,6 @@ void musicclass::init()
 	nicechange = -1;
 	nicefade = false;
 	resumesong = 0;
-	fadeoutqueuesong = -1;
 	dontquickfade = false;
 
 	songStart = 0;
@@ -199,14 +198,20 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 			}
 			else
 			{
-				if (Mix_FadingMusic() == MIX_FADING_OUT) {
+				if (Mix_FadingMusic() == MIX_FADING_OUT)
+				{
 					// We're already fading out
-					fadeoutqueuesong = t;
+					nicechange = t;
+					nicefade = true;
 					currentsong = -1;
 					if (!dontquickfade)
+					{
 						Mix_FadeOutMusic(500); // fade out quicker
+					}
 					else
+					{
 						dontquickfade = false;
+					}
 				}
 				else if(Mix_FadeInMusicPos(musicTracks[t].m_music, -1, fadein_ms, position_sec)==-1)
 				{
@@ -275,11 +280,6 @@ void musicclass::processmusic()
 	if(!safeToProcessMusic)
 	{
 		return;
-	}
-
-	if (fadeoutqueuesong != -1 && Mix_PlayingMusic() == 0) {
-		play(fadeoutqueuesong);
-		fadeoutqueuesong = -1;
 	}
 
 	if (nicefade && Mix_PlayingMusic() == 0)

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -137,7 +137,7 @@ void musicclass::init()
 
 	currentsong = 0;
 	nicechange = 0;
-	nicefade = 0;
+	nicefade = false;
 	resumesong = 0;
 	fadeoutqueuesong = -1;
 	dontquickfade = false;
@@ -282,10 +282,11 @@ void musicclass::processmusic()
 		fadeoutqueuesong = -1;
 	}
 
-	if (nicefade == 1 && Mix_PlayingMusic() == 0)
+	if (nicefade && Mix_PlayingMusic() == 0)
 	{
 		play(nicechange);
-		nicechange = -1; nicefade = 0;
+		nicechange = -1;
+		nicefade = false;
 	}
 
 	if(m_doFadeInVol)
@@ -305,7 +306,7 @@ void musicclass::niceplay(int t)
 			dontquickfade = true;
 			fadeout();
 		}
-		nicefade = 1;
+		nicefade = true;
 		nicechange = t;
 	}
 }

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -136,7 +136,7 @@ void musicclass::init()
 	FadeVolAmountPerFrame = 0;
 
 	currentsong = 0;
-	nicechange = 0;
+	nicechange = -1;
 	nicefade = false;
 	resumesong = 0;
 	fadeoutqueuesong = -1;

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -18,7 +18,7 @@ public:
 	void haltdasmusik();
 	void silencedasmusik();
 	void fadeMusicVolumeIn(int ms);
-	void fadeout();
+	void fadeout(const bool quick_fade_ = true);
 	void fadein();
 	void processmusicfadein();
 	void processmusic();
@@ -43,7 +43,7 @@ public:
 	int FadeVolAmountPerFrame;
 	int musicVolume;
 
-	bool dontquickfade;
+	bool quick_fade;
 
 	// MMMMMM mod settings
 	bool mmmmmm;

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -37,7 +37,7 @@ public:
 	bool safeToProcessMusic;
 
 	int nicechange;
-	int nicefade;
+	bool nicefade;
 
 	bool m_doFadeInVol;
 	int FadeVolAmountPerFrame;

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -36,14 +36,13 @@ public:
 	SoundSystem soundSystem;
 	bool safeToProcessMusic;
 
-	int nicechange;
+	int nicechange; // -1 if no song queued
 	bool nicefade;
 
 	bool m_doFadeInVol;
 	int FadeVolAmountPerFrame;
 	int musicVolume;
 
-	int fadeoutqueuesong; // -1 if no song queued
 	bool dontquickfade;
 
 	// MMMMMM mod settings

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -284,8 +284,7 @@ void scriptclass::run()
 			}
 			if (words[0] == "musicfadeout")
 			{
-				music.fadeout();
-				music.dontquickfade = true;
+				music.fadeout(false);
 			}
 			if (words[0] == "musicfadein")
 			{


### PR DESCRIPTION
The cause of #390 is the `music.fadeoutqueuesong` system stepping on the toes of the `music.nicechange` system, when they both do basically the same thing. So `music.fadeoutqueuesong` has been removed in favor of using `music.nicechange`, which fixes #390.

Also, I fixed some code that didn't properly account for being able to have a number of MMMMMM tracks that *wasn't* 16 (yet again, sigh...). And fixed some style.

Fixes #390.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
