### PR TITLE
Switch assets mounting to dedicated directory

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -231,7 +231,11 @@ static bool FILESYSTEM_mountAssetsFrom(const char *fname)
 
 	if (!PHYSFS_mount(path, NULL, 0))
 	{
-		printf("Error mounting: %s\n", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+		printf(
+			"Error mounting %s: %s\n",
+			fname,
+			PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
+		);
 		return false;
 	}
 

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -441,6 +441,19 @@ void FILESYSTEM_loadFileToMemory(
 	PHYSFS_close(handle);
 }
 
+void FILESYSTEM_loadAssetToMemory(
+	const char* name,
+	unsigned char** mem,
+	size_t* len,
+	const bool addnull
+) {
+	const char* path;
+
+	path = name;
+
+	FILESYSTEM_loadFileToMemory(path, mem, len, addnull);
+}
+
 void FILESYSTEM_freeMemory(unsigned char **mem)
 {
 	SDL_free(*mem);

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -213,7 +213,7 @@ static bool FILESYSTEM_exists(const char *fname)
 	return PHYSFS_exists(fname);
 }
 
-void FILESYSTEM_mount(const char *fname)
+static void FILESYSTEM_mount(const char *fname)
 {
 	const char* real_dir = PHYSFS_getRealDir(fname);
 	const char* dir_separator;

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -213,7 +213,7 @@ static bool FILESYSTEM_exists(const char *fname)
 	return PHYSFS_exists(fname);
 }
 
-static void FILESYSTEM_mount(const char *fname)
+static bool FILESYSTEM_mount(const char *fname)
 {
 	const char* real_dir = PHYSFS_getRealDir(fname);
 	const char* dir_separator;
@@ -225,7 +225,7 @@ static void FILESYSTEM_mount(const char *fname)
 			"Could not mount %s: real directory doesn't exist\n",
 			fname
 		);
-		return;
+		return false;
 	}
 
 	dir_separator = PHYSFS_getDirSeparator();
@@ -235,11 +235,11 @@ static void FILESYSTEM_mount(const char *fname)
 	if (!PHYSFS_mount(path, NULL, 0))
 	{
 		printf("Error mounting: %s\n", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+		return false;
 	}
-	else
-	{
-		SDL_strlcpy(assetDir, path, sizeof(assetDir));
-	}
+
+	SDL_strlcpy(assetDir, path, sizeof(assetDir));
+	return true;
 }
 
 void FILESYSTEM_loadZip(const char* filename)
@@ -298,7 +298,10 @@ void FILESYSTEM_mountassets(const char* path)
 	{
 		printf("Custom asset directory is .data.zip at %s\n", zip_data);
 
-		FILESYSTEM_mount(zip_data);
+		if (!FILESYSTEM_mount(zip_data))
+		{
+			return;
+		}
 
 		graphics.reloadresources();
 	}
@@ -321,18 +324,18 @@ void FILESYSTEM_mountassets(const char* path)
 				"Error loading .zip: %s\n",
 				PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
 			);
+			return;
 		}
-		else if (PHYSFS_mountHandle(zip, zip_data, "/", 0) == 0)
+		if (PHYSFS_mountHandle(zip, zip_data, "/", 0) == 0)
 		{
 			printf(
 				"Error mounting .zip: %s\n",
 				PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
 			);
+			return;
 		}
-		else
-		{
-			SDL_strlcpy(assetDir, zip_data, sizeof(assetDir));
-		}
+
+		SDL_strlcpy(assetDir, zip_data, sizeof(assetDir));
 
 		graphics.reloadresources();
 	}
@@ -340,7 +343,10 @@ void FILESYSTEM_mountassets(const char* path)
 	{
 		printf("Custom asset directory exists at %s\n", dir);
 
-		FILESYSTEM_mount(dir);
+		if (!FILESYSTEM_mount(dir))
+		{
+			return;
+		}
 
 		graphics.reloadresources();
 	}

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -94,7 +94,7 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 	SDL_snprintf(saveDir, sizeof(saveDir), "%s%s%s",
 		output,
 		"saves",
-		PHYSFS_getDirSeparator()
+		pathSep
 	);
 	printf("Save directory: %s\n", saveDir);
 
