### PR TITLE
Allow using Esc in Super Gravitron quit menu

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2215,13 +2215,16 @@ void mapinput(void)
         {
             game.press_action = true;
         }
-        if (game.menupage < 12 || (game.menupage >= 30 && game.menupage <= 32))
+        if (game.menupage < 12
+        || (game.menupage >= 20 && game.menupage <= 21)
+        || (game.menupage >= 30 && game.menupage <= 32))
         {
             if (key.isDown(KEYBOARD_ENTER) || key.isDown(game.controllerButton_map) ) game.press_map = true;
             if (key.isDown(27) && !game.mapheld)
             {
                 game.mapheld = true;
-                if (game.menupage < 9)
+                if (game.menupage < 9
+                || (game.menupage >= 20 && game.menupage <= 21))
                 {
                     game.menupage = 30;
                 }


### PR DESCRIPTION
This is a small quality-of-life fix in the same vein as allowing the player to press Esc in the teleporter menu (which they weren't able to do in 2.2, either).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
