### PR TITLE
Fix only removing duplicate script names from script name list

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3,7 +3,6 @@
 #define ED_DEFINITION
 #include "editor.h"
 
-#include <algorithm>
 #include <stdio.h>
 #include <string>
 #include <tinyxml2.h>
@@ -469,8 +468,16 @@ void editorclass::removehookfromscript(std::string t)
 void editorclass::removehook(std::string t)
 {
     //Check the hooklist for the hook t. If it's there, remove it from here and the script
+    size_t i;
     removehookfromscript(t);
-    hooklist.erase(std::remove(hooklist.begin(), hooklist.end(), t), hooklist.end());
+    /* When this loop reaches the end, it wraps to SIZE_MAX; SIZE_MAX + 1 is 0 */
+    for (i = hooklist.size() - 1; i + 1 > 0; --i)
+    {
+        if (hooklist[i] == t)
+        {
+            hooklist.erase(hooklist.begin() + i);
+        }
+    }
 }
 
 void editorclass::addhook(std::string t)
@@ -4263,8 +4270,15 @@ void editorinput(void)
                 ed.keydelay=6;
             }
 
-            // Remove all pipes, they are the line separator in the XML
-            key.keybuffer.erase(std::remove(key.keybuffer.begin(), key.keybuffer.end(), '|'), key.keybuffer.end());
+            /* Remove all pipes, they are the line separator in the XML
+             * When this loop reaches the end, it wraps to SIZE_MAX; SIZE_MAX + 1 is 0 */
+            {size_t i; for (i = key.keybuffer.length() - 1; i + 1 > 0; --i)
+            {
+                if (key.keybuffer[i] == '|')
+                {
+                    key.keybuffer.erase(key.keybuffer.begin() + i);
+                }
+            }}
 
             ed.sb[ed.pagey+ed.sby]=key.keybuffer;
             ed.sbx = utf8::unchecked::distance(ed.sb[ed.pagey+ed.sby].begin(), ed.sb[ed.pagey+ed.sby].end());

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -452,15 +452,14 @@ void editorclass::addhooktoscript(std::string t)
 
 void editorclass::removehookfromscript(std::string t)
 {
-    //Find hook t in the scriptclass, then removes it (and any other code with it)
-    for (size_t i = 0; i < script.customscripts.size(); i++)
+    /* Find hook t in the scriptclass, then removes it (and any other code with it)
+     * When this loop reaches the end, it wraps to SIZE_MAX; SIZE_MAX + 1 is 0 */
+    size_t i;
+    for (i = script.customscripts.size() - 1; i + 1 > 0; --i)
     {
-        Script& script_ = script.customscripts[i];
-
-        if (script_.name == t)
+        if (script.customscripts[i].name == t)
         {
             script.customscripts.erase(script.customscripts.begin() + i);
-            break;
         }
     }
 }


### PR DESCRIPTION
If there were two scripts with the same name, removing one of them would only remove the other script from the script name list, and not also remove the contents of said script - leading to a desync in state, which is probably bad.

Fixing this isn't as simple as removing the `break` statement - I either also have to decrement the loop variable when removing the script, or iterate backwards. I chose to iterate backwards here because it relocates less memory than iterating forwards.

Also I removed the `<algorithm>` include from `editor.cpp`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
