### PR TITLE
Use SDL_arraysize() - 1 to take length of INTERIM_COMMIT

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -66,7 +66,7 @@ void menurender()
         graphics.Print( 310 - (10*8), 210, COMMIT_DATE, tr/2, tg/2, tb/2);
 #endif
 #ifdef INTERIM_COMMIT
-        graphics.Print( 310 - SDL_strlen(INTERIM_COMMIT) * 8, 220, INTERIM_COMMIT, tr/2, tg/2, tb/2);
+        graphics.Print( 310 - (SDL_arraysize(INTERIM_COMMIT) - 1) * 8, 220, INTERIM_COMMIT, tr/2, tg/2, tb/2);
 #endif
         graphics.Print( 310 - (4*8), 230, "v2.3", tr/2, tg/2, tb/2);
 


### PR DESCRIPTION
Since `INTERIM_COMMIT` is a char array whose size we know for sure at compile time, and which we also know is an array (instead of being a pointer), we can take the `SDL_arraysize()` of it. However, `SDL_arraysize()` doesn't account for the null terminator unlike `SDL_strlen()`, so we'll have to do it ourselves. But at least we are guaranteed to get a constant value at compile time, unlike if we use `SDL_strlen()`, which would be repeatedly evaluating a constant value at runtime.

To my knowledge, there's no equivalent `SDL_arraysize()` for constant strings, and a quick `rg` (ripgrep) for `sizeof` in the SDL `include/` folder doesn't show anything like that. So we'll just have to use the `SDL_arraysize() - 1` and deal with it.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
