### PR TITLE
Fix three music regressions - incorrect fade durations, un-reset fade bools, 1-frame silence when playing track 0 or 7

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -15,7 +15,6 @@ musicclass::musicclass(void)
 	m_doFadeInVol = false;
 	m_doFadeOutVol = false;
 	musicVolume = 0;
-	FadeVolAmountPerFrame = 0;
 
 	user_music_volume = USER_VOLUME_MAX;
 	user_sound_volume = USER_VOLUME_MAX;
@@ -277,14 +276,45 @@ void musicclass::silencedasmusik(void)
 	musicVolume = 0;
 }
 
-void musicclass::setfadeamount(const int fade_ms)
+struct FadeState
 {
-	if (fade_ms == 0)
+	int start_volume;
+	int end_volume;
+	int duration_ms;
+	int step_ms;
+};
+
+static struct FadeState fade;
+
+enum FadeCode
+{
+	Fade_continue,
+	Fade_finished
+};
+
+static enum FadeCode processmusicfade(struct FadeState* state, int* volume)
+{
+	int range;
+	int new_volume;
+
+	if (state->duration_ms == 0 /* Fast path. */
+	|| state->start_volume == state->end_volume /* Fast path. */
+	|| state->step_ms >= state->duration_ms /* We're finished. */)
 	{
-		FadeVolAmountPerFrame = MIX_MAX_VOLUME;
-		return;
+		*volume = state->end_volume;
+		state->step_ms = 0;
+		return Fade_finished;
 	}
-	FadeVolAmountPerFrame = MIX_MAX_VOLUME / (fade_ms / game.get_timestep());
+
+	range = state->end_volume - state->start_volume;
+	new_volume = range * state->step_ms / state->duration_ms;
+	new_volume += state->start_volume;
+
+	*volume = new_volume;
+
+	state->step_ms += game.get_timestep();
+
+	return Fade_continue;
 }
 
 void musicclass::fadeMusicVolumeIn(int ms)
@@ -298,14 +328,19 @@ void musicclass::fadeMusicVolumeIn(int ms)
 	/* Fix 1-frame glitch */
 	Mix_VolumeMusic(0);
 
-	setfadeamount(ms);
+	fade.duration_ms = ms;
+	fade.start_volume = 0;
+	fade.end_volume = MIX_MAX_VOLUME;
 }
 
 void musicclass::fadeMusicVolumeOut(const int fadeout_ms)
 {
 	m_doFadeInVol = false;
 	m_doFadeOutVol = true;
-	setfadeamount(fadeout_ms);
+
+	fade.duration_ms = fadeout_ms;
+	fade.start_volume = musicVolume;
+	fade.end_volume = 0;
 }
 
 void musicclass::fadeout(const bool quick_fade_ /*= true*/)
@@ -316,8 +351,8 @@ void musicclass::fadeout(const bool quick_fade_ /*= true*/)
 
 void musicclass::processmusicfadein(void)
 {
-	musicVolume += FadeVolAmountPerFrame;
-	if (musicVolume >= MIX_MAX_VOLUME)
+	enum FadeCode fade_code = processmusicfade(&fade, &musicVolume);
+	if (fade_code == Fade_finished)
 	{
 		m_doFadeInVol = false;
 	}
@@ -325,8 +360,8 @@ void musicclass::processmusicfadein(void)
 
 void musicclass::processmusicfadeout(void)
 {
-	musicVolume -= FadeVolAmountPerFrame;
-	if (musicVolume < 0)
+	enum FadeCode fade_code = processmusicfade(&fade, &musicVolume);
+	if (fade_code == Fade_finished)
 	{
 		musicVolume = 0;
 		m_doFadeOutVol = false;

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -213,6 +213,7 @@ void musicclass::play(int t)
 		else
 		{
 			musicVolume = MIX_MAX_VOLUME;
+			Mix_VolumeMusic(musicVolume);
 		}
 	}
 	else

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -200,6 +200,9 @@ void musicclass::play(int t)
 		return;
 	}
 
+	m_doFadeInVol = false;
+	m_doFadeOutVol = false;
+
 	if (currentsong == 0 || currentsong == 7 || (!map.custommode && (currentsong == 0+num_mmmmmm_tracks || currentsong == 7+num_mmmmmm_tracks)))
 	{
 		// Level Complete theme, no fade in or repeat

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -27,7 +27,6 @@ public:
 	void pause(void);
 	void haltdasmusik(void);
 	void silencedasmusik(void);
-	void setfadeamount(const int fade_ms);
 	void fadeMusicVolumeIn(int ms);
 	void fadeMusicVolumeOut(const int fadeout_ms);
 	void fadeout(const bool quick_fade_ = true);
@@ -55,7 +54,6 @@ public:
 
 	bool m_doFadeInVol;
 	bool m_doFadeOutVol;
-	int FadeVolAmountPerFrame;
 	int musicVolume;
 
 	/* 0..USER_VOLUME_MAX */


### PR DESCRIPTION
This PR fixes three music regressions.

1. The fade durations ended up being longer than intended due to loss of precision in calculations.
2. Playing track 0 or 7 after music already faded out would end up immediately fading out those tracks, due to the fade booleans not being reset.
3. The first frame of track 0 or 7 would be silent, leading a lack of musical attack.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
