### PR TITLE
Remove time trial replay menu stack popping

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1580,15 +1580,6 @@ static void menuactionpress(void)
             map.nexttowercolour();
             break;
         case 1:
-            //Ok but first quickly remove the last stack frame to prevent piling up timetrialcomplete stack frames
-            if (game.menustack.empty())
-            {
-                puts("Error: menu stack is empty!");
-            }
-            else
-            {
-                game.menustack.pop_back();
-            }
             //duplicate the above based on given time trial level!
             if (game.timetriallevel == 0)   //space station 1
             {


### PR DESCRIPTION
It turns out this entire chunk of code is simply unneeded (and is actively harmful) since when we're done with the time trial, `quittomenu()` gets called, and that removes the previous stack frame anyway.

I'm guessing that I added this code, then added `quittomenu()`, then didn't consider how this code and `quittomenu()` would mix. But anyways, this bug is fixed.

Fixes #714.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
