### PR TITLE
Refactor loading arrays from XML to not use the STL

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -442,6 +442,22 @@ void Game::updatecustomlevelstats(std::string clevel, int cscore)
     savecustomlevelstats();
 }
 
+#define LOAD_ARRAY_RENAME(ARRAY_NAME, DEST) \
+    if (pKey == #ARRAY_NAME) \
+    { \
+        std::string TextString = pText; \
+        if (TextString.length()) \
+        { \
+            std::vector<std::string> values = split(TextString, ','); \
+            for (int i = 0; i < VVV_min(SDL_arraysize(DEST), values.size()); i++) \
+            { \
+                DEST[i] = help.Int(values[i].c_str()); \
+            } \
+        } \
+    }
+
+#define LOAD_ARRAY(ARRAY_NAME) LOAD_ARRAY_RENAME(ARRAY_NAME, ARRAY_NAME)
+
 void Game::loadcustomlevelstats()
 {
     //testing
@@ -4420,22 +4436,6 @@ void Game::unlocknum( int t )
     savestatsandsettings();
 #endif
 }
-
-#define LOAD_ARRAY_RENAME(ARRAY_NAME, DEST) \
-    if (pKey == #ARRAY_NAME) \
-    { \
-        std::string TextString = pText; \
-        if (TextString.length()) \
-        { \
-            std::vector<std::string> values = split(TextString, ','); \
-            for (int i = 0; i < VVV_min(SDL_arraysize(DEST), values.size()); i++) \
-            { \
-                DEST[i] = help.Int(values[i].c_str()); \
-            } \
-        } \
-    }
-
-#define LOAD_ARRAY(ARRAY_NAME) LOAD_ARRAY_RENAME(ARRAY_NAME, ARRAY_NAME)
 
 void Game::loadstats(ScreenSettings* screen_settings)
 {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -540,18 +540,7 @@ void Game::loadcustomlevelstats()
             pText = "";
         }
 
-        if (pKey == "customlevelscore")
-        {
-            std::string TextString = (pText);
-            if(TextString.length())
-            {
-                std::vector<std::string> values = split(TextString,',');
-                for(size_t i = 0; i < values.size(); i++)
-                {
-                    customlevelscores.push_back(help.Int(values[i].c_str()));
-                }
-            }
-        }
+        LOAD_ARRAY_RENAME(customlevelscore, customlevelscores)
 
         if (pKey == "customlevelstats")
         {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -446,11 +446,11 @@ void Game::updatecustomlevelstats(std::string clevel, int cscore)
     if (pKey == #ARRAY_NAME && pText[0] != '\0') \
     { \
         std::string TextString = pText; \
-            std::vector<std::string> values = split(TextString, ','); \
-            for (int i = 0; i < VVV_min(SDL_arraysize(DEST), values.size()); i++) \
-            { \
-                DEST[i] = help.Int(values[i].c_str()); \
-            } \
+        std::vector<std::string> values = split(TextString, ','); \
+        for (int i = 0; i < VVV_min(SDL_arraysize(DEST), values.size()); i++) \
+        { \
+            DEST[i] = help.Int(values[i].c_str()); \
+        } \
     }
 
 #define LOAD_ARRAY(ARRAY_NAME) LOAD_ARRAY_RENAME(ARRAY_NAME, ARRAY_NAME)
@@ -542,11 +542,11 @@ void Game::loadcustomlevelstats()
         if (pKey == "customlevelstats" && pText[0] != '\0')
         {
             std::string TextString = (pText);
-                std::vector<std::string> values = split(TextString,'|');
-                for(size_t i = 0; i < values.size(); i++)
-                {
-                    customlevelnames.push_back(values[i]);
-                }
+            std::vector<std::string> values = split(TextString,'|');
+            for(size_t i = 0; i < values.size(); i++)
+            {
+                customlevelnames.push_back(values[i]);
+            }
         }
     }
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -443,17 +443,14 @@ void Game::updatecustomlevelstats(std::string clevel, int cscore)
 }
 
 #define LOAD_ARRAY_RENAME(ARRAY_NAME, DEST) \
-    if (pKey == #ARRAY_NAME) \
+    if (pKey == #ARRAY_NAME && pText[0] != '\0') \
     { \
         std::string TextString = pText; \
-        if (TextString.length()) \
-        { \
             std::vector<std::string> values = split(TextString, ','); \
             for (int i = 0; i < VVV_min(SDL_arraysize(DEST), values.size()); i++) \
             { \
                 DEST[i] = help.Int(values[i].c_str()); \
             } \
-        } \
     }
 
 #define LOAD_ARRAY(ARRAY_NAME) LOAD_ARRAY_RENAME(ARRAY_NAME, ARRAY_NAME)
@@ -542,17 +539,14 @@ void Game::loadcustomlevelstats()
 
         LOAD_ARRAY_RENAME(customlevelscore, customlevelscores)
 
-        if (pKey == "customlevelstats")
+        if (pKey == "customlevelstats" && pText[0] != '\0')
         {
             std::string TextString = (pText);
-            if(TextString.length())
-            {
                 std::vector<std::string> values = split(TextString,'|');
                 for(size_t i = 0; i < values.size(); i++)
                 {
                     customlevelnames.push_back(values[i]);
                 }
-            }
         }
     }
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -445,11 +445,21 @@ void Game::updatecustomlevelstats(std::string clevel, int cscore)
 #define LOAD_ARRAY_RENAME(ARRAY_NAME, DEST) \
     if (pKey == #ARRAY_NAME && pText[0] != '\0') \
     { \
-        std::string TextString = pText; \
-        std::vector<std::string> values = split(TextString, ','); \
-        for (int i = 0; i < VVV_min(SDL_arraysize(DEST), values.size()); i++) \
+        /* We're loading in 32-bit integers. If we need more than 16 chars,
+         * something is seriously wrong */ \
+        char buffer[16]; \
+        size_t start = 0; \
+        size_t i = 0; \
+        \
+        while (next_split_s(buffer, sizeof(buffer), &start, pText, ',')) \
         { \
-            DEST[i] = help.Int(values[i].c_str()); \
+            if (i >= SDL_arraysize(DEST)) \
+            { \
+                break; \
+            } \
+            \
+            DEST[i] = help.Int(buffer); \
+            ++i; \
         } \
     }
 
@@ -541,11 +551,15 @@ void Game::loadcustomlevelstats()
 
         if (pKey == "customlevelstats" && pText[0] != '\0')
         {
-            std::string TextString = (pText);
-            std::vector<std::string> values = split(TextString,'|');
-            for(size_t i = 0; i < values.size(); i++)
+            size_t start = 0;
+            size_t len = 0;
+            size_t prev_start = 0;
+
+            while (next_split(&start, &len, &pText[start], '|'))
             {
-                customlevelnames.push_back(values[i]);
+                customlevelnames.push_back(std::string(&pText[prev_start], len));
+
+                prev_start = start;
             }
         }
     }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -15,9 +15,6 @@
 
 scriptclass::scriptclass()
 {
-	//Start SDL
-
-	//Init
 	position = 0;
 	scriptdelay = 0;
 	running = false;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -35,7 +35,8 @@ scriptclass::scriptclass()
 	texty = 0;
 }
 
-void scriptclass::clearcustom(){
+void scriptclass::clearcustom()
+{
 	customscripts.clear();
 }
 

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -4,6 +4,8 @@
 #include <SDL.h>
 #include <sstream>
 
+#include "Maths.h"
+
 static const char* GCChar(const SDL_GameControllerButton button)
 {
 	switch (button)
@@ -71,21 +73,61 @@ int ss_toi(const std::string& str)
 	return retval;
 }
 
-std::vector<std::string> split( const std::string &s, char delim, std::vector<std::string> &elems )
-{
-	std::stringstream ss(s);
-	std::string item;
-	while(std::getline(ss, item, delim))
+bool next_split(
+	size_t* start,
+	size_t* len,
+	const char* str,
+	const char delim
+) {
+	size_t idx = 0;
+	*len = 0;
+
+	if (str[idx] == '\0')
 	{
-		elems.push_back(item);
+		return false;
 	}
-	return elems;
+
+	while (true)
+	{
+		if (str[idx] == delim)
+		{
+			*start += 1;
+			return true;
+		}
+		else if (str[idx] == '\0')
+		{
+			return true;
+		}
+
+		idx += 1;
+		*start += 1;
+		*len += 1;
+	}
 }
 
-std::vector<std::string> split( const std::string &s, char delim )
-{
-	std::vector<std::string> elems;
-	return split(s, delim, elems);
+bool next_split_s(
+	char buffer[],
+	const size_t buffer_size,
+	size_t* start,
+	const char* str,
+	const char delim
+) {
+	size_t len = 0;
+	const size_t prev_start = *start;
+
+	const bool retval = next_split(start, &len, &str[*start], delim);
+
+	if (retval)
+	{
+		/* Using SDL_strlcpy() here results in calling SDL_strlen() */
+		/* on the whole string, which results in a visible freeze */
+		/* if it's a very large string */
+		const size_t length = VVV_min(buffer_size, len);
+		SDL_memcpy(buffer, &str[prev_start], length);
+		buffer[length] = '\0';
+	}
+
+	return retval;
 }
 
 UtilityClass::UtilityClass() :

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -7,9 +7,20 @@
 
 int ss_toi(const std::string& str);
 
-std::vector<std::string> split(const std::string &s, char delim, std::vector<std::string> &elems);
+bool next_split(
+    size_t* start,
+    size_t* len,
+    const char* str,
+    const char delim
+);
 
-std::vector<std::string> split(const std::string &s, char delim);
+bool next_split_s(
+    char buffer[],
+    const size_t buffer_size,
+    size_t* start,
+    const char* str,
+    const char delim
+);
 
 bool is_number(const char* str);
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1755,21 +1755,21 @@ bool editorclass::load(std::string& _path)
         if (pKey == "contents" && pText[0] != '\0')
         {
             std::string TextString = (pText);
-                std::vector<std::string> values = split(TextString,',');
-                SDL_memset(contents, 0, sizeof(contents));
-                int x =0;
-                int y =0;
-                for(size_t i = 0; i < values.size(); i++)
+            std::vector<std::string> values = split(TextString,',');
+            SDL_memset(contents, 0, sizeof(contents));
+            int x =0;
+            int y =0;
+            for(size_t i = 0; i < values.size(); i++)
+            {
+                contents[x + (maxwidth*40*y)] = help.Int(values[i].c_str());
+                x++;
+                if(x == mapwidth*40)
                 {
-                    contents[x + (maxwidth*40*y)] = help.Int(values[i].c_str());
-                    x++;
-                    if(x == mapwidth*40)
-                    {
-                        x=0;
-                        y++;
-                    }
-
+                    x=0;
+                    y++;
                 }
+
+             }
         }
 
 
@@ -1873,38 +1873,38 @@ bool editorclass::load(std::string& _path)
         if (pKey == "script" && pText[0] != '\0')
         {
             std::string TextString = (pText);
-                std::vector<std::string> values = split(TextString,'|');
-                script.clearcustom();
-                Script script_;
-                bool headerfound = false;
-                for(size_t i = 0; i < values.size(); i++)
+            std::vector<std::string> values = split(TextString,'|');
+            script.clearcustom();
+            Script script_;
+            bool headerfound = false;
+            for(size_t i = 0; i < values.size(); i++)
+            {
+                std::string& line = values[i];
+
+                if(line.length() && line[line.length() - 1] == ':')
                 {
-                    std::string& line = values[i];
-
-                    if(line.length() && line[line.length() - 1] == ':')
-                    {
-                        if(headerfound)
-                        {
-                            //Add the script if we have a preceding header
-                            script.customscripts.push_back(script_);
-                        }
-                        script_.name = line.substr(0, line.length()-1);
-                        script_.contents.clear();
-                        headerfound = true;
-                        continue;
-                    }
-
                     if(headerfound)
                     {
-                        script_.contents.push_back(line);
+                        //Add the script if we have a preceding header
+                        script.customscripts.push_back(script_);
                     }
+                    script_.name = line.substr(0, line.length()-1);
+                    script_.contents.clear();
+                    headerfound = true;
+                    continue;
                 }
-                //Add the last script
+
                 if(headerfound)
                 {
-                    //Add the script if we have a preceding header
-                    script.customscripts.push_back(script_);
+                    script_.contents.push_back(line);
                 }
+            }
+            //Add the last script
+            if(headerfound)
+            {
+                //Add the script if we have a preceding header
+                script.customscripts.push_back(script_);
+            }
         }
 
     }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1885,7 +1885,6 @@ bool editorclass::load(std::string& _path)
                 {
                     if (headerfound)
                     {
-                        //Add the script if we have a preceding header
                         script.customscripts.push_back(script_);
                     }
                     script_.name = line.substr(0, line.length()-1);
@@ -1900,10 +1899,9 @@ bool editorclass::load(std::string& _path)
                 }
             }
 
-            //Add the last script
+            /* Add the last script */
             if (headerfound)
             {
-                //Add the script if we have a preceding header
                 script.customscripts.push_back(script_);
             }
         }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -364,13 +364,7 @@ void editorclass::reset()
         }
     }
 
-    for (int j = 0; j < 30 * maxheight; j++)
-    {
-        for (int i = 0; i < 40 * maxwidth; i++)
-        {
-            contents[i+(j*40*maxwidth)]=0;
-        }
-    }
+    SDL_zeroa(contents);
 
     hooklist.clear();
 
@@ -387,7 +381,7 @@ void editorclass::reset()
 
     hookmenupage=0;
     hookmenu=0;
-    script.customscripts.clear();
+    script.clearcustom();
 
     returneditoralpha = 0;
     oldreturneditoralpha = 0;
@@ -1756,7 +1750,6 @@ bool editorclass::load(std::string& _path)
         {
             std::string TextString = (pText);
             std::vector<std::string> values = split(TextString,',');
-            SDL_memset(contents, 0, sizeof(contents));
             int x =0;
             int y =0;
             for(size_t i = 0; i < values.size(); i++)
@@ -1874,7 +1867,6 @@ bool editorclass::load(std::string& _path)
         {
             std::string TextString = (pText);
             std::vector<std::string> values = split(TextString,'|');
-            script.clearcustom();
             Script script_;
             bool headerfound = false;
             for(size_t i = 0; i < values.size(); i++)

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1752,11 +1752,9 @@ bool editorclass::load(std::string& _path)
         }
 
 
-        if (pKey == "contents")
+        if (pKey == "contents" && pText[0] != '\0')
         {
             std::string TextString = (pText);
-            if(TextString.length())
-            {
                 std::vector<std::string> values = split(TextString,',');
                 SDL_memset(contents, 0, sizeof(contents));
                 int x =0;
@@ -1772,7 +1770,6 @@ bool editorclass::load(std::string& _path)
                     }
 
                 }
-            }
         }
 
 
