### PR TITLE
Fix some unfocus pause and timer bugs

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4911,7 +4911,6 @@ void Game::readmaingamesave(tinyxml2::XMLDocument& doc)
         else if (SDL_strcmp(pKey, "frames") == 0)
         {
             frames = help.Int(pText);
-            frames = 0;
         }
         else if (SDL_strcmp(pKey, "seconds") == 0)
         {
@@ -5106,7 +5105,6 @@ void Game::customloadquick(std::string savfile)
         else if (SDL_strcmp(pKey, "frames") == 0)
         {
             frames = help.Int(pText);
-            frames = 0;
         }
         else if (SDL_strcmp(pKey, "seconds") == 0)
         {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -214,10 +214,7 @@ void Game::init(void)
 
     deathcounts = 0;
     gameoverdelay = 0;
-    frames = 0;
-    seconds = 0;
-    minutes = 0;
-    hours = 0;
+    resetgameclock();
     gamesaved = false;
     gamesavefailed = false;
     savetime = "00:00";

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5683,6 +5683,11 @@ std::string Game::unrescued(void)
 
 void Game::gameclock(void)
 {
+    if (timetrialcountdown > 0)
+    {
+        return;
+    }
+
     frames++;
     if (frames >= 30)
     {

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -731,7 +731,6 @@ void gamelogic(void)
 
             if (game.timetrialcountdown > 0)
             {
-                game.timetrialparlost = false;
                 game.hascontrol = true;
                 game.timetrialcountdown--;
                 if (game.timetrialcountdown > 30)

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1769,7 +1769,6 @@ void gamerender(void)
         {
             if (game.timetrialcountdown < 30)
             {
-                game.resetgameclock();
                 if (int(game.timetrialcountdown / 4) % 2 == 0) graphics.bigprint( -1, 100, "Go!", 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true, 4);
             }
             else if (game.timetrialcountdown < 60)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1542,10 +1542,7 @@ void scriptclass::run(void)
 				game.deathcounts = 0;
 				game.advancetext = false;
 				game.hascontrol = true;
-				game.frames = 0;
-				game.seconds = 0;
-				game.minutes = 0;
-				game.hours = 0;
+				game.resetgameclock();
 				game.gravitycontrol = 0;
 				game.teleport = false;
 				game.companion = 0;
@@ -3543,10 +3540,7 @@ void scriptclass::hardreset(void)
 
 	game.deathcounts = 0;
 	game.gameoverdelay = 0;
-	game.frames = 0;
-	game.seconds = 0;
-	game.minutes = 0;
-	game.hours = 0;
+	game.resetgameclock();
 	game.gamesaved = false;
 	game.gamesavefailed = false;
 	game.savetime = "00:00";

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -728,7 +728,9 @@ static void focused_begin(void)
 
 static void focused_end(void)
 {
-    /* no-op. */
+    game.gameclock();
+    music.processmusic();
+    graphics.processfade();
 }
 
 static enum LoopCode loop_end(void)
@@ -788,10 +790,6 @@ static enum LoopCode loop_end(void)
         key.resetWindow = false;
         gameScreen.ResizeScreen(-1, -1);
     }
-
-    music.processmusic();
-    graphics.processfade();
-    game.gameclock();
 
     return Loop_continue;
 }


### PR DESCRIPTION
I fixed #699, fixed music fades, fade bars, and the game clock ticking during unfocus pause, fixed another instance of logic code being entangled with rendering code, and fixed the frames portion of level saves always being discarded when loaded (I don't know why that ever happened, but whatever).

Fixes #699.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