@@ -102,7 +102,7 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 	SDL_snprintf(levelDir, sizeof(levelDir), "%s%s%s",
 		output,
 		"levels",
-		PHYSFS_getDirSeparator()
+		pathSep
 	);
 	printf("Level directory: %s\n", levelDir);
 

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -307,35 +307,12 @@ void FILESYSTEM_mountAssets(const char* path)
 	}
 	else if (zip_normal != NULL && endsWith(zip_normal, ".zip"))
 	{
-		PHYSFS_File* zip = PHYSFS_openRead(zip_normal);
-
 		printf("Custom asset directory is .zip at %s\n", zip_normal);
 
-		SDL_snprintf(
-			zip_data,
-			sizeof(zip_data),
-			"%s.data.zip",
-			zip_normal
-		);
-
-		if (zip == NULL)
+		if (!FILESYSTEM_mount(zip_normal))
 		{
-			printf(
-				"Error loading .zip: %s\n",
-				PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
-			);
 			return;
 		}
-		if (PHYSFS_mountHandle(zip, zip_data, "/", 0) == 0)
-		{
-			printf(
-				"Error mounting .zip: %s\n",
-				PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
-			);
-			return;
-		}
-
-		SDL_strlcpy(assetDir, zip_data, sizeof(assetDir));
 
 		graphics.reloadresources();
 	}

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -216,7 +216,6 @@ static bool FILESYSTEM_exists(const char *fname)
 static bool FILESYSTEM_mountAssetsFrom(const char *fname)
 {
 	const char* real_dir = PHYSFS_getRealDir(fname);
-	const char* dir_separator;
 	char path[MAX_PATH];
 
 	if (real_dir == NULL)
@@ -228,9 +227,7 @@ static bool FILESYSTEM_mountAssetsFrom(const char *fname)
 		return false;
 	}
 
-	dir_separator = PHYSFS_getDirSeparator();
-
-	SDL_snprintf(path, sizeof(path), "%s%s%s", real_dir, dir_separator, fname);
+	SDL_snprintf(path, sizeof(path), "%s/%s", real_dir, fname);
 
 	if (!PHYSFS_mount(path, NULL, 0))
 	{

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -213,7 +213,7 @@ static bool FILESYSTEM_exists(const char *fname)
 	return PHYSFS_exists(fname);
 }
 
-static bool FILESYSTEM_mount(const char *fname)
+static bool FILESYSTEM_mountAssetsFrom(const char *fname)
 {
 	const char* real_dir = PHYSFS_getRealDir(fname);
 	const char* dir_separator;
@@ -298,7 +298,7 @@ void FILESYSTEM_mountAssets(const char* path)
 	{
 		printf("Custom asset directory is .data.zip at %s\n", zip_data);
 
-		if (!FILESYSTEM_mount(zip_data))
+		if (!FILESYSTEM_mountAssetsFrom(zip_data))
 		{
 			return;
 		}
@@ -309,7 +309,7 @@ void FILESYSTEM_mountAssets(const char* path)
 	{
 		printf("Custom asset directory is .zip at %s\n", zip_normal);
 
-		if (!FILESYSTEM_mount(zip_normal))
+		if (!FILESYSTEM_mountAssetsFrom(zip_normal))
 		{
 			return;
 		}
@@ -320,7 +320,7 @@ void FILESYSTEM_mountAssets(const char* path)
 	{
 		printf("Custom asset directory exists at %s\n", dir);
 
-		if (!FILESYSTEM_mount(dir))
+		if (!FILESYSTEM_mountAssetsFrom(dir))
 		{
 			return;
 		}

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -256,7 +256,7 @@ void FILESYSTEM_loadZip(const char* filename)
 	}
 }
 
-void FILESYSTEM_mountassets(const char* path)
+void FILESYSTEM_mountAssets(const char* path)
 {
 	const size_t path_size = SDL_strlen(path);
 	char filename[MAX_PATH];
@@ -356,7 +356,7 @@ void FILESYSTEM_mountassets(const char* path)
 	}
 }
 
-void FILESYSTEM_unmountassets(void)
+void FILESYSTEM_unmountAssets(void)
 {
 	if (assetDir[0] != '\0')
 	{

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -22,6 +22,12 @@ bool FILESYSTEM_isAssetMounted(const char* filename);
 
 void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem,
                                  size_t *len, bool addnull);
+void FILESYSTEM_loadAssetToMemory(
+    const char* name,
+    unsigned char** mem,
+    size_t* len,
+    const bool addnull
+);
 void FILESYSTEM_freeMemory(unsigned char **mem);
 bool FILESYSTEM_saveTiXml2Document(const char *name, tinyxml2::XMLDocument& doc);
 bool FILESYSTEM_loadTiXml2Document(const char *name, tinyxml2::XMLDocument& doc);

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -21,7 +21,7 @@ void FILESYSTEM_unmountAssets(void);
 bool FILESYSTEM_isAssetMounted(const char* filename);
 
 void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem,
-                                 size_t *len, bool addnull = false);
+                                 size_t *len, bool addnull);
 void FILESYSTEM_freeMemory(unsigned char **mem);
 bool FILESYSTEM_saveTiXml2Document(const char *name, tinyxml2::XMLDocument& doc);
 bool FILESYSTEM_loadTiXml2Document(const char *name, tinyxml2::XMLDocument& doc);

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -16,8 +16,8 @@ bool FILESYSTEM_isFile(const char* filename);
 bool FILESYSTEM_isMounted(const char* filename);
 
 void FILESYSTEM_loadZip(const char* filename);
