### PR TITLE
Fix tower background smearing when pushing camera in invincibility mode

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -896,17 +896,25 @@ void gamelogic(void)
                 }
                 else if (INBOUNDS_VEC(player, obj.entities))
                 {
-                    if (obj.entities[player].yp-map.ypos <= 0)
+                    const bool above_screen = obj.entities[player].yp-map.ypos <= 8;
+                    const bool below_screen = obj.entities[player].yp-map.ypos >= 200;
+
+                    if (above_screen)
                     {
                         map.ypos-=10;
-                        graphics.towerbg.bypos = map.ypos / 2;
-                        graphics.towerbg.bscroll = 0;
                     }
-                    else if (obj.entities[player].yp-map.ypos >= 208)
+                    else if (below_screen)
                     {
                         map.ypos+=2;
+                    }
+
+                    if (above_screen || below_screen)
+                    {
                         graphics.towerbg.bypos = map.ypos / 2;
-                        graphics.towerbg.bscroll = 0;
+                        graphics.towerbg.bscroll = (map.ypos - map.oldypos) / 2;
+
+                        /* The buffer isn't big enough; we have to redraw */
+                        graphics.towerbg.tdrawback = true;
                     }
                 }
 

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -222,7 +222,6 @@ void gamelogic(void)
                 //do nothing!
                 //a trigger will set this off in the game
                 map.cameramode = 1;
-                graphics.towerbg.bscroll = 0;
             }
             else if (map.cameramode == 1)
             {
@@ -230,20 +229,15 @@ void gamelogic(void)
                 if(graphics.towerbg.scrolldir==0)
                 {
                     map.ypos -= 2;
-                    graphics.towerbg.bypos -= 1;
-                    graphics.towerbg.bscroll = -1;
                 }
                 else
                 {
                     map.ypos += 2;
-                    graphics.towerbg.bypos += 1;
-                    graphics.towerbg.bscroll = 1;
                 }
             }
             else if (map.cameramode == 2)
             {
                 //do nothing, but cycle colours (for taking damage)
-                graphics.towerbg.bscroll = 0;
             }
             else if (map.cameramode == 4)
             {
@@ -257,8 +251,6 @@ void gamelogic(void)
                 map.cameraseekframe = 10;
 
                 map.cameramode = 5;
-
-                graphics.towerbg.bscroll = map.cameraseek/2;
             }
             else if (map.cameramode == 5)
             {
@@ -284,7 +276,6 @@ void gamelogic(void)
                         }
                     }
                     map.cameraseekframe--;
-                    graphics.towerbg.bypos = map.ypos / 2;
                 }
                 else
                 {
@@ -293,30 +284,21 @@ void gamelogic(void)
                     {
                         map.ypos = obj.entities[i].yp - 120;
                     }
-                    graphics.towerbg.bypos = map.ypos / 2;
                     map.cameramode = 0;
                     map.colsuperstate = 0;
                 }
             }
         }
-        else
-        {
-            graphics.towerbg.bscroll = 0;
-        }
 
         if (map.ypos <= 0)
         {
             map.ypos = 0;
-            graphics.towerbg.bypos = 0;
-            graphics.towerbg.bscroll = 0;
         }
         if (map.towermode && map.minitowermode)
         {
             if (map.ypos >= 568)
             {
                 map.ypos = 568;
-                graphics.towerbg.bypos = map.ypos / 2;
-                graphics.towerbg.bscroll = 0;
             } //100-29 * 8 = 568
         }
         else
@@ -324,7 +306,6 @@ void gamelogic(void)
             if (map.ypos >= 5368)
             {
                 map.ypos = 5368;    //700-29 * 8 = 5368
-                graphics.towerbg.bypos = map.ypos / 2.0;
             }
         }
 
@@ -910,9 +891,6 @@ void gamelogic(void)
 
                     if (above_screen || below_screen)
                     {
-                        graphics.towerbg.bypos = map.ypos / 2;
-                        graphics.towerbg.bscroll = (map.ypos - map.oldypos) / 2;
-
                         /* The buffer isn't big enough; we have to redraw */
                         graphics.towerbg.tdrawback = true;
                     }
