### PR TITLE
Add error checking to base path setup 

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -39,7 +39,7 @@ static char levelDir[MAX_PATH] = {'\0'};
 static char assetDir[MAX_PATH] = {'\0'};
 static char virtualMountPath[MAX_PATH] = {'\0'};
 
-static void PLATFORM_getOSDirectory(char* output);
+static void PLATFORM_getOSDirectory(char* output, const size_t output_size);
 static void PLATFORM_migrateSaveData(char* output);
 static void PLATFORM_copyFile(const char *oldLocation, const char *newLocation);
 
@@ -86,7 +86,7 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 	}
 	else
 	{
-		PLATFORM_getOSDirectory(output);
+		PLATFORM_getOSDirectory(output, sizeof(output));
 	}
 
 	/* Mount our base user directory */
@@ -707,17 +707,17 @@ void FILESYSTEM_enumerateLevelDirFileNames(
 	}
 }
 
-static void PLATFORM_getOSDirectory(char* output)
+static void PLATFORM_getOSDirectory(char* output, const size_t output_size)
 {
 #ifdef _WIN32
 	/* This block is here for compatibility, do not touch it! */
 	WCHAR utf16_path[MAX_PATH];
 	SHGetFolderPathW(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, utf16_path);
-	WideCharToMultiByte(CP_UTF8, 0, utf16_path, -1, output, MAX_PATH, NULL, NULL);
+	WideCharToMultiByte(CP_UTF8, 0, utf16_path, -1, output, output_size, NULL, NULL);
 	SDL_strlcat(output, "\\VVVVVV\\", MAX_PATH);
 	mkdir(output, 0777);
 #else
-	SDL_strlcpy(output, PHYSFS_getPrefDir("distractionware", "VVVVVV"), MAX_PATH);
+	SDL_strlcpy(output, PHYSFS_getPrefDir("distractionware", "VVVVVV"), output_size);
 #endif
 }
 


### PR DESCRIPTION
Previously, if the game couldn't set the write dir to the base directory, or couldn't make the base directory, or couldn't calculate the base directory, it would probably dereference `NULL` or read from uninitialized memory or murder your family or something. But now, I've eliminated the potential Undefined Behavior from the code dealing with the base path.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
