### PR TITLE
Use SDL_fmodf() instead of libc fmodf()

### DIFF
--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -435,7 +435,7 @@ void inline deltaloop()
 
     while (accumulator >= timesteplimit)
     {
-        accumulator = fmodf(accumulator, timesteplimit);
+        accumulator = SDL_fmodf(accumulator, timesteplimit);
 
         fixedloop();
     }


### PR DESCRIPTION
Just a small thing I noticed when working on fixing #464. It's always good to use the SDL stdlib where possible.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
