### PR TITLE
Add graphic options and game options to editor settings

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -373,6 +373,9 @@ void Game::init(void)
     glitchrunnermode = false;
 
     ingame_titlemode = false;
+#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
+    ingame_editormode = false;
+#endif
     kludge_ingametemp = Menu::mainmenu;
 
     disablepause = false;
@@ -6394,6 +6397,8 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("editor ghosts");
         option("load level");
         option("save level");
+        option("graphic options");
+        option("game options");
         option("quit to main menu");
 
         menuyoff = -20;
@@ -7076,16 +7081,28 @@ void Game::returntoeditor(void)
 }
 #endif
 
-void Game::returntopausemenu(void)
+void Game::returntoingame(void)
 {
     ingame_titlemode = false;
-    returntomenu(kludge_ingametemp);
-    gamestate = MAPMODE;
     mapheld = true;
-    graphics.flipmode = graphics.setflipmode;
-    if (!map.custommode && !graphics.flipmode)
+#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
+    if (ingame_editormode)
     {
-        obj.flags[73] = true;
+        ingame_editormode = false;
+        returntomenu(Menu::ed_settings);
+        gamestate = EDITORMODE;
+        ed.settingskey = true;
+    }
+    else
+#endif
+    {
+        returntomenu(kludge_ingametemp);
+        gamestate = MAPMODE;
+        graphics.flipmode = graphics.setflipmode;
+        if (!map.custommode && !graphics.flipmode)
+        {
+            obj.flags[73] = true;
+        }
     }
 }
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -442,8 +442,11 @@ public:
     bool glitchrunnermode; // Have fun speedrunners! <3 Misa
 
     bool ingame_titlemode;
+#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
+    bool ingame_editormode;
+#endif
 
-    void returntopausemenu(void);
+    void returntoingame(void);
     void unlockAchievement(const char *name);
 
     bool disablepause;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -455,7 +455,7 @@ static void menuactionpress(void)
             music.playef(11);
             if (game.ingame_titlemode)
             {
-                game.returntopausemenu();
+                game.returntoingame();
             }
             else
             {
@@ -766,7 +766,7 @@ static void menuactionpress(void)
             music.playef(11);
             if (game.ingame_titlemode)
             {
-                game.returntopausemenu();
+                game.returntoingame();
             }
             else
             {
@@ -1634,7 +1634,7 @@ void titleinput(void)
                 && (game.currentmenuname == Menu::options
                 || game.currentmenuname == Menu::graphicoptions))
                 {
-                    game.returntopausemenu();
+                    game.returntoingame();
                 }
                 else
                 {

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3769,6 +3769,25 @@ static void editormenuactionpress()
             graphics.backgrounddrawn=false;
             break;
         case 6:
+        case 7:
+            /* Graphic options and game options */
+            music.playef(11);
+            game.gamestate = TITLEMODE;
+            game.ingame_titlemode = true;
+            game.ingame_editormode = true;
+
+            if (game.currentmenuoption == 6)
+            {
+                game.createmenu(Menu::graphicoptions);
+            }
+            else
+            {
+                game.createmenu(Menu::options);
+            }
+
+            map.nexttowercolour();
+            break;
+        default:
             music.playef(11);
             game.createmenu(Menu::ed_quit);
             map.nexttowercolour();


### PR DESCRIPTION
This is a small quality-of-life tweak that makes it so if you're in the middle of editing a level, you don't have to save the level, exit to the menu, change whatever setting you wanted, re-enter the editor, and type in the level name, just to change one setting. This is the same as adding Graphic Options and Game Options to the in-game pause menu, except for the editor, too.

To do this, I'm reusing `Game::returntopausemenu()` (because all of its callers are the same callers for returning to editor settings) and renamed it to `returntoingame()`, then added a variable named `ingame_editormode` to Game. When we're in the options menus but still in the editor, *both* `ingame_titlemode` and `ingame_editormode` will be true.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
