### PR TITLE
Remove unused x and y attributes of blockclass

### DIFF
--- a/desktop_version/src/BlockV.cpp
+++ b/desktop_version/src/BlockV.cpp
@@ -23,9 +23,6 @@ void blockclass::clear(void)
 	g = 0;
 	b = 0;
 
-	x = 0.0f;
-	y = 0.0f;
-
 	/* std::strings get initialized automatically, but this is */
 	/* in case this function gets called again after construction */
 	script.clear();

--- a/desktop_version/src/BlockV.h
+++ b/desktop_version/src/BlockV.h
@@ -21,11 +21,6 @@ public:
     int xp, yp, wp, hp;
     std::string script, prompt;
     int r, g, b;
-
-    //These would come from the sprite in the flash
-    float x;
-    float y;
-
 };
 
 #endif /* BLOCKV_H */

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -800,8 +800,6 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
         break;
     case TRIGGER: //Trigger
         block.type = TRIGGER;
-        block.x = xp;
-        block.y = yp;
         block.wp = w;
         block.hp = h;
         block.rectset(xp, yp, w, h);
@@ -810,16 +808,12 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
         break;
     case DAMAGE: //Damage
         block.type = DAMAGE;
-        block.x = xp;
-        block.y = yp;
         block.wp = w;
         block.hp = h;
         block.rectset(xp, yp, w, h);
         break;
     case DIRECTIONAL: //Directional
         block.type = DIRECTIONAL;
-        block.x = xp;
-        block.y = yp;
         block.wp = w;
         block.hp = h;
         block.rectset(xp, yp, w, h);
@@ -835,8 +829,6 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
         break;
     case ACTIVITY: //Activity Zone
         block.type = ACTIVITY;
-        block.x = xp;
-        block.y = yp;
         block.wp = w;
         block.hp = h;
         block.rectset(xp, yp, w, h);


### PR DESCRIPTION
These float attributes are assigned to, and then never read again. The coordinate systems of blocks are a bit of a mess - some use `xp`/`yp`, some use `xp`/`yp` and `rect.x`/`rect.y` - but I can confidently say that these are never used, because it compiles fine if I remove the attributes from the class, plus remove all assignments to it.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
