### PR TITLE
Add bounds check for color of createentity number 55

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2005,7 +2005,8 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         //2 - colour
         entity.rule = 3;
         entity.type = 55;
-        if(customcrewmoods[int(vy)]==1){
+        if(INBOUNDS_ARR((int) vy, customcrewmoods)
+        && customcrewmoods[int(vy)]==1){
           entity.tile = 144;
         }else{
           entity.tile = 0;


### PR DESCRIPTION
I just spotted this one - if `vy` isn't bounds-checked, this causes bogus input from the `createentity()` script command to commit Undefined Behavior. Should've spotted this one when I was adding bounds checks to the rest of `createentity()` earlier, but at least it's fixed now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
