### PR TITLE
Fix transitive includes and use SDL_floor() in GraphicsUtil

### DIFF
--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -1,6 +1,5 @@
 #include "GraphicsUtil.h"
 
-#include <math.h>
 #include <SDL.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -264,7 +263,7 @@ void BlitSurfaceTinted(
             double temp_pixgreen = pixgreen * 0.587;
             double temp_pixblue = pixblue * 0.114;
 
-            double gray = floor((temp_pixred + temp_pixgreen + temp_pixblue + 0.5));
+            double gray = SDL_floor((temp_pixred + temp_pixgreen + temp_pixblue + 0.5));
 
             Uint8 ctred = (ct.colour & graphics.backBuffer->format->Rmask) >> 16;
             Uint8 ctgreen = (ct.colour & graphics.backBuffer->format->Gmask) >> 8;

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -1,4 +1,12 @@
+#include "GraphicsUtil.h"
+
+#include <math.h>
+#include <SDL.h>
+#include <stddef.h>
+#include <stdlib.h>
+
 #include "Graphics.h"
+#include "Maths.h"
 
 
 


### PR DESCRIPTION
While I was working on fixing Flip Mode bugs, I ran Include What You Use on `GraphicsUtil.cpp` and fixed the evil transitive includes that the file relied upon. Include What You Use also told me to include `<math.h>` because of `floor()`; I've swapped out the `floor()` for `SDL_floor()` instead.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
