### PR TITLE
Move gravity line, Direct Mode drawer, and room name hiding updates to editorrenderfixed, and interpolate Direct Mode drawer

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3373,14 +3373,6 @@ void editorrender(void)
             //FillRect(graphics.backBuffer, 0,231,71,240, graphics.RGB(0,0,0));
             if(ed.level[ed.levx+(ed.maxwidth*ed.levy)].roomname!="")
             {
-                if(ed.tiley<28)
-                {
-                    if(ed.roomnamehide>0) ed.roomnamehide--;
-                }
-                else
-                {
-                    if(ed.roomnamehide<12) ed.roomnamehide++;
-                }
                 if (graphics.translucentroomname)
                 {
                     graphics.footerrect.y = 230+ed.roomnamehide;
@@ -3612,6 +3604,24 @@ void editorrenderfixed(void)
         if (ed.dmtileeditor > 0)
         {
             ed.dmtileeditor--;
+        }
+    }
+
+    if (ed.level[ed.levx + ed.maxwidth*ed.levy].roomname != "")
+    {
+        if (ed.tiley < 28)
+        {
+            if (ed.roomnamehide > 0)
+            {
+                ed.roomnamehide--;
+            }
+        }
+        else
+        {
+            if (ed.roomnamehide < 12)
+            {
+                ed.roomnamehide++;
+            }
         }
     }
 }

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2650,47 +2650,17 @@ void editorrender(void)
             case 11: //Gravity lines
                 if(edentity[i].p1==0)  //Horizontal
                 {
-                    int tx=edentity[i].x-(ed.levx*40);
-                    int tx2=edentity[i].x-(ed.levx*40);
-                    int ty=edentity[i].y-(ed.levy*30);
-                    if (edentity[i].p4 != 1)
-                    {
-                        // Unlocked
-                        while(ed.spikefree(tx,ty)==0) tx--;
-                        while(ed.spikefree(tx2,ty)==0) tx2++;
-                        tx++;
-                        edentity[i].p2=tx;
-                        edentity[i].p3=(tx2-tx)*8;
-                    }
-                    else
-                    {
-                        // Locked
-                        tx = edentity[i].p2;
-                        tx2 = tx + edentity[i].p3/8;
-                    }
+                    int tx = edentity[i].p2;
+                    int tx2 = tx + edentity[i].p3/8;
+                    int ty = edentity[i].y % 30;
                     FillRect(graphics.backBuffer, (tx*8),(ty*8)+4, (tx2-tx)*8,1, graphics.getRGB(194,194,194));
                     fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(164,255,164));
                 }
                 else  //Vertical
                 {
-                    int tx=edentity[i].x-(ed.levx*40);
-                    int ty=edentity[i].y-(ed.levy*30);
-                    int ty2=edentity[i].y-(ed.levy*30);
-                    if (edentity[i].p4 != 1)
-                    {
-                        // Unlocked
-                        while(ed.spikefree(tx,ty)==0) ty--;
-                        while(ed.spikefree(tx,ty2)==0) ty2++;
-                        ty++;
-                        edentity[i].p2=ty;
-                        edentity[i].p3=(ty2-ty)*8;
-                    }
-                    else
-                    {
-                        // Locked
-                        ty = edentity[i].p2;
-                        ty2 = ty + edentity[i].p3/8;
-                    }
+                    int tx = edentity[i].x % 40;
+                    int ty = edentity[i].p2;
+                    int ty2 = ty + edentity[i].p3/8;
                     FillRect(graphics.backBuffer, (tx*8)+3,(ty*8), 1,(ty2-ty)*8, graphics.getRGB(194,194,194));
                     fillboxabs((edentity[i].x*8)- (ed.levx*40*8),(edentity[i].y*8)- (ed.levy*30*8),8,8,graphics.getRGB(164,255,164));
                 }
@@ -3585,6 +3555,57 @@ void editorrenderfixed(void)
     else if (!game.colourblindmode)
     {
         graphics.updatetowerbackground(graphics.titlebg);
+    }
+
+    /* Correct gravity lines */
+    for (size_t i = 0; i < edentity.size(); ++i)
+    {
+        if (edentity[i].x / 40 != ed.levx
+        || edentity[i].y / 30 != ed.levy
+        || edentity[i].t != 11
+        /* Is the gravity line locked? */
+        || edentity[i].p4 == 1)
+        {
+            continue;
+        }
+
+        if (edentity[i].p1 == 0)
+        {
+            /* Horizontal */
+            int tx = edentity[i].x % 40;
+            int tx2 = tx;
+            int ty = edentity[i].y % 30;
+            while (!ed.spikefree(tx, ty))
+            {
+                --tx;
+            }
+            while (!ed.spikefree(tx2, ty))
+            {
+                ++tx2;
+            }
+            ++tx;
+            edentity[i].p2 = tx;
+            edentity[i].p3 = (tx2 - tx) * 8;
+        }
+        else
+        {
+            /* Vertical */
+            int tx = edentity[i].x % 40;
+            int ty = edentity[i].y % 30;
+            int ty2 = ty;
+            /* Unlocked */
+            while (!ed.spikefree(tx, ty))
+            {
+                --ty;
+            }
+            while (!ed.spikefree(tx, ty2))
+            {
+                ++ty2;
+            }
+            ++ty;
+            edentity[i].p2 = ty;
+            edentity[i].p3 = (ty2 - ty) * 8;
+        }
     }
 }
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2961,7 +2961,7 @@ void editorrender(void)
         {
             if(ed.dmtileeditor<=4)
             {
-                t2=(4-ed.dmtileeditor)*12;
+                t2=graphics.lerp((4-ed.dmtileeditor+1)*12, (4-ed.dmtileeditor)*12);
             }
 
             //Draw five lines of the editor

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -2959,7 +2959,6 @@ void editorrender(void)
         int t2=0;
         if(ed.dmtileeditor>0)
         {
-            ed.dmtileeditor--;
             if(ed.dmtileeditor<=4)
             {
                 t2=(4-ed.dmtileeditor)*12;
@@ -3605,6 +3604,14 @@ void editorrenderfixed(void)
             ++ty;
             edentity[i].p2 = ty;
             edentity[i].p3 = (ty2 - ty) * 8;
+        }
+    }
+
+    if (ed.level[ed.levx + ed.maxwidth*ed.levy].directmode == 1)
+    {
+        if (ed.dmtileeditor > 0)
+        {
+            ed.dmtileeditor--;
         }
     }
 }


### PR DESCRIPTION
When I did #220, I forgot about these things. So now they are no longer dependent on framerate.

Additionally, the Direct Mode drawer closing animation is now interpolated. Room name hiding isn't interpolated because it only changes by 1 pixel per frame, and you can't draw a fractional pixel.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
