### PR TITLE
Fix misplaced text boxes when toggling Flip Mode while Flip Mode-aware text boxes are active

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -714,6 +714,25 @@ void Game::actionprompt_textbox(void)
     graphics.textboxcenterx();
 }
 
+void Game::savetele_textbox(void)
+{
+    if (inspecial() || map.custommode)
+    {
+        return;
+    }
+
+    if (savetele())
+    {
+        graphics.createtextboxflipme("    Game Saved    ", -1, 12, 174, 174, 174);
+        graphics.textboxtimer(25);
+    }
+    else
+    {
+        graphics.createtextboxflipme("  ERROR: Could not save game!  ", -1, 12, 255, 60, 60);
+        graphics.textboxtimer(50);
+    }
+}
+
 void Game::updatestate(void)
 {
     statedelay--;
@@ -2000,24 +2019,8 @@ void Game::updatestate(void)
 
         case 2000:
             //Game Saved!
-            if (inspecial() || map.custommode)
-            {
-                state = 0;
-            }
-            else
-            {
-                if (savetele())
-                {
-                    graphics.createtextbox("    Game Saved    ", -1, graphics.flipmode ? 202 : 12, 174, 174, 174);
-                    graphics.textboxtimer(25);
-                }
-                else
-                {
-                    graphics.createtextbox("  ERROR: Could not save game!  ", -1, graphics.flipmode ? 202 : 12, 255, 60, 60);
-                    graphics.textboxtimer(50);
-                }
-                state = 0;
-            }
+            savetele_textbox();
+            state = 0;
             break;
 
         case 2500:

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -634,6 +634,86 @@ void Game::savecustomlevelstats(void)
     }
 }
 
+void Game::levelcomplete_textbox(void)
+{
+    if (graphics.flipmode)
+    {
+        graphics.createtextbox("", -1, 180, 165, 165, 255);
+    }
+    else
+    {
+        graphics.createtextbox("", -1, 12, 165, 165, 255);
+    }
+    graphics.addline("                                   ");
+    graphics.addline("");
+    graphics.addline("");
+    graphics.textboxcenterx();
+}
+
+void Game::crewmate_textbox(const int r, const int g, const int b)
+{
+    if (graphics.flipmode)
+    {
+        graphics.createtextbox("", -1, 104, r, g, b);
+    }
+    else
+    {
+        graphics.createtextbox("", -1, 64 + 8 + 16, r, g, b);
+    }
+    graphics.addline("     You have rescued  ");
+    graphics.addline("      a crew member!   ");
+    graphics.addline("");
+    graphics.textboxcenterx();
+}
+
+void Game::remaining_textbox(void)
+{
+    const int remaining = 6 - crewrescued();
+    const char* string;
+    char buffer[161]; /* 4 bytes per 40 chars (whole screen) plus 1 for null terminator */
+    if (remaining == 1)
+    {
+        string = "  One remains  ";
+    }
+    else if (remaining > 0)
+    {
+        SDL_snprintf(
+            buffer,
+            sizeof(buffer),
+            "  %s remain  ",
+            help.number(remaining).c_str()
+        );
+        string = buffer;
+    }
+    else
+    {
+        string = "  All Crew Members Rescued!  ";
+    }
+
+    if (graphics.flipmode)
+    {
+        graphics.createtextbox(string, -1, 72, 174, 174, 174);
+    }
+    else
+    {
+        graphics.createtextbox(string, -1, 128 + 16, 174, 174, 174);
+    }
+    graphics.textboxcenterx();
+}
+
+void Game::actionprompt_textbox(void)
+{
+    if (graphics.flipmode)
+    {
+        graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
+    }
+    else
+    {
+        graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
+    }
+    graphics.textboxcenterx();
+}
+
 void Game::updatestate(void)
 {
     statedelay--;
@@ -2180,93 +2260,25 @@ void Game::updatestate(void)
             state++;
             statedelay = 75;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox("", -1, 180, 165, 165, 255);
-            }
-            else
-            {
-                graphics.createtextbox("", -1, 12, 165, 165, 255);
-            }
-            graphics.addline("                                   ");
-            graphics.addline("");
-            graphics.addline("");
-            graphics.textboxcenterx();
+            levelcomplete_textbox();
             break;
         case 3007:
             state++;
             statedelay = 45;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox("", -1, 104, 175,174,174);
-            }
-            else
-            {
-                graphics.createtextbox("", -1, 64+8+16, 175,174,174);
-            }
-            graphics.addline("     You have rescued  ");
-            graphics.addline("      a crew member!   ");
-            graphics.addline("");
-            graphics.textboxcenterx();
+            crewmate_textbox(175, 174, 174);
             break;
         case 3008:
-        {
             state++;
             statedelay = 45;
 
-            int temp = 6 - crewrescued();
-            if (temp == 1)
-            {
-                std::string tempstring = "  One remains  ";
-                if (graphics.flipmode)
-                {
-                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
-                }
-            }
-            else if (temp > 0)
-            {
-                std::string tempstring = "  " + help.number(temp) + " remain  ";
-                if (graphics.flipmode)
-                {
-                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
-                }
-            }
-            else
-            {
-                if (graphics.flipmode)
-                {
-                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
-                }
-            }
-            graphics.textboxcenterx();
+            remaining_textbox();
             break;
-        }
         case 3009:
             state++;
             statedelay = 0;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
-            }
-            else
-            {
-                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
-            }
-            graphics.textboxcenterx();
+            actionprompt_textbox();
             break;
         case 3010:
             if (jumppressed)
@@ -2290,93 +2302,25 @@ void Game::updatestate(void)
             statedelay = 75;
 
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox("", -1, 180, 165, 165, 255);
-            }
-            else
-            {
-                graphics.createtextbox("", -1, 12, 165, 165, 255);
-            }
-            graphics.addline("                                   ");
-            graphics.addline("");
-            graphics.addline("");
-            graphics.textboxcenterx();
+            levelcomplete_textbox();
             break;
         case 3021:
             state++;
             statedelay = 45;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox("", -1, 104, 174,175,174);
