### PR TITLE
Use SDL allocators for PhysFS

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -30,12 +30,31 @@ static void PLATFORM_getOSDirectory(char* output);
 static void PLATFORM_migrateSaveData(char* output);
 static void PLATFORM_copyFile(const char *oldLocation, const char *newLocation);
 
+static void* bridged_malloc(PHYSFS_uint64 size)
+{
+	return SDL_malloc(size);
+}
+
+static void* bridged_realloc(void* ptr, PHYSFS_uint64 size)
+{
+	return SDL_realloc(ptr, size);
+}
+
+static const PHYSFS_Allocator allocator = {
+	NULL,
+	NULL,
+	bridged_malloc,
+	bridged_realloc,
+	SDL_free
+};
+
 int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 {
 	char output[MAX_PATH];
 	int mkdirResult;
 	const char* pathSep = PHYSFS_getDirSeparator();
 
+	PHYSFS_setAllocator(&allocator);
 	PHYSFS_init(argvZero);
 	PHYSFS_permitSymbolicLinks(1);
 


### PR DESCRIPTION
PhysFS by default just uses system `malloc()`, `realloc()`, and `free()`; it provides a way to change them, with a struct named `PHYSFS_Allocator` and a function named `PHYSFS_setAllocator()`.

According to PhysFS docs, this function should be called before `PHYSFS_init()`, which is why this allocator stuff is handled in `FileSystemUtils.cpp`.

Also, I've had to make two "bridge" functions, because `PHYSFS_Allocator` wants pointers to functions taking in `PHYSFS_uint64`s, not `size_t`s.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
