### PR TITLE
Remove functions marked as unused by cppcheck

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4372,27 +4372,6 @@ bool entityclass::testwallsy( int t, float tx, float ty )
     return true;
 }
 
-void entityclass::fixfriction( int t, float xfix, float xrate, float yrate )
-{
-    if (!INBOUNDS_VEC(t, entities))
-    {
-        puts("fixfriction() out-of-bounds!");
-        return;
-    }
-
-    if (entities[t].vx > xfix) entities[t].vx -= xrate;
-    if (entities[t].vx < xfix) entities[t].vx += xrate;
-    if (entities[t].vy > 0) entities[t].vy -= yrate;
-    if (entities[t].vy < 0) entities[t].vy += yrate;
-    if (entities[t].vy > 10) entities[t].vy = 10;
-    if (entities[t].vy < -10) entities[t].vy = -10;
-    if (entities[t].vx > 6) entities[t].vx = 6.0f;
-    if (entities[t].vx < -6) entities[t].vx = -6.0f;
-
-    if (SDL_fabsf(entities[t].vx-xfix) <= xrate) entities[t].vx = xfix;
-    if (SDL_fabsf(entities[t].vy) < yrate) entities[t].vy = 0;
-}
-
 void entityclass::applyfriction( int t, float xrate, float yrate )
 {
     if (!INBOUNDS_VEC(t, entities))

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -157,8 +157,6 @@ public:
 
     bool testwallsy(int t, float tx, float ty);
 
-    void fixfriction(int t, float xfix, float xrate, float yrate);
-
     void applyfriction(int t, float xrate, float yrate);
 
     void updateentitylogic(int t);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2836,18 +2836,6 @@ int Graphics::textboxwidth()
 	return textbox[m].w;
 }
 
