### PR TITLE
Fix unreachable code warnings

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -487,7 +487,6 @@ int mapclass::finalat(int x, int y)
 	{
 		return contents[x + vmult[y]];
 	}
-	return 0;
 }
 
 int mapclass::maptiletoenemycol(int t)

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -661,7 +661,6 @@ int editorclass::getenemycol(int t)
         return 6;
         break;
     }
-    return 0;
 }
 
 int editorclass::getwarpbackground(int rx, int ry)
@@ -939,7 +938,6 @@ int editorclass::getenemyframe(int t)
         return 78;
         break;
     }
-    return 78;
 }
 
 
@@ -1334,7 +1332,6 @@ int editorclass::edgetile( int x, int y )
         return 0;
         break;
     }
-    return 0;
 }
 
 int editorclass::outsideedgetile( int x, int y )
@@ -1352,7 +1349,6 @@ int editorclass::outsideedgetile( int x, int y )
         return 2;
         break;
     }
-    return 2;
 }
 
 
@@ -1404,7 +1400,6 @@ int editorclass::backedgetile( int x, int y )
         return 0;
         break;
     }
-    return 0;
 }
 
 int editorclass::labspikedir( int x, int y, int t )


### PR DESCRIPTION
MSVC complains about these, doesn't seem like GCC does. These can be safely removed because they're unreachable, and they always follow a case-switch or similar that has a default case which this code is a duplicate of anyway. (Unless it isn't, in which case all the better to remove it, becausee otherwise it looks misleading or confusing to casual glances at the code.)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
