### PR TITLE
Add bounds checks to fix undefined behavior with levels bigger than the size limit

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1250,9 +1250,8 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
 
 #if !defined(NO_CUSTOM_LEVELS)
     // Special case for gray Warp Zone tileset!
-    int room = game.roomx-100 + (game.roomy-100) * ed.maxwidth;
-    bool custom_gray = INBOUNDS_ARR(room, ed.level)
-    && ed.level[room].tileset == 3 && ed.level[room].tilecol == 6;
+    const edlevelclass* const room = ed.getroomprop(game.roomx - 100, game.roomy - 100);
+    bool custom_gray = room->tileset == 3 && room->tilecol == 6;
 #else
     bool custom_gray = false;
 #endif

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1726,9 +1726,8 @@ void Graphics::drawentity(const int i, const int yoff)
 
 #if !defined(NO_CUSTOM_LEVELS)
     // Special case for gray Warp Zone tileset!
-    const int room = game.roomx-100 + (game.roomy-100) * ed.maxwidth;
-    const bool custom_gray = INBOUNDS_ARR(room, ed.level)
-    && ed.level[room].tileset == 3 && ed.level[room].tilecol == 6;
+    const edlevelclass* const room = ed.getroomprop(game.roomx - 100, game.roomy - 100);
+    const bool custom_gray = room->tileset == 3 && room->tilecol == 6;
 #else
     const bool custom_gray = false;
 #endif

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2413,7 +2413,7 @@ void teleporterinput(void)
             {
                 point& tele = map.teleporters[i];
 
-                if (map.explored[tele.x + tele.y*20])
+                if (map.isexplored(tele.x, tele.y))
                 {
                     any_tele_unlocked = true;
                     break;
@@ -2430,7 +2430,7 @@ void teleporterinput(void)
                 tempx = map.teleporters[game.teleport_to_teleporter].x;
                 tempy = map.teleporters[game.teleport_to_teleporter].y;
             }
-            while (map.explored[tempx + (20 * tempy)] == 0);
+            while (!map.isexplored(tempx, tempy));
         }
         else if (game.press_right && any_tele_unlocked)
         {
@@ -2441,7 +2441,7 @@ void teleporterinput(void)
                 tempx = map.teleporters[game.teleport_to_teleporter].x;
                 tempy = map.teleporters[game.teleport_to_teleporter].y;
             }
-            while (map.explored[tempx + (20 * tempy)] == 0);
+            while (!map.isexplored(tempx, tempy));
         }
 
         if (game.press_map)

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -721,34 +721,46 @@ int mapclass::area(int _rx, int _ry)
 	}
 }
 
+bool mapclass::isexplored(const int rx, const int ry)
+{
+	const int roomnum = rx + ry*20;
+	return explored[roomnum];
+}
+
+void mapclass::setexplored(const int rx, const int ry, const bool status)
+{
+	const int roomnum = rx + ry*20;
+	explored[roomnum] = status;
+}
+
 void mapclass::exploretower(void)
 {
 	for (int i = 0; i < 20; i++)
 	{
-		explored[9 + (i * 20)] = 1;
+		setexplored(9, i, true);
 	}
 }
 
 void mapclass::hideship(void)
 {
 	//remove the ship from the explored areas
-	explored[2 + (10 * 20)] = 0;
-	explored[3 + (10 * 20)] = 0;
-	explored[4 + (10 * 20)] = 0;
-	explored[2 + (11 * 20)] = 0;
-	explored[3 + (11 * 20)] = 0;
-	explored[4 + (11 * 20)] = 0;
+	setexplored(2, 10, false);
+	setexplored(3, 10, false);
+	setexplored(4, 10, false);
+	setexplored(2, 11, false);
+	setexplored(3, 11, false);
+	setexplored(4, 11, false);
 }
 
 void mapclass::showship(void)
 {
-	//remove the ship from the explored areas
-	explored[2 + (10 * 20)] = 1;
-	explored[3 + (10 * 20)] = 1;
-	explored[4 + (10 * 20)] = 1;
-	explored[2 + (11 * 20)] = 1;
-	explored[3 + (11 * 20)] = 1;
-	explored[4 + (11 * 20)] = 1;
+	//show the ship in the explored areas
+	setexplored(2, 10, true);
+	setexplored(3, 10, true);
+	setexplored(4, 10, true);
+	setexplored(2, 11, true);
+	setexplored(3, 11, true);
+	setexplored(4, 11, true);
 }
 
 void mapclass::resetplayer(void)
