### PR TITLE
Fix game loop order to what it was in 2.2

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -125,6 +125,7 @@ SET(VVV_SRC
 	src/WarpClass.cpp
 	src/XMLUtils.cpp
 	src/main.cpp
+	src/DeferCallbacks.c
 	src/Network.c
 	src/ThirdPartyDeps.c
 )

--- a/desktop_version/src/DeferCallbacks.c
+++ b/desktop_version/src/DeferCallbacks.c
@@ -1,0 +1,84 @@
+#include "DeferCallbacks.h"
+
+#include <SDL.h>
+
+/* Callbacks to be deferred to the end of each sequence of gamestate functions
+ * in main. Useful for fixing frame-flicker glitches when doing a state
+ * transition in a function that gets executed before the render function.
+ *
+ * We store a linked list of callbacks, to allow for the possibility of having
+ * more than one callback active at a time (otherwise we could easily just
+ * have a single pointer here and the header would only be 1 line and an
+ * include guard) and to do it without having to allocate memory at runtime.
+ */
+
+static struct DEFER_Callback* head = NULL;
+
+/* Add a callback. Don't call this directly; use the DEFER_CALLBACK macro. */
+void DEFER_add_callback(struct DEFER_Callback* callback)
+{
+    struct DEFER_Callback* node;
+
+    /* Are we adding the first node? */
+    if (head == NULL)
+    {
+        head = callback;
+        return;
+    }
+
+    /* Time to walk the linked list */
+    node = head;
+
+    if (node == callback)
+    {
+        goto fail;
+    }
+
+    while (node->next != NULL)
+    {
+        node = node->next;
+
+        if (node == callback)
+        {
+            goto fail;
+        }
+    }
+
+    /* We're at the end */
+    node->next = callback;
+
+    /* Success! */
+    return;
+
+fail:
+    /* Having multiple instances of a callback isn't well-defined
+     * and is a bit complicated to reason about */
+    SDL_assert(0 && "Duplicate callback added!");
+}
+
+/* Call each callback in the list, along with deleting the entire list. */
+void DEFER_execute_callbacks(void)
+{
+    struct DEFER_Callback* node = head;
+    struct DEFER_Callback* next;
+
+    head = NULL;
+
+    if (node == NULL)
+    {
+        return;
+    }
+
+    next = node->next;
+    node->func();
+    node->next = NULL;
+
+    while (next != NULL)
+    {
+        node = next;
+        next = node->next;
+
+        node->func();
+        node->next = NULL;
+    }
+}

--- a/desktop_version/src/DeferCallbacks.h
+++ b/desktop_version/src/DeferCallbacks.h
@@ -1,0 +1,31 @@
+#ifndef DEFERCALLBACKS_H
+#define DEFERCALLBACKS_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+struct DEFER_Callback
+{
+    void (*func)(void);
+    struct DEFER_Callback* next;
+};
+
+void DEFER_add_callback(struct DEFER_Callback* callback);
+
+void DEFER_execute_callbacks(void);
+
+#define DEFER_CALLBACK(FUNC) \
+    do \
+    { \
+        static struct DEFER_Callback callback = {FUNC, NULL}; \
+        \
+        DEFER_add_callback(&callback); \
+    } while (0)
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* DEFERCALLBACKS_H */

--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -46,6 +46,8 @@ void entclass::clear(void)
 	gravity = false;
 	onground = 0;
 	onroof = 0;
+	visualonground = 0;
+	visualonroof = 0;
 
 	onentity = 0;
 	harmful = false;

--- a/desktop_version/src/Ent.h
+++ b/desktop_version/src/Ent.h
@@ -49,6 +49,7 @@ public:
     int onground, onroof;
     //Animation
     int framedelay, drawframe, walkingframe, dir, actionframe;
+    int visualonground, visualonroof;
     int yp;int xp;
 
     Uint32 realcol;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -3379,7 +3379,7 @@ void entityclass::animateentities( int _i )
                 entities[_i].drawframe=entities[_i].tile+3;
             }
 
