### PR TITLE
Separate pressing Enter to open map from pressing Enter to interact

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -838,151 +838,151 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
         switch(trig)
         {
         case 0: //testing zone
-            block.prompt = "Press ENTER to explode";
+            block.prompt = "Press %s to explode";
             block.script = "intro";
             block.setblockcolour("orange");
             trig=1;
             break;
         case 1:
-            block.prompt = "Press ENTER to talk to Violet";
+            block.prompt = "Press %s to talk to Violet";
             block.script = "talkpurple";
             block.setblockcolour("purple");
             trig=0;
             break;
         case 2:
-            block.prompt = "Press ENTER to talk to Vitellary";
+            block.prompt = "Press %s to talk to Vitellary";
             block.script = "talkyellow";
             block.setblockcolour("yellow");
             trig=0;
             break;
         case 3:
-            block.prompt = "Press ENTER to talk to Vermilion";
+            block.prompt = "Press %s to talk to Vermilion";
             block.script = "talkred";
             block.setblockcolour("red");
             trig=0;
             break;
         case 4:
-            block.prompt = "Press ENTER to talk to Verdigris";
+            block.prompt = "Press %s to talk to Verdigris";
             block.script = "talkgreen";
             block.setblockcolour("green");
             trig=0;
             break;
         case 5:
-            block.prompt = "Press ENTER to talk to Victoria";
+            block.prompt = "Press %s to talk to Victoria";
             block.script = "talkblue";
             block.setblockcolour("blue");
             trig=0;
             break;
         case 6:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_station_1";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 7:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_outside_1";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 8:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_outside_2";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 9:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_outside_3";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 10:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_outside_4";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 11:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_outside_5";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 12:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_outside_6";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 13:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_finallevel";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 14:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_station_2";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 15:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_station_3";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 16:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_station_4";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 17:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_warp_1";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 18:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_warp_2";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 19:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_lab_1";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 20:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_lab_2";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 21:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_secretlab";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 22:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_shipcomputer";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 23:
-            block.prompt = "Press ENTER to activate terminals";
+            block.prompt = "Press %s to activate terminals";
             block.script = "terminal_radio";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 24:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "terminal_jukebox";
             block.setblockcolour("orange");
             trig=0;
@@ -1048,7 +1048,7 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
             trig=0;
             break;
         case 35:
-            block.prompt = "Press ENTER to activate terminal";
+            block.prompt = "Press %s to activate terminal";
             block.script = "custom_"+customscript;
             block.setblockcolour("orange");
             trig=0;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -392,7 +392,9 @@ public:
     int activeactivity, act_fade;
     int prev_act_fade;
 
-    bool press_left, press_right, press_action, press_map;
+    bool press_left, press_right, press_action, press_map, press_interact;
+    bool interactheld;
+    bool separate_interact;
 
     //Some stats:
     int totalflips;
@@ -422,6 +424,7 @@ public:
     std::vector<SDL_GameControllerButton> controllerButton_flip;
     std::vector<SDL_GameControllerButton> controllerButton_esc;
     std::vector<SDL_GameControllerButton> controllerButton_restart;
+    std::vector<SDL_GameControllerButton> controllerButton_interact;
 
     bool skipfakeload;
     bool ghostsenabled;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -24,9 +24,12 @@ static void updatebuttonmappings(int bind)
         if (key.isDown(i))
         {
             bool dupe = false;
-            if (bind == 1)
+            switch (bind)
             {
-                for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
+            case 1:
+            {
+                size_t j;
+                for (j = 0; j < game.controllerButton_flip.size(); j += 1)
                 {
                     if (i == game.controllerButton_flip[j])
                     {
@@ -38,31 +41,40 @@ static void updatebuttonmappings(int bind)
                     game.controllerButton_flip.push_back(i);
                     music.playef(11);
                 }
-                for (size_t j = 0; j < game.controllerButton_map.size(); j += 1)
+                for (j = 0; j < game.controllerButton_map.size(); j += 1)
                 {
                     if (i == game.controllerButton_map[j])
                     {
                         game.controllerButton_map.erase(game.controllerButton_map.begin() + j);
                     }
                 }
-                for (size_t j = 0; j < game.controllerButton_esc.size(); j += 1)
+                for (j = 0; j < game.controllerButton_esc.size(); j += 1)
                 {
                     if (i == game.controllerButton_esc[j])
                     {
                         game.controllerButton_esc.erase(game.controllerButton_esc.begin() + j);
                     }
                 }
-                for (size_t j = 0; j < game.controllerButton_restart.size(); j += 1)
+                for (j = 0; j < game.controllerButton_restart.size(); j += 1)
                 {
                     if (i == game.controllerButton_restart[j])
                     {
                         game.controllerButton_restart.erase(game.controllerButton_restart.begin() + j);
                     }
                 }
+                for (j = 0; j < game.controllerButton_interact.size(); j += 1)
+                {
+                    if (i == game.controllerButton_interact[j])
+                    {
+                        game.controllerButton_interact.erase(game.controllerButton_interact.begin() + j);
+                    }
+                }
+                break;
             }
-            if (bind == 2)
+            case 2:
             {
-                for (size_t j = 0; j < game.controllerButton_map.size(); j += 1)
+                size_t j;
+                for (j = 0; j < game.controllerButton_map.size(); j += 1)
                 {
                     if (i == game.controllerButton_map[j])
                     {
@@ -74,31 +86,40 @@ static void updatebuttonmappings(int bind)
                     game.controllerButton_map.push_back(i);
                     music.playef(11);
                 }
-                for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
+                for (j = 0; j < game.controllerButton_flip.size(); j += 1)
                 {
                     if (i == game.controllerButton_flip[j])
                     {
                         game.controllerButton_flip.erase(game.controllerButton_flip.begin() + j);
                     }
                 }
-                for (size_t j = 0; j < game.controllerButton_esc.size(); j += 1)
+                for (j = 0; j < game.controllerButton_esc.size(); j += 1)
                 {
                     if (i == game.controllerButton_esc[j])
                     {
                         game.controllerButton_esc.erase(game.controllerButton_esc.begin() + j);
                     }
                 }
-                for (size_t j = 0; j < game.controllerButton_restart.size(); j += 1)
+                for (j = 0; j < game.controllerButton_restart.size(); j += 1)
                 {
                     if (i == game.controllerButton_restart[j])
                     {
                         game.controllerButton_restart.erase(game.controllerButton_restart.begin() + j);
                     }
                 }
+                for (j = 0; j < game.controllerButton_interact.size(); j += 1)
+                {
+                    if (i == game.controllerButton_interact[j])
+                    {
+                        game.controllerButton_interact.erase(game.controllerButton_interact.begin() + j);
+                    }
+                }
+                break;
             }
-            if (bind == 3)
+            case 3:
             {
-                for (size_t j = 0; j < game.controllerButton_esc.size(); j += 1)
+                size_t j;
+                for (j = 0; j < game.controllerButton_esc.size(); j += 1)
                 {
                     if (i == game.controllerButton_esc[j])
                     {
@@ -110,31 +131,40 @@ static void updatebuttonmappings(int bind)
                     game.controllerButton_esc.push_back(i);
                     music.playef(11);
                 }
-                for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
+                for (j = 0; j < game.controllerButton_flip.size(); j += 1)
                 {
                     if (i == game.controllerButton_flip[j])
                     {
                         game.controllerButton_flip.erase(game.controllerButton_flip.begin() + j);
                     }
                 }
-                for (size_t j = 0; j < game.controllerButton_map.size(); j += 1)
+                for (j = 0; j < game.controllerButton_map.size(); j += 1)
                 {
                     if (i == game.controllerButton_map[j])
                     {
                         game.controllerButton_map.erase(game.controllerButton_map.begin() + j);
                     }
                 }
-                for (size_t j = 0; j < game.controllerButton_restart.size(); j += 1)
+                for (j = 0; j < game.controllerButton_restart.size(); j += 1)
                 {
                     if (i == game.controllerButton_restart[j])
                     {
                         game.controllerButton_restart.erase(game.controllerButton_restart.begin() + j);
                     }
                 }
+                for (j = 0; j < game.controllerButton_interact.size(); j += 1)
+                {
+                    if (i == game.controllerButton_interact[j])
+                    {
+                        game.controllerButton_interact.erase(game.controllerButton_interact.begin() + j);
+                    }
+                }
+                break;
             }
-            if (bind == 4)
+            case 4:
             {
-                for (size_t j = 0; j < game.controllerButton_restart.size(); j += 1)
+                size_t j;
+                for (j = 0; j < game.controllerButton_restart.size(); j += 1)
                 {
                     if (i == game.controllerButton_restart[j])
                     {
@@ -146,27 +176,82 @@ static void updatebuttonmappings(int bind)
                     game.controllerButton_restart.push_back(i);
                     music.playef(11);
                 }
-                for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
+                for (j = 0; j < game.controllerButton_flip.size(); j += 1)
                 {
                     if (i == game.controllerButton_flip[j])
                     {
                         game.controllerButton_flip.erase(game.controllerButton_flip.begin() + j);
                     }
                 }
-                for (size_t j = 0; j < game.controllerButton_map.size(); j += 1)
+                for (j = 0; j < game.controllerButton_map.size(); j += 1)
                 {
                     if (i == game.controllerButton_map[j])
                     {
                         game.controllerButton_map.erase(game.controllerButton_map.begin() + j);
                     }
                 }
-                for (size_t j = 0; j < game.controllerButton_esc.size(); j += 1)
+                for (j = 0; j < game.controllerButton_esc.size(); j += 1)
                 {
                     if (i == game.controllerButton_esc[j])
                     {
                         game.controllerButton_esc.erase(game.controllerButton_esc.begin() + j);
                     }
                 }
+                for (j = 0; j < game.controllerButton_interact.size(); j += 1)
+                {
+                    if (i == game.controllerButton_interact[j])
+                    {
+                        game.controllerButton_interact.erase(game.controllerButton_interact.begin() + j);
+                    }
+                }
+                break;
+            }
+            case 5:
+            {
+                size_t j;
+                for (j = 0; j < game.controllerButton_interact.size(); j += 1)
+                {
+                    if (i == game.controllerButton_interact[j])
+                    {
+                        dupe = true;
+                    }
+                }
+                if (!dupe)
+                {
+                    game.controllerButton_interact.push_back(i);
+                    music.playef(11);
+                }
+                for (j = 0; j < game.controllerButton_flip.size(); j += 1)
+                {
+                    if (i == game.controllerButton_flip[j])
+                    {
+                        game.controllerButton_flip.erase(game.controllerButton_flip.begin() + j);
+                    }
+                }
+                for (j = 0; j < game.controllerButton_map.size(); j += 1)
+                {
+                    if (i == game.controllerButton_map[j])
+                    {
+                        game.controllerButton_map.erase(game.controllerButton_map.begin() + j);
+                    }
+                }
+                for (j = 0; j < game.controllerButton_esc.size(); j += 1)
+                {
+                    if (i == game.controllerButton_esc[j])
+                    {
+                        game.controllerButton_esc.erase(game.controllerButton_esc.begin() + j);
+                    }
+                }
+                for (j = 0; j < game.controllerButton_restart.size(); j += 1)
+                {
+                    if (i == game.controllerButton_restart[j])
+                    {
+                        game.controllerButton_restart.erase(game.controllerButton_restart.begin() + j);
+                    }
+                }
+                break;
+            }
+
             }
         }
     }
@@ -586,6 +671,12 @@ static void menuactionpress(void)
             game.savestatsandsettings_menu();
             break;
         case 2:
+            /* Interact button toggle */
+            music.playef(11);
+            game.separate_interact = !game.separate_interact;
+            game.savestatsandsettings_menu();
+            break;
+        case 3:
             // toggle fake load screen
             game.skipfakeload = !game.skipfakeload;
             game.savestatsandsettings_menu();
@@ -1310,7 +1401,7 @@ static void menuactionpress(void)
             game.savestatsandsettings_menu();
             break;
 
-        case 5:
+        case 6:
             music.playef(11);
             game.returnmenu();
             map.nexttowercolour();
@@ -1628,6 +1719,7 @@ void titleinput(void)
     game.press_right = false;
     game.press_action = false;
     game.press_map = false;
+    game.press_interact = false;
 
     if (graphics.flipmode)
     {
@@ -1744,7 +1836,7 @@ void titleinput(void)
         }
         if (    game.currentmenuname == Menu::controller &&
                 game.currentmenuoption > 0 &&
-                game.currentmenuoption < 5 &&
+                game.currentmenuoption < 6 &&
                 key.controllerButtonDown()      )
         {
             updatebuttonmappings(game.currentmenuoption);
@@ -1777,6 +1869,7 @@ void gameinput(void)
         game.press_left = false;
         game.press_right = false;
         game.press_action = false;
+        game.press_interact = false;
 
         if (key.isDown(KEYBOARD_LEFT) || key.isDown(KEYBOARD_a) || key.controllerWantsLeft(false))
         {
@@ -1790,7 +1883,12 @@ void gameinput(void)
                 || key.isDown(KEYBOARD_UP) || key.isDown(KEYBOARD_DOWN) || key.isDown(KEYBOARD_w) || key.isDown(KEYBOARD_s)|| key.isDown(game.controllerButton_flip))
         {
             game.press_action = true;
-        };
+        }
+
+        if (key.isDown(KEYBOARD_e) || key.isDown(game.controllerButton_interact))
+        {
+            game.press_interact = true;
+        }
     }
 
     game.press_map = false;
@@ -1838,6 +1936,11 @@ void gameinput(void)
         game.mapheld = false;
     }
 
+    if (!game.press_interact)
+    {
+        game.interactheld = false;
+    }
+
     if (game.intimetrial && graphics.fademode == 1 && game.quickrestartkludge)
     {
         //restart the time trial
@@ -1849,17 +1952,12 @@ void gameinput(void)
 
     //Returning to editor mode must always be possible
 #if !defined(NO_CUSTOM_LEVELS)
-    if(map.custommode && !map.custommodeforreal){
-        if ((game.press_map || key.isDown(27)) && !game.mapheld){
-            //Return to level editor
-            if (INBOUNDS_VEC(game.activeactivity, obj.blocks) && game.press_map){
-                //pass, let code block below handle it
-            }else if(game.activetele && game.readytotele > 20 && game.press_map){
-                //pass, let code block below handle it
-            }else{
-                game.returntoeditor();
-                game.mapheld = true;
-            }
+    if (map.custommode && !map.custommodeforreal)
+    {
+        if ((game.press_map || key.isDown(27)) && !game.mapheld)
+        {
+            game.returntoeditor();
+            game.mapheld = true;
         }
     }
 #endif
@@ -1868,6 +1966,15 @@ void gameinput(void)
     bool has_control = false;
     bool enter_pressed = game.press_map && !game.mapheld;
     bool enter_already_processed = false;
+    bool interact_pressed;
+    if (game.separate_interact)
+    {
+        interact_pressed = game.press_interact && !game.interactheld;
+    }
+    else
+    {
+        interact_pressed = enter_pressed;
+    }
     for (size_t ie = 0; ie < obj.entities.size(); ++ie)
     {
         if (obj.entities[ie].rule == 0)
@@ -1875,12 +1982,16 @@ void gameinput(void)
             if (game.hascontrol && game.deathseq == -1 && game.lifeseq <= 5)
             {
                 has_control = true;
-                if (enter_pressed)
+                if (interact_pressed)
                 {
-                    game.mapheld = true;
+                    game.interactheld = true;
+                    if (!game.separate_interact)
+                    {
+                        game.mapheld = true;
+                    }
                 }
 
-                if (enter_pressed && !script.running)
+                if (interact_pressed && !script.running)
                 {
                     if (game.activetele && game.readytotele > 20 && !game.intimetrial)
                     {
@@ -2058,9 +2169,10 @@ void gameinput(void)
         }
     }
 
-    // Continuation of Enter processing. The rest of the if-tree runs only if
-    // enter_pressed && !enter_already_pressed
-    if (!enter_pressed || enter_already_processed)
+    /* The rest of the if-tree runs only if enter is pressed and it has not
+     * already been processed with 'separate interact' off.
+     */
+    if (!enter_pressed || (enter_already_processed && !game.separate_interact))
     {
         // Do nothing
     }
@@ -2135,6 +2247,7 @@ void mapinput(void)
     game.press_right = false;
     game.press_action = false;
     game.press_map = false;
+    game.press_interact = false;
 
     if (game.glitchrunnermode && graphics.fademode == 1 && graphics.menuoffset == 0)
     {
@@ -2441,6 +2554,7 @@ void teleporterinput(void)
     game.press_right = false;
     game.press_action = false;
     game.press_map = false;
+    game.press_interact = false;
 
     if(graphics.menuoffset==0)
     {
@@ -2448,10 +2562,17 @@ void teleporterinput(void)
         if (key.isDown(KEYBOARD_RIGHT) || key.isDown(KEYBOARD_d)|| key.controllerWantsRight(false) ) game.press_right = true;
         if (key.isDown(KEYBOARD_z) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v)
                 || key.isDown(KEYBOARD_UP) || key.isDown(KEYBOARD_DOWN)||  key.isDown(KEYBOARD_w)||  key.isDown(KEYBOARD_s) || key.isDown(game.controllerButton_flip)) game.press_action = true;
-        if (key.isDown(KEYBOARD_ENTER) || key.isDown(game.controllerButton_map)) game.press_map = true;
+        if (!game.separate_interact && (key.isDown(KEYBOARD_ENTER) || key.isDown(game.controllerButton_map)))
+        {
+            game.press_map = true;
+        }
+        if (key.isDown(KEYBOARD_e) || key.isDown(game.controllerButton_interact))
+        {
+            game.press_interact = true;
+        }
 
         //In the menu system, all keypresses are single taps rather than holds. Therefore this test has to be done for all presses
-        if (!game.press_action && !game.press_left && !game.press_right) game.jumpheld = false;
+        if (!game.press_action && !game.press_left && !game.press_right && !game.press_interact) game.jumpheld = false;
         if (!game.press_map) game.mapheld = false;
 
         if (key.isDown(27))
@@ -2478,7 +2599,7 @@ void teleporterinput(void)
 
     if (!game.jumpheld)
     {
-        if (game.press_action || game.press_left || game.press_right || game.press_map)
+        if (game.press_action || game.press_left || game.press_right || game.press_map || game.press_interact)
         {
             game.jumpheld = true;
         }
@@ -2521,7 +2642,7 @@ void teleporterinput(void)
             while (!map.isexplored(tempx, tempy));
         }
 
-        if (game.press_map)
+        if ((game.separate_interact && game.press_interact) || game.press_map)
         {
             tempx = map.teleporters[game.teleport_to_teleporter].x;
             tempy = map.teleporters[game.teleport_to_teleporter].y;
@@ -2568,6 +2689,7 @@ void gamecompleteinput(void)
     game.press_right = false;
     game.press_action = false;
     game.press_map = false;
+    game.press_interact = false;
 
     //Do this before we update map.bypos
     if (!game.colourblindmode)
@@ -2617,6 +2739,7 @@ void gamecompleteinput2(void)
     game.press_right = false;
     game.press_action = false;
     game.press_map = false;
+    game.press_interact = false;
 
     //Do this here because input comes first
     game.oldcreditposx = game.creditposx;

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -19,6 +19,7 @@ enum Kybrd
 	KEYBOARD_s = SDLK_s,
 	KEYBOARD_a = SDLK_a,
 	KEYBOARD_d = SDLK_d,
+	KEYBOARD_e = SDLK_e,
 	KEYBOARD_m = SDLK_m,
 	KEYBOARD_n = SDLK_n,
 

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3995,6 +3995,7 @@ void editorinput(void)
     game.press_right = false;
     game.press_action = false;
     game.press_map = false;
+    game.press_interact = false;
 
     if (key.isDown(KEYBOARD_LEFT) || key.isDown(KEYBOARD_a) || key.controllerWantsLeft(false))
     {


### PR DESCRIPTION
This is a lot of copy-pasted code, but a little bit of copy-pasting never hurt anyone...

The keybind to interact with activity zones and teleporters is now separate from the keybind to open the map, or return to the editor from in-editor playtesting, or restart a time trial. The keybind is now E, and the default controller bind is X. No controller button prompts, but the game didn't have controller button prompts anyways, so whatever.

Doing this now because if people's muscle memory are going to be broken by not being able to spam the map keybind anymore, at least we can help a bit by changing the keybind so they can keep spamming it - their muscle memory is going to be broken anyways.

This option has to be enabled by going to the speedrunner menu options and selecting "interact button". It is disabled by default.

All prompt text needs to be string-interpolated every time they are drawn, because it is possible for people to change which interact button they use in the middle of gameplay, via the in-game options.

Closes #736.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
