### PR TITLE
Make the one-way recolor conditional check for specific files instead of any mounted asset

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -241,8 +241,6 @@ void FILESYSTEM_loadZip(const char* filename)
 	}
 }
 
-bool FILESYSTEM_assetsmounted = false;
-
 void FILESYSTEM_mountassets(const char* path)
 {
 	const size_t path_size = SDL_strlen(path);
@@ -288,8 +286,6 @@ void FILESYSTEM_mountassets(const char* path)
 		FILESYSTEM_mount(zip_data);
 
 		graphics.reloadresources();
-
-		FILESYSTEM_assetsmounted = true;
 	}
 	else if (zip_normal != NULL && endsWith(zip_normal, ".zip"))
 	{
@@ -323,8 +319,6 @@ void FILESYSTEM_mountassets(const char* path)
 			SDL_strlcpy(assetDir, zip_data, sizeof(assetDir));
 		}
 
-		FILESYSTEM_assetsmounted = true;
-
 		graphics.reloadresources();
 	}
 	else if (FILESYSTEM_exists(dir))
@@ -334,14 +328,10 @@ void FILESYSTEM_mountassets(const char* path)
 		FILESYSTEM_mount(dir);
 
 		graphics.reloadresources();
-
-		FILESYSTEM_assetsmounted = true;
 	}
 	else
 	{
 		puts("Custom asset directory does not exist");
-
-		FILESYSTEM_assetsmounted = false;
 	}
 }
 
@@ -358,7 +348,6 @@ void FILESYSTEM_unmountassets(void)
 	{
 		printf("Cannot unmount when no asset directory is mounted\n");
 	}
-	FILESYSTEM_assetsmounted = false;
 }
 
 bool FILESYSTEM_isAssetMounted(const char* filename)

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -26,6 +26,8 @@
 static char saveDir[MAX_PATH] = {'\0'};
 static char levelDir[MAX_PATH] = {'\0'};
 
+static char assetDir[MAX_PATH] = {'\0'};
+
 static void PLATFORM_getOSDirectory(char* output);
 static void PLATFORM_migrateSaveData(char* output);
 static void PLATFORM_copyFile(const char *oldLocation, const char *newLocation);
@@ -221,7 +223,7 @@ void FILESYSTEM_mount(const char *fname)
 	}
 	else
 	{
-		graphics.assetdir = std::string(path);
+		SDL_strlcpy(assetDir, path, sizeof(assetDir));
 	}
 }
 
@@ -318,7 +320,7 @@ void FILESYSTEM_mountassets(const char* path)
 		}
 		else
 		{
-			graphics.assetdir = std::string(zip_data);
+			SDL_strlcpy(assetDir, zip_data, sizeof(assetDir));
 		}
 
 		FILESYSTEM_assetsmounted = true;
@@ -345,11 +347,11 @@ void FILESYSTEM_mountassets(const char* path)
 
 void FILESYSTEM_unmountassets(void)
 {
-	if (graphics.assetdir != "")
+	if (assetDir[0] != '\0')
 	{
-		printf("Unmounting %s\n", graphics.assetdir.c_str());
-		PHYSFS_unmount(graphics.assetdir.c_str());
-		graphics.assetdir = "";
+		printf("Unmounting %s\n", assetDir);
+		PHYSFS_unmount(assetDir);
+		assetDir[0] = '\0';
 		graphics.reloadresources();
 	}
 	else

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -361,6 +361,26 @@ void FILESYSTEM_unmountassets(void)
 	FILESYSTEM_assetsmounted = false;
 }
 
+bool FILESYSTEM_isAssetMounted(const char* filename)
+{
+	const char* realDir;
+
+	/* Fast path */
+	if (assetDir[0] == '\0')
+	{
+		return false;
+	}
+
+	realDir = PHYSFS_getRealDir(filename);
+
+	if (realDir == NULL)
+	{
+		return false;
+	}
+
+	return SDL_strcmp(assetDir, realDir) == 0;
+}
+
 void FILESYSTEM_freeMemory(unsigned char **mem);
 
 void FILESYSTEM_loadFileToMemory(

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -17,7 +17,6 @@ bool FILESYSTEM_isMounted(const char* filename);
 
 void FILESYSTEM_mount(const char *fname);
 void FILESYSTEM_loadZip(const char* filename);
-extern bool FILESYSTEM_assetsmounted;
 void FILESYSTEM_mountassets(const char *path);
 void FILESYSTEM_unmountassets(void);
 bool FILESYSTEM_isAssetMounted(const char* filename);

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -20,6 +20,7 @@ void FILESYSTEM_loadZip(const char* filename);
 extern bool FILESYSTEM_assetsmounted;
 void FILESYSTEM_mountassets(const char *path);
 void FILESYSTEM_unmountassets(void);
+bool FILESYSTEM_isAssetMounted(const char* filename);
 
 void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem,
                                  size_t *len, bool addnull = false);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -146,6 +146,11 @@ void Graphics::init(void)
     col_tb = 0;
 
     kludgeswnlinewidth = false;
