### PR TITLE
Move temporary variables in mapclass::gotoroom() off of their classes

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1148,7 +1148,7 @@ void entityclass::removetrigger( int t )
     }
 }
 
-void entityclass::copylinecross( int t )
+void entityclass::copylinecross(std::vector<entclass>& linecrosskludge, int t)
 {
     if (!INBOUNDS_VEC(t, entities))
     {
@@ -1159,7 +1159,7 @@ void entityclass::copylinecross( int t )
     linecrosskludge.push_back(entities[t]);
 }
 
-void entityclass::revertlinecross( int t, int s )
+void entityclass::revertlinecross(std::vector<entclass>& linecrosskludge, int t, int s)
 {
     if (!INBOUNDS_VEC(t, entities) || !INBOUNDS_VEC(s, linecrosskludge))
     {

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -66,9 +66,9 @@ public:
 
     void removetrigger(int t);
 
-    void copylinecross(int t);
+    void copylinecross(std::vector<entclass>& linecrosskludge, int t);
 
-    void revertlinecross(int t, int s);
+    void revertlinecross(std::vector<entclass>& linecrosskludge, int t, int s);
 
     bool gridmatch(int p1, int p2, int p3, int p4, int p11, int p21, int p31, int p41);
 
@@ -164,8 +164,6 @@ public:
 
 
     std::vector<entclass> entities;
-
-    std::vector<entclass> linecrosskludge;
 
     int k;
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -124,7 +124,6 @@ void Game::init(void)
     teleport = false;
     edteleportent = 0; //Added in the port!
     companion = 0;
-    roomchange = false;
 
 
     quickrestartkludge = false;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -215,7 +215,7 @@ public:
     int door_right;
     int door_up;
     int door_down;
-    int roomx, roomy, roomchangedir;
+    int roomx, roomy;
     int prevroomx, prevroomy;
 
     int savex, savey, saverx, savery;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -384,7 +384,6 @@ public:
     float inertia;
 
     int companion;
-    bool roomchange;
     SDL_Rect teleblock;
     bool activetele;
     int readytotele;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -120,9 +120,19 @@ void gamecompletelogic2(void)
     }
 }
 
+static void gotoroom_wrapper(const int rx, const int ry)
+{
+    map.gotoroom(rx, ry);
+}
 
 void gamelogic(void)
 {
+    bool roomchange = false;
+#define GOTOROOM(rx, ry) \
+    gotoroom_wrapper(rx, ry); \
+    roomchange = true
+#define gotoroom Do not use map.gotoroom directly.
+
     /* Update old lerp positions of entities */
     {size_t i; for (i = 0; i < obj.entities.size(); ++i)
     {
@@ -1129,13 +1139,13 @@ void gamelogic(void)
             if (INBOUNDS_VEC(player, obj.entities) && game.door_down > -2 && obj.entities[player].yp >= 238)
             {
                 obj.entities[player].yp -= 240;
-                map.gotoroom(game.roomx, game.roomy + 1);
+                GOTOROOM(game.roomx, game.roomy + 1);
                 screen_transition = true;
             }
             if (INBOUNDS_VEC(player, obj.entities) && game.door_up > -2 && obj.entities[player].yp < -2)
             {
                 obj.entities[player].yp += 240;
-                map.gotoroom(game.roomx, game.roomy - 1);
+                GOTOROOM(game.roomx, game.roomy - 1);
                 screen_transition = true;
             }
         }
@@ -1147,13 +1157,13 @@ void gamelogic(void)
             if (INBOUNDS_VEC(player, obj.entities) && game.door_left > -2 && obj.entities[player].xp < -14)
             {
                 obj.entities[player].xp += 320;
-                map.gotoroom(game.roomx - 1, game.roomy);
+                GOTOROOM(game.roomx - 1, game.roomy);
                 screen_transition = true;
             }
             if (INBOUNDS_VEC(player, obj.entities) && game.door_right > -2 && obj.entities[player].xp >= 308)
             {
                 obj.entities[player].xp -= 320;
-                map.gotoroom(game.roomx + 1, game.roomy);
+                GOTOROOM(game.roomx + 1, game.roomy);
                 screen_transition = true;
             }
         }
@@ -1168,13 +1178,13 @@ void gamelogic(void)
                 if (INBOUNDS_VEC(player, obj.entities) && game.door_left > -2 && obj.entities[player].xp < -14)
                 {
                     obj.entities[player].xp += 320;
-                    map.gotoroom(48, 52);
+                    GOTOROOM(48, 52);
                 }
                 if (INBOUNDS_VEC(player, obj.entities) && game.door_right > -2 && obj.entities[player].xp >= 308)
                 {
                     obj.entities[player].xp -= 320;
                     obj.entities[player].yp -= (71*8);
-                    map.gotoroom(game.roomx + 1, game.roomy+1);
+                    GOTOROOM(game.roomx + 1, game.roomy+1);
                 }
             }
             else
@@ -1187,18 +1197,18 @@ void gamelogic(void)
                     {
                         obj.entities[player].xp += 320;
                         obj.entities[player].yp -= (71 * 8);
-                        map.gotoroom(50, 54);
+                        GOTOROOM(50, 54);
                     }
                     else
                     {
                         obj.entities[player].xp += 320;
-                        map.gotoroom(50, 53);
+                        GOTOROOM(50, 53);
                     }
                 }
                 if (INBOUNDS_VEC(player, obj.entities) && game.door_right > -2 && obj.entities[player].xp >= 308)
                 {
                     obj.entities[player].xp -= 320;
-                    map.gotoroom(52, 53);
+                    GOTOROOM(52, 53);
                 }
             }
         }
