### PR TITLE
Add F9 "reload resources" hotkey to list of hotkeys in Shift menu

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3463,14 +3463,15 @@ void editorrender()
 
         if(ed.shiftmenu)
         {
-            fillboxabs(0, 127,161+8,140,graphics.getRGB(64,64,64));
-            FillRect(graphics.backBuffer, 0,128,160+8,140, graphics.getRGB(0,0,0));
-            graphics.Print(4, 130, "F1: Change Tileset",164,164,164,false);
-            graphics.Print(4, 140, "F2: Change Colour",164,164,164,false);
-            graphics.Print(4, 150, "F3: Change Enemies",164,164,164,false);
-            graphics.Print(4, 160, "F4: Enemy Bounds",164,164,164,false);
-            graphics.Print(4, 170, "F5: Platform Bounds",164,164,164,false);
+            fillboxabs(0, 117,171+8,140,graphics.getRGB(64,64,64));
+            FillRect(graphics.backBuffer, 0,118,170+8,140, graphics.getRGB(0,0,0));
+            graphics.Print(4, 120, "F1: Change Tileset",164,164,164,false);
+            graphics.Print(4, 130, "F2: Change Colour",164,164,164,false);
+            graphics.Print(4, 140, "F3: Change Enemies",164,164,164,false);
+            graphics.Print(4, 150, "F4: Enemy Bounds",164,164,164,false);
+            graphics.Print(4, 160, "F5: Platform Bounds",164,164,164,false);
 
+            graphics.Print(4, 180, "F9: Reload Resources",164,164,164,false);
             graphics.Print(4, 190, "F10: Direct Mode",164,164,164,false);
 
             graphics.Print(4, 210, "W: Change Warp Dir",164,164,164,false);


### PR DESCRIPTION
2.3's per-level assets feature also added a hotkey to reload the custom assets of the level you're currently editing in the editor, so you wouldn't have to re-load the level yourself. This hotkey is F9, but however, it hasn't been documented in the hotkey list brought up by pressing Shift, until now.

![F9 hotkey screenshot](https://user-images.githubusercontent.com/59748578/104147412-0256db80-5383-11eb-9467-c4805a3a8ce9.png)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
