### PR TITLE
Use SDL_OpenURL in FILESYSTEM_openDirectory

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -565,8 +565,9 @@ bool FILESYSTEM_openDirectory(const char *dname)
 {
 	char url[MAX_PATH];
 	SDL_snprintf(url, sizeof(url), "file://%s", dname);
-	if (SDL_OpenURL(url))
+	if (SDL_OpenURL(url) == -1)
 	{
+		printf("Error opening directory: %s\n", SDL_GetError());
 		return false;
 	}
 	return true;

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -16,15 +16,11 @@
 #if defined(_WIN32)
 #include <windows.h>
 #include <shlobj.h>
-#include <shellapi.h>
 #elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__HAIKU__) || defined(__DragonFly__)
 #include <unistd.h>
 #include <dirent.h>
 #include <limits.h>
 #include <sys/stat.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <spawn.h>
 #define MAX_PATH PATH_MAX
 #endif
 

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -561,42 +561,16 @@ bool FILESYSTEM_openDirectoryEnabled()
 	return !SDL_GetHintBoolean("SteamTenfoot", SDL_FALSE);
 }
 
-#ifdef _WIN32
 bool FILESYSTEM_openDirectory(const char *dname)
 {
-	ShellExecute(NULL, "open", dname, NULL, NULL, SW_SHOWMINIMIZED);
+	char url[MAX_PATH];
+	SDL_snprintf(url, sizeof(url), "file://%s", dname);
+	if (SDL_OpenURL(url))
+	{
+		return false;
+	}
 	return true;
 }
-#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__HAIKU__) || defined(__DragonFly__)
- #if defined(__APPLE__) || defined(__HAIKU__)
-const char* open_cmd = "open";
- #else
-const char* open_cmd = "xdg-open";
- #endif
-
-extern "C" char** environ;
-
-bool FILESYSTEM_openDirectory(const char *dname)
-{
-	pid_t child;
-	// This const_cast is legal (ctrl-f "The statement" at https://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html
-	char* argv[3] =
-	{
-		const_cast<char*>(open_cmd),
-		const_cast<char*>(dname),
-		NULL
-	};
-	posix_spawnp(&child, open_cmd, NULL, NULL, argv, environ);
-	int status = 0;
-	waitpid(child, &status, 0);
-	return WIFEXITED(status) && WEXITSTATUS(status) == 0;
-}
-#else
-bool FILESYSTEM_openDirectory(const char *dname)
-{
-	return false;
-}
-#endif
 
 bool FILESYSTEM_delete(const char *name)
 {


### PR DESCRIPTION
## Changes:
The recently released SDL 2.0.14 adds a native function for opening URIs from the host system, superseding the OS-specific implementations of FILESYSTEM_openDirectory.

This has only been tested on Linux. It should be tested on other platforms too.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