@@ -1873,11 +1870,9 @@ bool editorclass::load(std::string& _path)
             }
         }
 
-        if (pKey == "script")
+        if (pKey == "script" && pText[0] != '\0')
         {
             std::string TextString = (pText);
-            if(TextString.length())
-            {
                 std::vector<std::string> values = split(TextString,'|');
                 script.clearcustom();
                 Script script_;
@@ -1910,8 +1905,6 @@ bool editorclass::load(std::string& _path)
                     //Add the script if we have a preceding header
                     script.customscripts.push_back(script_);
                 }
-
-            }
         }
 
     }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1881,9 +1881,9 @@ bool editorclass::load(std::string& _path)
             {
                 std::string& line = values[i];
 
-                if(line.length() && line[line.length() - 1] == ':')
+                if (line.length() && line[line.length() - 1] == ':')
                 {
-                    if(headerfound)
+                    if (headerfound)
                     {
                         //Add the script if we have a preceding header
                         script.customscripts.push_back(script_);
@@ -1894,19 +1894,19 @@ bool editorclass::load(std::string& _path)
                     continue;
                 }
 
-                if(headerfound)
+                if (headerfound)
                 {
                     script_.contents.push_back(line);
                 }
             }
+
             //Add the last script
-            if(headerfound)
+            if (headerfound)
             {
                 //Add the script if we have a preceding header
                 script.customscripts.push_back(script_);
             }
         }
