### PR TITLE
Restrict the ENTER menu to saving while in a cutscene

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2044,7 +2044,14 @@ void gameinput()
         game.gamesaved = false;
         game.gamesavefailed = false;
         graphics.resumegamemode = false;
-        game.menupage = 0; // The Map Page
+        if (script.running)
+        {
+            game.menupage = 3; // Only allow saving
+        }
+        else
+        {
+            game.menupage = 0; // The Map Page
+        }
         BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
         graphics.menuoffset = 240; //actually this should count the roomname
         graphics.oldmenuoffset = 240;
@@ -2237,7 +2244,11 @@ void mapinput()
             game.jumpheld = true;
         }
 
-        if (game.press_left)
+        if (script.running && game.menupage == 3)
+        {
+            // Force the player to stay in the SAVE tab while in a cutscene
+        }
+        else if (game.press_left)
         {
             game.menupage--;
         }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1728,7 +1728,12 @@ void maprender()
 
     // Draw the selected page name at the bottom
     // menupage 0 - 3 is the pause screen
-    if (game.menupage <= 3)
+    if (script.running && game.menupage == 3)
+    {
+        // While in a cutscene, you can only save
+        graphics.Print(-1, 220, "[SAVE]", 196, 196, 255 - help.glow, true);
+    }
+    else if (game.menupage <= 3)
     {
         std::string tab1;
         if (game.insecretlab)


### PR DESCRIPTION
## Changes:

PR #468 made it so you can use the menus while in a cutscene, in order to counteract softlocks. However, this has resulted in more unintentional behavior:
- `gamemode(teleporter)` breaks when opening the ENTER menu (Misa mentioned this)
- The player can now interrupt shakes and walks, and have their timers run out before resuming the cutscene
![Hurry hurry](https://user-images.githubusercontent.com/44736680/99200655-82572f80-279e-11eb-8f35-676c933735fd.png)
- After completing the game, the player can warp to the ship while a dialogue is active, and prevent themselves from advancing text (plus it's always rude to just teleport away while someone's talking)
!["Ok whatever, bye!"](https://user-images.githubusercontent.com/44736680/99200680-b2063780-279e-11eb-9d3d-17a46577f727.png)
- The player can peek at the map before hidecoordinates is run, and can also peek at what the game does with missing/rescued crewmates during cutscenes
![Evacuation map](https://user-images.githubusercontent.com/44736680/99200721-de21b880-279e-11eb-9181-277a6440ef4f.png)
![Everyone's location](https://user-images.githubusercontent.com/44736680/99200730-f0035b80-279e-11eb-81d0-74942ac9d2a1.png)


This PR fixes the latter two issues. While a script is running, only the SAVE tab is now available. Therefore the player can still get themselves out of softlocks as intended in #468, but they can't do things like looking at the map or teleporting away during a cutscene.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
