### PR TITLE
Interpolate scrolling in Analogue Mode filter

### DIFF
--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -316,6 +316,7 @@ void BlitSurfaceTinted(
 }
 
 
+int oldscrollamount = 0;
 int scrollamount = 0;
 bool isscrolling = 0;
 
@@ -326,12 +327,14 @@ void UpdateFilter()
         isscrolling = true;
     }
 
+    oldscrollamount = scrollamount;
     if(isscrolling == true)
     {
         scrollamount += 20;
         if(scrollamount > 240)
         {
             scrollamount = 0;
+            oldscrollamount = 0;
             isscrolling = false;
         }
     }
@@ -348,7 +351,7 @@ SDL_Surface* ApplyFilter( SDL_Surface* _src )
     {
         for(int y = 0; y < _src->h; y++)
         {
-            int sampley = (y + scrollamount )% 240;
+            int sampley = (y + (int) graphics.lerp(oldscrollamount, scrollamount) )% 240;
 
             Uint32 pixel = ReadPixel(_src, x,sampley);
 

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -382,8 +382,8 @@ SDL_Surface* ApplyFilter( SDL_Surface* _src )
                 blue =  static_cast<Uint8>(blue / 1.2f);
             }
 
-            int distX =  static_cast<int>((abs (160.0f -x ) / 160.0f) *16);
-            int distY =  static_cast<int>((abs (120.0f -y ) / 120.0f)*32);
+            int distX =  static_cast<int>((SDL_abs (160.0f -x ) / 160.0f) *16);
+            int distY =  static_cast<int>((SDL_abs (120.0f -y ) / 120.0f)*32);
 
             red = std::max(red - ( distX +distY), 0);
             green = std::max(green - ( distX +distY), 0);


### PR DESCRIPTION
I can't really make the filter update only every timestep, because it's per-pixel and operates on deltaframes too, so it *technically* runs faster in over-30-FPS mode than not. That said, it's not really noticeable, the filter doesn't look bad for updating more often or anything. However, I can at least interpolate the scrolling, so it's smooth in over-30-FPS mode.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
