### PR TITLE
Fix one-way recolors and music files not accounting for virtual mount path

### DIFF
--- a/desktop_version/src/BinaryBlob.h
+++ b/desktop_version/src/BinaryBlob.h
@@ -57,7 +57,6 @@ public:
 
 	static const int max_headers = 128;
 
-private:
 	int numberofHeaders;
 	resourceheader m_headers[max_headers];
 	char* m_memblocks[max_headers];

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -540,13 +540,16 @@ bool FILESYSTEM_loadBinaryBlob(binaryBlob* blob, const char* filename)
 	PHYSFS_File* handle;
 	int offset;
 	size_t i;
+	char path[MAX_PATH];
 
 	if (blob == NULL || filename == NULL)
 	{
 		return false;
 	}
 
-	handle = PHYSFS_openRead(filename);
+	getMountedPath(path, sizeof(path), filename);
+
+	handle = PHYSFS_openRead(path);
 	if (handle == NULL)
 	{
 		printf("Unable to open file %s\n", filename);

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -418,6 +418,7 @@ static void getMountedPath(
 bool FILESYSTEM_isAssetMounted(const char* filename)
 {
 	const char* realDir;
+	char path[MAX_PATH];
 
 	/* Fast path */
 	if (assetDir[0] == '\0')
@@ -425,7 +426,9 @@ bool FILESYSTEM_isAssetMounted(const char* filename)
 		return false;
 	}
 
-	realDir = PHYSFS_getRealDir(filename);
+	getMountedPath(path, sizeof(path), filename);
+
+	realDir = PHYSFS_getRealDir(path);
 
 	if (realDir == NULL)
 	{

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -383,6 +383,38 @@ void FILESYSTEM_unmountAssets(void)
 	}
 }
 
+static void getMountedPath(
+	char* buffer,
+	const size_t buffer_size,
+	const char* filename
+) {
+	const char* path;
+	const bool assets_mounted = assetDir[0] != '\0';
+	char mounted_path[MAX_PATH];
+
+	if (assets_mounted)
+	{
+		SDL_snprintf(
+			mounted_path,
+			sizeof(mounted_path),
+			"%s%s",
+			virtualMountPath,
+			filename
+		);
+	}
+
+	if (assets_mounted && PHYSFS_exists(mounted_path))
+	{
+		path = mounted_path;
+	}
+	else
+	{
+		path = filename;
+	}
+
+	SDL_strlcpy(buffer, path, buffer_size);
+}
+
 bool FILESYSTEM_isAssetMounted(const char* filename)
 {
 	const char* realDir;
@@ -485,29 +517,9 @@ void FILESYSTEM_loadAssetToMemory(
 	size_t* len,
 	const bool addnull
 ) {
-	const char* path;
-	const bool assets_mounted = assetDir[0] != '\0';
-	char mounted_path[MAX_PATH];
+	char path[MAX_PATH];
 
-	if (assets_mounted)
-	{
-		SDL_snprintf(
-			mounted_path,
-			sizeof(mounted_path),
-			"%s%s",
-			virtualMountPath,
-			name
-		);
-	}
-
-	if (assets_mounted && PHYSFS_exists(mounted_path))
-	{
-		path = mounted_path;
-	}
-	else
-	{
-		path = name;
-	}
+	getMountedPath(path, sizeof(path), name);
 
 	FILESYSTEM_loadFileToMemory(path, mem, len, addnull);
 }

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -1,6 +1,9 @@
 #ifndef FILESYSTEMUTILS_H
 #define FILESYSTEMUTILS_H
 
+/* Forward declaration */
+class binaryBlob;
+
 #include <stddef.h>
 
 // Forward declaration, including the entirety of tinyxml2.h across all files this file is included in is unnecessary
@@ -29,6 +32,9 @@ void FILESYSTEM_loadAssetToMemory(
     const bool addnull
 );
 void FILESYSTEM_freeMemory(unsigned char **mem);
+
+bool FILESYSTEM_loadBinaryBlob(binaryBlob* blob, const char* filename);
+
 bool FILESYSTEM_saveTiXml2Document(const char *name, tinyxml2::XMLDocument& doc);
 bool FILESYSTEM_loadTiXml2Document(const char *name, tinyxml2::XMLDocument& doc);
 


### PR DESCRIPTION
There were two other types of asset paths that I forgot to account for when implementing the virtual mount path system. So one-way recolors would always recolor because it didn't use the virtual mount path, and music files were unable to be mounted because they wouldn't use the virtual mount path. But both of those bugs are fixed now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
