### PR TITLE
Randomize game.lastsaved if rescuing Violet last

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -2641,6 +2641,9 @@ void Game::updatestate()
                 startscript = true;
                 if (crewrescued() == 6)
                 {
+                    // Randomize between everyone except Viridian and Violet (2..5)
+                    // Prevents having two Violets in the same room
+                    lastsaved = 2 + fRandom() * 3;
                     newscript = "startlevel_final";
                 }
                 else


### PR DESCRIPTION
Currently, if you rescue Violet last, the pre-Final Level cutscene will have two Violets in the same room. That's because Violet is programmed to always spawn, even if the last person rescued was Violet.

Now, I considered scripting an alternative cutscene that would happen if Violet was rescued last, but thinking about it more, if you rescue Violet out of order, there's really no way to reconcile that with what actually happens in the game. In the story, Violet is purportedly left on the Ship after everyone gets scattered throughout the dimension, but in actuality, Violet simply is not on the Ship at all, until you complete Space Station 1. And if you rescue Violet out of order (by pressing R at the starting cutscene), then you get to see this fact, plain as day. So, I don't really see much point in trying to add an alternative cutscene, when there's still that whole problem.

The least we can do is to at least prevent having two Violets in the same room. And to do that, `game.lastsaved` gets randomized if you rescue Violet last. The game chooses a random number between 2 and 5 (inclusive), because numbers 0 and 1 are Viridian and Violet respectively. So the game will randomly choose between Vitellary, Vermilion, Verdigris, or Victoria being the one that teleports out of the teleporter in the pre-Final Level cutscene.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
