### PR TITLE
Remove 2.3 example from pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,8 +29,7 @@ Describe your patch here!
 
 By submitting this pull request, I confirm that...
 
-- [ ] My changes may be used in a future commercial release of VVVVVV (for
-  example, a 2.3 update on Steam for Windows/macOS/Linux)
+- [ ] My changes may be used in a future commercial release of VVVVVV
 - [ ] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
   section of the credits for all of said releases, but will NOT be compensated
   for these changes


### PR DESCRIPTION
Mentioning 2.3 here is going to be anachronistic when 2.4 exists. And there's not really any point in bumping this version number every time the game's version number is bumped as well. So it's best to just remove it.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
