### PR TITLE
Move gamerenderfixed() in between gameinput() and gamelogic()

### DIFF
--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -573,8 +573,8 @@ void inline fixedloop()
             }
 
             gameinput();
-            gamelogic();
             gamerenderfixed();
+            gamelogic();
 
 
             break;


### PR DESCRIPTION
Line clipping and second-frame edge-flipping have been broken since #539 was merged (d910c5118dc47ed0847485e15e7b315fe0420ff6). The cause of this is moving the `onground`/`onroof` code around.

A proper loop order fix is going to come once #535 gets finalized and merged, so this is a stopgap measure just to make sure people don't report that line clipping or second-frame edge-flipping are broken in current builds of 2.3.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
