### PR TITLE
Axe mouse cursor config option in favor of automatically toggling mouse

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4215,11 +4215,6 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* s
             graphics.translucentroomname = help.Int(pText);
         }
 
-        if (SDL_strcmp(pKey, "showmousecursor") == 0)
-        {
-            graphics.showmousecursor = help.Int(pText);
-        }
-
         if (SDL_strcmp(pKey, "musicvolume") == 0)
         {
             music.user_music_volume = help.Int(pText);
@@ -4271,15 +4266,6 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* s
             key.sensitivity = help.Int(pText);
         }
 
-    }
-
-    if (graphics.showmousecursor)
-    {
-        SDL_ShowCursor(SDL_ENABLE);
-    }
-    else
-    {
-        SDL_ShowCursor(SDL_DISABLE);
     }
 
     if (controllerButton_flip.size() < 1)
@@ -4450,8 +4436,6 @@ void Game::serializesettings(tinyxml2::XMLElement* dataNode, const ScreenSetting
     xml::update_tag(dataNode, "notextoutline", (int) graphics.notextoutline);
 
     xml::update_tag(dataNode, "translucentroomname", (int) graphics.translucentroomname);
-
-    xml::update_tag(dataNode, "showmousecursor", (int) graphics.showmousecursor);
 
     xml::update_tag(dataNode, "over30mode", (int) over30mode);
 
@@ -6062,7 +6046,6 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         maxspacing = 15;
         break;
     case Menu::advancedoptions:
-        option("toggle mouse");
         option("unfocus pause");
         option("room name background");
         option("return");

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -125,7 +125,6 @@ void Graphics::init(void)
     warprect = SDL_Rect();
 
     translucentroomname = false;
-    showmousecursor = true;
 
     alpha = 1.0f;
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -323,8 +323,6 @@ public:
 
 	bool translucentroomname;
 
-	bool showmousecursor;
-
 	std::map<int, int> font_positions;
 
 	SDL_Surface* ghostbuffer;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -601,25 +601,12 @@ static void menuactionpress(void)
         switch (game.currentmenuoption)
         {
         case 0:
-            //toggle mouse cursor
-            music.playef(11);
-            if (graphics.showmousecursor == true) {
-                SDL_ShowCursor(SDL_DISABLE);
-                graphics.showmousecursor = false;
-            }
-            else {
-                SDL_ShowCursor(SDL_ENABLE);
-                graphics.showmousecursor = true;
-            }
-            game.savestatsandsettings_menu();
-            break;
-        case 1:
             // toggle unfocus pause
             game.disablepause = !game.disablepause;
             game.savestatsandsettings_menu();
             music.playef(11);
             break;
-        case 2:
+        case 1:
             // toggle translucent roomname BG
             graphics.translucentroomname = !graphics.translucentroomname;
             game.savestatsandsettings_menu();

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -595,17 +595,6 @@ static void menurender(void)
         switch (game.currentmenuoption)
         {
         case 0:
-            graphics.bigprint(-1, 30, "Toggle Mouse Cursor", tr, tg, tb, true);
-            graphics.Print(-1, 65, "Show/hide the system mouse cursor.", tr, tg, tb, true);
-
-            if (graphics.showmousecursor) {
-                graphics.Print(-1, 95, "Current mode: SHOW", tr, tg, tb, true);
-            }
-            else {
-                graphics.Print(-1, 95, "Current mode: HIDE", tr/2, tg/2, tb/2, true);
-            }
-            break;
-        case 1:
             graphics.bigprint( -1, 30, "Unfocus Pause", tr, tg, tb, true);
             graphics.Print( -1, 65, "Toggle if the game will pause", tr, tg, tb, true);
             graphics.Print( -1, 75, "when the window is unfocused.", tr, tg, tb, true);
@@ -618,7 +607,7 @@ static void menurender(void)
                 graphics.Print(-1, 95, "Unfocus pause is ON", tr, tg, tb, true);
             }
             break;
-        case 2:
+        case 1:
             graphics.bigprint(-1, 30, "Room Name BG", tr, tg, tb, true);
             graphics.Print( -1, 65, "Lets you see through what is behind", tr, tg, tb, true);
             graphics.Print( -1, 75, "the name at the bottom of the screen.", tr, tg, tb, true);


### PR DESCRIPTION
Instead of having a one-size-fits-all config option, just make it so we hide the mouse when the user uses their keyboard or controller, and show it again when they move their mouse.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
