### PR TITLE
Fix transitive includes in Screen.cpp

### DIFF
--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -1,6 +1,7 @@
 #include "Screen.h"
 
-#include <stdlib.h>
+#include <SDL.h>
+#include <stdio.h>
 
 #include "FileSystemUtils.h"
 #include "GraphicsUtil.h"


### PR DESCRIPTION
`Screen.cpp` wasn't explicitly including `SDL.h`, instead relying on `Screen.h` to include it.

It was also relying on `SDL.h` to include `stdio.h` on Linux, which breaks because `SDL.h` doesn't include `stdio.h` on Windows. So `stdio.h` is now explicitly included as well.

`stdlib.h` is not used in this file.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
