### PR TITLE
Add option to not use bundled TinyXML-2, PhysicsFS, and UTF8-CPP

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -7,6 +7,8 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
 OPTION(ENABLE_WARNINGS "Enable compilation warnings" ON)
 OPTION(ENABLE_WERROR "Treat compilation warnings as errors" OFF)
 
+SET(BUNDLE_DEPENDENCIES ON CACHE BOOL "Use bundled TinyXML-2, PhysicsFS, and UTF8-CPP (if disabled, TinyXML-2 and PhysicsFS will be dynamically linked, LodePNG and UTF8-CPP will still be statically linked)")
+
 SET(CUSTOM_LEVEL_SUPPORT ENABLED CACHE STRING "Optionally disable playing and/or editing of custom levels")
 SET_PROPERTY(CACHE CUSTOM_LEVEL_SUPPORT PROPERTY STRINGS ENABLED NO_EDITOR DISABLED)
 
@@ -74,13 +76,20 @@ IF(NOT WIN32)
 ENDIF()
 
 # Include Directories
-INCLUDE_DIRECTORIES(
-	src
-	../third_party/tinyxml2
-	../third_party/physfs
-	../third_party/lodepng
-	../third_party/utfcpp/source
-)
+IF(BUNDLE_DEPENDENCIES)
+	INCLUDE_DIRECTORIES(
+		src
+		../third_party/tinyxml2
+		../third_party/physfs
+		../third_party/lodepng
+		../third_party/utfcpp/source
+	)
+ELSE()
+	INCLUDE_DIRECTORIES(
+		src
+		../third_party/lodepng
+	)
+ENDIF()
 
 # Source Lists
 SET(VVV_SRC
@@ -233,9 +242,7 @@ ENDIF()
 SET_PROPERTY(TARGET VVVVVV PROPERTY CXX_STANDARD 98)
 SET_PROPERTY(TARGET VVVVVV PROPERTY CXX_EXTENSIONS FALSE)
 
-# Library information
-ADD_LIBRARY(tinyxml2-static STATIC ${XML2_SRC})
-ADD_LIBRARY(physfs-static STATIC ${PFS_SRC} ${PFSP_SRC})
+# Unfortunately, it doesn't seem like distros package LodePNG
 ADD_LIBRARY(lodepng-static STATIC ${PNG_SRC})
 
 TARGET_COMPILE_DEFINITIONS(lodepng-static PRIVATE
@@ -244,8 +251,16 @@ TARGET_COMPILE_DEFINITIONS(lodepng-static PRIVATE
 	-DLODEPNG_NO_COMPILE_ENCODER
 )
 
-# Static Dependencies
-TARGET_LINK_LIBRARIES(VVVVVV physfs-static tinyxml2-static lodepng-static)
+IF(BUNDLE_DEPENDENCIES)
+	ADD_LIBRARY(tinyxml2-static STATIC ${XML2_SRC})
+	ADD_LIBRARY(physfs-static STATIC ${PFS_SRC} ${PFSP_SRC})
+
+	TARGET_LINK_LIBRARIES(VVVVVV physfs-static tinyxml2-static lodepng-static)
+ELSE()
+	FIND_PACKAGE(utf8cpp CONFIG)
+
+	TARGET_LINK_LIBRARIES(VVVVVV physfs tinyxml2 utf8cpp lodepng-static)
+ENDIF()
 
 # SDL2 Dependency (Detection pulled from FAudio)
 if (DEFINED SDL2_INCLUDE_DIRS AND DEFINED SDL2_LIBRARIES)


### PR DESCRIPTION
If you configure the build with `-DBUNDLE_DEPENDENCIES=OFF`, then VVVVVV will dynamically link with TinyXML-2 and PhysicsFS instead of using the bundled source code in `third_party/` and statically linking with them.

Unfortunately, it doesn't seem like distros package LodePNG, and LodePNG isn't intended to be packaged, so we can't dynamically link with it, nor can we use some system LodePNG header files somewhere else because those don't exist.

UTF8-CPP is a special case, because no matter what, it's going to be statically linked with the binary (it doesn't come as a shared object file in any way). So with `-DBUNDLE_DEPENDENCIES=OFF`, we will use the system UTF8-CPP header files instead of the bundled ones, but it will still be statically linked in with the binary.

The main motivation for doing this is so if VVVVVV ever gets packaged in distros, distro maintainers would be more likely to accept it if there was an option to compile the game without bundled dependencies. Also, it discourages modifying the third-party dependencies we have, because it's always possible for someone to compile those dependencies without our changes, with this CMake option.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