-            }
-            else
-            {
-                graphics.createtextbox("", -1, 64+8+16, 174,175,174);
-            }
-            graphics.addline("     You have rescued  ");
-            graphics.addline("      a crew member!   ");
-            graphics.addline("");
-            graphics.textboxcenterx();
+            crewmate_textbox(174, 175, 174);
             break;
         case 3022:
-        {
             state++;
             statedelay = 45;
 
-            int temp = 6 - crewrescued();
-            if (temp == 1)
-            {
-                std::string tempstring = "  One remains  ";
-                if (graphics.flipmode)
-                {
-                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
-                }
-            }
-            else if (temp > 0)
-            {
-                std::string tempstring = "  " + help.number(temp) + " remain  ";
-                if (graphics.flipmode)
-                {
-                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
-                }
-            }
-            else
-            {
-                if (graphics.flipmode)
-                {
-                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
-                }
-            }
-            graphics.textboxcenterx();
+            remaining_textbox();
             break;
-        }
         case 3023:
             state++;
             statedelay = 0;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
-            }
-            else
-            {
-                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
-            }
-            graphics.textboxcenterx();
+            actionprompt_textbox();
             break;
         case 3024:
             if (jumppressed)
@@ -2399,93 +2343,25 @@ void Game::updatestate(void)
             state++;
             statedelay = 75;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox("", -1, 180, 165, 165, 255);
-            }
-            else
-            {
-                graphics.createtextbox("", -1, 12, 165, 165, 255);
-            }
-            graphics.addline("                                   ");
-            graphics.addline("");
-            graphics.addline("");
-            graphics.textboxcenterx();
+            levelcomplete_textbox();
             break;
         case 3041:
             state++;
             statedelay = 45;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox("", -1, 104, 174,174,175);
-            }
-            else
-            {
-                graphics.createtextbox("", -1, 64+8+16, 174,174,175);
-            }
-            graphics.addline("     You have rescued  ");
-            graphics.addline("      a crew member!   ");
-            graphics.addline("");
-            graphics.textboxcenterx();
+            crewmate_textbox(174, 174, 175);
             break;
         case 3042:
-        {
             state++;
             statedelay = 45;
 
-            int temp = 6 - crewrescued();
-            if (temp == 1)
-            {
-                std::string tempstring = "  One remains  ";
-                if (graphics.flipmode)
-                {
-                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
-                }
-            }
-            else if (temp > 0)
-            {
-                std::string tempstring = "  " + help.number(temp) + " remain  ";
-                if (graphics.flipmode)
-                {
-                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
-                }
-            }
-            else
-            {
-                if (graphics.flipmode)
-                {
-                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
-                }
-            }
-            graphics.textboxcenterx();
+            remaining_textbox();
             break;
-        }
         case 3043:
             state++;
             statedelay = 0;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
-            }
-            else
-            {
-                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
-            }
-            graphics.textboxcenterx();
+            actionprompt_textbox();
             break;
         case 3044:
             if (jumppressed)
@@ -2509,93 +2385,25 @@ void Game::updatestate(void)
             statedelay = 75;
 
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox("", -1, 180, 165, 165, 255);
-            }
-            else
-            {
-                graphics.createtextbox("", -1, 12, 165, 165, 255);
-            }
-            graphics.addline("                                   ");
-            graphics.addline("");
-            graphics.addline("");
-            graphics.textboxcenterx();
+            levelcomplete_textbox();
             break;
         case 3051:
             state++;
             statedelay = 45;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox("", -1, 104, 175,175,174);
-            }
-            else
-            {
-                graphics.createtextbox("", -1, 64+8+16, 175,175,174);
-            }
-            graphics.addline("     You have rescued  ");
-            graphics.addline("      a crew member!   ");
-            graphics.addline("");
-            graphics.textboxcenterx();
+            crewmate_textbox(175, 175, 174);
             break;
         case 3052:
-        {
             state++;
             statedelay = 45;
 
-            int temp = 6 - crewrescued();
-            if (temp == 1)
-            {
-                std::string tempstring = "  One remains  ";
-                if (graphics.flipmode)
-                {
-                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
-                }
-            }
-            else if (temp > 0)
-            {
-                std::string tempstring = "  " + help.number(temp) + " remain  ";
-                if (graphics.flipmode)
-                {
-                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
-                }
-            }
-            else
-            {
-                if (graphics.flipmode)
-                {
-                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
-                }
-            }
-            graphics.textboxcenterx();
+            remaining_textbox();
             break;
-        }
         case 3053:
             state++;
             statedelay = 0;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
-            }
-            else
-            {
-                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
-            }
-            graphics.textboxcenterx();
+            actionprompt_textbox();
             break;
         case 3054:
             if (jumppressed)
@@ -2643,93 +2451,25 @@ void Game::updatestate(void)
             state++;
             statedelay = 75;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox("", -1, 180, 165, 165, 255);
-            }
-            else
-            {
-                graphics.createtextbox("", -1, 12, 165, 165, 255);
-            }
-            graphics.addline("                                   ");
-            graphics.addline("");
-            graphics.addline("");
-            graphics.textboxcenterx();
+            levelcomplete_textbox();
             break;
         case 3061:
             state++;
             statedelay = 45;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox("", -1, 104, 175,174,175);
-            }
-            else
-            {
-                graphics.createtextbox("", -1, 64+8+16, 175,174,175);
-            }
-            graphics.addline("     You have rescued  ");
-            graphics.addline("      a crew member!   ");
-            graphics.addline("");
-            graphics.textboxcenterx();
+            crewmate_textbox(175, 174, 175);
             break;
         case 3062:
