### PR TITLE
Fix attempts to place enemy and platform bounds and script boxes with bad corner order (top-right to bottom-left, bottom-left to top-right)

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -4745,7 +4745,7 @@ void editorinput()
                         }
                         else if(ed.boundarymod==2)
                         {
-                            if((ed.tilex*8)+8>=ed.boundx1 || (ed.tiley*8)+8>=ed.boundy1)
+                            if((ed.tilex*8)+8>=ed.boundx1 && (ed.tiley*8)+8>=ed.boundy1)
                             {
                                 ed.boundx2=(ed.tilex*8)+8;
                                 ed.boundy2=(ed.tiley*8)+8;


### PR DESCRIPTION
There is a certain ordering of which corners you click on to place enemy and platform boundaries, and script boxes. You must first click on the top-left corner, then click on the bottom-right corner. The visual box that is drawn after you've first clicked on the top-left corner clearly shows this intended way of doing things.

However, it seems like despite the visuals, the game didn't properly prevent you from clicking on the corners in the wrong way. If you placed it from top-right to bottom-left, or bottom-left to top-right, then the game would place the boxes accordingly, and they would have a weird shape where two of its opposite sides would just be missing. But, placing them from bottom-right to top-left is prevented accordingly.

The bug comes down to a simple use of "or", instead of the correct "and". This isn't the first time the wrong conjunction was used in a conditional... (8260bb2696f4843b3e6a29b0c4deea7ba6779aea, #136)

Since the code block that the if-statement guards is the code that will execute if the corners placed were correct, the if-statement thus should be written in the positive case and use a more restrictive "and", instead of the negative case, which would use a more looser "or". There are less cases that are correct than cases which are incorrect - in this case, there is only 1 correct way of doing things (top-left to bottom-right), compared to 3 incorrect ways of doing things (top-right to bottom-left, bottom-left to top-right, bottom-right to top-left) - so when thinking of positive cases, you should be using "and".

Or, you can always just test it. This bug has been in the game since 2.0, so it seems like no one just tested that incorrect input actually didn't work.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
