### PR TITLE
Call VVV_exit() when SDL_QUIT is received

### DIFF
--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <utf8/unchecked.h>
 
+#include "Exit.h"
 #include "Game.h"
 #include "Graphics.h"
 #include "Music.h"
@@ -36,7 +37,6 @@ KeyPoll::KeyPoll(void)
 	// 0..5
 	sensitivity = 2;
 
-	quitProgram = 0;
 	keybuffer="";
 	leftbutton=0; rightbutton=0; middlebutton=0;
 	mx=0; my=0;
@@ -339,7 +339,7 @@ void KeyPoll::Poll(void)
 
 		/* Quit Event */
 		case SDL_QUIT:
-			quitProgram = true;
+			VVV_exit(0);
 			break;
 		}
 	}

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -37,7 +37,6 @@ public:
 
 	bool resetWindow;
 
-	bool quitProgram;
 	void toggleFullscreen(void);
 
 	int sensitivity;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -615,7 +615,7 @@ int main(int argc, char *argv[])
     gamestate_funcs = get_gamestate_funcs(game.gamestate, &num_gamestate_funcs);
     loop_assign_active_funcs();
 
-    while(!key.quitProgram)
+    while (true)
     {
         f_time = SDL_GetTicks();
 


### PR DESCRIPTION
This fixes a regression introduced by #535 where a quit signal (e.g. Ctrl-C) sent to the window while the game was in unfocus pause wouldn't close the game.

One problem was that `key.quitProgram` would only be checked when control flow switched back to the outer loop in `main()`, which would only happen when the loop order state machine switched to a delta function. As the unfocused func table didn't have any delta functions, this means `key.quitProgram` would never be checked.

So a naïve solution to this would just be to add a no-op delta func entry to the unfocused func table. However, we then run into a separate issue where a delta function at the end of a func list never reassigns the active funcs, causing the game to be stuck in the unfocus pause forever. Active func reassignment only happens after fixed funcs. So then a naïve solution after that would be to simply add a no-op fixed func entry after that. And indeed, that would fix the whole issue.

However, I want to do things the right way. And this does not seem like the right way. Even putting aside the separate last-func-being-delta issue, it mandates that every func list needs a delta function. Which seems quite unnecessary to me.

Another solution I considered was copy-pasting the `key.quitProgram` check to the inner loops, or adding some sort of signal propagation to the inner loops - implemented by copy-pasting checks after each loop - so we didn't need to copy-paste `key.quitProgram`... but that seems really messy, too.

So, I realized that we could throw away `key.quitProgram`, and simply call `VVV_exit()` directly when we receive an `SDL_QUIT` event. This fixes the issue, this removes an unnecessary middleman variable, and it's pretty cleanly and simply the right thing to do.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
