### PR TITLE
Remove game.gametimer in favor of game.frames

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -352,7 +352,6 @@ void Game::init(void)
     skipfakeload = false;
 
     ghostsenabled = false;
-    gametimer = 0;
 
     cliplaytest = false;
     playx = 0;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -436,8 +436,6 @@ public:
     void returntoeditor(void);
 #endif
 
-    int gametimer;
-
     bool inline inspecial(void)
     {
         return inintermission || insecretlab || intimetrial || nodeathmode;

--- a/desktop_version/src/RenderFixed.cpp
+++ b/desktop_version/src/RenderFixed.cpp
@@ -130,7 +130,7 @@ void gamerenderfixed(void)
     {
         if (map.custommode && !map.custommodeforreal)
         {
-            if (game.gametimer % 3 == 0)
+            if (game.frames % 3 == 0)
             {
                 int i = obj.getplayer();
                 GhostInfo ghost;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -612,7 +612,6 @@ int main(int argc, char *argv[])
 #endif
 
     key.isActive = true;
-    game.gametimer = 0;
 
     gamestate_funcs = get_gamestate_funcs(game.gamestate, &num_gamestate_funcs);
     loop_assign_active_funcs();
@@ -747,7 +746,6 @@ static void focused_begin(void)
 {
     Mix_Resume(-1);
     Mix_ResumeMusic();
-    game.gametimer++;
 }
 
 static void focused_end(void)


### PR DESCRIPTION
PR #279 added `game.gametimer` solely for the editor ghosts feature. It seems that whoever originally wrote it (Leo for the now-dead VVVVVV: Community Edition, I believe) forgot that the game already had its own timer, that they could use.

The game timer does increment on unfocus pause (whereas this doesn't), but that's a separate issue, and it ought to not do that.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
