### PR TITLE
Simplify and print XML errors from TinyXML-2

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4005,8 +4005,6 @@ void Game::loadstats(ScreenSettings* screen_settings)
         // Save unlock.vvv only. Maybe we have a settings.vvv laying around too,
         // and we don't want to overwrite that!
         savestats(screen_settings);
-
-        vlog_info("No Stats found. Assuming a new player");
     }
 
     tinyxml2::XMLHandle hDoc(&doc);
@@ -4550,7 +4548,7 @@ void Game::loadsettings(ScreenSettings* screen_settings)
     if (!FILESYSTEM_loadTiXml2Document("saves/settings.vvv", doc))
     {
         savesettings(screen_settings);
-        vlog_info("No settings.vvv found");
+        return;
     }
 
     tinyxml2::XMLHandle hDoc(&doc);

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -203,7 +203,7 @@ public:
 
     void loadsummary(void);
 
-    void readmaingamesave(tinyxml2::XMLDocument& doc);
+    void readmaingamesave(const char* savename, tinyxml2::XMLDocument& doc);
     std::string writemaingamesave(tinyxml2::XMLDocument& doc);
 
     void initteleportermode(void);


### PR DESCRIPTION
All XML functions now check the return value of `tinyxml2::XMLDocument::Error()` after each document gets loaded in to TinyXML-2. If there's an error, then all functions return. This isn't strictly necessary, but printing the error message that TinyXML-2 is the bare minimum we could do to be useful.

Additionally, I've standardized the error messages of missing or corrupted XML files.

Also, the way the game went about making the XML handles was... a bit roundabout. There were two XML handles, one for the document and one for the root element - although only one XML handle suffices. So I've cleaned that up too.

I could've gone further and added error checking for a whole bunch of things (e.g. missing elements, missing attributes), but this is good enough.

Also, if `unlock.vvv` or `settings.vvv` don't exist yet, the game is guaranteed to no-op instead of continuing with the function. Nothing bad seems to happen if the function continues, but the return statements should be there anyway to clearly indicate intent.

And duplicate messages are now prevented if `unlock.vvv` or `settings.vvv` don't exist yet.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
