### PR TITLE
Use SDL_fabsf where std::abs was previously used 

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4389,8 +4389,8 @@ void entityclass::fixfriction( int t, float xfix, float xrate, float yrate )
     if (entities[t].vx > 6) entities[t].vx = 6.0f;
     if (entities[t].vx < -6) entities[t].vx = -6.0f;
 
-    if (SDL_abs(entities[t].vx-xfix) <= xrate) entities[t].vx = xfix;
-    if (SDL_abs(entities[t].vy) < yrate) entities[t].vy = 0;
+    if (SDL_fabsf(entities[t].vx-xfix) <= xrate) entities[t].vx = xfix;
+    if (SDL_fabsf(entities[t].vy) < yrate) entities[t].vy = 0;
 }
 
 void entityclass::applyfriction( int t, float xrate, float yrate )
@@ -4410,8 +4410,8 @@ void entityclass::applyfriction( int t, float xrate, float yrate )
     if (entities[t].vx > 6.00f) entities[t].vx = 6.0f;
     if (entities[t].vx < -6.00f) entities[t].vx = -6.0f;
 
-    if (SDL_abs(entities[t].vx) < xrate) entities[t].vx = 0.0f;
-    if (SDL_abs(entities[t].vy) < yrate) entities[t].vy = 0.0f;
+    if (SDL_fabsf(entities[t].vx) < xrate) entities[t].vx = 0.0f;
+    if (SDL_fabsf(entities[t].vy) < yrate) entities[t].vy = 0.0f;
 }
 
 void entityclass::updateentitylogic( int t )

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4410,7 +4410,6 @@ void entityclass::applyfriction( int t, float xrate, float yrate )
     if (entities[t].vx > 6.00f) entities[t].vx = 6.0f;
     if (entities[t].vx < -6.00f) entities[t].vx = -6.0f;
 
-    // This should *not* be changed to use SDL_fabsf, which would cause noticable differences in physics.
     if (SDL_abs(entities[t].vx) < xrate) entities[t].vx = 0.0f;
     if (SDL_abs(entities[t].vy) < yrate) entities[t].vy = 0.0f;
 }

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1824,7 +1824,6 @@ void gameinput()
                     if (game.activetele && game.readytotele > 20 && !game.intimetrial)
                     {
                         enter_already_processed = true;
-                        // This should *not* be changed to use SDL_fabsf, which would prevent activating an teleporter when `vx > 1.0 && vx < 2.0`.
                         if(int(SDL_abs(obj.entities[ie].vx))<=1 && int(obj.entities[ie].vy)==0)
                         {
                             //wait! space station 2 debug thingy
@@ -1891,7 +1890,6 @@ void gameinput()
                     else if (INBOUNDS_VEC(game.activeactivity, obj.blocks))
                     {
                         enter_already_processed = true;
-                        // This should *not* be changed to use SDL_fabsf, which would prevent activating an activity zone when `vx > 1.0 && vx < 2.0`.
                         if((int(SDL_abs(obj.entities[ie].vx))<=1) && (int(obj.entities[ie].vy) == 0) )
                         {
                             script.load(obj.blocks[game.activeactivity].script);

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1824,7 +1824,7 @@ void gameinput()
                     if (game.activetele && game.readytotele > 20 && !game.intimetrial)
                     {
                         enter_already_processed = true;
-                        if(int(SDL_abs(obj.entities[ie].vx))<=1 && int(obj.entities[ie].vy)==0)
+                        if(int(SDL_fabsf(obj.entities[ie].vx))<=1 && int(obj.entities[ie].vy)==0)
                         {
                             //wait! space station 2 debug thingy
                             if (game.teleportscript != "")
@@ -1890,7 +1890,7 @@ void gameinput()
                     else if (INBOUNDS_VEC(game.activeactivity, obj.blocks))
                     {
                         enter_already_processed = true;
-                        if((int(SDL_abs(obj.entities[ie].vx))<=1) && (int(obj.entities[ie].vy) == 0) )
+                        if((int(SDL_fabsf(obj.entities[ie].vx))<=1) && (int(obj.entities[ie].vy) == 0) )
                         {
                             script.load(obj.blocks[game.activeactivity].script);
                             obj.removeblock(game.activeactivity);


### PR DESCRIPTION
## Changes:

Despite @InfoTeddy having written [a short essay](https://github.com/TerryCavanagh/VVVVVV/pull/574#discussion_r550822082) about how I should've used `SDL_abs` in #575, it turns out that [this isn't actually true](https://godbolt.org/z/Pnh3Gj).


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
