### PR TITLE
Fix handling of file sizes in FILESYSTEM_loadFileToMemory()

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -360,7 +360,7 @@ void FILESYSTEM_loadFileToMemory(
 	{
 		return;
 	}
-	PHYSFS_uint32 length = PHYSFS_fileLength(handle);
+	PHYSFS_sint64 length = PHYSFS_fileLength(handle);
 	if (len != NULL)
 	{
 		*len = length;

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -363,6 +363,10 @@ void FILESYSTEM_loadFileToMemory(
 	PHYSFS_sint64 length = PHYSFS_fileLength(handle);
 	if (len != NULL)
 	{
+		if (length < 0)
+		{
+			length = 0;
+		}
 		*len = length;
 	}
 	if (addnull)

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -386,7 +386,7 @@ void FILESYSTEM_loadFileToMemory(
 			VVV_exit(1);
 		}
 	}
-	int success = PHYSFS_readBytes(handle, *mem, length);
+	PHYSFS_sint64 success = PHYSFS_readBytes(handle, *mem, length);
 	if (success == -1)
 	{
 		FILESYSTEM_freeMemory(mem);


### PR DESCRIPTION
Three simple fixes: we no longer throw away 32 bits of information when grabbing the length of the file, if PhysFS gives us -1 for length we set it to 0, and the type of the return value of `PHYSFS_readBytes()` now matches the type of the value we store it in.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
