### PR TITLE
Clean up duplicate settings-related variables 

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -167,17 +167,12 @@ void Game::init(void)
     oldcreditposition = 0;
     bestgamedeaths = -1;
 
-    fullScreenEffect_badSignal = false;
-
     //Accessibility Options
     colourblindmode = false;
     noflashingmode = false;
     slowdown = 30;
     gameframerate=34;
 
-    fullscreen = false;// true; //Assumed true at first unless overwritten at some point!
-    stretchMode = 0;
-    useLinearFilter = false;
     // 0..5
     controllerSensitivity = 2;
 
@@ -4473,7 +4468,7 @@ void Game::unlocknum( int t )
 
 #define LOAD_ARRAY(ARRAY_NAME) LOAD_ARRAY_RENAME(ARRAY_NAME, ARRAY_NAME)
 
-void Game::loadstats(int *width, int *height, bool *vsync)
+void Game::loadstats(ScreenSettings* screen_settings)
 {
     tinyxml2::XMLDocument doc;
     if (!FILESYSTEM_loadTiXml2Document("saves/unlock.vvv", doc))
@@ -4549,10 +4544,10 @@ void Game::loadstats(int *width, int *height, bool *vsync)
         }
     }
 
-    deserializesettings(dataNode, width, height, vsync);
+    deserializesettings(dataNode, screen_settings);
 }
 
-void Game::deserializesettings(tinyxml2::XMLElement* dataNode, int* width, int* height, bool* vsync)
+void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* screen_settings)
 {
     // Don't duplicate controller buttons!
     controllerButton_flip.clear();
@@ -4569,26 +4564,26 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, int* width, int* 
 
         if (pKey == "fullscreen")
         {
-            fullscreen = help.Int(pText);
+            screen_settings->fullscreen = help.Int(pText);
         }
 
         if (pKey == "stretch")
         {
-            stretchMode = help.Int(pText);
+            screen_settings->stretch = help.Int(pText);
         }
 
         if (pKey == "useLinearFilter")
         {
-            useLinearFilter = help.Int(pText);
+            screen_settings->linearFilter = help.Int(pText);
         }
 
         if (pKey == "window_width")
         {
-            *width = help.Int(pText);
+            screen_settings->windowWidth = help.Int(pText);
         }
         if (pKey == "window_height")
         {
-            *height = help.Int(pText);
+            screen_settings->windowHeight = help.Int(pText);
         }
 
 
@@ -4638,7 +4633,7 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, int* width, int* 
 
         if (pKey == "advanced_smoothing")
         {
-            fullScreenEffect_badSignal = help.Int(pText);
+            screen_settings->badSignal = help.Int(pText);
         }
 
         if (pKey == "usingmmmmmm")
@@ -4677,7 +4672,7 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, int* width, int* 
 
         if (pKey == "vsync")
         {
-            *vsync = help.Int(pText);
+            screen_settings->useVsync = help.Int(pText);
         }
 
         if (pKey == "notextoutline")
@@ -4853,11 +4848,11 @@ void Game::serializesettings(tinyxml2::XMLElement* dataNode)
 {
     tinyxml2::XMLDocument& doc = xml::get_document(dataNode);
 
-    xml::update_tag(dataNode, "fullscreen", fullscreen);
+    xml::update_tag(dataNode, "fullscreen", !graphics.screenbuffer->isWindowed);
 
-    xml::update_tag(dataNode, "stretch", stretchMode);
+    xml::update_tag(dataNode, "stretch", graphics.screenbuffer->stretchMode);
 
-    xml::update_tag(dataNode, "useLinearFilter", useLinearFilter);
+    xml::update_tag(dataNode, "useLinearFilter", graphics.screenbuffer->isFiltered);
 
     int width, height;
     if (graphics.screenbuffer != NULL)
@@ -4884,7 +4879,7 @@ void Game::serializesettings(tinyxml2::XMLElement* dataNode)
     xml::update_tag(dataNode, "slowdown", slowdown);
 
 
-    xml::update_tag(dataNode, "advanced_smoothing", fullScreenEffect_badSignal);
+    xml::update_tag(dataNode, "advanced_smoothing", graphics.screenbuffer->badSignalEffect);
 
 
     xml::update_tag(dataNode, "usingmmmmmm", usingmmmmmm);
@@ -4974,7 +4969,7 @@ void Game::serializesettings(tinyxml2::XMLElement* dataNode)
     xml::update_tag(dataNode, "controllerSensitivity", controllerSensitivity);
 }
 
-void Game::loadsettings(int* width, int* height, bool* vsync)
+void Game::loadsettings(ScreenSettings* screen_settings)
 {
     tinyxml2::XMLDocument doc;
     if (!FILESYSTEM_loadTiXml2Document("saves/settings.vvv", doc))
@@ -5001,7 +4996,7 @@ void Game::loadsettings(int* width, int* height, bool* vsync)
 
     tinyxml2::XMLElement* dataNode = hRoot.FirstChildElement("Data").FirstChild().ToElement();
 
-    deserializesettings(dataNode, width, height, vsync);
+    deserializesettings(dataNode, screen_settings);
 }
 
 void Game::savesettings()

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -171,7 +171,6 @@ void Game::init(void)
     colourblindmode = false;
     noflashingmode = false;
     slowdown = 30;
-    gameframerate=34;
 
     // 0..5
     controllerSensitivity = 2;
@@ -4610,25 +4609,6 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* s
         if (pKey == "slowdown")
         {
             slowdown = help.Int(pText);
-            switch(slowdown)
-            {
-            case 30:
-                gameframerate=34;
-                break;
-            case 24:
-                gameframerate=41;
-                break;
-            case 18:
-                gameframerate=55;
-                break;
-            case 12:
-                gameframerate=83;
-                break;
-            default:
-                gameframerate=34;
-                break;
-            }
-
         }
 
         if (pKey == "advanced_smoothing")

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -12,6 +12,7 @@
 #include "Enums.h"
 #include "FileSystemUtils.h"
 #include "Graphics.h"
+#include "KeyPoll.h"
 #include "MakeAndPlay.h"
 #include "Map.h"
 #include "Music.h"
@@ -171,9 +172,6 @@ void Game::init(void)
     colourblindmode = false;
     noflashingmode = false;
     slowdown = 30;
-
-    // 0..5
-    controllerSensitivity = 2;
 
     nodeathmode = false;
     nocutscenes = false;
@@ -4704,7 +4702,7 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* s
 
         if (pKey == "controllerSensitivity")
         {
-            controllerSensitivity = help.Int(pText);
+            key.sensitivity = help.Int(pText);
         }
 
     }
