### PR TITLE
De-duplicate titleupdatetextcol() in gamecompletelogic()

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -145,15 +145,7 @@ void gamecompletelogic()
     graphics.titlebg.scrolldir = 1;
     graphics.updatetitlecolours();
 
-    graphics.col_tr = map.r - (help.glow / 4) - fRandom() * 4;
-    graphics.col_tg = map.g - (help.glow / 4) - fRandom() * 4;
-    graphics.col_tb = map.b - (help.glow / 4) - fRandom() * 4;
-    if (graphics.col_tr < 0) graphics.col_tr = 0;
-    if(graphics.col_tr>255) graphics.col_tr=255;
-    if (graphics.col_tg < 0) graphics.col_tg = 0;
-    if(graphics.col_tg>255) graphics.col_tg=255;
-    if (graphics.col_tb < 0) graphics.col_tb = 0;
-    if(graphics.col_tb>255) graphics.col_tb=255;
+    titleupdatetextcol();
 
     game.creditposition--;
     if (game.creditposition <= -Credits::creditmaxposition)


### PR DESCRIPTION
Originally this function was made because it needed to be exported to `gameinput()`, but this piece of code is actually also used in `gamecompletelogic()`. So it's good to de-duplicate it here, too.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