-void Graphics::textboxmove(int xo, int yo)
-{
-	if (!INBOUNDS_VEC(m, textbox))
-	{
-		puts("textboxmove() out-of-bounds!");
-		return;
-	}
-
-	textbox[m].xp += xo;
-	textbox[m].yp += yo;
-}
-
 void Graphics::textboxmoveto(int xo)
 {
 	if (!INBOUNDS_VEC(m, textbox))

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -515,40 +515,6 @@ void Graphics::bprintalpha( int x, int y, std::string t, int r, int g, int b, in
     PrintAlpha(x, y, t, r, g, b, a, cen);
 }
 
-void Graphics::RPrint( int _x, int _y, std::string _s, int r, int g, int b, bool cen /*= false*/ )
-{
-    std::vector<SDL_Surface*>& font = flipmode ? flipbfont : bfont;
-
-    r = clamp(r,0,255);
-    g = clamp(g,0,255);
-    b = clamp(b,0,255);
-    ct.colour = getRGB(r, g, b);
-
-    if (cen)
-        _x = ((308) - (_s.length() / 2));
-    int bfontpos = 0;
-    int curr;
-    int idx;
-    std::string::iterator iter = _s.begin();
-    while (iter != _s.end()) {
-        curr = utf8::unchecked::next(iter);
-        point tpoint;
-        tpoint.x = _x + bfontpos;
-        tpoint.y = _y;
-
-        SDL_Rect fontRect = bfont_rect;
-        fontRect.x = tpoint.x ;
-        fontRect.y = tpoint.y ;
-
-        idx = font_idx(curr);
-        if (INBOUNDS_VEC(idx, font))
-        {
-            BlitSurfaceColoured( font[idx], NULL, backBuffer, &fontRect , ct);
-        }
-        bfontpos+=bfontlen(curr) ;
-    }
-}
-
 void Graphics::printcrewname( int x, int y, int t )
 {
     //Print the name of crew member t in the right colour

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -679,17 +679,6 @@ void Graphics::drawtile3( int x, int y, int t, int off, int height_subtract /*= 
     BlitSurfaceStandard(tiles3[t], &src_rect, backBuffer, &rect);
 }
 
-void Graphics::drawentcolours( int x, int y, int t)
-{
-    if (!INBOUNDS_VEC(t, entcolours))
-    {
-        WHINE_ONCE("drawentcolours() out-of-bounds!")
-        return;
-    }
-    SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
-    BlitSurfaceStandard(entcolours[t], NULL, backBuffer, &rect);
-}
-
 void Graphics::drawtowertile( int x, int y, int t )
 {
     if (!INBOUNDS_VEC(t, tiles2))

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -455,10 +455,6 @@ int Graphics::len(std::string t)
     return bfontpos;
 }
 
-void Graphics::PrintOff( int _x, int _y, std::string _s, int r, int g, int b, bool cen /*= false*/ ) {
-    PrintOffAlpha(_x,_y,_s,r,g,b,255,cen);
-}
-
 void Graphics::PrintOffAlpha( int _x, int _y, std::string _s, int r, int g, int b, int a, bool cen /*= false*/ )
 {
     std::vector<SDL_Surface*>& font = flipmode ? flipbfont : bfont;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2814,18 +2814,6 @@ void Graphics::setwarprect( int a, int b, int c, int d )
 	warprect.h = d;
 }
 
-void Graphics::textboxcenter()
-{
-	if (!INBOUNDS_VEC(m, textbox))
-	{
-		puts("textboxcenter() out-of-bounds!");
-		return;
-	}
-
-	textbox[m].centerx();
-	textbox[m].centery();
-}
-
 void Graphics::textboxcenterx()
 {
 	if (!INBOUNDS_VEC(m, textbox))

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -111,8 +111,6 @@ public:
 
 	void PrintAlpha(int _x, int _y, std::string _s, int r, int g, int b, int a, bool cen = false);
 
-	void RPrint(int _x, int _y, std::string _s, int r, int g, int b, bool cen = false);
-
 	void PrintOffAlpha(int _x, int _y, std::string _s, int r, int g, int b, int a, bool cen = false);
 
 	void bprint(int x, int y, std::string t, int r, int g, int b, bool cen = false);

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -163,7 +163,6 @@ public:
 	void drawbackground(int t);
 	void updatebackground(int t);
 	void drawtile3( int x, int y, int t, int off, int height_subtract = 0 );
-	void drawentcolours( int x, int y, int t);
 	void drawtile2( int x, int y, int t );
 	void drawtile( int x, int y, int t );
 	void drawtowertile( int x, int y, int t );

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -53,8 +53,6 @@ public:
 
 	int textboxwidth();
 
-	void textboxmove(int xo, int yo);
-
 	void textboxmoveto(int xo);
 
 	void textboxcentery();

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -49,8 +49,6 @@ public:
 
 	void createtextbox(std::string t, int xp, int yp, int r= 255, int g= 255, int b = 255);
 
-	void textboxcenter();
-
 	void textboxcenterx();
 
 	int textboxwidth();

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -113,8 +113,6 @@ public:
 
 	void RPrint(int _x, int _y, std::string _s, int r, int g, int b, bool cen = false);
 
-	void PrintOff(int _x, int _y, std::string _s, int r, int g, int b, bool cen = false);
-
 	void PrintOffAlpha(int _x, int _y, std::string _s, int r, int g, int b, int a, bool cen = false);
 
 	void bprint(int x, int y, std::string t, int r, int g, int b, bool cen = false);

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -136,28 +136,6 @@ SDL_Surface * ScaleSurface( SDL_Surface *_surface, int Width, int Height, SDL_Su
     return _ret;
 }
 
-SDL_Surface *  FlipSurfaceHorizontal(SDL_Surface* _src)
-{
-    SDL_Surface * ret = SDL_CreateRGBSurface(_src->flags, _src->w, _src->h, _src->format->BitsPerPixel,
-        _src->format->Rmask, _src->format->Gmask, _src->format->Bmask, _src->format->Amask);
-    if(ret == NULL)
-    {
-        return NULL;
-    }
-
-    for(Sint32 y = 0; y < _src->h; y++)
-    {
-        for(Sint32 x = 0; x < _src->w; x++)
-        {
-            DrawPixel(ret,(_src->w -1) -x,y,ReadPixel(_src, x, y));
-        }
-
-
-    }
-
-    return ret;
-}
-
 SDL_Surface *  FlipSurfaceVerticle(SDL_Surface* _src)
 {
     SDL_Surface * ret = SDL_CreateRGBSurface(_src->flags, _src->w, _src->h, _src->format->BitsPerPixel,

--- a/desktop_version/src/GraphicsUtil.h
+++ b/desktop_version/src/GraphicsUtil.h
@@ -39,7 +39,6 @@ void FillRect( SDL_Surface* surface, SDL_Rect rect, int rgba );
 
 void ScrollSurface(SDL_Surface* _src, int pX, int py);
 
-SDL_Surface * FlipSurfaceHorizontal(SDL_Surface* _src);
 SDL_Surface * FlipSurfaceVerticle(SDL_Surface* _src);
 void UpdateFilter();
 SDL_Surface* ApplyFilter( SDL_Surface* _src );

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -323,11 +323,6 @@ bool KeyPoll::isDown(SDL_Keycode key)
 	return keymap[key];
 }
 
-bool KeyPoll::isUp(SDL_Keycode key)
-{
-	return !keymap[key];
-}
-
 bool KeyPoll::isDown(std::vector<SDL_GameControllerButton> buttons)
 {
 	for (size_t i = 0; i < buttons.size(); i += 1)

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -54,8 +54,6 @@ public:
 
 	bool isDown(SDL_Keycode key);
 
-	bool isUp(SDL_Keycode key);
-
 	bool isDown(std::vector<SDL_GameControllerButton> buttons);
 	bool isDown(SDL_GameControllerButton button);
 	bool controllerButtonDown();

--- a/desktop_version/src/SoundSystem.cpp
+++ b/desktop_version/src/SoundSystem.cpp
@@ -59,15 +59,3 @@ SoundSystem::SoundSystem()
 		SDL_assert(0 && "Unable to initialize audio!");
 	}
 }
-
-void SoundSystem::playMusic(MusicTrack* music)
-{
-	if(!music->m_isValid)
-	{
-		fprintf(stderr, "Invalid mix specified: %s\n", Mix_GetError());
-	}
-	if(Mix_PlayMusic(music->m_music, 0) == -1)
-	{
-		fprintf(stderr, "Unable to play Ogg file: %s\n", Mix_GetError());
-	}
-}

--- a/desktop_version/src/SoundSystem.h
+++ b/desktop_version/src/SoundSystem.h
@@ -23,7 +23,6 @@ class SoundSystem
 {
 public:
 	SoundSystem();
-	void playMusic(MusicTrack* music);
 };
 
 #endif /* SOUNDSYSTEM_H */

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2196,15 +2196,6 @@ int edentat( int xp, int yp )
     return -1;
 }
 
-bool edentclear( int xp, int yp )
-{
-    for(size_t i=0; i<edentity.size(); i++)
-    {
-        if(edentity[i].x==xp && edentity[i].y==yp) return false;
-    }
-    return true;
-}
-
 void fillbox( int x, int y, int x2, int y2, int c )
 {
     FillRect(graphics.backBuffer, x, y, x2-x, 1, c);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1241,27 +1241,6 @@ int editorclass::match( int x, int y )
     return 0;
 }
 
-int editorclass::warpzonematch( int x, int y )
-{
-    if(free(x-1,y)==0 && free(x,y-1)==0 && free(x+1,y)==0 && free(x,y+1)==0) return 0;
-
-    if(free(x-1,y)==0 && free(x,y-1)==0) return 10;
-    if(free(x+1,y)==0 && free(x,y-1)==0) return 11;
-    if(free(x-1,y)==0 && free(x,y+1)==0) return 12;
-    if(free(x+1,y)==0 && free(x,y+1)==0) return 13;
-
-    if(free(x,y-1)==0) return 1;
-    if(free(x-1,y)==0) return 2;
-    if(free(x,y+1)==0) return 3;
-    if(free(x+1,y)==0) return 4;
-    if(free(x-1,y-1)==0) return 5;
-    if(free(x+1,y-1)==0) return 6;
-    if(free(x-1,y+1)==0) return 7;
-    if(free(x+1,y+1)==0) return 8;
-
-    return 0;
-}
-
 int editorclass::outsidematch( int x, int y )
 {
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1347,57 +1347,6 @@ int editorclass::edgetile( int x, int y )
     return 0;
 }
 
-int editorclass::warpzoneedgetile( int x, int y )
-{
-    switch(backmatch(x,y))
-    {
-    case 14:
-        return 0;
-        break;
-    case 10:
-        return 80;
-        break;
-    case 11:
-        return 82;
-        break;
-    case 12:
-        return 160;
-        break;
-    case 13:
-        return 162;
-        break;
-    case 1:
-        return 81;
-        break;
-    case 2:
-        return 120;
-        break;
-    case 3:
-        return 161;
-        break;
-    case 4:
-        return 122;
-        break;
-    case 5:
-        return 42;
-        break;
-    case 6:
-        return 41;
-        break;
-    case 7:
-        return 2;
-        break;
-    case 8:
-        return 1;
-        break;
-    case 0:
-    default:
-        return 0;
-        break;
-    }
-    return 0;
-}
-
 int editorclass::outsideedgetile( int x, int y )
 {
     switch(outsidematch(x,y))

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -932,14 +932,6 @@ int editorclass::getenemyframe(int t)
 }
 
 
-void editorclass::placetile( int x, int y, int t )
-{
-    if(x>=0 && y>=0 && x<mapwidth*40 && y<mapheight*30)
-    {
-        contents[x+(levx*40)+vmult[y+(levy*30)]]=t;
-    }
-}
-
 void editorclass::placetilelocal( int x, int y, int t )
 {
     if(x>=0 && y>=0 && x<40 && y<30)

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -276,8 +276,6 @@ void removeedentity(int t);
 int edentat(int xp, int yp);
 
 
-bool edentclear(int xp, int yp);
-
 void fillbox(int x, int y, int x2, int y2, int c);
 
 void fillboxabs(int x, int y, int x2, int y2, int c);

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -121,8 +121,6 @@ class editorclass{
   void getlin(const enum textmode mode, const std::string& prompt, std::string* ptr);
   const short* loadlevel(int rxi, int ryi);
 
-  void placetile(int x, int y, int t);
-
   void placetilelocal(int x, int y, int t);
 
   int getenemyframe(int t);

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -155,7 +155,6 @@ class editorclass{
   bool save(std::string& _path);
   void generatecustomminimap();
   int edgetile(int x, int y);
-  int warpzoneedgetile(int x, int y);
   int outsideedgetile(int x, int y);
 
   int backedgetile(int x, int y);

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -141,7 +141,6 @@ class editorclass{
   int absfree(int x, int y);
 
   int match(int x, int y);
-  int warpzonematch(int x, int y);
   int outsidematch(int x, int y);
 
   int backmatch(int x, int y);


### PR DESCRIPTION
Unused code is code that can't be tested for correctness, and so is code that will slowly rot from lack of maintenance. I ran `cppcheck --std=c++03 --enable=unusedFunction *.cpp` and identified all functions that are unused everywhere in the codebase. In case we need them back in the future, we can always refer to the Git history.

Here's the list of removed functions:

- `FlipSurfaceHorizontal()`
- `Graphics::PrintOff()`
- `Graphics::RPrint()`
- `Graphics::drawentcolours()`
- `edentclear()`
- `entityclass::fixfriction()`
- `KeyPoll::isUp()`
- `editorclass::placetile()`
- `SoundSystem::playMusic()`
- `Graphics::textboxcenter()`
- `Graphics::textboxmove()`
- `editorclass::warpzoneedgetile()`
- `editorclass::warpzonematch()`

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