@@ -4942,7 +4940,7 @@ void Game::serializesettings(tinyxml2::XMLElement* dataNode)
         dataNode->LinkEndChild(msg);
     }
 
-    xml::update_tag(dataNode, "controllerSensitivity", controllerSensitivity);
+    xml::update_tag(dataNode, "controllerSensitivity", key.sensitivity);
 }
 
 void Game::loadsettings(ScreenSettings* screen_settings)

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4638,11 +4638,7 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* s
 
         if (pKey == "usingmmmmmm")
         {
-            if(help.Int(pText)>0){
-                usingmmmmmm = 1;
-            }else{
-                usingmmmmmm = 0;
-            }
+            music.usingmmmmmm = (bool) help.Int(pText);
         }
 
         if (pKey == "ghostsenabled")
@@ -4882,7 +4878,7 @@ void Game::serializesettings(tinyxml2::XMLElement* dataNode)
     xml::update_tag(dataNode, "advanced_smoothing", graphics.screenbuffer->badSignalEffect);
 
 
-    xml::update_tag(dataNode, "usingmmmmmm", usingmmmmmm);
+    xml::update_tag(dataNode, "usingmmmmmm", music.usingmmmmmm);
 
     xml::update_tag(dataNode, "ghostsenabled", (int) ghostsenabled);
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -275,7 +275,6 @@ public:
     bool  colourblindmode;
     bool noflashingmode;
     int slowdown;
-    Uint32 gameframerate;
 
     bool nodeathmode;
     int gameoverdelay;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -366,8 +366,6 @@ public:
     bool savemystats;
 
 
-    int controllerSensitivity;
-
     bool quickrestartkludge;
 
     //Custom stuff

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include "ScreenSettings.h"
+
 // Forward decl without including all of <tinyxml2.h>
 namespace tinyxml2
 {
@@ -128,17 +130,17 @@ public:
 
     void unlocknum(int t);
 
-    void loadstats(int *width, int *height, bool *vsync);
+    void loadstats(ScreenSettings* screen_settings);
 
     void  savestats(const bool stats_only = false);
 
     void deletestats();
 
-    void deserializesettings(tinyxml2::XMLElement* dataNode, int* width, int* height, bool* vsync);
+    void deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* screen_settings);
 
     void serializesettings(tinyxml2::XMLElement* dataNode);
 
