### PR TITLE
Fix physics regression with immediately flipping off of horizontally-moving platforms and conveyors, and re-fix glitchy y-position when spawning onto a conveyor

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -826,7 +826,6 @@ void gamelogic()
                 if (INBOUNDS_VEC(i, obj.entities) && j > -1000)
                 {
                     obj.entities[i].newxp = obj.entities[i].xp + j;
-                    obj.entities[i].newyp = obj.entities[i].yp;
                     obj.entitymapcollision(i);
                 }
                 else
@@ -835,7 +834,6 @@ void gamelogic()
                     if (INBOUNDS_VEC(i, obj.entities) && j > -1000)
                     {
                         obj.entities[i].newxp = obj.entities[i].xp + j;
-                        obj.entities[i].newyp = obj.entities[i].yp;
                         obj.entitymapcollision(i);
                     }
                 }

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -775,6 +775,11 @@ void mapclass::resetplayer(const bool player_died)
 		obj.entities[i].ay = 0;
 		obj.entities[i].xp = game.savex;
 		obj.entities[i].yp = game.savey;
+
+		//Fix conveyor death loop glitch
+		obj.entities[i].newxp = obj.entities[i].xp;
+		obj.entities[i].newyp = obj.entities[i].yp;
+
 		obj.entities[i].dir = game.savedir;
 		obj.entities[i].colour = 0;
 		if (player_died)


### PR DESCRIPTION
This is a re-do of 942217f871bf1182ded3a915b8c26b90c04d561a (#509), but with a more conservative fix that only resets the player's `newxp` and `newyp` when they respawn from a checkpoint or spawn in to the map. The previous fix (of a regression of a fix) has a regression where immediately flipping off of horizontally-moving platforms or conveyors will no longer provide you with a "boost" given certain vertical pixel alignments.

Unlike the previous patch, if the player were to suddenly collide with a conveyor or horizontally-moving platform during gameplay, their y-position would revert back to the intended next y-position of the previous frame. But this is the same behavior as before, I haven't ever seen such a contrived situation come up, and this behavior is probably more preferable for gameplay than actually going to the conveyor, so it's fine.

I also decided to reset `newxp` here, and not just `newyp`, because while resetting `newyp` seems to be enough, it's safer to also reset `newxp` (and so future readers won't question why only `newyp` is reset but not `newxp`).

I tested this and it once again fixes the death loop issue from earlier, while also still allowing for that Trench Warfare trick to be possible (I tested it with the libTAS movie I mentioned in #606; it syncs fine). There are no other known regressions resulting from this fix (hopefully).

Fixes #606.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
