### PR TITLE
Fix prompt fade out when activating overlapping activity zones

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1527,6 +1527,14 @@ void gamelogic(void)
 
     game.activeactivity = obj.checkactivity();
 
+    if (INBOUNDS_VEC(game.activeactivity, obj.entities))
+    {
+        game.activity_lastprompt = obj.blocks[game.activeactivity].prompt;
+        game.activity_r = obj.blocks[game.activeactivity].r;
+        game.activity_g = obj.blocks[game.activeactivity].g;
+        game.activity_b = obj.blocks[game.activeactivity].b;
+    }
+
     game.oldreadytotele = game.readytotele;
     if (game.activetele && !game.advancetext && game.hascontrol && !script.running && !game.intimetrial)
     {

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1527,7 +1527,8 @@ void gamelogic(void)
 
     game.activeactivity = obj.checkactivity();
 
-    if (INBOUNDS_VEC(game.activeactivity, obj.entities))
+    if (game.hascontrol && !script.running
+    && INBOUNDS_VEC(game.activeactivity, obj.entities))
     {
         game.activity_lastprompt = obj.blocks[game.activeactivity].prompt;
         game.activity_r = obj.blocks[game.activeactivity].r;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1688,13 +1688,6 @@ void gamerender(void)
     }
 
     float act_alpha = graphics.lerp(game.prev_act_fade, game.act_fade) / 10.0f;
-    if (INBOUNDS_VEC(game.activeactivity, obj.entities))
-    {
-        game.activity_lastprompt = obj.blocks[game.activeactivity].prompt;
-        game.activity_r = obj.blocks[game.activeactivity].r;
-        game.activity_g = obj.blocks[game.activeactivity].g;
-        game.activity_b = obj.blocks[game.activeactivity].b;
-    }
     if(game.act_fade>5 || game.prev_act_fade>5)
     {
         graphics.drawtextbox(16, 4, 36, 3, game.activity_r*act_alpha, game.activity_g*act_alpha, game.activity_b*act_alpha);


### PR DESCRIPTION
If you stood in two activity zones at once, you'll automatically select the one that got created first. And when you activated it, the activity zone prompt would switch to fading out the prompt of the *other* activity zone, the one you didn't activate.

This wasn't a problem in 2.2 and previous, because the fading animation was simply bugged and defaulted to being solid black. However, in 2.3, the fading animation is fixed, so this is possible.

Also, this really only happens in the main game. Since there's only one type of useful activity zone in custom levels - namely the terminal activity zone - if two activity zones did happen to overlap, activating one of them wouldn't result in visibly fading out a different activity zone (because they both look the same); furthermore custom level makers are careful to not overlap terminal activity zones, lest this result in player confusion; furthermore the placed activity zones only cover a small area, whereas in the main game, crewmates' activity zones are pretty big.

(Technically, you *can* create main game activity zones in custom levels, but those are hardcoded to call main game scripts, and basically nobody uses them.)

So what's the solution? Simply moving the updates of `game.activity_last[prompt|r|g|b]` to `gamerenderfixed()`, and adding `game.hascontrol` and `script.running` checks to them. Moving them to `gamerenderfixed()` does have a minor wrinkle where the fade animation is delayed by 1 frame, but that would be fixed by #535.

Why not add those checks to the assignment of `game.activeactivity`, just above? Because that would introduce a frame ordering issue (that would *not* be (automatically) fixed by #535) where the eligibility of pressing Enter on an activity zone now checks if you were standing in an activity zone *last* frame, and not *this* frame. (I tested this with libTAS.) Better to fiddle with the rendering code than fiddle with the actual physics code.

The specific spot I used to test this was standing in Violet's activity zone and the activity zone of the ship radio terminals (the three
terminals on the ground in her room); the ship radio terminals are first-placed, so if you're testing this (and you should!), make that the prompt is of the ship radio activity zone before activation.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
