### PR TITLE
Move all fixed-timestep render updates to new file RenderFixed.cpp

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -117,6 +117,7 @@ SET(VVV_SRC
 	src/Otherlevel.cpp
 	src/preloader.cpp
 	src/Render.cpp
+	src/RenderFixed.cpp
 	src/Screen.cpp
 	src/Script.cpp
 	src/Scripts.cpp

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -8,10 +8,10 @@
 #include "Game.h"
 #include "Graphics.h"
 #include "KeyPoll.h"
-#include "Logic.h"
 #include "MakeAndPlay.h"
 #include "Map.h"
 #include "Music.h"
+#include "RenderFixed.h"
 #include "Script.h"
 #include "UtilityClass.h"
 

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1,5 +1,4 @@
 #include "Credits.h"
-#include "editor.h"
 #include "Entity.h"
 #include "Enums.h"
 #include "FileSystemUtils.h"
@@ -11,19 +10,6 @@
 #include "Script.h"
 #include "UtilityClass.h"
 
-void titleupdatetextcol()
-{
-    graphics.col_tr = map.r - (help.glow / 4) - int(fRandom() * 4);
-    graphics.col_tg = map.g - (help.glow / 4) - int(fRandom() * 4);
-    graphics.col_tb = map.b - (help.glow / 4) - int(fRandom() * 4);
-    if (graphics.col_tr < 0) graphics.col_tr = 0;
-    if(graphics.col_tr>255) graphics.col_tr=255;
-    if (graphics.col_tg < 0) graphics.col_tg = 0;
-    if(graphics.col_tg>255) graphics.col_tg=255;
-    if (graphics.col_tb < 0) graphics.col_tb = 0;
-    if(graphics.col_tb>255) graphics.col_tb=255;
-}
-
 void titlelogic()
 {
     //Misc
@@ -32,31 +18,6 @@ void titlelogic()
 
     graphics.titlebg.bypos -= 2;
     graphics.titlebg.bscroll = -2;
-
-    if (!game.colourblindmode)
-    {
-        graphics.updatetowerbackground(graphics.titlebg);
-    }
-
-    if (!game.menustart)
-    {
-        graphics.col_tr = (int)(164 - (help.glow / 2) - int(fRandom() * 4));
-        graphics.col_tg = 164 - (help.glow / 2) - int(fRandom() * 4);
-        graphics.col_tb = 164 - (help.glow / 2) - int(fRandom() * 4);
-    }
-    else
-    {
-        titleupdatetextcol();
-
-        graphics.updatetitlecolours();
-    }
-
-    graphics.crewframedelay--;
-    if (graphics.crewframedelay <= 0)
-    {
-        graphics.crewframedelay = 8;
-        graphics.crewframe = (graphics.crewframe + 1) % 2;
-    }
 
     if (game.menucountdown > 0)
     {
@@ -84,55 +45,6 @@ void maplogic()
 {
     //Misc
     help.updateglow();
-    graphics.updatetextboxes();
-    graphics.updatetitlecolours();
-
-    graphics.crewframedelay--;
-    if (graphics.crewframedelay <= 0)
-    {
-        graphics.crewframedelay = 8;
-        graphics.crewframe = (graphics.crewframe + 1) % 2;
-    }
-
-    graphics.oldmenuoffset = graphics.menuoffset;
-    if (graphics.resumegamemode)
-    {
-        graphics.menuoffset += 25;
-        int threshold = map.extrarow ? 230 : 240;
-        if (graphics.menuoffset >= threshold)
-        {
-            graphics.menuoffset = threshold;
-            //go back to gamemode!
-            game.mapheld = true;
-            game.gamestate = GAMEMODE;
-        }
-    }
-    else if (graphics.menuoffset > 0)
-    {
-        graphics.menuoffset -= 25;
-        if (graphics.menuoffset < 0)
-        {
-            graphics.menuoffset = 0;
-        }
-    }
-
-    if (map.cursorstate == 0){
-        map.cursordelay++;
-        if (map.cursordelay > 10){
-            map.cursorstate = 1;
-            map.cursordelay = 0;
-        }
-    }else if (map.cursorstate == 1){
-        map.cursordelay++;
-        if (map.cursordelay > 30) map.cursorstate = 2;
-    }else if (map.cursorstate == 2){
-        map.cursordelay++;
-    }
-
-    if (map.finalmode)
-    {
-        map.glitchname = map.getglitchname(game.roomx, game.roomy);
-    }
 }
 
 
@@ -143,9 +55,6 @@ void gamecompletelogic()
     help.updateglow();
     graphics.crewframe = 0;
     graphics.titlebg.scrolldir = 1;
-    graphics.updatetitlecolours();
-
-    titleupdatetextcol();
 
     game.creditposition--;
     if (game.creditposition <= -Credits::creditmaxposition)
@@ -218,34 +127,6 @@ void gamecompletelogic2()
 
 void gamelogic()
 {
-    if (!game.blackout && !game.completestop)
-    {
-        for (size_t i = 0; i < obj.entities.size(); i++)
-        {
-            //Is this entity on the ground? (needed for jumping)
-            if (obj.entitycollidefloor(i))
-            {
-                obj.entities[i].onground = 2;
-            }
-            else
-            {
-                obj.entities[i].onground--;
-            }
-
-            if (obj.entitycollideroof(i))
-            {
-                obj.entities[i].onroof = 2;
-            }
-            else
-            {
-                obj.entities[i].onroof--;
-            }
-
-            //Animate the entities
-            obj.animateentities(i);
-        }
-    }
-
     //Misc
     if (map.towermode)
     {
@@ -1687,109 +1568,6 @@ void gamelogic()
     if (game.shouldreturntoeditor)
     {
         game.returntoeditor();
-    }
-#endif
-
-    game.prev_act_fade = game.act_fade;
-    if (INBOUNDS_VEC(game.activeactivity, obj.blocks) && game.hascontrol && !script.running)
-    {
-        if (game.act_fade < 5)
-        {
-            game.act_fade = 5;
-        }
-        if (game.act_fade < 10)
-        {
-            game.act_fade++;
-        }
-    }
-    else if (game.act_fade > 5)
-    {
-        game.act_fade--;
-    }
-
-    if (obj.trophytext > 0)
-    {
-        obj.trophytext--;
-    }
-
-    graphics.updatetextboxes();
-
-    if (!game.colourblindmode)
-    {
-        if (map.towermode)
-        {
-            graphics.updatetowerbackground(graphics.towerbg);
-        }
-        else
-        {
-            graphics.updatebackground(map.background);
-        }
-    }
-
-    if (!game.blackout)
-    {
-        //Update line colours!
-        if (graphics.linedelay <= 0)
-        {
-            graphics.linestate++;
-            if (graphics.linestate >= 10) graphics.linestate = 0;
-            graphics.linedelay = 2;
-        }
-        else
-        {
-            graphics.linedelay--;
-        }
-    }
-
-    graphics.trinketcolset = false;
-    for (int i = obj.entities.size() - 1; i >= 0; i--)
-    {
-        if (obj.entities[i].invis)
-        {
-            continue;
-        }
-
-        obj.entities[i].updatecolour();
-    }
-
-    if (map.finalmode)
-    {
-        map.glitchname = map.getglitchname(game.roomx, game.roomy);
-    }
-
-#if !defined(NO_CUSTOM_LEVELS)
-    ed.oldreturneditoralpha = ed.returneditoralpha;
-    if (map.custommode && !map.custommodeforreal && ed.returneditoralpha > 0)
-    {
-        ed.returneditoralpha -= 15;
-    }
-
-    // Editor ghosts!
-    if (game.ghostsenabled)
-    {
-        if (map.custommode && !map.custommodeforreal)
-        {
-            if (game.gametimer % 3 == 0)
-            {
-                int i = obj.getplayer();
-                GhostInfo ghost;
-                ghost.rx = game.roomx-100;
-                ghost.ry = game.roomy-100;
-                if (INBOUNDS_VEC(i, obj.entities))
-                {
-                    ghost.x = obj.entities[i].xp;
-                    ghost.y = obj.entities[i].yp;
-                    ghost.col = obj.entities[i].colour;
-                    ghost.realcol = obj.entities[i].realcol;
-                    ghost.frame = obj.entities[i].drawframe;
-                }
-                ed.ghosts.push_back(ghost);
-            }
-            if (ed.ghosts.size() > 100)
-            {
-                ed.ghosts.erase(ed.ghosts.begin());
-            }
-        }
     }
 #endif
 }

--- a/desktop_version/src/Logic.h
+++ b/desktop_version/src/Logic.h
@@ -1,8 +1,6 @@
 #ifndef LOGIC_H
 #define LOGIC_H
 
-void titleupdatetextcol();
-
 void titlelogic();
 
 void maplogic();

--- a/desktop_version/src/RenderFixed.cpp
+++ b/desktop_version/src/RenderFixed.cpp
@@ -1,0 +1,243 @@
+#include "editor.h"
+#include "Game.h"
+#include "Graphics.h"
+#include "Entity.h"
+#include "Enums.h"
+#include "Map.h"
+#include "Script.h"
+#include "UtilityClass.h"
+
+void titleupdatetextcol()
+{
+    graphics.col_tr = map.r - (help.glow / 4) - int(fRandom() * 4);
+    graphics.col_tg = map.g - (help.glow / 4) - int(fRandom() * 4);
+    graphics.col_tb = map.b - (help.glow / 4) - int(fRandom() * 4);
+    if (graphics.col_tr < 0) graphics.col_tr = 0;
+    if(graphics.col_tr>255) graphics.col_tr=255;
+    if (graphics.col_tg < 0) graphics.col_tg = 0;
+    if(graphics.col_tg>255) graphics.col_tg=255;
+    if (graphics.col_tb < 0) graphics.col_tb = 0;
+    if(graphics.col_tb>255) graphics.col_tb=255;
+}
+
+void gamerenderfixed()
+{
+    if (!game.blackout && !game.completestop)
+    {
+        for (size_t i = 0; i < obj.entities.size(); i++)
+        {
+            //Is this entity on the ground? (needed for jumping)
+            if (obj.entitycollidefloor(i))
+            {
+                obj.entities[i].onground = 2;
+            }
+            else
+            {
+                obj.entities[i].onground--;
+            }
+
+            if (obj.entitycollideroof(i))
+            {
+                obj.entities[i].onroof = 2;
+            }
+            else
+            {
+                obj.entities[i].onroof--;
+            }
+
+            //Animate the entities
+            obj.animateentities(i);
+        }
+    }
+
+    game.prev_act_fade = game.act_fade;
+    if (INBOUNDS_VEC(game.activeactivity, obj.blocks) && game.hascontrol && !script.running)
+    {
+        if (game.act_fade < 5)
+        {
+            game.act_fade = 5;
+        }
+        if (game.act_fade < 10)
+        {
+            game.act_fade++;
+        }
+    }
+    else if (game.act_fade > 5)
+    {
+        game.act_fade--;
+    }
+
+    if (obj.trophytext > 0)
+    {
+        obj.trophytext--;
+    }
+
+    graphics.updatetextboxes();
+
+    if (!game.colourblindmode)
+    {
+        if (map.towermode)
+        {
+            graphics.updatetowerbackground(graphics.towerbg);
+        }
+        else
+        {
+            graphics.updatebackground(map.background);
+        }
+    }
+
+    if (!game.blackout)
+    {
+        //Update line colours!
+        if (graphics.linedelay <= 0)
+        {
+            graphics.linestate++;
+            if (graphics.linestate >= 10) graphics.linestate = 0;
+            graphics.linedelay = 2;
+        }
+        else
+        {
+            graphics.linedelay--;
+        }
+    }
+
+    graphics.trinketcolset = false;
+    for (int i = obj.entities.size() - 1; i >= 0; i--)
+    {
+        if (obj.entities[i].invis)
+        {
+            continue;
+        }
+
+        obj.entities[i].updatecolour();
+    }
+
+    if (map.finalmode)
+    {
+        map.glitchname = map.getglitchname(game.roomx, game.roomy);
+    }
+
+#ifndef NO_CUSTOM_LEVELS
+    ed.oldreturneditoralpha = ed.returneditoralpha;
+    if (map.custommode && !map.custommodeforreal && ed.returneditoralpha > 0)
+    {
+        ed.returneditoralpha -= 15;
+    }
+
+    // Editor ghosts!
+    if (game.ghostsenabled)
+    {
+        if (map.custommode && !map.custommodeforreal)
+        {
+            if (game.gametimer % 3 == 0)
+            {
+                int i = obj.getplayer();
+                GhostInfo ghost;
+                ghost.rx = game.roomx-100;
+                ghost.ry = game.roomy-100;
+                if (INBOUNDS_VEC(i, obj.entities))
+                {
+                    ghost.x = obj.entities[i].xp;
+                    ghost.y = obj.entities[i].yp;
+                    ghost.col = obj.entities[i].colour;
+                    ghost.realcol = obj.entities[i].realcol;
+                    ghost.frame = obj.entities[i].drawframe;
+                }
+                ed.ghosts.push_back(ghost);
+            }
+            if (ed.ghosts.size() > 100)
+            {
+                ed.ghosts.erase(ed.ghosts.begin());
+            }
+        }
+    }
+#endif
+}
+
+void titlerenderfixed()
+{
+    if (!game.colourblindmode)
+    {
+        graphics.updatetowerbackground(graphics.titlebg);
+    }
+
+    if (!game.menustart)
+    {
+        graphics.col_tr = (int)(164 - (help.glow / 2) - int(fRandom() * 4));
+        graphics.col_tg = 164 - (help.glow / 2) - int(fRandom() * 4);
+        graphics.col_tb = 164 - (help.glow / 2) - int(fRandom() * 4);
+    }
+    else
+    {
+        titleupdatetextcol();
+
+        graphics.updatetitlecolours();
+    }
+
+    graphics.crewframedelay--;
+    if (graphics.crewframedelay <= 0)
+    {
+        graphics.crewframedelay = 8;
+        graphics.crewframe = (graphics.crewframe + 1) % 2;
+    }
+}
+
+void maprenderfixed()
+{
+    graphics.updatetextboxes();
+    graphics.updatetitlecolours();
+
+    graphics.crewframedelay--;
+    if (graphics.crewframedelay <= 0)
+    {
+        graphics.crewframedelay = 8;
+        graphics.crewframe = (graphics.crewframe + 1) % 2;
+    }
+
+    graphics.oldmenuoffset = graphics.menuoffset;
+    if (graphics.resumegamemode)
+    {
+        graphics.menuoffset += 25;
+        int threshold = map.extrarow ? 230 : 240;
+        if (graphics.menuoffset >= threshold)
+        {
+            graphics.menuoffset = threshold;
+            //go back to gamemode!
+            game.mapheld = true;
+            game.gamestate = GAMEMODE;
+        }
+    }
+    else if (graphics.menuoffset > 0)
+    {
+        graphics.menuoffset -= 25;
+        if (graphics.menuoffset < 0)
+        {
+            graphics.menuoffset = 0;
+        }
+    }
+
+    if (map.cursorstate == 0){
+        map.cursordelay++;
+        if (map.cursordelay > 10){
+            map.cursorstate = 1;
+            map.cursordelay = 0;
+        }
+    }else if (map.cursorstate == 1){
+        map.cursordelay++;
+        if (map.cursordelay > 30) map.cursorstate = 2;
+    }else if (map.cursorstate == 2){
+        map.cursordelay++;
+    }
+
+    if (map.finalmode)
+    {
+        map.glitchname = map.getglitchname(game.roomx, game.roomy);
+    }
+}
+
+void gamecompleterenderfixed()
+{
+    graphics.updatetitlecolours();
+
+    titleupdatetextcol();
+}

--- a/desktop_version/src/RenderFixed.h
+++ b/desktop_version/src/RenderFixed.h
@@ -1,0 +1,14 @@
+#ifndef RENDERFIXED_H
+#define RENDERFIXED_H
+
+void titleupdatetextcol();
+
+void gamerenderfixed();
+
+void titlerenderfixed();
+
+void maprenderfixed();
+
+void gamecompleterenderfixed();
+
+#endif /* RENDERFIXED_H */

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3645,11 +3645,9 @@ void editorrender()
     graphics.render();
 }
 
-void editorlogic()
+void editorrenderfixed()
 {
     extern editorclass ed;
-    //Misc
-    help.updateglow();
     graphics.updatetitlecolours();
 
     game.customcol=ed.getlevelcol(ed.levx+(ed.levy*ed.maxwidth))+1;
@@ -3657,27 +3655,6 @@ void editorlogic()
 
     graphics.setcol(ed.entcol);
     ed.entcolreal = graphics.ct.colour;
-
-    if (game.shouldreturntoeditor)
-    {
-        game.shouldreturntoeditor = false;
-    }
-
-    graphics.titlebg.bypos -= 2;
-    graphics.titlebg.bscroll = -2;
-
-    ed.entframedelay--;
-    if(ed.entframedelay<=0)
-    {
-        ed.entframe=(ed.entframe+1)%4;
-        ed.entframedelay=8;
-    }
-
-    ed.oldnotedelay = ed.notedelay;
-    if(ed.notedelay>0)
-    {
-        ed.notedelay--;
-    }
 
     if (game.ghostsenabled)
     {
@@ -3725,6 +3702,34 @@ void editorlogic()
     else if (!game.colourblindmode)
     {
         graphics.updatetowerbackground(graphics.titlebg);
+    }
+}
+
+void editorlogic()
+{
+    extern editorclass ed;
+    //Misc
+    help.updateglow();
+
+    if (game.shouldreturntoeditor)
+    {
+        game.shouldreturntoeditor = false;
+    }
+
+    graphics.titlebg.bypos -= 2;
+    graphics.titlebg.bscroll = -2;
+
+    ed.entframedelay--;
+    if(ed.entframedelay<=0)
+    {
+        ed.entframe=(ed.entframe+1)%4;
+        ed.entframedelay=8;
+    }
+
+    ed.oldnotedelay = ed.notedelay;
+    if(ed.notedelay>0)
+    {
+        ed.notedelay--;
     }
 
     if (graphics.fademode == 1)

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -285,6 +285,8 @@ void fillboxabs(int x, int y, int x2, int y2, int c);
 #if !defined(NO_EDITOR)
 void editorrender();
 
+void editorrenderfixed();
+
 void editorlogic();
 
 void editorinput();

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -16,6 +16,7 @@
 #include "Network.h"
 #include "preloader.h"
 #include "Render.h"
+#include "RenderFixed.h"
 #include "Screen.h"
 #include "Script.h"
 #include "SoundSystem.h"
@@ -526,7 +527,7 @@ void inline fixedloop()
         switch(game.gamestate)
         {
         case PRELOADER:
-            preloaderlogic();
+            preloaderrenderfixed();
             break;
 #if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
         case EDITORMODE:
@@ -534,6 +535,8 @@ void inline fixedloop()
             editorinput();
             ////Logic
             editorlogic();
+
+            editorrenderfixed();
             break;
 #endif
         case TITLEMODE:
@@ -541,6 +544,8 @@ void inline fixedloop()
             titleinput();
             ////Logic
             titlelogic();
+
+            titlerenderfixed();
             break;
         case GAMEMODE:
             // WARNING: If updating this code, don't forget to update Map.cpp mapclass::twoframedelayfix()
@@ -564,12 +569,14 @@ void inline fixedloop()
 
             gameinput();
             gamelogic();
+            gamerenderfixed();
 
 
             break;
         case MAPMODE:
             mapinput();
             maplogic();
+            maprenderfixed();
             break;
         case TELEPORTERMODE:
             if(game.useteleporter)
@@ -585,12 +592,15 @@ void inline fixedloop()
                 gameinput();
             }
             maplogic();
+            maprenderfixed();
             break;
         case GAMECOMPLETE:
             //Input
             gamecompleteinput();
             //Logic
             gamecompletelogic();
+
+            gamecompleterenderfixed();
             break;
         case GAMECOMPLETE2:
             //Input

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -10,7 +10,7 @@ int pre_darkcol=0, pre_lightcol=0, pre_curcol=0, pre_coltimer=0, pre_offset=0;
 int pre_frontrectx=30, pre_frontrecty=20, pre_frontrectw=260, pre_frontrecth=200;
 int pre_temprectx=0, pre_temprecty=0, pre_temprectw=320, pre_temprecth=240;
 
-void preloaderlogic()
+void preloaderrenderfixed()
 {
   if (pre_transition < 30) pre_transition--;
   if(pre_transition>=30){
@@ -26,6 +26,10 @@ void preloaderlogic()
       pre_curcol = (pre_curcol + int(fRandom() * 5.0f)) % 6;
       pre_coltimer = 8;
     }
+  }
+
+  if (pre_transition <= -10) {
+    game.gamestate = TITLEMODE;
   }
 }
 
@@ -88,7 +92,7 @@ void preloaderrender()
       pre_transition = 29;
     }
   }else if (pre_transition <= -10) {
-    game.gamestate=TITLEMODE;
+    //Switch to TITLEMODE (handled by preloaderrenderfixed)
   }else if (pre_transition < 5) {
     FillRect(graphics.backBuffer, 0, 0, 320,240, graphics.getBGR(0,0,0));
   }else if (pre_transition < 20) {

--- a/desktop_version/src/preloader.h
+++ b/desktop_version/src/preloader.h
@@ -3,6 +3,6 @@
 
 void preloaderrender();
 
-void preloaderlogic();
+void preloaderrenderfixed();
 
 #endif /* PRELOADER_H */


### PR DESCRIPTION
As part of fixing #464, I'll need to move these pieces of code around easily. In #220 I just kind of shoved them awkwardly in whatever fixed function would be last called in the gamestate loop, which I shouldn't have done as I've now had to make formal fixed-render functions anyway. Because these fixed functions need to be called directly before a render function, and I'm fixing the order to put render functions in their proper place, so I need to be able to move these around easily, and making them function calls instead of inlined makes them easier to manipulate.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
