### PR TITLE
Refactor extra binary blob tracks to not use STL data marshalling

### DIFF
--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -181,18 +181,24 @@ char* binaryBlob::getAddress(int _index)
 	return m_memblocks[_index];
 }
 
-std::vector<int> binaryBlob::getExtra()
+bool binaryBlob::nextExtra(size_t* start)
 {
-	std::vector<int> result;
-	for (size_t i = 0; i < SDL_arraysize(m_headers); i += 1)
+	size_t* idx;
+
+	if (start == NULL)
 	{
-		if (m_headers[i].valid
-#define FOREACH_TRACK(_, track_name) && SDL_strcmp(m_headers[i].name, track_name) != 0
+		return false;
+	}
+
+	for (idx = start; *idx < SDL_arraysize(m_headers); *idx += 1)
+	{
+		if (m_headers[*idx].valid
+#define FOREACH_TRACK(_, track_name) && SDL_strcmp(m_headers[*idx].name, track_name) != 0
 		TRACK_NAMES(_)
 #undef FOREACH_TRACK
 		) {
-			result.push_back(i);
+			return true;
 		}
 	}
-	return result;
+	return false;
 }

--- a/desktop_version/src/BinaryBlob.h
+++ b/desktop_version/src/BinaryBlob.h
@@ -1,7 +1,7 @@
 #ifndef BINARYBLOB_H
 #define BINARYBLOB_H
 
-#include <vector>
+#include <stddef.h>
 
 /* Laaaazyyyyyyy -flibit */
 // #define VVV_COMPILEMUSIC
@@ -49,7 +49,7 @@ public:
 
 	int getSize(int _index);
 
-	std::vector<int> getExtra();
+	bool nextExtra(size_t* start);
 
 	char* getAddress(int _index);
 

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -107,14 +107,14 @@ void musicclass::init()
 
 		num_mmmmmm_tracks += musicTracks.size();
 
-		const std::vector<int> extra = mmmmmm_blob.getExtra();
-		for (size_t i = 0; i < extra.size(); i++)
+		size_t index_ = 0;
+		while (mmmmmm_blob.nextExtra(&index_))
 		{
-			const int& index_ = extra[i];
 			rw = SDL_RWFromMem(mmmmmm_blob.getAddress(index_), mmmmmm_blob.getSize(index_));
 			musicTracks.push_back(MusicTrack( rw ));
 
 			num_mmmmmm_tracks++;
+			index_++;
 		}
 
 		bool ohCrap = pppppp_blob.unPackBinary("vvvvvvmusic.vvv");
@@ -130,14 +130,14 @@ void musicclass::init()
 
 	num_pppppp_tracks += musicTracks.size() - num_mmmmmm_tracks;
 
-	const std::vector<int> extra = pppppp_blob.getExtra();
-	for (size_t i = 0; i < extra.size(); i++)
+	size_t index_ = 0;
+	while (pppppp_blob.nextExtra(&index_))
 	{
-		const int& index_ = extra[i];
 		rw = SDL_RWFromMem(pppppp_blob.getAddress(index_), pppppp_blob.getSize(index_));
 		musicTracks.push_back(MusicTrack( rw ));
 
 		num_pppppp_tracks++;
+		index_++;
 	}
 }
 


### PR DESCRIPTION
Just like I refactored text splitting to no longer use `std::vector`s, `std::string`s, or temporary heap allocations, decreasing memory usage and improving performance; there's no reason to use a temporary heap-allocated `std::vector` to grab all extra binary blob indices, when instead the iteration can just be more immediate.

Instead, what I've done is replaced `binaryBlob::getExtra()` with `binaryBlob::nextExtra()`, which takes in a pointer to an index variable, and will increment the index variable until it reaches an extra track. After the caller processes the extra track, it is the caller's responsibility to increment the variable again before passing it back to `getExtra()`.

This avoids all heap allocations and brings down the memory usage of processing extra tracks.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
