### PR TITLE
Remove final_colorframe assignments when entering minitowers

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1491,7 +1491,6 @@ void mapclass::loadlevel(int rx, int ry)
 		tower.minitowermode = true;
 		graphics.towerbg.scrolldir = 0;
 		setbgobjlerp(graphics.towerbg);
-		final_colorframe = 2;
 
 		roomname = "The Final Challenge";
 		tileset = 1;
@@ -1537,7 +1536,6 @@ void mapclass::loadlevel(int rx, int ry)
 		tower.minitowermode = true;
 		graphics.towerbg.scrolldir = 0;
 		setbgobjlerp(graphics.towerbg);
-		final_colorframe = 2;
 
 		roomname = "The Final Challenge";
 		tileset = 1;


### PR DESCRIPTION
There's a bit of inconsistency with how long each color lasts for during final stretch. Initially, each color lasts for 40 frames, but when you enter either of the minitowers, the color switches to lasting for 15 frames only. This is because a `final_colorframe` of 1 makes it go for 40 frames, but a `final_colorframe` of 2 makes it go for 15 frames - and `final_colorframe` gets set to 2 whenever you enter a minitower.

This seems like an oversight because (1) `final_colorframe` doesn't affect anything inside the minitower, (2) `final_colorframe` doesn't get saved to the save file and always gets set to 1 if your save file has `finalstretch` set to true, so saving and reloading will set the colors back to 40 frames each, and (3) `final_colorframe` doesn't get set back to 1 when leaving the minitowers.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
