### PR TITLE
Fix entity and block indices after destroying them

### DIFF
--- a/desktop_version/src/BlockV.cpp
+++ b/desktop_version/src/BlockV.cpp
@@ -2,6 +2,11 @@
 
 blockclass::blockclass()
 {
+	clear();
+}
+
+void blockclass::clear()
+{
 	type = 0;
 	trigger = 0;
 
@@ -20,6 +25,11 @@ blockclass::blockclass()
 
 	x = 0.0f;
 	y = 0.0f;
+
+	/* std::strings get initialized automatically, but this is */
+	/* in case this function gets called again after construction */
+	script.clear();
+	prompt.clear();
 }
 
 void blockclass::rectset(const int xi, const int yi, const int wi, const int hi)

--- a/desktop_version/src/BlockV.h
+++ b/desktop_version/src/BlockV.h
@@ -8,6 +8,7 @@ class blockclass
 {
 public:
     blockclass();
+    void clear();
 
     void rectset(const int xi, const int yi, const int wi, const int hi);
 

--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -5,6 +5,11 @@
 
 entclass::entclass()
 {
+	clear();
+}
+
+void entclass::clear()
+{
 	invis = false;
 	type = 0;
 	size = 0;

--- a/desktop_version/src/Ent.h
+++ b/desktop_version/src/Ent.h
@@ -9,6 +9,7 @@ class entclass
 {
 public:
     entclass();
+    void clear();
 
     bool outside();
 

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -10,23 +10,6 @@
 #include "BlockV.h"
 #include "Game.h"
 
-#define removeentity_iter(index) \
-    do \
-    { \
-        extern entityclass obj; \
-        if (obj.removeentity(index)) \
-        { \
-            index--; \
-        } \
-    } while (false)
-#define removeblock_iter(index) \
-    do \
-    { \
-        extern entityclass obj; \
-        obj.removeblock(index); \
-        index--; \
-    } while (false)
-
 enum
 {
     BLOCK = 0,
@@ -71,17 +54,15 @@ public:
 
     void createblock(int t, int xp, int yp, int w, int h, int trig = 0, const std::string& script = "");
 
-    bool removeentity(int t);
+    bool disableentity(int t);
 
     void removeallblocks();
 
-    void removeblock(int t);
+    void disableblock(int t);
 
-    void removeblockat(int x, int y);
+    void disableblockat(int x, int y);
 
     void moveblockto(int x1, int y1, int x2, int y2, int w, int h);
-
-    void nocollisionat(int x, int y);
 
     void removetrigger(int t);
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -2173,7 +2173,7 @@ void Game::updatestate()
             i = obj.getcompanion();
             if(INBOUNDS_VEC(i, obj.entities))
             {
-                obj.removeentity(i);
+                obj.disableentity(i);
             }
 
             i = obj.getteleporter();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1891,7 +1891,7 @@ void gameinput()
                         if((int(SDL_fabsf(obj.entities[ie].vx))<=1) && (int(obj.entities[ie].vy) == 0) )
                         {
                             script.load(obj.blocks[game.activeactivity].script);
-                            obj.removeblock(game.activeactivity);
+                            obj.disableblock(game.activeactivity);
                             game.activeactivity = -1;
                         }
                     }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -347,7 +347,7 @@ void gamelogic()
                         //(and if the tile wasn't there it would pass straight through again)
                         int prevx = obj.entities[i].xp;
                         int prevy = obj.entities[i].yp;
-                        obj.nocollisionat(prevx, prevy);
+                        obj.disableblockat(prevx, prevy);
 
                         obj.entities[i].xp = 152;
                         obj.entities[i].newxp = 152;
@@ -668,7 +668,7 @@ void gamelogic()
                     obj.entities[line].xp += 24;
                     if (obj.entities[line].xp > 320)
                     {
-                        obj.removeentity(line);
+                        obj.disableentity(line);
                         game.swngame = 8;
                     }
                 }
@@ -783,7 +783,7 @@ void gamelogic()
 
                     int prevx = obj.entities[i].xp;
                     int prevy = obj.entities[i].yp;
-                    obj.nocollisionat(prevx, prevy);
+                    obj.disableblockat(prevx, prevy);
 
                     bool entitygone = obj.updateentities(i);                // Behavioral logic
                     if (entitygone) continue;
@@ -811,7 +811,7 @@ void gamelogic()
 
                     int prevx = obj.entities[ie].xp;
                     int prevy = obj.entities[ie].yp;
-                    obj.nocollisionat(prevx, prevy);
+                    obj.disableblockat(prevx, prevy);
 
                     bool entitygone = obj.updateentities(ie);                // Behavioral logic
                     if (entitygone) continue;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -871,11 +871,25 @@ void mapclass::gotoroom(int rx, int ry)
 		}
 	}
 
