### PR TITLE
Refactor assets mounting to not use the STL, and clean up some code as well

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -208,6 +208,14 @@ void FILESYSTEM_mountassets(const char* path)
 	const char* zip_normal;
 	char dir[MAX_PATH];
 
+	/* path is going to look like "levels/LEVELNAME.vvvvvv".
+	 * We want LEVELNAME, which entails starting from index 7
+	 * (which is how long "levels/" is)
+	 * and then grabbing path_size-14 characters
+	 * (14 chars because "levels/" and ".vvvvvv" are both 7 chars).
+	 * We also add 1 when calculating the amount of bytes to grab
+	 * to account for the null terminator.
+	 */
 	SDL_strlcpy(
 		filename,
 		&path[7],

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -164,7 +164,7 @@ char *FILESYSTEM_getUserLevelDirectory(void)
 	return levelDir;
 }
 
-static bool FILESYSTEM_directoryExists(const char *fname)
+static bool FILESYSTEM_exists(const char *fname)
 {
 	return PHYSFS_exists(fname);
 }
@@ -199,7 +199,7 @@ void FILESYSTEM_mountassets(const char* path)
 		zip_path = cstr;
 	}
 
-	if (cstr && FILESYSTEM_directoryExists(zippath.c_str())) {
+	if (cstr && FILESYSTEM_exists(zippath.c_str())) {
 		printf("Custom asset directory is .data.zip at %s\n", zippath.c_str());
 		FILESYSTEM_mount(zippath.c_str());
 		graphics.reloadresources();
@@ -223,7 +223,7 @@ void FILESYSTEM_mountassets(const char* path)
 		}
 		FILESYSTEM_assetsmounted = true;
 		graphics.reloadresources();
-	} else if (FILESYSTEM_directoryExists(dirpath.c_str())) {
+	} else if (FILESYSTEM_exists(dirpath.c_str())) {
 		printf("Custom asset directory exists at %s\n",dirpath.c_str());
 		FILESYSTEM_mount(dirpath.c_str());
 		graphics.reloadresources();

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -164,7 +164,7 @@ char *FILESYSTEM_getUserLevelDirectory(void)
 	return levelDir;
 }
 
-bool FILESYSTEM_directoryExists(const char *fname)
+static bool FILESYSTEM_directoryExists(const char *fname)
 {
 	return PHYSFS_exists(fname);
 }

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -240,10 +240,7 @@ void FILESYSTEM_mountassets(const char* path)
 
 		FILESYSTEM_assetsmounted = true;
 	}
-	else if (zip_normal != NULL
-	&& SDL_strcmp(zip_normal, "data.zip") != 0
-	&& !endsWith(zip_normal, "/data.zip")
-	&& endsWith(zip_normal, ".zip"))
+	else if (zip_normal != NULL && endsWith(zip_normal, ".zip"))
 	{
 		PHYSFS_File* zip = PHYSFS_openRead(zip_normal);
 

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -200,7 +200,7 @@ void FILESYSTEM_mountassets(const char* path)
 	}
 
 	if (cstr && FILESYSTEM_directoryExists(zippath.c_str())) {
-		printf("Custom asset directory exists at %s\n", zippath.c_str());
+		printf("Custom asset directory is .data.zip at %s\n", zippath.c_str());
 		FILESYSTEM_mount(zippath.c_str());
 		graphics.reloadresources();
 		FILESYSTEM_assetsmounted = true;
@@ -209,9 +209,15 @@ void FILESYSTEM_mountassets(const char* path)
 		PHYSFS_File* zip = PHYSFS_openRead(zip_path.c_str());
 		zip_path += ".data.zip";
 		if (zip == NULL) {
-			printf("error loading .zip: %s\n", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+			printf(
+				"Error loading .zip: %s\n",
+				PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
+			);
 		} else if (PHYSFS_mountHandle(zip, zip_path.c_str(), "/", 0) == 0) {
-			printf("error mounting .zip: %s\n", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+			printf(
+				"Error mounting .zip: %s\n",
+				PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
+			);
 		} else {
 			graphics.assetdir = zip_path;
 		}
@@ -223,7 +229,7 @@ void FILESYSTEM_mountassets(const char* path)
 		graphics.reloadresources();
 		FILESYSTEM_assetsmounted = true;
 	} else {
-		printf("Custom asset directory does not exist\n");
+		puts("Custom asset directory does not exist");
 		FILESYSTEM_assetsmounted = false;
 	}
 }

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -204,7 +204,7 @@ void FILESYSTEM_mountassets(const char* path)
 		FILESYSTEM_mount(zippath.c_str());
 		graphics.reloadresources();
 		FILESYSTEM_assetsmounted = true;
-	} else if (zip_path != "data.zip" && !endsWith(zip_path, "/data.zip") && endsWith(zip_path, ".zip")) {
+	} else if (zip_path != "data.zip" && !endsWith(zip_path.c_str(), "/data.zip") && endsWith(zip_path.c_str(), ".zip")) {
 		printf("Custom asset directory is .zip at %s\n", zip_path.c_str());
 		PHYSFS_File* zip = PHYSFS_openRead(zip_path.c_str());
 		zip_path += ".data.zip";

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -12,7 +12,6 @@ void FILESYSTEM_deinit(void);
 char *FILESYSTEM_getUserSaveDirectory(void);
 char *FILESYSTEM_getUserLevelDirectory(void);
 
-bool FILESYSTEM_directoryExists(const char *fname);
 void FILESYSTEM_mount(const char *fname);
 extern bool FILESYSTEM_assetsmounted;
 void FILESYSTEM_mountassets(const char *path);

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -323,15 +323,15 @@ bool is_positive_num(const char* str, const bool hex)
 	return true;
 }
 
