### PR TITLE
Fix memory leak when pasting text

### DIFF
--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -141,7 +141,12 @@ void KeyPoll::Poll(void)
 				else if (	evt.key.keysym.sym == SDLK_v &&
 						keymap[SDLK_LCTRL]	)
 				{
-					keybuffer += SDL_GetClipboardText();
+					char* text = SDL_GetClipboardText();
+					if (text != NULL)
+					{
+						keybuffer += text;
+						SDL_free(text);
+					}
 				}
 			}
 			break;


### PR DESCRIPTION
According to [SDL documentation](https://wiki.libsdl.org/SDL_GetClipboardText), the returned pointer needs to be freed. A glance at the source code confirms that the function allocates, and also Valgrind complains about it.

Also if it couldn't allocate, the game no longer segfaults (`std::string`s do not check if the pointer is non-`NULL` for `operator+=`).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
