### PR TITLE
Explicitly declare void for all void parameter functions

### DIFF
--- a/desktop_version/src/BinaryBlob.cpp
+++ b/desktop_version/src/BinaryBlob.cpp
@@ -7,7 +7,7 @@
 #include "Exit.h"
 #include "UtilityClass.h"
 
-binaryBlob::binaryBlob()
+binaryBlob::binaryBlob(void)
 {
 	numberofHeaders = 0;
 	SDL_zeroa(m_headers);
@@ -139,7 +139,7 @@ bool binaryBlob::unPackBinary(const char* name)
 	return true;
 }
 
-void binaryBlob::clear()
+void binaryBlob::clear(void)
 {
 	for (size_t i = 0; i < SDL_arraysize(m_headers); i += 1)
 	{

--- a/desktop_version/src/BinaryBlob.h
+++ b/desktop_version/src/BinaryBlob.h
@@ -35,7 +35,7 @@ struct resourceheader
 class binaryBlob
 {
 public:
-	binaryBlob();
+	binaryBlob(void);
 
 #ifdef VVV_COMPILEMUSIC
 	void AddFileToBinaryBlob(const char* _path);
@@ -53,7 +53,7 @@ public:
 
 	char* getAddress(int _index);
 
-	void clear();
+	void clear(void);
 
 	static const int max_headers = 128;
 

--- a/desktop_version/src/BlockV.cpp
+++ b/desktop_version/src/BlockV.cpp
@@ -1,11 +1,11 @@
 #include "BlockV.h"
 
-blockclass::blockclass()
+blockclass::blockclass(void)
 {
 	clear();
 }
 
-void blockclass::clear()
+void blockclass::clear(void)
 {
 	type = 0;
 	trigger = 0;

--- a/desktop_version/src/BlockV.h
+++ b/desktop_version/src/BlockV.h
@@ -7,8 +7,8 @@
 class blockclass
 {
 public:
-    blockclass();
-    void clear();
+    blockclass(void);
+    void clear(void);
 
     void rectset(const int xi, const int yi, const int wi, const int hi);
 

--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -3,12 +3,12 @@
 #include "Game.h"
 #include "Graphics.h"
 
-entclass::entclass()
+entclass::entclass(void)
 {
 	clear();
 }
 
-void entclass::clear()
+void entclass::clear(void)
 {
 	invis = false;
 	type = 0;
@@ -65,7 +65,7 @@ void entclass::clear()
 	lerpoldyp = 0;
 }
 
-bool entclass::outside()
+bool entclass::outside(void)
 {
 	// Returns true if any point of the entity is outside the map.
 	// Adjusts velocity for a clean collision.
@@ -603,7 +603,7 @@ void entclass::settreadmillcolour( int rx, int ry )
 	}
 }
 
-void entclass::updatecolour()
+void entclass::updatecolour(void)
 {
 	switch (size)
 	{
@@ -650,7 +650,7 @@ void entclass::updatecolour()
 	}
 }
 
-bool entclass::ishumanoid()
+bool entclass::ishumanoid(void)
 {
 	return type == 0
 		|| type == 12

--- a/desktop_version/src/Ent.h
+++ b/desktop_version/src/Ent.h
@@ -8,10 +8,10 @@
 class entclass
 {
 public:
-    entclass();
-    void clear();
+    entclass(void);
+    void clear(void);
 
-    bool outside();
+    bool outside(void);
 
     void setenemy(int t);
 
@@ -19,9 +19,9 @@ public:
 
     void settreadmillcolour(int rx, int ry);
 
-    void updatecolour();
+    void updatecolour(void);
 
-    bool ishumanoid();
+    bool ishumanoid(void);
 
 public:
     //Fundamentals

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -54,7 +54,7 @@ bool entityclass::checktowerspikes(int t)
     return false;
 }
 
-void entityclass::init()
+void entityclass::init(void)
 {
     platformtile = 0;
     customplatformtile=0;
@@ -82,7 +82,7 @@ void entityclass::init()
     k = 0;
 }
 
-void entityclass::resetallflags()
+void entityclass::resetallflags(void)
 {
     SDL_memset(flags, false, sizeof(flags));
 }
@@ -1093,7 +1093,7 @@ bool entityclass::disableentity(int t)
     return true;
 }
 
-void entityclass::removeallblocks()
+void entityclass::removeallblocks(void)
 {
     blocks.clear();
 }
@@ -3787,7 +3787,7 @@ void entityclass::animateentities( int _i )
     }
 }
 
-int entityclass::getcompanion()
+int entityclass::getcompanion(void)
 {
     //Returns the index of the companion with rule t
     for (size_t i = 0; i < entities.size(); i++)
@@ -3801,7 +3801,7 @@ int entityclass::getcompanion()
     return -1;
 }
 
-int entityclass::getplayer()
+int entityclass::getplayer(void)
 {
     //Returns the index of the first player entity
     for (size_t i = 0; i < entities.size(); i++)
@@ -3815,7 +3815,7 @@ int entityclass::getplayer()
     return -1;
 }
 
-int entityclass::getscm()
+int entityclass::getscm(void)
 {
     //Returns the supercrewmate
     for (size_t i = 0; i < entities.size(); i++)
@@ -3895,7 +3895,7 @@ int entityclass::getcustomcrewman( int t )
     return 0;
 }
 
-int entityclass::getteleporter()
+int entityclass::getteleporter(void)
 {
     for (size_t i = 0; i < entities.size(); i++)
     {
@@ -3986,7 +3986,7 @@ int entityclass::checktrigger(int* block_idx)
     return -1;
 }
 
-int entityclass::checkactivity()
+int entityclass::checkactivity(void)
 {
     //Returns an int player entity (rule 0) collides with an activity
     for(size_t i=0; i < entities.size(); i++)
@@ -4591,7 +4591,7 @@ void entityclass::customwarplinecheck(int i) {
     }
 }
 
-void entityclass::entitycollisioncheck()
+void entityclass::entitycollisioncheck(void)
 {
     for (size_t i = 0; i < entities.size(); i++)
     {

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -23,23 +23,23 @@ enum
 class entityclass
 {
 public:
-    void init();
+    void init(void);
 
-    void resetallflags();
+    void resetallflags(void);
 
-    void fatal_top()
+    void fatal_top(void)
     {
         createblock(DAMAGE, -8, -8, 384, 16);
     }
-    void fatal_bottom()
+    void fatal_bottom(void)
     {
         createblock(DAMAGE, -8, 224, 384, 16);
     }
-    void fatal_left()
+    void fatal_left(void)
     {
         createblock(DAMAGE, -8, -8, 16, 260);
     }
-    void fatal_right()
+    void fatal_right(void)
     {
         createblock(DAMAGE, 312, -8, 16, 260);
     }
@@ -56,7 +56,7 @@ public:
 
     bool disableentity(int t);
 
-    void removeallblocks();
+    void removeallblocks(void);
 
     void disableblock(int t);
 
@@ -81,18 +81,18 @@ public:
 
     void animateentities(int i);
 
-    int getcompanion();
+    int getcompanion(void);
 
-    int getplayer();
+    int getplayer(void);
 
-    int getscm();
+    int getscm(void);
 
     int getlineat(int t);
 
     int getcrewman(int t);
     int getcustomcrewman(int t);
 
-    int getteleporter();
+    int getteleporter(void);
 
     bool entitycollide(int a, int b);
 
@@ -100,7 +100,7 @@ public:
 
     int checktrigger(int* block_idx);
 
-    int checkactivity();
+    int checkactivity(void);
 
     int getgridpoint(int t);
 
@@ -147,7 +147,7 @@ public:
 
     void movingplatformfix(int t, int j);
 
-    void entitycollisioncheck();
+    void entitycollisioncheck(void);
 
     void collisioncheck(int i, int j, bool scm = false);
 

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -127,7 +127,7 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 	return 1;
 }
 
-void FILESYSTEM_deinit()
+void FILESYSTEM_deinit(void)
 {
 	if (PHYSFS_isInit())
 	{
@@ -135,12 +135,12 @@ void FILESYSTEM_deinit()
 	}
 }
 
-char *FILESYSTEM_getUserSaveDirectory()
+char *FILESYSTEM_getUserSaveDirectory(void)
 {
 	return saveDir;
 }
 
-char *FILESYSTEM_getUserLevelDirectory()
+char *FILESYSTEM_getUserLevelDirectory(void)
 {
 	return levelDir;
 }
@@ -209,7 +209,7 @@ void FILESYSTEM_mountassets(const char* path)
 	}
 }
 
-void FILESYSTEM_unmountassets()
+void FILESYSTEM_unmountassets(void)
 {
 	if (graphics.assetdir != "")
 	{
@@ -547,7 +547,7 @@ static void PLATFORM_copyFile(const char *oldLocation, const char *newLocation)
 	}
 }
 
-bool FILESYSTEM_openDirectoryEnabled()
+bool FILESYSTEM_openDirectoryEnabled(void)
 {
 	/* This is just a check to see if we're on a desktop or tenfoot setup.
 	 * If you're working on a tenfoot-only build, add a def that always

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -7,16 +7,16 @@
 namespace tinyxml2 { class XMLDocument; }
 
 int FILESYSTEM_init(char *argvZero, char* baseDir, char* assetsPath);
-void FILESYSTEM_deinit();
+void FILESYSTEM_deinit(void);
 
-char *FILESYSTEM_getUserSaveDirectory();
-char *FILESYSTEM_getUserLevelDirectory();
+char *FILESYSTEM_getUserSaveDirectory(void);
+char *FILESYSTEM_getUserLevelDirectory(void);
 
 bool FILESYSTEM_directoryExists(const char *fname);
 void FILESYSTEM_mount(const char *fname);
 extern bool FILESYSTEM_assetsmounted;
 void FILESYSTEM_mountassets(const char *path);
-void FILESYSTEM_unmountassets();
+void FILESYSTEM_unmountassets(void);
 
 void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem,
                                  size_t *len, bool addnull = false);
@@ -26,7 +26,7 @@ bool FILESYSTEM_loadTiXml2Document(const char *name, tinyxml2::XMLDocument& doc)
 
 void FILESYSTEM_enumerateLevelDirFileNames(void (*callback)(const char* filename));
 
-bool FILESYSTEM_openDirectoryEnabled();
+bool FILESYSTEM_openDirectoryEnabled(void);
 bool FILESYSTEM_openDirectory(const char *dname);
 
 bool FILESYSTEM_delete(const char *name);

--- a/desktop_version/src/GOGNetwork.c
+++ b/desktop_version/src/GOGNetwork.c
@@ -6,16 +6,16 @@
 
 /* Totally unimplemented right now! */
 
-int32_t GOG_init()
+int32_t GOG_init(void)
 {
 	return 0;
 }
 
-void GOG_shutdown()
+void GOG_shutdown(void)
 {
 }
 
-void GOG_update()
+void GOG_update(void)
 {
 }
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -378,7 +378,7 @@ void Game::init(void)
     disablepause = false;
 }
 
-void Game::lifesequence()
+void Game::lifesequence(void)
 {
     if (lifeseq > 0)
     {
@@ -400,7 +400,7 @@ void Game::lifesequence()
     }
 }
 
-void Game::clearcustomlevelstats()
+void Game::clearcustomlevelstats(void)
 {
     //just clearing the array
     customlevelstats.clear();
@@ -465,7 +465,7 @@ void Game::updatecustomlevelstats(std::string clevel, int cscore)
 
 #define LOAD_ARRAY(ARRAY_NAME) LOAD_ARRAY_RENAME(ARRAY_NAME, ARRAY_NAME)
 
-void Game::loadcustomlevelstats()
+void Game::loadcustomlevelstats(void)
 {
     //testing
     if(customlevelstatsloaded)
@@ -572,7 +572,7 @@ void Game::loadcustomlevelstats()
     }
 }
 
-void Game::savecustomlevelstats()
+void Game::savecustomlevelstats(void)
 {
     tinyxml2::XMLDocument doc;
     bool already_exists = FILESYSTEM_loadTiXml2Document("saves/levelstats.vvv", doc);
@@ -632,7 +632,7 @@ void Game::savecustomlevelstats()
     }
 }
 
-void Game::updatestate()
+void Game::updatestate(void)
 {
     statedelay--;
     if(statedelay<=0){
@@ -4348,7 +4348,7 @@ void Game::updatestate()
     }
 }
 
-void Game::gethardestroom()
+void Game::gethardestroom(void)
 {
     if (currentroomdeaths > hardestroomdeaths)
     {
@@ -4384,7 +4384,7 @@ void Game::gethardestroom()
     }
 }
 
-void Game::deletestats()
+void Game::deletestats(void)
 {
     if (!FILESYSTEM_delete("saves/unlock.vvv"))
     {
@@ -4412,7 +4412,7 @@ void Game::deletestats()
     }
 }
 
-void Game::deletesettings()
+void Game::deletesettings(void)
 {
     if (!FILESYSTEM_delete("saves/settings.vvv"))
     {
@@ -4703,7 +4703,7 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* s
     }
 }
 
-bool Game::savestats()
+bool Game::savestats(void)
 {
     if (graphics.screenbuffer == NULL)
     {
@@ -4795,7 +4795,7 @@ bool Game::savestats(const ScreenSettings* screen_settings)
     return FILESYSTEM_saveTiXml2Document("saves/unlock.vvv", doc);
 }
 
-bool Game::savestatsandsettings()
+bool Game::savestatsandsettings(void)
 {
     const bool stats_saved = savestats();
 
@@ -4804,7 +4804,7 @@ bool Game::savestatsandsettings()
     return stats_saved && settings_saved; // Not the same as `savestats() && savesettings()`!
 }
 
-void Game::savestatsandsettings_menu()
+void Game::savestatsandsettings_menu(void)
 {
     // Call Game::savestatsandsettings(), but upon failure, go to the save error screen
     if (!savestatsandsettings() && !silence_settings_error)
@@ -4950,7 +4950,7 @@ void Game::loadsettings(ScreenSettings* screen_settings)
     deserializesettings(dataNode, screen_settings);
 }
 
-bool Game::savesettings()
+bool Game::savesettings(void)
 {
     if (graphics.screenbuffer == NULL)
     {
@@ -4985,7 +4985,7 @@ bool Game::savesettings(const ScreenSettings* screen_settings)
     return FILESYSTEM_saveTiXml2Document("saves/settings.vvv", doc);
 }
 
-void Game::customstart()
+void Game::customstart(void)
 {
     jumpheld = true;
 
@@ -5010,7 +5010,7 @@ void Game::customstart()
     //if (!nocutscenes) music.play(5);
 }
 
-void Game::start()
+void Game::start(void)
 {
     jumpheld = true;
 
@@ -5034,7 +5034,7 @@ void Game::start()
     if (!nocutscenes) music.play(5);
 }
 
-void Game::deathsequence()
+void Game::deathsequence(void)
 {
     int i;
     if (supercrewmate && scmhurt)
@@ -5211,7 +5211,7 @@ void Game::starttrial( int t )
     lifeseq = 0;
 }
 
-void Game::loadquick()
+void Game::loadquick(void)
 {
     tinyxml2::XMLDocument doc;
     if (!FILESYSTEM_loadTiXml2Document("saves/qsave.vvv", doc)) return;
@@ -5564,7 +5564,7 @@ void Game::customloadquick(std::string savfile)
 
 }
 
-void Game::loadsummary()
+void Game::loadsummary(void)
 {
     tinyxml2::XMLDocument docTele;
     if (!FILESYSTEM_loadTiXml2Document("saves/tsave.vvv", docTele))
@@ -5725,7 +5725,7 @@ void Game::loadsummary()
 
 }
 
-void Game::initteleportermode()
+void Game::initteleportermode(void)
 {
     //Set the teleporter variable to the right position!
     teleport_to_teleporter = 0;
@@ -5739,7 +5739,7 @@ void Game::initteleportermode()
     }
 }
 
-bool Game::savetele()
+bool Game::savetele(void)
 {
     if (map.custommode || inspecial())
     {
@@ -5766,7 +5766,7 @@ bool Game::savetele()
 }
 
 
-bool Game::savequick()
+bool Game::savequick(void)
 {
     if (map.custommode || inspecial())
     {
@@ -6049,7 +6049,7 @@ void Game::loadtele()
     readmaingamesave(doc);
 }
 
-std::string Game::unrescued()
+std::string Game::unrescued(void)
 {
     //Randomly return the name of an unrescued crewmate
     if (fRandom() * 100 > 50)
@@ -6079,7 +6079,7 @@ std::string Game::unrescued()
     return "you";
 }
 
-void Game::gameclock()
+void Game::gameclock(void)
 {
     frames++;
     if (frames >= 30)
@@ -6110,7 +6110,7 @@ std::string Game::giventimestring( int hrs, int min, int sec )
     return tempstring;
 }
 
-std::string Game::timestring()
+std::string Game::timestring(void)
 {
     std::string tempstring = "";
     if (hours > 0)
@@ -6121,7 +6121,7 @@ std::string Game::timestring()
     return tempstring;
 }
 
-std::string Game::partimestring()
+std::string Game::partimestring(void)
 {
     //given par time in seconds:
     std::string tempstring = "";
@@ -6136,7 +6136,7 @@ std::string Game::partimestring()
     return tempstring;
 }
 
-std::string Game::resulttimestring()
+std::string Game::resulttimestring(void)
 {
     //given result time in seconds:
     std::string tempstring = "";
@@ -6168,7 +6168,7 @@ std::string Game::timetstring( int t )
     return tempstring;
 }
 
-void Game::returnmenu()
+void Game::returnmenu(void)
 {
     if (menustack.empty())
     {
@@ -6810,7 +6810,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
     menuxoff = (320-menuwidth)/2;
 }
 
-void Game::deletequick()
+void Game::deletequick(void)
 {
     if( !FILESYSTEM_delete( "saves/qsave.vvv" ) )
         puts("Error deleting saves/qsave.vvv");
@@ -6818,7 +6818,7 @@ void Game::deletequick()
         quicksummary = "";
 }
 
-void Game::deletetele()
+void Game::deletetele(void)
 {
     if( !FILESYSTEM_delete( "saves/tsave.vvv" ) )
         puts("Error deleting saves/tsave.vvv");
@@ -6826,7 +6826,7 @@ void Game::deletetele()
         telesummary = "";
 }
 
-void Game::swnpenalty()
+void Game::swnpenalty(void)
 {
     //set the SWN clock back to the closest 5 second interval
     if (swntimer <= 150)
@@ -6901,7 +6901,7 @@ void Game::swnpenalty()
     }
 }
 
-int Game::crewrescued()
+int Game::crewrescued(void)
 {
     int temp = 0;
     for (size_t i = 0; i < SDL_arraysize(crewstats); i++)
@@ -6914,7 +6914,7 @@ int Game::crewrescued()
     return temp;
 }
 
-void Game::resetgameclock()
+void Game::resetgameclock(void)
 {
     frames = 0;
     seconds = 0;
@@ -6922,7 +6922,7 @@ void Game::resetgameclock()
     hours = 0;
 }
 
-int Game::trinkets()
+int Game::trinkets(void)
 {
     int temp = 0;
     for (size_t i = 0; i < SDL_arraysize(obj.collect); i++)
@@ -6935,7 +6935,7 @@ int Game::trinkets()
     return temp;
 }
 
-int Game::crewmates()
+int Game::crewmates(void)
 {
     int temp = 0;
     for (size_t i = 0; i < SDL_arraysize(obj.customcollect); i++)
@@ -6948,7 +6948,7 @@ int Game::crewmates()
     return temp;
 }
 
-bool Game::anything_unlocked()
+bool Game::anything_unlocked(void)
 {
     for (size_t i = 0; i < SDL_arraysize(unlock); i++)
     {
@@ -6965,12 +6965,12 @@ bool Game::anything_unlocked()
     return false;
 }
 
-bool Game::save_exists()
+bool Game::save_exists(void)
 {
     return telesummary != "" || quicksummary != "";
 }
 
-void Game::quittomenu()
+void Game::quittomenu(void)
 {
     gamestate = TITLEMODE;
     graphics.fademode = 4;
@@ -7021,7 +7021,7 @@ void Game::quittomenu()
     script.hardreset();
 }
 
-void Game::returntolab()
+void Game::returntolab(void)
 {
     gamestate = GAMEMODE;
     graphics.fademode = 4;
@@ -7049,7 +7049,7 @@ void Game::returntolab()
 }
 
 #if !defined(NO_CUSTOM_LEVELS)
-void Game::returntoeditor()
+void Game::returntoeditor(void)
 {
     gamestate = EDITORMODE;
 
@@ -7081,7 +7081,7 @@ void Game::returntoeditor()
 }
 #endif
 
-void Game::returntopausemenu()
+void Game::returntopausemenu(void)
 {
     ingame_titlemode = false;
     returntomenu(kludge_ingametemp);
@@ -7122,7 +7122,7 @@ void Game::mapmenuchange(const int newgamestate)
     graphics.oldmenuoffset = graphics.menuoffset;
 }
 
-void Game::copyndmresults()
+void Game::copyndmresults(void)
 {
     ndmresultcrewrescued = crewrescued();
     ndmresulttrinkets = trinkets();

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -98,45 +98,45 @@ public:
     void init(void);
 
 
-    int crewrescued();
+    int crewrescued(void);
 
-    std::string unrescued();
+    std::string unrescued(void);
 
-    void resetgameclock();
+    void resetgameclock(void);
 
     bool customsavequick(std::string savfile);
-    bool savequick();
+    bool savequick(void);
 
-    void gameclock();
+    void gameclock(void);
 
     std::string giventimestring(int hrs, int min, int sec);
 
-    std::string  timestring();
+    std::string  timestring(void);
 
-    std::string partimestring();
+    std::string partimestring(void);
 
-    std::string resulttimestring();
+    std::string resulttimestring(void);
 
     std::string timetstring(int t);
 
-    void returnmenu();
+    void returnmenu(void);
     void returntomenu(enum Menu::MenuName t);
     void  createmenu(enum Menu::MenuName t, bool samemenu = false);
 
-    void lifesequence();
+    void lifesequence(void);
 
-    void gethardestroom();
+    void gethardestroom(void);
 
-    void updatestate();
+    void updatestate(void);
 
     void unlocknum(int t);
 
     void loadstats(ScreenSettings* screen_settings);
 
     bool savestats(const ScreenSettings* screen_settings);
-    bool savestats();
+    bool savestats(void);
 
-    void deletestats();
+    void deletestats(void);
 
     void deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* screen_settings);
 
@@ -145,43 +145,43 @@ public:
     void loadsettings(ScreenSettings* screen_settings);
 
     bool savesettings(const ScreenSettings* screen_settings);
-    bool savesettings();
+    bool savesettings(void);
 
-    bool savestatsandsettings();
+    bool savestatsandsettings(void);
 
-    void savestatsandsettings_menu();
+    void savestatsandsettings_menu(void);
 
-    void deletesettings();
+    void deletesettings(void);
 
-    void deletequick();
+    void deletequick(void);
 
-    bool savetele();
+    bool savetele(void);
 
-    void loadtele();
+    void loadtele(void);
 
-    void deletetele();
+    void deletetele(void);
 
-    void customstart();
+    void customstart(void);
 
-    void start();
+    void start(void);
 
     void startspecial(int t);
 
     void starttrial(int t);
 
-    void swnpenalty();
+    void swnpenalty(void);
 
-    void deathsequence();
+    void deathsequence(void);
 
     void customloadquick(std::string savfile);
-    void loadquick();
+    void loadquick(void);
 
-    void loadsummary();
+    void loadsummary(void);
 
     void readmaingamesave(tinyxml2::XMLDocument& doc);
     std::string writemaingamesave(tinyxml2::XMLDocument& doc);
 
-    void initteleportermode();
+    void initteleportermode(void);
 
     std::string saveFilePath;
 
@@ -293,7 +293,7 @@ public:
     int ndmresultcrewrescued;
     int ndmresulttrinkets;
     std::string ndmresulthardestroom;
-    void copyndmresults();
+    void copyndmresults(void);
 
     //Time Trials
     bool intimetrial, timetrialparlost;
@@ -323,7 +323,7 @@ public:
     static const int numunlock = 25;
     bool unlock[numunlock];
     bool unlocknotify[numunlock];
-    bool anything_unlocked();
+    bool anything_unlocked(void);
     int stat_trinkets;
     int bestgamedeaths;
 
@@ -348,8 +348,8 @@ public:
 
     int deathseq, lifeseq;
 
-    int trinkets();
-    int crewmates();
+    int trinkets(void);
+    int crewmates(void);
     int savepoint, teleportxpos;
     bool teleport;
     int edteleportent;
@@ -367,7 +367,7 @@ public:
     std::string activity_lastprompt;
 
     std::string telesummary, quicksummary, customquicksummary;
-    bool save_exists();
+    bool save_exists(void);
 
     bool backgroundtext;
 
@@ -392,9 +392,9 @@ public:
     std::string customleveltitle;
     std::string customlevelfilename;
 
-    void clearcustomlevelstats();
-    void loadcustomlevelstats();
-    void savecustomlevelstats();
+    void clearcustomlevelstats(void);
+    void loadcustomlevelstats(void);
+    void savecustomlevelstats(void);
     void updatecustomlevelstats(std::string clevel, int cscore);
 
     std::vector<CustomLevelStat> customlevelstats;
@@ -418,21 +418,21 @@ public:
     int playmusic;
     std::string playassets;
 
-    void quittomenu();
-    void returntolab();
+    void quittomenu(void);
+    void returntolab(void);
     bool fadetomenu;
     int fadetomenudelay;
     bool fadetolab;
     int fadetolabdelay;
 
 #if !defined(NO_CUSTOM_LEVELS)
-    void returntoeditor();
+    void returntoeditor(void);
     bool shouldreturntoeditor;
 #endif
 
     int gametimer;
 
-    bool inline inspecial()
+    bool inline inspecial(void)
     {
         return inintermission || insecretlab || intimetrial || nodeathmode;
     }
@@ -442,7 +442,7 @@ public:
 
     bool ingame_titlemode;
 
-    void returntopausemenu();
+    void returntopausemenu(void);
     void unlockAchievement(const char *name);
 
     bool disablepause;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -13,7 +13,7 @@
 #include "Screen.h"
 #include "UtilityClass.h"
 
-void Graphics::init()
+void Graphics::init(void)
 {
     flipmode = false;
     setRect(tiles_rect, 0,0,8,8);
@@ -148,7 +148,7 @@ void Graphics::init()
     kludgeswnlinewidth = false;
 }
 
-void Graphics::destroy()
+void Graphics::destroy(void)
 {
     #define CLEAR_ARRAY(name) \
         for (size_t i = 0; i < name.size(); i += 1) \
@@ -221,7 +221,7 @@ void Graphics::create_buffers(const SDL_PixelFormat* fmt)
     #undef CREATE_SURFACE
 }
 
-void Graphics::destroy_buffers()
+void Graphics::destroy_buffers(void)
 {
 #define FREE_SURFACE(SURFACE) \
     SDL_FreeSurface(SURFACE); \
@@ -278,7 +278,7 @@ void Graphics::drawspritesetcol(int x, int y, int t, int c)
     BlitSurfaceColoured(sprites[t],NULL,backBuffer, &rect, ct);
 }
 
-void Graphics::updatetitlecolours()
+void Graphics::updatetitlecolours(void)
 {
     setcol(15);
     col_crewred = ct.colour;
@@ -349,7 +349,7 @@ void Graphics::updatetitlecolours()
 #define PROCESS_TILESHEET(tilesheet, tile_square, extra_code) \
     PROCESS_TILESHEET_RENAME(tilesheet, tilesheet, tile_square, extra_code)
 
-void Graphics::Makebfont()
+void Graphics::Makebfont(void)
 {
     PROCESS_TILESHEET(bfont, 8,
     {
@@ -391,7 +391,7 @@ int Graphics::bfontlen(uint32_t ch)
     }
 }
 
-void Graphics::MakeTileArray()
+void Graphics::MakeTileArray(void)
 {
     PROCESS_TILESHEET(tiles, 8, )
     PROCESS_TILESHEET(tiles2, 8, )
@@ -399,12 +399,12 @@ void Graphics::MakeTileArray()
     PROCESS_TILESHEET(entcolours, 8, )
 }
 
-void Graphics::maketelearray()
+void Graphics::maketelearray(void)
 {
     PROCESS_TILESHEET_RENAME(teleporter, tele, 96, )
 }
 
-void Graphics::MakeSpriteArray()
+void Graphics::MakeSpriteArray(void)
 {
     PROCESS_TILESHEET(sprites, 32, )
     PROCESS_TILESHEET(flipsprites, 32, )
@@ -809,7 +809,7 @@ void Graphics::drawtowertile3( int x, int y, int t, TowerBG& bg_obj )
     BlitSurfaceStandard(tiles3[t], NULL, bg_obj.buffer, &rect);
 }
 
-void Graphics::drawgui()
+void Graphics::drawgui(void)
 {
     //Draw all the textboxes to the screen
     for (size_t i = 0; i<textbox.size(); i++)
@@ -956,7 +956,7 @@ void Graphics::drawgui()
     }
 }
 
-void Graphics::updatetextboxes()
+void Graphics::updatetextboxes(void)
 {
     for (size_t i = 0; i < textbox.size(); i++)
     {
@@ -1058,7 +1058,7 @@ void Graphics::drawpartimage( int t, int xp, int yp, int wp, int hp)
   BlitSurfaceStandard(images[t], &trect2, backBuffer, &trect);
 }
 
-void Graphics::cutscenebars()
+void Graphics::cutscenebars(void)
 {
     int usethispos = lerp(oldcutscenebarspos, cutscenebarspos);
     if (showcutscenebars)
@@ -1074,7 +1074,7 @@ void Graphics::cutscenebars()
     }
 }
 
-void Graphics::cutscenebarstimer()
+void Graphics::cutscenebarstimer(void)
 {
     oldcutscenebarspos = cutscenebarspos;
     if (showcutscenebars)
@@ -1230,7 +1230,7 @@ void Graphics::drawtextbox( int x, int y, int w, int h, int r, int g, int b )
     }
 }
 
-void Graphics::textboxactive()
+void Graphics::textboxactive(void)
 {
     //Remove all but the most recent textbox
     for (int i = 0; i < (int) textbox.size(); i++)
@@ -1239,7 +1239,7 @@ void Graphics::textboxactive()
     }
 }
 
-void Graphics::textboxremovefast()
+void Graphics::textboxremovefast(void)
 {
     //Remove all textboxes
     for (size_t i = 0; i < textbox.size(); i++)
@@ -1248,7 +1248,7 @@ void Graphics::textboxremovefast()
     }
 }
 
-void Graphics::textboxremove()
+void Graphics::textboxremove(void)
 {
     //Remove all textboxes
     for (size_t i = 0; i < textbox.size(); i++)
@@ -1279,7 +1279,7 @@ void Graphics::addline( std::string t )
     textbox[m].addline(t);
 }
 
-void Graphics::textboxadjust()
+void Graphics::textboxadjust(void)
 {
     if (!INBOUNDS_VEC(m, textbox))
     {
@@ -1309,7 +1309,7 @@ void Graphics::createtextbox( std::string t, int xp, int yp, int r/*= 255*/, int
     }
 }
 
-void Graphics::drawfade()
+void Graphics::drawfade(void)
 {
     int usethisamount = lerp(oldfadeamount, fadeamount);
     if ((fademode == 1)||(fademode == 4))
@@ -1333,7 +1333,7 @@ void Graphics::drawfade()
 
 }
 
-void Graphics::processfade()
+void Graphics::processfade(void)
 {
     oldfadeamount = fadeamount;
     if (fademode > 1)
@@ -1556,7 +1556,7 @@ void Graphics::drawgravityline( int t )
     }
 }
 
-void Graphics::drawtrophytext()
+void Graphics::drawtrophytext(void)
 {
     int temp, temp2, temp3;
 
@@ -1644,7 +1644,7 @@ void Graphics::drawtrophytext()
     }
 }
 
-void Graphics::drawentities()
+void Graphics::drawentities(void)
 {
     const int yoff = map.towermode ? lerp(map.oldypos, map.ypos) : 0;
 
@@ -2468,7 +2468,7 @@ void Graphics::updatebackground(int t)
     }
 }
 
-void Graphics::drawmap()
+void Graphics::drawmap(void)
 {
     if (!foregrounddrawn)
     {
@@ -2509,7 +2509,7 @@ void Graphics::drawmap()
 
 }
 
-void Graphics::drawfinalmap()
+void Graphics::drawfinalmap(void)
 {
     if (!foregrounddrawn) {
         FillRect(foregroundBuffer, 0x00000000);
@@ -2534,7 +2534,7 @@ void Graphics::drawfinalmap()
     SDL_BlitSurface(foregroundBuffer, NULL, backBuffer, NULL);
 }
 
-void Graphics::drawtowermap()
+void Graphics::drawtowermap(void)
 {
     int temp;
     int yoff = lerp(map.oldypos, map.ypos);
@@ -2548,7 +2548,7 @@ void Graphics::drawtowermap()
     }
 }
 
-void Graphics::drawtowerspikes()
+void Graphics::drawtowerspikes(void)
 {
     int spikeleveltop = lerp(map.oldspikeleveltop, map.spikeleveltop);
     int spikelevelbottom = lerp(map.oldspikelevelbottom, map.spikelevelbottom);
@@ -2820,7 +2820,7 @@ void Graphics::setcol( int t )
 	}
 }
 
-void Graphics::menuoffrender()
+void Graphics::menuoffrender(void)
 {
 	SDL_Rect offsetRect1;
 	setRect (offsetRect1, 0, 0, backBuffer->w ,backBuffer->h);
@@ -2916,7 +2916,7 @@ void Graphics::setwarprect( int a, int b, int c, int d )
 	warprect.h = d;
 }
 
-void Graphics::textboxcenterx()
+void Graphics::textboxcenterx(void)
 {
 	if (!INBOUNDS_VEC(m, textbox))
 	{
@@ -2927,7 +2927,7 @@ void Graphics::textboxcenterx()
 	textbox[m].centerx();
 }
 
-int Graphics::textboxwidth()
+int Graphics::textboxwidth(void)
 {
 	if (!INBOUNDS_VEC(m, textbox))
 	{
@@ -2949,7 +2949,7 @@ void Graphics::textboxmoveto(int xo)
 	textbox[m].xp = xo;
 }
 
-void Graphics::textboxcentery()
+void Graphics::textboxcentery(void)
 {
 	if (!INBOUNDS_VEC(m, textbox))
 	{
@@ -2972,12 +2972,12 @@ int Graphics::crewcolour(const int t)
 	return 0;
 }
 
-void Graphics::flashlight()
+void Graphics::flashlight(void)
 {
 	FillRect(backBuffer, 0xBBBBBBBB);
 }
 
-void Graphics::screenshake()
+void Graphics::screenshake(void)
 {
 	if(flipmode)
 	{
@@ -3006,13 +3006,13 @@ void Graphics::screenshake()
 	FillRect(backBuffer, 0x000000 );
 }
 
-void Graphics::updatescreenshake()
+void Graphics::updatescreenshake(void)
 {
 	screenshake_x =  static_cast<Sint32>((fRandom() * 7) - 4);
 	screenshake_y =  static_cast<Sint32>((fRandom() * 7) - 4);
 }
 
-void Graphics::render()
+void Graphics::render(void)
 {
 	if(screenbuffer == NULL)
 	{
@@ -3041,7 +3041,7 @@ void Graphics::render()
 	}
 }
 
-void Graphics::renderwithscreeneffects()
+void Graphics::renderwithscreeneffects(void)
 {
 	if (game.flashlight > 0 && !game.noflashingmode)
 	{

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -15,18 +15,18 @@
 class Graphics
 {
 public:
-	void init();
-	void destroy();
+	void init(void);
+	void destroy(void);
 
 	void create_buffers(const SDL_PixelFormat* fmt);
-	void destroy_buffers();
+	void destroy_buffers(void);
 
 	GraphicsResources grphx;
 
 	int bfontlen(uint32_t ch);
 	int font_idx(uint32_t ch);
 
-	void Makebfont();
+	void Makebfont(void);
 
 	void drawhuetile(int x, int y, int t);
 	void huetilesetcol(int t);
@@ -34,43 +34,43 @@ public:
 
 	void drawgravityline(int t);
 
-	void MakeTileArray();
+	void MakeTileArray(void);
 
-	void MakeSpriteArray();
+	void MakeSpriteArray(void);
 
-	void maketelearray();
+	void maketelearray(void);
 
 	void drawcoloredtile(int x, int y, int t, int r, int g, int b);
 
 	void drawmenu(int cr, int cg, int cb, bool levelmenu = false);
 
-	void processfade();
+	void processfade(void);
 
-	void drawfade();
+	void drawfade(void);
 
 	void setwarprect(int a, int b, int c, int d);
 
 	void createtextbox(std::string t, int xp, int yp, int r= 255, int g= 255, int b = 255);
 
-	void textboxcenterx();
+	void textboxcenterx(void);
 
-	int textboxwidth();
+	int textboxwidth(void);
 
 	void textboxmoveto(int xo);
 
-	void textboxcentery();
+	void textboxcentery(void);
 
-	void textboxadjust();
+	void textboxadjust(void);
 
 	void addline(std::string t);
 
 	void textboxtimer(int t);
 
-	void textboxremove();
+	void textboxremove(void);
 
-	void textboxremovefast();
+	void textboxremovefast(void);
 
-	void textboxactive();
+	void textboxactive(void);
 
 	void drawtextbox(int x, int y, int w, int h, int r, int g, int b);
 
@@ -81,8 +81,8 @@ public:
 
 	int crewcolour(const int t);
 
-	void cutscenebars();
-	void cutscenebarstimer();
+	void cutscenebars(void);
+	void cutscenebarstimer(void);
 
 	void drawpartimage(int t, int xp, int yp, int wp, int hp);
 
@@ -90,8 +90,8 @@ public:
 
 	void drawimagecol(int t, int xp, int yp, int r, int g, int b, bool cent= false);
 
-	void updatetextboxes();
-	void drawgui();
+	void updatetextboxes(void);
+	void drawgui(void);
 
 	void drawsprite(int x, int y, int t, int r, int g, int b);
 	void drawsprite(int x, int y, int t, Uint32 c);
@@ -121,23 +121,23 @@ public:
 	void drawspritesetcol(int x, int y, int t, int c);
 
 
-	void flashlight();
-	void screenshake();
-	void updatescreenshake();
+	void flashlight(void);
+	void screenshake(void);
+	void updatescreenshake(void);
 
 	int screenshake_x;
 	int screenshake_y;
 
-	void render();
-	void renderwithscreeneffects();
+	void render(void);
+	void renderwithscreeneffects(void);
 
 	bool Hitest(SDL_Surface* surface1, point p1, SDL_Surface* surface2, point p2);
 
-	void drawentities();
+	void drawentities(void);
 
 	void drawentity(const int i, const int yoff);
 
-	void drawtrophytext();
+	void drawtrophytext(void);
 
 	void bigrprint(int x, int y, std::string& t, int r, int g, int b, bool cen = false, float sc = 2);
 
@@ -167,7 +167,7 @@ public:
 	void drawtowertile( int x, int y, int t );
 	void drawtowertile3( int x, int y, int t, TowerBG& bg_obj );
 
-	void drawmap();
+	void drawmap(void);
 
 	void drawforetile(int x, int y, int t);
 
@@ -177,23 +177,23 @@ public:
 
 	void drawrect(int x, int y, int w, int h, int r, int g, int b);
 
-	void drawtowermap();
+	void drawtowermap(void);
 
-	void drawtowerspikes();
+	void drawtowerspikes(void);
 
 	bool onscreen(int t);
 
-	void reloadresources();
+	void reloadresources(void);
 	std::string assetdir;
 
 
-	void menuoffrender();
+	void menuoffrender(void);
 
 	void drawtowerbackground(const TowerBG& bg_obj);
 	void updatetowerbackground(TowerBG& bg_obj);
 
 	void setcol(int t);
-	void drawfinalmap();
+	void drawfinalmap(void);
 
 	colourTransform ct;
 
@@ -310,7 +310,7 @@ public:
 	int col_tr;
 	int col_tg;
 	int col_tb;
-	void updatetitlecolours();
+	void updatetitlecolours(void);
 
 	bool kludgeswnlinewidth;
 

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -298,7 +298,7 @@ static int oldscrollamount = 0;
 static int scrollamount = 0;
 static bool isscrolling = 0;
 
-void UpdateFilter()
+void UpdateFilter(void)
 {
     if (rand() % 4000 < 8)
     {

--- a/desktop_version/src/GraphicsUtil.h
+++ b/desktop_version/src/GraphicsUtil.h
@@ -38,7 +38,7 @@ void FillRect( SDL_Surface* surface, SDL_Rect rect, int rgba );
 void ScrollSurface(SDL_Surface* _src, int pX, int py);
 
 SDL_Surface * FlipSurfaceVerticle(SDL_Surface* _src);
-void UpdateFilter();
+void UpdateFilter(void);
 SDL_Surface* ApplyFilter( SDL_Surface* _src );
 
 #endif /* GRAPHICSUTIL_H */

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -173,7 +173,7 @@ static void updatebuttonmappings(int bind)
     }
 }
 
-static void menuactionpress()
+static void menuactionpress(void)
 {
     switch (game.currentmenuname)
     {
@@ -1607,7 +1607,7 @@ static void menuactionpress()
     }
 }
 
-void titleinput()
+void titleinput(void)
 {
     //game.mx = (mouseX / 4);
     //game.my = (mouseY / 4);
@@ -1706,7 +1706,7 @@ void titleinput()
         script.startgamemode(game.mainmenu);
 }
 
-void gameinput()
+void gameinput(void)
 {
     //TODO mouse input
     //game.mx = (mouseX / 2);
@@ -2059,9 +2059,9 @@ void gameinput()
     }
 }
 
-static void mapmenuactionpress();
+static void mapmenuactionpress(void);
 
-void mapinput()
+void mapinput(void)
 {
     //TODO Mouse Input!
     //game.mx = (mouseX / 2);
@@ -2248,7 +2248,7 @@ void mapinput()
     }
 }
 
-static void mapmenuactionpress()
+static void mapmenuactionpress(void)
 {
     switch (game.menupage)
     {
@@ -2380,7 +2380,7 @@ static void mapmenuactionpress()
     }
 }
 
-void teleporterinput()
+void teleporterinput(void)
 {
     //Todo Mouseinput!
     //game.mx = (mouseX / 2);
@@ -2513,7 +2513,7 @@ void teleporterinput()
     }
 }
 
-void gamecompleteinput()
+void gamecompleteinput(void)
 {
     game.press_left = false;
     game.press_right = false;
@@ -2562,7 +2562,7 @@ void gamecompleteinput()
     }
 }
 
-void gamecompleteinput2()
+void gamecompleteinput2(void)
 {
     game.press_left = false;
     game.press_right = false;

--- a/desktop_version/src/Input.h
+++ b/desktop_version/src/Input.h
@@ -1,16 +1,16 @@
 #ifndef INPUT_H
 #define INPUT_H
 
-void titleinput();
+void titleinput(void);
 
-void gameinput();
+void gameinput(void);
 
-void mapinput();
+void mapinput(void);
 
-void teleporterinput();
+void teleporterinput(void);
 
-void gamecompleteinput();
+void gamecompleteinput(void);
 
-void gamecompleteinput2();
+void gamecompleteinput2(void);
 
 #endif /* INPUT_H */

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -9,7 +9,7 @@
 #include "Graphics.h"
 #include "Music.h"
 
-int inline KeyPoll::getThreshold()
+int inline KeyPoll::getThreshold(void)
 {
 	switch (sensitivity)
 	{
@@ -29,7 +29,7 @@ int inline KeyPoll::getThreshold()
 
 }
 
-KeyPoll::KeyPoll()
+KeyPoll::KeyPoll(void)
 {
 	xVel = 0;
 	yVel = 0;
@@ -62,23 +62,23 @@ KeyPoll::KeyPoll()
 	isActive = true;
 }
 
-void KeyPoll::enabletextentry()
+void KeyPoll::enabletextentry(void)
 {
 	keybuffer="";
 	SDL_StartTextInput();
 }
 
-void KeyPoll::disabletextentry()
+void KeyPoll::disabletextentry(void)
 {
 	SDL_StopTextInput();
 }
 
-bool KeyPoll::textentry()
+bool KeyPoll::textentry(void)
 {
 	return SDL_IsTextInputActive() == SDL_TRUE;
 }
 
-void KeyPoll::Poll()
+void KeyPoll::Poll(void)
 {
 	bool altpressed = false;
 	SDL_Event evt;
@@ -345,7 +345,7 @@ bool KeyPoll::isDown(SDL_GameControllerButton button)
 	return buttonmap[button];
 }
 
-bool KeyPoll::controllerButtonDown()
+bool KeyPoll::controllerButtonDown(void)
 {
 	for (
 		SDL_GameControllerButton button = SDL_CONTROLLER_BUTTON_A;

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -42,28 +42,28 @@ public:
 
 	int sensitivity;
 
-	int inline getThreshold();
+	int inline getThreshold(void);
 
-	KeyPoll();
+	KeyPoll(void);
 
-	void enabletextentry();
+	void enabletextentry(void);
 
-	void disabletextentry();
+	void disabletextentry(void);
 
-	void Poll();
+	void Poll(void);
 
 	bool isDown(SDL_Keycode key);
 
 	bool isDown(std::vector<SDL_GameControllerButton> buttons);
 	bool isDown(SDL_GameControllerButton button);
-	bool controllerButtonDown();
+	bool controllerButtonDown(void);
 	bool controllerWantsLeft(bool includeVert);
 	bool controllerWantsRight(bool includeVert);
 
 	int leftbutton, rightbutton, middlebutton;
 	int mx, my;
 
-	bool textentry();
+	bool textentry(void);
 	bool pressedbackspace;
 	std::string keybuffer;
 

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -10,7 +10,7 @@
 #include "Script.h"
 #include "UtilityClass.h"
 
-void titlelogic()
+void titlelogic(void)
 {
     //Misc
     //map.updatetowerglow(graphics.titlebg);
@@ -41,14 +41,14 @@ void titlelogic()
     }
 }
 
-void maplogic()
+void maplogic(void)
 {
     //Misc
     help.updateglow();
 }
 
 
-void gamecompletelogic()
+void gamecompletelogic(void)
 {
     //Misc
     map.updatetowerglow(graphics.titlebg);
@@ -81,7 +81,7 @@ void gamecompletelogic()
     }
 }
 
-void gamecompletelogic2()
+void gamecompletelogic2(void)
 {
     //Misc
     map.updatetowerglow(graphics.titlebg);
@@ -121,7 +121,7 @@ void gamecompletelogic2()
 }
 
 
-void gamelogic()
+void gamelogic(void)
 {
     //Misc
     if (map.towermode)

--- a/desktop_version/src/Logic.h
+++ b/desktop_version/src/Logic.h
@@ -1,14 +1,14 @@
 #ifndef LOGIC_H
 #define LOGIC_H
 
-void titlelogic();
+void titlelogic(void);
 
-void maplogic();
+void maplogic(void);
 
-void gamecompletelogic();
+void gamecompletelogic(void);
 
-void gamecompletelogic2();
+void gamecompletelogic2(void);
 
-void gamelogic();
+void gamelogic(void);
 
 #endif /* LOGIC_H */

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -10,7 +10,7 @@
 #include "Script.h"
 #include "UtilityClass.h"
 
-mapclass::mapclass()
+mapclass::mapclass(void)
 {
 	//Start here!
 	colstatedelay = 0;
@@ -128,13 +128,13 @@ void mapclass::settrinket(int x, int y)
 	shinytrinkets.push_back(temp);
 }
 
-void mapclass::resetmap()
+void mapclass::resetmap(void)
 {
 	//clear the explored area of the map
 	SDL_memset(explored, 0, sizeof(explored));
 }
 
-void mapclass::resetnames()
+void mapclass::resetnames(void)
 {
 	//Reset all the special names
 	specialnames[0] = "Rear Window";
@@ -393,7 +393,7 @@ std::string mapclass::getglitchname(int x, int y)
 	return roomname;
 }
 
-void mapclass::initmapdata()
+void mapclass::initmapdata(void)
 {
 	if (custommode)
 	{
@@ -443,7 +443,7 @@ void mapclass::initmapdata()
 	settrinket(10, 8);
 }
 
-void mapclass::initcustommapdata()
+void mapclass::initcustommapdata(void)
 {
 	shinytrinkets.clear();
 
@@ -622,7 +622,7 @@ void mapclass::updatetowerglow(TowerBG& bg_obj)
 	}
 }
 
-void mapclass::nexttowercolour()
+void mapclass::nexttowercolour(void)
 {
 	graphics.titlebg.colstate+=5;
 	if (graphics.titlebg.colstate >= 30) graphics.titlebg.colstate = 0;
@@ -721,7 +721,7 @@ int mapclass::area(int _rx, int _ry)
 	}
 }
 
-void mapclass::exploretower()
+void mapclass::exploretower(void)
 {
 	for (int i = 0; i < 20; i++)
 	{
@@ -729,7 +729,7 @@ void mapclass::exploretower()
 	}
 }
 
-void mapclass::hideship()
+void mapclass::hideship(void)
 {
 	//remove the ship from the explored areas
 	explored[2 + (10 * 20)] = 0;
@@ -740,7 +740,7 @@ void mapclass::hideship()
 	explored[4 + (11 * 20)] = 0;
 }
 
-void mapclass::showship()
+void mapclass::showship(void)
 {
 	//remove the ship from the explored areas
 	explored[2 + (10 * 20)] = 1;
@@ -751,7 +751,7 @@ void mapclass::showship()
 	explored[4 + (11 * 20)] = 1;
 }
 
-void mapclass::resetplayer()
+void mapclass::resetplayer(void)
 {
 	resetplayer(false);
 }
@@ -2048,7 +2048,7 @@ void mapclass::loadlevel(int rx, int ry)
 	}
 }
 
-void mapclass::twoframedelayfix()
+void mapclass::twoframedelayfix(void)
 {
 	// Fixes the two-frame delay in custom levels that use scripts to spawn an entity upon room load.
 	// Because when the room loads and newscript is set to run, newscript has already ran for that frame,

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -21,7 +21,7 @@ struct Roomtext
 class mapclass
 {
 public:
-    mapclass();
+    mapclass(void);
 
     int intpol(int a, int b, float c);
 
@@ -29,16 +29,16 @@ public:
 
     void settrinket(int x, int y);
 
-    void resetmap();
+    void resetmap(void);
 
-    void resetnames();
+    void resetnames(void);
 
     void transformname(int t);
 
     std::string getglitchname(int x, int y);
 
-    void initmapdata();
-    void initcustommapdata();
+    void initmapdata(void);
+    void initcustommapdata(void);
 
     int finalat(int x, int y);
 
@@ -52,7 +52,7 @@ public:
 
     void updatetowerglow(TowerBG& bg_obj);
 
-    void nexttowercolour();
+    void nexttowercolour(void);
 
     void settowercolour(int t);
 
@@ -65,14 +65,14 @@ public:
 
     int area(int _rx, int _ry);
 
-    void exploretower();
+    void exploretower(void);
 
-    void hideship();
+    void hideship(void);
 
-    void showship();
+    void showship(void);
 
     void resetplayer(const bool player_died);
-    void resetplayer();
+    void resetplayer(void);
 
     void warpto(int rx, int ry , int t, int tx, int ty);
 
@@ -82,7 +82,7 @@ public:
 
     void loadlevel(int rx, int ry);
 
-    void twoframedelayfix();
+    void twoframedelayfix(void);
 
 
     int roomdeaths[20 * 20];

--- a/desktop_version/src/Maths.h
+++ b/desktop_version/src/Maths.h
@@ -9,7 +9,7 @@
 
 //random
 //Returns 0..1
-float inline fRandom()
+float inline fRandom(void)
 {
     return ( float(rand()) / float(RAND_MAX)) ;
 }

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -8,9 +8,9 @@
 #include "Map.h"
 #include "UtilityClass.h"
 
-static void songend();
+static void songend(void);
 
-musicclass::musicclass()
+musicclass::musicclass(void)
 {
 	safeToProcessMusic= false;
 	m_doFadeInVol = false;
@@ -31,7 +31,7 @@ musicclass::musicclass()
 	usingmmmmmm = false;
 }
 
-void musicclass::init()
+void musicclass::init(void)
 {
 	soundTracks.push_back(SoundTrack( "sounds/jump.wav" ));
 	soundTracks.push_back(SoundTrack( "sounds/jump2.wav" ));
@@ -141,14 +141,14 @@ void musicclass::init()
 	}
 }
 
-static void songend()
+static void songend(void)
 {
 	extern musicclass music;
 	music.songEnd = SDL_GetPerformanceCounter();
 	music.currentsong = -1;
 }
 
-void musicclass::destroy()
+void musicclass::destroy(void)
 {
 	for (size_t i = 0; i < soundTracks.size(); ++i)
 	{
@@ -257,18 +257,18 @@ void musicclass::resume(const int fadein_ms /*= 0*/)
 	play(resumesong, position_sec, fadein_ms);
 }
 
-void musicclass::fadein()
+void musicclass::fadein(void)
 {
 	resume(3000); // 3000 ms fadein
 }
 
-void musicclass::haltdasmusik()
+void musicclass::haltdasmusik(void)
 {
 	Mix_HaltMusic();
 	resumesong = currentsong;
 }
 
-void musicclass::silencedasmusik()
+void musicclass::silencedasmusik(void)
 {
 	musicVolume = 0;
 }
@@ -286,7 +286,7 @@ void musicclass::fadeout(const bool quick_fade_ /*= true*/)
 	quick_fade = quick_fade_;
 }
 
-void musicclass::processmusicfadein()
+void musicclass::processmusicfadein(void)
 {
 	musicVolume += FadeVolAmountPerFrame;
 	if (musicVolume >= MIX_MAX_VOLUME)
@@ -295,7 +295,7 @@ void musicclass::processmusicfadein()
 	}
 }
 
-void musicclass::processmusic()
+void musicclass::processmusic(void)
 {
 	if(!safeToProcessMusic)
 	{

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -11,19 +11,19 @@
 class musicclass
 {
 public:
-	musicclass();
-	void init();
-	void destroy();
+	musicclass(void);
+	void init(void);
+	void destroy(void);
 
 	void play(int t, const double position_sec = 0.0, const int fadein_ms = 3000);
 	void resume(const int fadein_ms = 0);
-	void haltdasmusik();
-	void silencedasmusik();
+	void haltdasmusik(void);
+	void silencedasmusik(void);
 	void fadeMusicVolumeIn(int ms);
 	void fadeout(const bool quick_fade_ = true);
-	void fadein();
-	void processmusicfadein();
-	void processmusic();
+	void fadein(void);
+	void processmusicfadein(void);
+	void processmusic(void);
 	void niceplay(int t);
 
 	void changemusicarea(int x, int y);

--- a/desktop_version/src/Network.c
+++ b/desktop_version/src/Network.c
@@ -26,10 +26,10 @@
 
 #define NUM_BACKENDS (STEAM_NUM+GOG_NUM)
 #define DECLARE_BACKEND(name) \
-	int32_t name##_init(); \
-	void name##_shutdown(); \
-	void name##_update(); \
-	void name##_unlockAchievement(); \
+	int32_t name##_init(void); \
+	void name##_shutdown(void); \
+	void name##_update(void); \
+	void name##_unlockAchievement(void); \
 	int32_t name##_getAchievementProgress(const char *name); \
 	void name##_setAchievementProgress(const char *name, int32_t stat);
 #ifdef STEAM_NETWORK
@@ -43,10 +43,10 @@ DECLARE_BACKEND(GOG)
 typedef struct NetworkBackend
 {
 	int32_t IsInit;
-	int32_t (*Init)();
-	void (*Shutdown)();
-	void (*Update)();
-	void (*UnlockAchievement)();
+	int32_t (*Init)(void);
+	void (*Shutdown)(void);
+	void (*Update)(void);
+	void (*UnlockAchievement)(void);
 	int32_t (*GetAchievementProgress)(const char*);
 	void (*SetAchievementProgress)(const char*, int32_t);
 } NetworkBackend;
@@ -55,7 +55,7 @@ typedef struct NetworkBackend
 static NetworkBackend backends[NUM_BACKENDS];
 #endif
 
-int NETWORK_init()
+int NETWORK_init(void)
 {
 	int32_t any = 0;
 	#define ASSIGN_BACKEND(name, index) \
@@ -83,7 +83,7 @@ int NETWORK_init()
 	return any;
 }
 
-void NETWORK_shutdown()
+void NETWORK_shutdown(void)
 {
 	#if NUM_BACKENDS > 0
 	int32_t i;
@@ -95,7 +95,7 @@ void NETWORK_shutdown()
 	#endif
 }
 
-void NETWORK_update()
+void NETWORK_update(void)
 {
 	#if NUM_BACKENDS > 0
 	int32_t i;

--- a/desktop_version/src/Network.c
+++ b/desktop_version/src/Network.c
@@ -29,7 +29,7 @@
 	int32_t name##_init(void); \
 	void name##_shutdown(void); \
 	void name##_update(void); \
-	void name##_unlockAchievement(void); \
+	void name##_unlockAchievement(const char *name); \
 	int32_t name##_getAchievementProgress(const char *name); \
 	void name##_setAchievementProgress(const char *name, int32_t stat);
 #ifdef STEAM_NETWORK
@@ -46,7 +46,7 @@ typedef struct NetworkBackend
 	int32_t (*Init)(void);
 	void (*Shutdown)(void);
 	void (*Update)(void);
-	void (*UnlockAchievement)(void);
+	void (*UnlockAchievement)(const char*);
 	int32_t (*GetAchievementProgress)(const char*);
 	void (*SetAchievementProgress)(const char*, int32_t);
 } NetworkBackend;

--- a/desktop_version/src/Network.h
+++ b/desktop_version/src/Network.h
@@ -7,11 +7,11 @@
 extern "C" {
 #endif
 
-int32_t NETWORK_init();
+int32_t NETWORK_init(void);
 
-void NETWORK_shutdown();
+void NETWORK_shutdown(void);
 
-void NETWORK_update();
+void NETWORK_update(void);
 
 void NETWORK_unlockAchievement(const char *name);
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -27,7 +27,7 @@ static int inline FLIP(int ypos)
     return ypos;
 }
 
-static inline void drawslowdowntext()
+static inline void drawslowdowntext(void)
 {
     switch (game.slowdown)
     {
@@ -46,7 +46,7 @@ static inline void drawslowdowntext()
     }
 }
 
-static void menurender()
+static void menurender(void)
 {
     int temp = 50;
 
@@ -1218,7 +1218,7 @@ void titlerender()
     graphics.renderwithscreeneffects();
 }
 
-void gamecompleterender()
+void gamecompleterender(void)
 {
     FillRect(graphics.backBuffer, 0x000000);
 
@@ -1364,7 +1364,7 @@ void gamecompleterender()
     graphics.render();
 }
 
-void gamecompleterender2()
+void gamecompleterender2(void)
 {
     FillRect(graphics.backBuffer, 0x000000);
 
@@ -1396,7 +1396,7 @@ void gamecompleterender2()
     graphics.render();
 }
 
-void gamerender()
+void gamerender(void)
 {
 
 
@@ -1710,7 +1710,7 @@ void gamerender()
     graphics.renderwithscreeneffects();
 }
 
-void maprender()
+void maprender(void)
 {
     FillRect(graphics.backBuffer, 0x000000);
 
@@ -2467,7 +2467,7 @@ void maprender()
     }
 }
 
-void teleporterrender()
+void teleporterrender(void)
 {
     FillRect(graphics.backBuffer, 0x000000);
     int tempx;

--- a/desktop_version/src/Render.h
+++ b/desktop_version/src/Render.h
@@ -1,16 +1,16 @@
 #ifndef RENDER_H
 #define RENDER_H
 
-void titlerender();
+void titlerender(void);
 
-void gamerender();
+void gamerender(void);
 
-void maprender();
+void maprender(void);
 
-void teleporterrender();
+void teleporterrender(void);
 
-void gamecompleterender();
+void gamecompleterender(void);
 
-void gamecompleterender2();
+void gamecompleterender2(void);
 
 #endif /* RENDER_H */

--- a/desktop_version/src/RenderFixed.cpp
+++ b/desktop_version/src/RenderFixed.cpp
@@ -7,7 +7,7 @@
 #include "Script.h"
 #include "UtilityClass.h"
 
-void titleupdatetextcol()
+void titleupdatetextcol(void)
 {
     graphics.col_tr = graphics.titlebg.r - (help.glow / 4) - int(fRandom() * 4);
     graphics.col_tg = graphics.titlebg.g - (help.glow / 4) - int(fRandom() * 4);
@@ -20,7 +20,7 @@ void titleupdatetextcol()
     if(graphics.col_tb>255) graphics.col_tb=255;
 }
 
-void gamerenderfixed()
+void gamerenderfixed(void)
 {
     if (!game.blackout && !game.completestop)
     {
@@ -154,7 +154,7 @@ void gamerenderfixed()
 #endif
 }
 
-void titlerenderfixed()
+void titlerenderfixed(void)
 {
     if (!game.colourblindmode)
     {
@@ -182,7 +182,7 @@ void titlerenderfixed()
     }
 }
 
-void maprenderfixed()
+void maprenderfixed(void)
 {
     graphics.updatetextboxes();
     graphics.updatetitlecolours();
@@ -248,7 +248,7 @@ void maprenderfixed()
     }
 }
 
-void gamecompleterenderfixed()
+void gamecompleterenderfixed(void)
 {
     graphics.updatetitlecolours();
 

--- a/desktop_version/src/RenderFixed.h
+++ b/desktop_version/src/RenderFixed.h
@@ -1,14 +1,14 @@
 #ifndef RENDERFIXED_H
 #define RENDERFIXED_H
 
-void titleupdatetextcol();
+void titleupdatetextcol(void);
 
-void gamerenderfixed();
+void gamerenderfixed(void);
 
-void titlerenderfixed();
+void titlerenderfixed(void);
 
-void maprenderfixed();
+void maprenderfixed(void);
 
-void gamecompleterenderfixed();
+void gamecompleterenderfixed(void);
 
 #endif /* RENDERFIXED_H */

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -17,7 +17,7 @@ extern "C"
 	);
 }
 
-ScreenSettings::ScreenSettings()
+ScreenSettings::ScreenSettings(void)
 {
 	windowWidth = 320;
 	windowHeight = 240;
@@ -93,7 +93,7 @@ void Screen::init(const ScreenSettings& settings)
 	ResizeScreen(settings.windowWidth, settings.windowHeight);
 }
 
-void Screen::destroy()
+void Screen::destroy(void)
 {
 #define X(CLEANUP, POINTER) \
 	CLEANUP(POINTER); \
@@ -123,7 +123,7 @@ void Screen::GetSettings(ScreenSettings* settings)
 	settings->badSignal = badSignalEffect;
 }
 
-void Screen::LoadIcon()
+void Screen::LoadIcon(void)
 {
 	unsigned char *fileIn = NULL;
 	size_t length = 0;
@@ -212,7 +212,7 @@ void Screen::ResizeScreen(int x, int y)
 	SDL_ShowWindow(m_window);
 }
 
-void Screen::ResizeToNearestMultiple()
+void Screen::ResizeToNearestMultiple(void)
 {
 	int w, h;
 	GetWindowSize(&w, &h);
@@ -297,12 +297,12 @@ void Screen::UpdateScreen(SDL_Surface* buffer, SDL_Rect* rect )
 
 }
 
-const SDL_PixelFormat* Screen::GetFormat()
+const SDL_PixelFormat* Screen::GetFormat(void)
 {
 	return m_screen->format;
 }
 
-void Screen::FlipScreen()
+void Screen::FlipScreen(void)
 {
 	SDL_UpdateTexture(
 		m_screenTexture,
@@ -321,19 +321,19 @@ void Screen::FlipScreen()
 	SDL_FillRect(m_screen, NULL, 0x00000000);
 }
 
-void Screen::toggleFullScreen()
+void Screen::toggleFullScreen(void)
 {
 	isWindowed = !isWindowed;
 	ResizeScreen(-1, -1);
 }
 
-void Screen::toggleStretchMode()
+void Screen::toggleStretchMode(void)
 {
 	stretchMode = (stretchMode + 1) % 3;
 	ResizeScreen(-1, -1);
 }
 
-void Screen::toggleLinearFilter()
+void Screen::toggleLinearFilter(void)
 {
 	isFiltered = !isFiltered;
 	SDL_SetHintWithPriority(
@@ -351,7 +351,7 @@ void Screen::toggleLinearFilter()
 	);
 }
 
-void Screen::resetRendererWorkaround()
+void Screen::resetRendererWorkaround(void)
 {
 	SDL_SetHintWithPriority(
 		SDL_HINT_RENDER_VSYNC,

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -9,25 +9,25 @@ class Screen
 {
 public:
 	void init(const ScreenSettings& settings);
-	void destroy();
+	void destroy(void);
 
 	void GetSettings(ScreenSettings* settings);
 
-	void LoadIcon();
+	void LoadIcon(void);
 
 	void ResizeScreen(int x, int y);
-	void ResizeToNearestMultiple();
+	void ResizeToNearestMultiple(void);
 	void GetWindowSize(int* x, int* y);
 
 	void UpdateScreen(SDL_Surface* buffer, SDL_Rect* rect);
-	void FlipScreen();
+	void FlipScreen(void);
 
-	const SDL_PixelFormat* GetFormat();
+	const SDL_PixelFormat* GetFormat(void);
 
-	void toggleFullScreen();
-	void toggleStretchMode();
-	void toggleLinearFilter();
-	void resetRendererWorkaround();
+	void toggleFullScreen(void);
+	void toggleStretchMode(void);
+	void toggleLinearFilter(void);
+	void resetRendererWorkaround(void);
 
 	bool isWindowed;
 	bool isFiltered;

--- a/desktop_version/src/ScreenSettings.h
+++ b/desktop_version/src/ScreenSettings.h
@@ -3,7 +3,7 @@
 
 struct ScreenSettings
 {
-	ScreenSettings();
+	ScreenSettings(void);
 
 	int windowWidth;
 	int windowHeight;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -13,7 +13,7 @@
 #include "Music.h"
 #include "UtilityClass.h"
 
-scriptclass::scriptclass()
+scriptclass::scriptclass(void)
 {
 	position = 0;
 	scriptdelay = 0;
@@ -32,7 +32,7 @@ scriptclass::scriptclass()
 	texty = 0;
 }
 
-void scriptclass::clearcustom()
+void scriptclass::clearcustom(void)
 {
 	customscripts.clear();
 }
@@ -76,7 +76,7 @@ void scriptclass::tokenize( const std::string& t )
 	}
 }
 
-void scriptclass::run()
+void scriptclass::run(void)
 {
 	if (!running)
 	{
@@ -2624,7 +2624,7 @@ void scriptclass::run()
 	}
 }
 
-void scriptclass::resetgametomenu()
+void scriptclass::resetgametomenu(void)
 {
 	obj.entities.clear();
 	game.quittomenu();
@@ -3400,7 +3400,7 @@ void scriptclass::startgamemode( int t )
 	}
 }
 
-void scriptclass::teleport()
+void scriptclass::teleport(void)
 {
 	//er, ok! Teleport to a new area, so!
 	//A general rule of thumb: if you teleport with a companion, get rid of them!
@@ -3526,7 +3526,7 @@ void scriptclass::teleport()
 	}
 }
 
-void scriptclass::hardreset()
+void scriptclass::hardreset(void)
 {
 	//Game:
 	game.hascontrol = true;

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -20,7 +20,7 @@ class scriptclass
 public:
 
 
-    scriptclass();
+    scriptclass(void);
 
     void load(const std::string& name);
     void loadother(const char* t);
@@ -31,19 +31,19 @@ public:
         commands.push_back(t);
     }
 
-    void clearcustom();
+    void clearcustom(void);
 
     void tokenize(const std::string& t);
 
-    void run();
+    void run(void);
 
-    void resetgametomenu();
+    void resetgametomenu(void);
 
     void startgamemode(int t);
 
-    void teleport();
+    void teleport(void);
 
-    void hardreset();
+    void hardreset(void);
 
     //Script contents
     std::vector<std::string> commands;

--- a/desktop_version/src/SoundSystem.cpp
+++ b/desktop_version/src/SoundSystem.cpp
@@ -48,7 +48,7 @@ SoundTrack::SoundTrack(const char* fileName)
 	}
 }
 
-SoundSystem::SoundSystem()
+SoundSystem::SoundSystem(void)
 {
 	int audio_rate = 44100;
 	Uint16 audio_format = AUDIO_S16SYS;

--- a/desktop_version/src/SoundSystem.h
+++ b/desktop_version/src/SoundSystem.h
@@ -22,7 +22,7 @@ public:
 class SoundSystem
 {
 public:
-	SoundSystem();
+	SoundSystem(void);
 };
 
 #endif /* SOUNDSYSTEM_H */

--- a/desktop_version/src/SteamNetwork.c
+++ b/desktop_version/src/SteamNetwork.c
@@ -25,12 +25,12 @@
 
 /* Function Pointer Types */
 
-typedef uint8_t (*SteamAPI_InitFunc)();
-typedef void (*SteamAPI_ShutdownFunc)();
-typedef void (*SteamAPI_RunCallbacksFunc)();
+typedef uint8_t (*SteamAPI_InitFunc)(void);
+typedef void (*SteamAPI_ShutdownFunc)(void);
+typedef void (*SteamAPI_RunCallbacksFunc)(void);
 typedef intptr_t (*SteamInternal_CreateInterfaceFunc)(const char*);
-typedef int32_t (*SteamAPI_GetHSteamUserFunc)();
-typedef int32_t (*SteamAPI_GetHSteamPipeFunc)();
+typedef int32_t (*SteamAPI_GetHSteamUserFunc)(void);
+typedef int32_t (*SteamAPI_GetHSteamPipeFunc)(void);
 typedef intptr_t (*SteamAPI_ISteamClient_GetISteamUserStatsFunc)(
 	intptr_t,
 	int32_t,
@@ -76,7 +76,7 @@ DEFINE_FUNC(SteamAPI_ISteamUserStats_SetAchievement)
 
 /* Clean up after ourselves... */
 
-static void ClearPointers()
+static void ClearPointers(void)
 {
 	SDL_UnloadObject(libHandle);
 	libHandle = NULL;
@@ -97,7 +97,7 @@ static void ClearPointers()
 
 /* NETWORK API Implementation */
 
-int32_t STEAM_init()
+int32_t STEAM_init(void)
 {
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__HAIKU__) || defined(__DragonFly__)
 	return 0;
@@ -167,7 +167,7 @@ int32_t STEAM_init()
 	return 1;
 }
 
-void STEAM_shutdown()
+void STEAM_shutdown(void)
 {
 	if (libHandle)
 	{
@@ -176,7 +176,7 @@ void STEAM_shutdown()
 	}
 }
 
-void STEAM_update()
+void STEAM_update(void)
 {
 	if (libHandle)
 	{

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -2,7 +2,7 @@
 
 #include <utf8/unchecked.h>
 
-textboxclass::textboxclass()
+textboxclass::textboxclass(void)
 {
     x = 0;
     y = 0;
@@ -29,20 +29,20 @@ textboxclass::textboxclass()
     textrect.h = 0;
 }
 
-void textboxclass::centerx()
+void textboxclass::centerx(void)
 {
     resize();
     xp = 160 - (w / 2);
     resize();
 }
-void textboxclass::centery()
+void textboxclass::centery(void)
 {
     resize();
     yp = 120 - (h / 2);
     resize();
 }
 
-void textboxclass::adjust()
+void textboxclass::adjust(void)
 {
     resize();
     if (xp < 10) xp = 10;
@@ -70,7 +70,7 @@ void textboxclass::setcol(int rr, int gg, int bb)
     b = bb;
 }
 
-void textboxclass::update()
+void textboxclass::update(void)
 {
     prev_tl = tl;
     if (tm == 0)
@@ -98,19 +98,19 @@ void textboxclass::update()
     }
 }
 
-void textboxclass::remove()
+void textboxclass::remove(void)
 {
     tm = 2;
     tl = 1.0f; //Remove mode
 }
 
-void textboxclass::removefast()
+void textboxclass::removefast(void)
 {
     tm = 2;
     tl = 0.4f; //Remove mode
 }
 
-void textboxclass::resize()
+void textboxclass::resize(void)
 {
     //Set the width and height to the correct sizes
     max = 0;

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -8,25 +8,25 @@
 class textboxclass
 {
 public:
-    textboxclass();
+    textboxclass(void);
 
-    void centerx();
+    void centerx(void);
 
-    void centery();
+    void centery(void);
 
-    void adjust();
+    void adjust(void);
 
     void initcol(int rr, int gg, int bb);
 
     void setcol(int rr, int gg, int bb);
 
-    void update();
+    void update(void);
 
-    void remove();
+    void remove(void);
 
-    void removefast();
+    void removefast(void);
 
-    void resize();
+    void resize(void);
 
     void addline(std::string t);
 public:

--- a/desktop_version/src/Tower.cpp
+++ b/desktop_version/src/Tower.cpp
@@ -3,7 +3,7 @@
 #include "MakeAndPlay.h"
 #include "UtilityClass.h"
 
-towerclass::towerclass()
+towerclass::towerclass(void)
 {
 	minitowermode = false;
 	//We init the lookup table:
@@ -91,7 +91,7 @@ int towerclass::miniat(int xp, int yp, int yoff)
 	return 0;
 }
 
-void towerclass::loadminitower1()
+void towerclass::loadminitower1(void)
 {
 	//Loads the first minitower into the array.
 #if !defined(MAKEANDPLAY)
@@ -202,7 +202,7 @@ void towerclass::loadminitower1()
 #endif
 }
 
-void towerclass::loadminitower2()
+void towerclass::loadminitower2(void)
 {
 #if !defined(MAKEANDPLAY)
 	static const short tmap[] = {
@@ -313,7 +313,7 @@ void towerclass::loadminitower2()
 }
 
 
-void towerclass::loadbackground()
+void towerclass::loadbackground(void)
 {
 	//Loads the background into the array.
 	static const short tmap[] = {
@@ -441,7 +441,7 @@ void towerclass::loadbackground()
 	SDL_memcpy(back, tmap, sizeof(back));
 }
 
-void towerclass::loadmap()
+void towerclass::loadmap(void)
 {
 	//Loads the map into the array.
 #if !defined(MAKEANDPLAY)

--- a/desktop_version/src/Tower.h
+++ b/desktop_version/src/Tower.h
@@ -4,7 +4,7 @@
 class towerclass
 {
 public:
-    towerclass();
+    towerclass(void);
 
     int backat(int xp, int yp, int yoff);
 
@@ -12,13 +12,13 @@ public:
 
     int miniat(int xp, int yp, int yoff);
 
-    void loadminitower1();
+    void loadminitower1(void);
 
-    void loadminitower2();
+    void loadminitower2(void);
 
-    void loadbackground();
+    void loadbackground(void);
 
-    void loadmap();
+    void loadmap(void);
 
     short back[40 * 120];
     short contents[40 * 700];

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -130,7 +130,7 @@ bool next_split_s(
 	return retval;
 }
 
-UtilityClass::UtilityClass() :
+UtilityClass::UtilityClass(void) :
 glow(0),
 	glowdir(0)
 {
@@ -251,7 +251,7 @@ bool UtilityClass::intersects( SDL_Rect A, SDL_Rect B )
 	return (SDL_HasIntersection(&A, &B) == SDL_TRUE);
 }
 
-void UtilityClass::updateglow()
+void UtilityClass::updateglow(void)
 {
 	slowsine++;
 	if (slowsine >= 64) slowsine = 0;

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -44,7 +44,7 @@ bool endsWith(const std::string& str, const std::string& suffix);
 class UtilityClass
 {
 public:
-    UtilityClass();
+    UtilityClass(void);
 
     static std::string String(int _v);
 
@@ -61,7 +61,7 @@ public:
 
     static bool intersects( SDL_Rect A, SDL_Rect B );
 
-    void updateglow();
+    void updateglow(void);
 
     int glow;
     int slowsine;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -29,7 +29,7 @@
 #endif
 #include <inttypes.h>
 
-edlevelclass::edlevelclass()
+edlevelclass::edlevelclass(void)
 {
     tileset=0;
     tilecol=0;
@@ -47,7 +47,7 @@ edlevelclass::edlevelclass()
     directmode=0;
 }
 
-editorclass::editorclass()
+editorclass::editorclass(void)
 {
     //We create a blank map
     SDL_memset(contents, 0, sizeof(contents));
@@ -97,7 +97,7 @@ static void levelZipCallback(const char* filename)
     }
 }
 
-void editorclass::loadZips()
+void editorclass::loadZips(void)
 {
     FILESYSTEM_enumerateLevelDirFileNames(levelZipCallback);
 }
@@ -219,7 +219,7 @@ static void levelMetaDataCallback(const char* filename)
     }
 }
 
-void editorclass::getDirectoryData()
+void editorclass::getDirectoryData(void)
 {
 
     ListOfMetaData.clear();
@@ -272,7 +272,7 @@ bool editorclass::getLevelMetaData(std::string& _path, LevelMetaData& _data )
     return true;
 }
 
-void editorclass::reset()
+void editorclass::reset(void)
 {
     version=2; //New smaller format change is 2
 
@@ -400,7 +400,7 @@ void editorclass::reset()
     loaded_filepath = "";
 }
 
-void editorclass::gethooks()
+void editorclass::gethooks(void)
 {
     //Scan through the script and create a hooks list based on it
     hooklist.clear();
@@ -486,7 +486,7 @@ bool editorclass::checkhook(std::string t)
 }
 
 
-void editorclass::clearscriptbuffer()
+void editorclass::clearscriptbuffer(void)
 {
     sb.clear();
 }
@@ -1423,7 +1423,7 @@ int editorclass::spikedir( int x, int y )
     return 8;
 }
 
-void editorclass::findstartpoint()
+void editorclass::findstartpoint(void)
 {
     //Ok! Scan the room for the closest checkpoint
     int testeditor=-1;
@@ -2120,7 +2120,7 @@ static void fillboxabs( int x, int y, int x2, int y2, int c )
 }
 
 
-void editorclass::generatecustomminimap()
+void editorclass::generatecustomminimap(void)
 {
     map.customwidth=mapwidth;
     map.customheight=mapheight;
@@ -2419,7 +2419,7 @@ static void editormenurender(int tr, int tg, int tb)
     }
 }
 
-void editorrender()
+void editorrender(void)
 {
     extern editorclass ed;
     if (game.shouldreturntoeditor)
@@ -3531,7 +3531,7 @@ void editorrender()
     graphics.render();
 }
 
-void editorrenderfixed()
+void editorrenderfixed(void)
 {
     extern editorclass ed;
     graphics.updatetitlecolours();
@@ -3591,7 +3591,7 @@ void editorrenderfixed()
     }
 }
 
-void editorlogic()
+void editorlogic(void)
 {
     extern editorclass ed;
     //Misc
@@ -3783,7 +3783,7 @@ static void editormenuactionpress()
     }
 }
 
-void editorinput()
+void editorinput(void)
 {
     extern editorclass ed;
     game.mx = (float) key.mx;
@@ -5614,7 +5614,7 @@ Uint32 editorclass::getonewaycol(const int rx, const int ry)
 }
 
 // This version detects the room automatically
-Uint32 editorclass::getonewaycol()
+Uint32 editorclass::getonewaycol(void)
 {
     if (game.gamestate == EDITORMODE)
         return getonewaycol(levx, levy);
@@ -5625,7 +5625,7 @@ Uint32 editorclass::getonewaycol()
     return graphics.getRGB(255, 255, 255);
 }
 
-int editorclass::numtrinkets()
+int editorclass::numtrinkets(void)
 {
     int temp = 0;
     for (size_t i = 0; i < edentity.size(); i++)
@@ -5638,7 +5638,7 @@ int editorclass::numtrinkets()
     return temp;
 }
 
-int editorclass::numcrewmates()
+int editorclass::numcrewmates(void)
 {
     int temp = 0;
     for (size_t i = 0; i < edentity.size(); i++)

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -43,7 +43,7 @@ public:
 
 class edlevelclass{
 public:
-  edlevelclass();
+  edlevelclass(void);
   int tileset, tilecol;
   std::string roomname;
   int warpdir;
@@ -76,7 +76,7 @@ class EditorData
 {
   public:
 
-  static EditorData& GetInstance()
+  static EditorData& GetInstance(void)
   {
     static EditorData  instance; // Guaranteed to be destroyed.
     // Instantiated on first use.
@@ -103,7 +103,7 @@ struct GhostInfo {
 class editorclass{
   //Special class to handle ALL editor variables locally
   public:
-  editorclass();
+  editorclass(void);
 
   std::string Desc1;
   std::string Desc2;
@@ -112,11 +112,11 @@ class editorclass{
 
   std::vector<LevelMetaData> ListOfMetaData;
 
-  void loadZips();
-  void getDirectoryData();
+  void loadZips(void);
+  void getDirectoryData(void);
   bool getLevelMetaData(std::string& filename, LevelMetaData& _data );
 
-  void reset();
+  void reset(void);
   void getlin(const enum textmode mode, const std::string& prompt, std::string* ptr);
   const short* loadlevel(int rxi, int ryi);
 
@@ -151,7 +151,7 @@ class editorclass{
 
   bool load(std::string& _path);
   bool save(std::string& _path);
-  void generatecustomminimap();
+  void generatecustomminimap(void);
   int edgetile(int x, int y);
   int outsideedgetile(int x, int y);
 
@@ -162,7 +162,7 @@ class editorclass{
   int findtrinket(int t);
   int findcrewmate(int t);
   int findwarptoken(int t);
-  void findstartpoint();
+  void findstartpoint(void);
   int getlevelcol(int t);
   int getenemycol(int t);
   int entcol;
@@ -176,8 +176,8 @@ class editorclass{
   static const int numrooms = maxwidth * maxheight;
   short contents[40 * 30 * numrooms];
   int vmult[30 * maxheight];
-  int numtrinkets();
-  int numcrewmates();
+  int numtrinkets(void);
+  int numcrewmates(void);
   edlevelclass level[numrooms]; //Maxwidth*maxheight
   int kludgewarpdir[numrooms]; //Also maxwidth*maxheight
 
@@ -242,8 +242,8 @@ class editorclass{
   void addhooktoscript(std::string t);
   void removehookfromscript(std::string t);
   void loadhookineditor(std::string t);
-  void clearscriptbuffer();
-  void gethooks();
+  void clearscriptbuffer(void);
+  void gethooks(void);
   bool checkhook(std::string t);
   std::vector<std::string> hooklist;
 
@@ -254,7 +254,7 @@ class editorclass{
   int dmtileeditor;
 
   Uint32 getonewaycol(const int rx, const int ry);
-  Uint32 getonewaycol();
+  Uint32 getonewaycol(void);
   bool onewaycol_override;
 
   int returneditoralpha;
@@ -265,13 +265,13 @@ class editorclass{
 };
 
 #if !defined(NO_EDITOR)
-void editorrender();
+void editorrender(void);
 
-void editorrenderfixed();
+void editorrenderfixed(void);
 
-void editorlogic();
+void editorlogic(void);
 
-void editorinput();
+void editorinput(void);
 #endif
 
 #ifndef ED_DEFINITION

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -73,10 +73,10 @@ static inline Uint32 get_framerate(const int slowdown)
     return 34;
 }
 
-static void inline deltaloop();
-static void inline fixedloop();
+static void inline deltaloop(void);
+static void inline fixedloop(void);
 
-static void cleanup();
+static void cleanup(void);
 
 int main(int argc, char *argv[])
 {
@@ -360,7 +360,7 @@ int main(int argc, char *argv[])
     return 0;
 }
 
-static void cleanup()
+static void cleanup(void)
 {
     /* Order matters! */
     game.savestatsandsettings();
@@ -380,7 +380,7 @@ void VVV_exit(const int exit_code)
     exit(exit_code);
 }
 
-static void inline deltaloop()
+static void inline deltaloop(void)
 {
     //timestep limit to 30
     const float rawdeltatime = static_cast<float>(time_ - timePrev);
@@ -448,7 +448,7 @@ static void inline deltaloop()
     }
 }
 
-static void inline fixedloop()
+static void inline fixedloop(void)
 {
     // Update network per frame.
     NETWORK_update();

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -11,7 +11,7 @@ static int pre_darkcol=0, pre_lightcol=0, pre_curcol=0, pre_coltimer=0, pre_offs
 static int pre_frontrectx=30, pre_frontrecty=20, pre_frontrectw=260, pre_frontrecth=200;
 static int pre_temprectx=0, pre_temprecty=0, pre_temprectw=320, pre_temprecth=240;
 
-void preloaderinput()
+void preloaderinput(void)
 {
   game.press_action = false;
 
@@ -26,7 +26,7 @@ void preloaderinput()
   }
 }
 
-void preloaderrenderfixed()
+void preloaderrenderfixed(void)
 {
   if (pre_transition < 30) pre_transition--;
   if(pre_transition>=30){
@@ -49,7 +49,7 @@ void preloaderrenderfixed()
   }
 }
 
-void preloaderrender()
+void preloaderrender(void)
 {
   if(pre_transition>=30){
     switch(pre_curcol) {

--- a/desktop_version/src/preloader.h
+++ b/desktop_version/src/preloader.h
@@ -1,10 +1,10 @@
 #ifndef PRELOADER_H
 #define PRELOADER_H
 
-void preloaderinput();
+void preloaderinput(void);
 
-void preloaderrender();
+void preloaderrender(void);
 
-void preloaderrenderfixed();
+void preloaderrenderfixed(void);
 
 #endif /* PRELOADER_H */


### PR DESCRIPTION
Apparently in C, if you have `void test();`, it's completely okay to do `test(2);`. The function will take in the argument, but just discard it and throw it away. It's like a trash can, and a rude one at that. If you declare it like `void test(void);`, this is prevented.

This is not a problem in C++ - doing `void test();` and `test(2);` is guaranteed to result in a compile error (this also means that right now, at least in all `.cpp` files, nobody is ever calling a void parameter function with arguments and having their arguments be thrown away). However, we may not be using C++ in the future, so I just want to lay down the precedent that if a function takes in no arguments, you must explicitly declare it as such.

And in fact, actually, doing this revealed that the forward-declares for `unlockAchievement()` in `Network.c` were mistakenly being declared with no arguments, even though that function takes in a `const char*` as an argument. I've fixed that in this PR, too.

I would've added `-Wstrict-prototypes`, but it produces an annoying warning message saying it doesn't work in C++ mode if you're compiling in C++ mode. So it can be added later.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
