### PR TITLE
Move resumesong assignment to songend()

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -145,6 +145,7 @@ static void songend(void)
 {
 	extern musicclass music;
 	music.songEnd = SDL_GetPerformanceCounter();
+	music.resumesong = music.currentsong;
 	music.currentsong = -1;
 }
 
@@ -265,7 +266,6 @@ void musicclass::fadein(void)
 void musicclass::haltdasmusik(void)
 {
 	Mix_HaltMusic();
-	resumesong = currentsong;
 }
 
 void musicclass::silencedasmusik(void)


### PR DESCRIPTION
This fixes a bug where the `resumemusic()` script command would always play MMMMMM track 15 (or, if you're using PPPPPP, just not work). This is because `musicclass::haltdasmusik()` assigns `resumesong` *after* calling `Mix_HaltMusic()`, but the `songend()` callback fires before the `resumesong` assignment, meaning `resumesong` gets set to -1 instead of whatever `currentsong` was previously.

To fix this, just move the assignment into the callback itself (I don't know why this wasn't done before). I could have moved it to before the `Mix_HaltMusic()` call, but moving it into the callback itself fixes it for all cases of the music stopping (such as when the music fades out).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
