### PR TITLE
Maintain game.swnmode until all gravitron squares are offscreen

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -788,8 +788,7 @@ void gamelogic()
                     if (obj.entities[line].xp > 320)
                     {
                         obj.removeentity(line);
-                        game.swnmode = false;
-                        game.swngame = 6;
+                        game.swngame = 8;
                     }
                 }
             }
@@ -808,6 +807,22 @@ void gamelogic()
                     game.swntimer = 0;
                     game.swncolstate = 3;
                     game.swncoldelay = 30;
+                }
+            }
+            else if (game.swngame == 8)    //extra kludge if player dies after game a ends
+            {
+                bool square_onscreen = false;
+                for (size_t i = 0; i < obj.entities.size(); i++)
+                {
+                    if (obj.entities[i].type == 23)
+                    {
+                        square_onscreen = true;
+                        break;
+                    }
+                }
+                if (!square_onscreen)
+                {
+                    game.swnmode = false;
                 }
             }
         }


### PR DESCRIPTION
Today, I saw a video posted by Chelito on the VVVVVV speedrunning Discord where he died inside a gravitron square over and over after the Gravitron in Intermission 2 ended.

https://cdn.discordapp.com/attachments/234787368522088448/779074864660480020/What.mp4

This is caused by the fact that after the Gravitron ends, the game no longer considers you to be inside swnmode, so it won't move the enemies offscreen when you die.

To fix this, after the Gravitron ends, the game will switch to swngame 8, where it will keep you inside swnmode until all gravitron squares are offscreen. This means that gravitron squares that are onscreen after the Gravitron ends will be moved offscreen if you die, preventing the above death loop from happening.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
