### PR TITLE
Fix glitchy behavior switching soundtracks on silence

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -748,7 +748,10 @@ static void menuactionpress(void)
             //**** TOGGLE MMMMMM
             music.usingmmmmmm = !music.usingmmmmmm;
             music.playef(11);
-            music.play(music.currentsong);
+            if (music.currentsong > -1)
+            {
+                music.play(music.currentsong);
+            }
             game.savestatsandsettings();
         }
 


### PR DESCRIPTION
If there was absolutely no music playing, and you went to the in-game options to switch between MMMMMM and PPPPPP, the behavior would be a bit glitchy.

If you started with PPPPPP, switching once to MMMMMM wouldn't play anything, but then switching back to PPPPPP would play MMMMMM track 15. Then switching back to MMMMMM wouldn't do anything, but then switching back to PPPPPP again would play PPPPPP track 15 - and from there, the behavior is stable.

If you started with MMMMMM, switching once to PPPPPP would play MMMMMM track 15. Then switching back to MMMMMM wouldn't do anything, but then switching back to PPPPPP would play PPPPPP track 15 - and as above, the behavior is stable after that.

Anyways, the point is, -1 shouldn't be passed to `musicclass::play()` unless you want glitchy things. And I'm not patching -1 out of `musicclass::play()` itself, because passing negative numbers results in a useful glitch (that's existed since 2.2) where you can play MMMMMM tracks while having PPPPPP selected, effectively doubling the amount of usable music tracks within a custom level; it also seems like the game does -1 checks elsewhere, so I'm just being consistent with the rest of the game (although, yes, I am technically single-case patching this).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
