### PR TITLE
Inline cutscene bars timer for gamemodes that used it in 2.2

### DIFF
--- a/desktop_version/src/RenderFixed.cpp
+++ b/desktop_version/src/RenderFixed.cpp
@@ -72,6 +72,8 @@ void gamerenderfixed(void)
         obj.trophytext--;
     }
 
+    graphics.cutscenebarstimer();
+
     graphics.updatetextboxes();
 
     if (!game.colourblindmode)
@@ -246,6 +248,13 @@ void maprenderfixed(void)
     {
         map.glitchname = map.getglitchname(game.roomx, game.roomy);
     }
+}
+
+void teleporterrenderfixed(void)
+{
+    maprenderfixed();
+
+    graphics.cutscenebarstimer();
 }
 
 void gamecompleterenderfixed(void)

--- a/desktop_version/src/RenderFixed.h
+++ b/desktop_version/src/RenderFixed.h
@@ -9,6 +9,8 @@ void titlerenderfixed(void);
 
 void maprenderfixed(void);
 
+void teleporterrenderfixed(void);
+
 void gamecompleterenderfixed(void);
 
 #endif /* RENDERFIXED_H */

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -478,7 +478,6 @@ static void inline fixedloop(void)
         Mix_Resume(-1);
         Mix_ResumeMusic();
         game.gametimer++;
-        graphics.cutscenebarstimer();
 
         switch(game.gamestate)
         {
@@ -546,7 +545,7 @@ static void inline fixedloop(void)
                 gameinput();
             }
             maplogic();
-            maprenderfixed();
+            teleporterrenderfixed();
             break;
         case GAMECOMPLETE:
             //Input


### PR DESCRIPTION
As part of my work in #535, I've noticed that 2.3 currently with 2.2 loop order doesn't have interpolated cutscene bars. This is because cutscene bars in 2.3 get updated at the start of the frame, which interpolates them correctly until the render functions are put in their proper place.

There is, however, a somewhat bigger issue, outside the scope of #535, where cutscene bars always get updated regardless of which gamemode you are in. Previously in 2.2 and previous, cutscene bars only got updated in GAMEMODE and TELEPORTERMODE; sometime during 2.3, the cutscene bars timer got pulled out of all the individual game modes and moved to the very start of the loop. (I was probably the one who did this change; I've been caught in a trap of my own devising.)

Thus, going to MAPMODE during the cutscene bars animation doesn't keep their position paused like it would in 2.2. This is also categorically a more-than-visual change, since the `untilbars()` script command depends on the cutscene bars timer. I see no reason for the cutscene bars to behave differently in this way than 2.2; #535 would also end up doing the same fix more-or-less anyway.

Since TELEPORTERMODE currently uses the same renderfixed function as MAPMODE, I've had to add a `teleporterrenderfixed()` that just calls `maprenderfixed()`, but also does the cutscene bars timer.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
