### PR TITLE
Fix a few missing implicit void arg declarations

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6044,7 +6044,7 @@ bool Game::customsavequick(std::string savfile)
 }
 
 
-void Game::loadtele()
+void Game::loadtele(void)
 {
     tinyxml2::XMLDocument doc;
     if (!FILESYSTEM_loadTiXml2Document("saves/tsave.vvv", doc)) return;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3237,7 +3237,7 @@ bool Graphics::onscreen(int t)
 	return (t >= -40 && t <= 280);
 }
 
-void Graphics::reloadresources()
+void Graphics::reloadresources(void)
 {
 	grphx.destroy();
 	grphx.init();

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1166,7 +1166,7 @@ static void menurender(void)
     }
 }
 
-void titlerender()
+void titlerender(void)
 {
 
     ClearSurface(graphics.backBuffer);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3680,7 +3680,7 @@ void editorlogic(void)
 }
 
 
-static void editormenuactionpress()
+static void editormenuactionpress(void)
 {
     extern editorclass ed;
     switch (game.currentmenuname)


### PR DESCRIPTION
While working on #535, I noticed that `editormenuactionpress()` still didn't do the explicit void declaration. Then I ran `rg 'void.*\(\)'` and found three other functions that I somehow missed in #628. Whoops. Well, now they no longer are missed.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
