### PR TITLE
Make map.ypos and map.oldypos ints instead of floats

### DIFF
--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -107,8 +107,8 @@ public:
 
     //Special tower stuff
     bool towermode;
-    float ypos;
-    float oldypos;
+    int ypos;
+    int oldypos;
     int cameramode;
     int cameraseek, cameraseekframe;
     int resumedelay;


### PR DESCRIPTION
So... I did see that `map.ypos` was a float when I added over-30-FPS mode, because `map.oldypos` wasn't there before... I'm guessing that I kind of just ignored it at the time. But, c'mon, `map.ypos` and `map.oldypos` are always treated as ints, so there's literally no reason for them to be actually floats in reality. I didn't even know they were anything other than ints until I checked `Map.h`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
