### PR TITLE
Fix VVVVVV-Man not warping horizontally and rescuable crewmates not warping at all

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -967,49 +967,49 @@ void gamelogic(void)
                     continue;
                 }
 
-                    if (game.roomx == 118 && game.roomy == 102 && obj.entities[i].rule==1 && !map.custommode)
+                if (game.roomx == 118 && game.roomy == 102 && obj.entities[i].rule==1 && !map.custommode)
+                {
+                    //ascii snakes
+                    if (obj.entities[i].xp <= -80)
                     {
-                        //ascii snakes
-                        if (obj.entities[i].xp <= -80)
+                        if (obj.entities[i].isplatform)
                         {
-                            if (obj.entities[i].isplatform)
-                            {
-                                obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp + 400, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
-                            }
-                            obj.entities[i].xp += 400;
-                            obj.entities[i].lerpoldxp += 400;
+                            obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp + 400, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
                         }
-                        else if (obj.entities[i].xp > 320)
-                        {
-                            if (obj.entities[i].isplatform)
-                            {
-                                obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp - 400, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
-                            }
-                            obj.entities[i].xp -= 400;
-                            obj.entities[i].lerpoldxp -= 400;
-                        }
+                        obj.entities[i].xp += 400;
+                        obj.entities[i].lerpoldxp += 400;
                     }
-                    else
+                    else if (obj.entities[i].xp > 320)
                     {
-                        if (obj.entities[i].xp <= -10)
+                        if (obj.entities[i].isplatform)
                         {
-                            if (obj.entities[i].isplatform)
-                            {
-                                obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp + 320, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
-                            }
-                            obj.entities[i].xp += 320;
-                            obj.entities[i].lerpoldxp += 320;
+                            obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp - 400, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
                         }
-                        else if (obj.entities[i].xp > 310)
-                        {
-                            if (obj.entities[i].isplatform)
-                            {
-                                obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp - 320, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
-                            }
-                            obj.entities[i].xp -= 320;
-                            obj.entities[i].lerpoldxp -= 320;
-                        }
+                        obj.entities[i].xp -= 400;
+                        obj.entities[i].lerpoldxp -= 400;
                     }
+                }
+                else
+                {
+                    if (obj.entities[i].xp <= -10)
+                    {
+                        if (obj.entities[i].isplatform)
+                        {
+                            obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp + 320, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
+                        }
+                        obj.entities[i].xp += 320;
+                        obj.entities[i].lerpoldxp += 320;
+                    }
+                    else if (obj.entities[i].xp > 310)
+                    {
+                        if (obj.entities[i].isplatform)
+                        {
+                            obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp - 320, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
+                        }
+                        obj.entities[i].xp -= 320;
+                        obj.entities[i].lerpoldxp -= 320;
+                    }
+                }
             }
         }
 
@@ -1023,24 +1023,24 @@ void gamelogic(void)
                     continue;
                 }
 
-                    if (obj.entities[i].yp <= -12)
+                if (obj.entities[i].yp <= -12)
+                {
+                    if (obj.entities[i].isplatform)
                     {
-                        if (obj.entities[i].isplatform)
-                        {
-                            obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp, obj.entities[i].yp + 232, obj.entities[i].w, obj.entities[i].h);
-                        }
-                        obj.entities[i].yp += 232;
-                        obj.entities[i].lerpoldyp += 232;
+                        obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp, obj.entities[i].yp + 232, obj.entities[i].w, obj.entities[i].h);
                     }
-                    else if (obj.entities[i].yp > 226)
+                    obj.entities[i].yp += 232;
+                    obj.entities[i].lerpoldyp += 232;
+                }
+                else if (obj.entities[i].yp > 226)
+                {
+                    if (obj.entities[i].isplatform)
                     {
-                        if (obj.entities[i].isplatform)
-                        {
-                            obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp, obj.entities[i].yp - 232, obj.entities[i].w, obj.entities[i].h);
-                        }
-                        obj.entities[i].yp -= 232;
-                        obj.entities[i].lerpoldyp -= 232;
+                        obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp, obj.entities[i].yp - 232, obj.entities[i].w, obj.entities[i].h);
                     }
+                    obj.entities[i].yp -= 232;
+                    obj.entities[i].lerpoldyp -= 232;
+                }
             }
         }
 
@@ -1055,24 +1055,24 @@ void gamelogic(void)
                     continue;
                 }
 
