### PR TITLE
Remove unneeded <algorithm> includes

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -1,4 +1,3 @@
-#include <algorithm>
 #include <iostream>
 #include <iterator>
 #include <physfs.h>

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -1,7 +1,6 @@
 #ifndef GRAPHICS_H
 #define GRAPHICS_H
 
-#include <algorithm>
 #include <map>
 #include <string>
 #include <vector>

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3,6 +3,7 @@
 #define ED_DEFINITION
 #include "editor.h"
 
+#include <algorithm>
 #include <physfs.h>
 #include <stdio.h>
 #include <string>


### PR DESCRIPTION
One of these days, I need to get around to running Include What You Use on this codebase. Until then, while I was working on #624, I noticed these; I'm removing them now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