@@ -1148,7 +1160,7 @@ void mapclass::loadlevel(int rx, int ry)
 	int t;
 	if (!finalmode)
 	{
-		explored[rx - 100 + ((ry - 100) * 20)] = true;
+		setexplored(rx - 100, ry - 100, true);
 		if (rx == 109 && !custommode)
 		{
 			exploretower();

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -724,13 +724,20 @@ int mapclass::area(int _rx, int _ry)
 bool mapclass::isexplored(const int rx, const int ry)
 {
 	const int roomnum = rx + ry*20;
-	return explored[roomnum];
+	if (INBOUNDS_ARR(roomnum, explored))
+	{
+		return explored[roomnum];
+	}
+	return false;
 }
 
 void mapclass::setexplored(const int rx, const int ry, const bool status)
 {
 	const int roomnum = rx + ry*20;
-	explored[roomnum] = status;
+	if (INBOUNDS_ARR(roomnum, explored))
+	{
+		explored[roomnum] = status;
+	}
 }
 
 void mapclass::exploretower(void)

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1571,24 +1571,11 @@ void mapclass::loadlevel(int rx, int ry)
 #if !defined(NO_CUSTOM_LEVELS)
 	case 12: //Custom level
 	{
-		const int curlevel = rx-100 + (ry-100) * ed.maxwidth;
-		const edlevelclass* room_ptr = NULL;
-		if (!INBOUNDS_ARR(curlevel, ed.level))
-		{
-			static edlevelclass blank;
-			blank.tileset = 1;
-			room_ptr = &blank;
-		}
-		else
-		{
-			room_ptr = &ed.level[curlevel];
-		}
-		const edlevelclass& room = *room_ptr;
-
-		game.customcol = ed.getlevelcol(curlevel) + 1;
+		const edlevelclass* const room = ed.getroomprop(rx - 100, ry - 100);
+		game.customcol = ed.getlevelcol(room->tileset, room->tilecol) + 1;
 		obj.customplatformtile = game.customcol * 12;
 
-		switch (room.tileset)
+		switch (room->tileset)
 		{
 		case 0: // Space Station
 			tileset = 0;
@@ -1601,7 +1588,7 @@ void mapclass::loadlevel(int rx, int ry)
 		case 2: // Lab
 			tileset = 1;
 			background = 2;
-			graphics.rcol = room.tilecol;
+			graphics.rcol = room->tilecol;
 			break;
 		case 3: // Warp Zone/intermission
 			tileset = 1;
@@ -1624,7 +1611,7 @@ void mapclass::loadlevel(int rx, int ry)
 			graphics.backgrounddrawn = false;
 		}
 
-		switch (room.warpdir)
+		switch (room->warpdir)
 		{
 		case 1:
 			warpx = true;
@@ -1644,7 +1631,7 @@ void mapclass::loadlevel(int rx, int ry)
 			break;
 		}
 
-		roomname = room.roomname;
+		roomname = room->roomname;
 		extrarow = 1;
 		const short* tmap = ed.loadlevel(rx, ry);
 		SDL_memcpy(contents, tmap, sizeof(contents));
@@ -1680,17 +1667,17 @@ void mapclass::loadlevel(int rx, int ry)
 			{
 				if (enemy)
 				{
-					bx1 = room.enemyx1;
-					by1 = room.enemyy1;
-					bx2 = room.enemyx2;
-					by2 = room.enemyy2;
+					bx1 = room->enemyx1;
+					by1 = room->enemyy1;
+					bx2 = room->enemyx2;
+					by2 = room->enemyy2;
 				}
 				else if (moving_plat)
 				{
-					bx1 = room.platx1;
-					by1 = room.platy1;
-					bx2 = room.platx2;
-					by2 = room.platy2;
+					bx1 = room->platx1;
+					by1 = room->platy1;
+					bx2 = room->platx2;
+					by2 = room->platy2;
 				}
 
 				// Enlarge bounding boxes to fix warping entities
@@ -1709,13 +1696,13 @@ void mapclass::loadlevel(int rx, int ry)
 			switch (ent.t)
 			{
 			case 1: // Enemies
-				obj.customenemy = room.enemytype;
+				obj.customenemy = room->enemytype;
 				obj.createentity(ex, ey, 56, ent.p1, 4, bx1, by1, bx2, by2);
 				break;
 			case 2: // Platforms and conveyors
 				if (ent.p1 <= 4)
 				{
-					obj.createentity(ex, ey, 2, ent.p1, room.platv, bx1, by1, bx2, by2);
+					obj.createentity(ex, ey, 2, ent.p1, room->platv, bx1, by1, bx2, by2);
 				}
 				else if (ent.p1 >= 5 && ent.p1 <= 8) // Conveyor
 				{

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -92,6 +92,9 @@ public:
     bool explored[20 * 20];
     int vmult[30];
 
+    bool isexplored(const int rx, const int ry);
+    void setexplored(const int rx, const int ry, const bool status);
+
     int background;
     int rcol;
     int tileset;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1813,7 +1813,7 @@ void maprender(void)
           if(map.customzoom==4){
             for (int j = 0; j < map.customheight; j++){
               for (int i = 0; i < map.customwidth; i++){
-                if(map.explored[i+(j*20)]==0){
+                if(!map.isexplored(i, j)){
                   //Draw the fog of war on the map
                   graphics.drawimage(2, map.custommmxoff+40 + (i * 48), map.custommmyoff+21 + (j * 36), false);
                   graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 48), map.custommmyoff+21 + (j * 36), false);
@@ -1840,7 +1840,7 @@ void maprender(void)
           }else if(map.customzoom==2){
             for (int j = 0; j < map.customheight; j++){
               for (int i = 0; i < map.customwidth; i++){
-                if(map.explored[i+(j*20)]==0){
+                if(!map.isexplored(i, j)){
                   //Draw the fog of war on the map
                   graphics.drawimage(2, map.custommmxoff+40 + (i * 24), map.custommmyoff+21 + (j * 18), false);
                   graphics.drawimage(2, map.custommmxoff+40 + 12 + (i * 24), map.custommmyoff+21 + (j * 18), false);
@@ -1852,7 +1852,7 @@ void maprender(void)
           }else{
             for (int j = 0; j < map.customheight; j++){
               for (int i = 0; i < map.customwidth; i++){
-                if(map.explored[i+(j*20)]==0){
+                if(!map.isexplored(i, j)){
                   //Draw the fog of war on the map
                   graphics.drawimage(2, map.custommmxoff+40 + (i * 12), map.custommmyoff+21 + (j * 9), false);
                 }
@@ -1923,7 +1923,7 @@ void maprender(void)
             {
                 for (int i = 0; i < 20; i++)
                 {
-                    if(map.explored[i+(j*20)]==0)
+                    if(!map.isexplored(i, j))
                     {
                         //Draw the fog of war on the map
                         graphics.drawimage(2, 40 + (i * 12), 21 + (j * 9), false);
@@ -1973,15 +1973,15 @@ void maprender(void)
             //draw legend details
             for (size_t i = 0; i < map.teleporters.size(); i++)
             {
-                if (map.showteleporters && map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)] > 0)
+                if (map.showteleporters && map.isexplored(map.teleporters[i].x, map.teleporters[i].y))
                 {
-                    int temp = 1126 + map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)];
+                    int temp = 1126 + (int) map.isexplored(map.teleporters[i].x, map.teleporters[i].y);
                     if (graphics.flipmode) temp += 3;
                     graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
                 }
-                else if(map.showtargets && map.explored[map.teleporters[i].x+(20*map.teleporters[i].y)]==0)
+                else if(map.showtargets && map.isexplored(map.teleporters[i].x, map.teleporters[i].y))
                 {
-                    int temp = 1126 + map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)];
+                    int temp = 1126 + (int) map.isexplored(map.teleporters[i].x, map.teleporters[i].y);
                     if (graphics.flipmode) temp += 3;
                     graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
                 }
@@ -2492,9 +2492,8 @@ void teleporterrender(void)
     {
         for (int i = 0; i < 20; i++)
         {
-            if(map.explored[i+(j*20)]==0)
+            if(!map.isexplored(i, j))
             {
-                //graphics.drawfillrect(10 + (i * 12), 21 + (j * 9), 12, 9, 16, 16, 16);
                 graphics.drawimage(2, 40 + (i * 12), 21 + (j * 9), false);
             }
         }
@@ -2525,15 +2524,15 @@ void teleporterrender(void)
     //draw legend details
     for (size_t i = 0; i < map.teleporters.size(); i++)
     {
-        if (map.showteleporters && map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)] > 0)
+        if (map.showteleporters && map.isexplored(map.teleporters[i].x, map.teleporters[i].y))
         {
-            temp = 1126 + map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)];
+            temp = 1126 + (int) map.isexplored(map.teleporters[i].x, map.teleporters[i].y);
             if (graphics.flipmode) temp += 3;
             graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
         }
-        else if(map.showtargets && map.explored[map.teleporters[i].x+(20*map.teleporters[i].y)]==0)
+        else if(map.showtargets && map.isexplored(map.teleporters[i].x, map.teleporters[i].y))
         {
-            temp = 1126 + map.explored[map.teleporters[i].x + (20 * map.teleporters[i].y)];
+            temp = 1126 + (int) map.isexplored(map.teleporters[i].x, map.teleporters[i].y);
             if (graphics.flipmode) temp += 3;
             graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
         }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1336,8 +1336,7 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "ifexplored")
 			{
-				int room = ss_toi(words[1]) + (20 * ss_toi(words[2]));
-				if (INBOUNDS_ARR(room, map.explored) && map.explored[room] == 1)
+				if (map.isexplored(ss_toi(words[1]), ss_toi(words[2])))
 				{
 					load(words[3]);
 					position--;
@@ -1395,19 +1394,11 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "hidecoordinates")
 			{
-				int room = ss_toi(words[1]) + (20 * ss_toi(words[2]));
-				if (INBOUNDS_ARR(room, map.explored))
-				{
-					map.explored[room] = false;
-				}
+				map.setexplored(ss_toi(words[1]), ss_toi(words[2]), false);
 			}
 			else if (words[0] == "showcoordinates")
 			{
-				int room = ss_toi(words[1]) + (20 * ss_toi(words[2]));
-				if (INBOUNDS_ARR(room, map.explored))
-				{
-					map.explored[room] = true;
-				}
+				map.setexplored(ss_toi(words[1]), ss_toi(words[2]), true);
 			}
 			else if (words[0] == "hideship")
 			{
@@ -1419,25 +1410,25 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "showsecretlab")
 			{
-				map.explored[16 + (20 * 5)] = 1;
-				map.explored[17 + (20 * 5)] = 1;
-				map.explored[18 + (20 * 5)] = 1;
-				map.explored[17 + (20 * 6)] = 1;
-				map.explored[18 + (20 * 6)] = 1;
-				map.explored[19 + (20 * 6)] = 1;
-				map.explored[19 + (20 * 7)] = 1;
-				map.explored[19 + (20 * 8)] = 1;
+				map.setexplored(16, 5, true);
+				map.setexplored(17, 5, true);
+				map.setexplored(18, 5, true);
+				map.setexplored(17, 6, true);
+				map.setexplored(18, 6, true);
+				map.setexplored(19, 6, true);
+				map.setexplored(19, 7, true);
+				map.setexplored(19, 8, true);
 			}
 			else if (words[0] == "hidesecretlab")
 			{
-				map.explored[16 + (20 * 5)] = 0;
-				map.explored[17 + (20 * 5)] = 0;
-				map.explored[18 + (20 * 5)] = 0;
-				map.explored[17 + (20 * 6)] = 0;
-				map.explored[18 + (20 * 6)] = 0;
-				map.explored[19 + (20 * 6)] = 0;
-				map.explored[19 + (20 * 7)] = 0;
-				map.explored[19 + (20 * 8)] = 0;
+				map.setexplored(16, 5, false);
+				map.setexplored(17, 5, false);
+				map.setexplored(18, 5, false);
+				map.setexplored(17, 6, false);
+				map.setexplored(18, 6, false);
+				map.setexplored(19, 6, false);
+				map.setexplored(19, 7, false);
+				map.setexplored(19, 8, false);
 			}
 			else if (words[0] == "showteleporters")
 			{
@@ -2969,7 +2960,7 @@ void scriptclass::startgamemode( int t )
 			obj.collect[j] = true;
 			for (i = 0; i < 20; i++)
 			{
-				map.explored[i + (j * 20)] = 1;
+				map.setexplored(i, j, true);
 			}
 		}
 		game.insecretlab = true;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -117,38 +117,36 @@ void scriptclass::run(void)
 			{
 				int temprx=ss_toi(words[1])-1;
 				int tempry=ss_toi(words[2])-1;
-				int curlevel=temprx+(ed.maxwidth*(tempry));
-				bool inbounds = INBOUNDS_ARR(curlevel, ed.level);
-				if (inbounds)
-				{
-					ed.level[curlevel].warpdir=ss_toi(words[3]);
-				}
+				const edlevelclass* room;
+				ed.setroomwarpdir(temprx, tempry, ss_toi(words[3]));
+
+				room = ed.getroomprop(temprx, tempry);
 
 				//Do we update our own room?
-				if(inbounds && game.roomx-100==temprx && game.roomy-100==tempry){
+				if(game.roomx-100==temprx && game.roomy-100==tempry){
 					//If screen warping, then override all that:
 					graphics.backgrounddrawn = false;
 					map.warpx=false; map.warpy=false;
-					if(ed.level[curlevel].warpdir==0){
+					if(room->warpdir==0){
 						map.background = 1;
 						//Be careful, we could be in a Lab or Warp Zone room...
-						if(ed.level[curlevel].tileset==2){
+						if(room->tileset==2){
 							//Lab
 							map.background = 2;
-							graphics.rcol = ed.level[curlevel].tilecol;
-						}else if(ed.level[curlevel].tileset==3){
+							graphics.rcol = room->tilecol;
+						}else if(room->tileset==3){
 							//Warp Zone
 							map.background = 6;
 						}
-					}else if(ed.level[curlevel].warpdir==1){
+					}else if(room->warpdir==1){
 						map.warpx=true;
 						map.background=3;
 						graphics.rcol = ed.getwarpbackground(temprx,tempry);
-					}else if(ed.level[curlevel].warpdir==2){
+					}else if(room->warpdir==2){
 						map.warpy=true;
 						map.background=4;
 						graphics.rcol = ed.getwarpbackground(temprx,tempry);
-					}else if(ed.level[curlevel].warpdir==3){
+					}else if(room->warpdir==3){
 						map.warpx=true; map.warpy=true;
 						map.background = 5;
 						graphics.rcol = ed.getwarpbackground(temprx,tempry);
@@ -157,8 +155,8 @@ void scriptclass::run(void)
 			}
 			if (words[0] == "ifwarp")
 			{
-				int room = ss_toi(words[1])-1+(ed.maxwidth*(ss_toi(words[2])-1));
-				if (INBOUNDS_ARR(room, ed.level) && ed.level[room].warpdir == ss_toi(words[3]))
+				const edlevelclass* const room = ed.getroomprop(ss_toi(words[1])-1, ss_toi(words[2])-1);
+				if (room->warpdir == ss_toi(words[3]))
 				{
 					load("custom_"+words[4]);
 					position--;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1032,13 +1032,28 @@ const edlevelclass* editorclass::getroomprop(const int rx, const int ry)
 {
     const int idx = getroompropidx(rx, ry);
 
-    return &level[idx];
+    if (INBOUNDS_ARR(idx, level))
+    {
+        return &level[idx];
+    }
+
+    static edlevelclass blank;
+    blank.tileset = 1;
+    blank.directmode = 1;
+    blank.roomname.clear();
+
+    return &blank;
 }
 
 #define FOREACH_PROP(NAME, TYPE) \
 void editorclass::setroom##NAME(const int rx, const int ry, const TYPE NAME) \
 { \
     const int idx = getroompropidx(rx, ry); \
+    \
+    if (!INBOUNDS_ARR(idx, level)) \
+    { \
+        return; \
+    } \
     \
     level[idx].NAME = NAME; \
 }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -547,27 +547,27 @@ const short* editorclass::loadlevel( int rxi, int ryi )
     return result;
 }
 
-int editorclass::getlevelcol(int t)
+int editorclass::getlevelcol(const int tileset, const int tilecol)
 {
-    if(level[t].tileset==0)  //Space Station
+    if(tileset==0)  //Space Station
     {
-        return level[t].tilecol;
+        return tilecol;
     }
-    else if(level[t].tileset==1)   //Outside
+    else if(tileset==1)   //Outside
     {
-        return 32+level[t].tilecol;
+        return 32+tilecol;
     }
-    else if(level[t].tileset==2)   //Lab
+    else if(tileset==2)   //Lab
     {
-        return 40+level[t].tilecol;
+        return 40+tilecol;
     }
-    else if(level[t].tileset==3)   //Warp Zone
+    else if(tileset==3)   //Warp Zone
     {
-        return 46+level[t].tilecol;
+        return 46+tilecol;
     }
-    else if(level[t].tileset==4)   //Ship
+    else if(tileset==4)   //Ship
     {
-        return 52+level[t].tilecol;
+        return 52+tilecol;
     }
     return 0;
 }
@@ -666,11 +666,11 @@ int editorclass::getenemycol(int t)
 
 int editorclass::getwarpbackground(int rx, int ry)
 {
-    int tmp=rx+(maxwidth*ry);
-    switch(level[tmp].tileset)
+    const edlevelclass* const room = getroomprop(rx, ry);
+    switch(room->tileset)
     {
     case 0: //Space Station
-        switch(level[tmp].tilecol)
+        switch(room->tilecol)
         {
         case 0:
             return 3;
@@ -774,7 +774,7 @@ int editorclass::getwarpbackground(int rx, int ry)
         }
         break;
     case 1: //Outside
-        switch(level[tmp].tilecol)
+        switch(room->tilecol)
         {
         case 0:
             return 3;
@@ -806,7 +806,7 @@ int editorclass::getwarpbackground(int rx, int ry)
         }
         break;
     case 2: //Lab
-        switch(level[tmp].tilecol)
+        switch(room->tilecol)
         {
         case 0:
             return 0;
@@ -835,7 +835,7 @@ int editorclass::getwarpbackground(int rx, int ry)
         }
         break;
     case 3: //Warp Zone
-        switch(level[tmp].tilecol)
+        switch(room->tilecol)
         {
         case 0:
             return 0;
@@ -864,7 +864,7 @@ int editorclass::getwarpbackground(int rx, int ry)
         }
         break;
     case 4: //Ship
-        switch(level[tmp].tilecol)
+        switch(room->tilecol)
         {
         case 0:
             return 5;
@@ -1023,6 +1023,31 @@ int editorclass::getabstile(const int x, const int y)
 }
 
 
+int editorclass::getroompropidx(const int rx, const int ry)
+{
+    return rx + ry*maxwidth;
+}
+
+const edlevelclass* editorclass::getroomprop(const int rx, const int ry)
+{
+    const int idx = getroompropidx(rx, ry);
+
+    return &level[idx];
+}
+
+#define FOREACH_PROP(NAME, TYPE) \
+void editorclass::setroom##NAME(const int rx, const int ry, const TYPE NAME) \
+{ \
+    const int idx = getroompropidx(rx, ry); \
+    \
+    level[idx].NAME = NAME; \
+}
+
+ROOM_PROPERTIES
+
+#undef FOREACH_PROP
+
+
 void editorclass::placetilelocal( int x, int y, int t )
 {
     if(x>=0 && y>=0 && x<40 && y<30)
@@ -1035,37 +1060,37 @@ void editorclass::placetilelocal( int x, int y, int t )
 int editorclass::base( int x, int y )
 {
     //Return the base tile for the given tileset and colour
-    int temp=x+(y*maxwidth);
-    if(level[temp].tileset==0)  //Space Station
+    const edlevelclass* const room = getroomprop(x, y);
+    if(room->tileset==0)  //Space Station
     {
-        if(level[temp].tilecol>=22)
+        if(room->tilecol>=22)
         {
-            return 483 + ((level[temp].tilecol-22)*3);
+            return 483 + ((room->tilecol-22)*3);
         }
-        else if(level[temp].tilecol>=11)
+        else if(room->tilecol>=11)
         {
-            return 283 + ((level[temp].tilecol-11)*3);
+            return 283 + ((room->tilecol-11)*3);
         }
         else
         {
-            return 83 + (level[temp].tilecol*3);
+            return 83 + (room->tilecol*3);
         }
     }
-    else if(level[temp].tileset==1)   //Outside
+    else if(room->tileset==1)   //Outside
     {
-        return 480 + (level[temp].tilecol*3);
+        return 480 + (room->tilecol*3);
     }
-    else if(level[temp].tileset==2)   //Lab
+    else if(room->tileset==2)   //Lab
     {
-        return 280 + (level[temp].tilecol*3);
+        return 280 + (room->tilecol*3);
     }
-    else if(level[temp].tileset==3)   //Warp Zone/Intermission
+    else if(room->tileset==3)   //Warp Zone/Intermission
     {
-        return 80 + (level[temp].tilecol*3);
+        return 80 + (room->tilecol*3);
     }
-    else if(level[temp].tileset==4)   //SHIP
+    else if(room->tileset==4)   //SHIP
     {
-        return 101 + (level[temp].tilecol*3);
+        return 101 + (room->tilecol*3);
     }
     return 0;
 }
@@ -1073,11 +1098,11 @@ int editorclass::base( int x, int y )
 int editorclass::backbase( int x, int y )
 {
     //Return the base tile for the background of the given tileset and colour
-    int temp=x+(y*maxwidth);
-    if(level[temp].tileset==0)  //Space Station
+    const edlevelclass* const room = getroomprop(x, y);
+    if(room->tileset==0)  //Space Station
     {
         //Pick depending on tilecol
-        switch(level[temp].tilecol)
+        switch(room->tilecol)
         {
         case 0:
         case 5:
@@ -1135,21 +1160,21 @@ int editorclass::backbase( int x, int y )
         }
 
     }
-    else if(level[temp].tileset==1)   //outside
+    else if(room->tileset==1)   //outside
     {
-        return 680 + (level[temp].tilecol*3);
+        return 680 + (room->tilecol*3);
     }
-    else if(level[temp].tileset==2)   //Lab
+    else if(room->tileset==2)   //Lab
     {
         return 0;
     }
-    else if(level[temp].tileset==3)   //Warp Zone/Intermission
+    else if(room->tileset==3)   //Warp Zone/Intermission
     {
-        return 120 + (level[temp].tilecol*3);
+        return 120 + (room->tilecol*3);
     }
-    else if(level[temp].tileset==4)   //SHIP
+    else if(room->tileset==4)   //SHIP
     {
-        return 741 + (level[temp].tilecol*3);
+        return 741 + (room->tilecol*3);
     }
     return 0;
 }
@@ -1578,14 +1603,8 @@ int editorclass::findwarptoken(int t)
 void editorclass::switch_tileset(const bool reversed /*= false*/)
 {
     const char* tilesets[] = {"Space Station", "Outside", "Lab", "Warp Zone", "Ship"};
-    const size_t roomnum = levx + levy*maxwidth;
-    if (!INBOUNDS_ARR(roomnum, level))
-    {
-        return;
-    }
-    edlevelclass& room = level[roomnum];
 
-    int tiles = room.tileset;
+    int tiles = getroomprop(levx, levy)->tileset;
 
     if (reversed)
     {
@@ -1598,7 +1617,7 @@ void editorclass::switch_tileset(const bool reversed /*= false*/)
 
     const int modulus = SDL_arraysize(tilesets);
     tiles = (tiles % modulus + modulus) % modulus;
-    room.tileset = tiles;
+    setroomtileset(levx, levy, tiles);
 
     clamp_tilecol(levx, levy);
 
@@ -1612,21 +1631,18 @@ void editorclass::switch_tileset(const bool reversed /*= false*/)
 
 void editorclass::switch_tilecol(const bool reversed /*= false*/)
 {
-    const size_t roomnum = levx + levy*maxwidth;
-    if (!INBOUNDS_ARR(roomnum, level))
-    {
-        return;
-    }
-    edlevelclass& room = level[roomnum];
+    int tilecol = getroomprop(levx, levy)->tilecol;
 
     if (reversed)
     {
-        room.tilecol--;
+        tilecol--;
     }
     else
     {
-        room.tilecol++;
+        tilecol++;
     }
+
+    setroomtilecol(levx, levy, tilecol);
 
     clamp_tilecol(levx, levy, true);
 
@@ -1637,15 +1653,9 @@ void editorclass::switch_tilecol(const bool reversed /*= false*/)
 
 void editorclass::clamp_tilecol(const int rx, const int ry, const bool wrap /*= false*/)
 {
-    const size_t roomnum = rx + ry*maxwidth;
-    if (!INBOUNDS_ARR(roomnum, level))
-    {
-        return;
-    }
-    edlevelclass& room = level[rx + ry*maxwidth];
-
-    const int tileset = room.tileset;
-    int tilecol = room.tilecol;
+    const edlevelclass* const room = getroomprop(rx, ry);
+    const int tileset = room->tileset;
+    int tilecol = room->tilecol;
 
     int mincol = -1;
     int maxcol = 5;
@@ -1682,19 +1692,14 @@ void editorclass::clamp_tilecol(const int rx, const int ry, const bool wrap /*= 
         tilecol = (wrap ? maxcol : mincol);
     }
 
-    room.tilecol = tilecol;
+    setroomtilecol(rx, ry, tilecol);
 }
 
 void editorclass::switch_enemy(const bool reversed /*= false*/)
 {
-    const size_t roomnum = levx + levy*maxwidth;
-    if (!INBOUNDS_ARR(roomnum, level))
-    {
-        return;
-    }
-    edlevelclass& room = level[roomnum];
+    const edlevelclass* const room = getroomprop(levx, levy);
 
-    int enemy = room.enemytype;
+    int enemy = room->enemytype;
 
     if (reversed)
     {
@@ -1707,7 +1712,7 @@ void editorclass::switch_enemy(const bool reversed /*= false*/)
 
     const int modulus = 10;
     enemy = (enemy % modulus + modulus) % modulus;
-    room.enemytype = enemy;
+    setroomenemytype(levx, levy, enemy);
 
     note = "Enemy Type Changed";
     notedelay = 45;
@@ -1930,6 +1935,11 @@ bool editorclass::load(std::string& _path)
             int i = 0;
             for( tinyxml2::XMLElement* edLevelClassElement = pElem->FirstChildElement(); edLevelClassElement; edLevelClassElement=edLevelClassElement->NextSiblingElement())
             {
+                if (!INBOUNDS_ARR(i, level))
+                {
+                    continue;
+                }
+
                 if(edLevelClassElement->GetText() != NULL)
                 {
                     level[i].roomname = std::string(edLevelClassElement->GetText()) ;
@@ -2248,7 +2258,7 @@ void editorclass::generatecustomminimap(void)
             {
                 //Ok, now scan over each square
                 tm=196;
-                if(level[i2 + (j2*maxwidth)].tileset==1) tm=96;
+                if(getroomprop(i2, j2)->tileset==1) tm=96;
 
                 for(int j=0; j<36; j++)
                 {
@@ -2274,7 +2284,7 @@ void editorclass::generatecustomminimap(void)
             {
                 //Ok, now scan over each square
                 tm=196;
-                if(level[i2 + (j2*maxwidth)].tileset==1) tm=96;
+                if(getroomprop(i2, j2)->tileset==1) tm=96;
 
                 for(int j=0; j<18; j++)
                 {
@@ -2299,7 +2309,7 @@ void editorclass::generatecustomminimap(void)
             {
                 //Ok, now scan over each square
                 tm=196;
-                if(level[i2 + (j2*maxwidth)].tileset==1) tm=96;
+                if(getroomprop(i2, j2)->tileset==1) tm=96;
 
                 for(int j=0; j<9; j++)
                 {
@@ -2501,6 +2511,8 @@ static void editormenurender(int tr, int tg, int tb)
 void editorrender(void)
 {
     extern editorclass ed;
+    const edlevelclass* const room = ed.getroomprop(ed.levx, ed.levy);
+
     //Draw grid
 
     ClearSurface(graphics.backBuffer);
@@ -2527,7 +2539,7 @@ void editorrender(void)
     //Or draw background
     if(!ed.settingsmod)
     {
-        switch(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir)
+        switch(room->warpdir)
         {
         case 1:
             graphics.rcol=ed.getwarpbackground(ed.levx, ed.levy);
@@ -2548,7 +2560,7 @@ void editorrender(void)
 
     //Draw map, in function
     int temp;
-    if(ed.level[ed.levx+(ed.maxwidth*ed.levy)].tileset==0 || ed.level[ed.levx+(ed.maxwidth*ed.levy)].tileset==10)
+    if(room->tileset==0 || room->tileset==10)
     {
         for (int j = 0; j < 30; j++)
         {
@@ -2607,9 +2619,7 @@ void editorrender(void)
     int temp2=edentat(ed.tilex+ (ed.levx*40),ed.tiley+ (ed.levy*30));
 
     // Special case for drawing gray entities
-    int current_room = (ed.levx+(ed.levy*ed.maxwidth));
-    bool custom_gray = INBOUNDS_ARR(current_room, ed.level)
-    && ed.level[current_room].tileset == 3 && ed.level[current_room].tilecol == 6;
+    bool custom_gray = room->tileset == 3 && room->tilecol == 6;
     colourTransform gray_ct;
     gray_ct.colour = 0xFFFFFFFF;
 
@@ -2629,7 +2639,7 @@ void editorrender(void)
                     graphics.setcol(18);
                     ed.entcolreal = graphics.ct.colour;
                 }
-                graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),ed.getenemyframe(ed.level[ed.levx+(ed.levy*ed.maxwidth)].enemytype),ed.entcolreal);
+                graphics.drawsprite((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),ed.getenemyframe(room->enemytype),ed.entcolreal);
                 if(edentity[i].p1==0) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "V", 255, 255, 255 - help.glow, false);
                 if(edentity[i].p1==1) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "^", 255, 255, 255 - help.glow, false);
                 if(edentity[i].p1==2) graphics.Print((edentity[i].x*8)- (ed.levx*40*8)+4,(edentity[i].y*8)- (ed.levy*30*8)+4, "<", 255, 255, 255 - help.glow, false);
@@ -2915,22 +2925,21 @@ void editorrender(void)
     else
     {
         //Draw boundaries
-        int tmp=ed.levx+(ed.levy*ed.maxwidth);
-        if(ed.level[tmp].enemyx1!=0 && ed.level[tmp].enemyy1!=0
-                && ed.level[tmp].enemyx2!=320 && ed.level[tmp].enemyy2!=240)
+        if(room->enemyx1!=0 && room->enemyy1!=0
+                && room->enemyx2!=320 && room->enemyy2!=240)
         {
-            fillboxabs( ed.level[tmp].enemyx1, ed.level[tmp].enemyy1,
-                       ed.level[tmp].enemyx2-ed.level[tmp].enemyx1,
-                       ed.level[tmp].enemyy2-ed.level[tmp].enemyy1,
+            fillboxabs( room->enemyx1, room->enemyy1,
+                       room->enemyx2-room->enemyx1,
+                       room->enemyy2-room->enemyy1,
                        graphics.getBGR(255-(help.glow/2),64,64));
         }
 
-        if(ed.level[tmp].platx1!=0 && ed.level[tmp].platy1!=0
-                && ed.level[tmp].platx2!=320 && ed.level[tmp].platy2!=240)
+        if(room->platx1!=0 && room->platy1!=0
+                && room->platx2!=320 && room->platy2!=240)
         {
-            fillboxabs( ed.level[tmp].platx1, ed.level[tmp].platy1,
-                       ed.level[tmp].platx2-ed.level[tmp].platx1,
-                       ed.level[tmp].platy2-ed.level[tmp].platy1,
+            fillboxabs( room->platx1, room->platy1,
+                       room->platx2-room->platx1,
+                       room->platy2-room->platy1,
                        graphics.getBGR(64,64,255-(help.glow/2)));
         }
     }
@@ -3030,7 +3039,7 @@ void editorrender(void)
     }
 
     //If in directmode, show current directmode tile
-    if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].directmode==1)
+    if(room->directmode==1)
     {
         //Tile box for direct mode
         int t2=0;
@@ -3046,7 +3055,7 @@ void editorrender(void)
             temp-=80;
             FillRect(graphics.backBuffer, 0,-t2,320,40, graphics.getRGB(0,0,0));
             FillRect(graphics.backBuffer, 0,-t2+40,320,2, graphics.getRGB(255,255,255));
-            if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
+            if(room->tileset==0)
             {
                 for(int i=0; i<40; i++)
                 {
@@ -3080,7 +3089,7 @@ void editorrender(void)
             FillRect(graphics.backBuffer, 44,44-t2,10,10, graphics.getRGB(196, 196, 255 - help.glow));
             FillRect(graphics.backBuffer, 45,45-t2,8,8, graphics.getRGB(0,0,0));
 
-            if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
+            if(room->tileset==0)
             {
                 graphics.drawtile(45,45-t2,ed.dmtile);
             }
@@ -3096,7 +3105,7 @@ void editorrender(void)
             FillRect(graphics.backBuffer, 44,11,10,10, graphics.getRGB(196, 196, 255 - help.glow));
             FillRect(graphics.backBuffer, 45,12,8,8, graphics.getRGB(0,0,0));
 
-            if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
+            if(room->tileset==0)
             {
                 graphics.drawtile(45,12,ed.dmtile);
             }
@@ -3448,7 +3457,7 @@ void editorrender(void)
         {
             //FillRect(graphics.backBuffer, 0,230,72,240, graphics.RGB(32,32,32));
             //FillRect(graphics.backBuffer, 0,231,71,240, graphics.RGB(0,0,0));
-            if(ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname!="")
+            if(room->roomname!="")
             {
                 if (graphics.translucentroomname)
                 {
@@ -3459,7 +3468,7 @@ void editorrender(void)
                 {
                     FillRect(graphics.backBuffer, 0,230+ed.roomnamehide,320,10, graphics.getRGB(0,0,0));
                 }
-                graphics.bprint(5,231+ed.roomnamehide,ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname, 196, 196, 255 - help.glow, true);
+                graphics.bprint(5,231+ed.roomnamehide,room->roomname, 196, 196, 255 - help.glow, true);
                 graphics.bprint(4, 222, "SPACE ^  SHIFT ^", 196, 196, 255 - help.glow, false);
                 graphics.bprint(268,222, "("+help.String(ed.levx+1)+","+help.String(ed.levy+1)+")",196, 196, 255 - help.glow, false);
             }
@@ -3569,9 +3578,10 @@ void editorrender(void)
 void editorrenderfixed(void)
 {
     extern editorclass ed;
+    const edlevelclass* const room = ed.getroomprop(ed.levx, ed.levy);
     graphics.updatetitlecolours();
 
-    game.customcol=ed.getlevelcol(ed.levx+(ed.levy*ed.maxwidth))+1;
+    game.customcol=ed.getlevelcol(room->tileset, room->tilecol)+1;
     ed.entcol=ed.getenemycol(game.customcol);
 
     graphics.setcol(ed.entcol);
@@ -3602,7 +3612,7 @@ void editorrenderfixed(void)
 
     if (!ed.settingsmod)
     {
-        switch(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir)
+        switch(room->warpdir)
         {
         case 1:
             graphics.rcol=ed.getwarpbackground(ed.levx, ed.levy);
@@ -3676,7 +3686,7 @@ void editorrenderfixed(void)
         }
     }
 
-    if (ed.level[ed.levx + ed.maxwidth*ed.levy].directmode == 1)
+    if (ed.getroomprop(ed.levx, ed.levy)->directmode == 1)
     {
         if (ed.dmtileeditor > 0)
         {
@@ -3688,7 +3698,7 @@ void editorrenderfixed(void)
         ed.dmtileeditor = 0;
     }
 
-    if (ed.level[ed.levx + ed.maxwidth*ed.levy].roomname != "")
+    if (ed.getroomprop(ed.levx, ed.levy)->roomname != "")
     {
         if (ed.tiley < 28)
         {
@@ -4633,14 +4643,14 @@ void editorinput(void)
             }
             if(key.keymap[SDLK_F10])
             {
-                if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].directmode==1)
+                if(ed.getroomprop(ed.levx, ed.levy)->directmode==1)
                 {
-                    ed.level[ed.levx+(ed.levy*ed.maxwidth)].directmode=0;
+                    ed.setroomdirectmode(ed.levx, ed.levy, 0);
                     ed.note="Direct Mode Disabled";
                 }
                 else
                 {
-                    ed.level[ed.levx+(ed.levy*ed.maxwidth)].directmode=1;
+                    ed.setroomdirectmode(ed.levx, ed.levy, 1);
                     ed.note="Direct Mode Enabled";
                 }
                 graphics.backgrounddrawn=false;
@@ -4669,26 +4679,26 @@ void editorinput(void)
 
             if(key.keymap[SDLK_w])
             {
-                ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir=(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir+1)%4;
-                if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir==0)
+                ed.setroomwarpdir(ed.levx, ed.levy, (ed.getroomprop(ed.levx, ed.levy)->warpdir+1)%4);
+                if(ed.getroomprop(ed.levx, ed.levy)->warpdir==0)
                 {
                     ed.note="Room warping disabled";
                     ed.notedelay=45;
                     graphics.backgrounddrawn=false;
                 }
-                else if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir==1)
+                else if(ed.getroomprop(ed.levx, ed.levy)->warpdir==1)
                 {
                     ed.note="Room warps horizontally";
                     ed.notedelay=45;
                     graphics.backgrounddrawn=false;
                 }
-                else if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir==2)
+                else if(ed.getroomprop(ed.levx, ed.levy)->warpdir==2)
                 {
                     ed.note="Room warps vertically";
                     ed.notedelay=45;
                     graphics.backgrounddrawn=false;
                 }
-                else if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].warpdir==3)
+                else if(ed.getroomprop(ed.levx, ed.levy)->warpdir==3)
                 {
                     ed.note="Room warps in all directions";
                     ed.notedelay=45;
@@ -4699,7 +4709,7 @@ void editorinput(void)
             if(key.keymap[SDLK_e])
             {
                 ed.keydelay = 6;
-                ed.getlin(TEXT_ROOMNAME, "Enter new room name:", &(ed.level[ed.levx+(ed.levy*ed.maxwidth)].roomname));
+                ed.getlin(TEXT_ROOMNAME, "Enter new room name:", const_cast<std::string*>(&(ed.getroomprop(ed.levx, ed.levy)->roomname)));
                 game.mapheld=true;
             }
             if (key.keymap[SDLK_g])
@@ -4936,20 +4946,18 @@ void editorinput(void)
                             else if(ed.boundarytype==1)
                             {
                                 //Enemy bounds
-                                int tmp=ed.levx+(ed.levy*ed.maxwidth);
-                                ed.level[tmp].enemyx1=ed.boundx1;
-                                ed.level[tmp].enemyy1=ed.boundy1;
-                                ed.level[tmp].enemyx2=ed.boundx2;
-                                ed.level[tmp].enemyy2=ed.boundy2;
+                                ed.setroomenemyx1(ed.levx, ed.levy, ed.boundx1);
+                                ed.setroomenemyy1(ed.levx, ed.levy, ed.boundy1);
+                                ed.setroomenemyx2(ed.levx, ed.levy, ed.boundx2);
+                                ed.setroomenemyy2(ed.levx, ed.levy, ed.boundy2);
                             }
                             else if(ed.boundarytype==2)
                             {
                                 //Platform bounds
-                                int tmp=ed.levx+(ed.levy*ed.maxwidth);
-                                ed.level[tmp].platx1=ed.boundx1;
-                                ed.level[tmp].platy1=ed.boundy1;
-                                ed.level[tmp].platx2=ed.boundx2;
-                                ed.level[tmp].platy2=ed.boundy2;
+                                ed.setroomplatx1(ed.levx, ed.levy, ed.boundx1);
+                                ed.setroomplaty1(ed.levx, ed.levy, ed.boundy1);
+                                ed.setroomplatx2(ed.levx, ed.levy, ed.boundx2);
+                                ed.setroomplaty2(ed.levx, ed.levy, ed.boundy2);
                             }
                             else if(ed.boundarytype==3)
                             {
@@ -5009,7 +5017,7 @@ void editorinput(void)
                         {
                             //place tiles
                             //Are we in direct mode?
-                            if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].directmode>=1)
+                            if(ed.getroomprop(ed.levx, ed.levy)->directmode>=1)
                             {
                                 if(ed.bmod)
                                 {
@@ -5488,11 +5496,11 @@ void editorinput(void)
         }
     }
 
-    if(ed.updatetiles && ed.level[ed.levx + (ed.levy*ed.maxwidth)].directmode==0)
+    if(ed.updatetiles && ed.getroomprop(ed.levx, ed.levy)->directmode==0)
     {
         ed.updatetiles=false;
         //Correctly set the tiles in the current room
-        switch(ed.level[ed.levx + (ed.levy*ed.maxwidth)].tileset)
+        switch(ed.getroomprop(ed.levx, ed.levy)->tileset)
         {
         case 0: //The Space Station
             for(int j=0; j<30; j++)
@@ -5583,7 +5591,7 @@ void editorinput(void)
                             ed.labspikedir(
                                 i,
                                 j,
-                                ed.level[ed.levx + (ed.maxwidth*ed.levy)].tilecol
+                                ed.getroomprop(ed.levx, ed.levy)->tilecol
                             )
                         );
                     }
@@ -5691,16 +5699,11 @@ void editorinput(void)
 // Much kudos to Dav999 for saving me a lot of work, because I stole these colors from const.lua in Ved! -Info Teddy
 Uint32 editorclass::getonewaycol(const int rx, const int ry)
 {
-    const int roomnum = rx + ry*maxwidth;
-    if (roomnum < 0 || roomnum >= 400)
-    {
-        return graphics.getRGB(255, 255, 255);
-    }
-    const edlevelclass& room = level[roomnum];
-    switch (room.tileset) {
+    const edlevelclass* const room = getroomprop(rx, ry);
+    switch (room->tileset) {
 
     case 0: // Space Station
-        switch (room.tilecol) {
+        switch (room->tilecol) {
         case -1:
             return graphics.getRGB(109, 109, 109);
         case 0:
@@ -5771,7 +5774,7 @@ Uint32 editorclass::getonewaycol(const int rx, const int ry)
         break;
 
     case 1: // Outside
-        switch (room.tilecol) {
+        switch (room->tilecol) {
         case 0:
             return graphics.getRGB(57, 86, 140);
         case 1:
@@ -5792,7 +5795,7 @@ Uint32 editorclass::getonewaycol(const int rx, const int ry)
         break;
 
     case 2: // Lab
-        switch (room.tilecol) {
+        switch (room->tilecol) {
         case 0:
             return graphics.getRGB(0, 165, 206);
         case 1:
@@ -5811,7 +5814,7 @@ Uint32 editorclass::getonewaycol(const int rx, const int ry)
         break;
 
     case 3: // Warp Zone
-        switch (room.tilecol) {
+        switch (room->tilecol) {
         case 0:
             return graphics.getRGB(113, 178, 197);
         case 1:
@@ -5830,7 +5833,7 @@ Uint32 editorclass::getonewaycol(const int rx, const int ry)
         break;
 
     case 4: // Ship
-        switch (room.tilecol) {
+        switch (room->tilecol) {
         case 0:
             return graphics.getRGB(0, 206, 39);
         case 1:

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -951,7 +951,14 @@ int editorclass::gettileidx(
     int mult;
     int idx;
 
-    mult = vmult[yoff];
+    if (INBOUNDS_ARR(yoff, vmult))
+    {
+        mult = vmult[yoff];
+    }
+    else
+    {
+        mult = 0;
+    }
 
     idx = x + rx*40 + mult;
 
@@ -967,6 +974,11 @@ void editorclass::settile(
 ) {
     const int idx = gettileidx(rx, ry, x, y);
 
+    if (!INBOUNDS_ARR(idx, contents))
+    {
+        return;
+    }
+
     contents[idx] = t;
 }
 
@@ -978,6 +990,11 @@ int editorclass::gettile(
 ) {
     const int idx = gettileidx(rx, ry, x, y);
 
+    if (!INBOUNDS_ARR(idx, contents))
+    {
+        return 0;
+    }
+
     return contents[idx];
 }
 
@@ -986,9 +1003,21 @@ int editorclass::getabstile(const int x, const int y)
     int idx;
     int yoff;
 
-    yoff = vmult[y];
+    if (INBOUNDS_ARR(y, vmult))
+    {
+        yoff = vmult[y];
+    }
+    else
+    {
+        yoff = 0;
+    }
 
     idx = x + yoff;
+
+    if (!INBOUNDS_ARR(idx, contents))
+    {
+        return 0;
+    }
 
     return contents[idx];
 }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -540,7 +540,7 @@ const short* editorclass::loadlevel( int rxi, int ryi )
     {
         for (int i = 0; i < 40; i++)
         {
-            result[i + j*40] = contents[i+(rxi*40)+vmult[j+(ryi*30)]];
+            result[i + j*40] = gettile(rxi, ryi, i, j);
         }
     }
 
@@ -941,12 +941,64 @@ int editorclass::getenemyframe(int t)
     }
 }
 
+int editorclass::gettileidx(
+    const int rx,
+    const int ry,
+    const int x,
+    const int y
+) {
+    const int yoff = y + ry*30;
+    int mult;
+    int idx;
+
+    mult = vmult[yoff];
+
+    idx = x + rx*40 + mult;
+
+    return idx;
+}
+
+void editorclass::settile(
+    const int rx,
+    const int ry,
+    const int x,
+    const int y,
+    const int t
+) {
+    const int idx = gettileidx(rx, ry, x, y);
+
+    contents[idx] = t;
+}
+
+int editorclass::gettile(
+    const int rx,
+    const int ry,
+    const int x,
+    const int y
+) {
+    const int idx = gettileidx(rx, ry, x, y);
+
+    return contents[idx];
+}
+
+int editorclass::getabstile(const int x, const int y)
+{
+    int idx;
+    int yoff;
+
+    yoff = vmult[y];
+
+    idx = x + yoff;
+
+    return contents[idx];
+}
+
 
 void editorclass::placetilelocal( int x, int y, int t )
 {
     if(x>=0 && y>=0 && x<40 && y<30)
     {
-        contents[x+(levx*40)+vmult[y+(levy*30)]]=t;
+        settile(levx, levy, x, y, t);
     }
     updatetiles=true;
 }
@@ -1082,7 +1134,7 @@ int editorclass::at( int x, int y )
 
     if(x>=0 && y>=0 && x<40 && y<30)
     {
-        return contents[x+(levx*40)+vmult[y+(levy*30)]];
+        return gettile(levx, levy, x, y);
     }
     return 0;
 }
@@ -1097,17 +1149,17 @@ int editorclass::freewrap( int x, int y )
 
     if(x>=0 && y>=0 && x<(mapwidth*40) && y<(mapheight*30))
     {
-        if(contents[x+vmult[y]]==0)
+        if(getabstile(x, y)==0)
         {
             return 0;
         }
         else
         {
-            if(contents[x+vmult[y]]>=2 && contents[x+vmult[y]]<80)
+            if(getabstile(x, y)>=2 && getabstile(x, y)<80)
             {
                 return 0;
             }
-            if(contents[x+vmult[y]]>=680)
+            if(getabstile(x, y)>=680)
             {
                 return 0;
             }
@@ -1126,7 +1178,7 @@ int editorclass::backonlyfree( int x, int y )
 
     if(x>=0 && y>=0 && x<40 && y<30)
     {
-        if(contents[x+(levx*40)+vmult[y+(levy*30)]]>=680)
+        if(gettile(levx, levy, x, y)>=680)
         {
             return 1;
         }
@@ -1144,7 +1196,7 @@ int editorclass::backfree( int x, int y )
 
     if(x>=0 && y>=0 && x<40 && y<30)
     {
-        if(contents[x+(levx*40)+vmult[y+(levy*30)]]==0)
+        if(gettile(levx, levy, x, y)==0)
         {
             return 0;
         }
@@ -1162,13 +1214,13 @@ int editorclass::spikefree( int x, int y )
 
     if(x>=0 && y>=0 && x<40 && y<30)
     {
-        if(contents[x+(levx*40)+vmult[y+(levy*30)]]==0)
+        if(gettile(levx, levy, x, y)==0)
         {
             return 0;
         }
         else
         {
-            if(contents[x+(levx*40)+vmult[y+(levy*30)]]>=680)
+            if(gettile(levx, levy, x, y)>=680)
             {
                 return 0;
             }
@@ -1187,17 +1239,17 @@ int editorclass::free( int x, int y )
 
     if(x>=0 && y>=0 && x<40 && y<30)
     {
-        if(contents[x+(levx*40)+vmult[y+(levy*30)]]==0)
+        if(gettile(levx, levy, x, y)==0)
         {
             return 0;
         }
         else
         {
-            if(contents[x+(levx*40)+vmult[y+(levy*30)]]>=2 && contents[x+(levx*40)+vmult[y+(levy*30)]]<80)
+            if(gettile(levx, levy, x, y)>=2 && gettile(levx, levy, x, y)<80)
             {
                 return 0;
             }
-            if(contents[x+(levx*40)+vmult[y+(levy*30)]]>=680)
+            if(gettile(levx, levy, x, y)>=680)
             {
                 return 0;
             }
@@ -1211,17 +1263,17 @@ int editorclass::absfree( int x, int y )
     //Returns 0 if tile is not a block, 1 otherwise, abs on grid
     if(x>=0 && y>=0 && x<mapwidth*40 && y<mapheight*30)
     {
-        if(contents[x+vmult[y]]==0)
+        if(getabstile(x, y)==0)
         {
             return 0;
         }
         else
         {
-            if(contents[x+vmult[y]]>=2 && contents[x+vmult[y]]<80)
+            if(getabstile(x, y)>=2 && getabstile(x, y)<80)
             {
                 return 0;
             }
-            if(contents[x+vmult[y]]>=680)
+            if(getabstile(x, y)>=680)
             {
                 return 0;
             }
@@ -1998,7 +2050,7 @@ bool editorclass::save(std::string& _path)
     {
         for(int x = 0; x < mapwidth*40; x++ )
         {
-            contentsString += help.String(contents[x + (maxwidth*40*y)]) + ",";
+            contentsString += help.String(getabstile(x, y)) + ",";
         }
     }
     xml::update_tag(data, "contents", contentsString.c_str());
@@ -2473,7 +2525,7 @@ void editorrender(void)
         {
             for (int i = 0; i < 40; i++)
             {
-                temp=ed.contents[i + (ed.levx*40) + ed.vmult[j+(ed.levy*30)]];
+                temp=ed.gettile(ed.levx, ed.levy, i, j);
                 if(temp>0) graphics.drawtile(i*8,j*8,temp);
             }
         }
@@ -2484,7 +2536,7 @@ void editorrender(void)
         {
             for (int i = 0; i < 40; i++)
             {
-                temp=ed.contents[i + (ed.levx*40) + ed.vmult[j+(ed.levy*30)]];
+                temp=ed.gettile(ed.levx, ed.levy, i, j);
                 if(temp>0) graphics.drawtile2(i*8,j*8,temp);
             }
         }
@@ -5401,7 +5453,7 @@ void editorinput(void)
 
                 if(key.middlebutton)
                 {
-                    ed.dmtile=ed.contents[ed.tilex + (ed.levx*40) + ed.vmult[ed.tiley + (ed.levy*30)]];
+                    ed.dmtile=ed.gettile(ed.levx, ed.levy, ed.tilex, ed.tiley);
                 }
             }
         }
@@ -5418,21 +5470,33 @@ void editorinput(void)
             {
                 for(int i=0; i<40; i++)
                 {
-                    int temp=i+(ed.levx*40) + ed.vmult[j+(ed.levy*30)];
-                    if(ed.contents[temp]>=3 && ed.contents[temp]<80)
+                    int temp=ed.gettile(ed.levx, ed.levy, i, j);
+                    if(temp>=3 && temp<80)
                     {
                         //Fix spikes
-                        ed.contents[temp]=ed.spikedir(i,j);
+                        ed.settile(ed.levx, ed.levy, i, j, ed.spikedir(i, j));
                     }
-                    else if(ed.contents[temp]==2 || ed.contents[temp]>=680)
+                    else if(temp==2 || temp>=680)
                     {
                         //Fix background
-                        ed.contents[temp]=ed.backedgetile(i,j)+ed.backbase(ed.levx,ed.levy);
+                        ed.settile(
+                            ed.levx,
+                            ed.levy,
+                            i,
+                            j,
+                            ed.backedgetile(i, j) + ed.backbase(ed.levx, ed.levy)
+                        );
                     }
-                    else if(ed.contents[temp]>0)
+                    else if(temp>0)
                     {
                         //Fix tiles
-                        ed.contents[temp]=ed.edgetile(i,j)+ed.base(ed.levx,ed.levy);
+                        ed.settile(
+                            ed.levx,
+                            ed.levy,
+                            i,
+                            j,
+                            ed.edgetile(i, j) + ed.base(ed.levx, ed.levy)
+                        );
                     }
                 }
             }
@@ -5442,21 +5506,33 @@ void editorinput(void)
             {
                 for(int i=0; i<40; i++)
                 {
-                    int temp=i+(ed.levx*40) + ed.vmult[j+(ed.levy*30)];
-                    if(ed.contents[temp]>=3 && ed.contents[temp]<80)
+                    int temp=ed.gettile(ed.levx, ed.levy, i, j);
+                    if(temp>=3 && temp<80)
                     {
                         //Fix spikes
-                        ed.contents[temp]=ed.spikedir(i,j);
+                        ed.settile(ed.levx, ed.levy, i, j, ed.spikedir(i, j));
                     }
-                    else if(ed.contents[temp]==2 || ed.contents[temp]>=680)
+                    else if(temp==2 || temp>=680)
                     {
                         //Fix background
-                        ed.contents[temp]=ed.outsideedgetile(i,j)+ed.backbase(ed.levx,ed.levy);
+                        ed.settile(
+                            ed.levx,
+                            ed.levy,
+                            i,
+                            j,
+                            ed.outsideedgetile(i, j) + ed.backbase(ed.levx, ed.levy)
+                        );
                     }
-                    else if(ed.contents[temp]>0)
+                    else if(temp>0)
                     {
                         //Fix tiles
-                        ed.contents[temp]=ed.edgetile(i,j)+ed.base(ed.levx,ed.levy);
+                        ed.settile(
+                            ed.levx,
+                            ed.levy,
+                            i,
+                            j,
+                            ed.edgetile(i, j) + ed.base(ed.levx, ed.levy)
+                        );
                     }
                 }
             }
@@ -5466,21 +5542,37 @@ void editorinput(void)
             {
                 for(int i=0; i<40; i++)
                 {
-                    int temp=i+(ed.levx*40) + ed.vmult[j+(ed.levy*30)];
-                    if(ed.contents[temp]>=3 && ed.contents[temp]<80)
+                    int temp=ed.gettile(ed.levx, ed.levy, i, j);
+                    if(temp>=3 && temp<80)
                     {
                         //Fix spikes
-                        ed.contents[temp]=ed.labspikedir(i,j, ed.level[ed.levx + (ed.maxwidth*ed.levy)].tilecol);
+                        ed.settile(
+                            ed.levx,
+                            ed.levy,
+                            i,
+                            j,
+                            ed.labspikedir(
+                                i,
+                                j,
+                                ed.level[ed.levx + (ed.maxwidth*ed.levy)].tilecol
+                            )
+                        );
                     }
-                    else if(ed.contents[temp]==2 || ed.contents[temp]>=680)
+                    else if(temp==2 || temp>=680)
                     {
                         //Fix background
-                        ed.contents[temp]=713;
+                        ed.settile(ed.levx, ed.levy, i, j, 713);
                     }
-                    else if(ed.contents[temp]>0)
+                    else if(temp>0)
                     {
                         //Fix tiles
-                        ed.contents[temp]=ed.edgetile(i,j)+ed.base(ed.levx,ed.levy);
+                        ed.settile(
+                            ed.levx,
+                            ed.levy,
+                            i,
+                            j,
+                            ed.edgetile(i, j) + ed.base(ed.levx, ed.levy)
+                        );
                     }
                 }
             }
@@ -5490,21 +5582,27 @@ void editorinput(void)
             {
                 for(int i=0; i<40; i++)
                 {
-                    int temp=i+(ed.levx*40) + ed.vmult[j+(ed.levy*30)];
-                    if(ed.contents[temp]>=3 && ed.contents[temp]<80)
+                    int temp=ed.gettile(ed.levx, ed.levy, i, j);
+                    if(temp>=3 && temp<80)
                     {
                         //Fix spikes
-                        ed.contents[temp]=ed.spikedir(i,j);
+                        ed.settile(ed.levx, ed.levy, i, j, ed.spikedir(i, j));
                     }
-                    else if(ed.contents[temp]==2 || ed.contents[temp]>=680)
+                    else if(temp==2 || temp>=680)
                     {
                         //Fix background
-                        ed.contents[temp]=713;
+                        ed.settile(ed.levx, ed.levy, i, j, 713);
                     }
-                    else if(ed.contents[temp]>0)
+                    else if(temp>0)
                     {
                         //Fix tiles
-                        ed.contents[temp]=ed.edgetile(i,j)+ed.base(ed.levx,ed.levy);
+                        ed.settile(
+                            ed.levx,
+                            ed.levy,
+                            i,
+                            j,
+                            ed.edgetile(i, j) + ed.base(ed.levx, ed.levy)
+                        );
                     }
                 }
             }
@@ -5514,21 +5612,33 @@ void editorinput(void)
             {
                 for(int i=0; i<40; i++)
                 {
-                    int temp=i+(ed.levx*40) + ed.vmult[j+(ed.levy*30)];
-                    if(ed.contents[temp]>=3 && ed.contents[temp]<80)
+                    int temp=ed.gettile(ed.levx, ed.levy, i, j);
+                    if(temp>=3 && temp<80)
                     {
                         //Fix spikes
-                        ed.contents[temp]=ed.spikedir(i,j);
+                        ed.settile(ed.levx, ed.levy, i, j, ed.spikedir(i, j));
                     }
-                    else if(ed.contents[temp]==2 || ed.contents[temp]>=680)
+                    else if(temp==2 || temp>=680)
                     {
                         //Fix background
-                        ed.contents[temp]=ed.backedgetile(i,j)+ed.backbase(ed.levx,ed.levy);
+                        ed.settile(
+                            ed.levx,
+                            ed.levy,
+                            i,
+                            j,
+                            ed.backedgetile(i, j) + ed.backbase(ed.levx, ed.levy)
+                        );
                     }
-                    else if(ed.contents[temp]>0)
+                    else if(temp>0)
                     {
                         //Fix tiles
-                        ed.contents[temp]=ed.edgetile(i,j)+ed.base(ed.levx,ed.levy);
+                        ed.settile(
+                            ed.levx,
+                            ed.levy,
+                            i,
+                            j,
+                            ed.edgetile(i, j) + ed.base(ed.levx, ed.levy)
+                        );
                     }
                 }
             }

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -120,6 +120,27 @@ class editorclass{
   void getlin(const enum textmode mode, const std::string& prompt, std::string* ptr);
   const short* loadlevel(int rxi, int ryi);
 
+  int gettileidx(
+    const int rx,
+    const int ry,
+    const int x,
+    const int y
+  );
+  void settile(
+    const int rx,
+    const int ry,
+    const int x,
+    const int y,
+    const int t
+  );
+  int gettile(
+    const int rx,
+    const int ry,
+    const int x,
+    const int y
+  );
+  int getabstile(const int x, const int y);
+
   void placetilelocal(int x, int y, int t);
 
   int getenemyframe(int t);

--- a/desktop_version/src/editor.h
+++ b/desktop_version/src/editor.h
@@ -41,15 +41,29 @@ public:
 };
 
 
+#define ROOM_PROPERTIES \
+  FOREACH_PROP(tileset, int) \
+  FOREACH_PROP(tilecol, int) \
+  FOREACH_PROP(roomname, std::string) \
+  FOREACH_PROP(warpdir, int) \
+  FOREACH_PROP(platx1, int) \
+  FOREACH_PROP(platy1, int) \
+  FOREACH_PROP(platx2, int) \
+  FOREACH_PROP(platy2, int) \
+  FOREACH_PROP(platv, int) \
+  FOREACH_PROP(enemyx1, int) \
+  FOREACH_PROP(enemyy1, int) \
+  FOREACH_PROP(enemyx2, int) \
+  FOREACH_PROP(enemyy2, int) \
+  FOREACH_PROP(enemytype, int) \
+  FOREACH_PROP(directmode, int)
+
 class edlevelclass{
 public:
   edlevelclass(void);
-  int tileset, tilecol;
-  std::string roomname;
-  int warpdir;
-  int platx1, platy1, platx2, platy2, platv;
-  int enemyx1, enemyy1, enemyx2, enemyy2, enemytype;
-  int directmode;
+#define FOREACH_PROP(NAME, TYPE) TYPE NAME;
+  ROOM_PROPERTIES
+#undef FOREACH_PROP
 };
 
 struct LevelMetaData
@@ -141,6 +155,13 @@ class editorclass{
   );
   int getabstile(const int x, const int y);
 
+  int getroompropidx(const int rx, const int ry);
+  const edlevelclass* getroomprop(const int rx, const int ry);
+#define FOREACH_PROP(NAME, TYPE) \
+  void setroom##NAME(const int rx, const int ry, const TYPE NAME);
+  ROOM_PROPERTIES
+#undef FOREACH_PROP
+
   void placetilelocal(int x, int y, int t);
 
   int getenemyframe(int t);
@@ -184,7 +205,7 @@ class editorclass{
   int findcrewmate(int t);
   int findwarptoken(int t);
   void findstartpoint(void);
-  int getlevelcol(int t);
+  int getlevelcol(const int tileset, const int tilecol);
   int getenemycol(int t);
   int entcol;
   Uint32 entcolreal;


### PR DESCRIPTION
This adds bounds checks so levels bigger than 20x20 don't run into undefined behavior.

Most of the work done is creating setter and getter funcs and replacing all existing raw accesses with those functions. Then the rest is just adding bounds checks to those functions.

Anyways, with this PR, it should no longer be possible to cause undefined behavior by going past the size limit. I tested it with Valgrind, to be sure.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
