### PR TITLE
Fix funcs not being reassigned if delta func is last func in list

### DIFF
--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -681,7 +681,12 @@ static void inline deltaloop(void)
 
     while (accumulator >= timesteplimit)
     {
-        increment_func_index();
+        enum IndexCode index_code = increment_func_index();
+
+        if (index_code == Index_end)
+        {
+            loop_assign_active_funcs();
+        }
 
         accumulator = SDL_fmodf(accumulator, timesteplimit);
 


### PR DESCRIPTION
One of the solutions to the quit signal unfocus pause regression is to add a no-op delta func to the unfocused func table. However, this results in the game being stuck in unfocus pause forever, because when it reaches the end of a list on a delta func, it won't reassign the active functions - only when the end of a list is a fixed func will it do so. A workaround is to then add a no-op fixed func afterwards, but that's inelegant.

The solution in the end to the quit signal regression is to not bother with adding a delta func, so the game as of right now actually never has a delta func at the end of a list, and probably never will - but this is one piece of technical debt I don't want to leave laying around. In case we're ever going to put a delta function at the end of a list, I've made it so that delta functions will now reassign the list of active funcs if they happen to be at the end of the func list.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
