### PR TITLE
Copy blend mode to recreated surfaces, fixing room name background during menu animation in Flip Mode

### DIFF
--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -17,6 +17,7 @@ static SDL_Surface* RecreateSurfaceWithDimensions(
     const int height
 ) {
     SDL_Surface* retval;
+    SDL_BlendMode blend_mode;
 
     if (surface == NULL)
     {
@@ -38,6 +39,9 @@ static SDL_Surface* RecreateSurfaceWithDimensions(
     {
         return NULL;
     }
+
+    SDL_GetSurfaceBlendMode(surface, &blend_mode);
+    SDL_SetSurfaceBlendMode(retval, blend_mode);
 
     return retval;
 }

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -11,6 +11,51 @@ void setRect( SDL_Rect& _r, int x, int y, int w, int h )
     _r.h = h;
 }
 
+static SDL_Surface* RecreateSurfaceWithDimensions(
+    SDL_Surface* surface,
+    const int width,
+    const int height
+) {
+    SDL_Surface* retval;
+
+    if (surface == NULL)
+    {
+        return NULL;
+    }
+
+    retval = SDL_CreateRGBSurface(
+        surface->flags,
+        width,
+        height,
+        surface->format->BitsPerPixel,
+        surface->format->Rmask,
+        surface->format->Gmask,
+        surface->format->Bmask,
+        surface->format->Amask
+    );
+
+    if (retval == NULL)
+    {
+        return NULL;
+    }
+
+    return retval;
+}
+
+static SDL_Surface* RecreateSurface(SDL_Surface* surface)
+{
+    if (surface == NULL)
+    {
+        return NULL;
+    }
+
+    return RecreateSurfaceWithDimensions(
+        surface,
+        surface->w,
+        surface->h
+    );
+}
+
 SDL_Surface* GetSubSurface( SDL_Surface* metaSurface, int x, int y, int width, int height )
 {
     // Create an SDL_Rect with the area of the _surface
@@ -21,15 +66,10 @@ SDL_Surface* GetSubSurface( SDL_Surface* metaSurface, int x, int y, int width, i
     area.h = height;
 
     //Convert to the correct display format after nabbing the new _surface or we will slow things down.
-    SDL_Surface* preSurface = SDL_CreateRGBSurface(
-        SDL_SWSURFACE,
+    SDL_Surface* preSurface = RecreateSurfaceWithDimensions(
+        metaSurface,
         width,
-        height,
-        metaSurface->format->BitsPerPixel,
-        metaSurface->format->Rmask,
-        metaSurface->format->Gmask,
-        metaSurface->format->Bmask,
-        metaSurface->format->Amask
+        height
     );
 
     // Lastly, apply the area from the meta _surface onto the whole of the sub _surface.
@@ -103,8 +143,7 @@ SDL_Surface * ScaleSurface( SDL_Surface *_surface, int Width, int Height, SDL_Su
     SDL_Surface *_ret;
     if(Dest == NULL)
     {
-        _ret = SDL_CreateRGBSurface(_surface->flags, Width, Height, _surface->format->BitsPerPixel,
-                                    _surface->format->Rmask, _surface->format->Gmask, _surface->format->Bmask, _surface->format->Amask);
+        _ret = RecreateSurfaceWithDimensions(_surface, Width, Height);
         if(_ret == NULL)
         {
             return NULL;
@@ -132,8 +171,7 @@ SDL_Surface * ScaleSurface( SDL_Surface *_surface, int Width, int Height, SDL_Su
 
 SDL_Surface *  FlipSurfaceVerticle(SDL_Surface* _src)
 {
-    SDL_Surface * ret = SDL_CreateRGBSurface(_src->flags, _src->w, _src->h, _src->format->BitsPerPixel,
-        _src->format->Rmask, _src->format->Gmask, _src->format->Bmask, _src->format->Amask);
+    SDL_Surface * ret = RecreateSurface(_src);
     if(ret == NULL)
     {
         return NULL;
@@ -168,16 +206,7 @@ void BlitSurfaceColoured(
 
     const SDL_PixelFormat& fmt = *(_src->format);
 
-    SDL_Surface* tempsurface =  SDL_CreateRGBSurface(
-        SDL_SWSURFACE,
-        _src->w,
-        _src->h,
-        fmt.BitsPerPixel,
-        fmt.Rmask,
-        fmt.Gmask,
-        fmt.Bmask,
-        fmt.Amask
-    );
+    SDL_Surface* tempsurface =  RecreateSurface(_src);
 
     for(int x = 0; x < tempsurface->w; x++)
     {
@@ -209,16 +238,7 @@ void BlitSurfaceTinted(
 
     const SDL_PixelFormat& fmt = *(_src->format);
 
-    SDL_Surface* tempsurface =  SDL_CreateRGBSurface(
-        SDL_SWSURFACE,
-        _src->w,
-        _src->h,
-        fmt.BitsPerPixel,
-        fmt.Rmask,
-        fmt.Gmask,
-        fmt.Bmask,
-        fmt.Amask
-    );
+    SDL_Surface* tempsurface =  RecreateSurface(_src);
 
     for (int x = 0; x < tempsurface->w; x++) {
         for (int y = 0; y < tempsurface->h; y++) {
@@ -295,8 +315,7 @@ void UpdateFilter(void)
 
 SDL_Surface* ApplyFilter( SDL_Surface* _src )
 {
-    SDL_Surface* _ret = SDL_CreateRGBSurface(_src->flags, _src->w, _src->h, _src->format->BitsPerPixel,
-        _src->format->Rmask, _src->format->Gmask, _src->format->Bmask, _src->format->Amask);
+    SDL_Surface* _ret = RecreateSurface(_src);
 
     int redOffset = rand() % 4;
 


### PR DESCRIPTION
This fixes a "root cause" bug (that's existed since 2.2 and below) where recreated surfaces wouldn't preserve the blend mode of their original surface.

The surface-level (pun genuinely unintended) bug that this root bug fixes is the one where there's no background to the room name during the map menu animation in Flip Mode.

This is because the room name background relies on `graphics.backBuffer` being filled with complete black. This is achieved by a call to `ClearSurface()` - however, `ClearSurface()` actually fills it with transparent black (this is not a regression; in 2.2 and previous, this was an "inlined" `FillRect(backBuffer, 0x00000000)`). This would be okay, and indeed the room name background renders fine in unflipped mode - but it suddenly breaks in Flip Mode.

Why? Because `backBuffer` gets fed through `FlipSurfaceVerticle()`, and `FlipSurfaceVerticle()` creates a temporary surface with the same dimensions and color masks as `backBuffer` - it, however, does *not* create it with the same blend mode, and kind of sort of just forgets that the original was `SDL_BLENDMODE_NONE`; the new surface is `SDL_BLENDMODE_BLEND`. Thus, transparency applies on the new surface, and instead of the room name being drawn against black, it gets drawn against transparency.

Before:
![Flip Mode menu animation room name before](https://user-images.githubusercontent.com/59748578/110195955-0f79cf00-7df6-11eb-8d33-0076f98071ca.png)

After:
![Flip Mode menu animation room name after](https://user-images.githubusercontent.com/59748578/110195953-0ee13880-7df6-11eb-91e5-6e3b801fe30b.png)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