@@ -1229,12 +1239,12 @@ void gamelogic(void)
                 {
                     obj.entities[player].xp += 320;
                     obj.entities[player].yp -= (671 * 8);
-                    map.gotoroom(108, 109);
+                    GOTOROOM(108, 109);
                 }
                 if (INBOUNDS_VEC(player, obj.entities) && game.door_right > -2 && obj.entities[player].xp >= 308)
                 {
                     obj.entities[player].xp -= 320;
-                    map.gotoroom(110, 104);
+                    GOTOROOM(110, 104);
                 }
             }
         }
@@ -1268,7 +1278,7 @@ void gamelogic(void)
                     {
                         obj.entities[i].yp = 225;
                     }
-                    map.gotoroom(119, 100);
+                    GOTOROOM(119, 100);
                     game.teleport = false;
                 }
                 else if (game.roomx == 119 && game.roomy == 100)
@@ -1278,7 +1288,7 @@ void gamelogic(void)
                     {
                         obj.entities[i].yp = 225;
                     }
-                    map.gotoroom(119, 103);
+                    GOTOROOM(119, 103);
                     game.teleport = false;
                 }
                 else if (game.roomx == 119 && game.roomy == 103)
@@ -1288,7 +1298,7 @@ void gamelogic(void)
                     {
                         obj.entities[i].xp = 0;
                     }
-                    map.gotoroom(116, 103);
+                    GOTOROOM(116, 103);
                     game.teleport = false;
                 }
                 else if (game.roomx == 116 && game.roomy == 103)
@@ -1298,7 +1308,7 @@ void gamelogic(void)
                     {
                         obj.entities[i].yp = 225;
                     }
-                    map.gotoroom(116, 100);
+                    GOTOROOM(116, 100);
                     game.teleport = false;
                 }
                 else if (game.roomx == 116 && game.roomy == 100)
@@ -1308,7 +1318,7 @@ void gamelogic(void)
                     {
                         obj.entities[i].xp = 0;
                     }
-                    map.gotoroom(114, 102);
+                    GOTOROOM(114, 102);
                     game.teleport = false;
                 }
                 else if (game.roomx == 114 && game.roomy == 102)
@@ -1318,7 +1328,7 @@ void gamelogic(void)
                     {
                         obj.entities[i].yp = 225;
                     }
