### PR TITLE
Fix undefined behavior when loading XML

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -292,6 +292,11 @@ void Game::init(void)
             const char* pKey = pElem->Value();
             const char* pText = pElem->GetText() ;
 
+            if (pText == NULL)
+            {
+                pText = "";
+            }
+
             if (SDL_strcmp(pKey, "summary") == 0)
             {
                 quicksummary = pText;
@@ -331,6 +336,11 @@ void Game::init(void)
         {
             const char* pKey = pElem->Value();
             const char* pText = pElem->GetText() ;
+
+            if (pText == NULL)
+            {
+                pText = "";
+            }
 
             if (SDL_strcmp(pKey, "summary") == 0)
             {
@@ -4016,6 +4026,11 @@ void Game::loadstats(ScreenSettings* screen_settings)
         const char* pKey = pElem->Value();
         const char* pText = pElem->GetText() ;
 
+        if (pText == NULL)
+        {
+            pText = "";
+        }
+
         LOAD_ARRAY(unlock)
 
         LOAD_ARRAY(unlocknotify)
@@ -4072,6 +4087,11 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* s
     {
         const char* pKey = pElem->Value();
         const char* pText = pElem->GetText();
+
+        if (pText == NULL)
+        {
+            pText = "";
+        }
 
         if (SDL_strcmp(pKey, "fullscreen") == 0)
         {
@@ -5132,6 +5152,11 @@ void Game::loadsummary(void)
             const char* pKey = pElem->Value();
             const char* pText = pElem->GetText() ;
 
+            if (pText == NULL)
+            {
+                pText = "";
+            }
+
             if (SDL_strcmp(pKey, "summary") == 0)
             {
                 telesummary = pText;
@@ -5208,6 +5233,11 @@ void Game::loadsummary(void)
         {
             const char* pKey = pElem->Value();
             const char* pText = pElem->GetText() ;
+
+            if (pText == NULL)
+            {
+                pText = "";
+            }
 
             if (SDL_strcmp(pKey, "summary") == 0)
             {

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1783,7 +1783,7 @@ bool editorclass::load(std::string& _path)
         {
             for( tinyxml2::XMLElement* edEntityEl = pElem->FirstChildElement(); edEntityEl; edEntityEl=edEntityEl->NextSiblingElement())
             {
-                edentities entity;
+                edentities entity = edentities();
                 const char* text = edEntityEl->GetText();
 
                 if (text != NULL)


### PR DESCRIPTION
XML loading is pretty safe due to the use of TinyXML-2 handles. However, that doesn't mean there aren't a few holes - namely, not re-assigning `pText` when it is `NULL`, and not initializing the temporary edentity created when loading custom levels; all of which I have fixed.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
