### PR TITLE
Fix Prize for the Reckless moving platform losing its block when you die and the platform's x-coordinate is to the left of x=152

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -465,8 +465,17 @@ void gamelogic()
                 {
                     if (obj.entities[i].xp < 152)
                     {
+                        //Move the platform to the right side of the disappearing platform,
+                        //otherwise it will get stuck on the kludge 18,9 tile we placed
+                        //(and if the tile wasn't there it would pass straight through again)
+                        int prevx = obj.entities[i].xp;
+                        int prevy = obj.entities[i].yp;
+                        obj.nocollisionat(prevx, prevy);
+
                         obj.entities[i].xp = 152;
                         obj.entities[i].newxp = 152;
+
+                        obj.moveblockto(prevx, prevy, obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
                     }
                 }
             }


### PR DESCRIPTION
This bug would happen if you die and the platform isn't completely clear of the space of its adjacent disappearing platform.

The block needs to be updated accordingly with calls to `obj.nocollisionat()` and `obj.moveblockto()`, else the block will simply be left behind and the platform will no longer have any collision. This is in contrast to 2.2 behavior, where the platform would simply unconditionally create a new block, which would actually end up with a duplicate block since the previous block didn't get cleaned up, but this didn't cause any problems because the room was carefully designed so you would never be able to touch that previous block after you died and respawned at the checkpoint. But it's still there.

I also added comments to document what this kludge code did, because otherwise it would be mysterious to readers who are unfamiliar with it.

Fixes #543.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
