### PR TITLE
Directly toggle fullscreen if keybind pressed in key.Poll()

### DIFF
--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -41,7 +41,6 @@ KeyPoll::KeyPoll(void)
 	leftbutton=0; rightbutton=0; middlebutton=0;
 	mx=0; my=0;
 	resetWindow = 0;
-	toggleFullscreen = false;
 	pressedbackspace=false;
 
 	useFullscreenSpaces = false;
@@ -78,9 +77,27 @@ bool KeyPoll::textentry(void)
 	return SDL_IsTextInputActive() == SDL_TRUE;
 }
 
+void KeyPoll::toggleFullscreen(void)
+{
+	if (graphics.screenbuffer != NULL)
+	{
+		graphics.screenbuffer->toggleFullScreen();
+	}
+
+	keymap.clear(); /* we lost the input due to a new window. */
+	if (game.glitchrunnermode)
+	{
+		game.press_left = false;
+		game.press_right = false;
+		game.press_action = true;
+		game.press_map = false;
+	}
+}
+
 void KeyPoll::Poll(void)
 {
 	bool altpressed = false;
+	bool fullscreenkeybind = false;
 	SDL_Event evt;
 	while (SDL_PollEvent(&evt))
 	{
@@ -106,7 +123,7 @@ void KeyPoll::Poll(void)
 			bool f11pressed = evt.key.keysym.sym == SDLK_F11;
 			if ((altpressed && (returnpressed || fpressed)) || f11pressed)
 			{
-				toggleFullscreen = true;
+				fullscreenkeybind = true;
 			}
 
 			if (textentry())
@@ -320,6 +337,11 @@ void KeyPoll::Poll(void)
 			quitProgram = true;
 			break;
 		}
+	}
+
+	if (fullscreenkeybind)
+	{
+		toggleFullscreen();
 	}
 }
 

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -38,7 +38,7 @@ public:
 	bool resetWindow;
 
 	bool quitProgram;
-	bool toggleFullscreen;
+	void toggleFullscreen(void);
 
 	int sensitivity;
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -454,20 +454,6 @@ static void inline fixedloop(void)
     NETWORK_update();
 
     key.Poll();
-    if(key.toggleFullscreen)
-    {
-        gameScreen.toggleFullScreen();
-        key.toggleFullscreen = false;
-
-        key.keymap.clear(); //we lost the input due to a new window.
-        if (game.glitchrunnermode)
-        {
-            game.press_left = false;
-            game.press_right = false;
-            game.press_action = true;
-            game.press_map = false;
-        }
-    }
 
     if(!key.isActive)
     {


### PR DESCRIPTION
This moves the responsibility of toggling fullscreen when any of the three toggle fullscreen keybinds are pressed (F11, Alt+Enter, Alt+F) directly into `key.Poll()` itself, and not its caller (which is `main()` - more specifically, `fixedloop()`). Furthermore, the fullscreen toggle itself has been moved to a separate function that `key.Poll()` just calls, to prevent cluttering `key.Poll()` with more business logic (the function is already quite big enough as it is).

As part of my work in re-removing the 1-frame input delay in #535, I'm moving the callsite of `key.Poll()` around, and I don't want to have to lug this block of code around with it. I'd rather refactor it upfront than touch any more lines than necessary in that PR.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