+
+#ifndef NO_CUSTOM_LEVELS
+    tiles1_mounted = false;
+    tiles2_mounted = false;
+#endif
 }
 
 void Graphics::destroy(void)
@@ -710,10 +715,10 @@ void Graphics::drawsprite(int x, int y, int t, Uint32 c)
 }
 
 #ifndef NO_CUSTOM_LEVELS
-bool Graphics::shouldrecoloroneway(const int tilenum)
+bool Graphics::shouldrecoloroneway(const int tilenum, const bool mounted)
 {
     return (tilenum >= 14 && tilenum <= 17
-    && (!FILESYSTEM_assetsmounted
+    && (!mounted
     || ed.onewaycol_override));
 }
 #endif
@@ -729,7 +734,7 @@ void Graphics::drawtile( int x, int y, int t )
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
 
 #if !defined(NO_CUSTOM_LEVELS)
-    if (shouldrecoloroneway(t))
+    if (shouldrecoloroneway(t, tiles1_mounted))
     {
         colourTransform thect = {ed.getonewaycol()};
         BlitSurfaceTinted(tiles[t], NULL, backBuffer, &rect, thect);
@@ -753,7 +758,7 @@ void Graphics::drawtile2( int x, int y, int t )
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
 
 #if !defined(NO_CUSTOM_LEVELS)
-    if (shouldrecoloroneway(t))
+    if (shouldrecoloroneway(t, tiles2_mounted))
     {
         colourTransform thect = {ed.getonewaycol()};
         BlitSurfaceTinted(tiles2[t], NULL, backBuffer, &rect, thect);
@@ -3153,7 +3158,7 @@ void Graphics::drawforetile(int x, int y, int t)
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
 
 #if !defined(NO_CUSTOM_LEVELS)
-	if (shouldrecoloroneway(t))
+	if (shouldrecoloroneway(t, tiles1_mounted))
 	{
 		colourTransform thect = {ed.getonewaycol()};
 		BlitSurfaceTinted(tiles[t], NULL, foregroundBuffer, &rect, thect);
@@ -3177,7 +3182,7 @@ void Graphics::drawforetile2(int x, int y, int t)
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
 
 #if !defined(NO_CUSTOM_LEVELS)
-	if (shouldrecoloroneway(t))
+	if (shouldrecoloroneway(t, tiles2_mounted))
 	{
 		colourTransform thect = {ed.getonewaycol()};
 		BlitSurfaceTinted(tiles2[t], NULL, foregroundBuffer, &rect, thect);
@@ -3268,6 +3273,11 @@ void Graphics::reloadresources()
 
 	music.destroy();
 	music.init();
+
+#ifndef NO_CUSTOM_LEVELS
+	tiles1_mounted = FILESYSTEM_isAssetMounted("graphics/tiles.png");
+	tiles2_mounted = FILESYSTEM_isAssetMounted("graphics/tiles2.png");
+#endif
 }
 
 Uint32 Graphics::crewcolourreal(int t)

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -709,6 +709,15 @@ void Graphics::drawsprite(int x, int y, int t, Uint32 c)
     BlitSurfaceColoured(sprites[t], NULL, backBuffer, &rect, ct);
 }
 
+#ifndef NO_CUSTOM_LEVELS
+bool Graphics::shouldrecoloroneway(const int tilenum)
+{
+    return (tilenum >= 14 && tilenum <= 17
+    && (!FILESYSTEM_assetsmounted
+    || ed.onewaycol_override));
+}
+#endif
+
 void Graphics::drawtile( int x, int y, int t )
 {
     if (!INBOUNDS_VEC(t, tiles))
@@ -720,7 +729,7 @@ void Graphics::drawtile( int x, int y, int t )
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
 
 #if !defined(NO_CUSTOM_LEVELS)
-    if (t >= 14 && t <= 17 && (!FILESYSTEM_assetsmounted || ed.onewaycol_override))
+    if (shouldrecoloroneway(t))
     {
         colourTransform thect = {ed.getonewaycol()};
         BlitSurfaceTinted(tiles[t], NULL, backBuffer, &rect, thect);
@@ -744,7 +753,7 @@ void Graphics::drawtile2( int x, int y, int t )
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
 
 #if !defined(NO_CUSTOM_LEVELS)
-    if (t >= 14 && t <= 17 && (!FILESYSTEM_assetsmounted || ed.onewaycol_override))
+    if (shouldrecoloroneway(t))
     {
         colourTransform thect = {ed.getonewaycol()};
         BlitSurfaceTinted(tiles2[t], NULL, backBuffer, &rect, thect);
@@ -3144,7 +3153,7 @@ void Graphics::drawforetile(int x, int y, int t)
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
 
 #if !defined(NO_CUSTOM_LEVELS)
-	if (t >= 14 && t <= 17 && (!FILESYSTEM_assetsmounted || ed.onewaycol_override))
+	if (shouldrecoloroneway(t))
 	{
 		colourTransform thect = {ed.getonewaycol()};
 		BlitSurfaceTinted(tiles[t], NULL, foregroundBuffer, &rect, thect);
@@ -3168,7 +3177,7 @@ void Graphics::drawforetile2(int x, int y, int t)
 	setRect(rect, x,y,tiles_rect.w, tiles_rect.h);
 
 #if !defined(NO_CUSTOM_LEVELS)
-	if (t >= 14 && t <= 17 && (!FILESYSTEM_assetsmounted || ed.onewaycol_override))
+	if (shouldrecoloroneway(t))
 	{
 		colourTransform thect = {ed.getonewaycol()};
 		BlitSurfaceTinted(tiles2[t], NULL, foregroundBuffer, &rect, thect);

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -184,7 +184,6 @@ public:
 	bool onscreen(int t);
 
 	void reloadresources(void);
-	std::string assetdir;
 
 
 	void menuoffrender(void);

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -161,6 +161,9 @@ public:
 
 	void drawbackground(int t);
 	void updatebackground(int t);
+#ifndef NO_CUSTOM_LEVELS
+	bool shouldrecoloroneway(const int tilenum);
+#endif
 	void drawtile3( int x, int y, int t, int off, int height_subtract = 0 );
 	void drawtile2( int x, int y, int t );
 	void drawtile( int x, int y, int t );

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -162,7 +162,7 @@ public:
 	void drawbackground(int t);
 	void updatebackground(int t);
 #ifndef NO_CUSTOM_LEVELS
-	bool shouldrecoloroneway(const int tilenum);
+	bool shouldrecoloroneway(const int tilenum, const bool mounted);
 #endif
 	void drawtile3( int x, int y, int t, int off, int height_subtract = 0 );
 	void drawtile2( int x, int y, int t );
@@ -187,6 +187,10 @@ public:
 	bool onscreen(int t);
 
 	void reloadresources(void);
+#ifndef NO_CUSTOM_LEVELS
+	bool tiles1_mounted;
+	bool tiles2_mounted;
+#endif
 
 
 	void menuoffrender(void);


### PR DESCRIPTION
So, 2.3 added recoloring one-way tiles to no longer make them be always yellow. However, custom levels that retexture the one-way tiles might not want them to be recolored. So, if there are *any* custom assets mounted, then the one-ways will not be recolored. However, if the XML has a `<onewaycol_override>1</onewaycol_override>` tag, then the one-way will be recolored again anyways.

When I added one-way recoloring, I didn't intend for any custom asset to disable the recoloring; I only did it because I couldn't find a way to check if a specific file was customized by the custom level or not.

However, I have figured out how to do so, and so now `tiles.png` one-way recolors will only be disabled if there's a custom `tiles.png`, and `tiles2.png` one-way recolors will only be disabled if there's a custom `tiles2.png`. This involves the use of `PHYSFS_getRealDir()`.

In order to make sure we're not calling PhysFS functions on every single deltaframe, I've added caching variables, `tiles1_mounted` and `tiles2_mounted`, to Graphics; these get assigned every time `reloadresources()` is called.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
