### PR TITLE
Don't mutate the decimal place in ss_toi()

### DIFF
--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -39,7 +39,6 @@ static const char* GCChar(const SDL_GameControllerButton button)
 int ss_toi(const std::string& str)
 {
 	int retval = 0;
-	int place = 1;
 	bool negative = false;
 	const int radix = 10;
 
@@ -55,9 +54,8 @@ int ss_toi(const std::string& str)
 
 		if (SDL_isdigit(chr))
 		{
-			retval *= place;
+			retval *= radix;
 			retval += chr - '0';
-			place *= radix;
 		}
 		else
 		{

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -40,7 +40,7 @@ int ss_toi(const std::string& str)
 {
 	int retval = 0;
 	bool negative = false;
-	const int radix = 10;
+	static const int radix = 10;
 
 	for (size_t i = 0; i < str.size(); ++i)
 	{


### PR DESCRIPTION
This fixes a bug where `"12"` gets properly evaluated as 12, but `"148"` gets evaluated as 1408. It's because `place` gets multiplied by `radix` again, so `retval` gets multipled by 100 instead of 10.

There's no reason to have a `place` variable, so I've removed it entirely. This simplifies the function a little bit.

Additionally, `radix` also now has static storage duration, because it's a constant integer literal.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