@@ -1345,6 +1323,11 @@ void gamelogic(void)
         {
             map.twoframedelayfix();
         }
+    }
+
+    if (map.towermode)
+    {
+        map.setbgobjlerp(graphics.towerbg);
     }
 
     //Update colour cycling for final level

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -595,6 +595,12 @@ void mapclass::updatebgobj(TowerBG& bg_obj)
 	bg_obj.tdrawback = true;
 }
 
+void mapclass::setbgobjlerp(TowerBG& bg_obj)
+{
+	bg_obj.bypos = ypos / 2;
+	bg_obj.bscroll = (ypos - oldypos) / 2;
+}
+
 void mapclass::updatetowerglow(TowerBG& bg_obj)
 {
 	if (colstatedelay <= 0 || colsuperstate > 0)
@@ -827,7 +833,7 @@ void mapclass::resetplayer(const bool player_died)
 				ypos = 0;
 			}
 			oldypos = ypos;
-			graphics.towerbg.bypos = ypos / 2;
+			setbgobjlerp(graphics.towerbg);
 		}
 	}
 
@@ -1249,7 +1255,7 @@ void mapclass::loadlevel(int rx, int ry)
 
 				ypos = (700-29) * 8;
 				oldypos = ypos;
-				graphics.towerbg.bypos = ypos / 2;
+				setbgobjlerp(graphics.towerbg);
 				cameramode = 0;
 				graphics.towerbg.colstate = 0;
 				colsuperstate = 0;
@@ -1259,7 +1265,7 @@ void mapclass::loadlevel(int rx, int ry)
 				//you've entered from the top floor
 				ypos = 0;
 				oldypos = ypos;
-				graphics.towerbg.bypos = 0;
+				setbgobjlerp(graphics.towerbg);
 				cameramode = 0;
 				graphics.towerbg.colstate = 0;
 				colsuperstate = 0;
@@ -1342,14 +1348,13 @@ void mapclass::loadlevel(int rx, int ry)
 		graphics.towerbg.tdrawback = true;
 		minitowermode = false;
 		tower.minitowermode = false;
-		graphics.towerbg.bscroll = 0;
 		graphics.towerbg.scrolldir = 0;
+		setbgobjlerp(graphics.towerbg);
 
 		roomname = "The Tower";
 		tileset = 1;
 		background = 3;
 		towermode = true;
-		//graphics.towerbg.bypos = 0; ypos = 0; cameramode = 0;
 
 		//All the entities for here are just loaded here; it's essentially one room after all
 
@@ -1433,8 +1438,8 @@ void mapclass::loadlevel(int rx, int ry)
 		graphics.towerbg.tdrawback = true;
 		minitowermode = true;
 		tower.minitowermode = true;
-		graphics.towerbg.bscroll = 0;
 		graphics.towerbg.scrolldir = 1;
+		setbgobjlerp(graphics.towerbg);
 
 		roomname = "Panic Room";
 		tileset = 1;
@@ -1445,7 +1450,7 @@ void mapclass::loadlevel(int rx, int ry)
 
 		ypos = 0;
 		oldypos = 0;
-		graphics.towerbg.bypos = 0;
+		setbgobjlerp(graphics.towerbg);
 		cameramode = 0;
 		graphics.towerbg.colstate = 0;
 		colsuperstate = 0;
@@ -1455,8 +1460,8 @@ void mapclass::loadlevel(int rx, int ry)
 		graphics.towerbg.tdrawback = true;
 		minitowermode = true;
 		tower.minitowermode = true;
-		graphics.towerbg.bscroll = 0;
 		graphics.towerbg.scrolldir = 1;
+		setbgobjlerp(graphics.towerbg);
 
 		roomname = "Panic Room";
 		tileset = 1;
@@ -1474,7 +1479,7 @@ void mapclass::loadlevel(int rx, int ry)
 
 		ypos = (100-29) * 8;
 		oldypos = ypos;