-        {
             state++;
             statedelay = 45;
 
-            int temp = 6 - crewrescued();
-            if (temp == 1)
-            {
-                std::string tempstring = "  One remains  ";
-                if (graphics.flipmode)
-                {
-                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
-                }
-            }
-            else if (temp > 0)
-            {
-                std::string tempstring = "  " + help.number(temp) + " remain  ";
-                if (graphics.flipmode)
-                {
-                    graphics.createtextbox(tempstring, -1, 72, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox(tempstring, -1, 128+16, 174, 174, 174);
-                }
-            }
-            else
-            {
-                if (graphics.flipmode)
-                {
-                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 72, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox("  All Crew Members Rescued!  ", -1, 128+16, 174, 174, 174);
-                }
-            }
-            graphics.textboxcenterx();
+            remaining_textbox();
             break;
-        }
         case 3063:
             state++;
             statedelay = 0;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
-            }
-            else
-            {
-                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
-            }
-            graphics.textboxcenterx();
+            actionprompt_textbox();
             break;
         case 3064:
             if (jumppressed)
@@ -3018,15 +2758,7 @@ void Game::updatestate(void)
             state++;
             statedelay = 0;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
-            }
-            else
-            {
-                graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
-            }
-            graphics.textboxcenterx();
+            actionprompt_textbox();
             break;
         case 3509:
             if (jumppressed)

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -636,14 +636,7 @@ void Game::savecustomlevelstats(void)
 
 void Game::levelcomplete_textbox(void)
 {
-    if (graphics.flipmode)
-    {
-        graphics.createtextbox("", -1, 180, 165, 165, 255);
-    }
-    else
-    {
-        graphics.createtextbox("", -1, 12, 165, 165, 255);
-    }
+    graphics.createtextboxflipme("", -1, 12, 165, 165, 255);
     graphics.addline("                                   ");
     graphics.addline("");
     graphics.addline("");
@@ -652,14 +645,7 @@ void Game::levelcomplete_textbox(void)
 
 void Game::crewmate_textbox(const int r, const int g, const int b)
 {
-    if (graphics.flipmode)
-    {
-        graphics.createtextbox("", -1, 104, r, g, b);
-    }
-    else
-    {
-        graphics.createtextbox("", -1, 64 + 8 + 16, r, g, b);
-    }
+    graphics.createtextboxflipme("", -1, 64 + 8 + 16, r, g, b);
     graphics.addline("     You have rescued  ");
     graphics.addline("      a crew member!   ");
     graphics.addline("");
@@ -690,27 +676,13 @@ void Game::remaining_textbox(void)
         string = "  All Crew Members Rescued!  ";
     }
 
-    if (graphics.flipmode)
-    {
-        graphics.createtextbox(string, -1, 72, 174, 174, 174);
-    }
-    else
-    {
-        graphics.createtextbox(string, -1, 128 + 16, 174, 174, 174);
-    }
+    graphics.createtextboxflipme(string, -1, 128 + 16, 174, 174, 174);
     graphics.textboxcenterx();
 }
 
 void Game::actionprompt_textbox(void)
 {
-    if (graphics.flipmode)
-    {
-        graphics.createtextbox(" Press ACTION to continue ", -1, 20, 164, 164, 255);
-    }
-    else
-    {
-        graphics.createtextbox(" Press ACTION to continue ", -1, 196, 164, 164, 255);
-    }
+    graphics.createtextboxflipme(" Press ACTION to continue ", -1, 196, 164, 164, 255);
     graphics.textboxcenterx();
 }
 
@@ -1839,45 +1811,22 @@ void Game::updatestate(void)
             //Found a trinket!
             advancetext = true;
             state++;
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox("        Congratulations!       ", 50, 105, 174, 174, 174);
-                graphics.addline("");
-                graphics.addline("You have found a shiny trinket!");
-                graphics.textboxcenterx();
+            graphics.createtextboxflipme("        Congratulations!       ", 50, 85, 174, 174, 174);
+            graphics.addline("");
+            graphics.addline("You have found a shiny trinket!");
+            graphics.textboxcenterx();
 
 #if !defined(NO_CUSTOM_LEVELS)
-                if(map.custommode)
-                {
-                    graphics.createtextbox(" " + help.number(trinkets()) + " out of " + help.number(ed.numtrinkets())+ " ", 50, 65, 174, 174, 174);
-                    graphics.textboxcenterx();
-                }
-                else
-#endif
-                {
-                    graphics.createtextbox(" " + help.number(trinkets()) + " out of Twenty ", 50, 65, 174, 174, 174);
-                    graphics.textboxcenterx();
-                }
+            if(map.custommode)
+            {
+                graphics.createtextboxflipme(" " + help.number(trinkets()) + " out of " + help.number(ed.numtrinkets())+ " ", 50, 135, 174, 174, 174);
+                graphics.textboxcenterx();
             }
             else
