### PR TITLE
Overhaul logging

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -112,6 +112,7 @@ set(VVV_SRC
 	src/GlitchrunnerMode.c
 	src/Network.c
 	src/ThirdPartyDeps.c
+	src/Vlogging.c
 	src/Xoshiro.c
 	../third_party/physfs/extras/physfsrwops.c
 )

--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -1,11 +1,14 @@
 #include "BinaryBlob.h"
 
 #include <SDL.h>
+#ifdef VVV_COMPILEMUSIC
 #include <stdio.h>
+#endif
 
 #include "Exit.h"
 #include "FileSystemUtils.h"
 #include "UtilityClass.h"
+#include "Vlogging.h"
 
 binaryBlob::binaryBlob(void)
 {
@@ -36,7 +39,7 @@ void binaryBlob::AddFileToBinaryBlob(const char* _path)
 
 		fclose(file);
 
-		printf("The complete file size: %li\n", size);
+		vlog_info("The complete file size: %li", size);
 
 		m_memblocks[numberofHeaders] = memblock;
 		for (int i = 0; _path[i]; i += 1)
@@ -50,7 +53,7 @@ void binaryBlob::AddFileToBinaryBlob(const char* _path)
 	}
 	else
 	{
-		printf("Unable to open file\n");
+		vlog_info("Unable to open file");
 	}
 }
 
@@ -70,7 +73,7 @@ void binaryBlob::writeBinaryBlob(const char* _name)
 	}
 	else
 	{
-		printf("Unable to open new file for writing. Feels bad.\n");
+		vlog_info("Unable to open new file for writing. Feels bad.");
 	}
 }
 #endif
