### PR TITLE
De-duplicate m_renderer and m_screenTexture creation in Screen.cpp

### DIFF
--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -34,6 +34,17 @@ void Screen::CreateRenderer(void)
 	m_renderer = SDL_CreateRenderer(m_window, -1, 0);
 }
 
+void Screen::CreateScreenTexture(void)
+{
+	m_screenTexture = SDL_CreateTexture(
+		m_renderer,
+		SDL_PIXELFORMAT_ARGB8888,
+		SDL_TEXTUREACCESS_STREAMING,
+		320,
+		240
+	);
+}
+
 void Screen::init(const ScreenSettings& settings)
 {
 	m_window = NULL;
@@ -86,14 +97,7 @@ void Screen::init(const ScreenSettings& settings)
 		0x000000FF,
 		0xFF000000
 	);
-	// ALSO FIXME: This SDL_CreateTexture() is duplicated twice in this file!
-	m_screenTexture = SDL_CreateTexture(
-		m_renderer,
-		SDL_PIXELFORMAT_ARGB8888,
-		SDL_TEXTUREACCESS_STREAMING,
-		320,
-		240
-	);
+	CreateScreenTexture();
 
 	badSignalEffect = settings.badSignal;
 
@@ -390,13 +394,7 @@ void Screen::resetRendererWorkaround(void)
 	SDL_DestroyRenderer(m_renderer);
 
 	CreateRenderer();
-	m_screenTexture = SDL_CreateTexture(
-		m_renderer,
-		SDL_PIXELFORMAT_ARGB8888,
-		SDL_TEXTUREACCESS_STREAMING,
-		320,
-		240
-	);
+	CreateScreenTexture();
 
 	/* Ugh, have to make sure to re-apply graphics options after doing the
 	 * above, otherwise letterbox/integer won't be applied...

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -29,6 +29,11 @@ ScreenSettings::ScreenSettings(void)
 	badSignal = false;
 }
 
+void Screen::CreateRenderer(void)
+{
+	m_renderer = SDL_CreateRenderer(m_window, -1, 0);
+}
+
 void Screen::init(const ScreenSettings& settings)
 {
 	m_window = NULL;
@@ -57,14 +62,15 @@ void Screen::init(const ScreenSettings& settings)
 
 	// Uncomment this next line when you need to debug -flibit
 	// SDL_SetHintWithPriority(SDL_HINT_RENDER_DRIVER, "software", SDL_HINT_OVERRIDE);
-	// FIXME: m_renderer is also created in resetRendererWorkaround()!
-	SDL_CreateWindowAndRenderer(
+	m_window = SDL_CreateWindow(
+		NULL,
+		SDL_WINDOWPOS_UNDEFINED,
+		SDL_WINDOWPOS_UNDEFINED,
 		640,
 		480,
-		SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI,
-		&m_window,
-		&m_renderer
+		SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI
 	);
+	CreateRenderer();
 	SDL_SetWindowTitle(m_window, "VVVVVV");
 
 	LoadIcon();
@@ -383,7 +389,7 @@ void Screen::resetRendererWorkaround(void)
 	SDL_DestroyTexture(m_screenTexture);
 	SDL_DestroyRenderer(m_renderer);
 
-	m_renderer = SDL_CreateRenderer(m_window, -1, 0);
+	CreateRenderer();
 	m_screenTexture = SDL_CreateTexture(
 		m_renderer,
 		SDL_PIXELFORMAT_ARGB8888,

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -12,6 +12,7 @@ public:
 	void destroy(void);
 
 	void CreateRenderer(void);
+	void CreateScreenTexture(void);
 
 	void GetSettings(ScreenSettings* settings);
 

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -11,6 +11,8 @@ public:
 	void init(const ScreenSettings& settings);
 	void destroy(void);
 
+	void CreateRenderer(void);
+
 	void GetSettings(ScreenSettings* settings);
 
 	void LoadIcon(void);


### PR DESCRIPTION
The code to create `m_renderer` and `m_screenTexture` is now no longer copy-pasted for the VSync reset workaround.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
