### PR TITLE
Don't recompile all files when the commit hash is changed

### DIFF
--- a/desktop_version/.gitignore
+++ b/desktop_version/.gitignore
@@ -9,6 +9,7 @@ VVVVVV.exe
 VVVVVV
 *.a
 *.gch
+src/Version.h.out
 
 # Game data
 data.zip

--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -28,15 +28,20 @@ ELSE()
 			ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
 		)
 
-		ADD_DEFINITIONS(-DINTERIM_COMMIT="${INTERIM_COMMIT}")
-
 		EXECUTE_PROCESS(
 			COMMAND "${GIT_EXECUTABLE}" log -1 --format=%cs
 			OUTPUT_VARIABLE COMMIT_DATE
 			ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
 		)
 
-		ADD_DEFINITIONS(-DCOMMIT_DATE="${COMMIT_DATE}")
+		MESSAGE(STATUS "This is interim commit ${INTERIM_COMMIT} (committed ${COMMIT_DATE})")
+
+		# Take template file and replace the macros with what we have
+		# Unfortunately the output is taken relative to binary path so we have to qualify it
+		CONFIGURE_FILE(src/Version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/src/Version.h.out)
+
+		# This lets Version.h know that Version.h.out exists
+		ADD_DEFINITIONS(-DVERSION_H_OUT_EXISTS)
 	ENDIF()
 ENDIF()
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -10,6 +10,7 @@
 #include "Music.h"
 #include "Script.h"
 #include "UtilityClass.h"
+#include "Version.h"
 
 int tr;
 int tg;

--- a/desktop_version/src/Version.h
+++ b/desktop_version/src/Version.h
@@ -1,0 +1,8 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+#ifdef VERSION_H_OUT_EXISTS
+#include "Version.h.out"
+#endif
+
+#endif /* VERSION_H */

--- a/desktop_version/src/Version.h.in
+++ b/desktop_version/src/Version.h.in
@@ -1,0 +1,7 @@
+#ifndef VERSION_H_OUT
+#define VERSION_H_OUT
+
+#define INTERIM_COMMIT "@INTERIM_COMMIT@"
+#define COMMIT_DATE "@COMMIT_DATE@"
+
+#endif /* VERSION_H_OUT */


### PR DESCRIPTION
The previous implementation of showing the commit hash on the title screen used a preprocessor definition added at CMake time to pass the hash and date. This was passed for every file compiled, so if the date or hash changed, then every file would be recompiled. This is especially annoying if you're working on the game and switching branches all the time - the game has at least 50 source files to recompile!

To fix this, we'll switch to using a generated file, named `Version.h.out`, that only gets included by the necessary files (which there is only one of - `Render.cpp`). It will be autogenerated by CMake (by using `CONFIGURE_FILE()`, which takes a templated file and does a find-and-replace on it, not unlike C macros), and since there's only one file that includes it, only one file will need to be recompiled when it changes.

And also to prevent `Version.h.out` being a required file, it will only be included if necessary (i.e. `OFFICIAL_BUILD` is off). Since the C preprocessor can't ignore non-existing include files and will always error on them, I wrapped the `#include` in an `#ifdef VERSION_H_OUT_EXISTS`, and CMake will add the `VERSION_H_OUT_EXISTS` define when generating `Version.h.out`. The wrapper is named `Version.h`, so any file that `#include`s the commit hash and date should `#include` `Version.h` instead of `Version.h.out`.

As an added bonus, I've also made it so CMake will print `This is interim commit [HASH] (committed [DATE])` at configure time if the game is going to be compiled with an interim commit hash.

Now, there is also the issue that the commit hash change will only be noticed in the first place if CMake needs to be re-ran for anything, but that's a less severe issue than requiring recompilation of 50(!) or so files.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