-bool endsWith(const std::string& str, const std::string& suffix)
+bool endsWith(const char* str, const char* suffix)
 {
-	if (str.size() < suffix.size())
+	const size_t str_size = SDL_strlen(str);
+	const size_t suffix_size = SDL_strlen(suffix);
+
+	if (str_size < suffix_size)
 	{
 		return false;
 	}
-	return str.compare(
-		str.size() - suffix.size(),
-		suffix.size(),
-		suffix
-	) == 0;
+
+	return SDL_strcmp(&str[str_size - suffix_size], suffix) == 0;
 }

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -26,7 +26,7 @@ bool is_number(const char* str);
 
 bool is_positive_num(const char* str, const bool hex);
 
-bool endsWith(const std::string& str, const std::string& suffix);
+bool endsWith(const char* str, const char* suffix);
 
 #define INBOUNDS_VEC(index, vector) ((int) index >= 0 && (int) index < (int) vector.size())
 #define INBOUNDS_ARR(index, array) ((int) index >= 0 && (int) index < (int) SDL_arraysize(array))

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -80,17 +80,15 @@ static bool compare_nocase (std::string first, std::string second)
 
 static void levelZipCallback(const char* filename)
 {
-    std::string filename_ = filename;
-
-    if (endsWith(filename_.c_str(), ".zip"))
+    if (endsWith(filename, ".zip"))
     {
-        PHYSFS_File* zip = PHYSFS_openRead(filename_.c_str());
+        PHYSFS_File* zip = PHYSFS_openRead(filename);
 
-        if (!PHYSFS_mountHandle(zip, filename_.c_str(), "levels", 1))
+        if (!PHYSFS_mountHandle(zip, filename, "levels", 1))
         {
             printf(
                 "Could not mount %s: %s\n",
-                filename_.c_str(),
+                filename,
                 PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
             );
         }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -82,7 +82,7 @@ static void levelZipCallback(const char* filename)
 {
     std::string filename_ = filename;
 
-    if (endsWith(filename_, ".zip"))
+    if (endsWith(filename_.c_str(), ".zip"))
     {
         PHYSFS_File* zip = PHYSFS_openRead(filename_.c_str());
 
@@ -1822,7 +1822,7 @@ bool editorclass::load(std::string& _path)
                     // the linefeed + the extremely specific amount of
                     // whitespace at the end of the contents.
 
-                    if (endsWith(text, "\n            ")) // linefeed + exactly 12 spaces
+                    if (endsWith(text.c_str(), "\n            ")) // linefeed + exactly 12 spaces
                     {
                         // 12 spaces + 1 linefeed = 13 chars
                         text = text.substr(0, text.length()-13);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1848,7 +1848,6 @@ bool editorclass::load(std::string& _path)
             int i = 0;
             for( tinyxml2::XMLElement* edLevelClassElement = pElem->FirstChildElement(); edLevelClassElement; edLevelClassElement=edLevelClassElement->NextSiblingElement())
             {
-                std::string pKey(edLevelClassElement->Value());
                 if(edLevelClassElement->GetText() != NULL)
                 {
                     level[i].roomname = std::string(edLevelClassElement->GetText()) ;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1783,11 +1783,11 @@ bool editorclass::load(std::string& _path)
             for( tinyxml2::XMLElement* edEntityEl = pElem->FirstChildElement(); edEntityEl; edEntityEl=edEntityEl->NextSiblingElement())
             {
                 edentities entity;
+                const char* text = edEntityEl->GetText();
 
-                std::string pKey(edEntityEl->Value());
-                if (edEntityEl->GetText() != NULL)
+                if (text != NULL)
                 {
-                    std::string text(edEntityEl->GetText());
+                    size_t len = SDL_strlen(text);
 
                     // And now we come to the part where we have to deal with
                     // the terrible decisions of the past.
@@ -1820,13 +1820,13 @@ bool editorclass::load(std::string& _path)
                     // the linefeed + the extremely specific amount of
                     // whitespace at the end of the contents.
 
-                    if (endsWith(text.c_str(), "\n            ")) // linefeed + exactly 12 spaces
+                    if (endsWith(text, "\n            ")) // linefeed + exactly 12 spaces
                     {
                         // 12 spaces + 1 linefeed = 13 chars
-                        text = text.substr(0, text.length()-13);
+                        len -= 13;
                     }
 
-                    entity.scriptname = text;
+                    entity.scriptname = std::string(text, len);
                 }
                 edEntityEl->QueryIntAttribute("x", &entity.x);
                 edEntityEl->QueryIntAttribute("y", &entity.y);


### PR DESCRIPTION
`FILESYSTEM_mountassets()`, `FILESYSTEM_assets()`, and `endsWith()` no longer use `std::string`s, since they don't need to. Along the way, I also cleaned up some other code that interacted with them, because they needed it too.

As always, look at the commits for more info.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
