### PR TITLE
Clean up all exit paths to the menu to use common code

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1288,6 +1288,7 @@ void Game::updatestate()
             break;
         case 81:
             quittomenu();
+            music.play(6); //should be after quittomenu()
             state = 0;
             break;
 
@@ -1341,11 +1342,7 @@ void Game::updatestate()
             if(graphics.fademode == 1)	state++;
             break;
         case 84:
-            graphics.flipmode = false;
-            gamestate = TITLEMODE;
-            graphics.fademode = 4;
-            graphics.backgrounddrawn = true;
-            graphics.titlebg.tdrawback = true;
+            quittomenu();
             createmenu(Menu::timetrialcomplete);
             state = 0;
             break;
@@ -1871,7 +1868,6 @@ void Game::updatestate()
                 if(!muted && ed.levmusic>0) music.fadeMusicVolumeIn(3000);
             }
             graphics.showcutscenebars = false;
-            returntomenu(Menu::levellist);
             break;
 #endif
         case 1014:
@@ -1896,6 +1892,7 @@ void Game::updatestate()
             }
 #endif
             quittomenu();
+            music.play(6); //should be after quittomenu()
             state = 0;
             break;
 
@@ -2852,7 +2849,6 @@ void Game::updatestate()
             {
                 graphics.fademode = 2;
                 companion = 0;
-                returnmenu();
                 state=3100;
             }
             else
@@ -2883,7 +2879,6 @@ void Game::updatestate()
                 state++;
                 graphics.fademode = 2;
                 music.fadeout();
-                returnmenu();
                 state=3100;
             }
             else
@@ -2909,12 +2904,8 @@ void Game::updatestate()
             if(graphics.fademode == 1)	state++;
             break;
         case 3101:
-            graphics.flipmode = false;
-            gamestate = TITLEMODE;
-            graphics.fademode = 4;
-            graphics.backgrounddrawn = true;
-            graphics.titlebg.tdrawback = true;
-            music.play(6);
+            quittomenu();
+            music.play(6); //should be after quittomenu();
             state = 0;
             break;
 
@@ -3218,11 +3209,7 @@ void Game::updatestate()
             if(graphics.fademode == 1)	state++;
             break;
         case 3522:
-            graphics.flipmode = false;
-            gamestate = TITLEMODE;
-            graphics.fademode = 4;
-            graphics.backgrounddrawn = true;
-            graphics.titlebg.tdrawback = true;
+            quittomenu();
             createmenu(Menu::nodeathmodecomplete);
             state = 0;
             break;
@@ -6972,9 +6959,7 @@ void Game::quittomenu()
 {
     gamestate = TITLEMODE;
     graphics.fademode = 4;
-    FILESYSTEM_unmountassets(); // should be before music.play(6)
-    music.play(6);
-    graphics.backgrounddrawn = false;
+    FILESYSTEM_unmountassets();
     graphics.titlebg.tdrawback = true;
     graphics.flipmode = false;
     //Don't be stuck on the summary screen,
@@ -6995,7 +6980,15 @@ void Game::quittomenu()
     }
     else if (map.custommode)
     {
-        returntomenu(Menu::levellist);
+        if (map.custommodeforreal)
+        {
+            returntomenu(Menu::levellist);
+        }
+        else
+        {
+            //Returning from editor
+            returntomenu(Menu::playerworlds);
+        }
     }
     else if (save_exists() || anything_unlocked())
     {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -227,6 +227,10 @@ void Game::init(void)
     timetrialpar = 0;
     timetrialresulttime = 0;
     timetrialresultframes = 0;
+    timetrialresultshinytarget = 0;
+    timetrialresulttrinkets = 0;
+    timetrialresultpar = 0;
+    timetrialresultdeaths = 0;
 
     totalflips = 0;
     hardestroom = "Welcome Aboard";
@@ -1296,8 +1300,14 @@ void Game::updatestate()
             //Time Trial Complete!
             obj.removetrigger(82);
             hascontrol = false;
+
             timetrialresulttime = seconds + (minutes * 60) + (hours * 60 * 60);
             timetrialresultframes = frames;
+            timetrialresulttrinkets = trinkets();
+            timetrialresultshinytarget = timetrialshinytarget;
+            timetrialresultpar = timetrialpar;
+            timetrialresultdeaths = deathcounts;
+
             timetrialrank = 0;
             if (timetrialresulttime <= timetrialpar) timetrialrank++;
             if (trinkets() >= timetrialshinytarget) timetrialrank++;
@@ -1310,7 +1320,7 @@ void Game::updatestate()
                 besttimes[timetriallevel] = timetrialresulttime;
                 bestframes[timetriallevel] = timetrialresultframes;
             }
