### PR TITLE
Fix oversight with unfocus pause screen in Flip Mode

### DIFF
--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -730,10 +730,12 @@ static void unfocused_run(void)
     if (!game.blackout)
     {
         ClearSurface(graphics.backBuffer);
-        graphics.bprint(5, 110, "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
-        graphics.bprint(5, 120, "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
-        graphics.bprint(5, 220, "Press M to mute in game", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
-        graphics.bprint(5, 230, "Press N to mute music only", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+#define FLIP(YPOS) graphics.flipmode ? 232 - YPOS : YPOS
+        graphics.bprint(5, FLIP(110), "Game paused", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
+        graphics.bprint(5, FLIP(120), "[click to resume]", 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
+        graphics.bprint(5, FLIP(220), "Press M to mute in game", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+        graphics.bprint(5, FLIP(230), "Press N to mute music only", 164 - help.glow, 196 - help.glow, 164 - help.glow, true);
+#undef FLIP
     }
     graphics.render();
     gameScreen.FlipScreen();


### PR DESCRIPTION
Flip Mode flips all the unfocus pause screen text upside-down, to make it read in reverse order. This looks kind of strange to me, and I don't think it was intended. So I'm flipping the text again so it's the right way up in Flip Mode.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
