### PR TITLE
Refactor Game::savestats() to not use a default argument

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1334,7 +1334,7 @@ void Game::updatestate()
                 }
             }
 
-            savestats();
+            savestatsandsettings();
 
             graphics.fademode = 2;
             music.fadeout();
@@ -3133,7 +3133,7 @@ void Game::updatestate()
         }
 
 
-            savestats();
+            savestatsandsettings();
             if (nodeathmode)
             {
                 unlockAchievement("vvvvvvmaster"); //bloody hell
@@ -4447,7 +4447,7 @@ void Game::unlocknum( int t )
     }
 
     unlock[t] = true;
-    savestats();
+    savestatsandsettings();
 #endif
 }
 
@@ -4474,7 +4474,7 @@ void Game::loadstats(ScreenSettings* screen_settings)
     {
         // Save unlock.vvv only. Maybe we have a settings.vvv laying around too,
         // and we don't want to overwrite that!
-        savestats(true);
+        savestats();
 
         printf("No Stats found. Assuming a new player\n");
     }
@@ -4736,7 +4736,7 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* s
     }
 }
 
-bool Game::savestats(const bool stats_only /*= true*/)
+bool Game::savestats()
 {
     tinyxml2::XMLDocument doc;
     bool already_exists = FILESYSTEM_loadTiXml2Document("saves/unlock.vvv", doc);
@@ -4812,20 +4812,22 @@ bool Game::savestats(const bool stats_only /*= true*/)
 
     serializesettings(dataNode);
 
-    bool success = FILESYSTEM_saveTiXml2Document("saves/unlock.vvv", doc);
-
-    if (!stats_only)
-    {
-        success &= savesettings();
-    }
-
-    return success;
+    return FILESYSTEM_saveTiXml2Document("saves/unlock.vvv", doc);
 }
 
-void Game::savestats_menu()
+bool Game::savestatsandsettings()
 {
-    // Call Game::savestats(), but upon failure, go to the save error screen
-    if (!savestats() && !silence_settings_error)
+    const bool stats_saved = savestats();
+
+    const bool settings_saved = savesettings();
+
+    return stats_saved && settings_saved; // Not the same as `savestats() && savesettings()`!
+}
+
+void Game::savestatsandsettings_menu()
+{
+    // Call Game::savestatsandsettings(), but upon failure, go to the save error screen
+    if (!savestatsandsettings() && !silence_settings_error)
     {
         createmenu(Menu::errorsavingsettings);
         map.nexttowercolour();

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -133,8 +133,7 @@ public:
 
     void loadstats(ScreenSettings* screen_settings);
 
-    bool savestats(const bool stats_only = false);
-    void savestats_menu();
+    bool savestats();
 
     void deletestats();
 
@@ -145,6 +144,10 @@ public:
     void loadsettings(ScreenSettings* screen_settings);
 
     bool savesettings();
+
+    bool savestatsandsettings();
+
+    void savestatsandsettings_menu();
 
     void deletesettings();
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -390,12 +390,12 @@ void menuactionpress()
             game.createmenu(game.currentmenuname, true);
             game.currentmenuoption = 0;
 
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 1:
             music.playef(11);
             graphics.screenbuffer->toggleStretchMode();
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 2:
             // resize to nearest multiple
@@ -403,7 +403,7 @@ void menuactionpress()
             {
                 music.playef(11);
                 graphics.screenbuffer->ResizeToNearestMultiple();
-                game.savestats_menu();
+                game.savestatsandsettings_menu();
             }
             else
             {
@@ -413,19 +413,19 @@ void menuactionpress()
         case 3:
             music.playef(11);
             graphics.screenbuffer->toggleLinearFilter();
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 4:
             //change smoothing
             music.playef(11);
             graphics.screenbuffer->badSignalEffect= !graphics.screenbuffer->badSignalEffect;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 5:
             //toggle 30+ fps
             music.playef(11);
             game.over30mode = !game.over30mode;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 6:
             //toggle vsync
@@ -433,7 +433,7 @@ void menuactionpress()
 #ifndef __HAIKU__ // FIXME: Remove after SDL VSync bug is fixed! -flibit
             graphics.screenbuffer->vsync = !graphics.screenbuffer->vsync;
             graphics.screenbuffer->resetRendererWorkaround();
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
 #endif
             break;
         default:
@@ -480,7 +480,7 @@ void menuactionpress()
             music.playef(11);
             game.returnmenu();
             map.nexttowercolour();
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         }
         break;
@@ -494,7 +494,7 @@ void menuactionpress()
             game.returnmenu();
             game.currentmenuoption = 4;
             map.nexttowercolour();
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 1:
             game.slowdown = 24;
@@ -502,7 +502,7 @@ void menuactionpress()
             game.returnmenu();
             game.currentmenuoption = 4;
             map.nexttowercolour();
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 2:
             game.slowdown = 18;
@@ -510,7 +510,7 @@ void menuactionpress()
             game.returnmenu();
             game.currentmenuoption = 4;
             map.nexttowercolour();
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 3:
             game.slowdown = 12;
@@ -518,7 +518,7 @@ void menuactionpress()
             game.returnmenu();
             game.currentmenuoption = 4;
             map.nexttowercolour();
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         }
         break;
@@ -536,31 +536,31 @@ void menuactionpress()
                 SDL_ShowCursor(SDL_ENABLE);
                 graphics.showmousecursor = true;
             }
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 1:
             // toggle unfocus pause
             game.disablepause = !game.disablepause;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             music.playef(11);
             break;
         case 2:
             // toggle fake load screen
             game.skipfakeload = !game.skipfakeload;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             music.playef(11);
             break;
         case 3:
             // toggle translucent roomname BG
             graphics.translucentroomname = !graphics.translucentroomname;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             music.playef(11);
             break;
         case 4:
             // Glitchrunner mode
             music.playef(11);
             game.glitchrunnermode = !game.glitchrunnermode;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 5:
             //back
