### PR TITLE
Add previous song option to editor music screen

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6417,6 +6417,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         break;
     case Menu::ed_music:
         option("next song");
+        option("previous song");
         option("back");
         menuyoff = 16;
         maxspacing = 15;

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3726,8 +3726,17 @@ static void editormenuactionpress()
         switch (game.currentmenuoption)
         {
         case 0:
-            ed.levmusic++;
-            if(ed.levmusic==16) ed.levmusic=0;
+        case 1:
+            switch (game.currentmenuoption)
+            {
+            case 0:
+                ed.levmusic++;
+                break;
+            case 1:
+                ed.levmusic--;
+                break;
+            }
+            ed.levmusic = (ed.levmusic % 16 + 16) % 16;
             if(ed.levmusic>0)
             {
                 music.play(ed.levmusic);
@@ -3738,7 +3747,7 @@ static void editormenuactionpress()
             }
             music.playef(11);
             break;
-        case 1:
+        case 2:
             music.playef(11);
             music.fadeout();
             game.returnmenu();


### PR DESCRIPTION
This is just a small quality-of-life feature - it's annoying to have to press ACTION 15 times in order to cycle back through to the previous song.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
