### PR TITLE
Fix segfault when settings.vvv or unlock.vvv is missing

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4474,7 +4474,7 @@ void Game::loadstats(ScreenSettings* screen_settings)
     {
         // Save unlock.vvv only. Maybe we have a settings.vvv laying around too,
         // and we don't want to overwrite that!
-        savestats();
+        savestats(screen_settings);
 
         printf("No Stats found. Assuming a new player\n");
     }
@@ -4953,7 +4953,7 @@ void Game::loadsettings(ScreenSettings* screen_settings)
     tinyxml2::XMLDocument doc;
     if (!FILESYSTEM_loadTiXml2Document("saves/settings.vvv", doc))
     {
-        savesettings();
+        savesettings(screen_settings);
         puts("No settings.vvv found");
     }
 


### PR DESCRIPTION
To fix this bug, all we have to do is just pass the existing `ScreenSettings*` that we have in `loadstats()` to `savestats()`, and in `loadsettings()` to `savesettings()`.

Fixes #556. Depends on #558.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
