### PR TITLE
Reset player invis attribute to false in mapclass::resetplayer()

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -831,6 +831,10 @@ void mapclass::resetplayer(const bool player_died)
 			game.lifeseq = 10;
 			obj.entities[i].invis = true;
 		}
+		else
+		{
+			obj.entities[i].invis = false;
+		}
 		if (!game.glitchrunnermode)
 		{
 			obj.entities[i].size = 0;


### PR DESCRIPTION
When I did #569, I forgot that taking out the code path that set the player's `invis` to false meant that the player would still be invisible upon loading back in to the game if they exited the game while invisible. Taking out that code path also meant that if `game.lifeseq` was nonzero, it wouldn't be reset properly, either. So this fixes those things.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
