### PR TITLE
Fix regression with playing the same track after it fades out

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2319,9 +2319,7 @@ void mapmenuactionpress()
         //This fixes an apparent frame flicker.
         FillRect(graphics.tempBuffer, 0x000000);
         graphics.fademode = 2;
-        if (music.currentsong != 6) {
-            music.fadeout();
-        }
+        music.fadeout();
         map.nexttowercolour();
         if (!game.glitchrunnermode)
         {

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -188,7 +188,7 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 	safeToProcessMusic = true;
 	musicVolume = MIX_MAX_VOLUME;
 
-	if (currentsong == t)
+	if (currentsong == t && Mix_PlayingMusic() != MIX_FADING_OUT)
 	{
 		return;
 	}


### PR DESCRIPTION
With commit 48313169b68f8ef8e6f83f29830b789061219ffd (PR #453), @AllyTally added a single-case patch for a regression, instead of fixing it at its root cause.

In fact, that commit only fixes the music if Presenting VVVVVV is playing while exiting to the menu, not if you enter a level that plays Presenting VVVVVV - so it only fixes it going one way, and not going the other way around; neither fixing also all the other cases this could happen.

It doesn't, say, fix the case where you are exited to the menu automatically after collecting the last crewmate in the level (or if the level calls gamestate 1013 itself), which is what happens in my MIRA-VIU TAS video at the end, and which I noted in the description of that video ([link](https://www.youtube.com/watch?v=OYQO4ePbYW4&t=111)).

So, the problem here is that when `musicclass::play()` is called, it sees that `currentsong` is the same as its input, and decides that since the music is already playing, it shouldn't play the music again. Thus, the music fades out, and we get silence instead of the music playing again.

But I said this was a regression. Why didn't this happen in 2.2? Well, it's because of the fact that 2.2 sets `currentsong` to -1 (no music playing at all) immediately when starting a fadeout, and not when the fadeout completes (commit facb079b3597b380f876537523cd351a0e637b62, PR #316). As you can imagine, this discrepancy could lead to bugs, given that the game would think that music wasn't playing when in actuality it was, but fixing this bug could also break code that expected this wrong behavior. And in this case, it has.

So to properly fix the root cause of this, instead of naïvely single-case patching out every case that comes up randomly, in `musicclass::play()`, the function will now ignore if the input given is the same as `currentsong` if the music is currently fading out.

Depends on #579.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