-    void loadsettings(int* width, int* height, bool* vsync);
+    void loadsettings(ScreenSettings* screen_settings);
 
     void savesettings();
 
@@ -308,7 +310,6 @@ public:
     bool unlocknotify[numunlock];
     bool anything_unlocked();
     int stat_trinkets;
-    bool fullscreen;
     int bestgamedeaths;
 
 
@@ -368,9 +369,6 @@ public:
     bool savemystats;
 
 
-    bool fullScreenEffect_badSignal;
-    bool useLinearFilter;
-    int stretchMode;
     int controllerSensitivity;
 
     bool quickrestartkludge;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -198,8 +198,6 @@ public:
 
     bool glitchrunkludge;
 
-    int usingmmmmmm;
-
     int gamestate;
     bool hascontrol, jumpheld;
     int jumppressed;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -385,7 +385,6 @@ void menuactionpress()
         case 0:
             music.playef(11);
             graphics.screenbuffer->toggleFullScreen();
-            game.fullscreen = !game.fullscreen;
             game.savestats();
 
             // Recreate menu to update "resize to nearest"
@@ -395,7 +394,6 @@ void menuactionpress()
         case 1:
             music.playef(11);
             graphics.screenbuffer->toggleStretchMode();
-            game.stretchMode = (game.stretchMode + 1) % 3;
             game.savestats();
             break;
         case 2:
@@ -414,13 +412,11 @@ void menuactionpress()
         case 3:
             music.playef(11);
             graphics.screenbuffer->toggleLinearFilter();
-            game.useLinearFilter = !game.useLinearFilter;
             game.savestats();
             break;
         case 4:
             //change smoothing
             music.playef(11);
