### PR TITLE
Custom activity zone text and colours

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -759,7 +759,7 @@ void entityclass::generateswnwave( int t )
     }
 }
 
-void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*= 0*/, const std::string& script /*= ""*/ )
+void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*= 0*/, const std::string& script /*= ""*/, bool custom /*= false*/)
 {
     k = blocks.size();
 
@@ -1051,7 +1051,12 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
             trig=0;
             break;
         case 35:
-            block.prompt = "Press %s to activate terminal";
+            if (custom)
+            {
+                block.prompt = "Press %s to interact";
+            } else {
+                block.prompt = "Press %s to activate terminal";
+            }
             block.script = "custom_"+customscript;
             block.setblockcolour("orange");
             trig=0;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1056,7 +1056,9 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
             if (custom)
             {
                 block.prompt = "Press %s to interact";
-            } else {
+            }
+            else
+            {
                 block.prompt = "Press %s to activate terminal";
             }
             block.script = "custom_"+customscript;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -67,9 +67,11 @@ void entityclass::init(void)
     upsetmode = false;
     upset = 0;
 
-    customenemy=0;
-    customwarpmode=false; customwarpmodevon=false; customwarpmodehon=false;
-    trophytext = 0 ;
+    customenemy = 0;
+    customwarpmode = false; customwarpmodevon = false; customwarpmodehon = false;
+    customactivitycolour = "";
+    customactivitytext = "";
+    trophytext = 0;
     oldtrophytext = 0;
     trophytype = 0;
     altstates = 0;
@@ -1063,6 +1065,18 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
             break;
         }
         break;
+    }
+
+    if (customactivitytext != "")
+    {
+        block.prompt = customactivitytext;
+        customactivitytext = "";
+    }
+
+    if (customactivitycolour != "")
+    {
+        block.setblockcolour(customactivitycolour);
+        customactivitycolour = "";
     }
 
     if (!reuse)

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -52,7 +52,7 @@ public:
 
     void generateswnwave(int t);
 
-    void createblock(int t, int xp, int yp, int w, int h, int trig = 0, const std::string& script = "");
+    void createblock(int t, int xp, int yp, int w, int h, int trig = 0, const std::string& script = "", bool custom = false);
 
     bool disableentity(int t);
 

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -193,6 +193,8 @@ public:
     bool customwarpmode, customwarpmodevon, customwarpmodehon;
     std::string customscript;
     bool customcrewmoods[Game::numcrew];
+    std::string customactivitycolour;
+    std::string customactivitytext;
 };
 
 #ifndef OBJ_DEFINITION

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1909,8 +1909,11 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "setactivitytext")
 			{
-				position++;
-				obj.customactivitytext = commands[position];
+				++position;
+				if (INBOUNDS_VEC(position, commands))
+				{
+					obj.customactivitytext = commands[position];
+				}
 			}
 			else if (words[0] == "createrescuedcrew")
 			{

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1903,6 +1903,15 @@ void scriptclass::run(void)
 					obj.createblock(5, obj.entities[crewman].xp - 32, 0, 96, 240, i, "", (i == 35));
 				}
 			}
+			else if (words[0] == "setactivitycolour")
+			{
+				obj.customactivitycolour = words[1];
+			}
+			else if (words[0] == "setactivitytext")
+			{
+				position++;
+				obj.customactivitytext = commands[position];
+			}
 			else if (words[0] == "createrescuedcrew")
 			{
 				//special for final level cutscene

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3592,6 +3592,9 @@ void scriptclass::hardreset(void)
 	{
 		words[ii] = "";
 	}
+
+    obj.customactivitycolour = "";
+    obj.customactivitytext = "";
 }
 
 void scriptclass::loadcustom(const std::string& t)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1896,11 +1896,11 @@ void scriptclass::run(void)
 				int crewman = obj.getcrewman(i);
 				if (INBOUNDS_VEC(crewman, obj.entities) && i == 4)
 				{
-					obj.createblock(5, obj.entities[crewman].xp - 32, obj.entities[crewman].yp-20, 96, 60, i);
+					obj.createblock(5, obj.entities[crewman].xp - 32, obj.entities[crewman].yp-20, 96, 60, i, "", (i == 35));
 				}
 				else if (INBOUNDS_VEC(crewman, obj.entities))
 				{
-					obj.createblock(5, obj.entities[crewman].xp - 32, 0, 96, 240, i);
+					obj.createblock(5, obj.entities[crewman].xp - 32, 0, 96, 240, i, "", (i == 35));
 				}
 			}
 			else if (words[0] == "createrescuedcrew")


### PR DESCRIPTION
This PR adds two new internal commands to the game, being `setactivitycolour` and `setactivitytext`.
`setactivitycolour(colour)` sets the colour of the next activity zone spawned to the colour you pass as an argument, and `setactivitytext` changes the text of the net activity zone spawned to the text on the next line.
These changes were made this way to keep forwards compatibility; levels that use these commands will not break on earlier versions, only have the default orange `Press ENTER to activate terminal` text which would be shown anyway.

Additionally, activity zones spawned with ID 35 (custom level terminal) which are spawned through `createactivityzone` have had their default text changed to `Press ENTER to interact` (from `Press ENTER to activate terminal`). This change was done because using `createactivityzone` with invalid arguments would spawn an activity zone with the value stored in the `i` variable, which we can manipulate through other commands to set to `35`, which is normally the activity zone that activates terminals, meaning it's the only custom activity zone we can actually control. Since we can use this without it being attached to terminals, I think it's better for the default to be `Press ENTER to interact` instead of `Press ENTER to activate terminal`.

Terry has said [that these changes are fine,](https://owo.whats-th.is/7EwJMoC.png) so I'm making the pull request now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
