### PR TITLE
Move mapclass r/g/b variables off onto TowerBG

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -13,9 +13,6 @@
 mapclass::mapclass()
 {
 	//Start here!
-	r = 196;
-	g = 196;
-	b = 196;
 	colstatedelay = 0;
 	colsuperstate = 0;
 	spikeleveltop = 0;
@@ -566,11 +563,41 @@ void mapclass::changefinalcol(int t)
 	}
 }
 
-void mapclass::setcol(const int r1, const int g1, const int b1 , const int r2, const int g2, const int b2, const int c)
+void mapclass::setcol(TowerBG& bg_obj, const int r1, const int g1, const int b1 , const int r2, const int g2, const int b2, const int c)
 {
-	r = intpol(r1, r2, c / 5);
-	g = intpol(g1, g2, c / 5);
-	b = intpol(b1, b2, c / 5);
+	bg_obj.r = intpol(r1, r2, c / 5);
+	bg_obj.g = intpol(g1, g2, c / 5);
+	bg_obj.b = intpol(b1, b2, c / 5);
+}
+
+void mapclass::updatebgobj(TowerBG& bg_obj)
+{
+	const int check = bg_obj.colstate % 5; //current state of phase
+	const int cmode = (bg_obj.colstate - check) / 5; // current colour transition;
+
+	switch(cmode)
+	{
+	case 0:
+		setcol(bg_obj, 255, 93, 107, 255, 255, 93, check);
+		break;
+	case 1:
+		setcol(bg_obj, 255, 255, 93, 159, 255, 93, check);
+		break;
+	case 2:
+		setcol(bg_obj, 159, 255, 93, 93, 245, 255, check);
+		break;
+	case 3:
+		setcol(bg_obj, 93, 245, 255, 177, 93, 255, check);
+		break;
+	case 4:
+		setcol(bg_obj, 177, 93, 255, 255, 93, 255, check);
+		break;
+	case 5:
+		setcol(bg_obj, 255, 93, 255, 255, 93, 107, check);
+		break;
+	}
+
+	bg_obj.tdrawback = true;
 }
 
 void mapclass::updatetowerglow(TowerBG& bg_obj)
@@ -580,30 +607,9 @@ void mapclass::updatetowerglow(TowerBG& bg_obj)
 		if (colsuperstate > 0) bg_obj.colstate--;
 		bg_obj.colstate++;
 		if (bg_obj.colstate >= 30) bg_obj.colstate = 0;
-		int check = bg_obj.colstate % 5; //current state of phase
-		int cmode = (bg_obj.colstate - check) / 5; // current colour transition
 
-		switch(cmode)
-		{
-		case 0:
-			setcol(255, 93, 107, 255, 255, 93, check);
-			break;
-		case 1:
-			setcol(255, 255, 93, 159, 255, 93, check);
-			break;
-		case 2:
-			setcol(159, 255, 93, 93, 245, 255, check);
-			break;
-		case 3:
-			setcol(93, 245, 255, 177, 93, 255, check);
-			break;
-		case 4:
-			setcol(177, 93, 255, 255, 93, 255, check);
-			break;
-		case 5:
-			setcol(255, 93, 255, 255, 93, 107, check);
-			break;
-		}
+		const int check = bg_obj.colstate % 5;
+		updatebgobj(bg_obj);
 
 		if (check == 0)
 		{
@@ -614,8 +620,6 @@ void mapclass::updatetowerglow(TowerBG& bg_obj)
 			colstatedelay = 0;
 		}
 		if (colsuperstate > 0) colstatedelay = 0;
