### PR TITLE
Fix bringing up map menu during gamemode(teleporter)

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -117,6 +117,8 @@ void Game::init(void)
     musicmutebutton = 0;
 
     glitchrunkludge = false;
+    gamestate = TITLEMODE;
+    prevgamestate = TITLEMODE;
     hascontrol = true;
     jumpheld = false;
     advancetext = false;
@@ -7149,13 +7151,22 @@ void Game::unlockAchievement(const char *name) {
 
 void Game::mapmenuchange(const int newgamestate)
 {
+    prevgamestate = gamestate;
     gamestate = newgamestate;
     graphics.resumegamemode = false;
+    mapheld = true;
 
-    graphics.menuoffset = 240;
-    if (map.extrarow)
+    if (prevgamestate == GAMEMODE)
     {
-        graphics.menuoffset -= 10;
+        graphics.menuoffset = 240;
+        if (map.extrarow)
+        {
+            graphics.menuoffset -= 10;
+        }
+    }
+    else
+    {
+        graphics.menuoffset = 0;
     }
     graphics.oldmenuoffset = graphics.menuoffset;
 }

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -206,6 +206,7 @@ public:
     bool glitchrunkludge;
 
     int gamestate;
+    int prevgamestate; //only used sometimes
     bool hascontrol, jumpheld;
     int jumppressed;
     int gravitycontrol;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1769,7 +1769,16 @@ void gameinput()
         }
     }
 
-    if (!game.press_map) game.mapheld = false;
+    if (!game.press_map
+    //Extra conditionals as a kludge fix so if you open the quit menu during
+    //the script command gamemode(teleporter) and close it with Esc, it won't
+    //immediately open again
+    //We really need a better input system soon...
+    && !key.isDown(27)
+    && !key.isDown(game.controllerButton_esc))
+    {
+        game.mapheld = false;
+    }
 
     if (game.intimetrial && graphics.fademode == 1 && game.quickrestartkludge)
     {
@@ -2034,7 +2043,9 @@ void gameinput()
         }
     }
 
-    if ((key.isDown(27) || key.isDown(game.controllerButton_esc)) && (!map.custommode || map.custommodeforreal))
+    if (!game.mapheld
+    && (key.isDown(27) || key.isDown(game.controllerButton_esc))
+    && (!map.custommode || map.custommodeforreal))
     {
         game.mapheld = true;
         //Quit menu, same conditions as in game menu

--- a/desktop_version/src/RenderFixed.cpp
+++ b/desktop_version/src/RenderFixed.cpp
@@ -197,14 +197,27 @@ void maprenderfixed()
     graphics.oldmenuoffset = graphics.menuoffset;
     if (graphics.resumegamemode)
     {
-        graphics.menuoffset += 25;
-        int threshold = map.extrarow ? 230 : 240;
-        if (graphics.menuoffset >= threshold)
+        if (game.prevgamestate == GAMEMODE
+        //Failsafe: if the script command gamemode(teleporter) got ran and the
+        //cutscene stopped without doing gamemode(game), then we need to go
+        //back to GAMEMODE, not game.prevgamestate (TELEPORTERMODE)
+        || !script.running)
         {
-            graphics.menuoffset = threshold;
-            //go back to gamemode!
+            graphics.menuoffset += 25;
+            int threshold = map.extrarow ? 230 : 240;
+            if (graphics.menuoffset >= threshold)
+            {
+                graphics.menuoffset = threshold;
+                //go back to gamemode!
+                game.mapheld = true;
+                game.gamestate = GAMEMODE;
+            }
+        }
+        else
+        {
             game.mapheld = true;
-            game.gamestate = GAMEMODE;
+            game.gamestate = game.prevgamestate;
+            graphics.resumegamemode = false;
         }
     }
     else if (graphics.menuoffset > 0)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1329,6 +1329,7 @@ void scriptclass::run()
 				else if (words[1] == "game")
 				{
 					graphics.resumegamemode = true;
+					game.prevgamestate = GAMEMODE;
 				}
 			}
 			else if (words[0] == "ifexplored")


### PR DESCRIPTION
When `gamemode(teleporter)` gets run in a script, it brings up a read-only version of the teleporter screen, intended only for displaying rooms on the minimap.

However, ever since 2.3 allowed bringing up the map screen during cutscenes (in order to prevent softlocks), bringing up the map screen during this mode would (1) do an unnecessary animation of suddenly switching back to the game and bringing up the menu screen again (even though the menu screen has already been brought up), and (2) would let you close the menu entirely and go back to `GAMEMODE`, thus unintentionally closing the teleporter screen and kind of ruining the cutscene.

To fix this, when you bring up the map screen, it will instead instantly transition to the map screen. And when you bring it down, it will also instantly transition back to the teleporter screen.

But that's not all. The previous behavior was actually kind of a nice failsafe, in that if you somehow got stuck in a state where a script ran `gamemode(teleporter)`, but stopped running before it could take you out of that mode by running `gamemode(game)`, then you could return to `GAMEMODE` yourself by bringing up the map screen and then bringing it back down. So I've made sure to keep that failsafe behavior, only as long as there isn't a script running.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
