### PR TITLE
Fix vertical entity wrapping render inconsistencies

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1801,12 +1801,12 @@ void Graphics::drawentity(const int i, const int yoff)
         if (tpoint.y < 0)
         {
             wrapY = true;
-            wrappedPoint.y += 230;
+            wrappedPoint.y += 232;
         }
         else if (tpoint.y > 210)
         {
             wrapY = true;
-            wrappedPoint.y -= 230;
+            wrappedPoint.y -= 232;
         }
 
         const bool isInWrappingAreaOfTower = map.towermode && !map.minitowermode && map.ypos >= 500 && map.ypos <= 5000;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1798,7 +1798,7 @@ void Graphics::drawentity(const int i, const int yoff)
         }
 
         wrappedPoint.y = tpoint.y;
-        if (tpoint.y < 0)
+        if (tpoint.y < 8)
         {
             wrapY = true;
             wrappedPoint.y += 232;


### PR DESCRIPTION
When an entity warps vertically, it teleports 232 pixels up or down - however, the rendering code uses an offset of 230 pixels, which is off by 2 pixels, and draws the wrapped entity at the wrong position. In the same vein, entities that just teleported through the bottom 8 pixels of the screen to the top weren't being drawn at the bottom of the screen (possibly because the code was originally written for rooms with room names), so I've increased the threshold for drawing entities near the top of the screen at the bottom of the screen.

Wrong render offset - before:
![Render offset before](https://user-images.githubusercontent.com/59748578/114644892-3f39b380-9c8d-11eb-8650-7ee736b2a9fe.png)

Correct render offset - after:
![Render offset after](https://user-images.githubusercontent.com/59748578/114644900-419c0d80-9c8d-11eb-97c1-d358b3c751b8.png)

Entity not drawn on bottom 8 pixels - before:
![Entity continuation before](https://user-images.githubusercontent.com/59748578/114644905-43fe6780-9c8d-11eb-8ed6-5dc5af4727b4.png)

Entity drawn on bottom 8 pixels - after:
![Entity continuation after](https://user-images.githubusercontent.com/59748578/114644910-4660c180-9c8d-11eb-9f15-077f415707cd.png)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