-            if (trinkets() > besttrinkets[timetriallevel] || besttrinkets[timetriallevel]==-1)
+            if (timetrialresulttrinkets > besttrinkets[timetriallevel] || besttrinkets[timetriallevel]==-1)
             {
                 besttrinkets[timetriallevel] = trinkets();
             }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -2918,35 +2918,10 @@ void Game::updatestate()
             state = 0;
             break;
 
-            //startscript = true;	newscript="returntohub";
-            //state = 0;
-
-            /*case 3025:
-            if (recording == 1) {
-            //if recording the input, output it to debug here
-            trace(recordstring);
-            help.toclipboard(recordstring);
-            }
-            test = true; teststring = recordstring;
-            graphics.createtextbox("   Congratulations!    ", 50, 80, 164, 164, 255);
-            graphics.addline("");
-            graphics.addline("Your play of this level has");
-            graphics.addline("been copied to the clipboard.");
-            graphics.addline("");
-            graphics.addline("Please consider pasting and");
-            graphics.addline("sending it to me! Even if you");
-            graphics.addline("made a lot of mistakes - knowing");
-            graphics.addline("exactly where people are having");
-            graphics.addline("trouble is extremely useful!");
-            graphics.textboxcenter();
-            state = 0;
-            break;*/
-
         case 3500:
             music.fadeout();
             state++;
             statedelay = 120;
-            //state = 3511; //testing
             break;
         case 3501:
             //Game complete!

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -171,10 +171,13 @@ void Game::init(void)
 
     nodeathmode = false;
     nocutscenes = false;
+    ndmresultcrewrescued = 0;
+    ndmresulttrinkets = 0;
 
     customcol=0;
 
     SDL_memset(crewstats, false, sizeof(crewstats));
+    SDL_memset(ndmresultcrewstats, false, sizeof(ndmresultcrewstats));
     SDL_memset(tele_crewstats, false, sizeof(tele_crewstats));
     SDL_memset(quick_crewstats, false, sizeof(quick_crewstats));
     SDL_memset(besttimes, -1, sizeof(besttimes));
@@ -3219,6 +3222,7 @@ void Game::updatestate()
             if(graphics.fademode == 1)	state++;
             break;
         case 3522:
+            copyndmresults();
             quittomenu();
             createmenu(Menu::nodeathmodecomplete);
             state = 0;
@@ -7115,4 +7119,12 @@ void Game::mapmenuchange(const int newgamestate)
         graphics.menuoffset = 0;
     }
     graphics.oldmenuoffset = graphics.menuoffset;
+}
+
+void Game::copyndmresults()
+{
+    ndmresultcrewrescued = crewrescued();
+    ndmresulttrinkets = trinkets();
+    ndmresulthardestroom = hardestroom;
+    SDL_memcpy(ndmresultcrewstats, crewstats, sizeof(ndmresultcrewstats));
 }

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -295,6 +295,8 @@ public:
     bool intimetrial, timetrialparlost;
     int timetrialcountdown, timetrialshinytarget, timetriallevel;
     int timetrialpar, timetrialresulttime, timetrialresultframes, timetrialrank;
+    int timetrialresultshinytarget, timetrialresulttrinkets, timetrialresultpar;
+    int timetrialresultdeaths;
 
     int creditposition;
     int oldcreditposition;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -290,6 +290,10 @@ public:
     bool nodeathmode;
     int gameoverdelay;
     bool nocutscenes;
+    int ndmresultcrewrescued;
+    int ndmresulttrinkets;
+    std::string ndmresulthardestroom;
+    void copyndmresults();
 
     //Time Trials
     bool intimetrial, timetrialparlost;
@@ -306,6 +310,7 @@ public:
 
     static const int numcrew = 6;
     bool crewstats[numcrew];
+    bool ndmresultcrewstats[numcrew];
 
     bool alarmon;
     int alarmdelay;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2117,6 +2117,7 @@ void mapinput()
         else
         {
             game.quittomenu();
+            music.play(6); //should be after game.quittomenu()
             game.fadetomenu = false;
         }
     }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -445,7 +445,11 @@ void gamelogic()
                 game.gethardestroom();
                 //start depressing sequence here...
                 if (game.gameoverdelay <= -10 && graphics.fademode==0) graphics.fademode = 2;
