### PR TITLE
De-duplicate menu animation code when bringing up map screen

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7146,3 +7146,16 @@ void Game::unlockAchievement(const char *name) {
     if (!map.custommode) NETWORK_unlockAchievement(name);
 #endif
 }
+
+void Game::mapmenuchange(const int newgamestate)
+{
+    gamestate = newgamestate;
+    graphics.resumegamemode = false;
+
+    graphics.menuoffset = 240;
+    if (map.extrarow)
+    {
+        graphics.menuoffset -= 10;
+    }
+    graphics.oldmenuoffset = graphics.menuoffset;
+}

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -218,6 +218,7 @@ public:
     int tapleft, tapright;
 
     //Menu interaction stuff
+    void mapmenuchange(const int newgamestate);
     bool mapheld;
     int menupage;
     int lastsaved;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1846,18 +1846,7 @@ void gameinput()
                             else if (game.companion == 0)
                             {
                                 //Alright, normal teleporting
-                                game.gamestate = TELEPORTERMODE;
-                                graphics.menuoffset = 240; //actually this should count the roomname
-                                graphics.oldmenuoffset = 240;
-                                if (map.extrarow)
-                                {
-                                    graphics.menuoffset -= 10;
-                                    graphics.oldmenuoffset -= 10;
-                                }
-
-                                BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
-
-                                graphics.resumegamemode = false;
+                                game.mapmenuchange(TELEPORTERMODE);
 
                                 game.useteleporter = true;
                                 game.initteleportermode();
@@ -2010,19 +1999,10 @@ void gameinput()
         //quitting the super gravitron
         game.mapheld = true;
         //Quit menu, same conditions as in game menu
-        game.gamestate = MAPMODE;
+        game.mapmenuchange(MAPMODE);
         game.gamesaved = false;
         game.gamesavefailed = false;
-        graphics.resumegamemode = false;
         game.menupage = 20; // The Map Page
-        BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
-        graphics.menuoffset = 240; //actually this should count the roomname
-        graphics.oldmenuoffset = 240;
-        if (map.extrarow)
-        {
-            graphics.menuoffset -= 10;
-            graphics.oldmenuoffset -= 10;
-        }
     }
     else if (game.intimetrial && graphics.fademode == 0)
     {
@@ -2039,12 +2019,11 @@ void gameinput()
     else
     {
         //Normal map screen, do transition later
-        game.gamestate = MAPMODE;
+        game.mapmenuchange(MAPMODE);
         map.cursordelay = 0;
         map.cursorstate = 0;
         game.gamesaved = false;
         game.gamesavefailed = false;
-        graphics.resumegamemode = false;
         if (script.running)
         {
             game.menupage = 3; // Only allow saving
@@ -2053,34 +2032,16 @@ void gameinput()
         {
             game.menupage = 0; // The Map Page
         }
-        BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
-        graphics.menuoffset = 240; //actually this should count the roomname
-        graphics.oldmenuoffset = 240;
-        if (map.extrarow)
-        {
-            graphics.menuoffset -= 10;
-            graphics.oldmenuoffset -= 10;
-        }
     }
 
     if ((key.isDown(27) || key.isDown(game.controllerButton_esc)) && (!map.custommode || map.custommodeforreal))
     {
         game.mapheld = true;
         //Quit menu, same conditions as in game menu
-        game.gamestate = MAPMODE;
+        game.mapmenuchange(MAPMODE);
         game.gamesaved = false;
         game.gamesavefailed = false;
-        graphics.resumegamemode = false;
         game.menupage = 30; // Pause screen
-
-        BlitSurfaceStandard(graphics.menubuffer,NULL,graphics.backBuffer, NULL);
-        graphics.menuoffset = 240; //actually this should count the roomname
-        graphics.oldmenuoffset = 240;
-        if (map.extrarow)
-        {
-            graphics.menuoffset -= 10;
-            graphics.oldmenuoffset -= 10;
-        }
     }
 
     if (game.deathseq == -1 && (key.isDown(SDLK_r) || key.isDown(game.controllerButton_restart)) && !game.nodeathmode)// && map.custommode) //Have fun glitchrunners!

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1322,17 +1322,7 @@ void scriptclass::run()
 			{
 				if (words[1] == "teleporter")
 				{
-					//TODO this draw the teleporter screen. This is a problem. :(
-					game.gamestate = TELEPORTERMODE;
-					graphics.menuoffset = 240; //actually this should count the roomname
-					graphics.oldmenuoffset = 240;
-					if (map.extrarow)
-					{
-						graphics.menuoffset -= 10;
-						graphics.oldmenuoffset -= 10;
-					}
-
-					graphics.resumegamemode = false;
+					game.mapmenuchange(TELEPORTERMODE);
 
 					game.useteleporter = false; //good heavens don't actually use it
 				}


### PR DESCRIPTION
When bringing up the map screen, the game does a small menu animation where the menu comes in from the bottom. The code to calculate the menu offset is copy-pasted everywhere, so I thought I'd de-duplicate it to make my life easier when working with it. I also included the `game.gamestate` assignment in the de-duplicated function, so it would be easier for a future bugfix.

At the same time, I'm also removing all the `BlitSurfaceStandard()`s that copied `menubuffer` to `backBuffer`. The red flag is that this blit happened for every single entry point to `MAPMODE` and `TELEPORTERMODE`, except for the script command `gamemode(teleporter)`. Pressing Enter to bring up the map screen, pressing Enter to quit the Super Gravitron, pressing Esc to bring up the pause screen, and pressing Enter to bring up the teleporter screen all do this blit, so if this blit was there to fix a bug, then there's a bug with using the script command `gamemode(teleporter)`... but, as far as I can tell, there isn't.

That's because the blit basically does nothing. All the blit does is copy `menubuffer` onto `backBuffer`. Then the next thing that happens is that either `maprender()` or `teleporterrender()` will be called, and the first thing that those functions will always do is fill `backBuffer` with solid black, completely overriding the previous blit. So that's why removing this blit won't have any effect, and it can be safely removed for code clarity.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