@@ -106,7 +109,7 @@ int binaryBlob::getSize(int _index)
 {
 	if (!INBOUNDS_ARR(_index, m_headers))
 	{
-		puts("getSize() out-of-bounds!");
+		vlog_error("getSize() out-of-bounds!");
 		return 0;
 	}
 	return m_headers[_index].size;
@@ -116,7 +119,7 @@ char* binaryBlob::getAddress(int _index)
 {
 	if (!INBOUNDS_ARR(_index, m_memblocks))
 	{
-		puts("getAddress() out-of-bounds!");
+		vlog_error("getAddress() out-of-bounds!");
 		return NULL;
 	}
 	return m_memblocks[_index];

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -11,13 +11,14 @@
 #include "Music.h"
 #include "Script.h"
 #include "UtilityClass.h"
+#include "Vlogging.h"
 #include "Xoshiro.h"
 
 bool entityclass::checktowerspikes(int t)
 {
     if (!INBOUNDS_VEC(t, entities))
     {
-        puts("checktowerspikes() out-of-bounds!");
+        vlog_error("checktowerspikes() out-of-bounds!");
         return false;
     }
 
@@ -1092,7 +1093,7 @@ bool entityclass::disableentity(int t)
 {
     if (!INBOUNDS_VEC(t, entities))
     {
-        puts("disableentity() out-of-bounds!");
+        vlog_error("disableentity() out-of-bounds!");
         return true;
     }
     if (entities[t].rule == 0 && t == getplayer())
@@ -1118,7 +1119,7 @@ void entityclass::disableblock( int t )
 {
     if (!INBOUNDS_VEC(t, blocks))
     {
-        puts("disableblock() out-of-bounds!");
+        vlog_error("disableblock() out-of-bounds!");
         return;
     }
 
@@ -1173,7 +1174,7 @@ void entityclass::copylinecross(std::vector<entclass>& linecrosskludge, int t)
 {
     if (!INBOUNDS_VEC(t, entities))
     {
-        puts("copylinecross() out-of-bounds!");
+        vlog_error("copylinecross() out-of-bounds!");
         return;
     }
     //Copy entity t into the first free linecrosskludge entity
@@ -1184,7 +1185,7 @@ void entityclass::revertlinecross(std::vector<entclass>& linecrosskludge, int t,
 {
     if (!INBOUNDS_VEC(t, entities) || !INBOUNDS_VEC(s, linecrosskludge))
     {
-        puts("revertlinecross() out-of-bounds!");
+        vlog_error("revertlinecross() out-of-bounds!");
         return;
     }
     //Restore entity t info from linecrossing s
@@ -2161,7 +2162,7 @@ bool entityclass::updateentities( int i )
 {
     if (!INBOUNDS_VEC(i, entities))
     {
-        puts("updateentities() out-of-bounds!");
+        vlog_error("updateentities() out-of-bounds!");
         return true;
     }
 
@@ -3385,7 +3386,7 @@ void entityclass::animateentities( int _i )
 {
     if (!INBOUNDS_VEC(_i, entities))
     {
-        puts("animateentities() out-of-bounds!");
+        vlog_error("animateentities() out-of-bounds!");
         return;
     }
 
@@ -3770,7 +3771,7 @@ void entityclass::animatehumanoidcollision(const int i)
 
     if (!INBOUNDS_VEC(i, entities))
     {
-        puts("animatehumanoidcollision() out-of-bounds!");
+        vlog_error("animatehumanoidcollision() out-of-bounds!");
         return;
     }
 
@@ -3972,7 +3973,7 @@ bool entityclass::entitycollide( int a, int b )
 {
     if (!INBOUNDS_VEC(a, entities) || !INBOUNDS_VEC(b, entities))
     {
-        puts("entitycollide() out-of-bounds!");
+        vlog_error("entitycollide() out-of-bounds!");
         return false;
     }
 
@@ -4199,7 +4200,7 @@ bool entityclass::entityhlinecollide( int t, int l )
 {
     if (!INBOUNDS_VEC(t, entities) || !INBOUNDS_VEC(l, entities))
     {
-        puts("entityhlinecollide() out-of-bounds!");
+        vlog_error("entityhlinecollide() out-of-bounds!");
         return false;
     }
 
@@ -4226,7 +4227,7 @@ bool entityclass::entityvlinecollide( int t, int l )
 {
     if (!INBOUNDS_VEC(t, entities) || !INBOUNDS_VEC(l, entities))
     {
-        puts("entityvlinecollide() out-of-bounds!");
+        vlog_error("entityvlinecollide() out-of-bounds!");
         return false;
     }
 
@@ -4250,7 +4251,7 @@ bool entityclass::entityvlinecollide( int t, int l )
 bool entityclass::entitywarphlinecollide(int t, int l) {
     if (!INBOUNDS_VEC(t, entities) || !INBOUNDS_VEC(l, entities))
     {
-        puts("entitywarphlinecollide() out-of-bounds!");
+        vlog_error("entitywarphlinecollide() out-of-bounds!");
         return false;
     }
 
@@ -4288,7 +4289,7 @@ bool entityclass::entitywarphlinecollide(int t, int l) {
 bool entityclass::entitywarpvlinecollide(int t, int l) {
     if (!INBOUNDS_VEC(t, entities) || !INBOUNDS_VEC(l, entities))
     {
-        puts("entitywarpvlinecollide() out-of-bounds!");
+        vlog_error("entitywarpvlinecollide() out-of-bounds!");
         return false;
     }
 
@@ -4323,7 +4324,7 @@ float entityclass::entitycollideplatformroof( int t )
 {
     if (!INBOUNDS_VEC(t, entities))
     {
-        puts("entitycollideplatformroof() out-of-bounds!");
+        vlog_error("entitycollideplatformroof() out-of-bounds!");
         return -1000;
     }
 
@@ -4346,7 +4347,7 @@ float entityclass::entitycollideplatformfloor( int t )
 {
     if (!INBOUNDS_VEC(t, entities))
     {
-        puts("entitycollideplatformfloor() out-of-bounds!");
+        vlog_error("entitycollideplatformfloor() out-of-bounds!");
         return -1000;
     }
 
@@ -4369,7 +4370,7 @@ bool entityclass::entitycollidefloor( int t )
 {
     if (!INBOUNDS_VEC(t, entities))
     {
-        puts("entitycollidefloor() out-of-bounds!");
+        vlog_error("entitycollidefloor() out-of-bounds!");
         return false;
     }
 
@@ -4387,7 +4388,7 @@ bool entityclass::entitycollideroof( int t )
 {
     if (!INBOUNDS_VEC(t, entities))
     {
-        puts("entitycollideroof() out-of-bounds!");
+        vlog_error("entitycollideroof() out-of-bounds!");
         return false;
     }
 
@@ -4405,7 +4406,7 @@ bool entityclass::testwallsx( int t, int tx, int ty, const bool skipdirblocks )
 {
     if (!INBOUNDS_VEC(t, entities))
     {
-        puts("testwallsx() out-of-bounds!");
+        vlog_error("testwallsx() out-of-bounds!");
         return false;
     }
 
@@ -4449,7 +4450,7 @@ bool entityclass::testwallsy( int t, float tx, float ty )
 {
     if (!INBOUNDS_VEC(t, entities))
     {
-        puts("testwallsy() out-of-bounds!");
+        vlog_error("testwallsy() out-of-bounds!");
         return false;
     }
 
@@ -4494,7 +4495,7 @@ void entityclass::applyfriction( int t, float xrate, float yrate )
 {
     if (!INBOUNDS_VEC(t, entities))
     {
-        puts("applyfriction() out-of-bounds!");
+        vlog_error("applyfriction() out-of-bounds!");
         return;
     }
 
@@ -4515,7 +4516,7 @@ void entityclass::updateentitylogic( int t )
 {
     if (!INBOUNDS_VEC(t, entities))
     {
-        puts("updateentitylogic() out-of-bounds!");
+        vlog_error("updateentitylogic() out-of-bounds!");
         return;
     }
 
@@ -4558,7 +4559,7 @@ void entityclass::entitymapcollision( int t )
 {
     if (!INBOUNDS_VEC(t, entities))
     {
-        puts("entitymapcollision() out-of-bounds!");
+        vlog_error("entitymapcollision() out-of-bounds!");
         return;
     }
 
@@ -4586,7 +4587,7 @@ void entityclass::movingplatformfix( int t, int j )
 {
     if (!INBOUNDS_VEC(t, entities) || !INBOUNDS_VEC(j, entities))
     {
-        puts("movingplatformfix() out-of-bounds!");
+        vlog_error("movingplatformfix() out-of-bounds!");
         return;
     }
 
@@ -4628,7 +4629,7 @@ void entityclass::movingplatformfix( int t, int j )
 void entityclass::customwarplinecheck(int i) {
     if (!INBOUNDS_VEC(i, entities))
     {
-        puts("customwarplinecheck() out-of-bounds!");
+        vlog_error("customwarplinecheck() out-of-bounds!");
         return;
     }
 
@@ -4728,7 +4729,7 @@ void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
 {
     if (!INBOUNDS_VEC(i, entities) || !INBOUNDS_VEC(j, entities))
     {
-        puts("collisioncheck() out-of-bounds!");
+        vlog_error("collisioncheck() out-of-bounds!");
         return;
     }
 
@@ -4862,7 +4863,7 @@ void entityclass::stuckprevention(int t)
 {
     if (!INBOUNDS_VEC(t, entities))
     {
-        puts("stuckprevention() out-of-bounds!");
+        vlog_error("stuckprevention() out-of-bounds!");
         return;
     }
 

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -562,13 +562,11 @@ bool FILESYSTEM_mountAssets(const char* path)
 
 				MAYBE_FAIL(graphics.reloadresources());
 			}
-#if 0 /* flibit removed this because it was noisy, maybe keep for debug? */
 			else
 			{
 				/* Wasn't a level zip, base zip, or folder! */
-				vlog_info("Asset directory does not exist");
+				vlog_debug("Asset directory does not exist");
 			}
-#endif
 		}
 	}
 
@@ -588,12 +586,10 @@ void FILESYSTEM_unmountAssets(void)
 		assetDir[0] = '\0';
 		graphics.reloadresources();
 	}
-#if 0 /* flibit removed this because it was noisy, maybe keep for debug? */
 	else
 	{
-		vlog_info("Cannot unmount when no asset directory is mounted");
+		vlog_debug("Cannot unmount when no asset directory is mounted");
 	}
-#endif
 }
 
 static void getMountedPath(
@@ -844,7 +840,7 @@ fail:
 		return false;
 	}
 
-	vlog_info("The complete reloaded file size: %lli", size);
+	vlog_debug("The complete reloaded file size: %lli", size);
 
 	for (i = 0; i < SDL_arraysize(blob->m_headers); ++i)
 	{
@@ -855,7 +851,7 @@ fail:
 			continue;
 		}
 
-		vlog_info("%s unpacked", header->name);
+		vlog_debug("%s unpacked", header->name);
 	}
 
 	return true;

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -14,6 +14,7 @@
 #include "Maths.h"
 #include "Unused.h"
 #include "UtilityClass.h"
+#include "Vlogging.h"
 
 /* These are needed for PLATFORM_* crap */
 #if defined(_WIN32)
@@ -68,8 +69,8 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 
 	if (!PHYSFS_init(argvZero))
 	{
-		printf(
-			"Unable to initialize PhysFS: %s\n",
+		vlog_error(
+			"Unable to initialize PhysFS: %s",
 			PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
 		);
 		return 0;
@@ -96,8 +97,8 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 	/* Mount our base user directory */
 	if (!PHYSFS_mount(output, NULL, 0))
 	{
-		printf(
-			"Could not mount %s: %s\n",
+		vlog_error(
+			"Could not mount %s: %s",
 			output,
 			PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
 		);
@@ -105,14 +106,14 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 	}
 	if (!PHYSFS_setWriteDir(output))
 	{
-		printf(
-			"Could not set write dir to %s: %s\n",
+		vlog_error(
+			"Could not set write dir to %s: %s",
 			output,
 			PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
 		);
 		return 0;
 	}
-	printf("Base directory: %s\n", output);
+	vlog_info("Base directory: %s", output);
 
 	/* Store full save directory */
 	SDL_snprintf(saveDir, sizeof(saveDir), "%s%s%s",
@@ -121,7 +122,7 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 		pathSep
 	);
 	mkdir(saveDir, 0777); /* FIXME: Why did I not | this? -flibit */
-	printf("Save directory: %s\n", saveDir);
+	vlog_info("Save directory: %s", saveDir);
 
 	/* Store full level directory */
 	SDL_snprintf(levelDir, sizeof(levelDir), "%s%s%s",
@@ -130,13 +131,13 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 		pathSep
 	);
 	mkdir(levelDir, 0777);
-	printf("Level directory: %s\n", levelDir);
+	vlog_info("Level directory: %s", levelDir);
 
 	basePath = SDL_GetBasePath();
 
 	if (basePath == NULL)
 	{
-		puts("Unable to determine base path, falling back to current directory");
+		vlog_warn("Unable to determine base path, falling back to current directory");
 		basePath = SDL_strdup("./");
 	}
 
@@ -154,10 +155,10 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 	}
 	if (!PHYSFS_mount(output, NULL, 1))
 	{
-		puts("Error: data.zip missing!");
-		puts("You do not have data.zip!");
-		puts("Grab it from your purchased copy of the game,");
-		puts("or get it from the free Make and Play Edition.");
+		vlog_error("Error: data.zip missing!");
+		vlog_error("You do not have data.zip!");
+		vlog_error("Grab it from your purchased copy of the game,");
+		vlog_error("or get it from the free Make and Play Edition.");
 
 		SDL_ShowSimpleMessageBox(
 			SDL_MESSAGEBOX_ERROR,
@@ -174,7 +175,7 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 	SDL_snprintf(output, sizeof(output), "%s%s", basePath, "gamecontrollerdb.txt");
 	if (SDL_GameControllerAddMappingsFromFile(output) < 0)
 	{
-		printf("gamecontrollerdb.txt not found!\n");
+		vlog_info("gamecontrollerdb.txt not found!");
 	}
 	retval = 1;
 
@@ -209,8 +210,8 @@ bool FILESYSTEM_isFile(const char* filename)
 
 	if (!success)
 	{
-		printf(
-			"Could not stat file: %s\n",
+		vlog_error(
+			"Could not stat file: %s",
 			PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
 		);
 		return false;
@@ -296,7 +297,7 @@ static int setLevelDirError(const char* text, ...)
 	retval = SDL_vsnprintf(levelDirError, sizeof(levelDirError), text, list);
 	va_end(list);
 
-	puts(levelDirError);
+	vlog_error(levelDirError);
 
 	return retval;
 }
@@ -321,8 +322,8 @@ static bool FILESYSTEM_mountAssetsFrom(const char *fname)
 
 	if (!PHYSFS_mount(path, virtualMountPath, 0))
 	{
-		printf(
-			"Error mounting %s: %s\n",
+		vlog_error(
+			"Error mounting %s: %s",
 			fname,
 			PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
 		);
@@ -393,8 +394,8 @@ static bool checkZipStructure(const char* filename)
 
 	if (real_dir == NULL)
 	{
-		printf(
-			"Could not check %s: real directory doesn't exist\n",
+		vlog_error(
+			"Could not check %s: real directory doesn't exist",
 			filename
 		);
 		return false;
@@ -407,8 +408,8 @@ static bool checkZipStructure(const char* filename)
 
 	if (!PHYSFS_mount(real_path, mount_path, 1))
 	{
-		printf(
-			"Error mounting and checking %s: %s\n",
+		vlog_error(
+			"Error mounting and checking %s: %s",
 			filename,
 			PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
 		);
@@ -465,8 +466,8 @@ static bool checkZipStructure(const char* filename)
 
 	if (!PHYSFS_unmount(real_path))
 	{
-		printf(
-			"Could not unmount %s: %s\n",
+		vlog_error(
+			"Could not unmount %s: %s",
 			mount_path,
 			PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
 		);
@@ -486,8 +487,8 @@ void FILESYSTEM_loadZip(const char* filename)
 
 	if (!PHYSFS_mountHandle(zip, filename, "levels", 1))
 	{
-		printf(
-			"Could not mount %s: %s\n",
+		vlog_error(
+			"Could not mount %s: %s",
 			filename,
 			PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
 		);
@@ -512,7 +513,7 @@ bool FILESYSTEM_mountAssets(const char* path)
 	);
 	if (FILESYSTEM_exists(virtual_path))
 	{
-		printf("Asset directory is .data.zip at %s\n", virtual_path);
+		vlog_info("Asset directory is .data.zip at %s", virtual_path);
 
 		if (!FILESYSTEM_mountAssetsFrom(virtual_path))
 		{
@@ -532,7 +533,7 @@ bool FILESYSTEM_mountAssets(const char* path)
 		if (FILESYSTEM_exists(virtual_path))
 		{
 			/* This is a full zipped-up level including assets */
-			printf("Asset directory is .zip at %s\n", virtual_path);
+			vlog_info("Asset directory is .zip at %s", virtual_path);
 
 			if (!FILESYSTEM_mountAssetsFrom(virtual_path))
 			{
@@ -552,7 +553,7 @@ bool FILESYSTEM_mountAssets(const char* path)
 			);
 			if (FILESYSTEM_exists(virtual_path))
 			{
-				printf("Asset directory exists at %s\n", virtual_path);
+				vlog_info("Asset directory exists at %s", virtual_path);
 
 				if (!FILESYSTEM_mountAssetsFrom(virtual_path))
 				{
@@ -565,7 +566,7 @@ bool FILESYSTEM_mountAssets(const char* path)
 			else
 			{
 				/* Wasn't a level zip, base zip, or folder! */
-				puts("Asset directory does not exist");
+				vlog_info("Asset directory does not exist");
 			}
 #endif
 		}
@@ -582,7 +583,7 @@ void FILESYSTEM_unmountAssets(void)
 {
 	if (assetDir[0] != '\0')
 	{
-		printf("Unmounting %s\n", assetDir);
+		vlog_info("Unmounting %s", assetDir);
 		PHYSFS_unmount(assetDir);
 		assetDir[0] = '\0';
 		graphics.reloadresources();
@@ -590,7 +591,7 @@ void FILESYSTEM_unmountAssets(void)
 #if 0 /* flibit removed this because it was noisy, maybe keep for debug? */
 	else
 	{
-		printf("Cannot unmount when no asset directory is mounted\n");
+		vlog_info("Cannot unmount when no asset directory is mounted");
 	}
 #endif
 }
@@ -784,7 +785,7 @@ bool FILESYSTEM_loadBinaryBlob(binaryBlob* blob, const char* filename)
 	handle = PHYSFS_openRead(path);
 	if (handle == NULL)
 	{
-		printf("Unable to open file %s\n", filename);
+		vlog_info("Unable to open file %s", filename);
 		return false;
 	}
 
@@ -843,7 +844,7 @@ fail:
 		return false;
 	}
 
-	printf("The complete reloaded file size: %lli\n", size);
+	vlog_info("The complete reloaded file size: %lli", size);
 
 	for (i = 0; i < SDL_arraysize(blob->m_headers); ++i)
 	{
@@ -854,7 +855,7 @@ fail:
 			continue;
 		}
 
-		printf("%s unpacked\n", header->name);
+		vlog_info("%s unpacked", header->name);
 	}
 
 	return true;
@@ -926,8 +927,8 @@ void FILESYSTEM_enumerateLevelDirFileNames(
 
 	if (success == 0)
 	{
-		printf(
-			"Could not get list of levels: %s\n",
+		vlog_error(
+			"Could not get list of levels: %s",
 			PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
 		);
 	}
@@ -949,8 +950,8 @@ static int PLATFORM_getOSDirectory(char* output, const size_t output_size)
 
 	if (FAILED(retcode))
 	{
-		printf(
-			"Could not get OS directory: SHGetFolderPathW returned 0x%08x\n",
+		vlog_error(
+			"Could not get OS directory: SHGetFolderPathW returned 0x%08x",
 			retcode
 		);
 		return 0;
@@ -968,8 +969,8 @@ static int PLATFORM_getOSDirectory(char* output, const size_t output_size)
 	);
 	if (num_bytes == 0)
 	{
-		printf(
-			"Could not get OS directory: UTF-8 conversion failed with %d\n",
+		vlog_error(
+			"Could not get OS directory: UTF-8 conversion failed with %d",
 			GetLastError()
 		);
 		return 0;
@@ -982,8 +983,8 @@ static int PLATFORM_getOSDirectory(char* output, const size_t output_size)
 	const char* prefDir = PHYSFS_getPrefDir("distractionware", "VVVVVV");
 	if (prefDir == NULL)
 	{
-		printf(
-			"Could not get OS directory: %s\n",
+		vlog_error(
+			"Could not get OS directory: %s",
 			PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
 		);
 		return 0;
@@ -1014,7 +1015,7 @@ bool FILESYSTEM_openDirectory(const char *dname)
 	SDL_snprintf(url, sizeof(url), "file://%s", dname);
 	if (SDL_OpenURL(url) == -1)
 	{
-		printf("Error opening directory: %s\n", SDL_GetError());
+		vlog_error("Error opening directory: %s", SDL_GetError());
 		return false;
 	}
 	return true;
@@ -1032,7 +1033,7 @@ static void levelSaveCallback(const char* filename)
 	{
 		if (!FILESYSTEM_delete(filename))
 		{
-			printf("Error deleting %s\n", filename);
+			vlog_error("Error deleting %s", filename);
 		}
 	}
 }
@@ -1050,8 +1051,8 @@ void FILESYSTEM_deleteLevelSaves(void)
 
 	if (success == 0)
 	{
-		printf(
-			"Could not enumerate saves/: %s\n",
+		vlog_error(
+			"Could not enumerate saves/: %s",
 			PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
 		);
 	}

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -2,7 +2,6 @@
 #include "Game.h"
 
 #include <sstream>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <tinyxml2.h>
@@ -21,6 +20,7 @@
 #include "Network.h"
 #include "Script.h"
 #include "UtilityClass.h"
+#include "Vlogging.h"
 #include "XMLUtils.h"
 
 static bool GetButtonFromString(const char *pText, SDL_GameControllerButton *button)
@@ -273,7 +273,7 @@ void Game::init(void)
     if (!FILESYSTEM_loadTiXml2Document("saves/qsave.vvv", doc))
     {
         quicksummary = "";
-        printf("Quick Save Not Found\n");
+        vlog_info("Quick Save Not Found");
     }
     else
     {
@@ -284,7 +284,7 @@ void Game::init(void)
         pElem=hDoc.FirstChildElement().ToElement();
         if (!pElem)
         {
-            printf("Quick Save Appears Corrupted: No XML Root\n");
+            vlog_error("Quick Save Appears Corrupted: No XML Root");
         }
 
         // save this for later
@@ -314,7 +314,7 @@ void Game::init(void)
     if (!FILESYSTEM_loadTiXml2Document("saves/tsave.vvv", docTele))
     {
         telesummary = "";
-        printf("Teleporter Save Not Found\n");
+        vlog_info("Teleporter Save Not Found");
     }
     else
     {
@@ -328,7 +328,7 @@ void Game::init(void)
             // should always have a valid root but handle gracefully if it does
             if (!pElem)
             {
-                printf("Teleporter Save Appears Corrupted: No XML Root\n");
+                vlog_error("Teleporter Save Appears Corrupted: No XML Root");
             }
 
             // save this for later
@@ -462,7 +462,7 @@ void Game::deletecustomlevelstats(void)
 
     if (!FILESYSTEM_delete("saves/levelstats.vvv"))
     {
-        puts("Error deleting levelstats.vvv");
+        vlog_error("Error deleting levelstats.vvv");
     }
 }
 
@@ -513,7 +513,7 @@ void Game::loadcustomlevelstats(void)
         // should always have a valid root but handle gracefully if it does
         if (!pElem)
         {
-            printf("Error: Levelstats file corrupted\n");
+            vlog_error("Error: Levelstats file corrupted");
         }
 
         // save this for later
@@ -605,7 +605,7 @@ void Game::savecustomlevelstats(void)
     bool already_exists = FILESYSTEM_loadTiXml2Document("saves/levelstats.vvv", doc);
     if (!already_exists)
     {
-        puts("No levelstats.vvv found. Creating new file");
+        vlog_info("No levelstats.vvv found. Creating new file");
     }
 
     xml::update_declaration(doc);
@@ -650,12 +650,12 @@ void Game::savecustomlevelstats(void)
 
     if(FILESYSTEM_saveTiXml2Document("saves/levelstats.vvv", doc))
     {
-        printf("Level stats saved\n");
+        vlog_info("Level stats saved");
     }
     else
     {
-        printf("Could Not Save level stats!\n");
-        printf("Failed: %s%s\n", saveFilePath, "levelstats.vvv");
+        vlog_error("Could Not Save level stats!");
+        vlog_error("Failed: %s%s", saveFilePath, "levelstats.vvv");
     }
 }
 
@@ -3983,7 +3983,7 @@ void Game::deletestats(void)
 {
     if (!FILESYSTEM_delete("saves/unlock.vvv"))
     {
-        puts("Error deleting saves/unlock.vvv");
+        vlog_error("Error deleting saves/unlock.vvv");
     }
     else
     {
@@ -4011,7 +4011,7 @@ void Game::deletesettings(void)
 {
     if (!FILESYSTEM_delete("saves/settings.vvv"))
     {
-        puts("Error deleting saves/settings.vvv");
+        vlog_error("Error deleting saves/settings.vvv");
     }
 }
 
@@ -4038,7 +4038,7 @@ void Game::loadstats(ScreenSettings* screen_settings)
         // and we don't want to overwrite that!
         savestats(screen_settings);
 
-        printf("No Stats found. Assuming a new player\n");
+        vlog_info("No Stats found. Assuming a new player");
     }
 
     tinyxml2::XMLHandle hDoc(&doc);
@@ -4357,7 +4357,7 @@ bool Game::savestats(const ScreenSettings* screen_settings)
     bool already_exists = FILESYSTEM_loadTiXml2Document("saves/unlock.vvv", doc);
     if (!already_exists)
     {
-        puts("No unlock.vvv found. Creating new file");
+        vlog_info("No unlock.vvv found. Creating new file");
     }
 
     xml::update_declaration(doc);
@@ -4582,7 +4582,7 @@ void Game::loadsettings(ScreenSettings* screen_settings)
     if (!FILESYSTEM_loadTiXml2Document("saves/settings.vvv", doc))
     {
         savesettings(screen_settings);
-        puts("No settings.vvv found");
+        vlog_info("No settings.vvv found");
     }
 
     tinyxml2::XMLHandle hDoc(&doc);
@@ -4625,7 +4625,7 @@ bool Game::savesettings(const ScreenSettings* screen_settings)
     bool already_exists = FILESYSTEM_loadTiXml2Document("saves/settings.vvv", doc);
     if (!already_exists)
     {
-        puts("No settings.vvv found. Creating new file");
+        vlog_info("No settings.vvv found. Creating new file");
     }
 
     xml::update_declaration(doc);
@@ -4876,7 +4876,7 @@ void Game::readmaingamesave(tinyxml2::XMLDocument& doc)
         // should always have a valid root but handle gracefully if it does
         if (!pElem)
         {
-            printf("Save Not Found\n");
+            vlog_error("Save Not Found");
         }
 
         // save this for later
@@ -5055,7 +5055,7 @@ void Game::customloadquick(std::string savfile)
         // should always have a valid root but handle gracefully if it does
         if (!pElem)
         {
-            printf("Save Not Found\n");
+            vlog_error("Save Not Found");
         }
 
         // save this for later
@@ -5238,7 +5238,7 @@ void Game::loadsummary(void)
             // should always have a valid root but handle gracefully if it does
             if (!pElem)
             {
-                printf("Save Not Found\n");
+                vlog_error("Save Not Found");
             }
 
             // save this for later
@@ -5320,7 +5320,7 @@ void Game::loadsummary(void)
             // should always have a valid root but handle gracefully if it does
             if (!pElem)
             {
-                printf("Save Not Found\n");
+                vlog_error("Save Not Found");
             }
 
             // save this for later
@@ -5416,17 +5416,17 @@ bool Game::savetele(void)
     bool already_exists = FILESYSTEM_loadTiXml2Document("saves/tsave.vvv", doc);
     if (!already_exists)
     {
-        puts("No tsave.vvv found. Creating new file");
+        vlog_info("No tsave.vvv found. Creating new file");
     }
     telesummary = writemaingamesave(doc);
 
     if(!FILESYSTEM_saveTiXml2Document("saves/tsave.vvv", doc))
     {
-        printf("Could Not Save game!\n");
-        printf("Failed: %s%s\n", saveFilePath, "tsave.vvv");
+        vlog_error("Could Not Save game!");
+        vlog_error("Failed: %s%s", saveFilePath, "tsave.vvv");
         return false;
     }
-    printf("Game saved\n");
+    vlog_info("Game saved");
     return true;
 }
 
@@ -5443,17 +5443,17 @@ bool Game::savequick(void)
     bool already_exists = FILESYSTEM_loadTiXml2Document("saves/qsave.vvv", doc);
     if (!already_exists)
     {
-        puts("No qsave.vvv found. Creating new file");
+        vlog_info("No qsave.vvv found. Creating new file");
     }
     quicksummary = writemaingamesave(doc);
 
     if(!FILESYSTEM_saveTiXml2Document("saves/qsave.vvv", doc))
     {
-        printf("Could Not Save game!\n");
-        printf("Failed: %s%s\n", saveFilePath, "qsave.vvv");
+        vlog_error("Could Not Save game!");
+        vlog_error("Failed: %s%s", saveFilePath, "qsave.vvv");
         return false;
     }
-    printf("Game saved\n");
+    vlog_info("Game saved");
     return true;
 }
 
@@ -5580,7 +5580,7 @@ bool Game::customsavequick(std::string savfile)
     bool already_exists = FILESYSTEM_loadTiXml2Document(("saves/" + levelfile + ".vvv").c_str(), doc);
     if (!already_exists)
     {
-        printf("No %s.vvv found. Creating new file\n", levelfile.c_str());
+        vlog_info("No %s.vvv found. Creating new file", levelfile.c_str());
     }
 
     xml::update_declaration(doc);
@@ -5703,11 +5703,11 @@ bool Game::customsavequick(std::string savfile)
 
     if(!FILESYSTEM_saveTiXml2Document(("saves/"+levelfile+".vvv").c_str(), doc))
     {
-        printf("Could Not Save game!\n");
-        printf("Failed: %s%s%s\n", saveFilePath, levelfile.c_str(), ".vvv");
+        vlog_error("Could Not Save game!");
+        vlog_error("Failed: %s%s%s", saveFilePath, levelfile.c_str(), ".vvv");
         return false;
     }
-    printf("Game saved\n");
+    vlog_info("Game saved");
     return true;
 }
 
@@ -5848,7 +5848,7 @@ void Game::returnmenu(void)
 {
     if (menustack.empty())
     {
-        puts("Error: returning to previous menu frame on empty stack!");
+        vlog_error("Error: returning to previous menu frame on empty stack!");
         return;
     }
 
@@ -6541,7 +6541,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
 void Game::deletequick(void)
 {
     if( !FILESYSTEM_delete( "saves/qsave.vvv" ) )
-        puts("Error deleting saves/qsave.vvv");
+        vlog_error("Error deleting saves/qsave.vvv");
     else
         quicksummary = "";
 }
@@ -6549,7 +6549,7 @@ void Game::deletequick(void)
 void Game::deletetele(void)
 {
     if( !FILESYSTEM_delete( "saves/tsave.vvv" ) )
-        puts("Error deleting saves/tsave.vvv");
+        vlog_error("Error deleting saves/tsave.vvv");
     else
         telesummary = "";
 }
@@ -6560,7 +6560,7 @@ void Game::customdeletequick(const std::string& file)
 
     if (!FILESYSTEM_delete(path.c_str()))
     {
-        printf("Error deleting %s\n", path.c_str());
+        vlog_error("Error deleting %s", path.c_str());
     }
 }
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1,7 +1,6 @@
 #define GRAPHICS_DEFINITION
 #include "Graphics.h"
 
-#include <stdio.h>
 #include <utf8/unchecked.h>
 
 #include "editor.h"
@@ -13,6 +12,7 @@
 #include "Music.h"
 #include "Screen.h"
 #include "UtilityClass.h"
+#include "Vlogging.h"
 
 void Graphics::init(void)
 {
@@ -323,7 +323,7 @@ void Graphics::updatetitlecolours(void)
         SDL_snprintf(error, sizeof(error), error_fmt, #tilesheet, tile_square); \
         SDL_snprintf(error_title, sizeof(error_title), error_title_fmt, #tilesheet); \
         \
-        puts(error); \
+        vlog_error(error); \
         \
         return false; \
     }
@@ -1416,7 +1416,7 @@ void Graphics::textboxtimer( int t )
 {
     if (!INBOUNDS_VEC(m, textbox))
     {
-        puts("textboxtimer() out-of-bounds!");
+        vlog_error("textboxtimer() out-of-bounds!");
         return;
     }
 
@@ -1427,7 +1427,7 @@ void Graphics::addline( std::string t )
 {
     if (!INBOUNDS_VEC(m, textbox))
     {
-        puts("addline() out-of-bounds!");
+        vlog_error("addline() out-of-bounds!");
         return;
     }
 
@@ -1438,7 +1438,7 @@ void Graphics::textboxadjust(void)
 {
     if (!INBOUNDS_VEC(m, textbox))
     {
-        puts("textboxadjust() out-of-bounds!");
+        vlog_error("textboxadjust() out-of-bounds!");
         return;
     }
 
@@ -3133,7 +3133,7 @@ void Graphics::textboxcenterx(void)
 {
 	if (!INBOUNDS_VEC(m, textbox))
 	{
-		puts("textboxcenterx() out-of-bounds!");
+		vlog_error("textboxcenterx() out-of-bounds!");
 		return;
 	}
 
@@ -3144,7 +3144,7 @@ int Graphics::textboxwidth(void)
 {
 	if (!INBOUNDS_VEC(m, textbox))
 	{
-		puts("textboxwidth() out-of-bounds!");
+		vlog_error("textboxwidth() out-of-bounds!");
 		return 0;
 	}
 
@@ -3155,7 +3155,7 @@ void Graphics::textboxmoveto(int xo)
 {
 	if (!INBOUNDS_VEC(m, textbox))
 	{
-		puts("textboxmoveto() out-of-bounds!");
+		vlog_error("textboxmoveto() out-of-bounds!");
 		return;
 	}
 
@@ -3166,7 +3166,7 @@ void Graphics::textboxcentery(void)
 {
 	if (!INBOUNDS_VEC(m, textbox))
 	{
-		puts("textboxcentery() out-of-bounds!");
+		vlog_error("textboxcentery() out-of-bounds!");
 		return;
 	}
 

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -1,9 +1,7 @@
 #include "GraphicsResources.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-
 #include "FileSystemUtils.h"
+#include "Vlogging.h"
 
 // Used to load PNG data
 extern "C"
@@ -82,7 +80,7 @@ static SDL_Surface* LoadImage(const char *filename, bool noBlend = true, bool no
 	else
 	{
 		SDL_free(data);
-		fprintf(stderr,"Image not found: %s\n", filename);
+		vlog_error("Image not found: %s", filename);
 		SDL_assert(0 && "Image not found! See stderr.");
 		return NULL;
 	}

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -14,6 +14,7 @@
 #include "Music.h"
 #include "Script.h"
 #include "UtilityClass.h"
+#include "Vlogging.h"
 
 static void updatebuttonmappings(int bind)
 {

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -1,7 +1,6 @@
 #define KEY_DEFINITION
 #include "KeyPoll.h"
 
-#include <stdio.h>
 #include <string.h>
 #include <utf8/unchecked.h>
 
@@ -10,6 +9,7 @@
 #include "GlitchrunnerMode.h"
 #include "Graphics.h"
 #include "Music.h"
+#include "Vlogging.h"
 
 int inline KeyPoll::getThreshold(void)
 {
@@ -291,8 +291,8 @@ void KeyPoll::Poll(void)
 		case SDL_CONTROLLERDEVICEADDED:
 		{
 			SDL_GameController *toOpen = SDL_GameControllerOpen(evt.cdevice.which);
-			printf(
-				"Opened SDL_GameController ID #%i, %s\n",
+			vlog_info(
+				"Opened SDL_GameController ID #%i, %s",
 				evt.cdevice.which,
 				SDL_GameControllerName(toOpen)
 			);
@@ -303,7 +303,7 @@ void KeyPoll::Poll(void)
 		{
 			SDL_GameController *toClose = controllers[evt.cdevice.which];
 			controllers.erase(evt.cdevice.which);
-			printf("Closing %s\n", SDL_GameControllerName(toClose));
+			vlog_info("Closing %s", SDL_GameControllerName(toClose));
 			SDL_GameControllerClose(toClose);
 			break;
 		}

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -2,7 +2,6 @@
 #include "Music.h"
 
 #include <SDL.h>
-#include <stdio.h>
 #include <physfsrwops.h>
 
 #include "BinaryBlob.h"
@@ -11,6 +10,7 @@
 #include "Map.h"
 #include "Script.h"
 #include "UtilityClass.h"
+#include "Vlogging.h"
 
 musicclass::musicclass(void)
 {
@@ -76,8 +76,9 @@ void musicclass::init(void)
 
 	if (!mmmmmm_blob.unPackBinary("mmmmmm.vvv"))
 	{
-		if (pppppp_blob.unPackBinary("vvvvvvmusic.vvv")) {
-			puts("Loading music from PPPPPP blob...");
+		if (pppppp_blob.unPackBinary("vvvvvvmusic.vvv"))
+		{
+			vlog_info("Loading music from PPPPPP blob...");
 
 			mmmmmm = false;
 			usingmmmmmm=false;
@@ -93,8 +94,10 @@ void musicclass::init(void)
 			TRACK_NAMES(pppppp_blob)
 
 #undef FOREACH_TRACK
-		} else {
-			puts("Loading music from loose files...");
+		}
+		else
+		{
+			vlog_info("Loading music from loose files...");
 
 			SDL_RWops* rw;
 #define FOREACH_TRACK(_, track_name) \
@@ -108,7 +111,7 @@ void musicclass::init(void)
 	}
 	else
 	{
-		puts("Loading PPPPPP and MMMMMM blobs...");
+		vlog_info("Loading PPPPPP and MMMMMM blobs...");
 
 		mmmmmm = true;
 		int index;
@@ -121,7 +124,7 @@ void musicclass::init(void)
 		rw = SDL_RWFromConstMem(blob.getAddress(index), blob.getSize(index)); \
 		if (rw == NULL) \
 		{ \
-			printf("Unable to read music file header: %s\n", SDL_GetError()); \
+			vlog_error("Unable to read music file header: %s", SDL_GetError()); \
 		} \
 		else \
 		{ \
@@ -223,7 +226,7 @@ void musicclass::play(int t)
 
 	if (!INBOUNDS_VEC(t, musicTracks))
 	{
-		puts("play() out-of-bounds!");
+		vlog_error("play() out-of-bounds!");
 		currentsong = -1;
 		return;
 	}
@@ -236,7 +239,7 @@ void musicclass::play(int t)
 		// Level Complete theme, no fade in or repeat
 		if (Mix_PlayMusic(musicTracks[t].m_music, 0) == -1)
 		{
-			printf("Mix_PlayMusic: %s\n", Mix_GetError());
+			vlog_error("Mix_PlayMusic: %s", Mix_GetError());
 		}
 		else
 		{
@@ -264,7 +267,7 @@ void musicclass::play(int t)
 		}
 		else if (Mix_PlayMusic(musicTracks[t].m_music, -1) == -1)
 		{
-			printf("Mix_PlayMusic: %s\n", Mix_GetError());
+			vlog_error("Mix_PlayMusic: %s", Mix_GetError());
 		}
 		else
 		{
@@ -535,7 +538,7 @@ void musicclass::playef(int t)
 	channel = Mix_PlayChannel(-1, soundTracks[t].sound, 0);
 	if(channel == -1)
 	{
-		fprintf(stderr, "Unable to play WAV file: %s\n", Mix_GetError());
+		vlog_error("Unable to play WAV file: %s", Mix_GetError());
 	}
 }
 

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -1,11 +1,11 @@
 #include "Screen.h"
 
 #include <SDL.h>
-#include <stdio.h>
 
 #include "FileSystemUtils.h"
 #include "Game.h"
 #include "GraphicsUtil.h"
+#include "Vlogging.h"
 
 // Used to create the window icon
 extern "C"
@@ -168,7 +168,7 @@ void Screen::ResizeScreen(int x, int y)
 		int result = SDL_SetWindowFullscreen(m_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
 		if (result != 0)
 		{
-			printf("Error: could not set the game to fullscreen mode: %s\n", SDL_GetError());
+			vlog_error("Error: could not set the game to fullscreen mode: %s", SDL_GetError());
 			return;
 		}
 	}
@@ -177,7 +177,7 @@ void Screen::ResizeScreen(int x, int y)
 		int result = SDL_SetWindowFullscreen(m_window, 0);
 		if (result != 0)
 		{
-			printf("Error: could not set the game to windowed mode: %s\n", SDL_GetError());
+			vlog_error("Error: could not set the game to windowed mode: %s", SDL_GetError());
 			return;
 		}
 		if (x != -1 && y != -1)
@@ -193,13 +193,13 @@ void Screen::ResizeScreen(int x, int y)
 		int result = SDL_RenderSetLogicalSize(m_renderer, winX, winY);
 		if (result != 0)
 		{
-			printf("Error: could not set logical size: %s\n", SDL_GetError());
+			vlog_error("Error: could not set logical size: %s", SDL_GetError());
 			return;
 		}
 		result = SDL_RenderSetIntegerScale(m_renderer, SDL_FALSE);
 		if (result != 0)
 		{
-			printf("Error: could not set scale: %s\n", SDL_GetError());
+			vlog_error("Error: could not set scale: %s", SDL_GetError());
 			return;
 		}
 	}
@@ -209,7 +209,7 @@ void Screen::ResizeScreen(int x, int y)
 		int result = SDL_RenderSetIntegerScale(m_renderer, (SDL_bool) (stretchMode == 2));
 		if (result != 0)
 		{
-			printf("Error: could not set scale: %s\n", SDL_GetError());
+			vlog_error("Error: could not set scale: %s", SDL_GetError());
 			return;
 		}
 	}

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -14,6 +14,7 @@
 #include "Map.h"
 #include "Music.h"
 #include "UtilityClass.h"
+#include "Vlogging.h"
 #include "Xoshiro.h"
 
 scriptclass::scriptclass(void)
@@ -2323,7 +2324,7 @@ void scriptclass::run(void)
 		if (execution_counter == SHRT_MAX)
 		{
 			// We must be in an infinite loop
-			printf("Warning: execution counter got to %i, stopping script\n", SHRT_MAX);
+			vlog_warn("Warning: execution counter got to %i, stopping script", SHRT_MAX);
 			running = false;
 		}
 		else

--- a/desktop_version/src/SoundSystem.cpp
+++ b/desktop_version/src/SoundSystem.cpp
@@ -1,9 +1,9 @@
 #include "SoundSystem.h"
 
 #include <SDL.h>
-#include <stdio.h>
 
 #include "FileSystemUtils.h"
+#include "Vlogging.h"
 
 MusicTrack::MusicTrack(const char* fileName)
 {
@@ -11,7 +11,7 @@ MusicTrack::MusicTrack(const char* fileName)
 	m_isValid = true;
 	if(m_music == NULL)
 	{
-		fprintf(stderr, "Unable to load Ogg Music file: %s\n", Mix_GetError());
+		vlog_error("Unable to load Ogg Music file: %s", Mix_GetError());
 		m_isValid = false;
 	}
 }
@@ -22,7 +22,7 @@ MusicTrack::MusicTrack(SDL_RWops *rw)
 	m_isValid = true;
 	if(m_music == NULL)
 	{
-		fprintf(stderr, "Unable to load Magic Binary Music file: %s\n", Mix_GetError());
+		vlog_error("Unable to load Magic Binary Music file: %s", Mix_GetError());
 		m_isValid = false;
 	}
 }
@@ -37,7 +37,7 @@ SoundTrack::SoundTrack(const char* fileName)
 	FILESYSTEM_loadAssetToMemory(fileName, &mem, &length, false);
 	if (mem == NULL)
 	{
-		fprintf(stderr, "Unable to load WAV file %s\n", fileName);
+		vlog_error("Unable to load WAV file %s", fileName);
 		SDL_assert(0 && "WAV file missing!");
 		return;
 	}
@@ -47,7 +47,7 @@ SoundTrack::SoundTrack(const char* fileName)
 
 	if (sound == NULL)
 	{
-		fprintf(stderr, "Unable to load WAV file: %s\n", Mix_GetError());
+		vlog_error("Unable to load WAV file: %s", Mix_GetError());
 	}
 }
 
@@ -60,7 +60,7 @@ SoundSystem::SoundSystem(void)
 
 	if (Mix_OpenAudio(audio_rate, audio_format, audio_channels, audio_buffers) != 0)
 	{
-		fprintf(stderr, "Unable to initialize audio: %s\n", Mix_GetError());
+		vlog_error("Unable to initialize audio: %s", Mix_GetError());
 		SDL_assert(0 && "Unable to initialize audio!");
 	}
 }

--- a/desktop_version/src/SteamNetwork.c
+++ b/desktop_version/src/SteamNetwork.c
@@ -6,6 +6,8 @@
 #include <stdint.h>
 #include <SDL.h>
 
+#include "Vlogging.h"
+
 /* Steamworks interface versions */
 
 #define VVVVVV_STEAMCLIENT "SteamClient017"
@@ -108,7 +110,7 @@ int32_t STEAM_init(void)
 	libHandle = SDL_LoadObject(STEAM_LIBRARY);
 	if (!libHandle)
 	{
-		printf("%s not found!\n", STEAM_LIBRARY);
+		vlog_info("%s not found!", STEAM_LIBRARY);
 		return 0;
 	}
 
@@ -116,7 +118,7 @@ int32_t STEAM_init(void)
 		name = (name##Func) SDL_LoadFunction(libHandle, #name); \
 		if (!name) \
 		{ \
-			printf("%s symbol %s not found!\n", STEAM_LIBRARY, #name); \
+			vlog_error("%s symbol %s not found!", STEAM_LIBRARY, #name); \
 			ClearPointers(); \
 			return 0; \
 		}
@@ -136,7 +138,7 @@ int32_t STEAM_init(void)
 
 	if (!SteamAPI_Init())
 	{
-		printf("Steamworks not initialized!\n");
+		vlog_error("Steamworks not initialized!");
 		ClearPointers();
 		return 0;
 	}
@@ -146,7 +148,7 @@ int32_t STEAM_init(void)
 	if (!steamClient || !steamUser || !steamPipe)
 	{
 		SteamAPI_Shutdown();
-		printf(VVVVVV_STEAMCLIENT " not created!\n");
+		vlog_error(VVVVVV_STEAMCLIENT " not created!");
 		ClearPointers();
 		return 0;
 	}
@@ -159,7 +161,7 @@ int32_t STEAM_init(void)
 	if (!steamUserStats)
 	{
 		SteamAPI_Shutdown();
-		printf(VVVVVV_STEAMUSERSTATS " not created!\n");
+		vlog_error(VVVVVV_STEAMUSERSTATS " not created!");
 		ClearPointers();
 		return 0;
 	}

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -42,7 +42,7 @@ void VVV_fillstring(
     if (whine) \
     { \
         whine = false; \
-        puts(message); \
+        vlog_error(message); \
     } \
     do { } while (false)
 

--- a/desktop_version/src/Vlogging.c
+++ b/desktop_version/src/Vlogging.c
@@ -22,9 +22,11 @@
 #define Color_BOLD COLOR("\x1b[1m")
 #define Color_BOLD_YELLOW COLOR("\x1b[1;33m")
 #define Color_BOLD_RED COLOR("\x1b[1;31m")
+#define Color_BOLD_GRAY COLOR("\x1b[1;90m")
 
 static int output_enabled = 1;
 static int color_enabled = 0;
+static int debug_enabled = 0;
 static int info_enabled = 1;
 static int warn_enabled = 1;
 static int error_enabled = 1;
@@ -61,6 +63,11 @@ void vlog_toggle_color(const int enable_color)
     color_enabled = enable_color;
 }
 
+void vlog_toggle_debug(const int enable_debug)
+{
+    debug_enabled = enable_debug;
+}
+
 void vlog_toggle_info(const int enable_info)
 {
     info_enabled = enable_info;
@@ -74,6 +81,30 @@ void vlog_toggle_warn(const int enable_warn)
 void vlog_toggle_error(const int enable_error)
 {
     error_enabled = enable_error;
+}
+
+int vlog_debug(const char* text, ...)
+{
+    va_list list;
+    int retval;
+
+    if (!output_enabled || !debug_enabled)
+    {
+        return 0;
+    }
+
+    printf(Color_BOLD_GRAY);
+    printf("[DEBUG]");
+    printf(Color_RESET);
+    printf(" ");
+
+    va_start(list, text);
+    retval = vprintf(text, list);
+    va_end(list);
+
+    putchar('\n');
+
+    return retval;
 }
 
 int vlog_info(const char* text, ...)

--- a/desktop_version/src/Vlogging.c
+++ b/desktop_version/src/Vlogging.c
@@ -1,0 +1,50 @@
+#include <stdarg.h>
+#include <stdio.h>
+
+int vlog_info(const char* text, ...)
+{
+    va_list list;
+    int retval;
+
+    printf("[INFO] ");
+
+    va_start(list, text);
+    retval = vprintf(text, list);
+    va_end(list);
+
+    putchar('\n');
+
+    return retval;
+}
+
+int vlog_warn(const char* text, ...)
+{
+    va_list list;
+    int retval;
+
+    fprintf(stderr, "[WARN] ");
+
+    va_start(list, text);
+    retval = vfprintf(stderr, text, list);
+    va_end(list);
+
+    fputc('\n', stderr);
+
+    return retval;
+}
+
+int vlog_error(const char* text, ...)
+{
+    va_list list;
+    int retval;
+
+    fprintf(stderr, "[ERROR] ");
+
+    va_start(list, text);
+    retval = vfprintf(stderr, text, list);
+    va_end(list);
+
+    fputc('\n', stderr);
+
+    return retval;
+}

--- a/desktop_version/src/Vlogging.c
+++ b/desktop_version/src/Vlogging.c
@@ -1,12 +1,61 @@
+#include <SDL_stdinc.h>
 #include <stdarg.h>
 #include <stdio.h>
+
+#if defined(__unix__) || defined(__APPLE__)
+ #include <unistd.h>
+ #define STDOUT_IS_TTY isatty(STDOUT_FILENO)
+ #define STDERR_IS_TTY isatty(STDERR_FILENO)
+#elif defined(_WIN32)
+ #include <io.h>
+ #include <windows.h>
+ #define STDOUT_IS_TTY _isatty(_fileno(stdout))
+ #define STDERR_IS_TTY _isatty(_fileno(stderr))
+#else
+ #define STDOUT_IS_TTY 0
+ #define STDERR_IS_TTY 0
+#endif
+
+#define COLOR(EXPR) color_enabled ? EXPR : ""
+
+#define Color_RESET COLOR("\x1b[0m")
+#define Color_BOLD COLOR("\x1b[1m")
+#define Color_BOLD_YELLOW COLOR("\x1b[1;33m")
+#define Color_BOLD_RED COLOR("\x1b[1;31m")
+
+static int color_enabled = 0;
+
+void vlog_init(void)
+{
+#ifdef _WIN32
+    OSVERSIONINFO osvi;
+    SDL_zero(osvi);
+    osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+    GetVersionExW(&osvi);
+#endif
+
+    if (STDOUT_IS_TTY
+    && STDERR_IS_TTY
+#ifdef _WIN32
+    /* Windows supports ANSI escape sequences starting with Windows 10
+     * build 10586. We don't care to emit them on anything lower. */
+    && osvi.dwMajorVersion >= 10
+    && osvi.dwBuildNumber >= 10586
+#endif
+    ) {
+        color_enabled = 1;
+    }
+}
 
 int vlog_info(const char* text, ...)
 {
     va_list list;
     int retval;
 
-    printf("[INFO] ");
+    printf(Color_BOLD);
+    printf("[INFO]");
+    printf(Color_RESET);
+    printf(" ");
 
     va_start(list, text);
     retval = vprintf(text, list);
@@ -22,7 +71,10 @@ int vlog_warn(const char* text, ...)
     va_list list;
     int retval;
 
-    fprintf(stderr, "[WARN] ");
+    fprintf(stderr, Color_BOLD_YELLOW);
+    fprintf(stderr, "[WARN]");
+    fprintf(stderr, Color_RESET);
+    fprintf(stderr, " ");
 
     va_start(list, text);
     retval = vfprintf(stderr, text, list);
@@ -38,7 +90,10 @@ int vlog_error(const char* text, ...)
     va_list list;
     int retval;
 
-    fprintf(stderr, "[ERROR] ");
+    fprintf(stderr, Color_BOLD_RED);
+    fprintf(stderr, "[ERROR]");
+    fprintf(stderr, Color_RESET);
+    fprintf(stderr, " ");
 
     va_start(list, text);
     retval = vfprintf(stderr, text, list);

--- a/desktop_version/src/Vlogging.c
+++ b/desktop_version/src/Vlogging.c
@@ -47,6 +47,11 @@ void vlog_init(void)
     }
 }
 
+void vlog_toggle_color(const int enable_color)
+{
+    color_enabled = enable_color;
+}
+
 int vlog_info(const char* text, ...)
 {
     va_list list;

--- a/desktop_version/src/Vlogging.c
+++ b/desktop_version/src/Vlogging.c
@@ -23,7 +23,11 @@
 #define Color_BOLD_YELLOW COLOR("\x1b[1;33m")
 #define Color_BOLD_RED COLOR("\x1b[1;31m")
 
+static int output_enabled = 1;
 static int color_enabled = 0;
+static int info_enabled = 1;
+static int warn_enabled = 1;
+static int error_enabled = 1;
 
 void vlog_init(void)
 {
@@ -47,15 +51,40 @@ void vlog_init(void)
     }
 }
 
+void vlog_toggle_output(const int enable_output)
+{
+    output_enabled = enable_output;
+}
+
 void vlog_toggle_color(const int enable_color)
 {
     color_enabled = enable_color;
+}
+
+void vlog_toggle_info(const int enable_info)
+{
+    info_enabled = enable_info;
+}
+
+void vlog_toggle_warn(const int enable_warn)
+{
+    warn_enabled = enable_warn;
+}
+
+void vlog_toggle_error(const int enable_error)
+{
+    error_enabled = enable_error;
 }
 
 int vlog_info(const char* text, ...)
 {
     va_list list;
     int retval;
+
+    if (!output_enabled || !info_enabled)
+    {
+        return 0;
+    }
 
     printf(Color_BOLD);
     printf("[INFO]");
@@ -76,6 +105,11 @@ int vlog_warn(const char* text, ...)
     va_list list;
     int retval;
 
+    if (!output_enabled || !warn_enabled)
+    {
+        return 0;
+    }
+
     fprintf(stderr, Color_BOLD_YELLOW);
     fprintf(stderr, "[WARN]");
     fprintf(stderr, Color_RESET);
@@ -94,6 +128,11 @@ int vlog_error(const char* text, ...)
 {
     va_list list;
     int retval;
+
+    if (!output_enabled || !error_enabled)
+    {
+        return 0;
+    }
 
     fprintf(stderr, Color_BOLD_RED);
     fprintf(stderr, "[ERROR]");

--- a/desktop_version/src/Vlogging.h
+++ b/desktop_version/src/Vlogging.h
@@ -1,0 +1,19 @@
+#ifndef VLOGGING_H
+#define VLOGGING_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+int vlog_info(const char* text, ...);
+
+int vlog_warn(const char* text, ...);
+
+int vlog_error(const char* text, ...);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* VLOGGING_H */

--- a/desktop_version/src/Vlogging.h
+++ b/desktop_version/src/Vlogging.h
@@ -8,7 +8,15 @@ extern "C"
 
 void vlog_init(void);
 
+void vlog_toggle_output(int enable_output);
+
 void vlog_toggle_color(int enable_color);
+
+void vlog_toggle_info(int enable_info);
+
+void vlog_toggle_warn(int enable_warn);
+
+void vlog_toggle_error(int enable_error);
 
 int vlog_info(const char* text, ...);
 

--- a/desktop_version/src/Vlogging.h
+++ b/desktop_version/src/Vlogging.h
@@ -8,6 +8,8 @@ extern "C"
 
 void vlog_init(void);
 
+void vlog_toggle_color(int enable_color);
+
 int vlog_info(const char* text, ...);
 
 int vlog_warn(const char* text, ...);

--- a/desktop_version/src/Vlogging.h
+++ b/desktop_version/src/Vlogging.h
@@ -12,11 +12,15 @@ void vlog_toggle_output(int enable_output);
 
 void vlog_toggle_color(int enable_color);
 
+void vlog_toggle_debug(int enable_debug);
+
 void vlog_toggle_info(int enable_info);
 
 void vlog_toggle_warn(int enable_warn);
 
 void vlog_toggle_error(int enable_error);
+
+int vlog_debug(const char* text, ...);
 
 int vlog_info(const char* text, ...);
 

--- a/desktop_version/src/Vlogging.h
+++ b/desktop_version/src/Vlogging.h
@@ -6,6 +6,8 @@ extern "C"
 {
 #endif
 
+void vlog_init(void);
+
 int vlog_info(const char* text, ...);
 
 int vlog_warn(const char* text, ...);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3,7 +3,6 @@
 #define ED_DEFINITION
 #include "editor.h"
 
-#include <stdio.h>
 #include <string>
 #include <tinyxml2.h>
 #include <utf8/unchecked.h>
@@ -18,6 +17,7 @@
 #include "Music.h"
 #include "Script.h"
 #include "UtilityClass.h"
+#include "Vlogging.h"
 #include "XMLUtils.h"
 
 #ifdef _WIN32
@@ -254,7 +254,7 @@ bool editorclass::getLevelMetaData(std::string& _path, LevelMetaData& _data )
 
     if (uMem == NULL)
     {
-        printf("Level %s not found :(\n", _path.c_str());
+        vlog_warn("Level %s not found :(", _path.c_str());
         return false;
     }
 
@@ -264,7 +264,7 @@ bool editorclass::getLevelMetaData(std::string& _path, LevelMetaData& _data )
 
     if (find_metadata(buf) == "")
     {
-        printf("Couldn't load metadata for %s\n", _path.c_str());
+        vlog_warn("Couldn't load metadata for %s", _path.c_str());
         return false;
     }
 
@@ -1819,7 +1819,7 @@ bool editorclass::load(std::string& _path)
 
     if (!FILESYSTEM_loadTiXml2Document(_path.c_str(), doc))
     {
-        printf("No level %s to load :(\n", _path.c_str());
+        vlog_warn("No level %s to load :(", _path.c_str());
         return false;
     }
 
@@ -1832,7 +1832,7 @@ bool editorclass::load(std::string& _path)
         // should always have a valid root but handle gracefully if it does
         if (!pElem)
         {
-            printf("No valid root! Corrupt level file?\n");
+            vlog_error("No valid root! Corrupt level file?");
         }
 
         pElem->QueryIntAttribute("version", &version);
@@ -2141,7 +2141,7 @@ bool editorclass::save(std::string& _path)
     bool already_exists = !loaded_filepath.empty() && FILESYSTEM_loadTiXml2Document(loaded_filepath.c_str(), doc);
     if (!already_exists && !loaded_filepath.empty())
     {
-        printf("Currently-loaded %s not found\n", loaded_filepath.c_str());
+        vlog_error("Currently-loaded %s not found", loaded_filepath.c_str());
     }
 
     loaded_filepath = newpath;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -444,6 +444,10 @@ int main(int argc, char *argv[])
         {
             vlog_toggle_color(0);
         }
+        else if (ARG("-debug"))
+        {
+            vlog_toggle_debug(1);
+        }
         else if (ARG("-noinfo"))
         {
             vlog_toggle_info(0);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -361,6 +361,8 @@ int main(int argc, char *argv[])
     char* baseDir = NULL;
     char* assetsPath = NULL;
 
+    vlog_init();
+
     for (int i = 1; i < argc; ++i)
     {
 #define ARG(name) (SDL_strcmp(argv[i], name) == 0)

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -432,6 +432,14 @@ int main(int argc, char *argv[])
                 playassets = "levels/" + std::string(argv[i]) + ".vvvvvv";
             })
         }
+        else if (ARG("-forcecolor") || ARG("-forcecolour"))
+        {
+            vlog_toggle_color(1);
+        }
+        else if (ARG("-nocolor") || ARG("-nocolour"))
+        {
+            vlog_toggle_color(0);
+        }
 #undef ARG_INNER
 #undef ARG
         else

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -432,6 +432,10 @@ int main(int argc, char *argv[])
                 playassets = "levels/" + std::string(argv[i]) + ".vvvvvv";
             })
         }
+        else if (ARG("-nooutput"))
+        {
+            vlog_toggle_output(0);
+        }
         else if (ARG("-forcecolor") || ARG("-forcecolour"))
         {
             vlog_toggle_color(1);
@@ -439,6 +443,18 @@ int main(int argc, char *argv[])
         else if (ARG("-nocolor") || ARG("-nocolour"))
         {
             vlog_toggle_color(0);
+        }
+        else if (ARG("-noinfo"))
+        {
+            vlog_toggle_info(0);
+        }
+        else if (ARG("-nowarn"))
+        {
+            vlog_toggle_warn(0);
+        }
+        else if (ARG("-noerror"))
+        {
+            vlog_toggle_error(0);
         }
 #undef ARG_INNER
 #undef ARG

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -1,5 +1,4 @@
 #include <SDL.h>
-#include <stdio.h>
 
 #include "DeferCallbacks.h"
 #include "editor.h"
@@ -22,6 +21,7 @@
 #include "Script.h"
 #include "SoundSystem.h"
 #include "UtilityClass.h"
+#include "Vlogging.h"
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
@@ -371,7 +371,7 @@ int main(int argc, char *argv[])
     } \
     else \
     { \
-        printf("%s option requires one argument.\n", argv[i]); \
+        vlog_error("%s option requires one argument.", argv[i]); \
         VVV_exit(1); \
     }
 
@@ -434,14 +434,14 @@ int main(int argc, char *argv[])
 #undef ARG
         else
         {
-            printf("Error: invalid option: %s\n", argv[i]);
+            vlog_error("Error: invalid option: %s", argv[i]);
             VVV_exit(1);
         }
     }
 
     if(!FILESYSTEM_init(argv[0], baseDir, assetsPath))
     {
-        puts("Unable to initialize filesystem!");
+        vlog_error("Unable to initialize filesystem!");
         VVV_exit(1);
     }
 
@@ -458,34 +458,34 @@ int main(int argc, char *argv[])
 
     NETWORK_init();
 
-    printf("\t\t\n");
-    printf("\t\t\n");
-    printf("\t\t       VVVVVV\n");
-    printf("\t\t\n");
-    printf("\t\t\n");
-    printf("\t\t  8888888888888888  \n");
-    printf("\t\t88888888888888888888\n");
-    printf("\t\t888888    8888    88\n");
-    printf("\t\t888888    8888    88\n");
-    printf("\t\t88888888888888888888\n");
-    printf("\t\t88888888888888888888\n");
-    printf("\t\t888888            88\n");
-    printf("\t\t88888888        8888\n");
-    printf("\t\t  8888888888888888  \n");
-    printf("\t\t      88888888      \n");
-    printf("\t\t  8888888888888888  \n");
-    printf("\t\t88888888888888888888\n");
-    printf("\t\t88888888888888888888\n");
-    printf("\t\t88888888888888888888\n");
-    printf("\t\t8888  88888888  8888\n");
-    printf("\t\t8888  88888888  8888\n");
-    printf("\t\t    888888888888    \n");
-    printf("\t\t    8888    8888    \n");
-    printf("\t\t  888888    888888  \n");
-    printf("\t\t  888888    888888  \n");
-    printf("\t\t  888888    888888  \n");
-    printf("\t\t\n");
-    printf("\t\t\n");
+    vlog_info("\t\t");
+    vlog_info("\t\t");
+    vlog_info("\t\t       VVVVVV");
+    vlog_info("\t\t");
+    vlog_info("\t\t");
+    vlog_info("\t\t  8888888888888888  ");
+    vlog_info("\t\t88888888888888888888");
+    vlog_info("\t\t888888    8888    88");
+    vlog_info("\t\t888888    8888    88");
+    vlog_info("\t\t88888888888888888888");
+    vlog_info("\t\t88888888888888888888");
+    vlog_info("\t\t888888            88");
+    vlog_info("\t\t88888888        8888");
+    vlog_info("\t\t  8888888888888888  ");
+    vlog_info("\t\t      88888888      ");
+    vlog_info("\t\t  8888888888888888  ");
+    vlog_info("\t\t88888888888888888888");
+    vlog_info("\t\t88888888888888888888");
+    vlog_info("\t\t88888888888888888888");
+    vlog_info("\t\t8888  88888888  8888");
+    vlog_info("\t\t8888  88888888  8888");
+    vlog_info("\t\t    888888888888    ");
+    vlog_info("\t\t    8888    8888    ");
+    vlog_info("\t\t  888888    888888  ");
+    vlog_info("\t\t  888888    888888  ");
+    vlog_info("\t\t  888888    888888  ");
+    vlog_info("\t\t");
+    vlog_info("\t\t");
 
     //Set up screen
 
@@ -598,7 +598,7 @@ int main(int argc, char *argv[])
                 ed.ListOfMetaData.clear();
                 ed.ListOfMetaData.push_back(meta);
             } else {
-                printf("Level not found\n");
+                vlog_error("Level not found");
                 VVV_exit(1);
             }
         }


### PR DESCRIPTION
In the spirit of naming things after Vs, I have named the log system "V-Log", so the function prefix is named `vlog`. I insist that everyone pronounce it as "VEE-log" and not "vuh-LOG"; defection from this norm will result in a fine of 500 V-Bucks (inflation adjusted).

Anyways, this introduces `vlog_info()`, `vlog_warn()`, `vlog_error()`, and `vlog_debug()`, which you should all start using instead of `printf()`, `puts()`, or `fprintf()`.

Everything except debug logs are enabled by default. To disable all output, pass in `-nooutput` on the command-line. To disable info, do `-noinfo`; to disable warnings, do `-nowarn`; to disable errors, do `-noerror`. To enable debug logs, do `-debug`.

There are also colors, which are enabled if the game thinks it's outputting to a TTY. Else, it's disabled. To force enable, do `-forcecolor`; to force disable, do `-nocolor`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