-                if (graphics.fademode == 1) script.resetgametomenu();
+                if (graphics.fademode == 1)
+                {
+                    game.copyndmresults();
+                    script.resetgametomenu();
+                }
             }
             else
             {

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -113,13 +113,9 @@ void gamecompletelogic2()
         game.savetele();
         music.currentsong=tmp;
         //Return to game
-        graphics.titlebg.colstate = 10;
-        game.gamestate = TITLEMODE;
-        graphics.fademode = 4;
-        FILESYSTEM_unmountassets(); // should be before music.playef(18)
-        music.playef(18);
-        game.returntomenu(Menu::play);
+        game.quittomenu();
         game.createmenu(Menu::gamecompletecontinue);
+        graphics.titlebg.colstate = 10;
         map.nexttowercolour();
     }
 }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -752,30 +752,30 @@ static void menurender()
     {
         graphics.bigprint( -1, 20, "Results", tr, tg, tb, true, 3);
 
-        std::string tempstring = game.resulttimestring() + " / " + game.partimestring() + ".99";
+        std::string tempstring = game.resulttimestring() + " / " + game.timetstring(game.timetrialresultpar) + ".99";
 
         graphics.drawspritesetcol(30, 80-15, 50, 22);
         graphics.Print(65, 80-15, "TIME TAKEN:", 255, 255, 255);
         graphics.Print(65, 90-15, tempstring, tr, tg, tb);
-        if (game.timetrialresulttime <= game.timetrialpar)
+        if (game.timetrialresulttime <= game.timetrialresultpar)
         {
             graphics.Print(220, 85-15, "+1 Rank!", 255, 255, 255);
         }
 
-        tempstring = help.String(game.deathcounts);
+        tempstring = help.String(game.timetrialresultdeaths);
         graphics.drawspritesetcol(30-4, 80+20-4, 12, 22);
         graphics.Print(65, 80+20, "NUMBER OF DEATHS:", 255, 255, 255);
         graphics.Print(65, 90+20, tempstring, tr, tg, tb);
-        if (game.deathcounts == 0)
+        if (game.timetrialresultdeaths == 0)
         {
             graphics.Print(220, 85+20, "+1 Rank!", 255, 255, 255);
         }
 
-        tempstring = help.String(game.trinkets()) + " of " + help.String(game.timetrialshinytarget);
+        tempstring = help.String(game.timetrialresulttrinkets) + " of " + help.String(game.timetrialresultshinytarget);
         graphics.drawspritesetcol(30, 80+55, 22, 22);
         graphics.Print(65, 80+55, "SHINY TRINKETS:", 255, 255, 255);
         graphics.Print(65, 90+55, tempstring, tr, tg, tb);
-        if (game.trinkets() >= game.timetrialshinytarget)
+        if (game.timetrialresulttrinkets >= game.timetrialresultshinytarget)
         {
             graphics.Print(220, 85+55, "+1 Rank!", 255, 255, 255);
         }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -686,22 +686,22 @@ static void menurender()
     {
         graphics.bigprint( -1, 25, "GAME OVER", tr, tg, tb, true, 3);
 
-        for (int i = 0; i < 6; i++)
+        for (size_t i = 0; i < SDL_arraysize(game.ndmresultcrewstats); i++)
         {
-            graphics.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], true);
+            graphics.drawcrewman(169-(3*42)+(i*42), 68, i, game.ndmresultcrewstats[i], true);
         }
         std::string tempstring;
-        tempstring = "You rescued " + help.number(game.crewrescued()) + (game.crewrescued() == 1 ? " crewmate" : " crewmates");
+        tempstring = "You rescued " + help.number(game.ndmresultcrewrescued) + (game.ndmresultcrewrescued == 1 ? " crewmate" : " crewmates");
         graphics.Print(0, 100, tempstring, tr, tg, tb, true);
 
-        tempstring = "and found " + help.number(game.trinkets()) + (game.trinkets() == 1 ? " trinket." : " trinkets.");
+        tempstring = "and found " + help.number(game.ndmresulttrinkets) + (game.ndmresulttrinkets == 1 ? " trinket." : " trinkets.");
         graphics.Print(0, 110, tempstring, tr, tg, tb, true);
 
         tempstring = "You managed to reach:";
         graphics.Print(0, 145, tempstring, tr, tg, tb, true);
-        graphics.Print(0, 155, game.hardestroom, tr, tg, tb, true);
+        graphics.Print(0, 155, game.ndmresulthardestroom, tr, tg, tb, true);
 