-
     }
 
     gethooks();

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -4114,15 +4114,34 @@ void editorinput()
             {
             case TEXT_GOTOROOM:
             {
-                std::vector<std::string> coords = split(key.keybuffer, ',');
-                if (coords.size() != 2)
+                char coord_x[16];
+                char coord_y[16];
+
+                const char* comma = SDL_strchr(key.keybuffer.c_str(), ',');
+
+                bool valid_input = comma != NULL;
+
+                if (valid_input)
+                {
+                    SDL_strlcpy(
+                        coord_x,
+                        key.keybuffer.c_str(),
+                        VVV_min(comma - key.keybuffer.c_str() + 1, sizeof(coord_x))
+                    );
+                    SDL_strlcpy(coord_y, &comma[1], sizeof(coord_y));
+
+                    valid_input = is_number(coord_x) && is_number(coord_y);
+                }
+
+                if (!valid_input)
                 {
                     ed.note = "[ ERROR: Invalid format ]";
                     ed.notedelay = 45;
                     break;
                 }
-                ed.levx = clamp(help.Int(coords[0].c_str()) - 1, 0, ed.mapwidth - 1);
-                ed.levy = clamp(help.Int(coords[1].c_str()) - 1, 0, ed.mapheight - 1);
+
+                ed.levx = clamp(help.Int(coord_x) - 1, 0, ed.mapwidth - 1);
+                ed.levy = clamp(help.Int(coord_y) - 1, 0, ed.mapheight - 1);
                 graphics.backgrounddrawn = false;
                 break;
             }


### PR DESCRIPTION
The current way "arrays" from XML files are loaded (before this PR is applied) goes something like this:

1. Read the buffer of the contents of the tag using TinyXML-2.

2. Allocate a buffer on the heap of the same size, and copy the existing buffer to it. (This is what the statement `std::string TextString = pText;` does.)

3. For each delimiter in the heap-allocated buffer...

   a. Allocate another buffer on the heap, and copy the characters from the previous delimiter to the delimiter you just hit.

   b. Then allocate the buffer *again*, to copy it into an std::vector.

4. Then re-allocate every single buffer *yet again*, because you need to make a copy of the `std::vector` in `split()` to return it to the caller.

As you can see, the existing way uses a lot of memory allocations and data marshalling, just to split some text.

The problem here is mostly making a temporary `std::vector` of split text, before doing any actual useful work (most likely, putting it into an array or *another* `std::vector` - if the latter, then that's yet another memory allocation on top of the memory allocation you already did; this memory allocation is unavoidable, unlike the ones mentioned earlier, which should be removed).

So I noticed that since we're iterating over the entire string once (just to shove its contents into a temporary `std::vector`), and then basically iterating over it again - why can't the whole thing just be more immediate, and just be iterated over once?

So that's what I've done here. I've axed the `split()` function (both of them, actually), and made `next_split()` and `next_split_s()`.

`next_split()` will take an existing string and a starting index, and it will find the next occurrence of the given delimiter in the string. Once it does so, it will return the length from the previous starting index, and modify your starting index as well. The price for immediateness is that you're supposed to handle keeping the index of the previous starting index around in order to be able to use the function; updating it after each iteration is also your responsibility.

(By the way, `next_split()` doesn't use `SDL_strchr()`, because we can't get the length of the substring for the last substring. We could handle this special case specifically, but it'd be uglier; it also introduces iterating over the last substring twice, when we only need to do it once.)

`next_split_s()` does the same thing as `next_split()`, except it will copy the resulting substring into a buffer that you provide (along with its size). Useful if you don't particularly care about the length of the substring.

All callers have been updated accordingly. This new system does not make *any* heap allocations at all; at worst, it allocates a temporary buffer on the stack, but that's only if you use `next_split_s()`; plus, it'd be a fixed-size buffer, and stack allocations are negligible anyway.

This improves performance when loading any sort of XML file, especially loading custom levels - which, on my system at least, I can noticeably tell (there's less of a freeze when I load in to a custom level with lots of scripts). It also decreases memory usage, because the heap isn't being used just to iterate over some delimiters when XML files are loaded.

Also some cleanups, because there's lots of related code to tidy up that I've decided to tidy up in this PR.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
