### PR TITLE
Fix duplicating ed_settings when opening editor menu second time

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -4079,13 +4079,17 @@ void editorinput(void)
 
             if (ed.settingsmod)
             {
-                bool edsettings_in_stack = false;
-                for (size_t i = 0; i < game.menustack.size(); i++)
+                bool edsettings_in_stack = game.currentmenuname == Menu::ed_settings;
+                if (!edsettings_in_stack)
                 {
-                    if (game.menustack[i].name == Menu::ed_settings)
+                    size_t i;
+                    for (i = 0; i < game.menustack.size(); ++i)
                     {
-                        edsettings_in_stack = true;
-                        break;
+                        if (game.menustack[i].name == Menu::ed_settings)
+                        {
+                            edsettings_in_stack = true;
+                            break;
+                        }
                     }
                 }
                 if (edsettings_in_stack)


### PR DESCRIPTION
This fixes a bug where after loading in to the level editor, pressing Esc and then switching your option to something other than the first option, then pressing Esc again to close the menu, then pressing Esc once more would not keep your menu option.

This is because the code that checks if `Menu::ed_settings` is already in the stack doesn't account for if `ed_settings` is the current menu - the current menu doesn't get put in to the stack.

In hindsight, maybe I could have designed the new menu system better so the current menu *is* on the stack, and/or should have used a statically-allocated linked list for each menu name for the stack frames (instead of an `std::vector`) and asserted if a menu that already existed in the stack was created instead... that'll have to be done later, though.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
