### PR TITLE
Fix out-of-bounds indexing with malformed XML entities in find_tag()

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -146,8 +146,19 @@ std::string find_tag(const std::string& buf, const std::string& start, const std
     size_t start_pos = 0;
     while ((start_pos = value.find("&#", start_pos)) != std::string::npos)
     {
+        if (start_pos + 2 >= value.length())
+        {
+            return "";
+        }
+
         bool hex = value[start_pos + 2] == 'x';
         size_t end = value.find(';', start_pos);
+
+        if (end == std::string::npos)
+        {
+            return "";
+        }
+
         size_t real_start = start_pos + 2 + ((int) hex);
         std::string number(value.substr(real_start, end - real_start));
 


### PR DESCRIPTION
`find_tag()` would commit out-of-bounds indexing if someone made a level file with malformed XML entity encodings in the metadata tags.

This would happen if the end of the string followed immediately after an ampersand and hash, or if there wasn't a semicolon ending an XML entity.

Valgrind complains about these, so I've fixed it.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
