### PR TITLE
Ensure oldcutscenebars and cutscenebars get set at the same time, and that oldfadeamount and fadeamount get set at the same time

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -3219,8 +3219,7 @@ void Game::updatestate(void)
             map.final_colorframe = 0;
             map.finalstretch = false;
 
-            graphics.cutscenebarspos = 320;
-            graphics.oldcutscenebarspos = 320;
+            graphics.setbars(320);
 
             teleport_to_new_area = true;
             teleportscript = "gamecomplete";

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -95,8 +95,7 @@ void Graphics::init(void)
     //Fading stuff
     SDL_memset(fadebars, 0, sizeof(fadebars));
 
-    fadeamount = 0;
-    oldfadeamount = 0;
+    setfade(0);
     fademode = 0;
 
     // initialize everything else to zero
@@ -1354,7 +1353,7 @@ void Graphics::processfade(void)
             {
                 fadebars[i] = -int(fRandom() * 12) * 8;
             }
-            fadeamount = 0;
+            setfade(0);
             fademode = 3;
         }
         else if (fademode == 3)
@@ -1372,7 +1371,7 @@ void Graphics::processfade(void)
             {
                 fadebars[i] = 320 + int(fRandom() * 12) * 8;
             }
-            fadeamount = 416;
+            setfade(416);
             fademode = 5;
         }
         else if (fademode == 5)
@@ -1384,6 +1383,12 @@ void Graphics::processfade(void)
             }
         }
     }
+}
+
+void Graphics::setfade(const int amount)
+{
+    fadeamount = amount;
+    oldfadeamount = amount;
 }
 
 void Graphics::drawmenu( int cr, int cg, int cb, bool levelmenu /*= false*/ )

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -35,8 +35,7 @@ void Graphics::init(void)
     trinketcolset = false;
 
     showcutscenebars = false;
-    cutscenebarspos = 0;
-    oldcutscenebarspos = 0;
+    setbars(0);
     notextoutline = false;
 
     flipmode = false;
@@ -1092,6 +1091,12 @@ void Graphics::cutscenebarstimer(void)
         cutscenebarspos -= 25;
         cutscenebarspos = VVV_max(cutscenebarspos, 0);
     }
+}
+
+void Graphics::setbars(const int position)
+{
+    cutscenebarspos = position;
+    oldcutscenebarspos = position;
 }
 
 void Graphics::drawcrewman( int x, int y, int t, bool act, bool noshift /*=false*/ )

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -45,6 +45,7 @@ public:
 	void drawmenu(int cr, int cg, int cb, bool levelmenu = false);
 
 	void processfade(void);
+	void setfade(const int amount);
 
 	void drawfade(void);
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -83,6 +83,7 @@ public:
 
 	void cutscenebars(void);
 	void cutscenebarstimer(void);
+	void setbars(const int position);
 
 	void drawpartimage(int t, int xp, int yp, int wp, int hp);
 

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -71,8 +71,7 @@ void gamecompletelogic(void)
     {
         //Fix some graphical things
         graphics.showcutscenebars = false;
-        graphics.cutscenebarspos = 0;
-        graphics.oldcutscenebarspos = 0;
+        graphics.setbars(0);
         graphics.titlebg.scrolldir = 0;
         graphics.titlebg.bypos = 0;
         //Return to game
@@ -104,7 +103,7 @@ void gamecompletelogic2(void)
     {
         //Fix some graphical things
         graphics.showcutscenebars = false;
-        graphics.cutscenebarspos = 0;
+        graphics.setbars(0);
         //Fix the save thingy
         game.deletequick();
         int tmp=music.currentsong;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1498,7 +1498,7 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "befadein")
 			{
-				graphics.fadeamount = 0;
+				graphics.setfade(0);
 				graphics.fademode= 0;
 			}
 			else if (words[0] == "fadein")

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2641,8 +2641,7 @@ void scriptclass::startgamemode( int t )
 		game.start();
 		game.jumpheld = true;
 		graphics.showcutscenebars = true;
-		graphics.cutscenebarspos = 320;
-		graphics.oldcutscenebarspos = 320;
+		graphics.setbars(320);
 
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
@@ -2908,8 +2907,7 @@ void scriptclass::startgamemode( int t )
 		game.start();
 		game.jumpheld = true;
 		graphics.showcutscenebars = true;
-		graphics.cutscenebarspos = 320;
-		graphics.oldcutscenebarspos = 320;
+		graphics.setbars(320);
 
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
@@ -2937,8 +2935,7 @@ void scriptclass::startgamemode( int t )
 		game.start();
 		game.jumpheld = true;
 		graphics.showcutscenebars = true;
-		graphics.cutscenebarspos = 320;
-		graphics.oldcutscenebarspos = 320;
+		graphics.setbars(320);
 
 		//set flipmode
 		if (graphics.setflipmode) graphics.flipmode = true;
@@ -3644,7 +3641,7 @@ void scriptclass::hardreset(void)
 	graphics.textbox.clear();
 	graphics.flipmode = false; //This will be reset if needs be elsewhere
 	graphics.showcutscenebars = false;
-	graphics.cutscenebarspos = 0;
+	graphics.setbars(0);
 
 	//mapclass
 	map.warpx = false;


### PR DESCRIPTION
This fixes over-30-FPS rendering glitches caused `graphics.oldfadeamount` not being assigned at the same times that `graphics.fadeamount` gets assigned. The same thing could happen with cutscene bars, but it doesn't seem like there are any glitches - still better to be safe than sorry, and make sure `graphics.oldcutscenebarspos` gets assigned at the same times that `graphics.cutscenebarspos` do.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
