### PR TITLE
Add braces around sub-object in unfocused_func_list

### DIFF
--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -242,8 +242,10 @@ static enum IndexCode increment_gamestate_func_index(void)
 static void unfocused_run(void);
 
 static const struct ImplFunc unfocused_func_list[] = {
-    Func_input, /* we still need polling when unfocused */
-    unfocused_run
+    {
+        Func_input, /* we still need polling when unfocused */
+        unfocused_run
+    }
 };
 static const struct ImplFunc* unfocused_funcs = unfocused_func_list;
 static int num_unfocused_funcs = SDL_arraysize(unfocused_func_list);


### PR DESCRIPTION
Clang warns on this. This doesn't fix anything but it does ensure that whoever's reading it won't be focused as to whether or not omitting the second set of braces is legal or not.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
