### PR TITLE
Fix all memory errors reported by Valgrind (including some 2.3 regressions)

### DIFF
--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -183,8 +183,8 @@ std::vector<int> binaryBlob::getExtra()
 	for (size_t i = 0; i < SDL_arraysize(m_headers); i += 1)
 	{
 		if (m_headers[i].valid
-#define FOREACH_TRACK(track_name) && SDL_strcmp(m_headers[i].name, track_name) != 0
-		TRACK_NAMES
+#define FOREACH_TRACK(_, track_name) && SDL_strcmp(m_headers[i].name, track_name) != 0
+		TRACK_NAMES(_)
 #undef FOREACH_TRACK
 		) {
 			result.push_back(i);

--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -3,8 +3,8 @@
 #include <physfs.h> /* FIXME: Abstract to FileSystemUtils! */
 #include <SDL.h>
 #include <stdio.h>
-#include <stdlib.h>
 
+#include "Exit.h"
 #include "UtilityClass.h"
 
 binaryBlob::binaryBlob()
@@ -113,7 +113,7 @@ bool binaryBlob::unPackBinary(const char* name)
 		m_memblocks[i] = (char*) SDL_malloc(m_headers[i].size);
 		if (m_memblocks[i] == NULL)
 		{
-			exit(1); /* Oh god we're out of memory, just bail */
+			VVV_exit(1); /* Oh god we're out of memory, just bail */
 		}
 		PHYSFS_readBytes(handle, m_memblocks[i], m_headers[i].size);
 		offset += m_headers[i].size;

--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -139,12 +139,10 @@ void binaryBlob::clear()
 {
 	for (size_t i = 0; i < SDL_arraysize(m_headers); i += 1)
 	{
-		if (m_headers[i].valid)
-		{
-			SDL_free(m_memblocks[i]);
-			m_headers[i].valid = false;
-		}
+		SDL_free(m_memblocks[i]);
 	}
+	SDL_zeroa(m_memblocks);
+	SDL_zeroa(m_headers);
 }
 
 int binaryBlob::getIndex(const char* _name)

--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -10,8 +10,8 @@
 binaryBlob::binaryBlob()
 {
 	numberofHeaders = 0;
-	SDL_memset(m_headers, 0, sizeof(m_headers));
-	SDL_memset(m_memblocks, 0, sizeof(m_memblocks));
+	SDL_zeroa(m_headers);
+	SDL_zeroa(m_memblocks);
 }
 
 #ifdef VVV_COMPILEMUSIC

--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -28,6 +28,10 @@ void binaryBlob::AddFileToBinaryBlob(const char* _path)
 		fseek(file, 0, SEEK_SET);
 
 		memblock = (char*) SDL_malloc(size);
+		if (memblock == NULL)
+		{
+			VVV_exit(1);
+		}
 		fread(memblock, 1, size, file);
 
 		fclose(file);

--- a/desktop_version/src/BinaryBlob.h
+++ b/desktop_version/src/BinaryBlob.h
@@ -6,23 +6,23 @@
 /* Laaaazyyyyyyy -flibit */
 // #define VVV_COMPILEMUSIC
 
-#define TRACK_NAMES \
-	FOREACH_TRACK("data/music/0levelcomplete.ogg") \
-	FOREACH_TRACK("data/music/1pushingonwards.ogg") \
-	FOREACH_TRACK("data/music/2positiveforce.ogg") \
-	FOREACH_TRACK("data/music/3potentialforanything.ogg") \
-	FOREACH_TRACK("data/music/4passionforexploring.ogg") \
-	FOREACH_TRACK("data/music/5intermission.ogg") \
-	FOREACH_TRACK("data/music/6presentingvvvvvv.ogg") \
-	FOREACH_TRACK("data/music/7gamecomplete.ogg") \
-	FOREACH_TRACK("data/music/8predestinedfate.ogg") \
-	FOREACH_TRACK("data/music/9positiveforcereversed.ogg") \
-	FOREACH_TRACK("data/music/10popularpotpourri.ogg") \
-	FOREACH_TRACK("data/music/11pipedream.ogg") \
-	FOREACH_TRACK("data/music/12pressurecooker.ogg") \
-	FOREACH_TRACK("data/music/13pacedenergy.ogg") \
-	FOREACH_TRACK("data/music/14piercingthesky.ogg") \
-	FOREACH_TRACK("data/music/predestinedfatefinallevel.ogg")
+#define TRACK_NAMES(blob) \
+	FOREACH_TRACK(blob, "data/music/0levelcomplete.ogg") \
+	FOREACH_TRACK(blob, "data/music/1pushingonwards.ogg") \
+	FOREACH_TRACK(blob, "data/music/2positiveforce.ogg") \
+	FOREACH_TRACK(blob, "data/music/3potentialforanything.ogg") \
+	FOREACH_TRACK(blob, "data/music/4passionforexploring.ogg") \
+	FOREACH_TRACK(blob, "data/music/5intermission.ogg") \
+	FOREACH_TRACK(blob, "data/music/6presentingvvvvvv.ogg") \
+	FOREACH_TRACK(blob, "data/music/7gamecomplete.ogg") \
+	FOREACH_TRACK(blob, "data/music/8predestinedfate.ogg") \
+	FOREACH_TRACK(blob, "data/music/9positiveforcereversed.ogg") \
+	FOREACH_TRACK(blob, "data/music/10popularpotpourri.ogg") \
+	FOREACH_TRACK(blob, "data/music/11pipedream.ogg") \
+	FOREACH_TRACK(blob, "data/music/12pressurecooker.ogg") \
+	FOREACH_TRACK(blob, "data/music/13pacedenergy.ogg") \
+	FOREACH_TRACK(blob, "data/music/14piercingthesky.ogg") \
+	FOREACH_TRACK(blob, "data/music/predestinedfatefinallevel.ogg")
 
 struct resourceheader
 {

--- a/desktop_version/src/Exit.h
+++ b/desktop_version/src/Exit.h
@@ -1,0 +1,6 @@
+#ifndef VVV_EXIT_H
+#define VVV_EXIT_H
+
+void VVV_exit(const int exit_code);
+
+#endif /* VVV_EXIT_H */

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -4,11 +4,11 @@
 #include <physfs.h>
 #include <SDL.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string>
 #include <tinyxml2.h>
 #include <vector>
 
+#include "Exit.h"
 #include "Graphics.h"
 #include "UtilityClass.h"
 
@@ -259,6 +259,10 @@ void FILESYSTEM_loadFileToMemory(
 
 		++length;
 		*mem = static_cast<unsigned char*>(SDL_malloc(length)); // STDIN_BUFFER.data() causes double-free
+		if (*mem == NULL)
+		{
+			VVV_exit(1);
+		}
 		std::copy(STDIN_BUFFER.begin(), STDIN_BUFFER.end(), reinterpret_cast<char*>(*mem));
 		return;
 	}
@@ -276,11 +280,19 @@ void FILESYSTEM_loadFileToMemory(
 	if (addnull)
 	{
 		*mem = (unsigned char *) SDL_malloc(length + 1);
+		if (*mem == NULL)
+		{
+			VVV_exit(1);
+		}
 		(*mem)[length] = 0;
 	}
 	else
 	{
 		*mem = (unsigned char*) SDL_malloc(length);
+		if (*mem == NULL)
+		{
+			VVV_exit(1);
+		}
 	}
 	int success = PHYSFS_readBytes(handle, *mem, length);
 	if (success == -1)
@@ -495,6 +507,10 @@ static void PLATFORM_copyFile(const char *oldLocation, const char *newLocation)
 	length = ftell(file);
 	fseek(file, 0, SEEK_SET);
 	data = (char*) SDL_malloc(length);
+	if (data == NULL)
+	{
+		VVV_exit(1);
+	}
 	bytes_read = fread(data, 1, length, file);
 	fclose(file);
 	if (bytes_read != length)

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -134,7 +134,10 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 
 void FILESYSTEM_deinit()
 {
-	PHYSFS_deinit();
+	if (PHYSFS_isInit())
+	{
+		PHYSFS_deinit();
+	}
 }
 
 char *FILESYSTEM_getUserSaveDirectory()

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4708,6 +4708,11 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* s
 
 bool Game::savestats()
 {
+    if (graphics.screenbuffer == NULL)
+    {
+        return false;
+    }
+
     ScreenSettings screen_settings;
     graphics.screenbuffer->GetSettings(&screen_settings);
 
@@ -4950,6 +4955,11 @@ void Game::loadsettings(ScreenSettings* screen_settings)
 
 bool Game::savesettings()
 {
+    if (graphics.screenbuffer == NULL)
+    {
+        return false;
+    }
+
     ScreenSettings screen_settings;
     graphics.screenbuffer->GetSettings(&screen_settings);
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6338,7 +6338,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
                     }
                     char text[menutextbytes];
                     SDL_snprintf(text, sizeof(text), "%s%s", prefix, ed.ListOfMetaData[i].title.c_str());
-                    for (size_t ii = 0; ii < SDL_arraysize(text); ii++)
+                    for (size_t ii = 0; text[ii] != '\0'; ++ii)
                     {
                         text[ii] = SDL_tolower(text[ii]);
                     }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -170,6 +170,57 @@ void Graphics::destroy()
     #undef CLEAR_ARRAY
 }
 
+void Graphics::create_buffers(const SDL_PixelFormat* fmt)
+{
+    #define CREATE_SURFACE(w, h) \
+        SDL_CreateRGBSurface( \
+            SDL_SWSURFACE, \
+            w, h, \
+            fmt->BitsPerPixel, \
+            fmt->Rmask, fmt->Gmask, fmt->Bmask, fmt->Amask \
+        )
+    backBuffer = CREATE_SURFACE(320, 240);
+    SDL_SetSurfaceBlendMode(backBuffer, SDL_BLENDMODE_NONE);
+
+    footerbuffer = CREATE_SURFACE(320, 10);
+    SDL_SetSurfaceBlendMode(footerbuffer, SDL_BLENDMODE_BLEND);
+    SDL_SetSurfaceAlphaMod(footerbuffer, 127);
+    FillRect(footerbuffer, SDL_MapRGB(fmt, 0, 0, 0));
+
+    ghostbuffer = CREATE_SURFACE(320, 240);
+    SDL_SetSurfaceBlendMode(ghostbuffer, SDL_BLENDMODE_BLEND);
+    SDL_SetSurfaceAlphaMod(ghostbuffer, 127);
+
+    foregroundBuffer =  CREATE_SURFACE(320, 240);
+    SDL_SetSurfaceBlendMode(foregroundBuffer, SDL_BLENDMODE_BLEND);
+
+    menubuffer = CREATE_SURFACE(320, 240);
+    SDL_SetSurfaceBlendMode(menubuffer, SDL_BLENDMODE_NONE);
+
+    warpbuffer = CREATE_SURFACE(320 + 16, 240 + 16);
+    SDL_SetSurfaceBlendMode(warpbuffer, SDL_BLENDMODE_NONE);
+
+    warpbuffer_lerp = CREATE_SURFACE(320 + 16, 240 + 16);
+    SDL_SetSurfaceBlendMode(warpbuffer_lerp, SDL_BLENDMODE_NONE);
+
+    towerbg.buffer =  CREATE_SURFACE(320 + 16, 240 + 16);
+    SDL_SetSurfaceBlendMode(towerbg.buffer, SDL_BLENDMODE_NONE);
+
+    towerbg.buffer_lerp = CREATE_SURFACE(320 + 16, 240 + 16);
+    SDL_SetSurfaceBlendMode(towerbg.buffer_lerp, SDL_BLENDMODE_NONE);
+
+    titlebg.buffer = CREATE_SURFACE(320 + 16, 240 + 16);
+    SDL_SetSurfaceBlendMode(titlebg.buffer, SDL_BLENDMODE_NONE);
+
+    titlebg.buffer_lerp = CREATE_SURFACE(320 + 16, 240 + 16);
+    SDL_SetSurfaceBlendMode(titlebg.buffer_lerp, SDL_BLENDMODE_NONE);
+
+    tempBuffer = CREATE_SURFACE(320, 240);
+    SDL_SetSurfaceBlendMode(tempBuffer, SDL_BLENDMODE_NONE);
+
+    #undef CREATE_SURFACE
+}
+
 void Graphics::destroy_buffers()
 {
 #define FREE_SURFACE(SURFACE) \

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3148,7 +3148,6 @@ bool Graphics::onscreen(int t)
 void Graphics::reloadresources()
 {
 	grphx.destroy();
-	grphx = GraphicsResources();
 	grphx.init();
 
 	#define CLEAR_ARRAY(name) \

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -148,6 +148,28 @@ void Graphics::init()
     kludgeswnlinewidth = false;
 }
 
+void Graphics::destroy()
+{
+    #define CLEAR_ARRAY(name) \
+        for (size_t i = 0; i < name.size(); i += 1) \
+        { \
+            SDL_FreeSurface(name[i]); \
+        } \
+        name.clear();
+
+    CLEAR_ARRAY(tiles)
+    CLEAR_ARRAY(tiles2)
+    CLEAR_ARRAY(tiles3)
+    CLEAR_ARRAY(entcolours)
+    CLEAR_ARRAY(sprites)
+    CLEAR_ARRAY(flipsprites)
+    CLEAR_ARRAY(tele)
+    CLEAR_ARRAY(bfont)
+    CLEAR_ARRAY(flipbfont)
+
+    #undef CLEAR_ARRAY
+}
+
 int Graphics::font_idx(uint32_t ch) {
     if (font_positions.size() > 0) {
         std::map<int, int>::iterator iter = font_positions.find(ch);
@@ -3150,24 +3172,7 @@ void Graphics::reloadresources()
 	grphx.destroy();
 	grphx.init();
 
-	#define CLEAR_ARRAY(name) \
-		for (size_t i = 0; i < name.size(); i += 1) \
-		{ \
-			SDL_FreeSurface(name[i]); \
-		} \
-		name.clear();
-
-	CLEAR_ARRAY(tiles)
-	CLEAR_ARRAY(tiles2)
-	CLEAR_ARRAY(tiles3)
-	CLEAR_ARRAY(entcolours)
-	CLEAR_ARRAY(sprites)
-	CLEAR_ARRAY(flipsprites)
-	CLEAR_ARRAY(tele)
-	CLEAR_ARRAY(bfont)
-	CLEAR_ARRAY(flipbfont)
-
-	#undef CLEAR_ARRAY
+	destroy();
 
 	MakeTileArray();
 	MakeSpriteArray();

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -170,6 +170,28 @@ void Graphics::destroy()
     #undef CLEAR_ARRAY
 }
 
+void Graphics::destroy_buffers()
+{
+#define FREE_SURFACE(SURFACE) \
+    SDL_FreeSurface(SURFACE); \
+    SURFACE = NULL;
+
+    FREE_SURFACE(backBuffer)
+    FREE_SURFACE(footerbuffer)
+    FREE_SURFACE(ghostbuffer)
+    FREE_SURFACE(foregroundBuffer)
+    FREE_SURFACE(menubuffer)
+    FREE_SURFACE(warpbuffer)
+    FREE_SURFACE(warpbuffer_lerp)
+    FREE_SURFACE(towerbg.buffer)
+    FREE_SURFACE(towerbg.buffer_lerp)
+    FREE_SURFACE(titlebg.buffer)
+    FREE_SURFACE(titlebg.buffer_lerp)
+    FREE_SURFACE(tempBuffer)
+
+#undef FREE_SURFACE
+}
+
 int Graphics::font_idx(uint32_t ch) {
     if (font_positions.size() > 0) {
         std::map<int, int>::iterator iter = font_positions.find(ch);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3145,7 +3145,8 @@ bool Graphics::onscreen(int t)
 	return (t >= -40 && t <= 280);
 }
 
-void Graphics::reloadresources() {
+void Graphics::reloadresources()
+{
 	grphx.destroy();
 	grphx = GraphicsResources();
 	grphx.init();

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3280,6 +3280,7 @@ void Graphics::reloadresources()
 		screenbuffer->LoadIcon();
 	}
 
+	music.destroy();
 	music.init();
 }
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -243,18 +243,24 @@ void Graphics::destroy_buffers()
 #undef FREE_SURFACE
 }
 
-int Graphics::font_idx(uint32_t ch) {
-    if (font_positions.size() > 0) {
+int Graphics::font_idx(uint32_t ch)
+{
+    if (font_positions.size() > 0)
+    {
         std::map<int, int>::iterator iter = font_positions.find(ch);
-        if (iter == font_positions.end()) {
+        if (iter == font_positions.end())
+        {
             iter = font_positions.find('?');
-            if (iter == font_positions.end()) {
+            if (iter == font_positions.end())
+            {
                 puts("font.txt missing fallback character!");
                 exit(1);
             }
         }
         return iter->second;
-    } else {
+    }
+    else
+    {
         return ch;
     }
 }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -341,7 +341,10 @@ void Graphics::updatetitlecolours()
             \
             extra_code \
         } \
-    }
+    } \
+    \
+    SDL_FreeSurface(grphx.im_##tilesheet); \
+    grphx.im_##tilesheet = NULL;
 
 #define PROCESS_TILESHEET(tilesheet, tile_square, extra_code) \
     PROCESS_TILESHEET_RENAME(tilesheet, tilesheet, tile_square, extra_code)

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -15,8 +15,6 @@
 
 void Graphics::init()
 {
-    grphx.init();
-
     flipmode = false;
     setRect(tiles_rect, 0,0,8,8);
     setRect(sprites_rect, 0,0,32,32);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2,11 +2,11 @@
 #include "Graphics.h"
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <utf8/unchecked.h>
 
 #include "editor.h"
 #include "Entity.h"
+#include "Exit.h"
 #include "FileSystemUtils.h"
 #include "Map.h"
 #include "Music.h"
@@ -254,7 +254,7 @@ int Graphics::font_idx(uint32_t ch)
             if (iter == font_positions.end())
             {
                 puts("font.txt missing fallback character!");
-                exit(1);
+                VVV_exit(1);
             }
         }
         return iter->second;
@@ -322,7 +322,7 @@ void Graphics::updatetitlecolours()
             NULL \
         ); \
         \
-        exit(1); \
+        VVV_exit(1); \
     }
 
 #define PROCESS_TILESHEET_RENAME(tilesheet, vector, tile_square, extra_code) \

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -19,6 +19,7 @@ public:
 	void init();
 	void destroy();
 
+	void create_buffers(const SDL_PixelFormat* fmt);
 	void destroy_buffers();
 
 	GraphicsResources grphx;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -19,6 +19,8 @@ public:
 	void init();
 	void destroy();
 
+	void destroy_buffers();
+
 	GraphicsResources grphx;
 
 	int bfontlen(uint32_t ch);

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -17,6 +17,7 @@ class Graphics
 {
 public:
 	void init();
+	void destroy();
 
 	GraphicsResources grphx;
 

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -33,24 +33,6 @@ musicclass::musicclass()
 
 void musicclass::init()
 {
-	for (size_t i = 0; i < soundTracks.size(); ++i)
-	{
-		Mix_FreeChunk(soundTracks[i].sound);
-	}
-	soundTracks.clear();
-
-	// Before we free all the music: stop playing music, else SDL2_mixer
-	// will call SDL_Delay() if we are fading, resulting in no-draw frames
-	Mix_HaltMusic();
-
-	for (size_t i = 0; i < musicTracks.size(); ++i)
-	{
-		Mix_FreeMusic(musicTracks[i].m_music);
-	}
-	musicTracks.clear();
-
-	musicReadBlob.clear();
-
 	soundTracks.push_back(SoundTrack( "sounds/jump.wav" ));
 	soundTracks.push_back(SoundTrack( "sounds/jump2.wav" ));
 	soundTracks.push_back(SoundTrack( "sounds/hurt.wav" ));
@@ -163,6 +145,27 @@ static void songend()
 	extern musicclass music;
 	music.songEnd = SDL_GetPerformanceCounter();
 	music.currentsong = -1;
+}
+
+void musicclass::destroy()
+{
+	for (size_t i = 0; i < soundTracks.size(); ++i)
+	{
+		Mix_FreeChunk(soundTracks[i].sound);
+	}
+	soundTracks.clear();
+
+	// Before we free all the music: stop playing music, else SDL2_mixer
+	// will call SDL_Delay() if we are fading, resulting in no-draw frames
+	Mix_HaltMusic();
+
+	for (size_t i = 0; i < musicTracks.size(); ++i)
+	{
+		Mix_FreeMusic(musicTracks[i].m_music);
+	}
+	musicTracks.clear();
+
+	musicReadBlob.clear();
 }
 
 void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fadein_ms /*= 3000*/)

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -69,6 +69,7 @@ void musicclass::init()
 #undef FOREACH_TRACK
 
 	musicWriteBlob.writeBinaryBlob("data/BinaryMusic.vvv");
+	musicWriteBlob.clear();
 #endif
 
 	num_mmmmmm_tracks = 0;

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -64,8 +64,8 @@ void musicclass::init()
 
 #ifdef VVV_COMPILEMUSIC
 	binaryBlob musicWriteBlob;
-#define FOREACH_TRACK(track_name) musicWriteBlob.AddFileToBinaryBlob(track_name);
-	TRACK_NAMES
+#define FOREACH_TRACK(blob, track_name) blob.AddFileToBinaryBlob(track_name);
+	TRACK_NAMES(musicWriteBlob)
 #undef FOREACH_TRACK
 
 	musicWriteBlob.writeBinaryBlob("data/BinaryMusic.vvv");
@@ -87,11 +87,11 @@ void musicclass::init()
 		int index;
 		SDL_RWops *rw;
 
-#define FOREACH_TRACK(track_name) \
-	index = musicReadBlob.getIndex(track_name); \
-	if (index >= 0 && index < musicReadBlob.max_headers) \
+#define FOREACH_TRACK(blob, track_name) \
+	index = blob.getIndex(track_name); \
+	if (index >= 0 && index < blob.max_headers) \
 	{ \
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index), musicReadBlob.getSize(index)); \
+		rw = SDL_RWFromMem(blob.getAddress(index), blob.getSize(index)); \
 		if (rw == NULL) \
 		{ \
 			printf("Unable to read music file header: %s\n", SDL_GetError()); \
@@ -102,7 +102,7 @@ void musicclass::init()
 		} \
 	}
 
-		TRACK_NAMES
+		TRACK_NAMES(musicReadBlob)
 
 		num_mmmmmm_tracks += musicTracks.size();
 
@@ -123,7 +123,7 @@ void musicclass::init()
 	int index;
 	SDL_RWops *rw;
 
-	TRACK_NAMES
+	TRACK_NAMES(musicReadBlob)
 
 #undef FOREACH_TRACK
 

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -74,11 +74,11 @@ void musicclass::init()
 	num_mmmmmm_tracks = 0;
 	num_pppppp_tracks = 0;
 
-	if (!musicReadBlob.unPackBinary("mmmmmm.vvv"))
+	if (!mmmmmm_blob.unPackBinary("mmmmmm.vvv"))
 	{
 		mmmmmm = false;
 		usingmmmmmm=false;
-		bool ohCrap = musicReadBlob.unPackBinary("vvvvvvmusic.vvv");
+		bool ohCrap = pppppp_blob.unPackBinary("vvvvvvmusic.vvv");
 		SDL_assert(ohCrap && "Music not found!");
 	}
 	else
@@ -102,38 +102,38 @@ void musicclass::init()
 		} \
 	}
 
-		TRACK_NAMES(musicReadBlob)
+		TRACK_NAMES(mmmmmm_blob)
 
 		num_mmmmmm_tracks += musicTracks.size();
 
-		const std::vector<int> extra = musicReadBlob.getExtra();
+		const std::vector<int> extra = mmmmmm_blob.getExtra();
 		for (size_t i = 0; i < extra.size(); i++)
 		{
 			const int& index_ = extra[i];
-			rw = SDL_RWFromMem(musicReadBlob.getAddress(index_), musicReadBlob.getSize(index_));
+			rw = SDL_RWFromMem(mmmmmm_blob.getAddress(index_), mmmmmm_blob.getSize(index_));
 			musicTracks.push_back(MusicTrack( rw ));
 
 			num_mmmmmm_tracks++;
 		}
 
-		bool ohCrap = musicReadBlob.unPackBinary("vvvvvvmusic.vvv");
+		bool ohCrap = pppppp_blob.unPackBinary("vvvvvvmusic.vvv");
 		SDL_assert(ohCrap && "Music not found!");
 	}
 
 	int index;
 	SDL_RWops *rw;
 
-	TRACK_NAMES(musicReadBlob)
+	TRACK_NAMES(pppppp_blob)
 
 #undef FOREACH_TRACK
 
 	num_pppppp_tracks += musicTracks.size() - num_mmmmmm_tracks;
 
-	const std::vector<int> extra = musicReadBlob.getExtra();
+	const std::vector<int> extra = pppppp_blob.getExtra();
 	for (size_t i = 0; i < extra.size(); i++)
 	{
 		const int& index_ = extra[i];
-		rw = SDL_RWFromMem(musicReadBlob.getAddress(index_), musicReadBlob.getSize(index_));
+		rw = SDL_RWFromMem(pppppp_blob.getAddress(index_), pppppp_blob.getSize(index_));
 		musicTracks.push_back(MusicTrack( rw ));
 
 		num_pppppp_tracks++;
@@ -165,7 +165,8 @@ void musicclass::destroy()
 	}
 	musicTracks.clear();
 
-	musicReadBlob.clear();
+	pppppp_blob.clear();
+	mmmmmm_blob.clear();
 }
 
 void musicclass::play(int t, const double position_sec /*= 0.0*/, const int fadein_ms /*= 3000*/)

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -51,7 +51,8 @@ public:
 	bool mmmmmm;
 	bool usingmmmmmm;
 
