### PR TITLE
Fix Shift+F1 from Space Station tileset not switching to Ship

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1508,7 +1508,7 @@ void editorclass::switch_tileset(const bool reversed /*= false*/)
         tiles++;
     }
 
-    const size_t modulus = SDL_arraysize(tilesets);
+    const int modulus = SDL_arraysize(tilesets);
     tiles = (tiles % modulus + modulus) % modulus;
     room.tileset = tiles;
 


### PR DESCRIPTION
So... it looks like being able to switch through tilesets backwards has been in 2.3 for a while, guess no one just uses 2.3 or the level editor that much. It seems like it's always been broken, too.

If you were on the Space Station tileset (tileset 0), pressing Shift+F1 would keep you on the Space Station tileset instead of switching to the Ship (tileset 4).

It looks like the problem here was mixing `size_t` and `int` together - so the modulus operation promoted the left-hand side to `size_t`, which is unsigned, so the -1 turned into `SIZE_MAX`, which is 18446744073709551615 on my system. You'll note that that ends in a 5, so the number is divisible by 5, meaning taking it modulo 5 leads to 0. So the tileset would be kept at 0.

At least unsigned integer underflow/overflow is properly defined, so there's no UB here. Just careless type mixing going on.

The solution is to make the modulus an `int` instead of a `size_t`. This introduces an implicit conversion, but I don't care because my compiler doesn't warn about it, and implicit conversion warnings ought to be disabled on MSVC anyway.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
