### PR TITLE
Clean up menu option reassignments and fix two menu inconsistencies

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6196,13 +6196,7 @@ void Game::returntomenu(enum Menu::MenuName t)
 {
     if (currentmenuname == t)
     {
-        //Re-create the menu
-        int keep_menu_option = currentmenuoption;
         createmenu(t, true);
-        if (keep_menu_option < (int) menuoptions.size())
-        {
-            currentmenuoption = keep_menu_option;
-        }
         return;
     }
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6239,9 +6239,9 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         frame.option = currentmenuoption;
         frame.name = currentmenuname;
         menustack.push_back(frame);
+        currentmenuoption = 0;
     }
 
-    currentmenuoption = 0;
     currentmenuname = t;
     menuyoff = 0;
     int maxspacing = 30; // maximum value for menuspacing, can only become lower.

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1121,7 +1121,6 @@ static void menuactionpress(void)
             music.playef(11);
             game.returnmenu();
             map.nexttowercolour();
-            music.niceplay(6);
             break;
         }
         break;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1233,6 +1233,7 @@ static void menuactionpress(void)
         case 5:
             music.playef(11);
             game.returnmenu();
+            map.nexttowercolour();
             break;
         }
         break;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -388,7 +388,6 @@ static void menuactionpress(void)
 
             // Recreate menu to update "resize to nearest"
             game.createmenu(game.currentmenuname, true);
-            game.currentmenuoption = 0;
 
             game.savestatsandsettings_menu();
             break;
@@ -492,7 +491,6 @@ static void menuactionpress(void)
             game.slowdown = 30;
             music.playef(11);
             game.returnmenu();
-            game.currentmenuoption = 4;
             map.nexttowercolour();
             game.savestatsandsettings_menu();
             break;
@@ -500,7 +498,6 @@ static void menuactionpress(void)
             game.slowdown = 24;
             music.playef(11);
             game.returnmenu();
-            game.currentmenuoption = 4;
             map.nexttowercolour();
             game.savestatsandsettings_menu();
             break;
@@ -508,7 +505,6 @@ static void menuactionpress(void)
             game.slowdown = 18;
             music.playef(11);
             game.returnmenu();
-            game.currentmenuoption = 4;
             map.nexttowercolour();
             game.savestatsandsettings_menu();
             break;
@@ -516,7 +512,6 @@ static void menuactionpress(void)
             game.slowdown = 12;
             music.playef(11);
             game.returnmenu();
-            game.currentmenuoption = 4;
             map.nexttowercolour();
             game.savestatsandsettings_menu();
             break;
@@ -783,7 +778,6 @@ static void menuactionpress(void)
             game.unlocknotify[9] = true;
             music.playef(11);
             game.createmenu(Menu::unlockmenutrials, true);
-            game.currentmenuoption = 0;
             game.savestatsandsettings_menu();
             break;
         case 1:   	//unlock 2
@@ -791,7 +785,6 @@ static void menuactionpress(void)
             game.unlocknotify[10] = true;
             music.playef(11);
             game.createmenu(Menu::unlockmenutrials, true);
-            game.currentmenuoption = 1;
             game.savestatsandsettings_menu();
             break;
         case 2:   	//unlock 3
@@ -799,7 +792,6 @@ static void menuactionpress(void)
             game.unlocknotify[11] = true;
             music.playef(11);
             game.createmenu(Menu::unlockmenutrials, true);
-            game.currentmenuoption = 2;
             game.savestatsandsettings_menu();
             break;
         case 3:   	//unlock 4
@@ -807,7 +799,6 @@ static void menuactionpress(void)
             game.unlocknotify[12] = true;
             music.playef(11);
             game.createmenu(Menu::unlockmenutrials, true);
-            game.currentmenuoption = 3;
             game.savestatsandsettings_menu();
             break;
         case 4:   	//unlock 5
@@ -815,7 +806,6 @@ static void menuactionpress(void)
             game.unlocknotify[13] = true;
             music.playef(11);
             game.createmenu(Menu::unlockmenutrials, true);
-            game.currentmenuoption = 4;
             game.savestatsandsettings_menu();
             break;
         case 5:   	//unlock 6
