### PR TITLE
Fix level list segfault when upgrading old levelstats.vvv

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -556,7 +556,16 @@ void Game::loadcustomlevelstats(void)
             pText = "";
         }
 
-        LOAD_ARRAY_RENAME(customlevelscore, customlevelscores)
+        if (SDL_strcmp(pKey, "customlevelscore") == 0 && pText[0] != '\0')
+        {
+            char buffer[16];
+            size_t start = 0;
+
+            while (next_split_s(buffer, sizeof(buffer), &start, pText, ','))
+            {
+                customlevelscores.push_back(help.Int(buffer));
+            }
+        }
 
         if (SDL_strcmp(pKey, "customlevelstats") == 0 && pText[0] != '\0')
         {


### PR DESCRIPTION
So some people reported the levels list crashing when they loaded it. But this wasn't reproducible every time. They didn't provide any debugging information, so I had to use my backup plan: doing a full audit of the code path taken for loading the levels list.

And then I found this. It turns out this was because I used a `LOAD_ARRAY_RENAME()` macro on an `std::vector`. You can't do that because you need to use `push_back()` to resize a vector, so the macro will end up indexing into nothing, causing a segfault. However, this code path would only be taken if you have an old `levelstats.vvv`, from 2.2 and previous - which explains why it wasn't 100% reproducible. But now that I know you need an old `levelstats.vvv`, this bug happens 100% of the time.

Anyways, to fix this, just ditch the macro and expand it manually, while replacing the indexing with a proper usage of `push_back()`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
