### PR TITLE
Fix deltaframe glitch when spawning No Death Mode trophy

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1259,8 +1259,6 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
     entclass& entity = *entptr;
     entity.xp = xp;
     entity.yp = yp;
-    entity.lerpoldxp = xp;
-    entity.lerpoldyp = yp;
     entity.type = t;
     switch(t)
     {
@@ -1829,7 +1827,6 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
                 entity.tile = 188 + meta1;
                 entity.colour = 37;
                 entity.h += 3;
-                entity.lerpoldyp -= 3;
                 entity.yp -= 3;
             }
             break;
@@ -2094,6 +2091,8 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         break;
     }
 
+    entity.lerpoldxp = entity.xp;
+    entity.lerpoldyp = entity.yp;
     entity.drawframe = entity.tile;
 
     if (!reuse)


### PR DESCRIPTION
If you have completed No Death Mode, and entered the Master of the Universe trophy room in the Secret Lab in over-30-FPS mode, it would appear to start at one position before quickly zipping to another during the deltaframes.

This is because it updates its position after the initial assignments of `lerpoldxp`/`lerpoldyp` in `entityclass::createentity()`.

Other entities do this too, and what's been done for them is to copy-paste the `lerpoldxp`/`lerpoldyp` updates alongside the `xp`/`yp` updates. However, instead of single-case patching this deltaframe glitch, I've opted to fix *all* cases by simply moving the `lerpoldxp`/`lerpoldyp` assignments to the end of the function, guaranteeing that all entities that update their position after the initial assignment in the function will not have any deltaframe glitches.

Of course, there's still the duplicate `lerpoldxp`/`lerpoldyp` updates in `entityclass::updateentities()`... I'm not sure what to do about those.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
