### PR TITLE
Abstract zip loading to FileSystemUtils

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -198,6 +198,20 @@ void FILESYSTEM_mount(const char *fname)
 	}
 }
 
+void FILESYSTEM_loadZip(const char* filename)
+{
+	PHYSFS_File* zip = PHYSFS_openRead(filename);
+
+	if (!PHYSFS_mountHandle(zip, filename, "levels", 1))
+	{
+		printf(
+			"Could not mount %s: %s\n",
+			filename,
+			PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
+		);
+	}
+}
+
 bool FILESYSTEM_assetsmounted = false;
 
 void FILESYSTEM_mountassets(const char* path)

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -13,6 +13,7 @@ char *FILESYSTEM_getUserSaveDirectory(void);
 char *FILESYSTEM_getUserLevelDirectory(void);
 
 void FILESYSTEM_mount(const char *fname);
+void FILESYSTEM_loadZip(const char* filename);
 extern bool FILESYSTEM_assetsmounted;
 void FILESYSTEM_mountassets(const char *path);
 void FILESYSTEM_unmountassets(void);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -4,7 +4,6 @@
 #include "editor.h"
 
 #include <algorithm>
-#include <physfs.h>
 #include <stdio.h>
 #include <string>
 #include <tinyxml2.h>
@@ -82,16 +81,7 @@ static void levelZipCallback(const char* filename)
 {
     if (endsWith(filename, ".zip"))
     {
-        PHYSFS_File* zip = PHYSFS_openRead(filename);
-
-        if (!PHYSFS_mountHandle(zip, filename, "levels", 1))
-        {
-            printf(
-                "Could not mount %s: %s\n",
-                filename,
-                PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
-            );
-        }
+        FILESYSTEM_loadZip(filename);
     }
 }
 


### PR DESCRIPTION
`editor.cpp` no longer calls PhysFS functions directly; its `physfs.h` include can now be dropped.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
