### PR TITLE
Don't hardcode offset of interim commit print

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -45,7 +45,7 @@ void menurender()
         graphics.Print( 310 - (10*8), 210, COMMIT_DATE, tr/2, tg/2, tb/2);
 #endif
 #ifdef INTERIM_COMMIT
-        graphics.Print( 310 - (8*8), 220, INTERIM_COMMIT, tr/2, tg/2, tb/2);
+        graphics.Print( 310 - SDL_strlen(INTERIM_COMMIT) * 8, 220, INTERIM_COMMIT, tr/2, tg/2, tb/2);
 #endif
         graphics.Print( 310 - (4*8), 230, "v2.3", tr/2, tg/2, tb/2);
 


### PR DESCRIPTION
Apparently, the amount of digits in a commit hash that git will output varies depending on how many objects are in the repository that the hash gets pulled from. The more objects, the more digits needed to avoid a hash collision.

Sources:
- https://stackoverflow.com/q/18134627/#comment26560283_18134919
- https://stackoverflow.com/a/21015031/

So that means we'll have to dynamically account for the length of the commit hash in order to get it properly right-aligned with the rest of the text.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