-            if(entities[_i].onground>0 || entities[_i].onroof>0)
+            if(entities[_i].visualonground>0 || entities[_i].visualonroof>0)
             {
                 if(entities[_i].vx > 0.00f || entities[_i].vx < -0.00f)
                 {
@@ -3393,9 +3393,9 @@ void entityclass::animateentities( int _i )
                     entities[_i].drawframe += entities[_i].walkingframe + 1;
                 }
 
-                if (entities[_i].onroof > 0) entities[_i].drawframe += 6;
+                if (entities[_i].visualonroof > 0) entities[_i].drawframe += 6;
                 // Stuck in a wall? Then default to gravitycontrol
-                if (entities[_i].onground > 0 && entities[_i].onroof > 0
+                if (entities[_i].visualonground > 0 && entities[_i].visualonroof > 0
                 && game.gravitycontrol == 0)
                 {
                     entities[_i].drawframe -= 6;
@@ -3639,7 +3639,7 @@ void entityclass::animateentities( int _i )
                 entities[_i].drawframe=entities[_i].tile+3;
             }
 
-            if(entities[_i].onground>0 || entities[_i].onroof>0)
+            if(entities[_i].visualonground>0 || entities[_i].visualonroof>0)
             {
                 if(entities[_i].vx > 0.0000f || entities[_i].vx < -0.000f)
                 {
@@ -3653,7 +3653,7 @@ void entityclass::animateentities( int _i )
                     entities[_i].drawframe += entities[_i].walkingframe + 1;
                 }
 
-                //if (entities[_i].onroof > 0) entities[_i].drawframe += 6;
+                //if (entities[_i].visualonroof > 0) entities[_i].drawframe += 6;
             }
             else
             {
@@ -4489,12 +4489,14 @@ void entityclass::movingplatformfix( int t, int j )
                     entities[j].yp = entities[t].yp + entities[t].h;
                     entities[j].vy = 0;
                     entities[j].onroof = 2;
+                    entities[j].visualonroof = entities[j].onroof;
                 }
                 else
                 {
                     entities[j].yp = entities[t].yp - entities[j].h-entities[j].cy;
                     entities[j].vy = 0;
                     entities[j].onground = 2;
+                    entities[j].visualonground = entities[j].onground;
                 }
             }
             else

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2108,72 +2108,6 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
     }
 
     entity.drawframe = entity.tile;