-	for (size_t i = 0; i < obj.entities.size(); i++)
+	/* Disable all entities in the room, and deallocate any unnecessary entity slots. */
+	/* However don't disable player entities, but do preserve holes between them (if any). */
+	bool player_found = false;
+	for (int i = obj.entities.size() - 1; i >= 0; --i)
 	{
-		if (obj.entities[i].rule != 0)
+		/* Iterate in reverse order to prevent unnecessary indice shifting */
+		if (obj.entities[i].rule == 0)
 		{
-			removeentity_iter(i);
+			player_found = true;
+			continue;
+		}
+
+		if (!player_found)
+		{
+			obj.entities.erase(obj.entities.begin() + i);
+		}
+		else
+		{
+			obj.disableentity(i);
 		}
 	}
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -167,16 +167,16 @@ void scriptclass::run()
 			{
 				if(words[1]=="gravitylines"){
 					for(size_t edi=0; edi<obj.entities.size(); edi++){
-						if(obj.entities[edi].type==9) removeentity_iter(edi);
-						if(obj.entities[edi].type==10) removeentity_iter(edi);
+						if(obj.entities[edi].type==9) obj.disableentity(edi);
+						if(obj.entities[edi].type==10) obj.disableentity(edi);
 					}
 				}else if(words[1]=="warptokens"){
 					for(size_t edi=0; edi<obj.entities.size(); edi++){
-						if(obj.entities[edi].type==11) removeentity_iter(edi);
+						if(obj.entities[edi].type==11) obj.disableentity(edi);
 					}
 				}else if(words[1]=="platforms"){
 					for(size_t edi=0; edi<obj.entities.size(); edi++){
-						if(obj.entities[edi].rule==2 && obj.entities[edi].animate==100) removeentity_iter(edi);
+						if(obj.entities[edi].rule==2 && obj.entities[edi].animate==100) obj.disableentity(edi);
 					}
 				}
 			}
@@ -3701,13 +3701,12 @@ void scriptclass::hardreset()
 		obj.entities[theplayer].tile = 0;
 	}
 
-	// Remove duplicate player entities
+	/* Disable duplicate player entities */
 	for (int i = 0; i < (int) obj.entities.size(); i++)
 	{
 		if (obj.entities[i].rule == 0 && i != theplayer)
 		{
-			removeentity_iter(i);
-			theplayer--; // just in case indice of player is not 0
+			obj.disableentity(i);
 		}
 	}
 


### PR DESCRIPTION
This patch restores some 2.2 behavior, fixing a regression caused by the refactor of properly using `std::vector`s.

In 2.2, the game allocated 200 items in `obj.entities`, but used a system where each entity had an `active` attribute to signify if the entity actually existed or not. When dealing with entities, you would have to check this `active` flag, or else you'd be dealing with an entity that didn't actually exist. (By the way, what I'm saying applies to blocks and `obj.blocks` as well, except for some small differing details like the game allocating 500 block slots versus `obj.entities`'s 200.)

As a consequence, the game had to use a separate tracking variable, `obj.nentity`, because `obj.entities.size()` would just report 200, instead of the actual amount of entities. Needless to say, having to check for `active` and use `obj.nentity` is a bit error-prone, and it's messier than simply using the `std::vector` the way it was intended. Also, this resulted in a hard limit of 200 entities, which custom level makers ran into surprisingly quite often.

2.3 comes along, and removes the whole system. Now, `std::vector`s are properly being used, and `obj.entities.size()` reports the actual number of entities in the vector; you no longer have to check for `active` when dealing with entities of any sort.

But there was one previous behavior of 2.2 that this system kind of forgets about - namely, the ability to have holes in between entities. You see, when an entity got disabled in 2.2 (which just meant turning its `active` off), the indices of all other entities stayed the same; the indice of the entity that got disabled stays there as a hole in the array. But when an entity gets removed in 2.3 (previous to this patch), the indices of every entity afterwards in the array get shifted down by one. `std::vector` isn't really meant to be able to contain holes.

Do the indices of entities and blocks matter? Yes; they determine the order in which entities and blocks get evaluated (the highest indice gets evaluated first), and I had to fix some block evaluation order stuff in previous PRs.

And in the case of entities, they matter hugely when using the recently-discovered Arbitrary Entity Manipulation glitch (where crewmate script commands are used on arbitrary entities by setting the `i` attribute of `scriptclass` and passing invalid crewmate identifiers to the commands). If you use Arbitrary Entity Manipulation after destroying some entities, there is a chance that your script won't work between 2.2 and 2.3.

The indices also still determine the rendering order of entities (highest indice gets drawn first, which means lowest indice gets drawn in front of other entities). As an example: let's say we have the player at 0, a gravity line at 1, and a checkpoint at 2; then we destroy the gravity line and create a crewmate (let's do Violet).

If we're able to have holes, then after removing the gravity line, none of the other indices shift. Then Violet will be created at indice 1, and will be drawn in front of the checkpoint.

But if we can't have holes, then removing the gravity line results in the indice of the checkpoint shifting down to indice 1. Then Violet is created at indice 2, and gets drawn behind the checkpoint! This is a clear illustration of changing the behavior that existed in 2.2.

And here is a level that you can run to see this behavior for yourself:

- [entity_indice_demonstration.zip](https://github.com/TerryCavanagh/VVVVVV/files/5992212/entity_indice_demonstration.zip)

However, I also don't want to go back to the `active` system of having to check an attribute before operating on an entity. So... what do we do to restore the holes?

Well, we don't need to have an `active` attribute, or modify any existing code that operates on entities. Instead, we can just set the attributes of the entities so that they naturally get ignored by everything that comes into contact with it. For entities, we set their `invis` to true, and their `size`, `type`, and `rule` to -1 (the game never uses a `size`, `type`, or `rule` of -1 anywhere); for blocks, we set their `type` to -1, and their width and height to 0.

`obj.entities.size()` will no longer necessarily equal the amount of entities in the room; rather, it will be the amount of entity *slots* that have been allocated. But nothing that uses `obj.entities.size()` needs to actually know the amount of entities; it's mostly used for iterating over every entity in the vector.

Excess entity slots get cleaned up upon every call of `mapclass::gotoroom()`, which will now deallocate entity slots starting from the end until it hits a player, at which point it will switch to disabling entity slots instead of removing them entirely.

The `entclass::clear()` and `blockclass::clear()` functions have been restored because we need to call their initialization functions when reusing a block/entity slot; it's possible to create an entity with an invalid type number (it creates a glitchy Viridian), and without calling the initialization function again, it would simply not create anything.

After this patch is applied, entity and block indices will be restored to how they behaved in 2.2.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
