### PR TITLE
Allow Game::savestats() to accept a pointer to ScreenSettings

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4738,6 +4738,14 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* s
 
 bool Game::savestats()
 {
+    ScreenSettings screen_settings;
+    graphics.screenbuffer->GetSettings(&screen_settings);
+
+    return savestats(&screen_settings);
+}
+
+bool Game::savestats(const ScreenSettings* screen_settings)
+{
     tinyxml2::XMLDocument doc;
     bool already_exists = FILESYSTEM_loadTiXml2Document("saves/unlock.vvv", doc);
     if (!already_exists)
@@ -4810,7 +4818,7 @@ bool Game::savestats()
 
     xml::update_tag(dataNode, "swnrecord", swnrecord);
 
-    serializesettings(dataNode);
+    serializesettings(dataNode, screen_settings);
 
     return FILESYSTEM_saveTiXml2Document("saves/unlock.vvv", doc);
 }
@@ -4834,29 +4842,19 @@ void Game::savestatsandsettings_menu()
     }
 }
 
-void Game::serializesettings(tinyxml2::XMLElement* dataNode)
+void Game::serializesettings(tinyxml2::XMLElement* dataNode, const ScreenSettings* screen_settings)
 {
     tinyxml2::XMLDocument& doc = xml::get_document(dataNode);
 
-    xml::update_tag(dataNode, "fullscreen", !graphics.screenbuffer->isWindowed);
+    xml::update_tag(dataNode, "fullscreen", (int) screen_settings->fullscreen);
 
-    xml::update_tag(dataNode, "stretch", graphics.screenbuffer->stretchMode);
+    xml::update_tag(dataNode, "stretch", screen_settings->stretch);
 
-    xml::update_tag(dataNode, "useLinearFilter", graphics.screenbuffer->isFiltered);
+    xml::update_tag(dataNode, "useLinearFilter", (int) screen_settings->linearFilter);
 
-    int width, height;
-    if (graphics.screenbuffer != NULL)
-    {
-        graphics.screenbuffer->GetWindowSize(&width, &height);
-    }
-    else
-    {
-        width = 320;
-        height = 240;
-    }
-    xml::update_tag(dataNode, "window_width", width);
+    xml::update_tag(dataNode, "window_width", screen_settings->windowWidth);
 
-    xml::update_tag(dataNode, "window_height", height);
+    xml::update_tag(dataNode, "window_height", screen_settings->windowHeight);
 
     xml::update_tag(dataNode, "noflashingmode", noflashingmode);
 
@@ -4869,7 +4867,7 @@ void Game::serializesettings(tinyxml2::XMLElement* dataNode)
     xml::update_tag(dataNode, "slowdown", slowdown);
 
 
-    xml::update_tag(dataNode, "advanced_smoothing", graphics.screenbuffer->badSignalEffect);
+    xml::update_tag(dataNode, "advanced_smoothing", (int) screen_settings->badSignal);
 
 
     xml::update_tag(dataNode, "usingmmmmmm", music.usingmmmmmm);
@@ -4890,16 +4888,7 @@ void Game::serializesettings(tinyxml2::XMLElement* dataNode)
 
     xml::update_tag(dataNode, "glitchrunnermode", (int) glitchrunnermode);
 
-    int vsyncOption;
-    if (graphics.screenbuffer != NULL)
-    {
-        vsyncOption = (int) graphics.screenbuffer->vsync;
-    }
-    else
-    {
-        vsyncOption = 0;
-    }
-    xml::update_tag(dataNode, "vsync", vsyncOption);
+    xml::update_tag(dataNode, "vsync", (int) screen_settings->useVsync);
 
     // Delete all controller buttons we had previously.
     // dataNode->FirstChildElement() shouldn't be NULL at this point...
@@ -4991,6 +4980,14 @@ void Game::loadsettings(ScreenSettings* screen_settings)
 
 bool Game::savesettings()
 {
+    ScreenSettings screen_settings;
+    graphics.screenbuffer->GetSettings(&screen_settings);
+
+    return savesettings(&screen_settings);
+}
+
+bool Game::savesettings(const ScreenSettings* screen_settings)
+{
     tinyxml2::XMLDocument doc;
     bool already_exists = FILESYSTEM_loadTiXml2Document("saves/settings.vvv", doc);
     if (!already_exists)
@@ -5006,7 +5003,7 @@ bool Game::savesettings()
 
     tinyxml2::XMLElement* dataNode = xml::update_element(root, "Data");
 
-    serializesettings(dataNode);
+    serializesettings(dataNode, screen_settings);
 
     return FILESYSTEM_saveTiXml2Document("saves/settings.vvv", doc);
 }

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -133,16 +133,18 @@ public:
 
     void loadstats(ScreenSettings* screen_settings);
 
+    bool savestats(const ScreenSettings* screen_settings);
     bool savestats();
 
     void deletestats();
 
     void deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* screen_settings);
 
-    void serializesettings(tinyxml2::XMLElement* dataNode);
+    void serializesettings(tinyxml2::XMLElement* dataNode, const ScreenSettings* screen_settings);
 
     void loadsettings(ScreenSettings* screen_settings);
 
+    bool savesettings(const ScreenSettings* screen_settings);
     bool savesettings();
 
     bool savestatsandsettings();

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -93,6 +93,21 @@ void Screen::init(const ScreenSettings& settings)
 	ResizeScreen(settings.windowWidth, settings.windowHeight);
 }
 
+void Screen::GetSettings(ScreenSettings* settings)
+{
+	int width, height;
+	GetWindowSize(&width, &height);
+
+	settings->windowWidth = width;
+	settings->windowHeight = height;
+
+	settings->fullscreen = !isWindowed;
+	settings->useVsync = vsync;
+	settings->stretch = stretchMode;
+	settings->linearFilter = isFiltered;
+	settings->badSignal = badSignalEffect;
+}
+
 void Screen::LoadIcon()
 {
 	unsigned char *fileIn = NULL;

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -10,6 +10,8 @@ class Screen
 public:
 	void init(const ScreenSettings& settings);
 
+	void GetSettings(ScreenSettings* settings);
+
 	void LoadIcon();
 
 	void ResizeScreen(int x, int y);


### PR DESCRIPTION
Another step to fix the bug #556 is to allow `Game::savestats()` to accept a pointer to an existing `ScreenSettings` struct. This entails refactoring `Game::savesettings()` and `Game::serializesettings()` to accept the function as well, along with adding `Screen::GetSettings()` so the settings of the current `Screen` can be easily grabbed.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
