### PR TITLE
Remove assigning block type to -1 when disabling them

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -767,8 +767,7 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
     bool reuse = false;
     for (size_t i = 0; i < blocks.size(); ++i)
     {
-        if (blocks[i].type == -1
-        && blocks[i].wp == 0
+        if (blocks[i].wp == 0
         && blocks[i].hp == 0
         && blocks[i].rect.w == 0
         && blocks[i].rect.h == 0)
@@ -1106,8 +1105,6 @@ void entityclass::disableblock( int t )
         puts("disableblock() out-of-bounds!");
         return;
     }
-
-    blocks[t].type = -1;
 
     blocks[t].wp = 0;
     blocks[t].hp = 0;


### PR DESCRIPTION
This fixes a regression where moving platforms had no collision. Because their width and height would be maintained, but their type would be -1. (Also because I didn't test enough.)

In #565, I decided to set blocks' types to -1 when disabling them, to be a bit safer in case there was some code that used block types but not their width and heights. However, this means that when blocks get disabled and re-created in the platform update loops, their types get set to -1, which effectively also disables their collision.

In the end, I'll just have to compromise and remove setting blocks to type -1. Because in a better world, we shouldn't be destroying and creating blocks constantly just to move some platforms - however, fixing such a fundamental problem is beyond the scope of at least 2.3 (there's also the fact that this problem also results in some bugs that are a part of compatibility, whether we like it or not). So I'll just remove the -1.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