-    if (!entity.invis)
-    {
-        entity.updatecolour();
-    }
-    if (entity.type == 1)
-    {
-        switch (entity.animate)
-        {
-        case 0: // Simple Loop
-        case 1: // Simple Loop
-        case 2: // Simpler Loop (just two frames)
-        case 5: // Simpler Loop (just two frames) (slower)
-        case 7: // Simpler Loop (just two frames) (slower) (with directions!)
-        case 11: // Conveyor right
-            entity.drawframe++;
-            break;
-        case 3: // Simpler Loop (just two frames, but double sized)
-        case 4: // Simpler Loop (just two frames, but double sized) (as above, but slower)
-        case 6: // Normal Loop (four frames, double sized)
-            entity.drawframe += 2;
-            break;
-        case 10: // Conveyor left
-            entity.drawframe += 3;
-            break;
-        default:
-            break;
-        }
-    }
-    else if (entity.type == 2 && entity.animate == 2)
-    {
-        entity.drawframe++;
-    }
-    // Make sure our crewmates are facing the player if applicable
-    // Also make sure they're flipped if they're flipped
-    // FIXME: Duplicated from updateentities!
-    if (entity.rule == 6 || entity.rule == 7)
-    {
-        if (entity.tile == 144 || entity.tile == 144+6)
-        {
-            entity.drawframe = 144;
-        }
-        if (entity.state == 18)
-        {
-            // Face the player
-            // FIXME: Duplicated from updateentities!
-            int j = getplayer();
-            if (INBOUNDS_VEC(j, entities) && entities[j].xp > entity.xp + 5)
-            {
-                entity.dir = 1;
-            }
-            else if (INBOUNDS_VEC(j, entities) && entities[j].xp < entity.xp - 5)
-            {
-                entity.dir = 0;
-            }
-        }
-        // Fix drawframe
-        // FIXME: Duplicated from animateentities!
-        if (entity.rule == 7)
-        {
-            entity.drawframe += 6;
-        }
-        if (entity.dir == 0)
-        {
-            entity.drawframe += 3;
-        }
-    }
 
     if (!reuse)
     {
@@ -3029,7 +2963,6 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 18)
             {
                 //Stand still and face the player
-                //FIXME: Duplicated in createentity!
                 int j = getplayer();
                 if (INBOUNDS_VEC(j, entities) && entities[j].xp > entities[i].xp + 5)
                 {
@@ -3678,7 +3611,6 @@ void entityclass::animateentities( int _i )
         case 12:
         case 55:
         case 14: //Crew member! Very similar to hero
-            //FIXME: Duplicated in createentity!
             entities[_i].framedelay--;
             if(entities[_i].dir==1)
             {

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2113,6 +2113,24 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
     {
         entities.push_back(entity);
     }
+
+    /* Fix crewmate facing directions
+     * This is a bit kludge-y but it's better than copy-pasting
+     * and is okay to do because entity 12 does not change state on its own
+     */
+    if (entity.type == 12)
+    {
+        size_t indice;
+        if (reuse)
+        {
+            indice = entptr - entities.data();
+        }
+        else
+        {
+            indice = entities.size() - 1;
+        }
+        updateentities(indice);
+    }
 }
 
 //Returns true if entity is removed

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7097,6 +7097,11 @@ static void returntoedsettings(void)
 }
 #endif
 
+static void nextbgcolor(void)
+{
+    map.nexttowercolour();
+}
+
 void Game::returntoingame(void)
 {
     ingame_titlemode = false;
@@ -7120,6 +7125,7 @@ void Game::returntoingame(void)
             obj.flags[73] = true;
         }
     }
+    DEFER_CALLBACK(nextbgcolor);
 }
 
 void Game::unlockAchievement(const char *name) {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7083,6 +7083,12 @@ void Game::returntoeditor(void)
 }
 #endif
 
+static void returntoingametemp(void)
+{
+    extern Game game;
+    game.returntomenu(game.kludge_ingametemp);
+}
+
 void Game::returntoingame(void)
 {
     ingame_titlemode = false;
@@ -7098,7 +7104,7 @@ void Game::returntoingame(void)
     else
 #endif
     {
-        returntomenu(kludge_ingametemp);
+        DEFER_CALLBACK(returntoingametemp);
         gamestate = MAPMODE;
         graphics.flipmode = graphics.setflipmode;
         if (!map.custommode && !graphics.flipmode)

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7089,6 +7089,14 @@ static void returntoingametemp(void)
     game.returntomenu(game.kludge_ingametemp);
 }
 
+#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
+static void returntoedsettings(void)
+{
+    extern Game game;
+    game.returntomenu(Menu::ed_settings);
+}
+#endif
+
 void Game::returntoingame(void)
 {
     ingame_titlemode = false;
@@ -7097,7 +7105,7 @@ void Game::returntoingame(void)
     if (ingame_editormode)
     {
         ingame_editormode = false;
-        returntomenu(Menu::ed_settings);
+        DEFER_CALLBACK(returntoedsettings);
         gamestate = EDITORMODE;
         ed.settingskey = true;
     }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <tinyxml2.h>
 
+#include "DeferCallbacks.h"
 #include "editor.h"
 #include "Entity.h"
 #include "Enums.h"
@@ -364,10 +365,6 @@ void Game::init(void)
     fadetomenudelay = 0;
     fadetolab = false;
     fadetolabdelay = 0;
-
-#if !defined(NO_CUSTOM_LEVELS)
-    shouldreturntoeditor = false;
-#endif
 
     over30mode = false;
     glitchrunnermode = false;
@@ -1887,7 +1884,7 @@ void Game::updatestate(void)
                 }
                 else
                 {
-                    shouldreturntoeditor = true;
+                    returntoeditor();
                     if(!muted && ed.levmusic>0) music.fadeMusicVolumeIn(3000);
                     if(ed.levmusic>0) music.fadeout();
                 }
@@ -7049,6 +7046,11 @@ void Game::returntolab(void)
 }
 
 #if !defined(NO_CUSTOM_LEVELS)
