### PR TITLE
Remove customlevelstatsloaded from Game

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -412,8 +412,6 @@ void Game::clearcustomlevelstats(void)
 {
     //just clearing the array
     customlevelstats.clear();
-
-    customlevelstatsloaded=false; //To ensure we don't load it where it isn't needed
 }
 
 
@@ -475,11 +473,6 @@ void Game::updatecustomlevelstats(std::string clevel, int cscore)
 
 void Game::loadcustomlevelstats(void)
 {
-    if(customlevelstatsloaded)
-    {
-        return;
-    }
-
     tinyxml2::XMLDocument doc;
     if (!FILESYSTEM_loadTiXml2Document("saves/levelstats.vvv", doc))
     {

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -416,7 +416,6 @@ public:
     void updatecustomlevelstats(std::string clevel, int cscore);
 
     std::vector<CustomLevelStat> customlevelstats;
-    bool customlevelstatsloaded;
 
 
     std::vector<SDL_GameControllerButton> controllerButton_map;


### PR DESCRIPTION
This boolean is assigned, and it is checked... but it's never assigned to true, thus making it useless. I also checked 2.2 source and the same thing happens there; to prevent any confusion, I'm removing this.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
