### PR TITLE
Fix background not changing when pressing Esc on main menu

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1626,6 +1626,7 @@ void titleinput(void)
             if (game.currentmenuname == Menu::mainmenu)
             {
                 game.createmenu(Menu::youwannaquit);
+                map.nexttowercolour();
             }
             else
             {


### PR DESCRIPTION
Followup to #664: Pressing "quit game" instead of using Esc changes the background, but pressing Esc doesn't. Whoops.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
