### PR TITLE
Fix player being invisible upon loading into game again

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -470,7 +470,7 @@ void gamelogic()
 
                 game.gravitycontrol = game.savegc;
                 graphics.textboxremove();
-                map.resetplayer();
+                map.resetplayer(true);
             }
         }
     }

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -803,6 +803,11 @@ void mapclass::showship()
 
 void mapclass::resetplayer()
 {
+	resetplayer(false);
+}
+
+void mapclass::resetplayer(const bool player_died)
+{
 	bool was_in_tower = towermode;
 	if (game.roomx != game.saverx || game.roomy != game.savery)
 	{
@@ -821,8 +826,11 @@ void mapclass::resetplayer()
 		obj.entities[i].yp = game.savey;
 		obj.entities[i].dir = game.savedir;
 		obj.entities[i].colour = 0;
-		game.lifeseq = 10;
-		obj.entities[i].invis = true;
+		if (player_died)
+		{
+			game.lifeseq = 10;
+			obj.entities[i].invis = true;
+		}
 		if (!game.glitchrunnermode)
 		{
 			obj.entities[i].size = 0;

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -69,6 +69,7 @@ public:
 
     void showship();
 
+    void resetplayer(const bool player_died);
     void resetplayer();
 
     void warpto(int rx, int ry , int t, int tx, int ty);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2675,7 +2675,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -2701,7 +2700,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		graphics.fademode = 4;
@@ -2742,7 +2740,6 @@ void scriptclass::startgamemode( int t )
 			map.cameramode = 0;
 			map.colsuperstate = 0;
 		}
-		game.lifeseq = 0;
 		graphics.fademode = 4;
 		break;
 	case 3:
@@ -2770,7 +2767,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		graphics.fademode = 4;
@@ -2800,7 +2796,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		graphics.fademode = 4;
@@ -2830,7 +2825,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		graphics.fademode = 4;
@@ -2860,7 +2854,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		graphics.fademode = 4;
@@ -2890,7 +2883,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		graphics.fademode = 4;
@@ -2926,7 +2918,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		graphics.fademode = 4;
@@ -2952,7 +2943,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -2982,7 +2972,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3019,7 +3008,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		music.play(11);
@@ -3056,7 +3044,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3093,7 +3080,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3130,7 +3116,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3167,7 +3152,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3201,7 +3185,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3235,7 +3218,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3269,7 +3251,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3303,7 +3284,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3328,7 +3308,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		graphics.fademode = 4;
@@ -3365,7 +3344,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		if(ed.levmusic>0){
@@ -3404,7 +3382,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 
@@ -3451,7 +3428,6 @@ void scriptclass::startgamemode( int t )
 		{
 			map.resetplayer();
 		}
-		game.lifeseq = 0;
 		map.gotoroom(game.saverx, game.savery);
 		map.initmapdata();
 		ed.generatecustomminimap();


### PR DESCRIPTION
When I did #567, I didn't test it. And I should have tested it, because it made the player invisible. This is because `map.resetplayer()` also sets the `invis` attribute of the player to true as well, and I only undid it setting `game.lifeseq` to 10.

So instead, I'll just add a flag to `map.resetplayer()` that by default doesn't set `game.lifeseq` or the player's `invis` attribute. And I tested it this time, and it works fine. I tested both respawning after death and exiting to the menu and loading in the game again.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