-            {
-                graphics.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
-                graphics.addline("");
-                graphics.addline("You have found a shiny trinket!");
-                graphics.textboxcenterx();
-
-#if !defined(NO_CUSTOM_LEVELS)
-                if(map.custommode)
-                {
-                    graphics.createtextbox(" " + help.number(trinkets()) + " out of " + help.number(ed.numtrinkets())+ " ", 50, 135, 174, 174, 174);
-                    graphics.textboxcenterx();
-                }
-                else
 #endif
-                {
-                    graphics.createtextbox(" " + help.number(trinkets()) + " out of Twenty ", 50, 135, 174, 174, 174);
-                    graphics.textboxcenterx();
-                }
+            {
+                graphics.createtextboxflipme(" " + help.number(trinkets()) + " out of Twenty ", 50, 135, 174, 174, 174);
+                graphics.textboxcenterx();
             }
             break;
         case 1002:
@@ -1909,49 +1858,24 @@ void Game::updatestate(void)
             //Found a crewmate!
             advancetext = true;
             state++;
-            if (graphics.flipmode)
+            graphics.createtextboxflipme("        Congratulations!       ", 50, 85, 174, 174, 174);
+            graphics.addline("");
+            graphics.addline("You have found a lost crewmate!");
+            graphics.textboxcenterx();
+
+            if(ed.numcrewmates()-crewmates()==0)
             {
-                graphics.createtextbox("        Congratulations!       ", 50, 105, 174, 174, 174);
-                graphics.addline("");
-                graphics.addline("You have found a lost crewmate!");
-                graphics.textboxcenterx();
-
-                if(ed.numcrewmates()-crewmates()==0)
-                {
-                    graphics.createtextbox("     All crewmates rescued!    ", 50, 65, 174, 174, 174);
-                }
-                else if(ed.numcrewmates()-crewmates()==1)
-                {
-                    graphics.createtextbox("    " + help.number(ed.numcrewmates()-crewmates())+ " remains    ", 50, 65, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox("     " + help.number(ed.numcrewmates()-crewmates())+ " remain    ", 50, 65, 174, 174, 174);
-                }
-                graphics.textboxcenterx();
-
+                graphics.createtextboxflipme("     All crewmates rescued!    ", 50, 135, 174, 174, 174);
+            }
+            else if(ed.numcrewmates()-crewmates()==1)
+            {
+                graphics.createtextboxflipme("    " + help.number(ed.numcrewmates()-crewmates())+ " remains    ", 50, 135, 174, 174, 174);
             }
             else
             {
-                graphics.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
-                graphics.addline("");
-                graphics.addline("You have found a lost crewmate!");
-                graphics.textboxcenterx();
-
-                if(ed.numcrewmates()-crewmates()==0)
-                {
-                    graphics.createtextbox("     All crewmates rescued!    ", 50, 135, 174, 174, 174);
-                }
-                else if(ed.numcrewmates()-crewmates()==1)
-                {
-                    graphics.createtextbox("    " + help.number(ed.numcrewmates()-crewmates())+ " remains    ", 50, 135, 174, 174, 174);
-                }
-                else
-                {
-                    graphics.createtextbox("     " + help.number(ed.numcrewmates()-crewmates())+ " remain    ", 50, 135, 174, 174, 174);
-                }
-                graphics.textboxcenterx();
+                graphics.createtextboxflipme("     " + help.number(ed.numcrewmates()-crewmates())+ " remain    ", 50, 135, 174, 174, 174);
             }
+            graphics.textboxcenterx();
             break;
         case 1012:
             if (!advancetext)
@@ -2644,14 +2568,7 @@ void Game::updatestate(void)
             statedelay = 75;
             music.play(7);
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox("", -1, 180, 164, 165, 255);
-            }
-            else
-            {
-                graphics.createtextbox("", -1, 12, 164, 165, 255);
-            }
+            graphics.createtextboxflipme("", -1, 12, 164, 165, 255);
             graphics.addline("                                   ");
             graphics.addline("");
             graphics.addline("");
@@ -2661,14 +2578,7 @@ void Game::updatestate(void)
             state++;
             statedelay = 45+15;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox("  All Crew Members Rescued!  ", -1, 175-24, 0, 0, 0);
-            }
-            else
-            {
-                graphics.createtextbox("  All Crew Members Rescued!  ", -1, 64, 0, 0, 0);
-            }
+            graphics.createtextboxflipme("  All Crew Members Rescued!  ", -1, 64, 0, 0, 0);
             savetime = timestring();
             savetime += "." + help.twodigits(frames*100 / 30);
             break;
@@ -2678,16 +2588,8 @@ void Game::updatestate(void)
             statedelay = 45;
 
             std::string tempstring = help.number(trinkets());
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox("Trinkets Found:", 48, 155-24, 0,0,0);
-                graphics.createtextbox(tempstring, 180, 155-24, 0, 0, 0);
-            }
-            else
-            {
-                graphics.createtextbox("Trinkets Found:", 48, 84, 0,0,0);
-                graphics.createtextbox(tempstring, 180, 84, 0, 0, 0);
-            }
+            graphics.createtextboxflipme("Trinkets Found:", 48, 84, 0,0,0);
+            graphics.createtextboxflipme(tempstring, 180, 84, 0, 0, 0);
             break;
         }
         case 3504:
@@ -2696,65 +2598,32 @@ void Game::updatestate(void)
             statedelay = 45+15;
 
             std::string tempstring = savetime;
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox("   Game Time:", 64, 143-24, 0,0,0);
-                graphics.createtextbox(tempstring, 180, 143-24, 0, 0, 0);
-            }
-            else
-            {
-                graphics.createtextbox("   Game Time:", 64, 96, 0,0,0);
-                graphics.createtextbox(tempstring, 180, 96, 0, 0, 0);
-            }
+            graphics.createtextboxflipme("   Game Time:", 64, 96, 0,0,0);
+            graphics.createtextboxflipme(tempstring, 180, 96, 0, 0, 0);
             break;
         }
         case 3505:
             state++;
             statedelay = 45;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox(" Total Flips:", 64, 116-24, 0,0,0);
-                graphics.createtextbox(help.String(totalflips), 180, 116-24, 0, 0, 0);
-            }
-            else
-            {
-                graphics.createtextbox(" Total Flips:", 64, 123, 0,0,0);
-                graphics.createtextbox(help.String(totalflips), 180, 123, 0, 0, 0);
-            }
+            graphics.createtextboxflipme(" Total Flips:", 64, 123, 0,0,0);
+            graphics.createtextboxflipme(help.String(totalflips), 180, 123, 0, 0, 0);
             break;
         case 3506:
             state++;
             statedelay = 45+15;
 
