### PR TITLE
Fix bugs with the status of having MMMMMM selected whenever a custom level with assets is entered or exited

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -10,6 +10,27 @@
 
 void songend();
 
+musicclass::musicclass()
+{
+	safeToProcessMusic= false;
+	m_doFadeInVol = false;
+	musicVolume = MIX_MAX_VOLUME;
+	FadeVolAmountPerFrame = 0;
+
+	currentsong = 0;
+	nicechange = -1;
+	nicefade = false;
+	resumesong = 0;
+	quick_fade = true;
+
+	songStart = 0;
+	songEnd = 0;
+
+	Mix_HookMusicFinished(&songend);
+
+	usingmmmmmm = false;
+}
+
 void musicclass::init()
 {
 	for (size_t i = 0; i < soundTracks.size(); ++i) {
@@ -129,24 +150,6 @@ void musicclass::init()
 
 		num_pppppp_tracks++;
 	}
-
-	safeToProcessMusic= false;
-	m_doFadeInVol = false;
-	musicVolume = MIX_MAX_VOLUME;
-	FadeVolAmountPerFrame = 0;
-
-	currentsong = 0;
-	nicechange = -1;
-	nicefade = false;
-	resumesong = 0;
-	quick_fade = true;
-
-	songStart = 0;
-	songEnd = 0;
-
-	Mix_HookMusicFinished(&songend);
-
-	usingmmmmmm = false;
 }
 
 void songend()

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -95,7 +95,6 @@ void musicclass::init()
 	else
 	{
 		mmmmmm = true;
-		usingmmmmmm = true;
 		int index;
 		SDL_RWops *rw;
 

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -11,6 +11,7 @@
 class musicclass
 {
 public:
+	musicclass();
 	void init();
 
 	void play(int t, const double position_sec = 0.0, const int fadein_ms = 3000);


### PR DESCRIPTION
This PR fixes a couple of annoying bugs I found just now that screw with the status of having MMMMMM selected in Game Options (which are tracked by *two different variables*(!!!) `game.usingmmmmmm` and `music.usingmmmmmm`) whenever you load a custom level that has assets. It would call `graphics.reloadresources()`, which would call `music.init()`, which would reset way more variables than necessary.

That duplicate variable thing should probably be fixed. In fact there's more duplicate state tracking than just this `game.usingmmmmmm` and `music.usingmmmmmm` example. But fixing those will be a separate patch...

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
