### PR TITLE
Fix kludge_ingametemp being assigned after menu creation

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2389,6 +2389,10 @@ void mapmenuactionpress()
         game.gamestate = TITLEMODE;
         graphics.flipmode = false;
         game.ingame_titlemode = true;
+
+        // Set this before we create the menu
+        game.kludge_ingametemp = game.currentmenuname;
+
         if (game.menupage == 32)
         {
             game.createmenu(Menu::graphicoptions);
@@ -2397,7 +2401,6 @@ void mapmenuactionpress()
         {
             game.createmenu(Menu::options);
         }
-        game.kludge_ingametemp = game.currentmenuname;
 
         map.nexttowercolour();
 


### PR DESCRIPTION
While working on #535, I noticed this bug.

When going to Graphic Options or Game Options from the pause menu, `kludge_ingametemp` was intended to save the current menu stack frame *before* either of those menus got created. However, it was actually assigned afterwards, meaning `kludge_ingametemp` would always be either `Menu::graphicoptions` or `Menu::options`.

This meant that the `returntomenu()` in `returntopausemenu()` would always attempt to return to the current in-game menu, and seeing as it's the same menu, would re-create the menu, instead of returning to the previous menu before it.

This patch also fixes a potential source of a trivial memory leak, if someone were to keep entering and exiting Graphic Options or Game Options from the pause menu. It would keep piling up duplicate Graphic Options or Game Options stack frames, which would never get removed. However, they do get removed when you exit to the menu properly, by `returntomenu()` again, so this doesn't seem like that serious of an issue, but it's still good to fix.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