-                    if (obj.entities[i].xp <= -30)
+                if (obj.entities[i].xp <= -30)
+                {
+                    if (obj.entities[i].isplatform)
                     {
-                        if (obj.entities[i].isplatform)
-                        {
-                            obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp + 350, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
-                        }
-                        obj.entities[i].xp += 350;
-                        obj.entities[i].lerpoldxp += 350;
+                        obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp + 350, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
                     }
-                    else if (obj.entities[i].xp > 320)
+                    obj.entities[i].xp += 350;
+                    obj.entities[i].lerpoldxp += 350;
+                }
+                else if (obj.entities[i].xp > 320)
+                {
+                    if (obj.entities[i].isplatform)
                     {
-                        if (obj.entities[i].isplatform)
-                        {
-                            obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp - 350, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
-                        }
-                        obj.entities[i].xp -= 350;
-                        obj.entities[i].lerpoldxp -= 350;
+                        obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp - 350, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
                     }
+                    obj.entities[i].xp -= 350;
+                    obj.entities[i].lerpoldxp -= 350;
+                }
             }
         }
 

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -963,7 +963,7 @@ void gamelogic(void)
             {
                 if ((obj.entities[i].type >= 51
                 && obj.entities[i].type <= 54) /* Don't warp warp lines */
-                || obj.entities[i].size >= 12) /* Don't warp gravitron squares */
+                || obj.entities[i].size == 12) /* Don't warp gravitron squares */
                 {
                     continue;
                 }

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -958,7 +958,8 @@ void gamelogic(void)
         //Finally: Are we changing room?
         if (map.warpx && !map.towermode)
         {
-            for (size_t i = 0; i < obj.entities.size();  i++)
+            size_t i;
+            for (i = 0; i < obj.entities.size(); ++i)
             {
                 if(obj.entities[i].type<50 //Don't warp warp lines
                 && obj.entities[i].size < 12)   //Don't wrap SWN enemies
@@ -1012,7 +1013,8 @@ void gamelogic(void)
 
         if (map.warpy && !map.towermode)
         {
-            for (size_t i = 0; i < obj.entities.size();  i++)
+            size_t i;
+            for (i = 0; i < obj.entities.size(); ++i)
             {
                 if(obj.entities[i].type<50){ //Don't warp warp lines
                     if (obj.entities[i].yp <= -12)
@@ -1039,7 +1041,8 @@ void gamelogic(void)
 
         if (map.warpy && !map.warpx && !map.towermode)
         {
-            for (size_t i = 0; i < obj.entities.size();  i++)
+            size_t i;
+            for (i = 0; i < obj.entities.size(); ++i)
             {
 
                 if(obj.entities[i].type<50 //Don't warp warp lines

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -961,7 +961,8 @@ void gamelogic(void)
             size_t i;
             for (i = 0; i < obj.entities.size(); ++i)
             {
-                if (obj.entities[i].type >= 50 /* Don't warp warp lines */
+                if ((obj.entities[i].type >= 51
+                && obj.entities[i].type <= 54) /* Don't warp warp lines */
                 || obj.entities[i].size >= 12) /* Don't warp gravitron squares */
                 {
                     continue;
@@ -1018,7 +1019,8 @@ void gamelogic(void)
             size_t i;
             for (i = 0; i < obj.entities.size(); ++i)
             {
-                if (obj.entities[i].type >= 50) /* Don't warp warp lines */
+                if (obj.entities[i].type >= 51
+                && obj.entities[i].type <= 54) /* Don't warp warp lines */
                 {
                     continue;
                 }
@@ -1049,7 +1051,8 @@ void gamelogic(void)
             size_t i;
             for (i = 0; i < obj.entities.size(); ++i)
             {
-                if (obj.entities[i].type >= 50 /* Don't warp warp lines */
+                if ((obj.entities[i].type >= 51
+                && obj.entities[i].type <= 54) /* Don't warp warp lines */
                 || obj.entities[i].rule == 0) /* Don't warp the player */
                 {
                     continue;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -961,9 +961,12 @@ void gamelogic(void)
             size_t i;
             for (i = 0; i < obj.entities.size(); ++i)
             {
-                if(obj.entities[i].type<50 //Don't warp warp lines
-                && obj.entities[i].size < 12)   //Don't wrap SWN enemies
+                if (obj.entities[i].type >= 50 /* Don't warp warp lines */
+                || obj.entities[i].size >= 12) /* Don't warp gravitron squares */
                 {
+                    continue;
+                }
+
                     if (game.roomx == 118 && game.roomy == 102 && obj.entities[i].rule==1 && !map.custommode)
                     {
                         //ascii snakes
@@ -1007,7 +1010,6 @@ void gamelogic(void)
                             obj.entities[i].lerpoldxp -= 320;
                         }
                     }
-                }
             }
         }
 
@@ -1016,7 +1018,11 @@ void gamelogic(void)
             size_t i;
             for (i = 0; i < obj.entities.size(); ++i)
             {
-                if(obj.entities[i].type<50){ //Don't warp warp lines
+                if (obj.entities[i].type >= 50) /* Don't warp warp lines */
+                {
+                    continue;
+                }
+
                     if (obj.entities[i].yp <= -12)
                     {
                         if (obj.entities[i].isplatform)
@@ -1035,7 +1041,6 @@ void gamelogic(void)
                         obj.entities[i].yp -= 232;
                         obj.entities[i].lerpoldyp -= 232;
                     }
-                }
             }
         }
 
@@ -1044,10 +1049,12 @@ void gamelogic(void)
             size_t i;
             for (i = 0; i < obj.entities.size(); ++i)
             {
-
-                if(obj.entities[i].type<50 //Don't warp warp lines
-                &&obj.entities[i].rule!=0)
+                if (obj.entities[i].type >= 50 /* Don't warp warp lines */
+                || obj.entities[i].rule == 0) /* Don't warp the player */
                 {
+                    continue;
+                }
+
                     if (obj.entities[i].xp <= -30)
                     {
                         if (obj.entities[i].isplatform)
@@ -1066,7 +1073,6 @@ void gamelogic(void)
                         obj.entities[i].xp -= 350;
                         obj.entities[i].lerpoldxp -= 350;
                     }
-                }
             }
         }
 


### PR DESCRIPTION
The game excludes warp lines and gravitron squares from warping; unfortunately it over-blacklists too much and VVVVVV-Man and rescuable crewmates can't warp at all. This fixes it and makes them able to warp.

I've been in the custom level community for 7 years, and I don't know of any levels that warp rescuable crewmates or even use VVVVVV-Man in the first place. Furthermore, this in fact is more likely to fix things rather than break them, because entities falling out of the room are basically irretrievable. So this should be okay to do.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
