### PR TITLE
Remove in-game menu kludge that was rendered unnecessary by #522

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -377,7 +377,6 @@ void Game::init(void)
 
     ingame_titlemode = false;
     kludge_ingametemp = Menu::mainmenu;
-    shouldreturntopausemenu = false;
 
     disablepause = false;
 }
@@ -7155,7 +7154,6 @@ void Game::returntopausemenu()
     {
         obj.flags[73] = true;
     }
-    shouldreturntopausemenu = true;
 }
 
 void Game::unlockAchievement(const char *name) {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7146,8 +7146,6 @@ void Game::returntopausemenu()
     ingame_titlemode = false;
     returntomenu(kludge_ingametemp);
     gamestate = MAPMODE;
-    graphics.titlebg.tdrawback = true;
-    graphics.backgrounddrawn = false;
     mapheld = true;
     graphics.flipmode = graphics.setflipmode;
     if (!map.custommode && !graphics.flipmode)

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -433,7 +433,6 @@ public:
 
     bool ingame_titlemode;
 
-    bool shouldreturntopausemenu;
     void returntopausemenu();
     void unlockAchievement(const char *name);
 

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -87,16 +87,6 @@ void maplogic()
     graphics.updatetextboxes();
     graphics.updatetitlecolours();
 
-    if (game.shouldreturntopausemenu)
-    {
-        game.shouldreturntopausemenu = false;
-        graphics.backgrounddrawn = false;
-        if (map.background == 3 || map.background == 4)
-        {
-            graphics.updatebackground(map.background);
-        }
-    }
-
     graphics.crewframedelay--;
     if (graphics.crewframedelay <= 0)
     {


### PR DESCRIPTION
In #522 itself, I removed some of the kludge that existed before the tower, title, and warp buffers each got separated, but I forgot to remove all of them in that PR. So this PR cleans up some of the stragglers.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
