### PR TITLE
Fix 1-frame glitch returning from in-game options with Flip Mode on

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6725,6 +6725,11 @@ static void setfademode(void)
     graphics.fademode = graphics.ingame_fademode;
 }
 
+static void setflipmode(void)
+{
+    graphics.flipmode = graphics.setflipmode;
+}
+
 void Game::returntoingame(void)
 {
     ingame_titlemode = false;
@@ -6742,7 +6747,7 @@ void Game::returntoingame(void)
     {
         DEFER_CALLBACK(returntoingametemp);
         gamestate = MAPMODE;
-        graphics.flipmode = graphics.setflipmode;
+        DEFER_CALLBACK(setflipmode);
         DEFER_CALLBACK(setfademode);
         if (!map.custommode && !graphics.flipmode)
         {


### PR DESCRIPTION
If you had Flip Mode enabled when exiting from in-game options, the game would flash the in-game options menu as flipped for 1 frame before returning to the pause menu.

To fix this, just defer the Flip Mode variable assignment to be done at the end of the frame.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
