### PR TITLE
Fix Direct Mode/room name timers being paused when switching to non-Direct Mode/unnamed rooms

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3628,6 +3628,17 @@ void editorrenderfixed(void)
             }
         }
     }
+    else
+    {
+        if (ed.tiley < 28)
+        {
+            ed.roomnamehide = 0;
+        }
+        else
+        {
+            ed.roomnamehide = 12;
+        }
+    }
 }
 
 void editorlogic(void)

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3606,6 +3606,10 @@ void editorrenderfixed(void)
             ed.dmtileeditor--;
         }
     }
+    else
+    {
+        ed.dmtileeditor = 0;
+    }
 
     if (ed.level[ed.levx + ed.maxwidth*ed.levy].roomname != "")
     {


### PR DESCRIPTION
It's always been a bit weird how moving to a non-Direct Mode after having the tile picker drawer open, and then moving back, will result in the drawer popping up only to close again. Same goes for the room name hiding animation activating again if your cursor moved after you moved out of an unnamed room and then back.

So I fixed both of those.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