-                    map.gotoroom(113, 100);
+                    GOTOROOM(113, 100);
                     game.teleport = false;
                 }
                 else if (game.roomx == 116 && game.roomy == 104)
@@ -1401,10 +1411,9 @@ void gamelogic(void)
         }
     }
 
-    if (game.roomchange)
+    if (roomchange)
     {
         //We've changed room? Let's bring our companion along!
-        game.roomchange = false;
         int i = obj.getplayer();
         if (game.companion > 0 && INBOUNDS_VEC(i, obj.entities))
         {
@@ -1644,4 +1653,7 @@ void gamelogic(void)
 
     if (game.teleport_to_new_area)
         script.teleport();
+
+#undef gotoroom
+#undef GOTOROOM
 }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1130,8 +1130,6 @@ void gamelogic(void)
             }
         }
 
-        bool screen_transition = false;
-
         if (!map.warpy && !map.towermode)
         {
             //Normal! Just change room
@@ -1140,13 +1138,11 @@ void gamelogic(void)
             {
                 obj.entities[player].yp -= 240;
                 GOTOROOM(game.roomx, game.roomy + 1);
-                screen_transition = true;
             }
             if (INBOUNDS_VEC(player, obj.entities) && game.door_up > -2 && obj.entities[player].yp < -2)
             {
                 obj.entities[player].yp += 240;
                 GOTOROOM(game.roomx, game.roomy - 1);
-                screen_transition = true;
             }
         }
 
@@ -1158,13 +1154,11 @@ void gamelogic(void)
             {
                 obj.entities[player].xp += 320;
                 GOTOROOM(game.roomx - 1, game.roomy);
-                screen_transition = true;
             }
             if (INBOUNDS_VEC(player, obj.entities) && game.door_right > -2 && obj.entities[player].xp >= 308)
             {
                 obj.entities[player].xp -= 320;
                 GOTOROOM(game.roomx + 1, game.roomy);
-                screen_transition = true;
             }
         }
 
@@ -1384,7 +1378,7 @@ void gamelogic(void)
             }
         }
 
-        if (screen_transition)
+        if (roomchange)
         {
             map.twoframedelayfix();
         }

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -904,6 +904,7 @@ void mapclass::warpto(int rx, int ry , int t, int tx, int ty)
 void mapclass::gotoroom(int rx, int ry)
 {
 	int roomchangedir;
+	std::vector<entclass> linecrosskludge;
 
 	//First, destroy the current room
 	obj.removeallblocks();
@@ -912,7 +913,6 @@ void mapclass::gotoroom(int rx, int ry)
 	game.oldreadytotele = 0;
 
 	//Ok, let's save the position of all lines on the screen
-	obj.linecrosskludge.clear();
 	for (size_t i = 0; i < obj.entities.size(); i++)
 	{
 		if (obj.entities[i].type == 9)
@@ -921,7 +921,7 @@ void mapclass::gotoroom(int rx, int ry)
 			if (obj.entities[i].xp <= 0 || (obj.entities[i].xp + obj.entities[i].w) >= 312)
 			{
 				//it's on a screen edge
-				obj.copylinecross(i);
+				obj.copylinecross(linecrosskludge, i);
 			}
 		}
 	}
