### PR TITLE
Fix using ii instead of i in script serialization

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2046,7 +2046,7 @@ bool editorclass::save(std::string& _path)
         Script& script_ = script.customscripts[i];
 
         scriptString += script_.name + ":|";
-        for (size_t ii = 0; ii < script_.contents.size(); i++)
+        for (size_t ii = 0; ii < script_.contents.size(); ++ii)
         {
             scriptString += script_.contents[ii];
 


### PR DESCRIPTION
Otherwise this results in an infinite loop. Whoops.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
