### PR TITLE
Fix bounds checks in drawentity()

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1895,10 +1895,6 @@ void Graphics::drawentity(const int i, const int yoff)
         // Note: This code is in the 4-tile code
         break;
     case 9:         // Really Big Sprite! (2x2)
-        if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
-        {
-            return;
-        }
         setcolreal(obj.entities[i].realcol);
 
         tpoint.x = xp;
@@ -1907,7 +1903,10 @@ void Graphics::drawentity(const int i, const int yoff)
         drawRect = sprites_rect;
         drawRect.x += tpoint.x;
         drawRect.y += tpoint.y;
-        BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+        if (INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
+        {
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+        }
 
         tpoint.x = xp+32;
         tpoint.y = yp - yoff;
@@ -1915,7 +1914,10 @@ void Graphics::drawentity(const int i, const int yoff)
         drawRect = sprites_rect;
         drawRect.x += tpoint.x;
         drawRect.y += tpoint.y;
-        BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
+        if (INBOUNDS_VEC(obj.entities[i].drawframe+1, spritesvec))
+        {
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
+        }
 
         tpoint.x = xp;
         tpoint.y = yp+32 - yoff;
@@ -1923,7 +1925,10 @@ void Graphics::drawentity(const int i, const int yoff)
         drawRect = sprites_rect;
         drawRect.x += tpoint.x;
         drawRect.y += tpoint.y;
-        BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe+12],NULL, backBuffer, &drawRect, ct);
+        if (INBOUNDS_VEC(obj.entities[i].drawframe+12, spritesvec))
+        {
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe+12],NULL, backBuffer, &drawRect, ct);
+        }
 
         tpoint.x = xp+32;
         tpoint.y = yp+32 - yoff;
@@ -1931,13 +1936,12 @@ void Graphics::drawentity(const int i, const int yoff)
         drawRect = sprites_rect;
         drawRect.x += tpoint.x;
         drawRect.y += tpoint.y;
-        BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe + 13],NULL, backBuffer, &drawRect, ct);
+        if (INBOUNDS_VEC(obj.entities[i].drawframe+13, spritesvec))
+        {
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe + 13],NULL, backBuffer, &drawRect, ct);
+        }
         break;
     case 10:         // 2x1 Sprite
-        if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
-        {
-            return;
-        }
         setcolreal(obj.entities[i].realcol);
 
         tpoint.x = xp;
@@ -1946,7 +1950,10 @@ void Graphics::drawentity(const int i, const int yoff)
         drawRect = sprites_rect;
         drawRect.x += tpoint.x;
         drawRect.y += tpoint.y;
-        BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+        if (INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
+        {
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+        }
 
         tpoint.x = xp+32;
         tpoint.y = yp - yoff;
@@ -1954,17 +1961,16 @@ void Graphics::drawentity(const int i, const int yoff)
         drawRect = sprites_rect;
         drawRect.x += tpoint.x;
         drawRect.y += tpoint.y;
-        BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
+        if (INBOUNDS_VEC(obj.entities[i].drawframe+1, spritesvec))
+        {
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe+1],NULL, backBuffer, &drawRect, ct);
+        }
         break;
     case 11:    //The fucking elephant
         setcolreal(obj.entities[i].realcol);
         drawimagecol(3, xp, yp - yoff);
         break;
     case 12:         // Regular sprites that don't wrap
-        if (!INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
-        {
-            return;
-        }
         tpoint.x = xp;
         tpoint.y = yp - yoff;
         setcolreal(obj.entities[i].realcol);
@@ -1972,7 +1978,10 @@ void Graphics::drawentity(const int i, const int yoff)
         drawRect = sprites_rect;
         drawRect.x += tpoint.x;
         drawRect.y += tpoint.y;
-        BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+        if (INBOUNDS_VEC(obj.entities[i].drawframe, spritesvec))
+        {
+            BlitSurfaceColoured(spritesvec[obj.entities[i].drawframe],NULL, backBuffer, &drawRect, ct);
+        }
 
 
         //if we're outside the screen, we need to draw indicators
@@ -1994,7 +2003,10 @@ void Graphics::drawentity(const int i, const int yoff)
             drawRect = tiles_rect;
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
-            BlitSurfaceColoured(tiles[1167],NULL, backBuffer, &drawRect, ct);
+            if (INBOUNDS_VEC(1167, tiles))
+            {
+                BlitSurfaceColoured(tiles[1167],NULL, backBuffer, &drawRect, ct);
+            }
 
         }
         else if (obj.entities[i].xp > 340 && obj.entities[i].vx < 0)
@@ -2014,7 +2026,10 @@ void Graphics::drawentity(const int i, const int yoff)
             drawRect = tiles_rect;
             drawRect.x += tpoint.x;
             drawRect.y += tpoint.y;
-            BlitSurfaceColoured(tiles[1166],NULL, backBuffer, &drawRect, ct);
+            if (INBOUNDS_VEC(1166, tiles))
+            {
+                BlitSurfaceColoured(tiles[1166],NULL, backBuffer, &drawRect, ct);
+            }
         }
         break;
     case 13:


### PR DESCRIPTION
The existing bounds checks were correct sometimes but other times were not.

The bounds check for 2x2 and 2x1 sprites only covered the top-left sprite drawn; the other sprites could still be out of bounds. But if the top-left sprite was out of bounds, then none of the other sprites wouldn't be drawn - although it ought to be that the other sprites still get attempted to be drawn. So I've updated the bounds checks accordingly, and now an out of bounds top-left sprite won't prevent the drawing of the rest of the sprites.

Similarly, if the sprite of a Gravitron square was out of bounds, that would prevent its indicators from being drawn. But the indicators weren't being bounds-checked either (2.3 lets you have less than 1200 tiles in a given tilesheet). So the bounds check has been moved to only cover the drawframe and the indicator indexes accordingly, and an out of bounds sprite won't prevent attempting to draw the indicators.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV (for
  example, a 2.3 update on Steam for Windows/macOS/Linux)
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
