### PR TITLE
Fix music stopping when restarting a time trial

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -11,6 +11,7 @@ Contributors
 * Brian Callahan (@ibara)
 * Dav999 (Dav999-v)
 * Allison Fleischer (AllisonFleischer)
+* Malte Grimm (@trelbutate)
 * Daniel Lee (@ddm999)
 * Fredrik Ljungdahl (@FredrIQ)
 * Nichole Mattera (@NicholeMattera)

--- a/desktop_version/src/Credits.h
+++ b/desktop_version/src/Credits.h
@@ -96,6 +96,7 @@ static const char* githubfriends[] = {
     "Brian Callahan",
     "Dav999",
     "Allison Fleischer",
+    "Malte Grimm",
     "Daniel Lee",
     "Fredrik Ljungdahl",
     "MAO3J1m0Op",

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2095,7 +2095,6 @@ void gameinput(void)
         //Quick restart of time trial
         graphics.fademode = 2;
         game.completestop = true;
-        music.fadeout();
         game.quickrestartkludge = true;
     }
     else if (game.intimetrial)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2713,172 +2713,59 @@ void scriptclass::startgamemode( int t )
 		graphics.fademode = 4;
 		break;
 	case 3:
-		//Start Time Trial 1
-		hardreset();
-		game.nocutscenes = true;
-		game.intimetrial = true;
-		game.timetrialcountdown = 150;
-		game.timetrialparlost = false;
-		game.timetriallevel = 0;
-		game.timetrialpar = 75;
-		game.timetrialshinytarget = 2;
-
-		music.fadeout();
-		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel);
-		game.jumpheld = true;
-
-		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
-		if(obj.entities.empty())
-		{
-			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
-		}
-		else
-		{
-			map.resetplayer();
-		}
-		map.gotoroom(game.saverx, game.savery);
-		map.initmapdata();
-		graphics.fademode = 4;
-		break;
 	case 4:
-		//Start Time Trial 2
-		hardreset();
-		game.nocutscenes = true;
-		game.intimetrial = true;
-		game.timetrialcountdown = 150;
-		game.timetrialparlost = false;
-		game.timetriallevel = 1;
-		game.timetrialpar = 165;
-		game.timetrialshinytarget = 4;
-
-		music.fadeout();
-		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel);
-		game.jumpheld = true;
-
-		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
-		if(obj.entities.empty())
-		{
-			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
-		}
-		else
-		{
-			map.resetplayer();
-		}
-		map.gotoroom(game.saverx, game.savery);
-		map.initmapdata();
-		graphics.fademode = 4;
-		break;
 	case 5:
-		//Start Time Trial 3 tow
-		hardreset();
-		game.nocutscenes = true;
-		game.intimetrial = true;
-		game.timetrialcountdown = 150;
-		game.timetrialparlost = false;
-		game.timetriallevel = 2;
-		game.timetrialpar = 105;
-		game.timetrialshinytarget = 2;
-
-		music.fadeout();
-		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel);
-		game.jumpheld = true;
-
-		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
-		if(obj.entities.empty())
-		{
-			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
-		}
-		else
-		{
-			map.resetplayer();
-		}
-		map.gotoroom(game.saverx, game.savery);
-		map.initmapdata();
-		graphics.fademode = 4;
-		break;
 	case 6:
-		//Start Time Trial 4 station
-		hardreset();
-		game.nocutscenes = true;
-		game.intimetrial = true;
-		game.timetrialcountdown = 150;
-		game.timetrialparlost = false;
-		game.timetriallevel = 3;
-		game.timetrialpar = 200;
-		game.timetrialshinytarget = 5;
-
-		music.fadeout();
-		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel);
-		game.jumpheld = true;
-
-		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
-		if(obj.entities.empty())
-		{
-			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
-		}
-		else
-		{
-			map.resetplayer();
-		}
-		map.gotoroom(game.saverx, game.savery);
-		map.initmapdata();
-		graphics.fademode = 4;
-		break;
 	case 7:
-		//Start Time Trial 5 warp
-		hardreset();
-		game.nocutscenes = true;
-		game.intimetrial = true;
-		game.timetrialcountdown = 150;
-		game.timetrialparlost = false;
-		game.timetriallevel = 4;
-		game.timetrialpar = 120;
-		game.timetrialshinytarget = 1;
-
-		music.fadeout();
-		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel);
-		game.jumpheld = true;
-
-		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
-		if(obj.entities.empty())
-		{
-			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
-		}
-		else
-		{
-			map.resetplayer();
-		}
-		map.gotoroom(game.saverx, game.savery);
-		map.initmapdata();
-		graphics.fademode = 4;
-		break;
 	case 8:
-		//Start Time Trial 6// final level!
+		//Start Time Trial
+		if (!game.intimetrial)
+			music.fadeout();
+
 		hardreset();
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
 		game.timetrialparlost = false;
-		game.timetriallevel = 5;
-		game.timetrialpar = 135;
-		game.timetrialshinytarget = 1;
+		game.timetriallevel = t - 3;
 
-		music.fadeout();
-		map.finalmode = true; //Enable final level mode
-		map.final_colormode = false;
-		map.final_mapcol = 0;
-		map.final_colorframe = 0;
+		switch (t) {
+		case 3:
+			game.timetrialpar = 75;
+			game.timetrialshinytarget = 2;
+			break;
+		case 4:
+			game.timetrialpar = 165;
+			game.timetrialshinytarget = 4;
+			break;
+		case 5:
+			game.timetrialpar = 105;
+			game.timetrialshinytarget = 2;
+			break;
+		case 6:
+			game.timetrialpar = 200;
+			game.timetrialshinytarget = 5;
+			break;
+		case 7:
+			game.timetrialpar = 120;
+			game.timetrialshinytarget = 1;
+			break;
+		case 8:
+			game.timetrialpar = 135;
+			game.timetrialshinytarget = 1;
+			map.finalmode = true; //Enable final level mode
+			map.final_colormode = false;
+			map.final_mapcol = 0;
+			map.final_colorframe = 0;
+			break;
+		}
+
 		game.gamestate = GAMEMODE;
 		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
 		if (graphics.setflipmode) graphics.flipmode = true;//set flipmode
-		if(obj.entities.empty())
+		if (obj.entities.empty())
 		{
 			obj.createentity(game.savex, game.savey, 0, 0); //In this game, constant, never destroyed
 		}


### PR DESCRIPTION
## Changes:

This fixes the current bug where quick restarting a time trial will completely stop the music until you go back to the main menu.
I also cleaned up the code around it a bit by merging several nearly identical switch cases into one.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
