### PR TITLE
Fix false positive warning messages when loading levels directory (or at least fix most of them)

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -186,6 +186,11 @@ bool FILESYSTEM_isFile(const char* filename)
 	|| stat.filetype == PHYSFS_FILETYPE_SYMLINK;
 }
 
+bool FILESYSTEM_isMounted(const char* filename)
+{
+	return PHYSFS_getMountPoint(filename) != NULL;
+}
+
 static bool FILESYSTEM_exists(const char *fname)
 {
 	return PHYSFS_exists(fname);

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -164,6 +164,28 @@ char *FILESYSTEM_getUserLevelDirectory(void)
 	return levelDir;
 }
 
+bool FILESYSTEM_isFile(const char* filename)
+{
+	PHYSFS_Stat stat;
+
+	bool success = PHYSFS_stat(filename, &stat);
+
+	if (!success)
+	{
+		printf(
+			"Could not stat file: %s\n",
+			PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
+		);
+		return false;
+	}
+
+	/* We unfortunately cannot follow symlinks (PhysFS limitation).
+	 * Let the caller deal with them.
+	 */
+	return stat.filetype == PHYSFS_FILETYPE_REGULAR
+	|| stat.filetype == PHYSFS_FILETYPE_SYMLINK;
+}
+
 static bool FILESYSTEM_exists(const char *fname)
 {
 	return PHYSFS_exists(fname);

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -12,6 +12,8 @@ void FILESYSTEM_deinit(void);
 char *FILESYSTEM_getUserSaveDirectory(void);
 char *FILESYSTEM_getUserLevelDirectory(void);
 
+bool FILESYSTEM_isFile(const char* filename);
+
 void FILESYSTEM_mount(const char *fname);
 void FILESYSTEM_loadZip(const char* filename);
 extern bool FILESYSTEM_assetsmounted;

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -13,6 +13,7 @@ char *FILESYSTEM_getUserSaveDirectory(void);
 char *FILESYSTEM_getUserLevelDirectory(void);
 
 bool FILESYSTEM_isFile(const char* filename);
+bool FILESYSTEM_isMounted(const char* filename);
 
 void FILESYSTEM_mount(const char *fname);
 void FILESYSTEM_loadZip(const char* filename);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -79,6 +79,11 @@ static bool compare_nocase (std::string first, std::string second)
 
 static void levelZipCallback(const char* filename)
 {
+    if (!FILESYSTEM_isFile(filename))
+    {
+        return;
+    }
+
     if (endsWith(filename, ".zip"))
     {
         FILESYSTEM_loadZip(filename);
@@ -200,6 +205,11 @@ static void levelMetaDataCallback(const char* filename)
     extern editorclass ed;
     LevelMetaData temp;
     std::string filename_ = filename;
+
+    if (!FILESYSTEM_isFile(filename))
+    {
+        return;
+    }
 
     if (ed.getLevelMetaData(filename_, temp))
     {

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -206,7 +206,7 @@ static void levelMetaDataCallback(const char* filename)
     LevelMetaData temp;
     std::string filename_ = filename;
 
-    if (!FILESYSTEM_isFile(filename))
+    if (!FILESYSTEM_isFile(filename) || FILESYSTEM_isMounted(filename))
     {
         return;
     }


### PR DESCRIPTION
I have a bunch of directories in my levels folder. I also have a zip file in there.

Currently, whenever I load the levels folder, I get this mess printed to the terminal:

```
Level levels/graphics not found :(
Level levels/backlog not found :(
Level levels/archives not found :(
Level levels/temp not found :(
Level levels/default_levels not found :(
Level levels/concepts not found :(
Level levels/files not found :(
Level levels/wip not found :(
Level levels/hidden_levels not found :(
Level levels/open2v2_r245 not found :(
Couldn't load metadata for levels/open2v2_r246.zip
Level levels/saves_test_level_1 not found :(
Level levels/open2v2_r246 not found :(
Level levels/more_levels not found :(
Level levels/tas not found :(
Level levels/graphics not found :(
```

All of these are basically more-or-less false positives. They happen because the game attempts to load a directory as a level file, and then fails; or it's because the game attempts to load a zip file as a level file, and also fails.

This PR makes it so the game will now ignore directories when it loads the level list. It will also ignore its own mounted files, so level zip files that were successfully loaded will also be ignored as well; preventing superfluous warning messages for those from being printed as well.

So with this PR, all those messages printed above are now completely gone whenever I load the levels list.

Unfortunately, 2.3 also added symlink support, so there's still false positive messages if you have a symlink that points to a directory. It seems to be a PhysFS limitation that we can't easily follow the symlink and check the type of the destination for ourselves; so we'll just have to deal with these still being false positives.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
