### PR TITLE
Reduce dependency on libc functions

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -117,6 +117,7 @@ SET(VVV_SRC
 	src/XMLUtils.cpp
 	src/main.cpp
 	src/Network.c
+	src/ThirdPartyDeps.c
 )
 IF(NOT CUSTOM_LEVEL_SUPPORT STREQUAL "DISABLED")
 	LIST(APPEND VVV_SRC src/editor.cpp)
@@ -231,6 +232,8 @@ SET_PROPERTY(TARGET VVVVVV PROPERTY CXX_EXTENSIONS FALSE)
 ADD_LIBRARY(tinyxml2-static STATIC ${XML2_SRC})
 ADD_LIBRARY(physfs-static STATIC ${PFS_SRC} ${PFSP_SRC})
 ADD_LIBRARY(lodepng-static STATIC ${PNG_SRC})
+
+TARGET_COMPILE_DEFINITIONS(lodepng-static PRIVATE -DLODEPNG_NO_COMPILE_ALLOCATORS)
 
 # Static Dependencies
 TARGET_LINK_LIBRARIES(VVVVVV physfs-static tinyxml2-static lodepng-static)

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -21,11 +21,6 @@
 #include "UtilityClass.h"
 #include "XMLUtils.h"
 
-// lol, Win32 -flibit
-#ifdef _WIN32
-#define strcasecmp stricmp
-#endif
-
 static bool GetButtonFromString(const char *pText, SDL_GameControllerButton *button)
 {
     if (*pText == '0' ||
@@ -35,7 +30,7 @@ static bool GetButtonFromString(const char *pText, SDL_GameControllerButton *but
         *button = SDL_CONTROLLER_BUTTON_A;
         return true;
     }
-    if (strcmp(pText, "1") == 0 ||
+    if (SDL_strcmp(pText, "1") == 0 ||
         *pText == 'b' ||
         *pText == 'B')
     {
@@ -57,43 +52,43 @@ static bool GetButtonFromString(const char *pText, SDL_GameControllerButton *but
         return true;
     }
     if (*pText == '4' ||
-        strcasecmp(pText, "BACK") == 0)
+        SDL_strcasecmp(pText, "BACK") == 0)
     {
         *button = SDL_CONTROLLER_BUTTON_BACK;
         return true;
     }
     if (*pText == '5' ||
-        strcasecmp(pText, "GUIDE") == 0)
+        SDL_strcasecmp(pText, "GUIDE") == 0)
     {
         *button = SDL_CONTROLLER_BUTTON_GUIDE;
         return true;
     }
     if (*pText == '6' ||
-        strcasecmp(pText, "START") == 0)
+        SDL_strcasecmp(pText, "START") == 0)
     {
         *button = SDL_CONTROLLER_BUTTON_START;
         return true;
     }
     if (*pText == '7' ||
-        strcasecmp(pText, "LS") == 0)
+        SDL_strcasecmp(pText, "LS") == 0)
     {
         *button = SDL_CONTROLLER_BUTTON_LEFTSTICK;
         return true;
     }
     if (*pText == '8' ||
-        strcasecmp(pText, "RS") == 0)
+        SDL_strcasecmp(pText, "RS") == 0)
     {
         *button = SDL_CONTROLLER_BUTTON_RIGHTSTICK;
         return true;
     }
     if (*pText == '9' ||
-        strcasecmp(pText, "LB") == 0)
+        SDL_strcasecmp(pText, "LB") == 0)
     {
         *button = SDL_CONTROLLER_BUTTON_LEFTSHOULDER;
         return true;
     }
-    if (strcmp(pText, "10") == 0 ||
-        strcasecmp(pText, "RB") == 0)
+    if (SDL_strcmp(pText, "10") == 0 ||
+        SDL_strcasecmp(pText, "RB") == 0)
     {
         *button = SDL_CONTROLLER_BUTTON_RIGHTSHOULDER;
         return true;
@@ -550,7 +545,7 @@ void Game::loadcustomlevelstats()
     }
 
     // If the two arrays happen to differ in length, just go with the smallest one
