### PR TITLE
Remove map.finalx/map.finaly and map.customx/map.customy

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -3229,8 +3229,6 @@ void Game::updatestate()
             map.final_mapcol = 0;
             map.final_colorframe = 0;
             map.finalstretch = false;
-            map.finalx = 100;
-            map.finaly = 100;
 
             graphics.cutscenebarspos = 320;
             graphics.oldcutscenebarspos = 320;
@@ -5289,15 +5287,7 @@ void Game::readmaingamesave(tinyxml2::XMLDocument& doc)
             map.finalstretch = help.Int(pText);
         }
 
-        if (pKey == "finalx")
-        {
-            map.finalx = help.Int(pText);
-        }
-        else if (pKey == "finaly")
-        {
-            map.finaly = help.Int(pText);
-        }
-        else if (pKey == "savex")
+        if (pKey == "savex")
         {
             savex = help.Int(pText);
         }
@@ -5492,15 +5482,7 @@ void Game::customloadquick(std::string savfile)
         }
 
 
-        if (pKey == "finalx")
-        {
-            map.finalx = help.Int(pText);
-        }
-        else if (pKey == "finaly")
-        {
-            map.finaly = help.Int(pText);
-        }
-        else if (pKey == "savex")
+        if (pKey == "savex")
         {
             savex = help.Int(pText);
         }
@@ -5885,10 +5867,6 @@ std::string Game::writemaingamesave(tinyxml2::XMLDocument& doc)
 
     //Position
 
-    xml::update_tag(msgs, "finalx", map.finalx);
-
-    xml::update_tag(msgs, "finaly", map.finaly);
-
     xml::update_tag(msgs, "savex", savex);
 
     xml::update_tag(msgs, "savey", savey);
@@ -6015,10 +5993,6 @@ bool Game::customsavequick(std::string savfile)
     xml::update_tag(msgs, "customcollect", customcollect.c_str());
 
     //Position
-
-    xml::update_tag(msgs, "finalx", map.finalx);
-
-    xml::update_tag(msgs, "finaly", map.finaly);
 
     xml::update_tag(msgs, "savex", savex);
 

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -29,8 +29,6 @@ mapclass::mapclass()
 
 	finalmode = false;
 	finalstretch = false;
-	finalx = 50;
-	finaly = 50;
 
 	cursorstate = 0;
 	cursordelay = 0;
@@ -48,7 +46,6 @@ mapclass::mapclass()
 
 	custommode=false;
 	custommodeforreal=false;
-	customx=0; customy=0;
 	customwidth=20; customheight=20;
 	custommmxoff=0; custommmyoff=0; custommmxsize=0; custommmysize=0;
 	customzoom=0;
@@ -897,18 +894,13 @@ void mapclass::gotoroom(int rx, int ry)
 	if (finalmode)
 	{
 		//Ok, what way are we moving?
-		finalx = rx;
-		finaly = ry;
-		game.roomx = finalx;
-		game.roomy = finaly;
+		game.roomx = rx;
+		game.roomy = ry;
 		game.roomchange = true;
-		rx = finalx;
-		ry = finaly;
 
 		if (game.roomy < 10)
 		{
 			game.roomy = 11;
-			finaly = 11;
 		}
 
 		if(game.roomx>=41 && game.roomy>=48 && game.roomx<61 && game.roomy<68 )
@@ -1377,7 +1369,7 @@ void mapclass::loadlevel(int rx, int ry)
 	}
 	case 6: //final level
 	{
-		const short* tmap = finallevel.loadlevel(finalx, finaly);
+		const short* tmap = finallevel.loadlevel(rx, ry);
 		SDL_memcpy(contents, tmap, sizeof(contents));
 		roomname = finallevel.roomname;
 		tileset = 1;
@@ -1452,7 +1444,6 @@ void mapclass::loadlevel(int rx, int ry)
 			obj.entities[i].yp += (71 * 8);
 		}
 		game.roomy--;
-		finaly--;
 
 		ypos = (100-29) * 8;
 		oldypos = ypos;
@@ -1497,7 +1488,6 @@ void mapclass::loadlevel(int rx, int ry)
 			obj.entities[i].yp += (71 * 8);
 		}
 		game.roomy--;
-		finaly--;
 
 		ypos = (100-29) * 8;
 		oldypos = ypos;

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -116,15 +116,12 @@ public:
     int spikeleveltop, spikelevelbottom;
     int oldspikeleveltop, oldspikelevelbottom;
     //final level navigation
-    int finalx;
-    int finaly;
     bool finalmode;
     bool finalstretch;
 
     //Variables for playing custom levels
     bool custommode;
     bool custommodeforreal;
