### PR TITLE
Update commit hash every time it changes, not just when CMake is re-ran

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -18,31 +18,6 @@ SET(OFFICIAL_BUILD OFF CACHE BOOL "Compile an official build of the game")
 IF(OFFICIAL_BUILD)
 	SET(STEAM ON)
 	SET(GOG ON)
-ELSE()
-	# Get interim commit and date of commit
-	FIND_PACKAGE(Git)
-	IF(GIT_FOUND)
-		EXECUTE_PROCESS(
-			COMMAND "${GIT_EXECUTABLE}" log -1 --format=%h
-			OUTPUT_VARIABLE INTERIM_COMMIT
-			ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
-		)
-
-		EXECUTE_PROCESS(
-			COMMAND "${GIT_EXECUTABLE}" log -1 --format=%cs
-			OUTPUT_VARIABLE COMMIT_DATE
-			ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
-		)
-
-		MESSAGE(STATUS "This is interim commit ${INTERIM_COMMIT} (committed ${COMMIT_DATE})")
-
-		# Take template file and replace the macros with what we have
-		# Unfortunately the output is taken relative to binary path so we have to qualify it
-		CONFIGURE_FILE(src/Version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/src/Version.h.out)
-
-		# This lets Version.h know that Version.h.out exists
-		ADD_DEFINITIONS(-DVERSION_H_OUT_EXISTS)
-	ENDIF()
 ENDIF()
 
 # Set standard to C++98/C++03
@@ -175,6 +150,38 @@ IF(WIN32)
 	ADD_EXECUTABLE(VVVVVV WIN32 ${VVV_SRC})
 ELSE()
 	ADD_EXECUTABLE(VVVVVV ${VVV_SRC})
+ENDIF()
+
+IF(NOT OFFICIAL_BUILD)
+	# Add interim commit hash and its date to the build
+
+	# FIND_PACKAGE sets GIT_FOUND and GIT_EXECUTABLE
+	FIND_PACKAGE(Git)
+
+	IF(GIT_FOUND)
+		# These filenames have to be qualified, because when we run
+		# the CMake script, its work dir gets set to the build folder
+		SET(VERSION_INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/Version.h.in)
+		SET(VERSION_OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/Version.h.out)
+
+		ADD_CUSTOM_TARGET(
+			GenerateVersion ALL
+			# This BYPRODUCTS line is required for this to be ran every time
+			BYPRODUCTS ${VERSION_OUTPUT_FILE}
+			COMMAND ${CMAKE_COMMAND}
+			# These args have to be passed through, otherwise the script can't see them
+			# Also, these args have to come BEFORE `-P`! (Otherwise it fails with an unclear error)
+			-DGIT_EXECUTABLE=${GIT_EXECUTABLE}
+			-DINPUT_FILE=${VERSION_INPUT_FILE}
+			-DOUTPUT_FILE=${VERSION_OUTPUT_FILE}
+			-P ${CMAKE_CURRENT_SOURCE_DIR}/version.cmake
+		)
+
+		ADD_DEPENDENCIES(VVVVVV GenerateVersion)
+
+		# This lets Version.h know that Version.h.out exists
+		ADD_DEFINITIONS(-DVERSION_H_OUT_EXISTS)
+	ENDIF()
 ENDIF()
 
 # Build options

--- a/desktop_version/version.cmake
+++ b/desktop_version/version.cmake
@@ -1,0 +1,19 @@
+# Expects INPUT_FILE and OUTPUT_FILE to be defined
+
+# Get interim commit and date of commit
+EXECUTE_PROCESS(
+	COMMAND "${GIT_EXECUTABLE}" log -1 --format=%h
+	OUTPUT_VARIABLE INTERIM_COMMIT
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+EXECUTE_PROCESS(
+	COMMAND "${GIT_EXECUTABLE}" log -1 --format=%cs
+	OUTPUT_VARIABLE COMMIT_DATE
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+MESSAGE(STATUS "This is interim commit ${INTERIM_COMMIT} (committed ${COMMIT_DATE})")
+
+# Take the template file and replace the macros with what we have
+CONFIGURE_FILE(${INPUT_FILE} ${OUTPUT_FILE})


### PR DESCRIPTION
The commit hash is now properly updated every time it gets changed, and not just when CMake gets re-ran.

For this to work, we need to use a few CMake tricks. We add a custom target with `ADD_CUSTOM_TARGET()`, which is apparently always considered out-of-date (but I had to add a `BYPRODUCTS` line to get it to actually work), and we use the target to run a `.cmake` file every time we build. Also, VVVVVV needs to depend on this custom target, to ensure that the game gets built *after* the version gets generated - otherwise there'll be an error. So we do an `ADD_DEPENDENCIES()` after the `ADD_EXECUTABLE()` for VVVVVV.

This file, `version.cmake`, is just the `Version.h.out` generation that I added previously, but the important thing about all of this is that if the contents of `Version.h.out` doesn't change, and thus if the commit hash hasn't changed, then CMake will never recompile and relink anything at all. (At least with the Ninja generator.)

On a small note, since the `Version.h.out` generation is now a separate script that is guaranteed to get ran on every single build, while the Git `FIND_PACKAGE()` gets ran only at configure time, it is possible for the cached path of the Git executable to get out of date. Fixing this requires a simple re-configure (ideally), but in case it wasn't fixed, the `INTERIM_COMMIT` and `COMMIT_DATE` variables would get set to empty strings instead of containing a value. To prevent this from happening, I've removed `ERROR_QUIET` from the `EXECUTE_PROCESS()` calls in `version.cmake`, because it's better to explicitly error if the Git executable wasn't found than implicitly carry on like nothing happened.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
