### PR TITLE
Clean up unnecessary exports and add static keywords

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -28,12 +28,12 @@
 #define MAX_PATH PATH_MAX
 #endif
 
-char saveDir[MAX_PATH] = {'\0'};
-char levelDir[MAX_PATH] = {'\0'};
+static char saveDir[MAX_PATH] = {'\0'};
+static char levelDir[MAX_PATH] = {'\0'};
 
-void PLATFORM_getOSDirectory(char* output);
-void PLATFORM_migrateSaveData(char* output);
-void PLATFORM_copyFile(const char *oldLocation, const char *newLocation);
+static void PLATFORM_getOSDirectory(char* output);
+static void PLATFORM_migrateSaveData(char* output);
+static void PLATFORM_copyFile(const char *oldLocation, const char *newLocation);
 
 int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 {
@@ -345,7 +345,7 @@ std::vector<std::string> FILESYSTEM_getLevelDirFileNames()
 	return list;
 }
 
-void PLATFORM_getOSDirectory(char* output)
+static void PLATFORM_getOSDirectory(char* output)
 {
 #ifdef _WIN32
 	/* This block is here for compatibility, do not touch it! */
@@ -358,7 +358,7 @@ void PLATFORM_getOSDirectory(char* output)
 #endif
 }
 
-void PLATFORM_migrateSaveData(char* output)
+static void PLATFORM_migrateSaveData(char* output)
 {
 	char oldLocation[MAX_PATH];
 	char newLocation[MAX_PATH];
@@ -521,7 +521,7 @@ void PLATFORM_migrateSaveData(char* output)
 #endif
 }
 
