### PR TITLE
Update Version Check Method

### DIFF
--- a/desktop_version/.gitignore
+++ b/desktop_version/.gitignore
@@ -9,7 +9,7 @@ VVVVVV.exe
 VVVVVV
 *.a
 *.gch
-src/Version.h.out
+src/Version.h
 
 # Game data
 data.zip

--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -158,37 +158,31 @@ ELSE()
 	ADD_EXECUTABLE(VVVVVV ${VVV_SRC})
 ENDIF()
 
-IF(NOT OFFICIAL_BUILD)
-	# Add interim commit hash and its date to the build
+FIND_PACKAGE(Git REQUIRED)
 
-	# FIND_PACKAGE sets GIT_FOUND and GIT_EXECUTABLE
-	FIND_PACKAGE(Git)
+# These filenames have to be qualified, because when we run
+# the CMake script, its work dir gets set to the build folder
+SET(VERSION_INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/Version.h.in)
+SET(VERSION_OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/Version.h)
 
-	IF(GIT_FOUND)
-		# These filenames have to be qualified, because when we run
-		# the CMake script, its work dir gets set to the build folder
-		SET(VERSION_INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/Version.h.in)
-		SET(VERSION_OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/Version.h.out)
+ADD_CUSTOM_TARGET(
+	GenerateVersion ALL
+	# This BYPRODUCTS line is required for this to be ran every time
+	BYPRODUCTS ${VERSION_OUTPUT_FILE}
+	COMMAND ${CMAKE_COMMAND}
+	# These args have to be passed through, otherwise the script can't see them
+	# Also, these args have to come BEFORE `-P`! (Otherwise it fails with an unclear error)
+	-DGIT_EXECUTABLE=${GIT_EXECUTABLE}
+	-DINPUT_FILE=${VERSION_INPUT_FILE}
+	-DOUTPUT_FILE=${VERSION_OUTPUT_FILE}
+	-P ${CMAKE_CURRENT_SOURCE_DIR}/version.cmake
+)
 
-		ADD_CUSTOM_TARGET(
-			GenerateVersion ALL
-			# This BYPRODUCTS line is required for this to be ran every time
-			BYPRODUCTS ${VERSION_OUTPUT_FILE}
-			COMMAND ${CMAKE_COMMAND}
-			# These args have to be passed through, otherwise the script can't see them
-			# Also, these args have to come BEFORE `-P`! (Otherwise it fails with an unclear error)
-			-DGIT_EXECUTABLE=${GIT_EXECUTABLE}
-			-DINPUT_FILE=${VERSION_INPUT_FILE}
-			-DOUTPUT_FILE=${VERSION_OUTPUT_FILE}
-			-P ${CMAKE_CURRENT_SOURCE_DIR}/version.cmake
-		)
-
-		ADD_DEPENDENCIES(VVVVVV GenerateVersion)
-
-		# This lets Version.h know that Version.h.out exists
-		ADD_DEFINITIONS(-DVERSION_H_OUT_EXISTS)
-	ENDIF()
+IF(OFFICIAL_BUILD)
+	ADD_DEFINITIONS(-DOFFICIAL_BUILD)
 ENDIF()
+
+ADD_DEPENDENCIES(VVVVVV GenerateVersion)
 
 # Build options
 IF(ENABLE_WARNINGS)

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -63,12 +63,9 @@ static void menurender()
         graphics.Print(-1,temp+35,"     MAKE AND PLAY EDITION",tr, tg, tb, true);
 #endif
 #ifdef COMMIT_DATE
-        graphics.Print( 310 - (10*8), 210, COMMIT_DATE, tr/2, tg/2, tb/2);
+        graphics.Print( 310 - (10*8), 220, COMMIT_DATE, tr/2, tg/2, tb/2);
 #endif
-#ifdef INTERIM_COMMIT
-        graphics.Print( 310 - (SDL_arraysize(INTERIM_COMMIT) - 1) * 8, 220, INTERIM_COMMIT, tr/2, tg/2, tb/2);
-#endif
-        graphics.Print( 310 - (4*8), 230, "v2.3", tr/2, tg/2, tb/2);
+        graphics.Print( 310 - (SDL_arraysize(VERSION) - 1) * 8, 230, VERSION, tr/2, tg/2, tb/2);
 
         if(music.mmmmmm){
             graphics.Print( 10, 230, "[MMMMMM Mod Installed]", tr/2, tg/2, tb/2);

--- a/desktop_version/src/Version.h
+++ b/desktop_version/src/Version.h
@@ -1,8 +1,0 @@
-#ifndef VERSION_H
-#define VERSION_H
-
-#ifdef VERSION_H_OUT_EXISTS
-#include "Version.h.out"
-#endif
-
-#endif /* VERSION_H */

--- a/desktop_version/src/Version.h.in
+++ b/desktop_version/src/Version.h.in
@@ -1,7 +1,10 @@
 #ifndef VERSION_H_OUT
 #define VERSION_H_OUT
 
-#define INTERIM_COMMIT "@INTERIM_COMMIT@"
+#define VERSION "v@INTERIM_COMMIT@"
+
+#ifndef OFFICIAL_BUILD
 #define COMMIT_DATE "@COMMIT_DATE@"
+#endif
 
 #endif /* VERSION_H_OUT */

--- a/desktop_version/version.cmake
+++ b/desktop_version/version.cmake
@@ -2,7 +2,7 @@
 
 # Get interim commit and date of commit
 EXECUTE_PROCESS(
-	COMMAND "${GIT_EXECUTABLE}" log -1 --format=%h
+	COMMAND "${GIT_EXECUTABLE}" describe --dirty --tags
 	OUTPUT_VARIABLE INTERIM_COMMIT
 	OUTPUT_STRIP_TRAILING_WHITESPACE
 )


### PR DESCRIPTION
## Changes:

Using this Patch, there is no need for duplicating Version Information. Official (tagged) Builds will remain as-is, but no longer require hardcoding the Version String. Unofficial/Development builds will additionally Display:
- Base Version upon which Patches (may) have been applied
- Current Commit hash
- Whether or not the tree is dirty

If no changes have been made, the Build Date will still be shown in unofficial Builds to detect Compile-Time discrepancies when Troubleshooting.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