+static void resetbg(void)
+{
+    graphics.backgrounddrawn = false;
+}
+
 void Game::returntoeditor(void)
 {
     gamestate = EDITORMODE;
@@ -7067,7 +7069,7 @@ void Game::returntoeditor(void)
     ed.notedelay = 0;
     ed.roomnamehide = 0;
 
-    graphics.backgrounddrawn=false;
+    DEFER_CALLBACK(resetbg);
     music.fadeout();
     //If warpdir() is used during playtesting, we need to set it back after!
     for (int j = 0; j < ed.maxheight; j++)

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -428,7 +428,6 @@ public:
 
 #if !defined(NO_CUSTOM_LEVELS)
     void returntoeditor(void);
-    bool shouldreturntoeditor;
 #endif
 
     int gametimer;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -8,6 +8,7 @@
 #include "Entity.h"
 #include "Exit.h"
 #include "FileSystemUtils.h"
+#include "GraphicsUtil.h"
 #include "Map.h"
 #include "Music.h"
 #include "Screen.h"
@@ -3043,6 +3044,32 @@ void Graphics::renderwithscreeneffects(void)
 	else
 	{
 		render();
+	}
+}
+
+void Graphics::renderfixedpre(void)
+{
+	if (game.screenshake > 0)
+	{
+		updatescreenshake();
+	}
+
+	if (screenbuffer != NULL && screenbuffer->badSignalEffect)
+	{
+		UpdateFilter();
+	}
+}
+
+void Graphics::renderfixedpost(void)
+{
+	/* Screen effects timers */
+	if (game.flashlight > 0)
+	{
+		--game.flashlight;
+	}
+	if (game.screenshake > 0)
+	{
+		--game.screenshake;
 	}
 }
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1518,7 +1518,7 @@ void Graphics::drawgravityline( int t )
         return;
     }
 
-    if (obj.entities[t].life == 0 || obj.entities[t].onentity == 1) // FIXME: Remove 'onentity == 1' when game loop order is fixed!
+    if (obj.entities[t].life == 0)
     {
         switch(linestate)
         {

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -130,6 +130,8 @@ public:
 
 	void render(void);
 	void renderwithscreeneffects(void);
+	void renderfixedpre(void);
+	void renderfixedpost(void);
 
 	bool Hitest(SDL_Surface* surface1, point p1, SDL_Surface* surface2, point p2);
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1779,7 +1779,7 @@ void gameinput(void)
             }else if(game.activetele && game.readytotele > 20 && game.press_map){
                 //pass, let code block below handle it
             }else{
-                game.shouldreturntoeditor = true;
+                game.returntoeditor();
                 game.mapheld = true;
             }
         }

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1638,10 +1638,9 @@ void titleinput(void)
                 else
                 {
                     game.returnmenu();
+                    map.nexttowercolour();
                 }
             }
-
-            map.nexttowercolour();
         }
 
         if(game.menustart)

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -11,7 +11,6 @@
 #include "MakeAndPlay.h"
 #include "Map.h"
 #include "Music.h"
-#include "RenderFixed.h"
 #include "Script.h"
 #include "UtilityClass.h"
 
@@ -2350,10 +2349,6 @@ static void mapmenuactionpress(void)
         }
 
         map.nexttowercolour();
-
-        // Fix delta rendering glitch
-        graphics.updatetowerbackground(graphics.titlebg);
-        titleupdatetextcol();
         break;
     }
 }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1577,11 +1577,4 @@ void gamelogic(void)
 
     if (game.teleport_to_new_area)
         script.teleport();
