### PR TITLE
Add being able to press Esc to return to previous menu

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -261,10 +261,9 @@ static void menuactionpress(void)
  #define MPOFFSET -2
 #endif
         case OFFSET+5:
-            //bye!
-            music.playef(2);
-            game.mainmenu = 100;
-            graphics.fademode = 2;
+            music.playef(11);
+            game.createmenu(Menu::youwannaquit);
+            map.nexttowercolour();
             break;
 #undef OFFSET
 #undef NOCUSTOMSOFFSET
@@ -477,8 +476,8 @@ static void menuactionpress(void)
             break;
         default:
             music.playef(11);
-            map.nexttowercolour(); //This goes first, otherwise mismatching continuemenu color is possible
             game.returnmenu();
+            map.nexttowercolour();
         }
         break;
     case Menu::setinvincibility:
@@ -1610,28 +1609,40 @@ void titleinput(void)
     if (key.isDown(KEYBOARD_ENTER)) game.press_map = true;
 
     //In the menu system, all keypresses are single taps rather than holds. Therefore this test has to be done for all presses
-    if (!game.press_action && !game.press_left && !game.press_right) game.jumpheld = false;
+    if (!game.press_action && !game.press_left && !game.press_right && !key.isDown(27) && !key.isDown(game.controllerButton_esc)) game.jumpheld = false;
     if (!game.press_map) game.mapheld = false;
 
     if (!game.jumpheld && graphics.fademode==0)
     {
-        if (game.press_action || game.press_left || game.press_right || game.press_map)
+        if (game.press_action || game.press_left || game.press_right || game.press_map || key.isDown(27) || key.isDown(game.controllerButton_esc))
         {
             game.jumpheld = true;
         }
 
-        if (key.isDown(27) && game.currentmenuname != Menu::youwannaquit && game.menustart)
+        if (game.menustart
+        && game.menucountdown <= 0
+        && (key.isDown(27) || key.isDown(game.controllerButton_esc)))
         {
             music.playef(11);
-            if (game.ingame_titlemode)
+            if (game.currentmenuname == Menu::mainmenu)
             {
-                game.returntopausemenu();
+                game.createmenu(Menu::youwannaquit);
             }
             else
             {
-                game.createmenu(Menu::youwannaquit);
-                map.nexttowercolour();
+                if (game.ingame_titlemode
+                && (game.currentmenuname == Menu::options
+                || game.currentmenuname == Menu::graphicoptions))
+                {
+                    game.returntopausemenu();
+                }
+                else
+                {
+                    game.returnmenu();
+                }
             }
+
+            map.nexttowercolour();
         }
 
         if(game.menustart)

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3928,7 +3928,30 @@ void editorinput(void)
         else
         {
 
-            ed.settingsmod=!ed.settingsmod;
+            music.playef(11);
+            if (ed.settingsmod)
+            {
+                if (ed.scripteditmod)
+                {
+                    ed.scripteditmod = false;
+                }
+                else if (ed.settingsmod)
+                {
+                    if (game.currentmenuname == Menu::ed_settings)
+                    {
+                        ed.settingsmod = false;
+                    }
+                    else
+                    {
+                        game.returnmenu();
+                        map.nexttowercolour();
+                    }
+                }
+            }
+            else
+            {
+                ed.settingsmod = true;
+            }
             graphics.backgrounddrawn=false;
 
             if (ed.settingsmod)
@@ -4036,12 +4059,6 @@ void editorinput(void)
                     }
                     key.keybuffer=ed.sb[ed.pagey+ed.sby];
                     ed.sbx = utf8::unchecked::distance(ed.sb[ed.pagey+ed.sby].begin(), ed.sb[ed.pagey+ed.sby].end());
-                }
-
-                if (key.isDown(27))
-                {
-                    ed.scripteditmod=false;
-                    ed.settingsmod=false;
                 }
             }
         }


### PR DESCRIPTION
This is a small quality-of-life thing that makes it so you don't have to move your menu selection all the way over to the "return" button in order to return to the previous menu. You can just press Escape instead to return to the previous menu. The previous behavior of pressing Escape was to bring up the 'confirm quit' menu, or if you were in an options menu in-game, return to the pause menu.

If you're on the main menu (and thus don't have any previous menu) and press Escape, the game will instead bring up the 'confirm quit' menu. For consistency, the "quit game" option on the main menu will also bring up the 'confirm quit' menu as well, instead of immediately closing the game.

Pressing the controller button mapped to Escape will also work as well.

The only menus that don't have return buttons are the 'countdown' menus - so the game will not let you press Escape if there's a menu countdown happening.

Now that pressing Escape in the 'continue' menu will just bring you back to the 'play' menu, there's no need to specifically put `map.nexttowercolour()` first when canceling the 'confirm quit' menu.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
