### PR TITLE
Blacklist non-.vvvvvv files in level metadata

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -212,7 +212,9 @@ static void levelMetaDataCallback(const char* filename)
     LevelMetaData temp;
     std::string filename_ = filename;
 
-    if (!FILESYSTEM_isFile(filename) || FILESYSTEM_isMounted(filename))
+    if (!endsWith(filename, ".vvvvvv")
+    || !FILESYSTEM_isFile(filename)
+    || FILESYSTEM_isMounted(filename))
     {
         return;
     }


### PR DESCRIPTION
While the game does support playing levels with filenames that don't have the `.vvvvvv` extension, it doesn't do it well.

Namely, those files can't be loaded or saved into the editor (because a `.vvvvvv` always gets tacked on to your input when saving or loading). In 2.3, this gets worse because you can't load a level without a `.vvvvvv` extension from command-line playtesting (because a `.vvvvvv` automatically gets added) and you can't load per-level custom assets.

The only place where extensionless level files are supported is when loading level metadata. But this makes it so they no longer work. This is technically an API break, but it's easily fixed (just add the `.vvvvvv`), plus there's nothing to be gained from not having an extension, plus basically no one ever actually did this in the first place (as far as I know, I am the only person to have ever done this, and no one else ever has).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
