### PR TITLE
Add option to re-enable 1-frame input delay

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -385,6 +385,7 @@ void Game::init(void)
     kludge_ingametemp = Menu::mainmenu;
 
     disablepause = false;
+    inputdelay = false;
 }
 
 void Game::lifesequence(void)
@@ -4173,6 +4174,11 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* s
             over30mode = help.Int(pText);
         }
 
+        if (SDL_strcmp(pKey, "inputdelay") == 0)
+        {
+            inputdelay = help.Int(pText);
+        }
+
         if (SDL_strcmp(pKey, "glitchrunnermode") == 0)
         {
             glitchrunnermode = help.Int(pText);
@@ -4422,6 +4428,8 @@ void Game::serializesettings(tinyxml2::XMLElement* dataNode, const ScreenSetting
     xml::update_tag(dataNode, "showmousecursor", (int) graphics.showmousecursor);
 
     xml::update_tag(dataNode, "over30mode", (int) over30mode);
+
+    xml::update_tag(dataNode, "inputdelay", (int) inputdelay);
 
     xml::update_tag(dataNode, "glitchrunnermode", (int) glitchrunnermode);
 
@@ -6017,6 +6025,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("fake load screen");
         option("room name background");
         option("glitchrunner mode");
+        option("input delay");
         option("return");
         menuyoff = 0;
         break;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -452,6 +452,7 @@ public:
     void unlockAchievement(const char *name);
 
     bool disablepause;
+    bool inputdelay;
 };
 
 #ifndef GAME_DEFINITION

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -578,6 +578,12 @@ static void menuactionpress(void)
             game.savestatsandsettings_menu();
             break;
         case 5:
+            /* Input delay */
+            music.playef(11);
+            game.inputdelay = !game.inputdelay;
+            game.savestatsandsettings_menu();
+            break;
+        default:
             //back
             music.playef(11);
             game.returnmenu();

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -518,6 +518,19 @@ static void menurender(void)
                 graphics.Print( -1, 95, "Glitchrunner mode is OFF", tr/2, tg/2, tb/2, true);
             }
             break;
+        case 5:
+            graphics.bigprint(-1, 30, "Input Delay", tr, tg, tb, true);
+            graphics.Print(-1, 65, "Re-enable the 1-frame input delay", tr, tg, tb, true);
+            graphics.Print(-1, 75, "from previous versions of the game.", tr, tg, tb, true);
+            if (game.inputdelay)
+            {
+                graphics.Print(-1, 95, "Input delay is ON", tr, tg, tb, true);
+            }
+            else
+            {
+                graphics.Print(-1, 95, "Input delay is OFF", tr/2, tg/2, tb/2, true);
+            }
+            break;
         }
         break;
     case Menu::accessibility:

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -302,7 +302,7 @@ static enum LoopCode loop_run_active_funcs(void)
         const struct ImplFunc* implfunc = &(*active_funcs)[*active_func_index];
         enum IndexCode index_code;
 
-        if (implfunc->type == Func_input)
+        if (implfunc->type == Func_input && !game.inputdelay)
         {
             key.Poll();
         }
@@ -716,6 +716,11 @@ static void inline deltaloop(void)
 
 static enum LoopCode loop_begin(void)
 {
+    if (game.inputdelay)
+    {
+        key.Poll();
+    }
+
     // Update network per frame.
     NETWORK_update();
 


### PR DESCRIPTION
This is an option for speedrunners whose muscle memory is precisely trained and used to the 1-frame input delay that existed in 2.2 and below. It is located in Game Options -> Advanced Options, and is off by default.

To re-add the 1-frame input delay, we simply move the `key.Poll()` to the start of the frame, instead of before an input function gets ran - undoing what #535 did.

There is a frame ordering-sensitive issue here, where toggling `game.inputdelay` at the wrong time could cause double-polling. However, we only toggle it in an input function, which regardless is always guaranteed to be ran after `key.Poll()` (it either happened at the start of the frame or just before the input function got ran), so this is not an issue. But, in case we ever need to toggle this variable in the future, we can just use the defer callbacks system to defer the toggle to the end of the frame - also added by #535.

Added at the request of Habeechee on the VVVVVV speedrunning Discord server.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
