### PR TITLE
Initialize bcol and bcol2 in Graphics::drawbackground()

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1932,7 +1932,7 @@ void Graphics::drawbackground( int t )
         break;
     case 2:
     {
-        int bcol, bcol2;
+        int bcol = 0, bcol2 = 0;
 
             //Lab
             switch(rcol)


### PR DESCRIPTION
While compiling in release mode, GCC warns about these two potentially being used uninitialized further down. The only way this could happen is if the case-switches below didn't match up with a case, which would require the game to be in an invalid state (and have invalid values for `rcol` and `spcol`), but it's better to be safe than sorry.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
