### PR TITLE
Fix using fullscreen toggle keybind in graphic options not updating grayness of 'resize to nearest'

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -456,10 +456,6 @@ static void menuactionpress(void)
         case 0:
             music.playef(11);
             graphics.screenbuffer->toggleFullScreen();
-
-            // Recreate menu to update "resize to nearest"
-            game.createmenu(game.currentmenuname, true);
-
             game.savestatsandsettings_menu();
             break;
         case 1:

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -445,6 +445,12 @@ static void menuactionpress(void)
         map.nexttowercolour();
         break;
     case Menu::graphicoptions:
+        if (graphics.screenbuffer == NULL)
+        {
+            SDL_assert(0 && "Screenbuffer is NULL!");
+            break;
+        }
+
         switch (game.currentmenuoption)
         {
         case 0:

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -251,6 +251,12 @@ static void menurender(void)
         }
         break;
     case Menu::graphicoptions:
+        if (graphics.screenbuffer == NULL)
+        {
+            SDL_assert(0 && "Screenbuffer is NULL!");
+            break;
+        }
+
         switch (game.currentmenuoption)
         {
         case 0:

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -4,6 +4,7 @@
 #include <stdio.h>
 
 #include "FileSystemUtils.h"
+#include "Game.h"
 #include "GraphicsUtil.h"
 
 // Used to create the window icon
@@ -328,6 +329,12 @@ void Screen::toggleFullScreen(void)
 {
 	isWindowed = !isWindowed;
 	ResizeScreen(-1, -1);
+
+	if (game.currentmenuname == Menu::graphicoptions)
+	{
+		/* Recreate menu to update "resize to nearest" */
+		game.createmenu(game.currentmenuname, true);
+	}
 }
 
 void Screen::toggleStretchMode(void)


### PR DESCRIPTION
Title says it all. I also added a `NULL` pointer check when pressing ACTION in or rendering the graphic options menu, just to be safe.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
