### PR TITLE
De-duplicate toggling flip mode in Input.cpp

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -173,6 +173,22 @@ static void updatebuttonmappings(int bind)
     }
 }
 
+static void toggleflipmode(void)
+{
+    graphics.setflipmode = !graphics.setflipmode;
+    game.savestatsandsettings();
+    if (graphics.setflipmode)
+    {
+        music.playef(18);
+        game.screenshake = 10;
+        game.flashlight = 5;
+    }
+    else
+    {
+        music.playef(11);
+    }
+}
+
 static void menuactionpress(void)
 {
     switch (game.currentmenuname)
@@ -680,19 +696,7 @@ static void menuactionpress(void)
         if (game.ingame_titlemode && game.unlock[18])
 #endif
         {
-            // toggle Flip Mode
-            graphics.setflipmode = !graphics.setflipmode;
-            game.savestatsandsettings();
-            if (graphics.setflipmode)
-            {
-                music.playef(18);
-                game.screenshake = 10;
-                game.flashlight = 5;
-            }
-            else
-            {
-                music.playef(11);
-            }
+            toggleflipmode();
             // Fix wrong area music in Tower (Positive Force vs. ecroF evitisoP)
             if (map.custommode)
             {
@@ -1282,19 +1286,7 @@ static void menuactionpress(void)
         }
         else if (game.currentmenuoption == 3 && game.unlock[18])    //enable/disable flip mode
         {
-            // WARNING: Partially duplicated in Menu::options
-            graphics.setflipmode = !graphics.setflipmode;
-            game.savestatsandsettings();
-            if (graphics.setflipmode)
-            {
-                music.playef(18);
-                game.screenshake = 10;
-                game.flashlight = 5;
-            }
-            else
-            {
-                music.playef(11);
-            }
+            toggleflipmode();
         }
         else if (game.currentmenuoption == 4)
         {


### PR DESCRIPTION
Flip Mode toggling is now no longer copy-pasted.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