-
-#if !defined(NO_CUSTOM_LEVELS)
-    if (game.shouldreturntoeditor)
-    {
-        game.returntoeditor();
-    }
-#endif
 }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -130,6 +130,32 @@ void gamelogic(void)
         obj.entities[i].lerpoldyp = obj.entities[i].yp;
     }}
 
+    if (!game.blackout && !game.completestop)
+    {
+        size_t i;
+        for (i = 0; i < obj.entities.size(); ++i)
+        {
+            /* Is this entity on the ground? (needed for jumping) */
+            if (obj.entitycollidefloor(i))
+            {
+                obj.entities[i].onground = 2;
+            }
+            else
+            {
+                --obj.entities[i].onground;
+            }
+
+            if (obj.entitycollideroof(i))
+            {
+                obj.entities[i].onroof = 2;
+            }
+            else
+            {
+                --obj.entities[i].onroof;
+            }
+        }
+    }
+
     //Misc
     if (map.towermode)
     {

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -123,6 +123,13 @@ void gamecompletelogic2(void)
 
 void gamelogic(void)
 {
+    /* Update old lerp positions of entities */
+    {size_t i; for (i = 0; i < obj.entities.size(); ++i)
+    {
+        obj.entities[i].lerpoldxp = obj.entities[i].xp;
+        obj.entities[i].lerpoldyp = obj.entities[i].yp;
+    }}
+
     //Misc
     if (map.towermode)
     {

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -2075,6 +2075,4 @@ void mapclass::twoframedelayfix(void)
 	game.state = 0;
 	game.statedelay = 0;
 	script.load(game.newscript);
-	script.run();
-	script.dontrunnextframe = true;
 }

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1408,14 +1408,6 @@ void mapclass::loadlevel(int rx, int ry)
 
 		graphics.rcol = 6;
 		changefinalcol(final_mapcol);
-		for (size_t i = 0; i < obj.entities.size(); i++)
-		{
-			if (obj.entities[i].type == 1 || obj.entities[i].type == 2)
-			{
-				//Fix 1-frame glitch
-				obj.entities[i].drawframe = obj.entities[i].tile;
-			}
-		}
 		break;
 	}
 	case 7: //Final Level, Tower 1

--- a/desktop_version/src/RenderFixed.cpp
+++ b/desktop_version/src/RenderFixed.cpp
@@ -45,6 +45,9 @@ void gamerenderfixed(void)
                 obj.entities[i].onroof--;
             }
 
+            obj.entities[i].visualonground = obj.entities[i].onground;
+            obj.entities[i].visualonroof = obj.entities[i].onroof;
+
             //Animate the entities
             obj.animateentities(i);
         }

