### PR TITLE
Don't update crewmate colors in text boxes every deltaframe

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -955,7 +955,7 @@ void Graphics::drawgui(void)
         if (textbox[i].tr == 175 && textbox[i].tg == 175)
         {
             //purple guy
-            drawsprite(80 - 6, crew_yp, crew_sprite, 220- help.glow/4 - int(fRandom()*20), 120- help.glow/4, 210 - help.glow/4);
+            drawsprite(80 - 6, crew_yp, crew_sprite, 220- help.glow/4 - textbox[i].rand, 120- help.glow/4, 210 - help.glow/4);
         }
         else if (textbox[i].tr == 175 && textbox[i].tb == 175)
         {
@@ -965,17 +965,17 @@ void Graphics::drawgui(void)
         else if (textbox[i].tr == 175)
         {
             //green guy
-            drawsprite(80 - 6, crew_yp, crew_sprite, 120 - help.glow / 4 - int(fRandom() * 20), 220 - help.glow / 4, 120 - help.glow / 4);
+            drawsprite(80 - 6, crew_yp, crew_sprite, 120 - help.glow / 4 - textbox[i].rand, 220 - help.glow / 4, 120 - help.glow / 4);
         }
         else if (textbox[i].tg == 175)
         {
             //yellow guy
-            drawsprite(80 - 6, crew_yp, crew_sprite, 220- help.glow/4 - int(fRandom()*20), 210 - help.glow/4, 120- help.glow/4);
+            drawsprite(80 - 6, crew_yp, crew_sprite, 220- help.glow/4 - textbox[i].rand, 210 - help.glow/4, 120- help.glow/4);
         }
         else if (textbox[i].tb == 175)
         {
             //blue guy
-            drawsprite(80 - 6, crew_yp, crew_sprite, 75, 75, 255- help.glow/4 - int(fRandom()*20));
+            drawsprite(80 - 6, crew_yp, crew_sprite, 75, 75, 255- help.glow/4 - textbox[i].rand);
         }
     }
 }
@@ -991,6 +991,16 @@ void Graphics::updatetextboxes(void)
             textbox.erase(textbox.begin() + i);
             i--;
             continue;
+        }
+
+        if (textbox[i].tl >= 1.0f
+        && ((textbox[i].tr == 175 && textbox[i].tg == 175)
+        || textbox[i].tr == 175
+        || textbox[i].tg == 175
+        || textbox[i].tb == 175)
+        && (textbox[i].tr != 175 || textbox[i].tb != 175))
+        {
+            textbox[i].rand = fRandom() * 20;
         }
     }
 }

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -23,6 +23,8 @@ textboxclass::textboxclass(void)
     max = 0;
 
     flipme = false;
+
+    rand = 0;
 }
 
 void textboxclass::centerx(void)

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -45,6 +45,8 @@ public:
 
     /* Whether to flip text box y-position in Flip Mode. */
     bool flipme;
+
+    int rand;
 };
 
 #endif /* TEXTBOX_H */


### PR DESCRIPTION
Colors in over-30-FPS mode shouldn't be updating every deltaframe; mostly to ensure determinism between switching 30-mode and over-30 mode. I'm going to overhaul RNG in 2.4 anyway, but right now I'm going to fix this because I missed it.

The RNG of each special text box is stored in a temporary variable on the text box itself, and only updated if the color uses it (hence the big if-statement). Lots of code duplication, but this is acceptable for now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
