### PR TITLE
Replace all SDL_RWFromMem() with SDL_RWFromConstMem()

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -92,7 +92,7 @@ void musicclass::init(void)
 	index = blob.getIndex(track_name); \
 	if (index >= 0 && index < blob.max_headers) \
 	{ \
-		rw = SDL_RWFromMem(blob.getAddress(index), blob.getSize(index)); \
+		rw = SDL_RWFromConstMem(blob.getAddress(index), blob.getSize(index)); \
 		if (rw == NULL) \
 		{ \
 			printf("Unable to read music file header: %s\n", SDL_GetError()); \
@@ -110,7 +110,7 @@ void musicclass::init(void)
 		size_t index_ = 0;
 		while (mmmmmm_blob.nextExtra(&index_))
 		{
-			rw = SDL_RWFromMem(mmmmmm_blob.getAddress(index_), mmmmmm_blob.getSize(index_));
+			rw = SDL_RWFromConstMem(mmmmmm_blob.getAddress(index_), mmmmmm_blob.getSize(index_));
 			musicTracks.push_back(MusicTrack( rw ));
 
 			num_mmmmmm_tracks++;
@@ -133,7 +133,7 @@ void musicclass::init(void)
 	size_t index_ = 0;
 	while (pppppp_blob.nextExtra(&index_))
 	{
-		rw = SDL_RWFromMem(pppppp_blob.getAddress(index_), pppppp_blob.getSize(index_));
+		rw = SDL_RWFromConstMem(pppppp_blob.getAddress(index_), pppppp_blob.getSize(index_));
 		musicTracks.push_back(MusicTrack( rw ));
 
 		num_pppppp_tracks++;

--- a/desktop_version/src/SoundSystem.cpp
+++ b/desktop_version/src/SoundSystem.cpp
@@ -38,7 +38,7 @@ SoundTrack::SoundTrack(const char* fileName)
 		fprintf(stderr, "Unable to load WAV file %s\n", fileName);
 		return;
 	}
-	SDL_RWops *fileIn = SDL_RWFromMem(mem, length);
+	SDL_RWops *fileIn = SDL_RWFromConstMem(mem, length);
 	sound = Mix_LoadWAV_RW(fileIn, 1);
 	FILESYSTEM_freeMemory(&mem);
 


### PR DESCRIPTION
Since we're not going to be writing to any of these RWops, we might as well just ensure that we don't by using `SDL_RWFromConstMem()`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
