### PR TITLE
Fix regression being able to activate activity zones during cutscenes

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1795,7 +1795,10 @@ void gameinput(void)
                 if (enter_pressed)
                 {
                     game.mapheld = true;
+                }
 
+                if (enter_pressed && !script.running)
+                {
                     if (game.activetele && game.readytotele > 20 && !game.intimetrial)
                     {
                         enter_already_processed = true;


### PR DESCRIPTION
Since you're now allowed to bring up the map screen during cutscenes, you've also been able to activate activity zones and teleporter prompts during cutscenes. This only really affects custom levels; nowhere in the main game can you overlap with an activity zone while in a cutscene.

To fix this, I've just added a `script.running` check to Enter keybind processing.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
