### PR TITLE
Fix editor tool menu inconsistencies

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3287,22 +3287,15 @@ void editorrender()
                 tx+=tg;
                 FillRect(graphics.backBuffer, tx+2,ty+8,12,1,graphics.getRGB(255,255,255));
 
-                for(int i=0; i<9; i++)
+                for (int i = 0; i < 10; i++)
                 {
                     fillboxabs(4+(i*tg), 209,20,20,graphics.getRGB(96,96,96));
-                    graphics.Print(22+(i*tg)-4, 225-4,help.String(i+1),164,164,164,false);
+                    const int col = i == ed.drawmode ? 255 : 164;
+                    const std::string glyph = i == 9 ? "0" : help.String(i + 1);
+                    graphics.Print(22 + i*tg - 4, 225 - 4, glyph, col, col, col, false);
                 }
-
-                if(ed.drawmode==9)graphics.Print(22+(ed.drawmode*tg)-4, 225-4,"0",255,255,255,false);
-
-                fillboxabs(4+(9*tg), 209,20,20,graphics.getRGB(96,96,96));
-                graphics.Print(22+(9*tg)-4, 225-4, "0",164,164,164,false);
 
                 fillboxabs(4+(ed.drawmode*tg), 209,20,20,graphics.getRGB(200,200,200));
-                if(ed.drawmode<9)
-                {
-                    graphics.Print(22+(ed.drawmode*tg)-4, 225-4,help.String(ed.drawmode+1),255,255,255,false);
-                }
 
                 graphics.Print(4, 232, "1/2", 196, 196, 255 - help.glow, false);
             }
@@ -3337,28 +3330,15 @@ void editorrender()
                 tx+=tg;
                 graphics.drawsprite(tx,ty,184,graphics.col_crewcyan);
 
-                if(ed.drawmode==10)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"R",255,255,255,false);
-                if(ed.drawmode==11)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"T",255,255,255,false);
-                if(ed.drawmode==12)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"Y",255,255,255,false);
-                if(ed.drawmode==13)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"U",255,255,255,false);
-                if(ed.drawmode==14)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"I",255,255,255,false);
-                if(ed.drawmode==15)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"O",255,255,255,false);
-                if(ed.drawmode==16)graphics.Print(22+((ed.drawmode-10)*tg)-4, 225-4,"P",255,255,255,false);
+                for (int i = 0; i < 7; i++)
+                {
+                    fillboxabs(4 +  i*tg, 209, 20, 20, graphics.getRGB(96, 96, 96));
+                    const int col = i + 10 == ed.drawmode ? 255 : 164;
+                    static const char glyphs[] = "RTYUIOP";
+                    graphics.Print(22 + i*tg - 4, 225 - 4, std::string(1, glyphs[i]), col, col, col, false);
+                }
 
-                fillboxabs(4+(0*tg), 209,20,20,graphics.getRGB(96,96,96));
-                graphics.Print(22+(0*tg)-4, 225-4, "R",164,164,164,false);
-                fillboxabs(4+(1*tg), 209,20,20,graphics.getRGB(96,96,96));
-                graphics.Print(22+(1*tg)-4, 225-4, "T",164,164,164,false);
-                fillboxabs(4+(2*tg), 209,20,20,graphics.getRGB(96,96,96));
-                graphics.Print(22+(2*tg)-4, 225-4, "Y",164,164,164,false);
-                fillboxabs(4+(3*tg), 209,20,20,graphics.getRGB(96,96,96));
-                graphics.Print(22+(3*tg)-4, 225-4, "U",164,164,164,false);
-                fillboxabs(4+(4*tg), 209,20,20,graphics.getRGB(96,96,96));
-                graphics.Print(22+(4*tg)-4, 225-4, "I",164,164,164,false);
-                fillboxabs(4+(5*tg), 209,20,20,graphics.getRGB(96,96,96));
-                graphics.Print(22+(5*tg)-4, 225-4, "O",164,164,164,false);
-                fillboxabs(4+(6*tg), 209,20,20,graphics.getRGB(96,96,96));
-                graphics.Print(22+(6*tg)-4, 225-4, "P",164,164,164,false);
+                fillboxabs(4 + (ed.drawmode - 10) * tg, 209, 20, 20, graphics.getRGB(200, 200, 200));
 
                 graphics.Print(4, 232, "2/2", 196, 196, 255 - help.glow, false);
             }


### PR DESCRIPTION
This patch de-duplicates the tool drawing code a bit in the menu that gets brought up when you press Space in the level editor, as well as fixes several bugs related to the fact that the original author(s) of the code decided to copy-paste everything. (It was most likely Terry, judging by the distinct lack of whitespace between tokens in the code.)

There are two "pages" of tools that get shown when you open the tool menu, according to your currently-selected tool.

1. On the first page, your currently-selected tool gets a brighter outline. However, on the second page, the code to draw the outline over your currently-selected tool is missing. So I've fixed that.

2. On the first page, the glyph indicator next to the tool icon also gets brighter when you have that tool selected. However, on the second page, the code that drew the brighter-colored indicator got ran before the code that drew the normal-colored indicator, so this was never shown. This is also fixed.

3. The glyph indicator of the gravity line tool didn't get brighter when you had it selected, due to its special-cased copy-pasted code drawing its brighter color before drawing its normal color. This has also been fixed.

4. Lastly, the tool menu no longer draws the brighter-colored glyphs on top of the normal-colored glyphs. Instead, the menu will simply draw the brighter-colored glyphs and will not draw the normal-colored glyphs in the first place. This is because double-drawing text like this will look bad if the user has a custom `font.png` that has translucent pixels, like I do.

![Outline and glyph highlight fixed for second page](https://user-images.githubusercontent.com/59748578/104160620-46a7a300-53a6-11eb-9d08-3bb223c7b41d.gif)
<sup>Outline and glyph highlight fixed for second page (bugs 1 and 2)</sup>

![Glyph highlight for gravity line tool fixed](https://user-images.githubusercontent.com/59748578/104160617-460f0c80-53a6-11eb-98f9-51c707f2dce0.gif)
<sup>Glyph highlight for gravity line tool fixed (bug 3)</sup>

![Double rendering removed](https://user-images.githubusercontent.com/59748578/104160614-44dddf80-53a6-11eb-9f00-7b203f291b5b.gif)
<sup>Double rendering removed (bug 4)</sup>

All of these bugs have been fixed by paying off the technical debt of copy-pasting code.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
