### PR TITLE
Consistently play Viridian squeak for pause menu inputs

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2235,6 +2235,7 @@ void mapinput(void)
                 {
                     graphics.resumegamemode = true;
                 }
+                music.playef(11);
             }
         }
         else
@@ -2403,6 +2404,7 @@ static void mapmenuactionpress(void)
     case 30:
         // Return to game
         graphics.resumegamemode = true;
+        music.playef(11);
         break;
     case 31:
         // Graphic options and game options


### PR DESCRIPTION
Pressing Esc to cancel the confirm quit menu didn't play the squeak, in contrast to pressing ACTION to cancel it, so now it does; pressing Esc to close the pause menu or pressing ACTION will also now play the Viridian squeak too.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
