### PR TITLE
Remove game.savemystats

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -130,7 +130,6 @@ void Game::init(void)
     roomchange = false;
 
 
-    savemystats = false;
     quickrestartkludge = false;
 
     tapleft = 0;
@@ -6649,12 +6648,12 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
             if (temp == 1)
             {
                 createmenu(Menu::unlocktimetrial, true);
-                savemystats = true;
+                savestatsandsettings();
             }
             else if (temp > 1)
             {
                 createmenu(Menu::unlocktimetrials, true);
-                savemystats = true;
+                savestatsandsettings();
             }
         }
         else
@@ -6673,7 +6672,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
                 unlocknotify[17] = true;
                 unlock[17] = true;
                 createmenu(Menu::unlocknodeathmode, true);
-                savemystats = true;
+                savestatsandsettings();
             }
             //Alright then! Flip mode?
             else if (unlock[5] && !unlocknotify[18])
@@ -6681,7 +6680,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
                 unlock[18] = true;
                 unlocknotify[18] = true;
                 createmenu(Menu::unlockflipmode, true);
-                savemystats = true;
+                savestatsandsettings();
             }
             //What about the intermission levels?
             else if (unlock[7] && !unlocknotify[16])
@@ -6689,7 +6688,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
                 unlock[16] = true;
                 unlocknotify[16] = true;
                 createmenu(Menu::unlockintermission, true);
-                savemystats = true;
+                savestatsandsettings();
             }
             else
             {

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -374,8 +374,6 @@ public:
     std::string hardestroom;
     int hardestroomdeaths, currentroomdeaths;
 
-    bool savemystats;
-
 
     bool quickrestartkludge;
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -687,7 +687,7 @@ static void menuactionpress()
         {
             // toggle Flip Mode
             graphics.setflipmode = !graphics.setflipmode;
-            game.savemystats = true;
+            game.savestatsandsettings();
             if (graphics.setflipmode)
             {
                 music.playef(18);
@@ -1307,7 +1307,7 @@ static void menuactionpress()
         {
             // WARNING: Partially duplicated in Menu::options
             graphics.setflipmode = !graphics.setflipmode;
-            game.savemystats = true;
+            game.savestatsandsettings();
             if (graphics.setflipmode)
             {
                 music.playef(18);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -639,12 +639,6 @@ static void inline fixedloop()
     //We did editorinput, now it's safe to turn this off
     key.linealreadyemptykludge = false;
 
-    if (game.savemystats)
-    {
-        game.savemystats = false;
-        game.savestatsandsettings();
-    }
-
     //Mute button
     if (key.isDown(KEYBOARD_m) && game.mutebutton<=0 && !key.textentry())
     {


### PR DESCRIPTION
This variable seems to have been intended to make sure `game.savestatsandsettings()` was called at the end of the frame, or make sure that it didn't get called more than once per frame. I don't see any frame ordering-related reason why it needs to be called specifically at the end of the frame (the function doesn't modify any state), so it's more plausible that it was added to make sure it didn't get called more than one per frame.

However, upon further analysis, none of the code paths where `game.savemystats` is used ever calls or sets `game.savemystats` more than once, and a majority of the code directly calls `game.savestatsandsettings()` anyway, so there's no reason for this variable to exist. If we ever need to make sure it doesn't get called more than once, and there's no way to change the code paths around to prevent it otherwise, we can use the defer callbacks system that I added to #535, when it gets merged.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
