### PR TITLE
De-duplicate script.running checks

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -2101,9 +2101,6 @@ void mapclass::twoframedelayfix()
 	game.state = 0;
 	game.statedelay = 0;
 	script.load(game.newscript);
-	if (script.running)
-	{
-		script.run();
-		script.dontrunnextframe = true;
-	}
+	script.run();
+	script.dontrunnextframe = true;
 }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -79,6 +79,11 @@ void scriptclass::tokenize( const std::string& t )
 
 void scriptclass::run()
 {
+	if (!running)
+	{
+		return;
+	}
+
 	// This counter here will stop the function when it gets too high
 	short execution_counter = 0;
 	while(running && scriptdelay<=0 && !game.pausescript)

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -556,7 +556,7 @@ void inline fixedloop()
             {
                 script.dontrunnextframe = false;
             }
-            else if (script.running)
+            else
             {
                 script.run();
             }
@@ -586,10 +586,7 @@ void inline fixedloop()
             }
             else
             {
-                if (script.running)
-                {
-                    script.run();
-                }
+                script.run();
                 gameinput();
             }
             maplogic();


### PR DESCRIPTION
While I was working on #535, I noticed that all the call sites of `script.run()` have the exact same code, namely:

```c++
if (script.running)
{
    script.run();
}
```

I figured, why not move the `script.running` check into the function itself? That way, we won't have to duplicate the check every single time, and we don't risk forgetting to add the check and causing a bug because of that.

The check was already duplicated once since 2.0 (it's used in both GAMEMODE and TELEPORTERMODE), and with the fix of the two-frame delay in 2.3, it's now duplicated twice, leading to *three* instances of this check in the code, when there should be only one.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