-void FILESYSTEM_mountassets(const char *path);
-void FILESYSTEM_unmountassets(void);
+void FILESYSTEM_mountAssets(const char *path);
+void FILESYSTEM_unmountAssets(void);
 bool FILESYSTEM_isAssetMounted(const char* filename);
 
 void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem,

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -15,7 +15,6 @@ char *FILESYSTEM_getUserLevelDirectory(void);
 bool FILESYSTEM_isFile(const char* filename);
 bool FILESYSTEM_isMounted(const char* filename);
 
-void FILESYSTEM_mount(const char *fname);
 void FILESYSTEM_loadZip(const char* filename);
 void FILESYSTEM_mountassets(const char *path);
 void FILESYSTEM_unmountassets(void);

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6544,7 +6544,7 @@ void Game::quittomenu(void)
 {
     gamestate = TITLEMODE;
     graphics.fademode = 4;
-    FILESYSTEM_unmountassets();
+    FILESYSTEM_unmountAssets();
     graphics.titlebg.tdrawback = true;
     graphics.flipmode = false;
     //Don't be stuck on the summary screen,

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -364,7 +364,7 @@ void Graphics::Makebfont(void)
 
     unsigned char* charmap = NULL;
     size_t length;
-    FILESYSTEM_loadFileToMemory("graphics/font.txt", &charmap, &length);
+    FILESYSTEM_loadFileToMemory("graphics/font.txt", &charmap, &length, false);
     if (charmap != NULL)
     {
         unsigned char* current = charmap;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -364,7 +364,7 @@ void Graphics::Makebfont(void)
 
     unsigned char* charmap = NULL;
     size_t length;
-    FILESYSTEM_loadFileToMemory("graphics/font.txt", &charmap, &length, false);
+    FILESYSTEM_loadAssetToMemory("graphics/font.txt", &charmap, &length, false);
     if (charmap != NULL)
     {
         unsigned char* current = charmap;

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -36,7 +36,7 @@ static SDL_Surface* LoadImage(const char *filename, bool noBlend = true, bool no
 
 	unsigned char *fileIn = NULL;
 	size_t length = 0;
-	FILESYSTEM_loadFileToMemory(filename, &fileIn, &length, false);
+	FILESYSTEM_loadAssetToMemory(filename, &fileIn, &length, false);
 	if (noAlpha)
 	{
 		lodepng_decode24(&data, &width, &height, fileIn, length);

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -36,7 +36,7 @@ static SDL_Surface* LoadImage(const char *filename, bool noBlend = true, bool no
 
 	unsigned char *fileIn = NULL;
 	size_t length = 0;
-	FILESYSTEM_loadFileToMemory(filename, &fileIn, &length);
+	FILESYSTEM_loadFileToMemory(filename, &fileIn, &length, false);
 	if (noAlpha)
 	{
 		lodepng_decode24(&data, &width, &height, fileIn, length);

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -131,7 +131,7 @@ void Screen::LoadIcon(void)
 	size_t length = 0;
 	unsigned char *data;
 	unsigned int width, height;
-	FILESYSTEM_loadFileToMemory("VVVVVV.png", &fileIn, &length, false);
+	FILESYSTEM_loadAssetToMemory("VVVVVV.png", &fileIn, &length, false);
 	lodepng_decode24(&data, &width, &height, fileIn, length);
 	FILESYSTEM_freeMemory(&fileIn);
 	SDL_Surface *icon = SDL_CreateRGBSurfaceFrom(

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -131,7 +131,7 @@ void Screen::LoadIcon(void)
 	size_t length = 0;
 	unsigned char *data;
 	unsigned int width, height;
-	FILESYSTEM_loadFileToMemory("VVVVVV.png", &fileIn, &length);
+	FILESYSTEM_loadFileToMemory("VVVVVV.png", &fileIn, &length, false);
 	lodepng_decode24(&data, &width, &height, fileIn, length);
 	FILESYSTEM_freeMemory(&fileIn);
 	SDL_Surface *icon = SDL_CreateRGBSurfaceFrom(

--- a/desktop_version/src/SoundSystem.cpp
+++ b/desktop_version/src/SoundSystem.cpp
@@ -33,7 +33,7 @@ SoundTrack::SoundTrack(const char* fileName)
 
 	unsigned char *mem;
 	size_t length = 0;
-	FILESYSTEM_loadFileToMemory(fileName, &mem, &length);
+	FILESYSTEM_loadFileToMemory(fileName, &mem, &length, false);
 	if (mem == NULL)
 	{
 		fprintf(stderr, "Unable to load WAV file %s\n", fileName);

--- a/desktop_version/src/SoundSystem.cpp
+++ b/desktop_version/src/SoundSystem.cpp
@@ -33,7 +33,7 @@ SoundTrack::SoundTrack(const char* fileName)
 
 	unsigned char *mem;
 	size_t length = 0;
-	FILESYSTEM_loadFileToMemory(fileName, &mem, &length, false);
+	FILESYSTEM_loadAssetToMemory(fileName, &mem, &length, false);
 	if (mem == NULL)
 	{
 		fprintf(stderr, "Unable to load WAV file %s\n", fileName);

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1748,14 +1748,14 @@ bool editorclass::load(std::string& _path)
         _path = levelDir + _path;
     }
 
-    FILESYSTEM_unmountassets();
+    FILESYSTEM_unmountAssets();
     if (game.playassets != "")
     {
-        FILESYSTEM_mountassets(game.playassets.c_str());
+        FILESYSTEM_mountAssets(game.playassets.c_str());
     }
     else
     {
-        FILESYSTEM_mountassets(_path.c_str());
+        FILESYSTEM_mountAssets(_path.c_str());
     }
 
     tinyxml2::XMLDocument doc;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -409,7 +409,7 @@ int main(int argc, char *argv[])
         {
             ARG_INNER({
                 i++;
-                // Even if this is a directory, FILESYSTEM_mountassets() expects '.vvvvvv' on the end
+                // Even if this is a directory, FILESYSTEM_mountAssets() expects '.vvvvvv' on the end
                 playassets = "levels/" + std::string(argv[i]) + ".vvvvvv";
             })
         }


### PR DESCRIPTION
This fixes an issue where you would be able to mount things other than custom assets in per-level custom asset directories and zips.

To be fair, the effects of this issue were fairly limited - about the only thing I could do with it was to override a user-made quicksave of a custom level with one of my own. However, since the quicksave check happens before assets are mounted, if the user didn't have an existing quicksave then they wouldn't be able load my quicksave. Furthermore, mounting things like `settings.vvv` simply doesn't work because assets only get mounted when the level gets loaded, but the game only reads from `settings.vvv` on startup.

Still, this is an issue, and just because it only has one effect doesn't mean we should single-case patch that one effect only. So what can we do?

I was thinking that we should (1) mount custom assets in a dedicated directory, and then from there (2) mount each specific asset directly - namely, mount the graphics/ and sounds/ folders, and mount the `vvvvvvmusic.vvv` and `mmmmmm.vvv` files. For (1), assets are now mounted at a (non-existent) location named `.vvv-mnt/assets/`. However, (2) doesn't fully work due to how PhysFS works.

What *does* work is being able to mount the `graphics/` and `sounds/` folders, but only if the custom assets directory is a directory. And, you actually have to use the real directory where those `graphics/` and `sounds/` folders are located, and not the mounted directory, because `PHYSFS_mount()` only accepts real directories. (In which case why bother mounting the directory in the first place if we have to use real directories anyway?) So already this seems like having different directory and zip mounting paths, which I don't want...

I tried to unify the directory and zip paths and get around the real directory limitation. So for mounting each individual asset (i.e. `graphics/`, `sounds/`, but especially `vvvvvvmusic.vvv` and `mmmmmm.vvv`), I tried doing `PHYSFS_openRead()` followed by `PHYSFS_mountHandle()` with that `PHYSFS_File`, but this simply doesn't work, because `PHYSFS_mountHandle()` will always create a `PHYSFS_Io` object, and pass it to a PhysFS internal helper function named `openDirectory()` which will only attempt to treat it as a directory if the `PHYSFS_Io*` passed is `NULL`. Since `PHYSFS_mountHandle()` always passes a non-`NULL` `PHYSFS_Io*`, `openDirectory()` will always treat it like a zip file and never as a directory - in contrast, `PHYSFS_mount()` will always pass a `NULL` `PHYSFS_Io*` to `openDirectory()`, so `PHYSFS_mount()` is the only function that works for mounting directories.

(And even if this did work, having to keep the file open (because of the `PHYSFS_openRead()`) results in the user being unable to touch the file on Windows until it gets closed, which I also don't want.)

As for zip files, `PHYSFS_mount()` works just fine on them, but then we run into the issue of accessing the individual assets inside it. As covered above, `PHYSFS_mount()` only accepts real directories, so we can't use it to access the assets inside, but then if we do the `PHYSFS_openRead()` and `PHYSFS_mountHandle()` approach, `PHYSFS_mountHandle()` will treat the assets inside as zip files instead of just mounting them normally!

So in short, PhysFS only seems to be able to mount directories and zip files, and not any loose individual files (like `vvvvvvmusic.vvv` and `mmmmmm.vvv`). Furthermore, directories inside directories works, but directories inside zip files doesn't (only zip files inside zip files work).

It seems like our asset paths don't really work well with PhysFS's design. Currently, `graphics/`, `sounds/`, `vvvvvvmusic.vvv`, and `mmmmmm.vvv` all live at the root directory of the VVVVVV folder. But what would work better is if all of those items were organized into a subfolder, for example, a folder named `assets/`. So the previous assets mounting system before this patch would just have mounted `assets/` and be done with it, and there would be no risk of mounting extraneous files that could do bad things. However, due to our unorganized asset paths, the previous system has to mount assets at the root of the VVVVVV folder, which invites the possibility of those extraneous bad files being mounted.

Well, we can't change the asset paths now, that would be a pretty big API break (maybe it should be a 2.4 thing). So what can we do?

What I've done is, after mounting the assets at `.vvv-mnt/assets/`, when the game loads an asset, it checks if there's an override available inside `.vvv-mnt/assets/`, and if so, the game will load that asset instead of the regular one. This is basically reimplementing what PhysFS *should* be able to do for us, but can't. This fixes the issue of being able to mount a quicksave for a custom level inside its asset directory.

I should also note, the unorganized asset paths issue also means that for `.zip` files (which contain the level file), the level file itself is also technically mounted at `.vvv-mnt/assets/`. This is harmless (because when we load a level file, we never load it as an asset) but it's still a bit ugly. Changing the asset paths now seems more and more like a good thing to do...

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
