### PR TITLE
Move title screen color initialization to main()

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1686,8 +1686,6 @@ void titleinput()
                 music.playef(18);
                 game.screenshake = 10;
                 game.flashlight = 5;
-                graphics.titlebg.colstate = 10;
-                map.nexttowercolour();
             }
             else
             {

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -227,6 +227,10 @@ int main(int argc, char *argv[])
     game.menustart = false;
     game.mainmenu = 0;
 
+    // Initialize title screen to cyan
+    graphics.titlebg.colstate = 10;
+    map.nexttowercolour();
+
     map.ypos = (700-29) * 8;
     graphics.towerbg.bypos = map.ypos / 2;
     graphics.titlebg.bypos = map.ypos / 2;


### PR DESCRIPTION
This fixes a bug where if you completed a custom level during command-line playtesting, when returning to the title screen, the background would be red and the text would be white.

![White text on red background](https://user-images.githubusercontent.com/59748578/103718295-4b6df080-4f7b-11eb-8998-6ce167616d7d.png)

This is because playtesting skips over the code path of pressing ACTION to start the game and advance to the title screen, and the code path of that ACTION press specifically initializes the title screen colors to cyan.

This is also caused by the fact that completing a custom level doesn't call `map.nexttowercolour()`, but my guess is that the intent there was that the player would select a custom level, complete it, and return to the title screen on the same screen with the same colors, so I decided not to add a `map.nexttowercolour()` there.

Instead, I've moved the cyan color initialization to `main()`, so that it is always executed no matter what, and doesn't require you to take a specific code path to do it.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
