### PR TITLE
Fix MMMMMM and Flip Mode options ignoring save failure

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -176,7 +176,7 @@ static void updatebuttonmappings(int bind)
 static void toggleflipmode(void)
 {
     graphics.setflipmode = !graphics.setflipmode;
-    game.savestatsandsettings();
+    game.savestatsandsettings_menu();
     if (graphics.setflipmode)
     {
         music.playef(18);
@@ -756,7 +756,7 @@ static void menuactionpress(void)
             {
                 music.play(music.currentsong);
             }
-            game.savestatsandsettings();
+            game.savestatsandsettings_menu();
         }
 
         offset += mmmmmm_offset;


### PR DESCRIPTION
In #553, when @Dav999-v added error messages to settings menus if the game was unable to successfully save the changed settings, he seemed to have forgotten the PPPPPP/MMMMMM toggle option.

However, I can fully blame him for only that miss. The Flip Mode options were using `game.savemystats` (which was removed in #591), so if he searched for all instances of `game.savestats()` (`game.savestatsandsettings()` was only added in #557), he would've missed the `game.savemystats`.

Later, when I did #591, I didn't realize that I should've replaced the ones in the Flip Mode options with `game.savestatsandsettings_menu()`, so part of the blame does fall on me.

Anyways, this is fixed now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
