### PR TITLE
Remove advancetext check from teleporter prompt logic

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1554,7 +1554,7 @@ void gamelogic(void)
     }
 
     game.oldreadytotele = game.readytotele;
-    if (game.activetele && !game.advancetext && game.hascontrol && !script.running && !game.intimetrial)
+    if (game.activetele && game.hascontrol && !script.running && !game.intimetrial)
     {
         int i = obj.getplayer();
         SDL_Rect temprect = SDL_Rect();


### PR DESCRIPTION
This fixes being unable to use teleporters while the "- Press ACTION to advance text -" prompt is up, which is used to perform credits warp.

In 2.2 and 2.0, this advancetext check was only in `gamerender()` for rendering the "- Press ENTER to Teleport -" prompt and didn't affect any logic. In 2.3, I moved the check (and the rest of the conditional it was in) to `gamelogic()` - same as the activity zone prompt conditionals - so if you gained control while being in a prompt zone, the prompt wouldn't suddenly appear<sup>[1]</sup>.

As a side effect, this ended up aligning rendering and logic together, so if you couldn't see the teleporter prompt, you weren't able to teleport - whereas in 2.2 and 2.0, you could still use the teleporter even though the prompt wasn't up.

So by removing the `advancetext` check, you are now able to use the teleporter again, *and* the "- Press ENTER to Teleport -" prompt will also show up as well.

Habeechee reported this regression on the VVVVVV speedrunning Discord server.

<sup>[1]</sup>: f07a8d2143479a465c31aea2e08764197a37a2e3, PR #421

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
