### PR TITLE
Fix tower camera invincibility inconsistencies

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -892,11 +892,53 @@ void gamelogic(void)
 
                     if (above_screen)
                     {
-                        map.ypos-=10;
+                        if (obj.entities[player].yp - map.ypos <= 0)
+                        {
+                            if (graphics.towerbg.scrolldir == 1)
+                            {
+                                /* Descending tower:
+                                 * Counteract 10 pixels of terminal velocity
+                                 * + 2 pixels of camera movement */
+                                map.ypos -= 12;
+                            }
+                            else
+                            {
+                                /* Ascending tower:
+                                 * Move 8 out of 10 pixels of terminal velocity
+                                 * Camera movement will move 2 pixels for us */
+                                map.ypos -= 8;
+                            }
+                        }
+                        else
+                        {
+                            /* Counter 2 pixels of camera movement */
+                            map.ypos -= 2;
+                        }
                     }
                     else if (below_screen)
                     {
-                        map.ypos+=2;
+                        if (obj.entities[player].yp - map.ypos >= 208)
+                        {
+                            if (graphics.towerbg.scrolldir == 0)
+                            {
+                                /* Ascending tower:
+                                 * Counteract 10 pixels of terminal velocity
+                                 * + 2 pixels of camera movement */
+                                map.ypos += 12;
+                            }
+                            else
+                            {
+                                /* Descending tower:
+                                 * Move 8 out of 10 pixels of terminal velocity
+                                 * Camera movement will move 2 pixels for us */
+                                map.ypos += 8;
+                            }
+                        }
+                        else
+                        {
+                            /* Counter 2 pixels of camera movement */
+                            map.ypos += 2;
+                        }
                     }
 
                     if (above_screen || below_screen)


### PR DESCRIPTION
If you have invincibility enabled, the tower camera behavior is inconsistent.

In ascending towers, you can "push" the camera upwards; however you cannot push it downwards; at least it stays still when it comes up to you if you stay still. In descending towers, the camera moves quicker when you're at the bottom of the screen, but it's slower than your falling speed and quickly loses sight of you; the camera can be pushed upwards; unfortunately it also does a "bumping" motion if you're standing still when the camera reaches you, which gets real annoying and isn't particularly pleasant to look at.

There are two problems, so this PR does two fixes:

1. Pushing the camera now applies the appropriate counter-offset depending on the direction of the tower. You can now push the camera downwards in ascending towers.

2. To fix the "bumping" when the camera reaches you if you stand still, there are now a 8-pixel-high "gray areas" at the top and bottom of the screen where the camera simply won't move if you're in them.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
