### PR TITLE
Add finalmode check to drawfinalmap call

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1560,7 +1560,7 @@ void gamerender(void)
             {
                 ClearSurface(graphics.backBuffer);
             }
-            if (map.final_colormode)
+            if ((map.finalmode || map.custommode) && map.final_colormode)
             {
                 graphics.drawfinalmap();
             }


### PR DESCRIPTION
This fixes the finalstretch tile shifting persisting if you return to the main dimension and `final_colormode` isn't reset properly.

It's possible to do so in the main game by using a teleporter in finalmode while having the Intermission 1 or 2 companion active.

For custom levels, level makers can make a setup that automatically turns on finalstretch, goes to finalmode, and then returns to the main dimension. The only thing being... as a level maker myself, this tile shifting *really* doesn't seem useful (and no one has ever used it because the setup to do so hadn't really been found or documented until this year). For one, the exact shift is randomized every time (there's an `fRandom()` call to cycle the colors). For two, it goes away after the player saves and reloads the level. And for three, it doesn't animate like it does in finalmode (this is the biggest reason IMO).

Nevertheless, I've decided to keep support for this in custom levels, in case someone in the future does want to use it and is okay with the limitations.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
