### PR TITLE
Clean up is_number(), is_positive_num(), and VVV_isxdigit(), and fix some of their bugs

### DIFF
--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -272,7 +272,7 @@ bool is_number(const char* str)
 		return false;
 	}
 
-	for (size_t i = 1; str[i] != '\0'; i++)
+	for (size_t i = 1; str[i] != '\0'; ++i)
 	{
 		if (!SDL_isdigit(str[i]))
 		{

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -272,7 +272,7 @@ bool is_number(const char* str)
 		return false;
 	}
 
-	for (int i = 1; str[i] != '\0'; i++)
+	for (size_t i = 1; str[i] != '\0'; i++)
 	{
 		if (!SDL_isdigit(str[i]))
 		{

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -286,6 +286,11 @@ static bool VVV_isxdigit(const unsigned char digit)
 
 bool is_positive_num(const char* str, const bool hex)
 {
+	if (str[0] == '\0')
+	{
+		return false;
+	}
+
 	for (size_t i = 0; str[i] != '\0'; ++i)
 	{
 		if (hex)

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -313,6 +313,7 @@ bool is_positive_num(const char* str, const bool hex)
 			}
 		}
 	}
+
 	return true;
 }
 

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -272,6 +272,11 @@ bool is_number(const char* str)
 		return false;
 	}
 
+	if (str[0] == '-' && str[1] == '\0')
+	{
+		return false;
+	}
+
 	for (size_t i = 1; str[i] != '\0'; ++i)
 	{
 		if (!SDL_isdigit(str[i]))

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -279,6 +279,7 @@ bool is_number(const char* str)
 			return false;
 		}
 	}
+
 	return true;
 }
 

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -267,9 +267,14 @@ void UtilityClass::updateglow()
 
 bool is_number(const char* str)
 {
-	for (int i = 0; str[i] != '\0'; i++)
+	if (!SDL_isdigit(str[0]) && str[0] != '-')
 	{
-		if (!SDL_isdigit(str[i]) && (i != 0 || str[0] != '-'))
+		return false;
+	}
+
+	for (int i = 1; str[i] != '\0'; i++)
+	{
+		if (!SDL_isdigit(str[i]))
 		{
 			return false;
 		}

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -290,8 +290,8 @@ bool is_number(const char* str)
 
 static bool VVV_isxdigit(const unsigned char digit)
 {
-	return (digit >= 'a' && digit <= 'z')
-	|| (digit >= 'A' && digit <= 'Z')
+	return (digit >= 'a' && digit <= 'f')
+	|| (digit >= 'A' && digit <= 'F')
 	|| SDL_isdigit(digit);
 }
 

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -269,7 +269,7 @@ bool is_number(const char* str)
 {
 	for (int i = 0; str[i] != '\0'; i++)
 	{
-		if (!SDL_isdigit(static_cast<unsigned char>(str[i])) && (i != 0 || str[0] != '-'))
+		if (!SDL_isdigit(str[i]) && (i != 0 || str[0] != '-'))
 		{
 			return false;
 		}

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -284,7 +284,7 @@ static bool VVV_isxdigit(const unsigned char digit)
 	|| SDL_isdigit(digit);
 }
 
-bool is_positive_num(const std::string& str, bool hex)
+bool is_positive_num(const std::string& str, const bool hex)
 {
 	for (size_t i = 0; i < str.length(); i++)
 	{

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -284,9 +284,9 @@ static bool VVV_isxdigit(const unsigned char digit)
 	|| SDL_isdigit(digit);
 }
 
-bool is_positive_num(const std::string& str, const bool hex)
+bool is_positive_num(const char* str, const bool hex)
 {
-	for (size_t i = 0; i < str.length(); i++)
+	for (size_t i = 0; str[i] != '\0'; ++i)
 	{
 		if (hex)
 		{

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -290,14 +290,14 @@ bool is_positive_num(const std::string& str, bool hex)
 	{
 		if (hex)
 		{
-			if (!VVV_isxdigit(static_cast<unsigned char>(str[i])))
+			if (!VVV_isxdigit(str[i]))
 			{
 				return false;
 			}
 		}
 		else
 		{
-			if (!SDL_isdigit(static_cast<unsigned char>(str[i])))
+			if (!SDL_isdigit(str[i]))
 			{
 				return false;
 			}

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -24,7 +24,7 @@ bool next_split_s(
 
 bool is_number(const char* str);
 
-bool is_positive_num(const std::string& str, bool hex);
+bool is_positive_num(const std::string& str, const bool hex);
 
 bool endsWith(const std::string& str, const std::string& suffix);
 

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -24,7 +24,7 @@ bool next_split_s(
 
 bool is_number(const char* str);
 
-bool is_positive_num(const std::string& str, const bool hex);
+bool is_positive_num(const char* str, const bool hex);
 
 bool endsWith(const std::string& str, const std::string& suffix);
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -162,7 +162,7 @@ std::string find_tag(const std::string& buf, const std::string& start, const std
         size_t real_start = start_pos + 2 + ((int) hex);
         std::string number(value.substr(real_start, end - real_start));
 
-        if (!is_positive_num(number, hex))
+        if (!is_positive_num(number.c_str(), hex))
         {
             return "";
         }


### PR DESCRIPTION
While working on an unrelated patchset, I noticed that these two functions could use some work. Then I worked on that other patchset further and it turned out that it didn't need to depend on any of the changes I was planning to make to these functions. So I've split these changes off into their own PR, which is this PR.

`is_positive_num()` no longer uses an `std::string` and instead uses a `const char*`, along with its `hex` argument becoming const. Code style of both `is_positive_num()` and `is_number()` has also been cleaned up.

But the biggest thing is probably the bug fixes; `is_positive_num()` and `is_number()` no longer accept empty strings as numbers, and `is_number()` no longer accepts the string `"-"` as a number, either. `VVV_isxdigit()` no longer accepts the entire alphabet as being hexadecimal digits.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