-        switch (game.crewrescued())
+        switch (game.ndmresultcrewrescued)
         {
         case 1:
             tempstring = "Keep trying! You'll get there!";
@@ -731,14 +731,14 @@ static void menurender()
     {
         graphics.bigprint( -1, 8, "WOW", tr, tg, tb, true, 4);
 
-        for (int i = 0; i < 6; i++)
+        for (size_t i = 0; i < SDL_arraysize(game.ndmresultcrewstats); i++)
         {
-            graphics.drawcrewman(169-(3*42)+(i*42), 68, i, game.crewstats[i], true);
+            graphics.drawcrewman(169-(3*42)+(i*42), 68, i, game.ndmresultcrewstats[i], true);
         }
         std::string tempstring = "You rescued all the crewmates!";
         graphics.Print(0, 100, tempstring, tr, tg, tb, true);
 
-        tempstring = "And you found " + help.number(game.trinkets()) + " trinkets.";
+        tempstring = "And you found " + help.number(game.ndmresulttrinkets) + " trinkets.";
         graphics.Print(0, 110, tempstring, tr, tg, tb, true);
 
         graphics.Print(0, 160, "A new trophy has been awarded and", tr, tg, tb, true);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3594,7 +3594,6 @@ void scriptclass::hardreset()
 	game.timetrialshinytarget = 0;
 	game.timetrialparlost = false;
 	game.timetrialpar = 0;
-	game.timetrialresulttime = 0;
 
 	game.totalflips = 0;
 	game.hardestroom = "Welcome Aboard";

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2627,11 +2627,8 @@ void scriptclass::run()
 
 void scriptclass::resetgametomenu()
 {
-	game.gamestate = TITLEMODE;
-	graphics.flipmode = false;
 	obj.entities.clear();
-	graphics.fademode = 4;
-	graphics.titlebg.tdrawback = true;
+	game.quittomenu();
 	game.createmenu(Menu::gameover);
 }
 
@@ -3262,6 +3259,8 @@ void scriptclass::startgamemode( int t )
 		hardreset();
 		ed.reset();
 		music.fadeout();
+		map.custommode = true;
+		map.custommodeforreal = false;
 
 		game.gamestate = EDITORMODE;
 		game.jumpheld = true;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3627,18 +3627,11 @@ void editorlogic()
     if (graphics.fademode == 1)
     {
         //Return to game
-        map.nexttowercolour();
         graphics.titlebg.colstate = 10;
-        game.gamestate = TITLEMODE;
-        script.hardreset();
-        graphics.fademode = 4;
-        music.haltdasmusik();
-        FILESYSTEM_unmountassets(); // should be before music.play(6)
-        music.play(6);
         map.nexttowercolour();
+        game.quittomenu();
+        music.play(6); //should be before game.quittomenu()
         ed.settingsmod=false;
-        graphics.backgrounddrawn=false;
-        game.returntomenu(Menu::playerworlds);
     }
 }
 


### PR DESCRIPTION
There are multiple different exit paths to the main menu. In 2.2, they all had a bunch of copy-pasted code. In 2.3 currently, most of them use `game.quittomenu()`, but there are some stragglers that still use hand-copied code.

This is a bit of a problem, because all exit paths should consistently have `FILESYSTEM_unmountassets(),` as part of the 2.3 feature of per-level custom assets. Furthermore, most (but not all) of the paths call `script.hardreset()` too, and some of the stragglers don't. So there could be something persisting through to the title screen (like a really long flash/shake timer) that could only persist if exiting to the title screen through those paths.

But, actually, it seems like there's a good reason for some of those to not call `script.hardreset()` - namely, dying or completing No Death Mode and completing a Time Trial presents some information onscreen that would get reset by `script.hardreset()`.

So what I've done for this PR is found every exit path that didn't already use `game.quittomenu()`, and made them use `game.quittomenu()`. As well, some of them had special handling that existed on top of them already having a corresponding entry in `game.quittomenu()` (but the path would take the special handling because it never did `game.quittomenu()`), so I removed that special handling as well (e.g. exiting from a custom level used `returntomenu(Menu::levellist)` when `quittomenu()` already had that same `returntomenu()`).

And as for the fact that the exit paths of Time Trial and No Death Mode reset displayed onscreen information, I worked around that by adding special variables that the results of a Time Trial or No Death Mode run get copied to, which will never get reset by `script.hardreset()`, and using those variables instead.

The menu that exiting from the level editor returns to is now handled in `game.quittomenu()` as well, where the `map.custommode` branch now also checks for `map.custommodeforreal`. Unfortunately, it seems like entering the level editor doesn't properly initialize `map.custommode`, so entering the level editor now initializes `map.custommode`, too.

I've also taken the `music.play(6)` out of `game.quittomenu()`, because not all exit paths immediately play Presenting VVVVVV, so all exit paths that *do* immediately play Presenting VVVVVV now have `music.play(6)` special-cased for them, which is fine enough for me.

Here is the list of all exit paths to the menu:
- Exiting through the pause menu (without glitchrunner mode)
- Exiting through the pause menu (with glitchrunner mode)
- Completing a custom level
- Completing a Time Trial
- Dying in No Death Mode
- Completing No Death Mode
- Completing an Intermission replay
- Exiting from the level editor
- Completing the main game

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