-	binaryBlob musicReadBlob;
+	binaryBlob pppppp_blob;
+	binaryBlob mmmmmm_blob;
 	int num_pppppp_tracks;
 	int num_mmmmmm_tracks;
 

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -13,6 +13,7 @@ class musicclass
 public:
 	musicclass();
 	void init();
+	void destroy();
 
 	void play(int t, const double position_sec = 0.0, const int fadein_ms = 3000);
 	void resume(const int fadein_ms = 0);

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -93,6 +93,21 @@ void Screen::init(const ScreenSettings& settings)
 	ResizeScreen(settings.windowWidth, settings.windowHeight);
 }
 
+void Screen::destroy()
+{
+#define X(CLEANUP, POINTER) \
+	CLEANUP(POINTER); \
+	POINTER = NULL;
+
+	/* Order matters! */
+	X(SDL_DestroyTexture, m_screenTexture);
+	X(SDL_FreeSurface, m_screen);
+	X(SDL_DestroyRenderer, m_renderer);
+	X(SDL_DestroyWindow, m_window);
+
+#undef X
+}
+
 void Screen::GetSettings(ScreenSettings* settings)
 {
 	int width, height;

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -56,7 +56,7 @@ void Screen::init(const ScreenSettings& settings)
 
 	// Uncomment this next line when you need to debug -flibit
 	// SDL_SetHintWithPriority(SDL_HINT_RENDER_DRIVER, "software", SDL_HINT_OVERRIDE);
-	// FIXME: m_renderer is also created in Graphics::processVsync()!
+	// FIXME: m_renderer is also created in resetRendererWorkaround()!
 	SDL_CreateWindowAndRenderer(
 		640,
 		480,
@@ -79,7 +79,7 @@ void Screen::init(const ScreenSettings& settings)
 		0x000000FF,
 		0xFF000000
 	);
-	// ALSO FIXME: This SDL_CreateTexture() is duplicated in Graphics::processVsync()!
+	// ALSO FIXME: This SDL_CreateTexture() is duplicated twice in this file!
 	m_screenTexture = SDL_CreateTexture(
 		m_renderer,
 		SDL_PIXELFORMAT_ARGB8888,

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -9,6 +9,7 @@ class Screen
 {
 public:
 	void init(const ScreenSettings& settings);
+	void destroy();
 
 	void GetSettings(ScreenSettings* settings);
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1,6 +1,8 @@
 #define SCRIPT_DEFINITION
 #include "Script.h"
 
+#include <limits.h>
+
 #include "editor.h"
 #include "Entity.h"
 #include "Enums.h"
@@ -9,8 +11,6 @@
 #include "Map.h"
 #include "Music.h"
 #include "UtilityClass.h"
-
-#include <limits.h>
 
 scriptclass::scriptclass()
 {

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -6,6 +6,7 @@
 #include "editor.h"
 #include "Entity.h"
 #include "Enums.h"
+#include "Exit.h"
 #include "Graphics.h"
 #include "KeyPoll.h"
 #include "Map.h"
@@ -3396,10 +3397,7 @@ void scriptclass::startgamemode( int t )
 	}
 #endif
 	case 100:
-		game.savestatsandsettings();
-
-		SDL_Quit();
-		exit(0);
+		VVV_exit(0);
 		break;
 	}
 }

--- a/desktop_version/src/SoundSystem.cpp
+++ b/desktop_version/src/SoundSystem.cpp
@@ -35,10 +35,7 @@ SoundTrack::SoundTrack(const char* fileName)
 	FILESYSTEM_loadFileToMemory(fileName, &mem, &length);
 	SDL_RWops *fileIn = SDL_RWFromMem(mem, length);
 	sound = Mix_LoadWAV_RW(fileIn, 1);
-	if (length)
-	{
-		FILESYSTEM_freeMemory(&mem);
-	}
+	FILESYSTEM_freeMemory(&mem);
 
 	if (sound == NULL)
 	{

--- a/desktop_version/src/SoundSystem.cpp
+++ b/desktop_version/src/SoundSystem.cpp
@@ -33,6 +33,11 @@ SoundTrack::SoundTrack(const char* fileName)
 	unsigned char *mem;
 	size_t length = 0;
 	FILESYSTEM_loadFileToMemory(fileName, &mem, &length);
+	if (mem == NULL)
+	{
+		fprintf(stderr, "Unable to load WAV file %s\n", fileName);
+		return;
+	}
 	SDL_RWops *fileIn = SDL_RWFromMem(mem, length);
 	sound = Mix_LoadWAV_RW(fileIn, 1);
 	FILESYSTEM_freeMemory(&mem);

--- a/desktop_version/src/SoundSystem.cpp
+++ b/desktop_version/src/SoundSystem.cpp
@@ -17,7 +17,7 @@ MusicTrack::MusicTrack(const char* fileName)
 
 MusicTrack::MusicTrack(SDL_RWops *rw)
 {
-	m_music = Mix_LoadMUS_RW(rw, 0);
+	m_music = Mix_LoadMUS_RW(rw, 1);
 	m_isValid = true;
 	if(m_music == NULL)
 	{

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -247,6 +247,8 @@ bool editorclass::getLevelMetaData(std::string& _path, LevelMetaData& _data )
 
     std::string buf((char*) uMem);
 
+    FILESYSTEM_freeMemory(&uMem);
+
     if (find_metadata(buf) == "")
     {
         printf("Couldn't load metadata for %s\n", _path.c_str());

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -365,7 +365,13 @@ int main(int argc, char *argv[])
 
 static void cleanup()
 {
+    /* Order matters! */
     game.savestatsandsettings();
+    gameScreen.destroy();
+    graphics.grphx.destroy();
+    graphics.destroy_buffers();
+    graphics.destroy();
+    music.destroy();
     NETWORK_shutdown();
     SDL_Quit();
     FILESYSTEM_deinit();

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -4,6 +4,7 @@
 #include "editor.h"
 #include "Enums.h"
 #include "Entity.h"
+#include "Exit.h"
 #include "FileSystemUtils.h"
 #include "Game.h"
 #include "Graphics.h"
@@ -93,7 +94,7 @@ int main(int argc, char *argv[])
     else \
     { \
         printf("%s option requires one argument.\n", argv[i]); \
-        return 1; \
+        VVV_exit(1); \
     }
 
         if (ARG("-renderer"))
@@ -156,14 +157,14 @@ int main(int argc, char *argv[])
         else
         {
             printf("Error: invalid option: %s\n", argv[i]);
-            return 1;
+            VVV_exit(1);
         }
     }
 
     if(!FILESYSTEM_init(argv[0], baseDir, assetsPath))
     {
         puts("Unable to initialize filesystem!");
-        return 1;
+        VVV_exit(1);
     }
 
     SDL_Init(
@@ -311,7 +312,7 @@ int main(int argc, char *argv[])
                 ed.ListOfMetaData.push_back(meta);
             } else {
                 printf("Level not found\n");
-                return 1;
+                VVV_exit(1);
             }
         }
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -245,54 +245,7 @@ int main(int argc, char *argv[])
     }
     graphics.screenbuffer = &gameScreen;
 
-    const SDL_PixelFormat* fmt = gameScreen.GetFormat();
-    #define CREATE_SURFACE(w, h) \
-        SDL_CreateRGBSurface( \
-            SDL_SWSURFACE, \
-            w, h, \
-            fmt->BitsPerPixel, \
-            fmt->Rmask, fmt->Gmask, fmt->Bmask, fmt->Amask \
-        )
-    graphics.backBuffer = CREATE_SURFACE(320, 240);
-    SDL_SetSurfaceBlendMode(graphics.backBuffer, SDL_BLENDMODE_NONE);
-
-    graphics.footerbuffer = CREATE_SURFACE(320, 10);
-    SDL_SetSurfaceBlendMode(graphics.footerbuffer, SDL_BLENDMODE_BLEND);
-    SDL_SetSurfaceAlphaMod(graphics.footerbuffer, 127);
-    FillRect(graphics.footerbuffer, SDL_MapRGB(fmt, 0, 0, 0));
-
-    graphics.ghostbuffer = CREATE_SURFACE(320, 240);
-    SDL_SetSurfaceBlendMode(graphics.ghostbuffer, SDL_BLENDMODE_BLEND);
-    SDL_SetSurfaceAlphaMod(graphics.ghostbuffer, 127);
-
-    graphics.foregroundBuffer =  CREATE_SURFACE(320, 240);
-    SDL_SetSurfaceBlendMode(graphics.foregroundBuffer, SDL_BLENDMODE_BLEND);
-
-    graphics.menubuffer = CREATE_SURFACE(320, 240);
-    SDL_SetSurfaceBlendMode(graphics.menubuffer, SDL_BLENDMODE_NONE);
-
-    graphics.warpbuffer = CREATE_SURFACE(320 + 16, 240 + 16);
-    SDL_SetSurfaceBlendMode(graphics.warpbuffer, SDL_BLENDMODE_NONE);
-
-    graphics.warpbuffer_lerp = CREATE_SURFACE(320 + 16, 240 + 16);
-    SDL_SetSurfaceBlendMode(graphics.warpbuffer_lerp, SDL_BLENDMODE_NONE);
-
-    graphics.towerbg.buffer =  CREATE_SURFACE(320 + 16, 240 + 16);
-    SDL_SetSurfaceBlendMode(graphics.towerbg.buffer, SDL_BLENDMODE_NONE);
-
-    graphics.towerbg.buffer_lerp = CREATE_SURFACE(320 + 16, 240 + 16);
-    SDL_SetSurfaceBlendMode(graphics.towerbg.buffer_lerp, SDL_BLENDMODE_NONE);
-
-    graphics.titlebg.buffer = CREATE_SURFACE(320 + 16, 240 + 16);
-    SDL_SetSurfaceBlendMode(graphics.titlebg.buffer, SDL_BLENDMODE_NONE);
-
-    graphics.titlebg.buffer_lerp = CREATE_SURFACE(320 + 16, 240 + 16);
-    SDL_SetSurfaceBlendMode(graphics.titlebg.buffer_lerp, SDL_BLENDMODE_NONE);
-
-    graphics.tempBuffer = CREATE_SURFACE(320, 240);
-    SDL_SetSurfaceBlendMode(graphics.tempBuffer, SDL_BLENDMODE_NONE);
-
-    #undef CREATE_SURFACE
+    graphics.create_buffers(gameScreen.GetFormat());
 
     if (game.skipfakeload)
         game.gamestate = TITLEMODE;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -377,6 +377,12 @@ static void cleanup()
     FILESYSTEM_deinit();
 }
 
+void VVV_exit(const int exit_code)
+{
+    cleanup();
+    exit(exit_code);
+}
+
 static void inline deltaloop()
 {
     //timestep limit to 30

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -1,6 +1,5 @@
 #include <SDL.h>
 #include <stdio.h>
-#include <string.h>
 
 #include "editor.h"
 #include "Enums.h"

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -76,6 +76,8 @@ static inline Uint32 get_framerate(const int slowdown)
 static void inline deltaloop();
 static void inline fixedloop();
 
+static void cleanup();
+
 int main(int argc, char *argv[])
 {
     char* baseDir = NULL;
@@ -357,12 +359,16 @@ int main(int argc, char *argv[])
         deltaloop();
     }
 
+    cleanup();
+    return 0;
+}
+
+static void cleanup()
+{
     game.savestatsandsettings();
     NETWORK_shutdown();
     SDL_Quit();
     FILESYSTEM_deinit();
-
-    return 0;
 }
 
 static void inline deltaloop()


### PR DESCRIPTION
The other day, I ran this game under Valgrind and it reported a ton of stuff. Some of it was memory that wasn't really leaked but which we should clean up on program exit anyway just so Valgrind is useful, and most of the rest of it is 2.3 regressions that didn't exist in 2.2.

Here are all the resources which weren't technically being leaked (because they can't get leaked more than once), but which Valgrind reports, and is now properly cleaned up by the time of the game exiting:

- All `Screen` resources
- All `GraphicsResources` resources
- All `Graphics` resources (tile vectors and buffers)
- All `musicclass` resources
- The `musicWriteBlob` that writes a `BinaryMusic.vvv` to disk (if `VVV_COMPILEMUSIC` is defined)

Here are all the memory leaks that are fixed:

- Leaking memory if an `mmmmmm.vvv` file exists while assets are mounted or unmounted, which is a 2.3 regression

  (@leo60228 earlier fixed a memory leak for the case of only PPPPPP existing, but not if *both* PPPPPP and MMMMMM exist - which is slightly disappointing for someone who primarily programs in a language whose entire point of existing at all is based around a compiler that forces you to correctly manage your memory; you would expect this to facilitate better reasoning about memory management, but I guess single-case patching can affect anyone, even if they are a Rust developer; single-case patching strikes again!)

- Leaking memory every single time a file is loaded when the levels list is loaded, another 2.3 regression

- Leaking memory for every `SDL_RWops` allocated in `MusicTrack::MusicTrack()` (this is only really a leak if custom assets are mounted or unmounted)

There is also a reading of uninitialized memory when the levels list gets created, which Valgrind reported, and which I've also fixed.

All exit paths of the game have been cleaned up to use common code (so it is guaranteed that the game will attempt to write `unlock.vvv` and `settings.vvv` if it managed to exit gracefully). Lastly, there are cleanups in other various parts of the code; view the commits for more details. Actually, you should always view the commits for more details; I'm the only one around here who actually writes something useful in their commit descriptions.

After this PR is merged, the only thing that `valgrind --leak-check=full ./VVVVVV` will ever complain about (on my system, at least) is something about 8 bytes of memory being leaked by PulseAudio. This is obviously not us, it's only 8 bytes, and PulseAudio is stupid anyways; so we don't need to worry about that.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
