### PR TITLE
Make saveFilePath not an std::string

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -628,7 +628,7 @@ void Game::savecustomlevelstats(void)
     else
     {
         printf("Could Not Save level stats!\n");
-        printf("Failed: %s%s\n", saveFilePath.c_str(), "levelstats.vvv");
+        printf("Failed: %s%s\n", saveFilePath, "levelstats.vvv");
     }
 }
 
@@ -5758,7 +5758,7 @@ bool Game::savetele(void)
     if(!FILESYSTEM_saveTiXml2Document("saves/tsave.vvv", doc))
     {
         printf("Could Not Save game!\n");
-        printf("Failed: %s%s\n", saveFilePath.c_str(), "tsave.vvv");
+        printf("Failed: %s%s\n", saveFilePath, "tsave.vvv");
         return false;
     }
     printf("Game saved\n");
@@ -5785,7 +5785,7 @@ bool Game::savequick(void)
     if(!FILESYSTEM_saveTiXml2Document("saves/qsave.vvv", doc))
     {
         printf("Could Not Save game!\n");
-        printf("Failed: %s%s\n", saveFilePath.c_str(), "qsave.vvv");
+        printf("Failed: %s%s\n", saveFilePath, "qsave.vvv");
         return false;
     }
     printf("Game saved\n");
@@ -6033,7 +6033,7 @@ bool Game::customsavequick(std::string savfile)
     if(!FILESYSTEM_saveTiXml2Document(("saves/"+levelfile+".vvv").c_str(), doc))
     {
         printf("Could Not Save game!\n");
-        printf("Failed: %s%s%s\n", saveFilePath.c_str(), levelfile.c_str(), ".vvv");
+        printf("Failed: %s%s%s\n", saveFilePath, levelfile.c_str(), ".vvv");
         return false;
     }
     printf("Game saved\n");

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -183,7 +183,7 @@ public:
 
     void initteleportermode(void);
 
-    std::string saveFilePath;
+    const char* saveFilePath;
 
 
     int door_left;


### PR DESCRIPTION
Since it only ever gets assigned from `FILESYSTEM_getUserSaveDirectory()`, and that function returns a C string, and the variable is only ever read from again, this doesn't need to be an `std::string`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
