### PR TITLE
Use SDL_abs instead of std::abs

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4389,8 +4389,8 @@ void entityclass::fixfriction( int t, float xfix, float xrate, float yrate )
     if (entities[t].vx > 6) entities[t].vx = 6.0f;
     if (entities[t].vx < -6) entities[t].vx = -6.0f;
 
-    if (std::abs(entities[t].vx-xfix) <= xrate) entities[t].vx = xfix;
-    if (std::abs(entities[t].vy) < yrate) entities[t].vy = 0;
+    if (SDL_abs(entities[t].vx-xfix) <= xrate) entities[t].vx = xfix;
+    if (SDL_abs(entities[t].vy) < yrate) entities[t].vy = 0;
 }
 
 void entityclass::applyfriction( int t, float xrate, float yrate )
@@ -4410,8 +4410,8 @@ void entityclass::applyfriction( int t, float xrate, float yrate )
     if (entities[t].vx > 6.00f) entities[t].vx = 6.0f;
     if (entities[t].vx < -6.00f) entities[t].vx = -6.0f;
 
-    if (std::abs(entities[t].vx) < xrate) entities[t].vx = 0.0f;
-    if (std::abs(entities[t].vy) < yrate) entities[t].vy = 0.0f;
+    if (SDL_abs(entities[t].vx) < xrate) entities[t].vx = 0.0f;
+    if (SDL_abs(entities[t].vy) < yrate) entities[t].vy = 0.0f;
 }
 
 void entityclass::updateentitylogic( int t )

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4410,6 +4410,7 @@ void entityclass::applyfriction( int t, float xrate, float yrate )
     if (entities[t].vx > 6.00f) entities[t].vx = 6.0f;
     if (entities[t].vx < -6.00f) entities[t].vx = -6.0f;
 
+    // This should *not* be changed to use SDL_fabsf, which would cause noticable differences in physics.
     if (SDL_abs(entities[t].vx) < xrate) entities[t].vx = 0.0f;
     if (SDL_abs(entities[t].vy) < yrate) entities[t].vy = 0.0f;
 }

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1824,7 +1824,7 @@ void gameinput()
                     if (game.activetele && game.readytotele > 20 && !game.intimetrial)
                     {
                         enter_already_processed = true;
-                        if(int(std::abs(obj.entities[ie].vx))<=1 && int(obj.entities[ie].vy)==0)
+                        if(int(SDL_abs(obj.entities[ie].vx))<=1 && int(obj.entities[ie].vy)==0)
                         {
                             //wait! space station 2 debug thingy
                             if (game.teleportscript != "")
@@ -1890,7 +1890,7 @@ void gameinput()
                     else if (INBOUNDS_VEC(game.activeactivity, obj.blocks))
                     {
                         enter_already_processed = true;
-                        if((int(std::abs(obj.entities[ie].vx))<=1) && (int(obj.entities[ie].vy) == 0) )
+                        if((int(SDL_abs(obj.entities[ie].vx))<=1) && (int(obj.entities[ie].vy) == 0) )
                         {
                             script.load(obj.blocks[game.activeactivity].script);
                             obj.removeblock(game.activeactivity);

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1824,6 +1824,7 @@ void gameinput()
                     if (game.activetele && game.readytotele > 20 && !game.intimetrial)
                     {
                         enter_already_processed = true;
+                        // This should *not* be changed to use SDL_fabsf, which would prevent activating an teleporter when `vx > 1.0 && vx < 2.0`.
                         if(int(SDL_abs(obj.entities[ie].vx))<=1 && int(obj.entities[ie].vy)==0)
                         {
                             //wait! space station 2 debug thingy
@@ -1890,6 +1891,7 @@ void gameinput()
                     else if (INBOUNDS_VEC(game.activeactivity, obj.blocks))
                     {
                         enter_already_processed = true;
+                        // This should *not* be changed to use SDL_fabsf, which would prevent activating an activity zone when `vx > 1.0 && vx < 2.0`.
                         if((int(SDL_abs(obj.entities[ie].vx))<=1) && (int(obj.entities[ie].vy) == 0) )
                         {
                             script.load(obj.blocks[game.activeactivity].script);


### PR DESCRIPTION
## Changes:

This prevents issues when calling std::abs with a float on some older compilers. While it would normally be promoted to an int, std::abs is special due to being overloaded despite being a C function. This can cause errors due to the compiler being unable to find a float overload. SDL_abs doesn't have this problem, since it's a normal C function.

From some testing, this issue occurs in g++ 6.4, but not 7.1. In addition, there does not appear to be a difference caused by `-std` flags (I tried the default, `-std=c++03`, `-std=c++11`, `-std=gnu++03`, and `-std=gnu++11`).

See discussion in #574.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
