### PR TITLE
Free data upon failure in LoadImage()

### DIFF
--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -76,6 +76,7 @@ static SDL_Surface* LoadImage(const char *filename, bool noBlend = true, bool no
 	}
 	else
 	{
+		SDL_free(data);
 		fprintf(stderr,"Image not found: %s\n", filename);
 		SDL_assert(0 && "Image not found! See stderr.");
 		return NULL;


### PR DESCRIPTION
Otherwise, if `SDL_CreateRGBSurfaceFrom()` returned NULL, then this memory would be leaked.

(Anyone testing this at the moment should cherry-pick #602 until that gets merged.)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
