### PR TITLE
Change final stretch song to Piercing the Sky

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1472,7 +1472,7 @@ void Game::updatestate(void)
             //Init final stretch
             state++;
             music.playef(9);
-            music.play(2);
+            music.play(14);
             obj.flags[72] = true;
 
             screenshake = 10;

--- a/desktop_version/src/TerminalScripts.cpp
+++ b/desktop_version/src/TerminalScripts.cpp
@@ -434,7 +434,7 @@ void scriptclass::loadother(const char* t)
         "speak_active",
         "endtext",
 
-        "play(2)",
+        "play(14)",
         "changemood(player,0)",
 
         "endcutscene()",


### PR DESCRIPTION
After the dimension destabilizes, the song that plays is Positive Force. Which has already been played twice in the game at that point (first in Tower, then in the Gravitron). Since Piercing the Sky is unused, why not play a song that the player hasn't heard before? It would also be musically fitting for the scenario.

The song gets played in two places - one for if you have cutscenes enabled, and one for if you don't - so we just need to change both of them.

I asked Terry in Discord DMs if he wanted this change and he approved of it.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
