### PR TITLE
Set game as DPI-aware

### DIFF
--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -60,7 +60,7 @@ void Screen::init(const ScreenSettings& settings)
 	SDL_CreateWindowAndRenderer(
 		640,
 		480,
-		SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE,
+		SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI,
 		&m_window,
 		&m_renderer
 	);

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -170,7 +170,7 @@ void Screen::ResizeScreen(int x, int y)
 	if (stretchMode == 1)
 	{
 		int winX, winY;
-		SDL_GetRendererOutputSize(m_renderer, &winX, &winY);
+		GetWindowSize(&winX, &winY);
 		int result = SDL_RenderSetLogicalSize(m_renderer, winX, winY);
 		if (result != 0)
 		{

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -170,7 +170,7 @@ void Screen::ResizeScreen(int x, int y)
 	if (stretchMode == 1)
 	{
 		int winX, winY;
-		SDL_GetWindowSize(m_window, &winX, &winY);
+		SDL_GetRendererOutputSize(m_renderer, &winX, &winY);
 		int result = SDL_RenderSetLogicalSize(m_renderer, winX, winY);
 		if (result != 0)
 		{
@@ -256,7 +256,7 @@ void Screen::ResizeToNearestMultiple()
 
 void Screen::GetWindowSize(int* x, int* y)
 {
-	SDL_GetWindowSize(m_window, x, y);
+	SDL_GetRendererOutputSize(m_renderer, x, y);
 }
 
 void Screen::UpdateScreen(SDL_Surface* buffer, SDL_Rect* rect )

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -22,6 +22,10 @@
 #include "SoundSystem.h"
 #include "UtilityClass.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 scriptclass script;
 
 #if !defined(NO_CUSTOM_LEVELS)
@@ -158,6 +162,10 @@ int main(int argc, char *argv[])
             return 1;
         }
     }
+
+#ifdef _WIN32
+    SetProcessDPIAware();
+#endif
 
     if(!FILESYSTEM_init(argv[0], baseDir, assetsPath))
     {


### PR DESCRIPTION
## Changes:

This prevents the OS from performing bilinear scaling in addition to whatever the game is doing. SDL_WINDOW_ALLOW_HIGHDPI should do this on all platforms, but it's only implemented for macOS, Wayland (X11 doesn't have a concept of DPI-awareness), and a few more esoteric ones. Windows has a few ways of doing it, but SetProcessDPIAware is the easiest. The docs say that this can cause unexpected behavior, but my understanding is that this relates to multithreading, and in this case nothing should be able to go wrong.

I don't currently have a way to do Windows builds locally, so I'm relying on CI to make sure this compiles. It'd be nice if someone could test it on HiDPI Windows/Wayland/macOS, but I'm pretty confident that this should work if it builds.
## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
