### PR TITLE
Add x-room = 13 check to entity 1 `behave` 13

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2361,7 +2361,7 @@ bool entityclass::updateentities( int i )
                     {
                         return removeentity(i);
                     }
-                    if (game.roomy == 108)
+                    if (game.roomx == 113 && game.roomy == 108)
                     {
                         if (entities[i].yp <= 60)
                         {


### PR DESCRIPTION
This check is clearly meant for destroying the factory clouds in the room "Level Complete!" in the main game, but it covers all rooms on row 8, instead of only (13,8). Adding an x-room check restricts this behavior to only (13,8).

Trinket9 reported that this weird behavior of destroying specifically above y-position 60 was undesirable, since they were creating an enemy with this `behave` in a room on row 8 and it kept disappearing instantly.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