@@ -1069,24 +1069,24 @@ void mapclass::gotoroom(int rx, int ry)
 			if (obj.entities[i].xp <= 0 || obj.entities[i].xp + obj.entities[i].w >= 312)
 			{
 				//it's on a screen edge
-				for (size_t j = 0; j < obj.linecrosskludge.size(); j++)
+				for (size_t j = 0; j < linecrosskludge.size(); j++)
 				{
-					if (obj.entities[i].yp == obj.linecrosskludge[j].yp)
+					if (obj.entities[i].yp == linecrosskludge[j].yp)
 					{
 						//y's match, how about x's?
 						//we're moving left:
 						if (roomchangedir == 0)
 						{
-							if (obj.entities[i].xp + obj.entities[i].w >= 312 && obj.linecrosskludge[j].xp <= 0)
+							if (obj.entities[i].xp + obj.entities[i].w >= 312 && linecrosskludge[j].xp <= 0)
 							{
-								obj.revertlinecross(i, j);
+								obj.revertlinecross(linecrosskludge, i, j);
 							}
 						}
 						else
 						{
-							if (obj.entities[i].xp <= 0 && obj.linecrosskludge[j].xp + obj.linecrosskludge[j].w >= 312)
+							if (obj.entities[i].xp <= 0 && linecrosskludge[j].xp + linecrosskludge[j].w >= 312)
 							{
-								obj.revertlinecross(i, j);
+								obj.revertlinecross(linecrosskludge, i, j);
 							}
 						}
 					}

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -967,7 +967,6 @@ void mapclass::gotoroom(int rx, int ry)
 		//Ok, what way are we moving?
 		game.roomx = rx;
 		game.roomy = ry;
-		game.roomchange = true;
 
 		if (game.roomy < 10)
 		{
@@ -994,7 +993,6 @@ void mapclass::gotoroom(int rx, int ry)
 	{
 		game.roomx = rx;
 		game.roomy = ry;
-		game.roomchange = true;
 		if (game.roomx < 100) game.roomx = 100 + ed.mapwidth-1;
 		if (game.roomy < 100) game.roomy = 100 + ed.mapheight-1;
 		if (game.roomx > 100 + ed.mapwidth-1) game.roomx = 100;
@@ -1005,7 +1003,6 @@ void mapclass::gotoroom(int rx, int ry)
 	{
 		game.roomx = rx;
 		game.roomy = ry;
-		game.roomchange = true;
 		if (game.roomx < 100) game.roomx = 119;
 		if (game.roomy < 100) game.roomy = 119;
 		if (game.roomx > 119) game.roomx = 100;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -903,6 +903,8 @@ void mapclass::warpto(int rx, int ry , int t, int tx, int ty)
 
 void mapclass::gotoroom(int rx, int ry)
 {
+	int roomchangedir;
+
 	//First, destroy the current room
 	obj.removeallblocks();
 	game.activetele = false;
@@ -953,11 +955,11 @@ void mapclass::gotoroom(int rx, int ry)
 
 	if (rx < game.roomx)
 	{
-		game.roomchangedir = 0;
+		roomchangedir = 0;
 	}
 	else
 	{
-		game.roomchangedir = 1;
+		roomchangedir = 1;
 	}
 
 	if (finalmode)
@@ -1073,7 +1075,7 @@ void mapclass::gotoroom(int rx, int ry)
 					{
 						//y's match, how about x's?
 						//we're moving left:
-						if (game.roomchangedir == 0)
+						if (roomchangedir == 0)
 						{
 							if (obj.entities[i].xp + obj.entities[i].w >= 312 && obj.linecrosskludge[j].xp <= 0)
 							{

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1572,7 +1572,6 @@ void scriptclass::run(void)
 				game.gravitycontrol = 0;
 				game.teleport = false;
 				game.companion = 0;
-				game.roomchange = false;
 				game.teleport_to_new_area = false;
 				game.teleport_to_x = 0;
 				game.teleport_to_y = 0;
@@ -3386,7 +3385,6 @@ void scriptclass::hardreset(void)
 	game.gravitycontrol = 0;
 	game.teleport = false;
 	game.companion = 0;
-	game.roomchange = false;
 	if (!version2_2)
 	{
 		// Ironically, resetting more variables makes the janky fadeout system in glitchrunnermode even more glitchy


### PR DESCRIPTION
The three temporary variables were `game.roomchangedir`, `obj.linecrosskludge`, and `game.roomchange`. Moving them off makes it easier to reason about what happens in `mapclass::gotoroom()`.

Also, the `screen_transition` variable in `gamelogic()` got axed in favor of using the already-existing `roomchange` instead.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