-    int customx, customy;
     int customwidth, customheight;
     int custommmxoff, custommmyoff, custommmxsize, custommmysize;
     int customzoom;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1584,11 +1584,7 @@ void scriptclass::run()
 			else if (words[0] == "finalmode")
 			{
 				map.finalmode = true;
-				map.finalx = ss_toi(words[1]);
-				map.finaly = ss_toi(words[2]);
-				game.roomx = map.finalx;
-				game.roomy = map.finaly;
-				map.gotoroom(game.roomx, game.roomy);
+				map.gotoroom(ss_toi(words[1]), ss_toi(words[2]));
 			}
 			else if (words[0] == "rescued")
 			{
@@ -2056,8 +2052,6 @@ void scriptclass::run()
 			else if (words[0] == "startintermission2")
 			{
 				map.finalmode = true; //Enable final level mode
-				map.finalx = 46;
-				map.finaly = 54; //Current
 
 				game.savex = 228;
 				game.savey = 129;
@@ -2891,8 +2885,6 @@ void scriptclass::startgamemode( int t )
 
 		music.fadeout();
 		map.finalmode = true; //Enable final level mode
-		map.finalx = 46;
-		map.finaly = 54; //Current
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
@@ -3017,8 +3009,6 @@ void scriptclass::startgamemode( int t )
 		game.supercrewmate = true;
 		game.scmprogress = 0;
 		map.finalmode = true;
-		map.finalx = 41;
-		map.finaly = 56;
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
@@ -3053,8 +3043,6 @@ void scriptclass::startgamemode( int t )
 		game.supercrewmate = true;
 		game.scmprogress = 0;
 		map.finalmode = true;
-		map.finalx = 41;
-		map.finaly = 56;
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
@@ -3089,8 +3077,6 @@ void scriptclass::startgamemode( int t )
 		game.supercrewmate = true;
 		game.scmprogress = 0;
 		map.finalmode = true;
-		map.finalx = 41;
-		map.finaly = 56;
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
@@ -3125,8 +3111,6 @@ void scriptclass::startgamemode( int t )
 		game.supercrewmate = true;
 		game.scmprogress = 0;
 		map.finalmode = true;
-		map.finalx = 41;
-		map.finaly = 56;
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
@@ -3158,8 +3142,6 @@ void scriptclass::startgamemode( int t )
 		game.crewstats[game.lastsaved] = true;
 		game.inintermission = true;
 		map.finalmode = true;
-		map.finalx = 41;
-		map.finaly = 56;
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
@@ -3191,8 +3173,6 @@ void scriptclass::startgamemode( int t )
 		game.crewstats[game.lastsaved] = true;
 		game.inintermission = true;
 		map.finalmode = true;
-		map.finalx = 41;
-		map.finaly = 56;
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
@@ -3224,8 +3204,6 @@ void scriptclass::startgamemode( int t )
 		game.crewstats[game.lastsaved] = true;
 		game.inintermission = true;
 		map.finalmode = true;
-		map.finalx = 41;
-		map.finaly = 56;
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
@@ -3257,8 +3235,6 @@ void scriptclass::startgamemode( int t )
 		game.crewstats[game.lastsaved] = true;
 		game.inintermission = true;
 		map.finalmode = true;
-		map.finalx = 41;
-		map.finaly = 56;
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
@@ -3321,8 +3297,6 @@ void scriptclass::startgamemode( int t )
 		ed.ghosts.clear();
 
 		map.custommode = true;
-		map.customx = 100;
-		map.customy = 100;
 
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
@@ -3359,8 +3333,6 @@ void scriptclass::startgamemode( int t )
 
 		map.custommodeforreal = true;
 		map.custommode = true;
-		map.customx = 100;
-		map.customy = 100;
 
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
@@ -3399,8 +3371,6 @@ void scriptclass::startgamemode( int t )
 		hardreset();
 		map.custommodeforreal = true;
 		map.custommode = true;
-		map.customx = 100;
-		map.customy = 100;
 
 		game.customstart();
 		game.customloadquick(ed.ListOfMetaData[game.playcustomlevel].filename);
@@ -3690,8 +3660,6 @@ void scriptclass::hardreset()
 	map.showtrinkets = false;
 	map.finalmode = false;
 	map.finalstretch = false;
-	map.finalx = 50;
-	map.finaly = 50;
 	map.final_colormode = false;
 	map.final_colorframe = 0;
 	map.final_colorframedelay = 0;


### PR DESCRIPTION
These variables basically serve no purpose. `map.customx` and `map.customy` are clearly never used. `map.finalx` and `map.finaly`, on the other hand, are basically always `game.roomx` and `game.roomy` respectively if `map.finalmode` is on, and if it's off, then they don't matter.

Also, there are some weird and redundant variable assignments going on with these; most notably in `map.gotoroom()`, where `rx`/`ry` (local variables) get assigned to `finalx`/`finaly`, then `finalx`/`finaly` get assigned to `game.roomx`/`game.roomy`, then `finalx`/`finaly` get assigned to `rx`/`ry`. If `finalx`/`finaly` made a difference, then there'd be no need to assign `finalx`/`finaly` back to `rx`/`ry`. So it makes the code clearer to remove these weird bits of code.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
