### PR TITLE
Fix a bunch of music regressions and inconsistencies

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -341,13 +341,6 @@ void musicclass::processmusic(void)
 		return;
 	}
 
-	if (nicefade && Mix_PausedMusic() == 1)
-	{
-		play(nicechange);
-		nicechange = -1;
-		nicefade = false;
-	}
-
 	if(m_doFadeInVol)
 	{
 		processmusicfadein();
@@ -356,6 +349,14 @@ void musicclass::processmusic(void)
 	if (m_doFadeOutVol)
 	{
 		processmusicfadeout();
+	}
+
+	/* This needs to come after processing fades */
+	if (nicefade && Mix_PausedMusic() == 1)
+	{
+		play(nicechange);
+		nicechange = -1;
+		nicefade = false;
 	}
 }
 

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -238,7 +238,6 @@ void musicclass::play(int t)
 		else
 		{
 			fadeMusicVolumeIn(3000);
-			musicVolume = 0;
 		}
 	}
 }
@@ -290,6 +289,10 @@ void musicclass::fadeMusicVolumeIn(int ms)
 {
 	m_doFadeInVol = true;
 	m_doFadeOutVol = false;
+
+	/* Ensure it starts at 0 */
+	musicVolume = 0;
+
 	setfadeamount(ms);
 }
 

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -268,6 +268,7 @@ void musicclass::haltdasmusik(void)
 {
 	/* Just pauses music. This is intended. */
 	pause();
+	currentsong = -1;
 }
 
 void musicclass::silencedasmusik(void)

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -293,6 +293,9 @@ void musicclass::fadeMusicVolumeIn(int ms)
 	/* Ensure it starts at 0 */
 	musicVolume = 0;
 
+	/* Fix 1-frame glitch */
+	Mix_VolumeMusic(0);
+
 	setfadeamount(ms);
 }
 

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -268,6 +268,8 @@ void musicclass::haltdasmusik(void)
 	/* Just pauses music. This is intended. */
 	pause();
 	currentsong = -1;
+	m_doFadeInVol = false;
+	m_doFadeOutVol = false;
 }
 
 void musicclass::silencedasmusik(void)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1947,7 +1947,7 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "foundtrinket")
 			{
-				music.haltdasmusik();
+				music.silencedasmusik();
 				music.playef(3);
 
 				size_t trinket = ss_toi(words[1]);

--- a/desktop_version/src/Scripts.cpp
+++ b/desktop_version/src/Scripts.cpp
@@ -5469,8 +5469,7 @@ void scriptclass::load(const std::string& name)
         //found a trinket!
         "foundtrinket(18)",
         "endtext",
-        //"musicfadein",
-        "trinketscriptmusic",
+        "musicfadein",
 
         "delay(30)",
         "createentity(136,80,22,18,0)",
@@ -5577,8 +5576,7 @@ void scriptclass::load(const std::string& name)
         //found a trinket!
         "foundtrinket(18)",
         "endtext",
-        //"musicfadein",
-        "trinketscriptmusic",
+        "musicfadein",
 
         "delay(30)",
         "createentity(136,80,22,18,0)",
@@ -5766,8 +5764,7 @@ void scriptclass::load(const std::string& name)
         //found a trinket!
         "foundtrinket(18)",
         "endtext",
-        //"musicfadein",
-        "trinketscriptmusic",
+        "musicfadein",
 
         "delay(30)",
 


### PR DESCRIPTION
As usual, I aimed to fix one bug, and then one thing led to another, and then ~~I'm now gay~~ I ended up fixing all the music regressions on the tracker. Oh and other things that weren't even reported yet.

Anyways: This fixes the music stopping after collecting the trinket that Victoria or Vitellary gives you, fixes the inconsistencies between the trinket cutscenes and trinkets found in the wild (trinket cutscenes now silence music instead of halting, and fade the music back in instead of restarting it), fixes some fade-ins not starting from zero (which I ran into when fixing the trinket cutscenes thing), fixes the 2.2-and-below music blocking workaround not working in 2.3, and fixes the level music not playing when starting playtesting in the editor.

Fixes #701, fixes #710, and fixes #712.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
