### PR TITLE
Fix regression with background of level minimaps not being black

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2152,7 +2152,7 @@ void editorclass::generatecustomminimap(void)
         map.custommmysize=180-(map.custommmyoff*2);
     }
 
-    ClearSurface(graphics.images[12]);
+    FillRect(graphics.images[12], graphics.getRGB(0, 0, 0));
 
     int tm=0;
     int temp=0;


### PR DESCRIPTION
I had misread this line in #629 and thought that it was just clearing the entire surface, when really it was filling the surface with opaque black. `ClearSurface()` would instead make it transparent, which would mean when it got drawn, it would get drawn against blue, and not black. Whoops.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
