### PR TITLE
Enable returning to Secret Lab immediately from Super Gravitron

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2064,7 +2064,8 @@ void gameinput(void)
     {
         // Do nothing
     }
-    else if (game.swnmode == 1 && game.swngame == 1)
+    else if (game.swnmode == 1
+    && (game.swngame == 1 || game.swngame == 6 || game.swngame == 7))
     {
         //quitting the super gravitron
         game.mapheld = true;


### PR DESCRIPTION
When you enter the Super Gravitron, you have to wait until the Super Gravitron actually starts before being able to press Enter to return to the Secret Lab. This is annoying if you just want to get back to the Secret Lab. So, I've made it so the press-Enter-to-return functionality is enabled from the moment that the Super Gravitron starts.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
