### PR TITLE
Fix pause menu inconsistencies from Terry's menu cleanup

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -447,15 +447,8 @@ static void menuactionpress(void)
         default:
             //back
             music.playef(11);
-            if (game.ingame_titlemode)
-            {
-                game.returntoingame();
-            }
-            else
-            {
-                game.returnmenu();
-                map.nexttowercolour();
-            }
+            game.returnmenu();
+            map.nexttowercolour();
             break;
         }
         break;
@@ -735,15 +728,8 @@ static void menuactionpress(void)
         else if (game.currentmenuoption == gameplayoptionsoffset + 4) {
             //return to previous menu
             music.playef(11);
-            if (game.ingame_titlemode)
-            {
-                game.returntoingame();
-            }
-            else
-            {
-                game.returnmenu();
-                map.nexttowercolour();
-            }
+            game.returnmenu();
+            map.nexttowercolour();
         }
 
         break;
@@ -1632,8 +1618,7 @@ void titleinput(void)
             else
             {
                 if (game.ingame_titlemode
-                && (game.currentmenuname == Menu::options
-                || game.currentmenuname == Menu::graphicoptions))
+                && game.currentmenuname == Menu::options)
                 {
                     game.returntoingame();
                 }

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2147,7 +2147,7 @@ void mapinput(void)
         {
             game.press_action = true;
         }
-        if (game.menupage < 12 || (game.menupage >= 30 && game.menupage <= 33))
+        if (game.menupage < 12 || (game.menupage >= 30 && game.menupage <= 32))
         {
             if (key.isDown(KEYBOARD_ENTER) || key.isDown(game.controllerButton_map) ) game.press_map = true;
             if (key.isDown(27) && !game.mapheld)
@@ -2159,7 +2159,7 @@ void mapinput(void)
                 }
                 else if (game.menupage < 12)
                 {
-                    game.menupage = 31;
+                    game.menupage = 32;
                 }
                 else
                 {
@@ -2297,7 +2297,7 @@ static void mapmenuactionpress(void)
     case 10:
         //return to pause menu
         music.playef(11);
-        game.menupage = 31;
+        game.menupage = 32;
         break;
     case 11:
         //quit to menu


### PR DESCRIPTION
This fixes returning from the confirm quit menu placing you on the options button instead of the quit to menu button, using the return button in gameplay or graphic options putting you back at the pause menu instead of the options menu, and pressing Esc in graphic options putting you back at the pause menu instead of the options menu.

Fixes #711.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
