### PR TITLE
Reverse menu animation direction in Flip Mode

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2829,7 +2829,7 @@ void Graphics::menuoffrender(void)
 		BlitSurfaceStandard(tempbufferFlipped, NULL, backBuffer, NULL);
 		SDL_FreeSurface(tempbufferFlipped);
 		SDL_Rect offsetRect;
-		setRect (offsetRect, 0, usethisoffset, backBuffer->w ,backBuffer->h);
+		setRect (offsetRect, 0, -usethisoffset, backBuffer->w ,backBuffer->h);
 		SDL_Surface* temp = FlipSurfaceVerticle(menubuffer);
 		BlitSurfaceStandard(temp,NULL,backBuffer,&offsetRect);
 		SDL_FreeSurface(temp);


### PR DESCRIPTION
In normal mode, the room name is at the bottom of the screen. When you bring up the map screen, it appears as if the room name is moving up from the bottom of the screen, and the map screen is "pushing" it up. The effect is pretty seamless, and when I first played the game (back in 2014), I thought it was pretty cool.

However, in Flip Mode, the room name is at the top of the screen. So one would expect the menu animation to come from above the screen. Well, no, it still goes from the bottom of screen; ruining the effect because it seems like there are two room names on the screen, when there ought to be only one.

To be fair, I only noticed this while fixing another bug now, but it's one of those things you can't unsee (I have cursed you with knowledge!); not to mention that I probably only didn't notice this because I don't play in Flip Mode that often (and I'd wager almost no one does; Flip Mode previous to 2.3 seems to have been really untested, like I said in #165). It feels like a bit of an oversight that the direction of the animation is the same direction as in unflipped mode. So I'm fixing this.

Before:
![Flip Mode menu animation before](https://user-images.githubusercontent.com/59748578/110195839-00465180-7df5-11eb-8cce-ed35489d23a7.png)

After:
![Flip Mode menu animation after](https://user-images.githubusercontent.com/59748578/110195838-ffadbb00-7df4-11eb-893c-c13db27e32cc.png)
(ignore the lack of background behind the room name; that's an unrelated bug that existed previously)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
