### PR TITLE
Add in-game music and sound volume sliders and a new audio category to options

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6031,13 +6031,9 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
     case Menu::options:
         option("gameplay");
         option("graphics");
+        option("audio");
         option("game pad");
         option("accessibility");
-        //Add extra menu for mmmmmm mod
-        if(music.mmmmmm){
-            option("soundtrack");
-        }
-
         option("return");
         menuyoff = 0;
         maxspacing = 15;
@@ -6054,6 +6050,17 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("toggle mouse");
         option("unfocus pause");
         option("room name background");
+        option("return");
+        menuyoff = 0;
+        maxspacing = 15;
+        break;
+    case Menu::audiooptions:
+        option("music volume");
+        option("sound volume");
+        if (music.mmmmmm)
+        {
+            option("soundtrack");
+        }
         option("return");
         menuyoff = 0;
         maxspacing = 15;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -383,6 +383,7 @@ void Game::init(void)
     ingame_editormode = false;
 #endif
     kludge_ingametemp = Menu::mainmenu;
+    slidermode = SLIDER_NONE;
 
     disablepause = false;
     inputdelay = false;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4222,6 +4222,16 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* s
             graphics.showmousecursor = help.Int(pText);
         }
 
+        if (SDL_strcmp(pKey, "musicvolume") == 0)
+        {
+            music.user_music_volume = help.Int(pText);
+        }
+
+        if (SDL_strcmp(pKey, "soundvolume") == 0)
+        {
+            music.user_sound_volume = help.Int(pText);
+        }
+
         if (SDL_strcmp(pKey, "flipButton") == 0)
         {
             SDL_GameControllerButton newButton;
@@ -4452,6 +4462,10 @@ void Game::serializesettings(tinyxml2::XMLElement* dataNode, const ScreenSetting
     xml::update_tag(dataNode, "glitchrunnermode", (int) glitchrunnermode);
 
     xml::update_tag(dataNode, "vsync", (int) screen_settings->useVsync);
+
+    xml::update_tag(dataNode, "musicvolume", music.user_music_volume);
+
+    xml::update_tag(dataNode, "soundvolume", music.user_sound_volume);
 
     // Delete all controller buttons we had previously.
     // dataNode->FirstChildElement() shouldn't be NULL at this point...

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -44,6 +44,7 @@ namespace Menu
         gameplayoptions,
         speedrunneroptions,
         advancedoptions,
+        audiooptions,
         accessibility,
         controller,
         cleardatamenu,

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -84,6 +84,13 @@ namespace Menu
     };
 }
 
