### PR TITLE
Revert part of #727, and fix EVERY case where a track could restart after fading out, and not just only one single case

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2095,6 +2095,7 @@ void gameinput(void)
         //Quick restart of time trial
         graphics.fademode = 2;
         game.completestop = true;
+        music.fadeout();
         game.quickrestartkludge = true;
     }
     else if (game.intimetrial)

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -330,7 +330,7 @@ void musicclass::processmusicfadeout(void)
 	{
 		musicVolume = 0;
 		m_doFadeOutVol = false;
-		pause();
+		haltdasmusik();
 	}
 }
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2719,8 +2719,7 @@ void scriptclass::startgamemode( int t )
 	case 7:
 	case 8:
 		//Start Time Trial
-		if (!game.intimetrial)
-			music.fadeout();
+		music.fadeout();
 
 		hardreset();
 		game.nocutscenes = true;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2729,7 +2729,8 @@ void scriptclass::startgamemode( int t )
 		game.timetrialparlost = false;
 		game.timetriallevel = t - 3;
 
-		switch (t) {
+		switch (t)
+		{
 		case 3:
 			game.timetrialpar = 75;
 			game.timetrialshinytarget = 2;


### PR DESCRIPTION
This reverts only a part of f196fcd896defc0b24690851c701b8273ba8074b - as the original commit author did not do their changes atomically, they also squashed in a de-duplication within the same commit. So I'm only reverting the part of the commit that wasn't the de-duplication, which is simply the changes to the `music.fadeout()` calls.

#727 is being (partially) reverted for several reasons:

1. It's not the correct behavior. What this does instead is persist the track through after you restart the time trial, instead of fading it out, then restarting it again. This is in contrast to behavior in 2.2, and I see no reason to not keep the same behavior.

2. It's a single-case patch. The time trials are not the only time in the game a music track could fade out and then be restarted with the same track - custom levels could do the same thing too. Instead of fixing only one case, we should strive to fix *every* case.

The original commit author (@trelbutate) also didn't write anything in the commit description of f196fcd896defc0b24690851c701b8273ba8074b. What you should write in the commit description is things like rationale, analysis, and other good information that would be useful to anyone looking at your commit to understand why you did what you did. Having no commit description leaves readers in the dark as to why you did what you did.

Thus, I don't know why @trelbutate went with this solution, or if they knew that it was only a single-case patching, or if they knew that it wasn't 2.2 behavior.

By not writing the commit description, they miss a chance for reflection; speaking from personal experience, I myself have gone back and improved my commits countless times because I wrote commit descriptions for every single one of them, and sometimes whenever I write them, I think to myself "hang on a minute, that doesn't sound quite right" and end up finding improvements.

If @trelbutate wrote a commit description, they might have realized that it wasn't 2.2 behavior, and gone back and fixed up their commit to be correct. As it stands, though, they didn't have to think about it in the first place because they never bothered to write a commit description.

So what's the correct solution? Well, the actual bug itself is the following: If a track was restarted after it faded out, then it wouldn't play. This is because `currentsong` wasn't set to -1 after fading out, and that is because the fade out calls `pause()` instead of `haltdasmusik()` when it finishes.

So swapping out that `pause()` call for a `haltdasmusik()` fixes it - and unlike f196fcd896defc0b24690851c701b8273ba8074b, this fixes the time trial music while keeping it to the same behavior as 2.2, and fixes every single possible case that this music bug could have happened, instead of just only one particular case.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
