### PR TITLE
Allow pressing ACTION to skip the fake loading screen

### DIFF
--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -527,6 +527,7 @@ void inline fixedloop()
         switch(game.gamestate)
         {
         case PRELOADER:
+            preloaderinput();
             preloaderrenderfixed();
             break;
 #if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -1,6 +1,7 @@
 #include "Enums.h"
 #include "Game.h"
 #include "Graphics.h"
+#include "KeyPoll.h"
 #include "UtilityClass.h"
 
 int pre_fakepercent=0, pre_transition=30;
@@ -9,6 +10,21 @@ int pre_darkcol=0, pre_lightcol=0, pre_curcol=0, pre_coltimer=0, pre_offset=0;
 
 int pre_frontrectx=30, pre_frontrecty=20, pre_frontrectw=260, pre_frontrecth=200;
 int pre_temprectx=0, pre_temprecty=0, pre_temprectw=320, pre_temprecth=240;
+
+void preloaderinput()
+{
+  game.press_action = false;
+
+  if (key.isDown(KEYBOARD_z) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v) || key.isDown(game.controllerButton_flip)) {
+    game.press_action = true;
+  }
+
+  if (game.press_action) {
+    //Skip to TITLEMODE immediately
+    game.gamestate = TITLEMODE;
+    game.jumpheld = true;
+  }
+}
 
 void preloaderrenderfixed()
 {

--- a/desktop_version/src/preloader.h
+++ b/desktop_version/src/preloader.h
@@ -1,6 +1,8 @@
 #ifndef PRELOADER_H
 #define PRELOADER_H
 
+void preloaderinput();
+
 void preloaderrender();
 
 void preloaderrenderfixed();


### PR DESCRIPTION
While there already exists an option to skip the fake loading screen entirely (without requiring an ACTION press), there are several reasons for including this option as well:

 * So people upgrading from 2.2 won't have to sit through the fake loading screen the first time they open 2.3.

 * So if people are too lazy to use the existing option, they can use this one instead.

 * So tool-assisted speedruns (TASes) of this game can skip the fake loading screen without requiring an existing `settings.vvv` beforehand.

   This last one is the biggest reason for me, since I'm not sure what TASVideos.org rules are regarding existing save files, but with this change nobody has to worry about their rules and can safely just press ACTION to skip the fake loading screen automatically.

Currently, when you press ACTION, the game will draw a solid black frame before drawing the ACTION prompt of `TITLEMODE`. This is because the current game loop code immediately switches which rendering functions it uses if `game.gamestate` changes in the middle of the execution of the loop, but this is a bug that will be fixed when #535 gets merged, which prevents switching rendering functions in the middle of the game loop.

Also, I discussed with @flibitijibibo in Discord DMs about adding this change, and his response was that he would defer to @TerryCavanagh whether or not this should be merged, because he doesn't know how important the fake loading screen is to Terry.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