+enum SLIDERMODE
+{
+    SLIDER_NONE,
+    SLIDER_MUSICVOLUME,
+    SLIDER_SOUNDVOLUME
+};
+
 struct MenuStackFrame
 {
     int option;
@@ -259,6 +266,7 @@ public:
     int currentmenuoption ;
     enum Menu::MenuName currentmenuname;
     enum Menu::MenuName kludge_ingametemp;
+    enum SLIDERMODE slidermode;
     int current_credits_list_index;
     int menuxoff, menuyoff;
     int menuspacing;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1475,7 +1475,7 @@ void Graphics::drawmenu( int cr, int cg, int cb, bool levelmenu /*= false*/ )
         SDL_strlcpy(tempstring, opt.text, sizeof(tempstring));
 
         char buffer[MENU_TEXT_BYTES];
-        if ((int) i == game.currentmenuoption)
+        if ((int) i == game.currentmenuoption && game.slidermode == SLIDER_NONE)
         {
             if (opt.active)
             {

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -750,34 +750,25 @@ static void menuactionpress(void)
             map.nexttowercolour();
             break;
         case 2:
+            /* Audio options */
+            music.playef(11);
+            game.createmenu(Menu::audiooptions);
+            map.nexttowercolour();
+            break;
+        case 3:
             //gamepad options
             music.playef(11);
             game.createmenu(Menu::controller);
             map.nexttowercolour();
             break;
-        case 3:
+        case 4:
             //accessibility options
             music.playef(11);
             game.createmenu(Menu::accessibility);
             map.nexttowercolour();
             break;
-        }
-
-        if (game.currentmenuoption == 4 && music.mmmmmm)
-        {
-            //**** TOGGLE MMMMMM
-            music.usingmmmmmm = !music.usingmmmmmm;
-            music.playef(11);
-            if (music.currentsong > -1)
-            {
-                music.play(music.currentsong);
-            }
-            game.savestatsandsettings_menu();
-        }
-
-        if (game.currentmenuoption == 4 + (music.mmmmmm?1:0))
-        {
-            //Last option here is "return"
+        default:
+            /* Return */
             music.playef(11);
             if (game.ingame_titlemode)
             {
@@ -788,8 +779,41 @@ static void menuactionpress(void)
                 game.returnmenu();
                 map.nexttowercolour();
             }
+            break;
+        }
+        break;
+    case Menu::audiooptions:
+        switch (game.currentmenuoption)
+        {
+        case 0:
+            /* Not implemented */
+            break;
+        case 1:
+            /* Not implemented */
+            break;
+        case 2:
+            if (!music.mmmmmm)
+            {
+                break;
+            }
+
+            /* Toggle MMMMMM */
+            music.usingmmmmmm = !music.usingmmmmmm;
+            music.playef(11);
+            if (music.currentsong > -1)
+            {
+                music.play(music.currentsong);
+            }
+            game.savestatsandsettings_menu();
+            break;
         }
 
+        if (game.currentmenuoption == 2 + (int) music.mmmmmm)
+        {
+            /* Return */
+            game.returnmenu();
+            map.nexttowercolour();
+        }
         break;
     case Menu::unlockmenutrials:
         switch (game.currentmenuoption)

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -17,6 +17,9 @@ musicclass::musicclass(void)
 	musicVolume = 0;
 	FadeVolAmountPerFrame = 0;
 
+	user_music_volume = USER_VOLUME_MAX;
+	user_sound_volume = USER_VOLUME_MAX;
+
 	currentsong = 0;
 	nicechange = -1;
 	nicefade = false;

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -8,6 +8,9 @@
 
 #define musicroom(rx, ry) ((rx) + ((ry) * 20))
 
+/* The amount of "space" for the scale of the user-set volume. */
+#define USER_VOLUME_MAX 256
+
 class musicclass
 {
 public:
@@ -51,6 +54,10 @@ public:
 	bool m_doFadeOutVol;
 	int FadeVolAmountPerFrame;
 	int musicVolume;
+
+	/* 0..USER_VOLUME_MAX */
+	int user_music_volume;
+	int user_sound_volume;
 
 	bool quick_fade;
 

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -11,6 +11,9 @@
 /* The amount of "space" for the scale of the user-set volume. */
 #define USER_VOLUME_MAX 256
 
+/* It is advised that USER_VOLUME_MAX be divisible by this. */
+#define USER_VOLUME_STEP 32
+
 class musicclass
 {
 public:

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -46,6 +46,62 @@ static inline void drawslowdowntext(void)
     }
 }
 
+static void volumesliderrender(void)
+{
+    char buffer[40 + 1];
+
+    char slider[20 + 1];
+    int slider_length;
+
+    const char symbol[] = "[]";
+    int symbol_length;
+
+    int offset;
+    int num_positions;
+
+    const int* volume_ptr;
+
+    switch (game.currentmenuoption)
+    {
+    case 0:
+        volume_ptr = &music.user_music_volume;
+        break;
+    case 1:
+        volume_ptr = &music.user_sound_volume;
+        break;
+    default:
+        SDL_assert(0 && "Unhandled volume slider menu option!");
+        return;
+    }
+
+    VVV_fillstring(slider, sizeof(slider), '.');
+    slider_length = sizeof(slider) - 1;
+
+    symbol_length = sizeof(symbol) - 1;
+
+    num_positions = slider_length - symbol_length + 1;
+
+    offset = num_positions * (*volume_ptr) / USER_VOLUME_MAX;
+    offset = clamp(offset, 0, slider_length - symbol_length);
+
+    /* SDL_strlcpy null-terminates, which would end the string in the middle of
+     * it, which we don't want!
+     */
+    SDL_memcpy(&slider[offset], symbol, symbol_length);
+
+    if (game.slidermode == SLIDER_NONE)
+    {
+        SDL_strlcpy(buffer, slider, sizeof(buffer));
+    }
+    else
+    {
+        /* Draw selection brackets. */
+        SDL_snprintf(buffer, sizeof(buffer), "[ %s ]", slider);
+    }
+
+    graphics.Print(-1, 85, buffer, tr, tg, tb, true);
+}
+
 static void menurender(void)
 {
     int temp = 50;
@@ -281,10 +337,14 @@ static void menurender(void)
         switch (game.currentmenuoption)
         {
         case 0:
-            /* Not implemented */
+            graphics.bigprint(-1, 30, "Music Volume", tr, tg, tb, true);
+            graphics.Print(-1, 65, "Change the volume of the music.", tr, tg, tb, true);
+            volumesliderrender();
             break;
         case 1:
-            /* Not implemented */
+            graphics.bigprint(-1, 30, "Sound Volume", tr, tg, tb, true);
+            graphics.Print(-1, 65, "Change the volume of sound effects.", tr, tg, tb, true);
+            volumesliderrender();
             break;
         case 2:
             if (!music.mmmmmm)

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -175,27 +175,23 @@ static void menurender(void)
             graphics.Print(-1, 65, "Adjust screen settings", tr, tg, tb, true);
             break;
         case 2:
+            graphics.bigprint(-1, 30, "Audio Options", tr, tg, tb, true);
+            graphics.Print(-1, 65, "Adjust volume settings", tr, tg, tb, true);
+            if (music.mmmmmm)
+            {
+                graphics.Print(-1, 75, "and soundtrack", tr, tg, tb, true);
+            }
+            break;
+        case 3:
             graphics.bigprint(-1, 30, "Game Pad Options", tr, tg, tb, true);
             graphics.Print(-1, 65, "Rebind your controller's buttons", tr, tg, tb, true);
             graphics.Print(-1, 75, "and adjust sensitivity", tr, tg, tb, true);
             break;
-        case 3:
+        case 4:
             graphics.bigprint(-1, 30, "Accessibility", tr, tg, tb, true);
             graphics.Print(-1, 65, "Disable screen effects, enable", tr, tg, tb, true);
             graphics.Print(-1, 75, "slowdown modes or invincibility", tr, tg, tb, true);
             break;
-        }
-
-        if (game.currentmenuoption == 4 && music.mmmmmm)
-        {
-            graphics.bigprint(-1, 30, "Soundtrack", tr, tg, tb, true);
-            graphics.Print(-1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);
-            if (music.usingmmmmmm) {
-                graphics.Print(-1, 85, "Current soundtrack: MMMMMM", tr, tg, tb, true);
-            }
-            else {
-                graphics.Print(-1, 85, "Current soundtrack: PPPPPP", tr, tg, tb, true);
-            }
         }
         break;
     case Menu::graphicoptions:
@@ -279,6 +275,44 @@ static void menurender(void)
                 graphics.Print(-1, 95, "Current mode: VSYNC ON", tr, tg, tb, true);
             }
             break;
+        }
+        break;
+    case Menu::audiooptions:
+        switch (game.currentmenuoption)
+        {
+        case 0:
+            /* Not implemented */
+            break;
+        case 1:
+            /* Not implemented */
+            break;
+        case 2:
+            if (!music.mmmmmm)
+            {
+                break;
+            }
+        {
+            /* Screen width 40 chars, 4 per char */
+            char buffer[160 + 1];
+            char soundtrack[6 + 1];
+            char letter;
+            if (music.usingmmmmmm)
+            {
+                letter = 'M';
+            }
+            else
+            {
+                letter = 'P';
+            }
+            VVV_fillstring(soundtrack, sizeof(soundtrack), letter);
+            SDL_snprintf(buffer, sizeof(buffer), "Current soundtrack: %s", soundtrack);
+
+            graphics.bigprint(-1, 30, "Soundtrack", tr, tg, tb, true);
+            graphics.Print(-1, 65, "Toggle between MMMMMM and PPPPPP", tr, tg, tb, true);
+            graphics.Print(-1, 85, buffer, tr, tg, tb, true);
+            break;
+        }
+
         }
         break;
     case Menu::credits:

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -335,3 +335,12 @@ bool endsWith(const char* str, const char* suffix)
 
 	return SDL_strcmp(&str[str_size - suffix_size], suffix) == 0;
 }
