### PR TITLE
Fix wrong function being used for musicclass::play() check

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -188,7 +188,7 @@ void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fade
 	safeToProcessMusic = true;
 	musicVolume = MIX_MAX_VOLUME;
 
-	if (currentsong == t && Mix_PlayingMusic() != MIX_FADING_OUT)
+	if (currentsong == t && Mix_FadingMusic() != MIX_FADING_OUT)
 	{
 		return;
 	}


### PR DESCRIPTION
Whoops.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