-		graphics.towerbg.bypos = ypos/2;
+		setbgobjlerp(graphics.towerbg);
 		cameramode = 0;
 		graphics.towerbg.colstate = 0;
 		colsuperstate = 0;}
@@ -1484,8 +1489,8 @@ void mapclass::loadlevel(int rx, int ry)
 		graphics.towerbg.tdrawback = true;
 		minitowermode = true;
 		tower.minitowermode = true;
-		graphics.towerbg.bscroll = 0;
 		graphics.towerbg.scrolldir = 0;
+		setbgobjlerp(graphics.towerbg);
 		final_colorframe = 2;
 
 		roomname = "The Final Challenge";
@@ -1518,7 +1523,7 @@ void mapclass::loadlevel(int rx, int ry)
 
 		ypos = (100-29) * 8;
 		oldypos = ypos;
-		graphics.towerbg.bypos = ypos/2;
+		setbgobjlerp(graphics.towerbg);
 		cameramode = 0;
 		graphics.towerbg.colstate = 0;
 		colsuperstate = 0;
@@ -1530,8 +1535,8 @@ void mapclass::loadlevel(int rx, int ry)
 		graphics.towerbg.tdrawback = true;
 		minitowermode = true;
 		tower.minitowermode = true;
-		graphics.towerbg.bscroll = 0;
 		graphics.towerbg.scrolldir = 0;
+		setbgobjlerp(graphics.towerbg);
 		final_colorframe = 2;
 
 		roomname = "The Final Challenge";
@@ -1557,7 +1562,7 @@ void mapclass::loadlevel(int rx, int ry)
 
 		ypos = 0;
 		oldypos = 0;
-		graphics.towerbg.bypos = 0;
+		setbgobjlerp(graphics.towerbg);
 		cameramode = 0;
 		graphics.towerbg.colstate = 0;
 		colsuperstate = 0;

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -50,6 +50,8 @@ public:
 
     void updatebgobj(TowerBG& bg_obj);
 
+    void setbgobjlerp(TowerBG& bg_obj);
+
     void updatetowerglow(TowerBG& bg_obj);
 
     void nexttowercolour(void);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2707,7 +2707,7 @@ void scriptclass::startgamemode( int t )
 				map.ypos = obj.entities[i].yp - 120;
 				map.oldypos = map.ypos;
 			}
-			graphics.towerbg.bypos = map.ypos / 2;
+			map.setbgobjlerp(graphics.towerbg);
 			map.cameramode = 0;
 			map.colsuperstate = 0;
 		}

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2705,6 +2705,7 @@ void scriptclass::startgamemode( int t )
 			if (INBOUNDS_VEC(i, obj.entities))
 			{
 				map.ypos = obj.entities[i].yp - 120;
+				map.oldypos = map.ypos;
 			}
 			graphics.towerbg.bypos = map.ypos / 2;
 			map.cameramode = 0;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -494,6 +494,7 @@ int main(int argc, char *argv[])
     map.nexttowercolour();
 
     map.ypos = (700-29) * 8;
+    map.oldypos = map.ypos;
     graphics.towerbg.bypos = map.ypos / 2;
     graphics.titlebg.bypos = map.ypos / 2;
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -495,8 +495,8 @@ int main(int argc, char *argv[])
 
     map.ypos = (700-29) * 8;
     map.oldypos = map.ypos;
-    graphics.towerbg.bypos = map.ypos / 2;
-    graphics.titlebg.bypos = map.ypos / 2;
+    map.setbgobjlerp(graphics.towerbg);
+    map.setbgobjlerp(graphics.titlebg);
 
     {
         // Prioritize unlock.vvv first (2.2 and below),


### PR DESCRIPTION
If you have invincibility enabled and push the camera, the background would smear. This is because the game doesn't calculate the proper `bscroll` and `bypos` of the tower background, and also doesn't end up redrawing it.

We do both these things now, so this is fixed.

Additionally, all `bscroll` and `bypos` calculations have been consolidated, to fix any other potential issues with the background.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