-    for (size_t i = 0; i < std::min(customlevelnames.size(), customlevelscores.size()); i++)
+    for (int i = 0; i < VVV_min(customlevelnames.size(), customlevelscores.size()); i++)
     {
         CustomLevelStat stat = {customlevelnames[i], customlevelscores[i]};
         customlevelstats.push_back(stat);
@@ -4457,7 +4452,7 @@ void Game::unlocknum( int t )
         if (TextString.length()) \
         { \
             std::vector<std::string> values = split(TextString, ','); \
-            for (size_t i = 0; i < SDL_min(SDL_arraysize(DEST), values.size()); i++) \
+            for (int i = 0; i < VVV_min(SDL_arraysize(DEST), values.size()); i++) \
             { \
                 DEST[i] = help.Int(values[i].c_str()); \
             } \

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -412,7 +412,7 @@ void Graphics::bigprint(  int _x, int _y, std::string _s, int r, int g, int b, b
 
     if (cen)
     {
-        _x = std::max(160 - (int((len(_s)/ 2.0)*sc)), 0 );
+        _x = VVV_max(160 - (int((len(_s)/ 2.0)*sc)), 0 );
     }
 
     int bfontpos = 0;
@@ -978,13 +978,13 @@ void Graphics::cutscenebarstimer()
     if (showcutscenebars)
     {
         cutscenebarspos += 25;
-        cutscenebarspos = std::min(cutscenebarspos, 361);
+        cutscenebarspos = VVV_min(cutscenebarspos, 361);
     }
     else if (cutscenebarspos > 0)
     {
         //disappearing
         cutscenebarspos -= 25;
-        cutscenebarspos = std::max(cutscenebarspos, 0);
+        cutscenebarspos = VVV_max(cutscenebarspos, 0);
     }
 }
 
@@ -1381,10 +1381,10 @@ bool Graphics::Hitest(SDL_Surface* surface1, point p1, SDL_Surface* surface2, po
 
     if(intersection)
     {
-        int r3_left = SDL_max(r1_left, r2_left);
-        int r3_top = SDL_min(r1_top, r2_top);
-        int r3_right = SDL_min(r1_right, r2_right);
-        int r3_bottom= SDL_max(r1_bottom, r2_bottom);
+        int r3_left = VVV_max(r1_left, r2_left);
+        int r3_top = VVV_min(r1_top, r2_top);
+        int r3_right = VVV_min(r1_right, r2_right);
+        int r3_bottom= VVV_max(r1_bottom, r2_bottom);
 
         //for every pixel inside rectangle
         for(int x = r3_left; x < r3_right; x++)
@@ -2971,7 +2971,7 @@ void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool
 
 	if (cen)
 	{
-		x = std::max(160 - (int((len(t)/ 2.0)*sc)), 0 );
+		x = VVV_max(160 - (int((len(t)/ 2.0)*sc)), 0 );
 	}
 	else
 	{

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -67,7 +67,7 @@ static SDL_Surface* LoadImage(const char *filename, bool noBlend = true, bool no
 			0
 		);
 		SDL_FreeSurface( loadedImage );
-		free(data);
+		SDL_free(data);
 		if (noBlend)
 		{
 			SDL_SetSurfaceBlendMode(optimizedImage, SDL_BLENDMODE_BLEND);

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -336,20 +336,20 @@ SDL_Surface* ApplyFilter( SDL_Surface* _src )
             Uint8 green = (pixel & _src->format->Gmask) >> 8;
             Uint8 blue = (pixel & _src->format->Bmask) >> 0;
 
-            Uint32 pixelOffset = ReadPixel(_src, std::min(x+redOffset, 319), sampley) ;
+            Uint32 pixelOffset = ReadPixel(_src, VVV_min(x+redOffset, 319), sampley) ;
             Uint8 red = (pixelOffset & _src->format->Rmask) >> 16 ;
 
             if(isscrolling && sampley > 220 && ((rand() %10) < 4))
             {
-                red = std::min(int(red+(fRandom() * 0.6)  * 254) , 255);
-                green = std::min(int(green+(fRandom() * 0.6)  * 254) , 255);
-                blue = std::min(int(blue+(fRandom() * 0.6)  * 254) , 255);
+                red = VVV_min(int(red+(fRandom() * 0.6)  * 254) , 255);
+                green = VVV_min(int(green+(fRandom() * 0.6)  * 254) , 255);
+                blue = VVV_min(int(blue+(fRandom() * 0.6)  * 254) , 255);
             }
             else
             {
-                red = std::min(int(red+(fRandom() * 0.2)  * 254) , 255);
-                green = std::min(int(green+(fRandom() * 0.2)  * 254) , 255);
-                blue = std::min(int(blue+(fRandom() * 0.2)  * 254) , 255);
+                red = VVV_min(int(red+(fRandom() * 0.2)  * 254) , 255);
+                green = VVV_min(int(green+(fRandom() * 0.2)  * 254) , 255);
+                blue = VVV_min(int(blue+(fRandom() * 0.2)  * 254) , 255);
             }
 
 
@@ -363,9 +363,9 @@ SDL_Surface* ApplyFilter( SDL_Surface* _src )
             int distX =  static_cast<int>((SDL_abs (160.0f -x ) / 160.0f) *16);
             int distY =  static_cast<int>((SDL_abs (120.0f -y ) / 120.0f)*32);
 
-            red = std::max(red - ( distX +distY), 0);
-            green = std::max(green - ( distX +distY), 0);
-            blue = std::max(blue - ( distX +distY), 0);
+            red = VVV_max(red - ( distX +distY), 0);
+            green = VVV_max(green - ( distX +distY), 0);
+            blue = VVV_max(blue - ( distX +distY), 0);
 
             Uint32 finalPixel = ((red<<16) + (green<<8) + (blue<<0)) | (pixel &_src->format->Amask);
             DrawPixel(_ret,x,y,  finalPixel);

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -45,13 +45,13 @@ KeyPoll::KeyPoll()
 	pressedbackspace=false;
 
 	useFullscreenSpaces = false;
-	if (strcmp(SDL_GetPlatform(), "Mac OS X") == 0)
+	if (SDL_strcmp(SDL_GetPlatform(), "Mac OS X") == 0)
 	{
 		useFullscreenSpaces = true;
 		const char *hint = SDL_GetHint(SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES);
 		if (hint != NULL)
 		{
-			useFullscreenSpaces = (strcmp(hint, "1") == 0);
+			useFullscreenSpaces = (SDL_strcmp(hint, "1") == 0);
 		}
 	}
 

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -472,8 +472,7 @@ int mapclass::finalat(int x, int y)
 		//Special case: animated tiles
 		if (final_mapcol == 1)
 		{
-			// Windows hits fRandom() == 1 frequently! For fuck sake! -flibit
-			return 737 + (std::min(int(fRandom() * 12), 11) * 40);
+			return 737 + (int(fRandom() * 11) * 40);
 		}
 		else
 		{
@@ -713,7 +712,6 @@ int mapclass::area(int _rx, int _ry)
 	else
 	{
 		int lookup = (_rx - 100) + ((_ry - 100) * 20);
-		//lookup = std::max(0,lookup);
 		if(_rx-100>=0 && _rx-100<20 && _ry-100>=0 && _ry-100<20){
 			return areamap[lookup];
 		}

--- a/desktop_version/src/Maths.h
+++ b/desktop_version/src/Maths.h
@@ -25,4 +25,28 @@ struct point
     int y;
 };
 
+inline int VVV_min(const int a, const int b)
+{
+    if (a < b)
+    {
+        return a;
+    }
+    else
+    {
+        return b;
+    }
+}
+
+inline int VVV_max(const int a, const int b)
+{
+    if (a > b)
+    {
+        return a;
+    }
+    else
+    {
+        return b;
+    }
+}
+
 #endif /* MATHGAME_H */

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -315,7 +315,7 @@ static void menurender()
         graphics.Print( 40, 30, "the following patrons", tr, tg, tb, true);
 
         int startidx = game.current_credits_list_index;
-        int endidx = std::min(startidx + 9, (int)SDL_arraysize(Credits::superpatrons));
+        int endidx = VVV_min(startidx + 9, (int)SDL_arraysize(Credits::superpatrons));
 
         int xofs = 80 - 16;
         int yofs = 40 + 20;
@@ -333,7 +333,7 @@ static void menurender()
         graphics.Print( -1, 20, "and also by", tr, tg, tb, true);
 
         int startidx = game.current_credits_list_index;
-        int endidx = std::min(startidx + 14, (int)SDL_arraysize(Credits::patrons));
+        int endidx = VVV_min(startidx + 14, (int)SDL_arraysize(Credits::patrons));
 
         int maxheight = 10 * 14;
         int totalheight = (endidx - startidx) * 10;
@@ -354,7 +354,7 @@ static void menurender()
         graphics.Print( 40, 30, "GitHub from", tr, tg, tb, true);
 
         int startidx = game.current_credits_list_index;
-        int endidx = std::min(startidx + 9, (int)SDL_arraysize(Credits::githubfriends));
+        int endidx = VVV_min(startidx + 9, (int)SDL_arraysize(Credits::githubfriends));
 
         int maxheight = 14 * 9;
         int totalheight = (endidx - startidx) * 14;

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -130,7 +130,7 @@ void Screen::LoadIcon()
 	);
 	SDL_SetWindowIcon(m_window, icon);
 	SDL_FreeSurface(icon);
-	free(data);
+	SDL_free(data);
 }
 
 void Screen::ResizeScreen(int x, int y)

--- a/desktop_version/src/ThirdPartyDeps.c
+++ b/desktop_version/src/ThirdPartyDeps.c
@@ -1,0 +1,18 @@
+#include <SDL_stdinc.h>
+
+// Handle third-party dependencies' needs here
+
+void* lodepng_malloc(size_t size)
+{
+    return SDL_malloc(size);
+}
+
+void* lodepng_realloc(void* ptr, size_t new_size)
+{
+    return SDL_realloc(ptr, new_size);
+}
+
+void lodepng_free(void* ptr)
+{
+    SDL_free(ptr);
+}

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -228,13 +228,20 @@ bool is_number(const char* str)
 	return true;
 }
 
+static bool VVV_isxdigit(const unsigned char digit)
+{
+	return (digit >= 'a' && digit <= 'z')
+	|| (digit >= 'A' && digit <= 'Z')
+	|| SDL_isdigit(digit);
+}
+
 bool is_positive_num(const std::string& str, bool hex)
 {
 	for (size_t i = 0; i < str.length(); i++)
 	{
 		if (hex)
 		{
-			if (!isxdigit(static_cast<unsigned char>(str[i])))
+			if (!VVV_isxdigit(static_cast<unsigned char>(str[i])))
 			{
 				return false;
 			}

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -159,11 +159,11 @@ std::string find_tag(const std::string& buf, const std::string& start, const std
         uint32_t character = 0;
         if (hex)
         {
-            sscanf(number.c_str(), "%" SCNx32, &character);
+            SDL_sscanf(number.c_str(), "%" SCNx32, &character);
         }
         else
         {
-            sscanf(number.c_str(), "%" SCNu32, &character);
+            SDL_sscanf(number.c_str(), "%" SCNu32, &character);
         }
         uint32_t utf32[] = {character, 0};
         std::string utf8;
@@ -1630,7 +1630,7 @@ bool editorclass::load(std::string& _path)
     reset();
 
     static const char *levelDir = "levels/";
-    if (_path.compare(0, strlen(levelDir), levelDir) != 0)
+    if (_path.compare(0, SDL_strlen(levelDir), levelDir) != 0)
     {
         _path = levelDir + _path;
     }

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
 
     for (int i = 1; i < argc; ++i)
     {
-#define ARG(name) (strcmp(argv[i], name) == 0)
+#define ARG(name) (SDL_strcmp(argv[i], name) == 0)
 #define ARG_INNER(code) \
     if (i + 1 < argc) \
     { \


### PR DESCRIPTION
During 2.3 development, there's been a gradual shift to using SDL stdlib functions instead of libc functions, but there are still some libc functions (or the same libc function but from the STL) in the code.

Well, this patch replaces all the rest of them in one fell swoop.

SDL's stdlib can replace most of these, but its `SDL_min()` and `SDL_max()` are inadequate - they aren't really functions, they're more like macros with a nasty penchant for double-evaluation. So I just made my own `VVV_min()` and `VVV_max()` functions and placed them in `Maths.h` instead, then replaced all the previous usages of `min()`, `max()`, `std::min()`, `std::max()`, `SDL_min()`, and `SDL_max()` with `VVV_min()` and `VVV_max()`.

Additionally, there's no `SDL_isxdigit()`, so I just implemented my own `VVV_isxdigit()`.

There's one usage of `min()` that I simply removed - it was the generation of a random number between 0 and 12 that got capped to 11 with `min()` (because otherwise 12 would index a vector out-of-bounds, or at least before I added bounds checks to all tile drawing functions). I opted to simply remove the `min()` and change the range to be between 0 and 11 instead. The random range is effectively the same, but the distribution of random numbers won't be - however, I don't think the distribution of randomness matters here.

SDL has `SDL_malloc()` and `SDL_free()`, but they have some refcounting built in to them, so in order to use them with LodePNG, I have to replace the `malloc()` and `free()` that LodePNG uses. Which isn't too hard, I did it in a new file called `ThirdPartyDeps.c`, and LodePNG is now compiled with the `LODEPNG_NO_COMPILE_ALLOCATORS` definition.

Lastly, I also refactored the awful `strcpy()` and `strcat()` usages in `PLATFORM_migrateSaveData()` to use `SDL_snprintf()` instead. I know save migration is getting axed in 2.4, but it still bothers me to have something like that in the codebase otherwise.

Without further ado, here is the full list of functions that the codebase now uses:

- `SDL_strlcpy()` instead of `strcpy()`
- `SDL_strlcat()` instead of `strcat()`
- `SDL_snprintf()` instead of `sprintf()`, `strcpy()`, or `strcat()` (see above)
- `VVV_min()` instead of `min()`, `std::min()`, or `SDL_min()`
- `VVV_max()` instead of `max()`, `std::max()`, or `SDL_max()`
- `VVV_isxdigit()` instead of `isxdigit()`
- `SDL_strcmp()` instead of `strcmp()`
- `SDL_strcasecmp()` instead of `strcasecmp()` or Win32 `strcmpi()`
- `SDL_strstr()` instead of `strstr()`
- `SDL_strlen()` instead of `strlen()`
- `SDL_sscanf()` instead of `sscanf()`
- `SDL_getenv()` instead of `getenv()`
- `SDL_malloc()` instead of `malloc()` (replacing in LodePNG as well)
- `SDL_free()` instead of `free()` (replacing in LodePNG as well)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
