### PR TITLE
Fix softlocks from mistimed trinket text skip and turning advancetext off at the wrong time

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -739,6 +739,7 @@ void Game::updatestate(void)
             if (!script.running)
             {
                 hascontrol = true;
+                completestop = false;
             }
             break;
         case 1:

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -735,9 +735,17 @@ void Game::updatestate(void)
         case 0:
             //Do nothing here! Standard game state
 
-            //Prevent softlocks if there's no cutscene running right now
-            if (!script.running)
+            if (script.running)
             {
+                if (pausescript && !advancetext)
+                {
+                    /* Prevent softlocks if we somehow don't have advancetext */
+                    pausescript = false;
+                }
+            }
+            else
+            {
+                /* Prevent softlocks if there's no cutscene running right now */
                 hascontrol = true;
                 completestop = false;
             }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3606,6 +3606,7 @@ void scriptclass::hardreset(void)
 	}
 
 	game.pausescript = false;
+	game.completestop = false;
 
 	game.flashlight = 0;
 	game.screenshake = 0;


### PR DESCRIPTION
Two softlocks, two bug fixes. One of them is getting stuck in `completestop` and the other is getting stuck with `pausescript` on but `advancetext` off.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
