### PR TITLE
Add official, M&P, no custom levels, and no editor builds to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,40 @@ jobs:
       if: startsWith(matrix.os, 'macos')
       run: brew install ninja sdl2 sdl2_mixer
 
-    - name: CMake configure
+    - name: CMake configure (default version)
       run: |
         mkdir ${SRC_DIR_PATH}/build && cd ${SRC_DIR_PATH}/build
         cmake -GNinja ..
-    - name: Build
+    - name: Build (default version)
+      run: ninja -C ${SRC_DIR_PATH}/build
+
+    - name: CMake configure (official)
+      run: |
+        cd ${SRC_DIR_PATH}/build
+        cmake -DOFFICIAL_BUILD=ON ..
+    - name: Build (official)
+      run: |
+        ninja -C ${SRC_DIR_PATH}/build
+
+    - name: CMake configure (M&P)
+      run: |
+        cd ${SRC_DIR_PATH}/build
+        cmake -DOFFICIAL_BUILD=OFF -DMAKEANDPLAY=ON ..
+    - name: Build (M&P)
+      run: ninja -C ${SRC_DIR_PATH}/build
+
+    - name: CMake configure (no custom levels)
+      run: |
+        cd ${SRC_DIR_PATH}/build
+        cmake -DMAKEANDPLAY=OFF -DCUSTOM_LEVEL_SUPPORT=DISABLED ..
+    - name: Build (no custom levels)
+      run: ninja -C ${SRC_DIR_PATH}/build
+
+    - name: CMake configure (no editor)
+      run: |
+        cd ${SRC_DIR_PATH}/build
+        cmake -DCUSTOM_LEVEL_SUPPORT=NO_EDITOR ..
+    - name: Build (no editor)
       run: ninja -C ${SRC_DIR_PATH}/build
 
   build-win:
@@ -52,7 +81,7 @@ jobs:
       run: |
         vcpkg install sdl2 sdl2-mixer
 
-    - name: CMake configure
+    - name: CMake configure (default version)
       run: |
         cd $env:SRC_DIR_PATH
         $env:LDFLAGS =  "/LIBPATH:$env:VCPKG_INSTALLATION_ROOT\installed\x86-windows\lib "
@@ -60,7 +89,43 @@ jobs:
         cmake -G "Visual Studio 16 2019" -A Win32 `
               -DSDL2_INCLUDE_DIRS="$env:VCPKG_INSTALLATION_ROOT\installed\x86-windows\include\SDL2" `
               -DSDL2_LIBRARIES="SDL2;SDL2main;SDL2_mixer" .
-    - name: Build
+    - name: Build (default version)
+      run: |
+        cd $env:SRC_DIR_PATH
+        cmake --build .
+
+    - name: CMake configure (official)
+      run: |
+        cd $env:SRC_DIR_PATH
+        cmake -DOFFICIAL_BUILD=ON .
+    - name: Build (official)
+      run: |
+        cd $env:SRC_DIR_PATH
+        cmake --build .
+
+    - name: CMake configure (M&P)
+      run: |
+        cd $env:SRC_DIR_PATH
+        cmake -DOFFICIAL_BUILD=OFF -DMAKEANDPLAY=ON .
+    - name: Build (M&P)
+      run: |
+        cd $env:SRC_DIR_PATH
+        cmake --build .
+
+    - name: CMake configure (no custom levels)
+      run: |
+        cd $env:SRC_DIR_PATH
+        cmake -DMAKEANDPLAY=OFF -DCUSTOM_LEVEL_SUPPORT=DISABLED .
+    - name: Build (no custom levels)
+      run: |
+        cd $env:SRC_DIR_PATH
+        cmake --build .
+
+    - name: CMake configure (no editor)
+      run: |
+        cd $env:SRC_DIR_PATH
+        cmake -DCUSTOM_LEVEL_SUPPORT=NO_EDITOR .
+    - name: Build (no editor)
       run: |
         cd $env:SRC_DIR_PATH
         cmake --build .

--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -15,9 +15,15 @@ SET(GOG OFF CACHE BOOL "Use the GOG API")
 
 SET(OFFICIAL_BUILD OFF CACHE BOOL "Compile an official build of the game")
 
-IF(OFFICIAL_BUILD)
+SET(MAKEANDPLAY OFF CACHE BOOL "Compile a version of the game without the main campaign (provided for convenience; consider modifying MakeAndPlay.h instead")
+
+IF(OFFICIAL_BUILD AND NOT MAKEANDPLAY)
 	SET(STEAM ON)
 	SET(GOG ON)
+ENDIF()
+
+IF(MAKEANDPLAY)
+	ADD_DEFINITIONS(-DMAKEANDPLAY)
 ENDIF()
 
 # Set standard to C++98/C++03


### PR DESCRIPTION
CI builds were added to this repository on the first day it was released, and haven't really been touched since then. And since then, 2.3 has added `NO_CUSTOM_LEVELS`, `NO_EDITOR`, and `OFFICIAL_BUILD` builds to the CMake file.

On top of the `MAKEANDPLAY` define already existing, this means CI coverage is a bit sparse - covering compile failures for changes made to most of the codebase, except for Steam and GOG, and not covering compile failures if certain parts of the code get stripped out. And people do forget to check for those configurations as well.

These mess of configurations is kind of a wake-up call to refactor and generalize the code a bit, because we would probably be able to get rid of at least two of these (Make & Play, and no-custom-levels) by making it so custom levels behave indistinguishably from the main game. But, that's something to do in 2.4. At the very least, we should cover these in CI right now.

On a small note, I had to add a `MAKEANDPLAY` configure option to the CMake file to be able to easily configure a Make & Play build from the CI runner. This option shouldn't really be used otherwise, so I added a note to it telling people to consider modifying `MakeAndPlay.h` instead.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
