### PR TITLE
Remove duplicate graphics.Makebfont() in main()

### DIFF
--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -265,8 +265,6 @@ int main(int argc, char *argv[])
     SDL_SetSurfaceBlendMode(graphics.ghostbuffer, SDL_BLENDMODE_BLEND);
     SDL_SetSurfaceAlphaMod(graphics.ghostbuffer, 127);
 
-    graphics.Makebfont();
-
     graphics.foregroundBuffer =  CREATE_SURFACE(320, 240);
     SDL_SetSurfaceBlendMode(graphics.foregroundBuffer, SDL_BLENDMODE_BLEND);
 


### PR DESCRIPTION
This call to `Makebfont()` always existed, but ever since 2.3's per-level custom assets were added, `graphics.reloadresources()` also calls `graphics.Makebfont()`, meaning this call is unnecessary. Calling it twice results in `graphics.bfont` and `graphics.flipbfont` having twice the number of elements, until custom assets get mounted (or unmounted, technically).

(Anyone testing this at the moment should cherry-pick #602 until that gets merged.)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
