### PR TITLE
De-duplicate number of menu text bytes

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6327,7 +6327,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
                         static const char tmp[] = "   ";
                         prefix = tmp;
                     }
-                    char text[menutextbytes];
+                    char text[MENU_TEXT_BYTES];
                     SDL_snprintf(text, sizeof(text), "%s%s", prefix, ed.ListOfMetaData[i].title.c_str());
                     for (size_t ii = 0; text[ii] != '\0'; ++ii)
                     {

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -14,10 +14,12 @@ namespace tinyxml2
     class XMLElement;
 }
 
+/* 40 chars (160 bytes) covers the entire screen, + 1 more for null terminator */
+#define MENU_TEXT_BYTES 161
+
 struct MenuOption
 {
-    char text[161]; // 40 chars (160 bytes) covers the entire screen, + 1 more for null terminator
-    // WARNING: should match Game::menutextbytes below
+    char text[MENU_TEXT_BYTES];
     bool active;
 };
 
@@ -252,7 +254,6 @@ public:
     int current_credits_list_index;
     int menuxoff, menuyoff;
     int menuspacing;
-    static const int menutextbytes = 161; // this is just sizeof(MenuOption::text), but doing that is non-standard
     std::vector<MenuStackFrame> menustack;
 
     void inline option(const char* text, bool active = true)

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1420,10 +1420,10 @@ void Graphics::drawmenu( int cr, int cg, int cb, bool levelmenu /*= false*/ )
             }
         }
 
-        char tempstring[Game::menutextbytes];
+        char tempstring[MENU_TEXT_BYTES];
         SDL_strlcpy(tempstring, opt.text, sizeof(tempstring));
 
-        char buffer[Game::menutextbytes];
+        char buffer[MENU_TEXT_BYTES];
         if ((int) i == game.currentmenuoption)
         {
             if (opt.active)


### PR DESCRIPTION
I've moved this to a define that gets declared in `Game.h`. I could've made it a const int, but that's only legal in C++ mode.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
