### PR TITLE
Draw minimap.png if it is mounted

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -149,6 +149,7 @@ void Graphics::init(void)
 #ifndef NO_CUSTOM_LEVELS
     tiles1_mounted = false;
     tiles2_mounted = false;
+    minimap_mounted = false;
 #endif
 }
 
@@ -3402,6 +3403,7 @@ void Graphics::reloadresources(void)
 #ifndef NO_CUSTOM_LEVELS
 	tiles1_mounted = FILESYSTEM_isAssetMounted("graphics/tiles.png");
 	tiles2_mounted = FILESYSTEM_isAssetMounted("graphics/tiles2.png");
+	minimap_mounted = FILESYSTEM_isAssetMounted("graphics/minimap.png");
 #endif
 }
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -220,6 +220,7 @@ public:
 #ifndef NO_CUSTOM_LEVELS
 	bool tiles1_mounted;
 	bool tiles2_mounted;
+	bool minimap_mounted;
 #endif
 
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1929,11 +1929,19 @@ void maprender(void)
             }
             graphics.Print(-1, 105, "NO SIGNAL", 245, 245, 245, true);
         }
+#ifndef NO_CUSTOM_LEVELS
         else if(map.custommode)
         {
           //draw the map image
           graphics.drawcustompixeltextbox(35+map.custommmxoff, 16+map.custommmyoff, map.custommmxsize+10, map.custommmysize+10, (map.custommmxsize+10)/8, (map.custommmysize+10)/8, 65, 185, 207,4,0);
-          graphics.drawpartimage(12, 40+map.custommmxoff, 21+map.custommmyoff, map.custommmxsize,map.custommmysize);
+          if (graphics.minimap_mounted)
+          {
+            graphics.drawpartimage(1, 40+map.custommmxoff, 21+map.custommmyoff, map.custommmxsize, map.custommmysize);
+          }
+          else
+          {
+            graphics.drawpartimage(12, 40+map.custommmxoff, 21+map.custommmyoff, map.custommmxsize,map.custommmysize);
+          }
 
           //Black out here
           if(map.customzoom==4){
@@ -2038,6 +2046,7 @@ void maprender(void)
             }
           }
         }
+#endif /* NO_CUSTOM_LEVELS */
         else
         {
             //draw the map image


### PR DESCRIPTION
This is a simple change - we draw `minimap.png`, instead of the generated custom map, if it is a per-level mounted custom asset.

Custom levels have already been able to utilize `minimap.png`, but it was limited - they could do `gamemode(teleporter)` in a script, and that would show their customized `minimap.png`, but it's not like the player could look at it during gameplay.

I would have done this earlier if I had figured out how to check if a specific asset was mounted or not.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
