### PR TITLE
Add bounds check to use of edteleportent

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1188,7 +1188,7 @@ void gamelogic(void)
 
         //Warp tokens
         if (map.custommode){
-            if (game.teleport)
+            if (game.teleport && INBOUNDS_VEC(game.edteleportent, obj.entities))
             {
                 int edi=obj.entities[game.edteleportent].behave;
                 int edj=obj.entities[game.edteleportent].para;


### PR DESCRIPTION
`edteleportent` is a global variable that gets assigned whenever the player collides with a warp token, and gets read from later down the line in `gamelogic()`. While I don't know of any way to cause anything bad with this (and I did try), storing a temporary indexing variable like this is only bound to be a liability in the future - so we might as well prevent badness now by adding a bounds check here.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
