### PR TITLE
Remove unneeded graphics.titlebg assignments when going to in-game settings

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2387,9 +2387,6 @@ void mapmenuactionpress()
         }
         game.kludge_ingametemp = game.currentmenuname;
 
-        graphics.titlebg.scrolldir = 0;
-        graphics.titlebg.colstate = ((int) (graphics.titlebg.colstate / 5)) * 5;
-        graphics.titlebg.bypos = 0;
         map.nexttowercolour();
 
         // Fix delta rendering glitch


### PR DESCRIPTION
These were needed when the title and tower background shared the same buffer, but since #522 got merged, these are no longer necessary.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
