### PR TITLE
Reset cliplaytest when exiting to menu and check it when loading

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6601,6 +6601,7 @@ void Game::quittomenu(void)
     gamestate = TITLEMODE;
     graphics.fademode = 4;
     FILESYSTEM_unmountAssets();
+    cliplaytest = false;
     graphics.titlebg.tdrawback = true;
     graphics.flipmode = false;
     //Don't be stuck on the summary screen,

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1751,7 +1751,7 @@ bool editorclass::load(std::string& _path)
     }
 
     FILESYSTEM_unmountAssets();
-    if (game.playassets != "")
+    if (game.cliplaytest && game.playassets != "")
     {
         FILESYSTEM_mountAssets(game.playassets.c_str());
     }


### PR DESCRIPTION
This fixes a bug where quitting to the menu from command-line playtesting with `-playassets` specified would always use those assets when loading back in to any custom level. This also fixes loading in to a custom level quicksave always using the command-line playtesting arguments instead of using the actual quicksave.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