-            game.fullScreenEffect_badSignal = !game.fullScreenEffect_badSignal;
             graphics.screenbuffer->badSignalEffect= !graphics.screenbuffer->badSignalEffect;
             game.savestats();
             break;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1238,11 +1238,11 @@ void menuactionpress()
         switch (game.currentmenuoption)
         {
         case 0:
-            game.controllerSensitivity++;
+            key.sensitivity++;
             music.playef(11);
-            if(game.controllerSensitivity > 4)
+            if(key.sensitivity > 4)
             {
-                game.controllerSensitivity = 0;
+                key.sensitivity = 0;
             }
             break;
 
@@ -1594,9 +1594,6 @@ void titleinput()
 {
     //game.mx = (mouseX / 4);
     //game.my = (mouseY / 4);
-
-    //TODO bit wasteful doing this every poll
-    key.setSensitivity(game.controllerSensitivity);
 
     game.press_left = false;
     game.press_right = false;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -748,11 +748,6 @@ void menuactionpress()
         else if (game.currentmenuoption == 6+offset && music.mmmmmm)
         {
             //**** TOGGLE MMMMMM
-            if(game.usingmmmmmm > 0){
-                game.usingmmmmmm=0;
-            }else{
-                game.usingmmmmmm=1;
-            }
             music.usingmmmmmm = !music.usingmmmmmm;
             music.playef(11);
             music.play(music.currentsong);

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -488,7 +488,6 @@ void menuactionpress()
         {
         case 0:
             //back
-            game.gameframerate=34;
             game.slowdown = 30;
             game.savestats();
             music.playef(11);
@@ -497,7 +496,6 @@ void menuactionpress()
             map.nexttowercolour();
             break;
         case 1:
-            game.gameframerate=41;
             game.slowdown = 24;
             game.savestats();
             music.playef(11);
@@ -506,7 +504,6 @@ void menuactionpress()
             map.nexttowercolour();
             break;
         case 2:
-            game.gameframerate=55;
             game.slowdown = 18;
             game.savestats();
             music.playef(11);
@@ -515,7 +512,6 @@ void menuactionpress()
             map.nexttowercolour();
             break;
         case 3:
-            game.gameframerate=83;
             game.slowdown = 12;
             game.savestats();
             music.playef(11);
@@ -630,7 +626,7 @@ void menuactionpress()
             else
             {
                 music.playef(2);
-                game.gameframerate = 34;
+                game.slowdown = 30;
             }
             break;
         case 5:

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -9,26 +9,23 @@
 #include "Graphics.h"
 #include "Music.h"
 
-void KeyPoll::setSensitivity(int _value)
+int inline KeyPoll::getThreshold()
 {
-	switch (_value)
+	switch (sensitivity)
 	{
-		case 0:
-			sensitivity = 28000;
-			break;
-		case 1:
-			sensitivity = 16000;
-			break;
-		case 2:
-			sensitivity = 8000;
-			break;
-		case 3:
-			sensitivity = 4000;
-			break;
-		case 4:
-			sensitivity = 2000;
-			break;
+	case 0:
+		return 28000;
+	case 1:
+		return 16000;
+	case 2:
+		return 8000;
+	case 3:
+		return 4000;
+	case 4:
+		return 2000;
 	}
+
+	return 8000;
 
 }
 
@@ -36,7 +33,8 @@ KeyPoll::KeyPoll()
 {
 	xVel = 0;
 	yVel = 0;
-	setSensitivity(2);
+	// 0..5
+	sensitivity = 2;
 
 	quitProgram = 0;
 	keybuffer="";
@@ -199,11 +197,13 @@ void KeyPoll::Poll()
 			buttonmap[(SDL_GameControllerButton) evt.cbutton.button] = false;
 			break;
 		case SDL_CONTROLLERAXISMOTION:
+		{
+			const int threshold = getThreshold();
 			switch (evt.caxis.axis)
 			{
 			case SDL_CONTROLLER_AXIS_LEFTX:
-				if (	evt.caxis.value > -sensitivity &&
-					evt.caxis.value < sensitivity	)
+				if (	evt.caxis.value > -threshold &&
+					evt.caxis.value < threshold	)
 				{
 					xVel = 0;
 				}
@@ -213,8 +213,8 @@ void KeyPoll::Poll()
 				}
 				break;
 			case SDL_CONTROLLER_AXIS_LEFTY:
-				if (	evt.caxis.value > -sensitivity &&
-					evt.caxis.value < sensitivity	)
+				if (	evt.caxis.value > -threshold &&
+					evt.caxis.value < threshold	)
 				{
 					yVel = 0;
 				}
@@ -225,6 +225,7 @@ void KeyPoll::Poll()
 				break;
 			}
 			break;
+		}
 		case SDL_CONTROLLERDEVICEADDED:
 		{
 			SDL_GameController *toOpen = SDL_GameControllerOpen(evt.cdevice.which);

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -42,7 +42,7 @@ public:
 
 	int sensitivity;
 
-	void setSensitivity(int _value);
+	int inline getThreshold();
 
 	KeyPoll();
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -25,6 +25,25 @@ int inline FLIP(int ypos)
     return ypos;
 }
 
+static inline void drawslowdowntext()
+{
+    switch (game.slowdown)
+    {
+    case 30:
+        graphics.Print( -1, 105, "Game speed is normal.", tr/2, tg/2, tb/2, true);
+        break;
+    case 24:
+        graphics.Print( -1, 105, "Game speed is at 80%", tr, tg, tb, true);
+        break;
+    case 18:
+        graphics.Print( -1, 105, "Game speed is at 60%", tr, tg, tb, true);
+        break;
+    case 12:
+        graphics.Print( -1, 105, "Game speed is at 40%", tr, tg, tb, true);
+        break;
+    }
+}
+
 void menurender()
 {
     int temp = 50;
@@ -369,21 +388,7 @@ void menurender()
     case Menu::setslowdown:
         graphics.bigprint( -1, 40, "Game Speed", tr, tg, tb, true);
         graphics.Print( -1, 75, "Select a new game speed below.", tr, tg, tb, true);
-        switch (game.gameframerate)
-        {
-        case 34:
-            graphics.Print( -1, 105, "Game speed is normal.", tr/2, tg/2, tb/2, true);
-            break;
-        case 41:
-            graphics.Print( -1, 105, "Game speed is at 80%", tr, tg, tb, true);
-            break;
-        case 55:
-            graphics.Print( -1, 105, "Game speed is at 60%", tr, tg, tb, true);
-            break;
-        case 83:
-            graphics.Print( -1, 105, "Game speed is at 40%", tr, tg, tb, true);
-            break;
-        }
+        drawslowdowntext();
         break;
     case Menu::newgamewarning:
         graphics.Print( -1, 100, "Are you sure? This will", tr, tg, tb, true);
@@ -556,23 +561,7 @@ void menurender()
             graphics.bigprint( -1, 40, "Game Speed", tr, tg, tb, true);
             graphics.Print( -1, 75, "May be useful for disabled gamers", tr, tg, tb, true);
             graphics.Print( -1, 85, "using one switch devices.", tr, tg, tb, true);
-            if (game.gameframerate==34)
-            {
-                graphics.Print( -1, 105, "Game speed is normal.", tr/2, tg/2, tb/2, true);
-            }
-            else if (game.gameframerate==41)
-            {
-                graphics.Print( -1, 105, "Game speed is at 80%", tr, tg, tb, true);
-            }
-            else if (game.gameframerate==55)
-            {
-                graphics.Print( -1, 105, "Game speed is at 60%", tr, tg, tb, true);
-            }
-            else if (game.gameframerate==83)
-            {
-                graphics.Print( -1, 105, "Game speed is at 40%", tr, tg, tb, true);
-            }
-            break;
+            drawslowdowntext();
         }
         break;
     case Menu::playint1:
@@ -588,7 +577,7 @@ void menurender()
             graphics.Print( -1, 65, "Replay any level in the game in", tr, tg, tb, true);
             graphics.Print( -1, 75, "a competitive time trial mode.", tr, tg, tb, true);
 
-            if (game.gameframerate > 34 || map.invincibility)
+            if (game.slowdown < 30 || map.invincibility)
             {
                 graphics.Print( -1, 105, "Time Trials are not available", tr, tg, tb, true);
                 graphics.Print( -1, 115, "with slowdown or invincibility.", tr, tg, tb, true);
@@ -609,7 +598,7 @@ void menurender()
             graphics.Print( -1, 65, "Play the entire game", tr, tg, tb, true);
             graphics.Print( -1, 75, "without dying once.", tr, tg, tb, true);
 
-            if (game.gameframerate > 34 || map.invincibility)
+            if (game.slowdown < 30 || map.invincibility)
             {
                 graphics.Print( -1, 105, "No Death Mode is not available", tr, tg, tb, true);
                 graphics.Print( -1, 115, "with slowdown or invincibility.", tr, tg, tb, true);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -173,10 +173,13 @@ void menurender()
             graphics.bigprint( -1, 30, "Toggle Fullscreen", tr, tg, tb, true);
             graphics.Print( -1, 65, "Change to fullscreen/windowed mode.", tr, tg, tb, true);
 
-            if(game.fullscreen){
-              graphics.Print( -1, 85, "Current mode: FULLSCREEN", tr, tg, tb, true);
-            }else{
-              graphics.Print( -1, 85, "Current mode: WINDOWED", tr, tg, tb, true);
+            if (graphics.screenbuffer->isWindowed)
+            {
+                graphics.Print( -1, 85, "Current mode: WINDOWED", tr, tg, tb, true);
+            }
+            else
+            {
+                graphics.Print( -1, 85, "Current mode: FULLSCREEN", tr, tg, tb, true);
             }
             break;
 
@@ -184,12 +187,17 @@ void menurender()
             graphics.bigprint( -1, 30, "Scaling Mode", tr, tg, tb, true);
             graphics.Print( -1, 65, "Choose letterbox/stretch/integer mode.", tr, tg, tb, true);
 
-            if(game.stretchMode == 2){
-              graphics.Print( -1, 85, "Current mode: INTEGER", tr, tg, tb, true);
-            }else if (game.stretchMode == 1){
-              graphics.Print( -1, 85, "Current mode: STRETCH", tr, tg, tb, true);
-            }else{
-              graphics.Print( -1, 85, "Current mode: LETTERBOX", tr, tg, tb, true);
+            switch (graphics.screenbuffer->stretchMode)
+            {
+            case 2:
+                graphics.Print( -1, 85, "Current mode: INTEGER", tr, tg, tb, true);
+                break;
+            case 1:
+                graphics.Print( -1, 85, "Current mode: STRETCH", tr, tg, tb, true);
+                break;
+            default:
+                graphics.Print( -1, 85, "Current mode: LETTERBOX", tr, tg, tb, true);
+                break;
             }
             break;
         case 2:
@@ -206,10 +214,13 @@ void menurender()
             graphics.bigprint( -1, 30, "Toggle Filter", tr, tg, tb, true);
             graphics.Print( -1, 65, "Change to nearest/linear filter.", tr, tg, tb, true);
 
-            if(game.useLinearFilter){
-              graphics.Print( -1, 85, "Current mode: LINEAR", tr, tg, tb, true);
-            }else{
-              graphics.Print( -1, 85, "Current mode: NEAREST", tr, tg, tb, true);
+            if (graphics.screenbuffer->isFiltered)
+            {
+                graphics.Print( -1, 85, "Current mode: LINEAR", tr, tg, tb, true);
+            }
+            else
+            {
+                graphics.Print( -1, 85, "Current mode: NEAREST", tr, tg, tb, true);
             }
             break;
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -3,6 +3,7 @@
 #include "Entity.h"
 #include "FileSystemUtils.h"
 #include "Graphics.h"
+#include "KeyPoll.h"
 #include "MakeAndPlay.h"
 #include "Map.h"
 #include "Maths.h"
@@ -410,7 +411,7 @@ void menurender()
         switch (game.currentmenuoption)
         {
         case 0:
-            switch(game.controllerSensitivity)
+            switch(key.sensitivity)
             {
             case 0:
                 graphics.Print( -1, 85, " Low     Medium     High", tr, tg, tb, true);

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -17,23 +17,27 @@ extern "C"
 	);
 }
 
-void Screen::init(
-	int windowWidth,
-	int windowHeight,
-	bool fullscreen,
-	bool useVsync,
-	int stretch,
-	bool linearFilter,
-	bool badSignal
-) {
+ScreenSettings::ScreenSettings()
+{
+	windowWidth = 320;
+	windowHeight = 240;
+	fullscreen = false;
+	useVsync = false;
+	stretch = 0;
+	linearFilter = false;
+	badSignal = false;
+}
+
+void Screen::init(const ScreenSettings& settings)
+{
 	m_window = NULL;
 	m_renderer = NULL;
 	m_screenTexture = NULL;
 	m_screen = NULL;
-	isWindowed = !fullscreen;
-	stretchMode = stretch;
-	isFiltered = linearFilter;
-	vsync = useVsync;
+	isWindowed = !settings.fullscreen;
+	stretchMode = settings.stretch;
+	isFiltered = settings.linearFilter;
+	vsync = settings.useVsync;
 	filterSubrect.x = 1;
 	filterSubrect.y = 1;
 	filterSubrect.w = 318;
@@ -84,9 +88,9 @@ void Screen::init(
 		240
 	);
 
-	badSignalEffect = badSignal;
+	badSignalEffect = settings.badSignal;
 
-	ResizeScreen(windowWidth, windowHeight);
+	ResizeScreen(settings.windowWidth, settings.windowHeight);
 }
 
 void Screen::LoadIcon()

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -3,18 +3,12 @@
 
 #include <SDL.h>
 
+#include "ScreenSettings.h"
+
 class Screen
 {
 public:
-	void init(
-		int windowWidth,
-		int windowHeight,
-		bool fullscreen,
-		bool useVsync,
-		int stretch,
-		bool linearFilter,
-		bool badSignal
-	);
+	void init(const ScreenSettings& settings);
 
 	void LoadIcon();
 

--- a/desktop_version/src/ScreenSettings.h
+++ b/desktop_version/src/ScreenSettings.h
@@ -1,0 +1,17 @@
+#ifndef SCREENSETTINGS_H
+#define SCREENSETTINGS_H
+
+struct ScreenSettings
+{
+	ScreenSettings();
+
+	int windowWidth;
+	int windowHeight;
+	bool fullscreen;
+	bool useVsync;
+	int stretch;
+	bool linearFilter;
+	bool badSignal;
+};
+
+#endif /* SCREENSETTINGS_H */

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3906,7 +3906,7 @@ void editorinput()
     game.my = (float) key.my;
     ed.tilex=(game.mx - (game.mx%8))/8;
     ed.tiley=(game.my - (game.my%8))/8;
-    if (game.stretchMode == 1) {
+    if (graphics.screenbuffer->stretchMode == 1) {
         // In this mode specifically, we have to fix the mouse coordinates
         int winwidth, winheight;
         graphics.screenbuffer->GetWindowSize(&winwidth, &winheight);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -55,6 +55,23 @@ volatile Uint32 accumulator = 0;
 volatile Uint32 f_time = 0;
 volatile Uint32 f_timePrev = 0;
 
+static inline Uint32 get_framerate(const int slowdown)
+{
+    switch (slowdown)
+    {
+    case 30:
+        return 34;
+    case 24:
+        return 41;
+    case 18:
+        return 55;
+    case 12:
+        return 83;
+    }
+
+    return 34;
+}
+
 void inline deltaloop();
 void inline fixedloop();
 
@@ -278,14 +295,6 @@ int main(int argc, char *argv[])
         game.gamestate = TITLEMODE;
     if (game.slowdown == 0) game.slowdown = 30;
 
-    switch(game.slowdown){
-        case 30: game.gameframerate=34; break;
-        case 24: game.gameframerate=41; break;
-        case 18: game.gameframerate=55; break;
-        case 12: game.gameframerate=83; break;
-        default: game.gameframerate=34; break;
-    }
-
     //Check to see if you've already unlocked some achievements here from before the update
     if (game.swnbestrank > 0){
         if(game.swnbestrank >= 1) game.unlockAchievement("vvvvvvsupgrav5");
@@ -413,7 +422,7 @@ void inline deltaloop()
     }
     else if (game.gamestate == GAMEMODE)
     {
-        timesteplimit = game.gameframerate;
+        timesteplimit = get_framerate(game.slowdown);
     }
     else
     {

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -213,25 +213,14 @@ int main(int argc, char *argv[])
     graphics.towerbg.bypos = map.ypos / 2;
     graphics.titlebg.bypos = map.ypos / 2;
 
-    //Moved screensetting init here from main menu V2.1
-    int width = 320;
-    int height = 240;
-    bool vsync = false;
-
-    // Prioritize unlock.vvv first (2.2 and below),
-    // but settings have been migrated to settings.vvv (2.3 and up)
-    game.loadstats(&width, &height, &vsync);
-    game.loadsettings(&width, &height, &vsync);
-
-    gameScreen.init(
-        width,
-        height,
-        game.fullscreen,
-        vsync,
-        game.stretchMode,
-        game.useLinearFilter,
-        game.fullScreenEffect_badSignal
-    );
+    {
+        // Prioritize unlock.vvv first (2.2 and below),
+        // but settings have been migrated to settings.vvv (2.3 and up)
+        ScreenSettings screen_settings;
+        game.loadstats(&screen_settings);
+        game.loadsettings(&screen_settings);
+        gameScreen.init(screen_settings);
+    }
     graphics.screenbuffer = &gameScreen;
 
     const SDL_PixelFormat* fmt = gameScreen.GetFormat();
@@ -490,7 +479,6 @@ void inline fixedloop()
     if(key.toggleFullscreen)
     {
         gameScreen.toggleFullScreen();
-        game.fullscreen = !game.fullscreen;
         key.toggleFullscreen = false;
 
         key.keymap.clear(); //we lost the input due to a new window.

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -276,8 +276,6 @@ int main(int argc, char *argv[])
 
     if (game.skipfakeload)
         game.gamestate = TITLEMODE;
-    if(game.usingmmmmmm==0) music.usingmmmmmm=false;
-    if(game.usingmmmmmm==1) music.usingmmmmmm=true;
     if (game.slowdown == 0) game.slowdown = 30;
 
     switch(game.slowdown){


### PR DESCRIPTION
There were a bunch of duplicate configuration variables in the game, e.g. having MMMMMM selected was tracked by both `game.usingmmmmmm` and `music.usingmmmmmm`. My guess is this was probably because argument passing in 2.2 would have gotten in the way of directly accessing variables (it seems like that's the reason why `invincibility` is on Game instead of mapclass), but either way, these duplicate variables can lead to a bunch of headache as they could get desynced, and one part of the code operates on one variable and another part uses the other one.

- `game.fullScreenEffect_badSignal` is a duplicate of `graphics.screenbuffer->badSignalEffect`
- `game.fullscreen` is a duplicate of `!graphics.screenbuffer->isWindowed`
- `game.stretchMode` is a duplicate of `graphics.screenbuffer->stretchMode`
- `game.useLinearFilter` is a duplicate of `graphics.screenbuffer->isFiltered`
- `game.usingmmmmmm` is a duplicate of `music.usingmmmmmm`
- `game.gameframerate` is an indirect duplicate of `game.slowdown`
- `game.controllerSensitivity` is an indirect duplicate of `key.sensitivity`

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
