### PR TITLE
Fix undefined behavior if assets are missing and asserts if some of them are missing

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -451,6 +451,11 @@ void FILESYSTEM_loadFileToMemory(
 	PHYSFS_sint64 length;
 	PHYSFS_sint64 success;
 
+	if (name == NULL || mem == NULL)
+	{
+		goto fail;
+	}
+
 	if (SDL_strcmp(name, "levels/special/stdin.vvvvvv") == 0)
 	{
 		// this isn't *technically* necessary when piping directly from a file, but checking for that is annoying

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -484,7 +484,7 @@ void FILESYSTEM_loadFileToMemory(
 	handle = PHYSFS_openRead(name);
 	if (handle == NULL)
 	{
-		return;
+		goto fail;
 	}
 	length = PHYSFS_fileLength(handle);
 	if (len != NULL)
@@ -518,6 +518,17 @@ void FILESYSTEM_loadFileToMemory(
 		FILESYSTEM_freeMemory(mem);
 	}
 	PHYSFS_close(handle);
+	return;
+
+fail:
+	if (mem != NULL)
+	{
+		*mem = NULL;
+	}
+	if (len != NULL)
+	{
+		*len = 0;
+	}
 }
 
 void FILESYSTEM_loadAssetToMemory(
@@ -645,7 +656,7 @@ bool FILESYSTEM_saveTiXml2Document(const char *name, tinyxml2::XMLDocument& doc)
 bool FILESYSTEM_loadTiXml2Document(const char *name, tinyxml2::XMLDocument& doc)
 {
 	/* XMLDocument.LoadFile doesn't account for Unicode paths, PHYSFS does */
-	unsigned char *mem = NULL;
+	unsigned char *mem;
 	FILESYSTEM_loadFileToMemory(name, &mem, NULL, true);
 	if (mem == NULL)
 	{

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -447,11 +447,16 @@ void FILESYSTEM_loadFileToMemory(
 	size_t *len,
 	bool addnull
 ) {
+	PHYSFS_File *handle;
+	PHYSFS_sint64 length;
+	PHYSFS_sint64 success;
+
 	if (SDL_strcmp(name, "levels/special/stdin.vvvvvv") == 0)
 	{
 		// this isn't *technically* necessary when piping directly from a file, but checking for that is annoying
 		static std::vector<char> STDIN_BUFFER;
 		static bool STDIN_LOADED = false;
+		size_t stdin_length;
 		if (!STDIN_LOADED)
 		{
 			std::istreambuf_iterator<char> begin(std::cin), end;
@@ -460,14 +465,14 @@ void FILESYSTEM_loadFileToMemory(
 			STDIN_LOADED = true;
 		}
 
-		size_t length = STDIN_BUFFER.size() - 1;
+		stdin_length = STDIN_BUFFER.size() - 1;
 		if (len != NULL)
 		{
-			*len = length;
+			*len = stdin_length;
 		}
 
-		++length;
-		*mem = static_cast<unsigned char*>(SDL_malloc(length)); // STDIN_BUFFER.data() causes double-free
+		++stdin_length;
+		*mem = static_cast<unsigned char*>(SDL_malloc(stdin_length)); // STDIN_BUFFER.data() causes double-free
 		if (*mem == NULL)
 		{
 			VVV_exit(1);
@@ -476,12 +481,12 @@ void FILESYSTEM_loadFileToMemory(
 		return;
 	}
 
-	PHYSFS_File *handle = PHYSFS_openRead(name);
+	handle = PHYSFS_openRead(name);
 	if (handle == NULL)
 	{
 		return;
 	}
-	PHYSFS_sint64 length = PHYSFS_fileLength(handle);
+	length = PHYSFS_fileLength(handle);
 	if (len != NULL)
 	{
 		if (length < 0)
@@ -507,7 +512,7 @@ void FILESYSTEM_loadFileToMemory(
 			VVV_exit(1);
 		}
 	}
-	PHYSFS_sint64 success = PHYSFS_readBytes(handle, *mem, length);
+	success = PHYSFS_readBytes(handle, *mem, length);
 	if (success == -1)
 	{
 		FILESYSTEM_freeMemory(mem);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -361,7 +361,7 @@ void Graphics::Makebfont(void)
         flipbfont.push_back(TempFlipped);
     })
 
-    unsigned char* charmap = NULL;
+    unsigned char* charmap;
     size_t length;
     FILESYSTEM_loadAssetToMemory("graphics/font.txt", &charmap, &length, false);
     if (charmap != NULL)

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -716,6 +716,7 @@ void Graphics::drawsprite( int x, int y, int t, int r, int g,  int b )
     if (!INBOUNDS_VEC(t, sprites))
     {
         WHINE_ONCE("drawsprite() out-of-bounds!");
+        return;
     }
 
     SDL_Rect rect = {x, y, sprites_rect.w, sprites_rect.h};
@@ -728,6 +729,7 @@ void Graphics::drawsprite(int x, int y, int t, Uint32 c)
     if (!INBOUNDS_VEC(t, sprites))
     {
         WHINE_ONCE("drawsprite() out-of-bounds!");
+        return;
     }
 
     SDL_Rect rect = {x, y, sprites_rect.w, sprites_rect.h};

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -306,15 +306,19 @@ void Graphics::updatetitlecolours(void)
 }
 
 #define PROCESS_TILESHEET_CHECK_ERROR(tilesheet, tile_square) \
-    if (grphx.im_##tilesheet->w % tile_square != 0 \
+    if (grphx.im_##tilesheet == NULL) \
+    { \
+        /* We have already asserted; just no-op. */ \
+    } \
+    else if (grphx.im_##tilesheet->w % tile_square != 0 \
     || grphx.im_##tilesheet->h % tile_square != 0) \
     { \
         const char* error = "Error: %s.png dimensions not exact multiples of %i!"; \
         char message[128]; \
-        SDL_snprintf(message, sizeof(message), error, #tilesheet, tile_square); \
-        \
         const char* error_title = "Error with %s.png"; \
         char message_title[128]; \
+        \
+        SDL_snprintf(message, sizeof(message), error, #tilesheet, tile_square); \
         SDL_snprintf(message_title, sizeof(message_title), error_title, #tilesheet); \
         \
         puts(message); \
@@ -332,23 +336,28 @@ void Graphics::updatetitlecolours(void)
 #define PROCESS_TILESHEET_RENAME(tilesheet, vector, tile_square, extra_code) \
     PROCESS_TILESHEET_CHECK_ERROR(tilesheet, tile_square) \
     \
-    for (int j = 0; j < grphx.im_##tilesheet->h / tile_square; j++) \
+    else \
     { \
-        for (int i = 0; i < grphx.im_##tilesheet->w / tile_square; i++) \
+        int j; \
+        for (j = 0; j < grphx.im_##tilesheet->h / tile_square; ++j) \
         { \
-            SDL_Surface* temp = GetSubSurface( \
-                grphx.im_##tilesheet, \
-                i * tile_square, j * tile_square, \
-                tile_square, tile_square \
-            ); \
-            vector.push_back(temp); \
-            \
-            extra_code \
+            int i; \
+            for (i = 0; i < grphx.im_##tilesheet->w / tile_square; ++i) \
+            { \
+                SDL_Surface* temp = GetSubSurface( \
+                    grphx.im_##tilesheet, \
+                    i * tile_square, j * tile_square, \
+                    tile_square, tile_square \
+                ); \
+                vector.push_back(temp); \
+                \
+                extra_code \
+            } \
         } \
-    } \
-    \
-    SDL_FreeSurface(grphx.im_##tilesheet); \
-    grphx.im_##tilesheet = NULL;
+        \
+        SDL_FreeSurface(grphx.im_##tilesheet); \
+        grphx.im_##tilesheet = NULL; \
+    }
 
 #define PROCESS_TILESHEET(tilesheet, tile_square, extra_code) \
     PROCESS_TILESHEET_RENAME(tilesheet, tilesheet, tile_square, extra_code)

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -37,6 +37,11 @@ static SDL_Surface* LoadImage(const char *filename, bool noBlend = true, bool no
 	unsigned char *fileIn;
 	size_t length;
 	FILESYSTEM_loadAssetToMemory(filename, &fileIn, &length, false);
+	if (fileIn == NULL)
+	{
+		SDL_assert(0 && "Image file missing!");
+		return NULL;
+	}
 	if (noAlpha)
 	{
 		lodepng_decode24(&data, &width, &height, fileIn, length);

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -34,8 +34,8 @@ static SDL_Surface* LoadImage(const char *filename, bool noBlend = true, bool no
 	unsigned char *data;
 	unsigned int width, height;
 
-	unsigned char *fileIn = NULL;
-	size_t length = 0;
+	unsigned char *fileIn;
+	size_t length;
 	FILESYSTEM_loadAssetToMemory(filename, &fileIn, &length, false);
 	if (noAlpha)
 	{

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -127,8 +127,8 @@ void Screen::GetSettings(ScreenSettings* settings)
 void Screen::LoadIcon(void)
 {
 #ifndef __APPLE__
-	unsigned char *fileIn = NULL;
-	size_t length = 0;
+	unsigned char *fileIn;
+	size_t length;
 	unsigned char *data;
 	unsigned int width, height;
 	FILESYSTEM_loadAssetToMemory("VVVVVV.png", &fileIn, &length, false);

--- a/desktop_version/src/SoundSystem.cpp
+++ b/desktop_version/src/SoundSystem.cpp
@@ -38,6 +38,7 @@ SoundTrack::SoundTrack(const char* fileName)
 	if (mem == NULL)
 	{
 		fprintf(stderr, "Unable to load WAV file %s\n", fileName);
+		SDL_assert(0 && "WAV file missing!");
 		return;
 	}
 	SDL_RWops *fileIn = SDL_RWFromConstMem(mem, length);

--- a/desktop_version/src/SoundSystem.cpp
+++ b/desktop_version/src/SoundSystem.cpp
@@ -30,7 +30,7 @@ MusicTrack::MusicTrack(SDL_RWops *rw)
 SoundTrack::SoundTrack(const char* fileName)
 {
 	unsigned char *mem;
-	size_t length = 0;
+	size_t length;
 
 	sound = NULL;
 

--- a/desktop_version/src/SoundSystem.cpp
+++ b/desktop_version/src/SoundSystem.cpp
@@ -29,10 +29,11 @@ MusicTrack::MusicTrack(SDL_RWops *rw)
 
 SoundTrack::SoundTrack(const char* fileName)
 {
-	sound = NULL;
-
 	unsigned char *mem;
 	size_t length = 0;
+
+	sound = NULL;
+
 	FILESYSTEM_loadAssetToMemory(fileName, &mem, &length, false);
 	if (mem == NULL)
 	{

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -248,7 +248,7 @@ void editorclass::getDirectoryData(void)
 }
 bool editorclass::getLevelMetaData(std::string& _path, LevelMetaData& _data )
 {
-    unsigned char *uMem = NULL;
+    unsigned char *uMem;
     FILESYSTEM_loadFileToMemory(_path.c_str(), &uMem, NULL, true);
 
     if (uMem == NULL)


### PR DESCRIPTION
It's simple: The game committed undefined behavior if it had no assets. But now it doesn't.

To test this, I created a zip file with nothing inside (`touch nothing`, then `zip nothing.zip nothing`), then did `./VVVVVV -assets nothing.zip` and fixed every segfault until it worked properly.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
