### PR TITLE
Fix 1-frame flicker when entering a room with warp lines that also has an entity on a warping screen edge

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1983,6 +1983,8 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         if (map.custommode)
         {
             customwarpmode = true;
+            map.warpx = false;
+            map.warpy = false;
         }
         break;
       case 55: // Crew Member (custom, collectable)

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1954,51 +1954,36 @@ void entityclass::createentity( float xp, float yp, int t, float vx /*= 0*/, flo
         entity.size = 13;
         break;
 
-    case 51: //Vertical Warp Line
-        entity.rule = 5;
-        entity.type = 51;
-        entity.size = 6;
-        entity.life = 0;
-        entity.w = 1;
-        entity.h = vx;
-        //entity.colour = 0;
+    /* Warp lines */
+    case 51: /* Vertical */
+    case 52: /* Vertical */
+    case 53: /* Horizontal */
+    case 54: /* Horizontal */
+        entity.type = t;
         entity.onentity = 1;
-        entity.invis=true;
-        if (map.custommode) customwarpmode = true;
-        break;
-      case 52: //Vertical Warp Line
-        entity.rule = 5;
-        entity.type = 52;
-        entity.size = 6;
+        entity.invis = true;
         entity.life = 0;
-        entity.w = 1;
-        entity.h = vx;
-        //entity.colour = 0;
-        entity.onentity = 1;
-        entity.invis=true;
-        if (map.custommode) customwarpmode = true;
-        break;
-      case 53: //Horizontal Warp Line
-        entity.rule = 7;
-        entity.type = 53;
-        entity.size = 5;
-        entity.life = 0;
-        entity.w = vx;
-        entity.h = 1;
-        entity.onentity = 1;
-        entity.invis=true;
-        if (map.custommode) customwarpmode = true;
-        break;
-      case 54: //Horizontal Warp Line
-        entity.rule = 7;
-        entity.type = 54;
-        entity.size = 5;
-        entity.life = 0;
-        entity.w = vx;
-        entity.h = 1;
-        entity.onentity = 1;
-        entity.invis=true;
-        if (map.custommode) customwarpmode = true;
+        switch (t)
+        {
+        case 51:
+        case 52:
+            entity.rule = 5;
+            entity.size = 6;
+            entity.w = 1;
+            entity.h = vx;
+            break;
+        case 53:
+        case 54:
+            entity.rule = 7;
+            entity.size = 5;
+            entity.w = vx;
+            entity.h = 1;
+            break;
+        }
+        if (map.custommode)
+        {
+            customwarpmode = true;
+        }
         break;
       case 55: // Crew Member (custom, collectable)
         //1 - position in array


### PR DESCRIPTION
Custom levels can have warp lines. If you have a warp line and a warping background in the same room, the warp line takes precedence over the warp background.

However, whenever you enter a room with a warp line and warp background, any entities on the warping edges will be drawn with screenwrapping for one frame, even though they never wrapped at all.

This is due to frame ordering: when the warp line gets created, `obj.customwarpmode` gets set to true. Then when the screen edges and warping logic gets ran, the very first thing that gets checked is this exact variable, and `map.warpx`/`map.warpy` get set appropriately - so there's no way the entity could legitimately screenwrap.

However, that happens in `gamelogic()`. `gamelogic()` is also the one responsible for creating entities upon room load, but that happens after the `obj.customwarpmode` check - so when the game gets around to rendering in `gamerender()`, it sees that `map.warpx` or `map.warpy` is on, and draws the screenwrapping accordingly, even though `map.warpx`/`map.warpy` aren't really on at all. Only when `gamelogic()` is called in the frame later do `map.warpx` and `map.warpy` finally get set to false.

To fix this, just set `map.warpx` and `map.warpy` to false when creating warp lines.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
