### PR TITLE
Fix ACTION press processing on the same frame as the fade to the title screen ticks to 0

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2157,7 +2157,7 @@ void mapinput()
     }
 
     if(graphics.menuoffset==0
-    && ((!game.glitchrunnermode && game.fadetomenudelay <= 0 && game.fadetolabdelay <= 0)
+    && ((!game.glitchrunnermode && !game.fadetomenu && game.fadetomenudelay <= 0 && !game.fadetolab && game.fadetolabdelay <= 0)
     || graphics.fademode == 0))
     {
         if (graphics.flipmode)


### PR DESCRIPTION
Here's what causes #401: After the fade to menu delay ticks down to 0, the game calls `game.quittomenu()`, but the rest of `mapinput()` still executes. This means that the block that detects your ACTION press gets executed, because there's a check that `fadetomenudelay` is less than or equal to 0, and, well, it is.

So if you've pressed ACTION on the exact frame that it counts down to 0, then the game detects your ACTION press, then processes it accordingly, and then sets the `fadetomenudelay`, which means it'll get reactivated the next time you open the map screen. But at this point, you get sent to TITLEMODE, because `game.quittomenu()` set `game.gamestate` accordingly. (This is why resetting `game.fadetomenu` or `game.fadetomenudelay` in `game.quittomenu()` or `script.hardreset()` won't fix this bug.)

The solution here is to add a `game.fadetomenu` check to the ACTION press processing.

Same-frame state transition logic is hard... actually, any sort of thing where two things happen on the same frame is really annoying.

This also applies to `fadetolab` and `fadetolabdelay`, too.

Fixes #401.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