-void PLATFORM_copyFile(const char *oldLocation, const char *newLocation)
+static void PLATFORM_copyFile(const char *oldLocation, const char *newLocation)
 {
 	char *data;
 	size_t length, bytes_read, bytes_written;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -26,7 +26,7 @@
 #define strcasecmp stricmp
 #endif
 
-bool GetButtonFromString(const char *pText, SDL_GameControllerButton *button)
+static bool GetButtonFromString(const char *pText, SDL_GameControllerButton *button)
 {
     if (*pText == '0' ||
         *pText == 'a' ||

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -24,7 +24,7 @@ extern "C"
 	);
 }
 
-SDL_Surface* LoadImage(const char *filename, bool noBlend = true, bool noAlpha = false)
+static SDL_Surface* LoadImage(const char *filename, bool noBlend = true, bool noAlpha = false)
 {
 	//Temporary storage for the image that's loaded
 	SDL_Surface* loadedImage = NULL;

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -42,7 +42,7 @@ SDL_Surface* GetSubSurface( SDL_Surface* metaSurface, int x, int y, int width, i
     return preSurface;
 }
 
-void DrawPixel( SDL_Surface *_surface, int x, int y, Uint32 pixel )
+static void DrawPixel( SDL_Surface *_surface, int x, int y, Uint32 pixel )
 {
     int bpp = _surface->format->BytesPerPixel;
     /* Here p is the address to the pixel we want to set */
@@ -294,9 +294,9 @@ void BlitSurfaceTinted(
 }
 
 
-int oldscrollamount = 0;
-int scrollamount = 0;
-bool isscrolling = 0;
+static int oldscrollamount = 0;
+static int scrollamount = 0;
+static bool isscrolling = 0;
 
 void UpdateFilter()
 {

--- a/desktop_version/src/GraphicsUtil.h
+++ b/desktop_version/src/GraphicsUtil.h
@@ -13,8 +13,6 @@ void setRect(SDL_Rect& _r, int x, int y, int w, int h);
 
 SDL_Surface* GetSubSurface( SDL_Surface* metaSurface, int x, int y, int width, int height );
 
-void DrawPixel( SDL_Surface *surface, int x, int y, Uint32 pixel );
-
 Uint32 ReadPixel( SDL_Surface *surface, int x, int y );
 
 SDL_Surface * ScaleSurface( SDL_Surface *Surface, int Width, int Height, SDL_Surface * Dest = NULL );

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -15,7 +15,7 @@
 #include "Script.h"
 #include "UtilityClass.h"
 
-void updatebuttonmappings(int bind)
+static void updatebuttonmappings(int bind)
 {
     for (
         SDL_GameControllerButton i = SDL_CONTROLLER_BUTTON_A;
@@ -173,7 +173,7 @@ void updatebuttonmappings(int bind)
     }
 }
 
-void menuactionpress()
+static void menuactionpress()
 {
     switch (game.currentmenuname)
     {
@@ -2059,7 +2059,7 @@ void gameinput()
     }
 }
 
-void mapmenuactionpress();
+static void mapmenuactionpress();
 
 void mapinput()
 {
@@ -2247,7 +2247,7 @@ void mapinput()
     }
 }
 
-void mapmenuactionpress()
+static void mapmenuactionpress()
 {
     switch (game.menupage)
     {

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -8,7 +8,7 @@
 #include "Map.h"
 #include "UtilityClass.h"
 
-void songend();
+static void songend();
 
 musicclass::musicclass()
 {
@@ -158,7 +158,7 @@ void musicclass::init()
 	}
 }
 
-void songend()
+static void songend()
 {
 	extern musicclass music;
 	music.songEnd = SDL_GetPerformanceCounter();

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -12,13 +12,13 @@
 #include "UtilityClass.h"
 #include "Version.h"
 
-int tr;
-int tg;
-int tb;
+static int tr;
+static int tg;
+static int tb;
 
 // Macro-like inline function used in maprender()
 // Used to keep some text positions the same in Flip Mode
-int inline FLIP(int ypos)
+static int inline FLIP(int ypos)
 {
     if (graphics.flipmode)
     {
@@ -46,7 +46,7 @@ static inline void drawslowdowntext()
     }
 }
 
-void menurender()
+static void menurender()
 {
     int temp = 50;
 

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 
 /* Used by UtilityClass::GCString to generate a button list */
-const char *GCChar(SDL_GameControllerButton button)
+static const char *GCChar(SDL_GameControllerButton button)
 {
 	if (button == SDL_CONTROLLER_BUTTON_A)
 	{

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -60,7 +60,7 @@ editorclass::editorclass()
 }
 
 // comparison, not case sensitive.
-bool compare_nocase (std::string first, std::string second)
+static bool compare_nocase (std::string first, std::string second)
 {
     unsigned int i=0;
     while ( (i<first.length()) && (i<second.length()) )
@@ -2084,7 +2084,7 @@ bool editorclass::save(std::string& _path)
 }
 
 
-void addedentity( int xp, int yp, int tp, int p1/*=0*/, int p2/*=0*/, int p3/*=0*/, int p4/*=0*/, int p5/*=320*/, int p6/*=240*/)
+static void addedentity( int xp, int yp, int tp, int p1 = 0, int p2 = 0, int p3 = 0, int p4 = 0, int p5 = 320, int p6 = 240)
 {
     edentities entity;
 
@@ -2102,12 +2102,12 @@ void addedentity( int xp, int yp, int tp, int p1/*=0*/, int p2/*=0*/, int p3/*=0
     edentity.push_back(entity);
 }
 
-void removeedentity( int t )
+static void removeedentity( int t )
 {
     edentity.erase(edentity.begin() + t);
 }
 
-int edentat( int xp, int yp )
+static int edentat( int xp, int yp )
 {
     for(size_t i=0; i<edentity.size(); i++)
     {
@@ -2116,7 +2116,7 @@ int edentat( int xp, int yp )
     return -1;
 }
 
-void fillbox( int x, int y, int x2, int y2, int c )
+static void fillbox( int x, int y, int x2, int y2, int c )
 {
     FillRect(graphics.backBuffer, x, y, x2-x, 1, c);
     FillRect(graphics.backBuffer, x, y2-1, x2-x, 1, c);
@@ -2124,7 +2124,7 @@ void fillbox( int x, int y, int x2, int y2, int c )
     FillRect(graphics.backBuffer, x2-1, y, 1, y2-y, c);
 }
 
-void fillboxabs( int x, int y, int x2, int y2, int c )
+static void fillboxabs( int x, int y, int x2, int y2, int c )
 {
     FillRect(graphics.backBuffer, x, y, x2, 1, c);
     FillRect(graphics.backBuffer, x, y+y2-1, x2, 1, c);
@@ -2253,7 +2253,7 @@ void editorclass::generatecustomminimap()
 }
 
 #if !defined(NO_EDITOR)
-void editormenurender(int tr, int tg, int tb)
+static void editormenurender(int tr, int tg, int tb)
 {
     extern editorclass ed;
     switch (game.currentmenuname)
@@ -3662,7 +3662,7 @@ void editorlogic()
 }
 
 
-void editormenuactionpress()
+static void editormenuactionpress()
 {
     extern editorclass ed;
     switch (game.currentmenuname)

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -265,17 +265,6 @@ class editorclass{
   int currentghosts;
 };
 
-void addedentity(int xp, int yp, int tp, int p1=0, int p2=0, int p3=0, int p4=0, int p5=320, int p6=240);
-
-void removeedentity(int t);
-
-int edentat(int xp, int yp);
-
-
-void fillbox(int x, int y, int x2, int y2, int c);
-
-void fillboxabs(int x, int y, int x2, int y2, int c);
-
 #if !defined(NO_EDITOR)
 void editorrender();
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -38,23 +38,23 @@ mapclass map;
 entityclass obj;
 Screen gameScreen;
 
-bool startinplaytest = false;
-bool savefileplaytest = false;
-int savex = 0;
-int savey = 0;
-int saverx = 0;
-int savery = 0;
-int savegc = 0;
-int savemusic = 0;
-std::string playassets;
+static bool startinplaytest = false;
+static bool savefileplaytest = false;
+static int savex = 0;
+static int savey = 0;
+static int saverx = 0;
+static int savery = 0;
+static int savegc = 0;
+static int savemusic = 0;
+static std::string playassets;
 
-std::string playtestname;
+static std::string playtestname;
 
-volatile Uint32 time_ = 0;
-volatile Uint32 timePrev = 0;
-volatile Uint32 accumulator = 0;
-volatile Uint32 f_time = 0;
-volatile Uint32 f_timePrev = 0;
+static volatile Uint32 time_ = 0;
+static volatile Uint32 timePrev = 0;
+static volatile Uint32 accumulator = 0;
+static volatile Uint32 f_time = 0;
+static volatile Uint32 f_timePrev = 0;
 
 static inline Uint32 get_framerate(const int slowdown)
 {
@@ -73,8 +73,8 @@ static inline Uint32 get_framerate(const int slowdown)
     return 34;
 }
 
-void inline deltaloop();
-void inline fixedloop();
+static void inline deltaloop();
+static void inline fixedloop();
 
 int main(int argc, char *argv[])
 {
@@ -414,7 +414,7 @@ int main(int argc, char *argv[])
     return 0;
 }
 
-void inline deltaloop()
+static void inline deltaloop()
 {
     //timestep limit to 30
     const float rawdeltatime = static_cast<float>(time_ - timePrev);
@@ -482,7 +482,7 @@ void inline deltaloop()
     }
 }
 
-void inline fixedloop()
+static void inline fixedloop()
 {
     // Update network per frame.
     NETWORK_update();

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -4,12 +4,12 @@
 #include "KeyPoll.h"
 #include "UtilityClass.h"
 
-int pre_fakepercent=0, pre_transition=30;
-bool pre_startgame=false;
-int pre_darkcol=0, pre_lightcol=0, pre_curcol=0, pre_coltimer=0, pre_offset=0;
+static int pre_fakepercent=0, pre_transition=30;
+static bool pre_startgame=false;
+static int pre_darkcol=0, pre_lightcol=0, pre_curcol=0, pre_coltimer=0, pre_offset=0;
 
-int pre_frontrectx=30, pre_frontrecty=20, pre_frontrectw=260, pre_frontrecth=200;
-int pre_temprectx=0, pre_temprecty=0, pre_temprectw=320, pre_temprecth=240;
+static int pre_frontrectx=30, pre_frontrecty=20, pre_frontrectw=260, pre_frontrecth=200;
+static int pre_temprectx=0, pre_temprecty=0, pre_temprectw=320, pre_temprecth=240;
 
 void preloaderinput()
 {


### PR DESCRIPTION
This patch cleans up unnecessary exports from header files (there were only a few), as well as adds the `static` keyword to all symbols that aren't exported and are specific to a file. This helps the linker out in not doing any unnecessary work, speeding it up and avoiding silent symbol conflicts (otherwise two symbols with the same name (and type/signature in C++) would quietly resolve as okay by the linker).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
