### PR TITLE
Fix targets (question marks) not showing up on minimap

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1979,7 +1979,7 @@ void maprender(void)
                     if (graphics.flipmode) temp += 3;
                     graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
                 }
-                else if(map.showtargets && map.isexplored(map.teleporters[i].x, map.teleporters[i].y))
+                else if(map.showtargets && !map.isexplored(map.teleporters[i].x, map.teleporters[i].y))
                 {
                     int temp = 1126 + (int) map.isexplored(map.teleporters[i].x, map.teleporters[i].y);
                     if (graphics.flipmode) temp += 3;
@@ -2530,7 +2530,7 @@ void teleporterrender(void)
             if (graphics.flipmode) temp += 3;
             graphics.drawtile(40 + 3 + (map.teleporters[i].x * 12), 22 + (map.teleporters[i].y * 9), temp);
         }
-        else if(map.showtargets && map.isexplored(map.teleporters[i].x, map.teleporters[i].y))
+        else if(map.showtargets && !map.isexplored(map.teleporters[i].x, map.teleporters[i].y))
         {
             temp = 1126 + (int) map.isexplored(map.teleporters[i].x, map.teleporters[i].y);
             if (graphics.flipmode) temp += 3;


### PR DESCRIPTION
Followup to #635: I had misread the original `==0` comparisons as being truthy comparisons instead of being falsy comparisons. Whoops.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