@@ -576,7 +576,7 @@ void menuactionpress()
         case 0:
             //disable animated backgrounds
             game.colourblindmode = !game.colourblindmode;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             graphics.towerbg.tdrawback = true;
             graphics.titlebg.tdrawback = true;
             music.playef(11);
@@ -584,7 +584,7 @@ void menuactionpress()
         case 1:
             //disable screeneffects
             game.noflashingmode = !game.noflashingmode;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             if (!game.noflashingmode)
             {
                 music.playef(18);
@@ -597,7 +597,7 @@ void menuactionpress()
         case 2:
             //disable text outline
             graphics.notextoutline = !graphics.notextoutline;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             music.playef(11);
             break;
         case 3:
@@ -612,7 +612,7 @@ void menuactionpress()
                 else
                 {
                     map.invincibility = !map.invincibility;
-                    game.savestats_menu();
+                    game.savestatsandsettings_menu();
                 }
                 music.playef(11);
             }
@@ -754,7 +754,7 @@ void menuactionpress()
             music.usingmmmmmm = !music.usingmmmmmm;
             music.playef(11);
             music.play(music.currentsong);
-            game.savestats();
+            game.savestatsandsettings();
         }
 
         offset += mmmmmm_offset;
@@ -784,7 +784,7 @@ void menuactionpress()
             music.playef(11);
             game.createmenu(Menu::unlockmenutrials, true);
             game.currentmenuoption = 0;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 1:   	//unlock 2
             game.unlock[10] = true;
@@ -792,7 +792,7 @@ void menuactionpress()
             music.playef(11);
             game.createmenu(Menu::unlockmenutrials, true);
             game.currentmenuoption = 1;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 2:   	//unlock 3
             game.unlock[11] = true;
@@ -800,7 +800,7 @@ void menuactionpress()
             music.playef(11);
             game.createmenu(Menu::unlockmenutrials, true);
             game.currentmenuoption = 2;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 3:   	//unlock 4
             game.unlock[12] = true;
