### PR TITLE
Fix '-Wpedantic' warnings under gcc 10.x

### DIFF
--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -79,9 +79,9 @@ namespace Menu
         timetrialcomplete,
         timetrialcomplete2,
         timetrialcomplete3,
-        gamecompletecontinue,
+        gamecompletecontinue
     };
-};
+}
 
 struct MenuStackFrame
 {

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -398,21 +398,21 @@ int Graphics::bfontlen(uint32_t ch)
 
 void Graphics::MakeTileArray(void)
 {
-    PROCESS_TILESHEET(tiles, 8, )
-    PROCESS_TILESHEET(tiles2, 8, )
-    PROCESS_TILESHEET(tiles3, 8, )
-    PROCESS_TILESHEET(entcolours, 8, )
+    PROCESS_TILESHEET(tiles, 8, {})
+    PROCESS_TILESHEET(tiles2, 8, {})
+    PROCESS_TILESHEET(tiles3, 8, {})
+    PROCESS_TILESHEET(entcolours, 8, {})
 }
 
 void Graphics::maketelearray(void)
 {
-    PROCESS_TILESHEET_RENAME(teleporter, tele, 96, )
+    PROCESS_TILESHEET_RENAME(teleporter, tele, 96, {})
 }
 
 void Graphics::MakeSpriteArray(void)
 {
-    PROCESS_TILESHEET(sprites, 32, )
-    PROCESS_TILESHEET(flipsprites, 32, )
+    PROCESS_TILESHEET(sprites, 32, {})
+    PROCESS_TILESHEET(flipsprites, 32, {})
 }
 
 #undef PROCESS_TILESHEET

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -195,14 +195,14 @@ static std::string NAME(const std::string& buf) \
     return find_tag(buf, "<" TAG ">", "</" TAG ">"); \
 }
 
-TAG_FINDER(find_metadata, "MetaData"); //only for checking that it exists
+TAG_FINDER(find_metadata, "MetaData") //only for checking that it exists
 
-TAG_FINDER(find_creator, "Creator");
-TAG_FINDER(find_title, "Title");
-TAG_FINDER(find_desc1, "Desc1");
-TAG_FINDER(find_desc2, "Desc2");
-TAG_FINDER(find_desc3, "Desc3");
-TAG_FINDER(find_website, "website");
+TAG_FINDER(find_creator, "Creator")
+TAG_FINDER(find_title, "Title")
+TAG_FINDER(find_desc1, "Desc1")
+TAG_FINDER(find_desc2, "Desc2")
+TAG_FINDER(find_desc3, "Desc3")
+TAG_FINDER(find_website, "website")
 
 #undef TAG_FINDER
 


### PR DESCRIPTION
## Changes:

Fix some compilation warnings due to redundant semicolons or empty macro arguments under `-Wpedantic`.
Feel free to not credit me for these small changes. 

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
