### PR TITLE
Replace other usage of PHYSFS_getBaseDir() with SDL_GetBasePath()

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -54,7 +54,9 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 {
 	char output[MAX_PATH];
 	int mkdirResult;
+	int retval;
 	const char* pathSep = PHYSFS_getDirSeparator();
+	char* basePath;
 
 	PHYSFS_setAllocator(&allocator);
 	PHYSFS_init(argvZero);
@@ -110,6 +112,14 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 		PLATFORM_migrateSaveData(output);
 	}
 
+	basePath = SDL_GetBasePath();
+
+	if (basePath == NULL)
+	{
+		puts("Unable to get base path!");
+		return 0;
+	}
+
 	/* Mount the stock content last */
 	if (assetsPath)
 	{
@@ -117,12 +127,10 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 	}
 	else
 	{
-		char *basePath = SDL_GetBasePath();
 		SDL_snprintf(output, sizeof(output), "%s%s",
 			basePath,
 			"data.zip"
 		);
-		SDL_free(basePath);
 	}
 	if (!PHYSFS_mount(output, NULL, 1))
 	{
@@ -139,15 +147,20 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 			"\nor get it from the free Make and Play Edition.",
 			NULL
 		);
-		return 0;
+		retval = 0;
+		goto end;
 	}
 
-	SDL_snprintf(output, sizeof(output), "%s%s", PHYSFS_getBaseDir(), "gamecontrollerdb.txt");
+	SDL_snprintf(output, sizeof(output), "%s%s", basePath, "gamecontrollerdb.txt");
 	if (SDL_GameControllerAddMappingsFromFile(output) < 0)
 	{
 		printf("gamecontrollerdb.txt not found!\n");
 	}
-	return 1;
+	retval = 1;
+
+end:
+	SDL_free(basePath);
+	return retval;
 }
 
 void FILESYSTEM_deinit(void)


### PR DESCRIPTION
Ethan, you forgot this other one.

I do have to rejiggle the control flow of the function a bit, so it doesn't leak memory upon failure. (Although the SDL message box leaks memory anyway because of X11 so... whatever.) Also, there's a `NULL` check for if `SDL_GetBasePath()` fails now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