-            if (graphics.flipmode)
-            {
-                graphics.createtextbox("Total Deaths:", 64, 104-24, 0,0,0);
-                graphics.createtextbox(help.String(deathcounts), 180, 104-24, 0, 0, 0);
-            }
-            else
-            {
-                graphics.createtextbox("Total Deaths:", 64, 135, 0,0,0);
-                graphics.createtextbox(help.String(deathcounts), 180, 135, 0, 0, 0);
-            }
+            graphics.createtextboxflipme("Total Deaths:", 64, 135, 0,0,0);
+            graphics.createtextboxflipme(help.String(deathcounts), 180, 135, 0, 0, 0);
             break;
         case 3507:
         {
             state++;
             statedelay = 45+15;
 
-            if (graphics.flipmode)
-            {
-                std::string tempstring = "Hardest Room (with " + help.String(hardestroomdeaths) + " deaths)";
-                graphics.createtextbox(tempstring, -1, 81-24, 0,0,0);
-                graphics.createtextbox(hardestroom, -1, 69-24, 0, 0, 0);
-            }
-            else
-            {
-                std::string tempstring = "Hardest Room (with " + help.String(hardestroomdeaths) + " deaths)";
-                graphics.createtextbox(tempstring, -1, 158, 0,0,0);
-                graphics.createtextbox(hardestroom, -1, 170, 0, 0, 0);
-            }
+            std::string tempstring = "Hardest Room (with " + help.String(hardestroomdeaths) + " deaths)";
+            graphics.createtextboxflipme(tempstring, -1, 158, 0,0,0);
+            graphics.createtextboxflipme(hardestroom, -1, 170, 0, 0, 0);
             break;
         }
         case 3508:

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -470,7 +470,6 @@ void Game::updatecustomlevelstats(std::string clevel, int cscore)
 
 void Game::loadcustomlevelstats(void)
 {
-    //testing
     if(customlevelstatsloaded)
     {
         return;
@@ -678,10 +677,6 @@ void Game::updatestate(void)
             //Demo over
             advancetext = true;
             hascontrol = false;
-            /*graphics.createtextbox("   Prototype Complete    ", 50, 80, 164, 164, 255);
-            graphics.addline("Congrats! More Info Soon!");
-            graphics.textboxcenter();
-            */
 
             startscript = true;
             newscript="returntohub";
@@ -1630,7 +1625,6 @@ void Game::updatestate(void)
             state++;
             music.playef(2);
             graphics.textboxactive();
-            int i = obj.getcompanion(); if (INBOUNDS_VEC(i, obj.entities)) {	/*obj.entities[i].tile = 66;	obj.entities[i].state = 0;*/	}
             break;
         }
         case 126:
@@ -1673,7 +1667,6 @@ void Game::updatestate(void)
             //Init final stretch
             state++;
             music.playef(9);
-            //music.play(2);
             obj.flags[72] = true;
 
             screenshake = 10;
@@ -1801,7 +1794,6 @@ void Game::updatestate(void)
             advancetext = false;
             completestop = false;
             state = 0;
-            //music.play(music.resumesong);
             if(!muted && music.currentsong>-1) music.fadeMusicVolumeIn(3000);
             graphics.showcutscenebars = false;
             break;
@@ -2044,11 +2036,6 @@ void Game::updatestate(void)
         case 2507:
         {
             state++;
-            int i = obj.getplayer();
-            if (INBOUNDS_VEC(i, obj.entities))
-            {
-                //obj.entities[i].xp += 4;
-            }
             break;
         }
         case 2508:
@@ -2141,9 +2128,6 @@ void Game::updatestate(void)
             //Activating a teleporter 2
             state++;
             statedelay = 50;
-            //testing!
-            //state = 3006; //Warp Zone
-            //state = 3020; //Space Station
             switch(companion)
             {
             case 6:
@@ -2204,17 +2188,10 @@ void Game::updatestate(void)
             {
                 graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
-            //graphics.addline("      Level Complete!      ");
             graphics.addline("                                   ");
             graphics.addline("");
             graphics.addline("");
             graphics.textboxcenterx();
-
-            /*												advancetext = true;
-            hascontrol = false;
-            state = 3;
-            graphics.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            graphics.addline("intro to story!");*/
             break;
         case 3007:
             state++;
@@ -2321,17 +2298,10 @@ void Game::updatestate(void)
             {
                 graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
-            //graphics.addline("      Level Complete!      ");
             graphics.addline("                                   ");
             graphics.addline("");
             graphics.addline("");
             graphics.textboxcenterx();
-
-            /*												advancetext = true;
-            hascontrol = false;
-            state = 3;
-            graphics.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            graphics.addline("intro to story!");*/
             break;
         case 3021:
             state++;
@@ -2437,17 +2407,10 @@ void Game::updatestate(void)
             {
                 graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
-            //graphics.addline("      Level Complete!      ");
             graphics.addline("                                   ");
             graphics.addline("");
             graphics.addline("");
             graphics.textboxcenterx();
-
-            /*												advancetext = true;
-            hascontrol = false;
-            state = 3;
-            graphics.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            graphics.addline("intro to story!");*/
             break;
         case 3041:
             state++;
@@ -2554,17 +2517,10 @@ void Game::updatestate(void)
             {
                 graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
-            //graphics.addline("      Level Complete!      ");
             graphics.addline("                                   ");
             graphics.addline("");
             graphics.addline("");
             graphics.textboxcenterx();
-
-            /*												advancetext = true;
-            hascontrol = false;
-            state = 3;
-            graphics.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            graphics.addline("intro to story!");*/
             break;
         case 3051:
             state++;
@@ -2695,17 +2651,10 @@ void Game::updatestate(void)
             {
                 graphics.createtextbox("", -1, 12, 165, 165, 255);
             }
-            //graphics.addline("      Level Complete!      ");
             graphics.addline("                                   ");
             graphics.addline("");
             graphics.addline("");
             graphics.textboxcenterx();
-
-            /*												advancetext = true;
-            hascontrol = false;
-            state = 3;
-            graphics.createtextbox("To do: write quick", 50, 80, 164, 164, 255);
-            graphics.addline("intro to story!");*/
             break;
         case 3061:
             state++;
@@ -3210,8 +3159,6 @@ void Game::updatestate(void)
             graphics.fademode = 4;
             state = 0;
             statedelay = 30;
-            //music.play(5);
-            //music.play(10);
 
             map.finalmode = false;
             map.final_colormode = false;
@@ -3265,10 +3212,6 @@ void Game::updatestate(void)
             //Activating a teleporter 2
             state++;
             statedelay = 10;
-            //testing!
-            //state = 3006; //Warp Zone
-            //state = 3020; //Space Station
-            //state = 3040; //Lab
 
             int i = obj.getplayer();
             if (INBOUNDS_VEC(i, obj.entities))
@@ -4998,18 +4941,12 @@ void Game::customstart(void)
 
     savegc = edsavegc;
     savedir = edsavedir; //Worldmap Start
-    //savex = 6 * 8; savey = 15 * 8; saverx = 46; savery = 54; savegc = 0; savedir = 1; //Final Level Current
     savepoint = 0;
     gravitycontrol = savegc;
 
-    //state = 2; deathseq = -1; lifeseq = 10; //Not dead, in game initilisation state
     state = 0;
     deathseq = -1;
     lifeseq = 0;
-
-    //let's teleport in!
-    //state = 2500;
-    //if (!nocutscenes) music.play(5);
 }
 
 void Game::start(void)
@@ -5022,17 +4959,13 @@ void Game::start(void)
     savery = 110;
     savegc = 0;
     savedir = 1; //Worldmap Start
-    //savex = 6 * 8; savey = 15 * 8; saverx = 46; savery = 54; savegc = 0; savedir = 1; //Final Level Current
     savepoint = 0;
     gravitycontrol = savegc;
 
-    //state = 2; deathseq = -1; lifeseq = 10; //Not dead, in game initilisation state
     state = 0;
     deathseq = -1;
     lifeseq = 0;
 
-    //let's teleport in!
-    //state = 2500;
     if (!nocutscenes) music.play(5);
 }
 
@@ -5207,7 +5140,6 @@ void Game::starttrial( int t )
     savepoint = 0;
     gravitycontrol = savegc;
 
-    //state = 2; deathseq = -1; lifeseq = 10; //Not dead, in game initilisation state
     state = 0;
     deathseq = -1;
     lifeseq = 0;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -133,6 +133,7 @@ public:
     void crewmate_textbox(const int r, const int g, const int b);
     void remaining_textbox(void);
     void actionprompt_textbox(void);
+    void savetele_textbox(void);
 
     void updatestate(void);
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -129,6 +129,11 @@ public:
 
     void gethardestroom(void);
 
+    void levelcomplete_textbox(void);
+    void crewmate_textbox(const int r, const int g, const int b);
+    void remaining_textbox(void);
+    void actionprompt_textbox(void);
+
     void updatestate(void);
 
     void unlocknum(int t);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1274,7 +1274,7 @@ void Graphics::textboxadjust(void)
 }
 
 
-void Graphics::createtextbox( std::string t, int xp, int yp, int r/*= 255*/, int g/*= 255*/, int b /*= 255*/ )
+void Graphics::createtextbox( std::string t, int xp, int yp, int r, int g, int b)
 {
     m = textbox.size();
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -855,8 +855,9 @@ void Graphics::drawgui(void)
         }
         else
         {
+            SDL_Rect textrect = {textbox[i].xp, textbox[i].yp, textbox[i].w, textbox[i].h};
 
-            FillRect(backBuffer,textbox[i].textrect, textbox[i].r/6, textbox[i].g/6, textbox[i].b / 6 );
+            FillRect(backBuffer, textrect, textbox[i].r/6, textbox[i].g/6, textbox[i].b / 6 );
 
             drawcoloredtile(textbox[i].xp, textbox[i].yp, 40, textbox[i].r, textbox[i].g, textbox[i].b);
             drawcoloredtile(textbox[i].xp+textbox[i].w-8, textbox[i].yp, 42, textbox[i].r, textbox[i].g, textbox[i].b);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -833,6 +833,7 @@ void Graphics::drawgui(void)
     for (size_t i = 0; i<textbox.size(); i++)
     {
         int text_yoff;
+        int yp;
         if (flipmode)
         {
             text_yoff = textbox[i].line.size() * 8;
@@ -840,6 +841,12 @@ void Graphics::drawgui(void)
         else
         {
             text_yoff = 8;
+        }
+
+        yp = textbox[i].yp;
+        if (flipmode && textbox[i].flipme)
+        {
+            yp += 2 * (120 - yp) - 8 * (textbox[i].line.size() + 2);
         }
 
         //This routine also updates textbox colors
@@ -850,33 +857,33 @@ void Graphics::drawgui(void)
         {
             for (size_t j = 0; j < textbox[i].line.size(); j++)
             {
-                Print(textbox[i].xp + 8, textbox[i].yp + text_yoff + text_sign * (j * 8), textbox[i].line[j], 196, 196, 255 - help.glow);
+                Print(textbox[i].xp + 8, yp + text_yoff + text_sign * (j * 8), textbox[i].line[j], 196, 196, 255 - help.glow);
             }
         }
         else
         {
-            SDL_Rect textrect = {textbox[i].xp, textbox[i].yp, textbox[i].w, textbox[i].h};
+            SDL_Rect textrect = {textbox[i].xp, yp, textbox[i].w, textbox[i].h};
 
             FillRect(backBuffer, textrect, textbox[i].r/6, textbox[i].g/6, textbox[i].b / 6 );
 
-            drawcoloredtile(textbox[i].xp, textbox[i].yp, 40, textbox[i].r, textbox[i].g, textbox[i].b);
-            drawcoloredtile(textbox[i].xp+textbox[i].w-8, textbox[i].yp, 42, textbox[i].r, textbox[i].g, textbox[i].b);
-            drawcoloredtile(textbox[i].xp, textbox[i].yp+textbox[i].h-8, 45, textbox[i].r, textbox[i].g, textbox[i].b);
-            drawcoloredtile(textbox[i].xp+textbox[i].w-8, textbox[i].yp+textbox[i].h-8, 47, textbox[i].r, textbox[i].g, textbox[i].b);
+            drawcoloredtile(textbox[i].xp, yp, 40, textbox[i].r, textbox[i].g, textbox[i].b);
+            drawcoloredtile(textbox[i].xp+textbox[i].w-8, yp, 42, textbox[i].r, textbox[i].g, textbox[i].b);
+            drawcoloredtile(textbox[i].xp, yp+textbox[i].h-8, 45, textbox[i].r, textbox[i].g, textbox[i].b);
+            drawcoloredtile(textbox[i].xp+textbox[i].w-8, yp+textbox[i].h-8, 47, textbox[i].r, textbox[i].g, textbox[i].b);
             for (int k = 0; k < textbox[i].lw; k++)
             {
-                drawcoloredtile(textbox[i].xp + 8 + (k * 8), textbox[i].yp, 41, textbox[i].r, textbox[i].g, textbox[i].b);
-                drawcoloredtile(textbox[i].xp + 8 + (k * 8), textbox[i].yp+textbox[i].h-8, 46, textbox[i].r, textbox[i].g, textbox[i].b);
+                drawcoloredtile(textbox[i].xp + 8 + (k * 8), yp, 41, textbox[i].r, textbox[i].g, textbox[i].b);
+                drawcoloredtile(textbox[i].xp + 8 + (k * 8), yp+textbox[i].h-8, 46, textbox[i].r, textbox[i].g, textbox[i].b);
             }
             for (size_t k = 0; k < textbox[i].line.size(); k++)
             {
-                drawcoloredtile(textbox[i].xp, textbox[i].yp + 8 + (k * 8), 43, textbox[i].r, textbox[i].g, textbox[i].b);
-                drawcoloredtile(textbox[i].xp + textbox[i].w-8, textbox[i].yp + 8 + (k * 8), 44, textbox[i].r, textbox[i].g, textbox[i].b);
+                drawcoloredtile(textbox[i].xp, yp + 8 + (k * 8), 43, textbox[i].r, textbox[i].g, textbox[i].b);
+                drawcoloredtile(textbox[i].xp + textbox[i].w-8, yp + 8 + (k * 8), 44, textbox[i].r, textbox[i].g, textbox[i].b);
             }
 
             for (size_t j = 0; j < textbox[i].line.size(); j++)
             {
-                Print(textbox[i].xp + 8, textbox[i].yp + text_yoff + text_sign * (j * 8), textbox[i].line[j], textbox[i].r, textbox[i].g, textbox[i].b);
+                Print(textbox[i].xp + 8, yp + text_yoff + text_sign * (j * 8), textbox[i].line[j], textbox[i].r, textbox[i].g, textbox[i].b);
             }
         }
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -891,7 +891,7 @@ void Graphics::drawgui(void)
         // This prevents flashes of special images during delta frames
         bool drawspecial = textbox[i].tl >= 1.0;
 
-        if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].r == 165 && drawspecial)
+        if (textbox[i].yp == 12 && textbox[i].r == 165 && drawspecial)
         {
             if (flipmode)
             {
@@ -902,7 +902,7 @@ void Graphics::drawgui(void)
                 drawimage(0, 0, 12, true);
             }
         }
-        else if ((textbox[i].yp == 12 || textbox[i].yp == 180) && textbox[i].g == 165 && drawspecial)
+        else if (textbox[i].yp == 12 && textbox[i].g == 165 && drawspecial)
         {
             if (flipmode)
             {

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1282,8 +1282,15 @@ void Graphics::textboxadjust(void)
 }
 
 
-void Graphics::createtextbox( std::string t, int xp, int yp, int r, int g, int b)
-{
+void Graphics::createtextboxreal(
+    std::string t,
+    int xp,
+    int yp,
+    int r,
+    int g,
+    int b,
+    bool flipme
+) {
     m = textbox.size();
 
     if(m<20)
@@ -1295,9 +1302,32 @@ void Graphics::createtextbox( std::string t, int xp, int yp, int r, int g, int b
         if (xp == -1) text.xp = 160 - (((length / 2) + 1) * 8);
         text.yp = yp;
         text.initcol(r, g, b);
+        text.flipme = flipme;
         text.resize();
         textbox.push_back(text);
     }
+}
+
+void Graphics::createtextbox(
+    std::string t,
+    int xp,
+    int yp,
+    int r,
+    int g,
+    int b
+) {
+    createtextboxreal(t, xp, yp, r, g, b, false);
+}
+
+void Graphics::createtextboxflipme(
+    std::string t,
+    int xp,
+    int yp,
+    int r,
+    int g,
+    int b
+) {
+    createtextboxreal(t, xp, yp, r, g, b, true);
 }
 
 void Graphics::drawfade(void)

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -51,7 +51,7 @@ public:
 
 	void setwarprect(int a, int b, int c, int d);
 
-	void createtextbox(std::string t, int xp, int yp, int r= 255, int g= 255, int b = 255);
+	void createtextbox(std::string t, int xp, int yp, int r, int g, int b);
 
 	void textboxcenterx(void);
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -51,7 +51,31 @@ public:
 
 	void setwarprect(int a, int b, int c, int d);
 
-	void createtextbox(std::string t, int xp, int yp, int r, int g, int b);
+	void createtextboxreal(
+		std::string t,
+		int xp,
+		int yp,
+		int r,
+		int g,
+		int b,
+		bool flipme
+	);
+	void createtextbox(
+		std::string t,
+		int xp,
+		int yp,
+		int r,
+		int g,
+		int b
+	);
+	void createtextboxflipme(
+		std::string t,
+		int xp,
+		int yp,
+		int r,
+		int g,
+		int b
+	);
 
 	void textboxcenterx(void);
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3506,19 +3506,7 @@ void scriptclass::teleport(void)
 		{
 			music.changemusicarea(game.teleport_to_x, game.teleport_to_y);
 		}
-		if (!game.intimetrial && !game.nodeathmode && !game.inintermission)
-		{
-			if (game.savetele())
-			{
-				graphics.createtextbox("    Game Saved    ", -1, graphics.flipmode ? 202 : 12, 174, 174, 174);
-				graphics.textboxtimer(25);
-			}
-			else
-			{
-				graphics.createtextbox("  ERROR: Could not save game!  ", -1, graphics.flipmode ? 202 : 12, 255, 60, 60);
-				graphics.textboxtimer(50);
-			}
-		}
+		game.savetele_textbox();
 	}
 }
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -30,6 +30,7 @@ scriptclass::scriptclass(void)
 	r = 0;
 	textx = 0;
 	texty = 0;
+	textflipme = false;
 }
 
 void scriptclass::clearcustom(void)
@@ -624,7 +625,7 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "flipme")
 			{
-				if(graphics.flipmode) texty += 2*(120 - texty) - 8*(txt.size()+2);
+				textflipme = !textflipme;
 			}
 			else if (words[0] == "speak_active" || words[0] == "speak")
 			{
@@ -634,7 +635,8 @@ void scriptclass::run(void)
 				{
 					txt.resize(1);
 				}
-				graphics.createtextbox(txt[0], textx, texty, r, g, b);
+				graphics.createtextboxreal(txt[0], textx, texty, r, g, b, textflipme);
+				textflipme = false;
 				if ((int) txt.size() > 1)
 				{
 					for (i = 1; i < (int) txt.size(); i++)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1966,7 +1966,7 @@ void scriptclass::run(void)
 
 				graphics.textboxremovefast();
 
-				graphics.createtextbox("        Congratulations!       ", 50, 85, 174, 174, 174);
+				graphics.createtextboxflipme("        Congratulations!       ", 50, 85, 174, 174, 174);
 				graphics.addline("");
 				graphics.addline("You have found a shiny trinket!");
 				graphics.textboxcenterx();
@@ -1982,7 +1982,7 @@ void scriptclass::run(void)
 				{
 					usethisnum = "Twenty";
 				}
-				graphics.createtextbox(" " + help.number(game.trinkets()) + " out of " + usethisnum + " ", 50, 135, 174, 174, 174);
+				graphics.createtextboxflipme(" " + help.number(game.trinkets()) + " out of " + usethisnum + " ", 50, 135, 174, 174, 174);
 				graphics.textboxcenterx();
 
 				if (!game.backgroundtext)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1953,7 +1953,6 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "foundtrinket")
 			{
-				//music.silencedasmusik();
 				music.haltdasmusik();
 				music.playef(3);
 

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -60,6 +60,7 @@ public:
     int textx;
     int texty;
     int r,g,b;
+    bool textflipme;
 
     //Misc
     int i, j, k;

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -21,10 +21,6 @@ textboxclass::textboxclass(void)
     tg = 0;
     tb = 0;
     max = 0;
-    textrect.x = 0;
-    textrect.y = 0;
-    textrect.w = 0;
-    textrect.h = 0;
 }
 
 void textboxclass::centerx(void)
@@ -121,10 +117,6 @@ void textboxclass::resize(void)
     lw = max;
     w = (max +2) * 8;
     h = (line.size() + 2) * 8;
-    textrect.x = xp;
-    textrect.y = yp;
-    textrect.w = w;
-    textrect.h = h;
 }
 
 void textboxclass::addline(std::string t)

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -4,8 +4,6 @@
 
 textboxclass::textboxclass(void)
 {
-    x = 0;
-    y = 0;
     w = 0;
     h = 0;
     lw = 0;

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -21,6 +21,8 @@ textboxclass::textboxclass(void)
     tg = 0;
     tb = 0;
     max = 0;
+
+    flipme = false;
 }
 
 void textboxclass::centerx(void)

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -33,7 +33,6 @@ public:
     //Fundamentals
     std::vector<std::string> line;
     int xp, yp, lw, w, h;
-    int x,y;
     int r,g,b;
     int tr,tg,tb;
     SDL_Rect textrect;

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -43,6 +43,8 @@ public:
 
     int max;
 
+    /* Whether to flip text box y-position in Flip Mode. */
+    bool flipme;
 };
 
 #endif /* TEXTBOX_H */

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -35,7 +35,6 @@ public:
     int xp, yp, lw, w, h;
     int r,g,b;
     int tr,tg,tb;
-    SDL_Rect textrect;
     int timer;
 
     float tl;


### PR DESCRIPTION
2.3 added being able to go to the options menus from the pause menu. It also added Flip Mode to Game Options in the in-game options menu, if you have it unlocked or are using an M&P build. It also added being able to go to these options during cutscenes.

So if you toggle Flip Mode when certain text boxes are onscreen...

![Unpreserved awareness with Flip Mode off](https://user-images.githubusercontent.com/59748578/111857785-1c67e980-88f1-11eb-9930-41e1bf4cff93.png)
<sup>Everything seems ok.</sup>

...then this happens:

![Unpreserved awareness with Flip Mode on](https://user-images.githubusercontent.com/59748578/111857793-2853ab80-88f1-11eb-8899-3fd0979021e5.png)
<sup>Uh oh.</sup>

So what went wrong here? Well, these text boxes only check for Flip Mode when they get created, and assume that that Flip Mode-ness will continue until after the text boxes go away. In contrast, the rescued crewmate sprite (Violet in these screenshots) and the Level Complete image always check for Flip Mode and don't assume that Flip Mode status will persist until the end of their lifetime.

What's the fix? Well, we should store the attribute of Flip Mode awareness (whether or not a text box should be flipped during Flip Mode and thus still be right-side-up) with the text box itself, and not throw away that information when we create it. Then, when the game draws all text boxes, it will check this attribute, and flip the text box position if needed. That way, it doesn't matter what Flip Mode is at the time of text box creation - if it changes after being created, then the game will recognize this and adjust the text box position accordingly.

I also noticed that the text boxes created by the `foundtrinket()` script command weren't Flip Mode aware, in contrast to the normal 'trinket found' text boxes (gamestates 1000-1003) that *are* Flip Mode aware. So I've fixed that too.

And I've also refactored a bunch of things, because I usually do that.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
