### PR TITLE
Fix calling startgamemode when going to in-game options while faded out and not in glitchrunner mode

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6666,6 +6666,11 @@ static void nextbgcolor(void)
     map.nexttowercolour();
 }
 
+static void setfademode(void)
+{
+    graphics.fademode = graphics.ingame_fademode;
+}
+
 void Game::returntoingame(void)
 {
     ingame_titlemode = false;
@@ -6684,6 +6689,7 @@ void Game::returntoingame(void)
         DEFER_CALLBACK(returntoingametemp);
         gamestate = MAPMODE;
         graphics.flipmode = graphics.setflipmode;
+        DEFER_CALLBACK(setfademode);
         if (!map.custommode && !graphics.flipmode)
         {
             obj.flags[73] = true;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -242,7 +242,6 @@ public:
     bool startscript;
     std::string newscript;
 
-    int mainmenu;
     bool menustart;
 
     //Teleporting

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -98,6 +98,7 @@ void Graphics::init(void)
 
     setfade(0);
     fademode = 0;
+    ingame_fademode = 0;
 
     // initialize everything else to zero
     backBuffer = NULL;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -295,6 +295,7 @@ public:
 	int fadeamount;
 	int oldfadeamount;
 	int fadebars[15];
+	int ingame_fademode;
 
 	bool trinketcolset;
 	int trinketr, trinketg, trinketb;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -190,10 +190,11 @@ static void toggleflipmode(void)
 
 static bool fadetomode = false;
 static int fadetomodedelay = 0;
+static int gotomode = 0;
 
 static void startmode(const int mode)
 {
-    game.mainmenu = mode;
+    gotomode = mode;
     graphics.fademode = 2; /* fading out */
     fadetomode = true;
     fadetomodedelay = 16;
@@ -1668,7 +1669,7 @@ void titleinput(void)
         else
         {
             fadetomode = false;
-            script.startgamemode(game.mainmenu);
+            script.startgamemode(gotomode);
         }
     }
 }

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -188,10 +188,15 @@ static void toggleflipmode(void)
     }
 }
 
+static bool fadetomode = false;
+static int fadetomodedelay = 0;
+
 static void startmode(const int mode)
 {
     game.mainmenu = mode;
     graphics.fademode = 2; /* fading out */
+    fadetomode = true;
+    fadetomodedelay = 16;
 }
 
 static void menuactionpress(void)
@@ -1654,8 +1659,18 @@ void titleinput(void)
 
     }
 
-    if (graphics.fademode == 1)
-        script.startgamemode(game.mainmenu);
+    if (fadetomode)
+    {
+        if (fadetomodedelay > 0)
+        {
+            --fadetomodedelay;
+        }
+        else
+        {
+            fadetomode = false;
+            script.startgamemode(game.mainmenu);
+        }
+    }
 }
 
 void gameinput(void)

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -188,6 +188,12 @@ static void toggleflipmode(void)
     }
 }
 
