### PR TITLE
Consistently set game.lifeseq to 0 when script.startgamemode() is called

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2675,6 +2675,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -2700,6 +2701,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		graphics.fademode = 4;
@@ -2740,6 +2742,7 @@ void scriptclass::startgamemode( int t )
 			map.cameramode = 0;
 			map.colsuperstate = 0;
 		}
+		game.lifeseq = 0;
 		graphics.fademode = 4;
 		break;
 	case 3:
@@ -2767,6 +2770,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		graphics.fademode = 4;
@@ -2796,6 +2800,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		graphics.fademode = 4;
@@ -2825,6 +2830,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		graphics.fademode = 4;
@@ -2854,6 +2860,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		graphics.fademode = 4;
@@ -2883,6 +2890,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		graphics.fademode = 4;
@@ -2918,6 +2926,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		graphics.fademode = 4;
@@ -2943,6 +2952,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -2972,6 +2982,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3008,6 +3019,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		music.play(11);
@@ -3044,6 +3056,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3080,6 +3093,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3116,6 +3130,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3152,6 +3167,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3185,6 +3201,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3218,6 +3235,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3251,6 +3269,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3284,6 +3303,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3308,6 +3328,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		graphics.fademode = 4;
@@ -3344,6 +3365,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		if(ed.levmusic>0){
@@ -3382,6 +3404,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3428,6 +3451,7 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
+		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		ed.generatecustomminimap();


### PR DESCRIPTION
There's a small inconsistency where the first time you load in to the game, `game.lifeseq` is at 0, but when you exit to the menu and load in again, `game.lifeseq` becomes 10. This is visible as Viridian blinking when loading in only after the first time you load in, and this also means that after the first time you load in, you also have to wait 5 frames before being able to move Viridian.

The reason for this inconsistency is because on the first time you load in to the game, there are no entities loaded in `obj.entities` yet, so the game creates a player entity, and doesn't mess with `game.lifeseq`. When you exit and then load in for the second time, `obj.entities` contains at least one entity (all the entities from the room you just exited out of - `map.gotoroom()` hasn't even been called yet, so it doesn't even check for only the player entity), so the game calls `map.resetplayer()` instead, and `map.resetplayer()` sets `game.lifeseq` to 10.

There's even an inconsistency to this inconsistency - when you die in No Death Mode, all entities will be removed from `obj.entities`, so the next time you load in to the game, `game.lifeseq` will be 0.

This inconsistency is pretty minor in the grand scheme of things, but it still bothers me, so I'm going to fix it.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