@@ -823,7 +813,6 @@ static void menuactionpress(void)
             game.unlocknotify[14] = true;
             music.playef(11);
             game.createmenu(Menu::unlockmenutrials, true);
-            game.currentmenuoption = 5;
             game.savestatsandsettings_menu();
             break;
         case 6:   	//back
@@ -851,7 +840,6 @@ static void menuactionpress(void)
             game.unlock[6] = true;
             game.unlock[7] = true;
             game.createmenu(Menu::unlockmenu, true);
-            game.currentmenuoption = 1;
             game.savestatsandsettings_menu();
             break;
         case 2:
@@ -860,7 +848,6 @@ static void menuactionpress(void)
             game.unlock[17] = true;
             game.unlocknotify[17] = true;
             game.createmenu(Menu::unlockmenu, true);
-            game.currentmenuoption = 2;
             game.savestatsandsettings_menu();
             break;
         case 3:
@@ -869,7 +856,6 @@ static void menuactionpress(void)
             game.unlock[18] = true;
             game.unlocknotify[18] = true;
             game.createmenu(Menu::unlockmenu, true);
-            game.currentmenuoption = 3;
             game.savestatsandsettings_menu();
             break;
         case 4:
@@ -877,7 +863,6 @@ static void menuactionpress(void)
             music.playef(11);
             game.stat_trinkets = 20;
             game.createmenu(Menu::unlockmenu, true);
-            game.currentmenuoption = 4;
             game.savestatsandsettings_menu();
             break;
         case 5:
@@ -886,7 +871,6 @@ static void menuactionpress(void)
             game.unlock[8] = true;
             game.unlocknotify[8] = true;
             game.createmenu(Menu::unlockmenu, true);
-            game.currentmenuoption = 5;
             game.savestatsandsettings_menu();
             break;
         default:
@@ -910,7 +894,6 @@ static void menuactionpress(void)
             //last page
             music.playef(11);
             game.createmenu(Menu::credits6, true);
-            game.currentmenuoption = 1;
             map.nexttowercolour();
             break;
         default:
@@ -934,7 +917,6 @@ static void menuactionpress(void)
             //previous page
             music.playef(11);
             game.createmenu(Menu::credits, true);
-            game.currentmenuoption = 1;
             map.nexttowercolour();
             break;
         case 2:
@@ -958,7 +940,6 @@ static void menuactionpress(void)
             //previous page
             music.playef(11);
             game.createmenu(Menu::credits2, true);
-            game.currentmenuoption = 1;
             map.nexttowercolour();
             break;
         default:
@@ -1007,7 +988,6 @@ static void menuactionpress(void)
                 //There are more super patrons. Refresh the menu with the next ones
                 game.createmenu(Menu::credits3, true);
             }
-            game.currentmenuoption = 1;
 
             map.nexttowercolour();
             break;
@@ -1058,7 +1038,6 @@ static void menuactionpress(void)
                 //There are more patrons. Refresh the menu with the next ones
                 game.createmenu(Menu::credits4, true);
             }
-            game.currentmenuoption = 1;
 
             map.nexttowercolour();
             break;
@@ -1109,7 +1088,6 @@ static void menuactionpress(void)
                 //There are more GitHub contributors. Refresh the menu with the next ones
                 game.createmenu(Menu::credits5, true);
             }
-            game.currentmenuoption = 1;
 
             map.nexttowercolour();
             break;
@@ -1136,7 +1114,6 @@ static void menuactionpress(void)
             music.playef(11);
             game.current_credits_list_index = SDL_arraysize(Credits::githubfriends) - 1 - (SDL_arraysize(Credits::githubfriends)-1)%9;
             game.createmenu(Menu::credits5, true);
-            game.currentmenuoption = 1;
             map.nexttowercolour();
             break;
         default:


### PR DESCRIPTION
If we're recreating the same menu, then we no longer need to reassign `game.currentmenuoption` ourselves; this simplifies the code a bit. Also, there was an errant `music.niceplay(6)` in the `credits6` menu, as well as a missing `map.nexttowercolour()` when returning from the game pad rebind screen.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