+static void startmode(const int mode)
+{
+    game.mainmenu = mode;
+    graphics.fademode = 2; /* fading out */
+}
+
 static void menuactionpress(void)
 {
     switch (game.currentmenuname)
@@ -216,8 +222,7 @@ static void menuactionpress(void)
             {
                 //No saves exist, just start a new game
                 music.playef(11);
-                game.mainmenu = 0;
-                graphics.fademode = 2;
+                startmode(0);
             }
             else
             {
@@ -309,8 +314,7 @@ static void menuactionpress(void)
             std::string name = "saves/" + ed.ListOfMetaData[game.playcustomlevel].filename.substr(7) + ".vvv";
             tinyxml2::XMLDocument doc;
             if (!FILESYSTEM_loadTiXml2Document(name.c_str(), doc)){
-                game.mainmenu = 22;
-                graphics.fademode = 2;
+                startmode(22);
             }else{
                 game.createmenu(Menu::quickloadlevel);
                 map.nexttowercolour();
@@ -323,13 +327,11 @@ static void menuactionpress(void)
         {
         case 0: //continue save
             music.playef(11);
-            game.mainmenu = 23;
-            graphics.fademode = 2;
+            startmode(23);
             break;
         case 1:
             music.playef(11);
-            game.mainmenu = 22;
-            graphics.fademode = 2;
+            startmode(22);
             break;
         case 2:
             music.playef(11);
@@ -360,8 +362,7 @@ static void menuactionpress(void)
         case 1:
             //LEVEL EDITOR HOOK
             music.playef(11);
-            game.mainmenu = 20;
-            graphics.fademode = 2;
+            startmode(20);
             ed.filename="";
             break;
  #endif
@@ -470,8 +471,7 @@ static void menuactionpress(void)
         case 0:
             //bye!
             music.playef(2);
-            game.mainmenu = 100;
-            graphics.fademode = 2;
+            startmode(100);
             break;
         default:
             music.playef(11);
@@ -1143,22 +1143,19 @@ static void menuactionpress(void)
             {
                 //You have no saves but have something unlocked, or you couldn't have gotten here
                 music.playef(11);
-                game.mainmenu = 0;
-                graphics.fademode = 2;
+                startmode(0);
             }
             else if (game.telesummary == "")
             {
                 //You at least have a quicksave, or you couldn't have gotten here
                 music.playef(11);
-                game.mainmenu = 2;
-                graphics.fademode = 2;
+                startmode(2);
             }
             else if (game.quicksummary == "")
             {
                 //You at least have a telesave, or you couldn't have gotten here
                 music.playef(11);
-                game.mainmenu = 1;
-                graphics.fademode = 2;
+                startmode(1);
             }
             else
             {
@@ -1172,8 +1169,7 @@ static void menuactionpress(void)
         {
             if(!map.invincibility && game.slowdown == 30){
                 music.playef(11);
-                game.mainmenu = 11;
-                graphics.fademode = 2;
+                startmode(11);
             }else{
                 //Can't do yet! play sad sound
                 music.playef(2);
@@ -1208,8 +1204,7 @@ static void menuactionpress(void)
         case 0:
             //yep
             music.playef(11);
-            game.mainmenu = 0;
-            graphics.fademode = 2;
+            startmode(0);
             game.deletequick();
             game.deletetele();
             break;
@@ -1307,13 +1302,11 @@ static void menuactionpress(void)
         {
         case 0:   //start no death mode, disabling cutscenes
             music.playef(11);
-            game.mainmenu = 10;
-            graphics.fademode = 2;
+            startmode(10);
             break;
         case 1:
             music.playef(11);
-            game.mainmenu = 9;
-            graphics.fademode = 2;
+            startmode(9);
             break;
         case 2:
             //back
@@ -1328,13 +1321,11 @@ static void menuactionpress(void)
         {
         case 0:
             music.playef(11);
-            game.mainmenu = 1;
-            graphics.fademode = 2;
+            startmode(1);
             break;
         case 1:
             music.playef(11);
-            game.mainmenu = 2;
-            graphics.fademode = 2;
+            startmode(2);
             break;
         case 2:
             //back
@@ -1372,23 +1363,19 @@ static void menuactionpress(void)
         {
         case 0:
             music.playef(11);
-            game.mainmenu = 12;
-            graphics.fademode = 2;
+            startmode(12);
             break;
         case 1:
             music.playef(11);
-            game.mainmenu = 13;
-            graphics.fademode = 2;
+            startmode(13);
             break;
         case 2:
             music.playef(11);
-            game.mainmenu = 14;
-            graphics.fademode = 2;
+            startmode(14);
             break;
         case 3:
             music.playef(11);
-            game.mainmenu = 15;
-            graphics.fademode = 2;
+            startmode(15);
             break;
         case 4:
             //back
@@ -1403,23 +1390,19 @@ static void menuactionpress(void)
         {
         case 0:
             music.playef(11);
-            game.mainmenu = 16;
-            graphics.fademode = 2;
+            startmode(16);
             break;
         case 1:
             music.playef(11);
-            game.mainmenu = 17;
-            graphics.fademode = 2;
+            startmode(17);
             break;
         case 2:
             music.playef(11);
-            game.mainmenu = 18;
-            graphics.fademode = 2;
+            startmode(18);
             break;
         case 3:
             music.playef(11);
-            game.mainmenu = 19;
-            graphics.fademode = 2;
+            startmode(19);
             break;
         case 4:
             //back
@@ -1450,38 +1433,32 @@ static void menuactionpress(void)
         if (game.currentmenuoption == 0 && game.unlock[9])   //space station 1
         {
             music.playef(11);
-            game.mainmenu = 3;
-            graphics.fademode = 2;
+            startmode(3);
         }
         else if (game.currentmenuoption == 1 && game.unlock[10])    //lab
         {
             music.playef(11);
-            game.mainmenu = 4;
-            graphics.fademode = 2;
+            startmode(4);
         }
         else if (game.currentmenuoption == 2 && game.unlock[11])    //tower
         {
             music.playef(11);
-            game.mainmenu = 5;
-            graphics.fademode = 2;
+            startmode(5);
         }
         else if (game.currentmenuoption == 3 && game.unlock[12])    //station 2
         {
             music.playef(11);
-            game.mainmenu = 6;
-            graphics.fademode = 2;
+            startmode(6);
         }
         else if (game.currentmenuoption == 4 && game.unlock[13])    //warp
         {
             music.playef(11);
-            game.mainmenu = 7;
-            graphics.fademode = 2;
+            startmode(7);
         }
         else if (game.currentmenuoption == 5 && game.unlock[14])    //final
         {
             music.playef(11);
-            game.mainmenu = 8;
-            graphics.fademode = 2;
+            startmode(8);
         }
         else if (game.currentmenuoption == 6)    //go to the time trial menu
         {
@@ -1520,38 +1497,32 @@ static void menuactionpress(void)
             if (game.timetriallevel == 0)   //space station 1
             {
                 music.playef(11);
-                game.mainmenu = 3;
-                graphics.fademode = 2;
+                startmode(3);
             }
             else if (game.timetriallevel == 1)    //lab
             {
                 music.playef(11);
-                game.mainmenu = 4;
-                graphics.fademode = 2;
+                startmode(4);
             }
             else if (game.timetriallevel == 2)    //tower
             {
                 music.playef(11);
-                game.mainmenu = 5;
-                graphics.fademode = 2;
+                startmode(5);
             }
             else if (game.timetriallevel == 3)    //station 2
             {
                 music.playef(11);
-                game.mainmenu = 6;
-                graphics.fademode = 2;
+                startmode(6);
             }
             else if (game.timetriallevel == 4)    //warp
             {
                 music.playef(11);
-                game.mainmenu = 7;
-                graphics.fademode = 2;
+                startmode(7);
             }
             else if (game.timetriallevel == 5)    //final
             {
                 music.playef(11);
-                game.mainmenu = 8;
-                graphics.fademode = 2;
+                startmode(8);
             }
             break;
         }

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2320,6 +2320,8 @@ static void mapmenuactionpress(void)
         game.gamestate = TITLEMODE;
         graphics.flipmode = false;
         game.ingame_titlemode = true;
+        graphics.ingame_fademode = graphics.fademode;
+        graphics.fademode = 0;
 
         // Set this before we create the menu
         game.kludge_ingametemp = game.currentmenuname;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -505,7 +505,6 @@ int main(int argc, char *argv[])
     game.gamestate = PRELOADER;
 
     game.menustart = false;
-    game.mainmenu = 0;
 
     // Initialize title screen to cyan
     graphics.titlebg.colstate = 10;


### PR DESCRIPTION
If you have glitchrunner mode off, and open the pause menu while fully faded out, then go to the in-game options, the game would call `startgamemode()` immediately, basically replaying the option you chose on the title screen, whether that be going to the start of the level or the start of the new game or reloading your save file or whatever you chose.

This fixes that by making the title screen no longer rely on `graphics.fademode` to call `startgamemode()`, and temporarily storing `graphics.fademode` to a different variable when going to the in-game options so the screen isn't black when you do so.

(Opening the map or pause screen while faded out and having glitchrunner mode on results in immediately returning to the title screen - this is intentional glitchrunner behavior.)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