--- a/desktop_version/src/RenderFixed.cpp
+++ b/desktop_version/src/RenderFixed.cpp
@@ -26,27 +26,23 @@ void gamerenderfixed(void)
     {
         for (size_t i = 0; i < obj.entities.size(); i++)
         {
-            //Is this entity on the ground? (needed for jumping)
             if (obj.entitycollidefloor(i))
             {
-                obj.entities[i].onground = 2;
+                obj.entities[i].visualonground = 2;
             }
             else
             {
-                obj.entities[i].onground--;
+                --obj.entities[i].visualonground;
             }
 
             if (obj.entitycollideroof(i))
             {
-                obj.entities[i].onroof = 2;
+                obj.entities[i].visualonroof = 2;
             }
             else
             {
-                obj.entities[i].onroof--;
+                --obj.entities[i].visualonroof;
             }
-
-            obj.entities[i].visualonground = obj.entities[i].onground;
-            obj.entities[i].visualonroof = obj.entities[i].onroof;
 
             //Animate the entities
             obj.animateentities(i);

--- a/desktop_version/src/RenderFixed.cpp
+++ b/desktop_version/src/RenderFixed.cpp
@@ -7,7 +7,7 @@
 #include "Script.h"
 #include "UtilityClass.h"
 
-void titleupdatetextcol(void)
+static inline void titleupdatetextcol(void)
 {
     graphics.col_tr = graphics.titlebg.r - (help.glow / 4) - int(fRandom() * 4);
     graphics.col_tg = graphics.titlebg.g - (help.glow / 4) - int(fRandom() * 4);

--- a/desktop_version/src/RenderFixed.h
+++ b/desktop_version/src/RenderFixed.h
@@ -1,8 +1,6 @@
 #ifndef RENDERFIXED_H
 #define RENDERFIXED_H
 
-void titleupdatetextcol(void);
-
 void gamerenderfixed(void);
 
 void titlerenderfixed(void);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -305,6 +305,8 @@ void scriptclass::run(void)
 				{
 					obj.entities[player].xp = ss_toi(words[1]);
 					obj.entities[player].yp = ss_toi(words[2]);
+					obj.entities[player].lerpoldxp = obj.entities[player].xp;
+					obj.entities[player].lerpoldyp = obj.entities[player].yp;
 				}
 				game.gravitycontrol = ss_toi(words[3]);
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -106,6 +106,8 @@ void scriptclass::run(void)
 				{
 					obj.entities[player].xp += ss_toi(words[1]);
 					obj.entities[player].yp += ss_toi(words[2]);
+					obj.entities[player].lerpoldxp = obj.entities[player].xp;
+					obj.entities[player].lerpoldyp = obj.entities[player].yp;
 				}
 				scriptdelay = 1;
 			}

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -18,7 +18,6 @@ scriptclass::scriptclass(void)
 	position = 0;
 	scriptdelay = 0;
 	running = false;
-	dontrunnextframe = false;
 
 	b = 0;
 	g = 0;
@@ -3494,10 +3493,6 @@ void scriptclass::teleport(void)
 		game.state = 0;
 		load(game.teleportscript);
 		game.teleportscript = "";
-
-		// FIXME: Remove this once game loop order is fixed in 2.4!
-		run();
-		dontrunnextframe = true;
 	}
 	else
 	{

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -54,7 +54,7 @@ public:
     int looppoint, loopcount;
 
     int scriptdelay;
-    bool running, dontrunnextframe;
+    bool running;
 
     //Textbox stuff
     int textx;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -9,6 +9,7 @@
 #include <tinyxml2.h>
 #include <utf8/unchecked.h>
 
+#include "DeferCallbacks.h"
 #include "Entity.h"
 #include "Enums.h"
 #include "FileSystemUtils.h"
@@ -3669,6 +3670,20 @@ void editorlogic(void)
     }
 }
 
+static void creategraphicoptions(void)
+{
+    game.createmenu(Menu::graphicoptions);
+}
+
+static void creategameoptions(void)
+{
+    game.createmenu(Menu::options);
+}
+
+static void nextbgcolor(void)
+{
+    map.nexttowercolour();
+}
 
 static void editormenuactionpress(void)
 {
@@ -3768,14 +3783,14 @@ static void editormenuactionpress(void)
 
             if (game.currentmenuoption == 6)
             {
-                game.createmenu(Menu::graphicoptions);
+                DEFER_CALLBACK(creategraphicoptions);
             }
             else
             {
-                game.createmenu(Menu::options);
+                DEFER_CALLBACK(creategameoptions);
             }
 
-            map.nexttowercolour();
+            DEFER_CALLBACK(nextbgcolor);
             break;
         default:
             music.playef(11);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2419,11 +2419,6 @@ static void editormenurender(int tr, int tg, int tb)
 void editorrender(void)
 {
     extern editorclass ed;
-    if (game.shouldreturntoeditor)
-    {
-        graphics.backgrounddrawn = false;
-    }
-
     //Draw grid
 
     ClearSurface(graphics.backBuffer);
@@ -3646,11 +3641,6 @@ void editorlogic(void)
     extern editorclass ed;
     //Misc
     help.updateglow();
-
-    if (game.shouldreturntoeditor)
-    {
-        game.shouldreturntoeditor = false;
-    }
 
     graphics.titlebg.bypos -= 2;
     graphics.titlebg.bscroll = -2;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -93,18 +93,6 @@ static void runscript(void)
 
 static void gamemodefunc1(void)
 {
-    // WARNING: If updating this code, don't forget to update Map.cpp mapclass::twoframedelayfix()
-
-    // Ugh, I hate this kludge variable but it's the only way to do it
-    if (script.dontrunnextframe)
-    {
-        script.dontrunnextframe = false;
-    }
-    else
-    {
-        runscript();
-    }
-
     //Update old lerp positions of entities - has to be done BEFORE gameinput!
     for (size_t i = 0; i < obj.entities.size(); i++)
     {
@@ -158,6 +146,7 @@ static const inline struct ImplFunc* get_gamestate_funcs(
     }
 
     FUNC_LIST_BEGIN(GAMEMODE)
+        {Func_fixed, runscript},
         {Func_fixed, gamemodefunc1},
         {Func_fixed, gameinput},
         {Func_fixed, gamerenderfixed},

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -318,6 +318,9 @@ static enum LoopCode loop_run_active_funcs(void)
         }
     }
 
+    /* About to switch over to rendering... but call this first. */
+    graphics.renderfixedpre();
+
     return Loop_stop;
 }
 
@@ -682,6 +685,9 @@ static void inline deltaloop(void)
 
         accumulator = SDL_fmodf(accumulator, timesteplimit);
 
+        /* We are done rendering. */
+        graphics.renderfixedpost();
+
         fixedloop();
     }
     const float alpha = game.over30mode ? static_cast<float>(accumulator) / timesteplimit : 1.0f;