-
-		bg_obj.tdrawback = true;
 	}
 	else
 	{
@@ -627,64 +631,16 @@ void mapclass::nexttowercolour()
 {
 	graphics.titlebg.colstate+=5;
 	if (graphics.titlebg.colstate >= 30) graphics.titlebg.colstate = 0;
-	int check = graphics.titlebg.colstate % 5; //current state of phase
-	int cmode = (graphics.titlebg.colstate - check) / 5; // current colour transition
 
-	switch(cmode)
-	{
-	case 0:
-		setcol(255, 93, 107, 255, 255, 93, check);
-		break;
-	case 1:
-		setcol(255, 255, 93, 159, 255, 93, check);
-		break;
-	case 2:
-		setcol(159, 255, 93, 93, 245, 255, check);
-		break;
-	case 3:
-		setcol(93, 245, 255, 177, 93, 255, check);
-		break;
-	case 4:
-		setcol(177, 93, 255, 255, 93, 255, check);
-		break;
-	case 5:
-		setcol(255, 93, 255, 255, 93, 107, check);
-		break;
-	}
-
-	graphics.titlebg.tdrawback = true;
+	updatebgobj(graphics.titlebg);
 }
 
 void mapclass::settowercolour(int t)
 {
 	graphics.titlebg.colstate=t*5;
 	if (graphics.titlebg.colstate >= 30) graphics.titlebg.colstate = 0;
-	int check = graphics.titlebg.colstate % 5; //current state of phase
-	int cmode = (graphics.titlebg.colstate - check) / 5; // current colour transition
 
-	switch(cmode)
-	{
-	case 0:
-		setcol(255, 93, 107, 255, 255, 93, check);
-		break;
-	case 1:
-		setcol(255, 255, 93, 159, 255, 93, check);
-		break;
-	case 2:
-		setcol(159, 255, 93, 93, 245, 255, check);
-		break;
-	case 3:
-		setcol(93, 245, 255, 177, 93, 255, check);
-		break;
-	case 4:
-		setcol(177, 93, 255, 255, 93, 255, check);
-		break;
-	case 5:
-		setcol(255, 93, 255, 255, 93, 107, check);
-		break;
-	}
-
-	graphics.titlebg.tdrawback = true;
+	updatebgobj(graphics.titlebg);
 }
 
 bool mapclass::spikecollide(int x, int y)

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -46,7 +46,9 @@ public:
 
     void changefinalcol(int t);
 
-    void setcol(const int r1, const int g1, const int b1 , const int r2, const  int g2, const int b2, const int c);
+    void setcol(TowerBG& bg_obj, const int r1, const int g1, const int b1 , const int r2, const  int g2, const int b2, const int c);
+
+    void updatebgobj(TowerBG& bg_obj);
 
     void updatetowerglow(TowerBG& bg_obj);
 
@@ -109,8 +111,6 @@ public:
     int resumedelay;
     bool minitowermode;
 
-    //This is the old colour cycle
-    int r, g,b;
     int colstatedelay;
     int colsuperstate;
     int spikeleveltop, spikelevelbottom;

--- a/desktop_version/src/RenderFixed.cpp
+++ b/desktop_version/src/RenderFixed.cpp
@@ -9,9 +9,9 @@
 
 void titleupdatetextcol()
 {
-    graphics.col_tr = map.r - (help.glow / 4) - int(fRandom() * 4);
-    graphics.col_tg = map.g - (help.glow / 4) - int(fRandom() * 4);
-    graphics.col_tb = map.b - (help.glow / 4) - int(fRandom() * 4);
+    graphics.col_tr = graphics.titlebg.r - (help.glow / 4) - int(fRandom() * 4);
+    graphics.col_tg = graphics.titlebg.g - (help.glow / 4) - int(fRandom() * 4);
+    graphics.col_tb = graphics.titlebg.b - (help.glow / 4) - int(fRandom() * 4);
     if (graphics.col_tr < 0) graphics.col_tr = 0;
     if(graphics.col_tr>255) graphics.col_tr=255;
     if (graphics.col_tg < 0) graphics.col_tg = 0;

--- a/desktop_version/src/TowerBG.h
+++ b/desktop_version/src/TowerBG.h
@@ -12,6 +12,9 @@ struct TowerBG
 	int bscroll;
 	int colstate;
 	int scrolldir;
+	int r;
+	int g;
+	int b;
 };
 
 #endif /* TOWERBG_H */

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3194,9 +3194,9 @@ void editorrender()
             FillRect(graphics.backBuffer, 0, 0, 320, 240, 0x00000000);
         }
 
-        int tr = map.r - (help.glow / 4) - int(fRandom() * 4);
-        int tg = map.g - (help.glow / 4) - int(fRandom() * 4);
-        int tb = map.b - (help.glow / 4) - int(fRandom() * 4);
+        int tr = graphics.titlebg.r - (help.glow / 4) - int(fRandom() * 4);
+        int tg = graphics.titlebg.g - (help.glow / 4) - int(fRandom() * 4);
+        int tb = graphics.titlebg.b - (help.glow / 4) - int(fRandom() * 4);
         if (tr < 0) tr = 0;
         if(tr>255) tr=255;
         if (tg < 0) tg = 0;


### PR DESCRIPTION
This fixes a bug where if you entered a tower before watching the credits sequence, the credits sequence would have mismatched text and background colors.

![Mismatched text and background colors on the credits screen](https://user-images.githubusercontent.com/59748578/103964385-2e1e5b00-5110-11eb-8654-f23f6b474eb1.png)

This bug happened because entering a tower modified the `r`/`g`/`b` attributes of mapclass, and updated `graphics.towerbg`, without updating `graphics.titlebg` too. Then `gamecompleterender()` uses the `r`/`g`/`b` attributes of mapclass, which were meant to work with `graphics.towerbg`, but draws `graphics.titlebg` instead.

The solution is to put the `r`/`g`/`b` attributes on TowerBG instead. That way, entering a tower will only modify the `r`/`g`/`b` attributes used to render towers, and won't affect the `r`/`g`/`b` attributes used to render the credits sequence.

Additionally, I also de-duplicated the case-switch that updated the `r`/`g`/`b` attributes based off of the current `colstate`, because it got copy-pasted twice, leading to three instances of one piece of code.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