+
+void VVV_fillstring(
+	char* buffer,
+	const size_t buffer_size,
+	const char fillchar
+) {
+	SDL_memset(buffer, fillchar, buffer_size - 1);
+	buffer[buffer_size - 1] = '\0';
+}

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -28,6 +28,12 @@ bool is_positive_num(const char* str, const bool hex);
 
 bool endsWith(const char* str, const char* suffix);
 
+void VVV_fillstring(
+    char* buffer,
+    const size_t buffer_size,
+    const char fillchar
+);
+
 #define INBOUNDS_VEC(index, vector) ((int) index >= 0 && (int) index < (int) vector.size())
 #define INBOUNDS_ARR(index, array) ((int) index >= 0 && (int) index < (int) SDL_arraysize(array))
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -771,7 +771,7 @@ static enum LoopCode loop_end(void)
     }
     else
     {
-        Mix_Volume(-1,MIX_MAX_VOLUME);
+        Mix_Volume(-1,MIX_MAX_VOLUME * music.user_sound_volume / USER_VOLUME_MAX);
 
         if (game.musicmuted)
         {
@@ -779,7 +779,7 @@ static enum LoopCode loop_end(void)
         }
         else
         {
-            Mix_VolumeMusic(music.musicVolume);
+            Mix_VolumeMusic(music.musicVolume * music.user_music_volume / USER_VOLUME_MAX);
         }
     }
 


### PR DESCRIPTION
There is now a new audio category in options, which includes the new volume sliders for the music and sound effects, along with the MMMMMM/PPPPPP soundtrack switching option.

![Music volume unselected](https://user-images.githubusercontent.com/59748578/114327663-d1f01c00-9aee-11eb-82d1-1561033f84e0.png)

The audio sliders are quite simple: Once you navigate one of them, pressing ACTION on it will transfer your control to the slider itself - this is indicated by your selection brackets switching to surround the slider instead of the menu option.

![Music volume selected](https://user-images.githubusercontent.com/59748578/114327680-ea603680-9aee-11eb-917c-61e1779fba18.png)

Once you have a slider selected, you press left or right to change the volume. After that, you can either press ACTION to confirm that this is the volume you want, or press Esc to cancel the volume change and go back to the previous volume. Either way, your settings will be written to disk when you do so.

Closes #706.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
