### PR TITLE
Clean up whitespace and control flow of musicclass::play()

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -188,8 +188,11 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 	safeToProcessMusic = true;
 	musicVolume = MIX_MAX_VOLUME;
 
-	if (currentsong != t)
+	if (currentsong == t)
 	{
+		return;
+	}
+
 		if (t != -1)
 		{
 			currentsong = t;
@@ -239,7 +242,6 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 		{
 			currentsong = -1;
 		}
-	}
 }
 
 void musicclass::resume(const int fadein_ms /*= 0*/)

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -180,27 +180,31 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 		t %= num_pppppp_tracks;
 	}
 
-	if(mmmmmm && !usingmmmmmm)
+	if (mmmmmm && !usingmmmmmm)
 	{
 		t += num_mmmmmm_tracks;
 	}
+
 	safeToProcessMusic = true;
 	musicVolume = MIX_MAX_VOLUME;
-	if (currentsong !=t)
+
+	if (currentsong != t)
 	{
 		if (t != -1)
 		{
 			currentsong = t;
+
 			if (!INBOUNDS_VEC(t, musicTracks))
 			{
 				puts("play() out-of-bounds!");
 				currentsong = -1;
 				return;
 			}
+
 			if (currentsong == 0 || currentsong == 7 || (!map.custommode && (currentsong == 0+num_mmmmmm_tracks || currentsong == 7+num_mmmmmm_tracks)))
 			{
 				// Level Complete theme, no fade in or repeat
-				if(Mix_FadeInMusicPos(musicTracks[t].m_music, 0, 0, position_sec)==-1)
+				if (Mix_FadeInMusicPos(musicTracks[t].m_music, 0, 0, position_sec) == -1)
 				{
 					printf("Mix_FadeInMusicPos: %s\n", Mix_GetError());
 				}
@@ -213,6 +217,7 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 					nicechange = t;
 					nicefade = true;
 					currentsong = -1;
+
 					if (quick_fade)
 					{
 						Mix_FadeOutMusic(500); // fade out quicker
@@ -222,7 +227,7 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 						quick_fade = true;
 					}
 				}
-				else if(Mix_FadeInMusicPos(musicTracks[t].m_music, -1, fadein_ms, position_sec)==-1)
+				else if (Mix_FadeInMusicPos(musicTracks[t].m_music, -1, fadein_ms, position_sec) == -1)
 				{
 					printf("Mix_FadeInMusicPos: %s\n", Mix_GetError());
 				}

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -195,51 +195,51 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 
 	currentsong = t;
 
-		if (t == -1)
+	if (t == -1)
+	{
+		return;
+	}
+
+	if (!INBOUNDS_VEC(t, musicTracks))
+	{
+		puts("play() out-of-bounds!");
+		currentsong = -1;
+		return;
+	}
+
+	if (currentsong == 0 || currentsong == 7 || (!map.custommode && (currentsong == 0+num_mmmmmm_tracks || currentsong == 7+num_mmmmmm_tracks)))
+	{
+		// Level Complete theme, no fade in or repeat
+		if (Mix_FadeInMusicPos(musicTracks[t].m_music, 0, 0, position_sec) == -1)
 		{
-			return;
+			printf("Mix_FadeInMusicPos: %s\n", Mix_GetError());
 		}
+	}
+	else
+	{
+		if (Mix_FadingMusic() == MIX_FADING_OUT)
+		{
+			// We're already fading out
+			nicechange = t;
+			nicefade = true;
+			currentsong = -1;
 
-			if (!INBOUNDS_VEC(t, musicTracks))
+			if (quick_fade)
 			{
-				puts("play() out-of-bounds!");
-				currentsong = -1;
-				return;
-			}
-
-			if (currentsong == 0 || currentsong == 7 || (!map.custommode && (currentsong == 0+num_mmmmmm_tracks || currentsong == 7+num_mmmmmm_tracks)))
-			{
-				// Level Complete theme, no fade in or repeat
-				if (Mix_FadeInMusicPos(musicTracks[t].m_music, 0, 0, position_sec) == -1)
-				{
-					printf("Mix_FadeInMusicPos: %s\n", Mix_GetError());
-				}
+				Mix_FadeOutMusic(500); // fade out quicker
 			}
 			else
 			{
-				if (Mix_FadingMusic() == MIX_FADING_OUT)
-				{
-					// We're already fading out
-					nicechange = t;
-					nicefade = true;
-					currentsong = -1;
-
-					if (quick_fade)
-					{
-						Mix_FadeOutMusic(500); // fade out quicker
-					}
-					else
-					{
-						quick_fade = true;
-					}
-				}
-				else if (Mix_FadeInMusicPos(musicTracks[t].m_music, -1, fadein_ms, position_sec) == -1)
-				{
-					printf("Mix_FadeInMusicPos: %s\n", Mix_GetError());
-				}
+				quick_fade = true;
 			}
+		}
+		else if (Mix_FadeInMusicPos(musicTracks[t].m_music, -1, fadein_ms, position_sec) == -1)
+		{
+			printf("Mix_FadeInMusicPos: %s\n", Mix_GetError());
+		}
+	}
 
-			songStart = SDL_GetPerformanceCounter();
+	songStart = SDL_GetPerformanceCounter();
 }
 
 void musicclass::resume(const int fadein_ms /*= 0*/)

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -193,9 +193,12 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 		return;
 	}
 
-		if (t != -1)
+	currentsong = t;
+
+		if (t == -1)
 		{
-			currentsong = t;
+			return;
+		}
 
 			if (!INBOUNDS_VEC(t, musicTracks))
 			{
@@ -237,11 +240,6 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 			}
 
 			songStart = SDL_GetPerformanceCounter();
-		}
-		else
-		{
-			currentsong = -1;
-		}
 }
 
 void musicclass::resume(const int fadein_ms /*= 0*/)


### PR DESCRIPTION
While working on #580, I noticed that `musicclass::play()` had some inconsistent whitespace, as well as having control flow that meant nesting the rest of the function in two unnecessary levels of indentation. And that other PR would be much more readable if this function was improved. So I thought I'd fix it up first.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