@@ -744,25 +750,11 @@ static void focused_begin(void)
 
 static void focused_end(void)
 {
-    //Screen effects timers
-    if (game.flashlight > 0)
-    {
-        game.flashlight--;
-    }
-    if (game.screenshake > 0)
-    {
-        game.screenshake--;
-        graphics.updatescreenshake();
-    }
+    /* no-op. */
 }
 
 static enum LoopCode loop_end(void)
 {
-    if (graphics.screenbuffer->badSignalEffect)
-    {
-        UpdateFilter();
-    }
-
     //We did editorinput, now it's safe to turn this off
     key.linealreadyemptykludge = false;
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -1,6 +1,7 @@
 #include <SDL.h>
 #include <stdio.h>
 
+#include "DeferCallbacks.h"
 #include "editor.h"
 #include "Enums.h"
 #include "Entity.h"
@@ -225,6 +226,9 @@ static enum IndexCode increment_gamestate_func_index(void)
             game.gamestate,
             &num_gamestate_funcs
         );
+
+        /* Also run callbacks that were deferred to end of func sequence. */
+        DEFER_execute_callbacks();
 
         gamestate_func_index = 0;
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -732,28 +732,28 @@ static enum LoopCode loop_begin(void)
 
 static void unfocused_run(void)
 {
-        Mix_Pause(-1);
-        Mix_PauseMusic();
+    Mix_Pause(-1);
+    Mix_PauseMusic();
 
-        if (!game.blackout)
-        {
-            ClearSurface(graphics.backBuffer);
-            graphics.bprint(5, 110, "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
-            graphics.bprint(5, 120, "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
-            graphics.bprint(5, 220, "Press M to mute in game", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
-            graphics.bprint(5, 230, "Press N to mute music only", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
-        }
-        graphics.render();
-        gameScreen.FlipScreen();
-        //We are minimised, so lets put a bit of a delay to save CPU
-        SDL_Delay(100);
+    if (!game.blackout)
+    {
+        ClearSurface(graphics.backBuffer);
+        graphics.bprint(5, 110, "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
+        graphics.bprint(5, 120, "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
+        graphics.bprint(5, 220, "Press M to mute in game", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+        graphics.bprint(5, 230, "Press N to mute music only", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+    }
+    graphics.render();
+    gameScreen.FlipScreen();
+    //We are minimised, so lets put a bit of a delay to save CPU
+    SDL_Delay(100);
 }
 
 static void focused_begin(void)
 {
-        Mix_Resume(-1);
-        Mix_ResumeMusic();
-        game.gametimer++;
+    Mix_Resume(-1);
+    Mix_ResumeMusic();
+    game.gametimer++;
 }
 
 static void focused_end(void)

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -139,9 +139,9 @@ static const inline struct ImplFunc* get_gamestate_funcs(
 
     FUNC_LIST_BEGIN(GAMEMODE)
         {Func_fixed, runscript},
-        {Func_input, gameinput},
         {Func_fixed, gamerenderfixed},
         {Func_delta, gamerender},
+        {Func_input, gameinput},
         {Func_fixed, gamelogic},
     FUNC_LIST_END
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -91,16 +91,6 @@ static void runscript(void)
     script.run();
 }
 
-static void gamemodefunc1(void)
-{
-    //Update old lerp positions of entities - has to be done BEFORE gameinput!
-    for (size_t i = 0; i < obj.entities.size(); i++)
-    {
-        obj.entities[i].lerpoldxp = obj.entities[i].xp;
-        obj.entities[i].lerpoldyp = obj.entities[i].yp;
-    }
-}
-
 static void teleportermodeinput(void)
 {
     if (game.useteleporter)
@@ -147,7 +137,6 @@ static const inline struct ImplFunc* get_gamestate_funcs(
 
     FUNC_LIST_BEGIN(GAMEMODE)
         {Func_fixed, runscript},
-        {Func_fixed, gamemodefunc1},
         {Func_fixed, gameinput},
         {Func_fixed, gamerenderfixed},
         {Func_delta, gamerender},


### PR DESCRIPTION
Okay, so the reason why all render functions were moved to the end of the frame in #220 is because it's simpler to call two fixed functions and then a delta function instead of one fixed function, then a delta function, and then another fixed function.

This is because fixed functions need special handling inside `deltaloop()`, and you can't simply duplicate this handling after calling a delta function. Oh, and to make matters worse, it's not always fixed-delta-fixed, sometimes (like in MAPMODE and TELEPORTERMODE) it's delta-fixed-fixed, so we'd need to handle that somehow too.

The solution here is to generalize the game loop and factor out each function, instead of hardcoding it. Instead of having hardcoded case-switches directly in the loop, I made a function that returns an array of functions for a given gamestate, along with the number of functions, then the game loop processes it accordingly. In `fixedloop()`, it iterates over the array and executes each function until it reaches a delta function, at which point it stops. And when it reaches the end of the array, it goes back to the start of the array.

But anyway, if it gets to a delta function, it'll stop the loop and finish `fixedloop()`. Then `deltaloop()` will call the delta function. And then on the next frame, the function index will be incremented again, so `fixedloop()` will call the fixed functions again.

Actually, the previous game loop was actually made up of one big loop, with a gamestate function loop nested inside it, flanked with code that ran at the start and end of the "big loop". This would be easy to handle with one loop (just include the beginning and end functions with the gamestate functions in the array), except that the gamestate functions could suddenly be swapped out with unfocused functions (the ones that run when you unfocus the window) at any time (well, on frame boundaries, since `key.isActive` only got checked once, guarding the entire "inner loop" - and I made sure that changing `key.isActive` wouldn't immediately apply, just like the previous game loop order) - so I had to add yet another layer of indirection, where the gamestate functions could immediately be swapped out with the unfocused functions (while still running the beginning and end code, because that was how the previous loop order worked, after all).

This also fixes a regression that the game loop that #220 introduced had, where if the fixed functions switched the gamestate, the game would prematurely start rendering the gamestate function of the new gamestate in the deltaframes, which was a source of some deltaframe glitches. But fixing this is likely to just as well cause deltaframe glitches, so it'd be better to fix this along with fixing the loop order, and only have one round of QA to do in the end, instead of doing one round after each change separately.

This PR fixes a bunch of regressions, including backgrounds taking 1 frame to update, Viridian's respawn animation variables being 1 frame out of sync with each other, and 1-frame glitches when going to and from in-game options from editor settings; it also removes a bunch of kludge, like the `createentity()` deltaframe kludge, or the gravity line constant-`gotoroom` kludge fix, or the fix to update entity colors whenever a room is entered in finalmode.

Fixes #464.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