@@ -808,7 +808,7 @@ void menuactionpress()
             music.playef(11);
             game.createmenu(Menu::unlockmenutrials, true);
             game.currentmenuoption = 3;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 4:   	//unlock 5
             game.unlock[13] = true;
@@ -816,7 +816,7 @@ void menuactionpress()
             music.playef(11);
             game.createmenu(Menu::unlockmenutrials, true);
             game.currentmenuoption = 4;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 5:   	//unlock 6
             game.unlock[14] = true;
@@ -824,7 +824,7 @@ void menuactionpress()
             music.playef(11);
             game.createmenu(Menu::unlockmenutrials, true);
             game.currentmenuoption = 5;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 6:   	//back
             //back
@@ -852,7 +852,7 @@ void menuactionpress()
             game.unlock[7] = true;
             game.createmenu(Menu::unlockmenu, true);
             game.currentmenuoption = 1;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 2:
             //unlock no death mode
@@ -861,7 +861,7 @@ void menuactionpress()
             game.unlocknotify[17] = true;
             game.createmenu(Menu::unlockmenu, true);
             game.currentmenuoption = 2;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 3:
             //unlock flip mode
@@ -870,7 +870,7 @@ void menuactionpress()
             game.unlocknotify[18] = true;
             game.createmenu(Menu::unlockmenu, true);
             game.currentmenuoption = 3;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 4:
             //unlock jukebox
@@ -878,7 +878,7 @@ void menuactionpress()
             game.stat_trinkets = 20;
             game.createmenu(Menu::unlockmenu, true);
             game.currentmenuoption = 4;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         case 5:
             //unlock secret lab
@@ -887,7 +887,7 @@ void menuactionpress()
             game.unlocknotify[8] = true;
             game.createmenu(Menu::unlockmenu, true);
             game.currentmenuoption = 5;
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
         default:
             //back
@@ -1251,7 +1251,7 @@ void menuactionpress()
             {
                 key.sensitivity = 0;
             }
-            game.savestats_menu();
+            game.savestatsandsettings_menu();
             break;
 
         case 5:

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -432,7 +432,7 @@ void gamelogic()
                     if (game.swnmessage == 0)
                     {
                         music.playef(25);
-                        game.savestats();
+                        game.savestatsandsettings();
                     }
                     game.swnmessage = 1;
                 }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3431,7 +3431,7 @@ void scriptclass::startgamemode( int t )
 	}
 #endif
 	case 100:
-		game.savestats();
+		game.savestatsandsettings();
 
 		SDL_Quit();
 		exit(0);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -402,7 +402,7 @@ int main(int argc, char *argv[])
         deltaloop();
     }
 
-    game.savestats();
+    game.savestatsandsettings();
     NETWORK_shutdown();
     SDL_Quit();
     FILESYSTEM_deinit();
@@ -641,7 +641,7 @@ void inline fixedloop()
     if (game.savemystats)
     {
         game.savemystats = false;
-        game.savestats();
+        game.savestatsandsettings();
     }
 
     //Mute button


### PR DESCRIPTION
In order to be able to fix the bug #556, I'm planning on adding `ScreenSettings*` to the `settings.vvv` write function. However, that entails adding another argument to `Game::savesettings()`, which is going to be really messy given the default argument of `Game::savestats()`. That, combined with the fact that the code comment at the site of the implementation of `Game::savestats()` being wrong (!!!), leads me to believe that using default function arguments here isn't worth it.

Instead, what I've done is made it so callers are explicit about whether or not they're calling `savestats()`, `savesettings()`, or both at the same time. If they are calling both at the same time, then they will be using a new function named `savestatsandsettings()`.

In short, these are the interface changes:
 * `bool Game::savestats(bool)` has been removed
 * `bool Game::savestatsandsettings()` has been added
 * `void Game::savestats_menu()` has been renamed to `void Game::savestatsandsettings_menu()`
 * All previous callers of `bool Game::savestats()` are now using `bool Game::savestatsandsettings()`
 * The one caller of `bool Game::savestats(bool)` is now using `bool Game::savestats()`

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
