### PR TITLE
Fix Super Gravitron pattern oversight

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -418,6 +418,7 @@ void entityclass::generateswnwave( int t )
             case 3:
                 //Choose a major action
                 game.swnstate2 = int(fRandom() * 100);
+                game.swnstate4 = 0;
                 if (game.swnstate2 < 25)
                 {
                     //complex


### PR DESCRIPTION
There is a pattern in the Super Gravitron that is meant to "staircase", similar to the Gravitron in Intermission 2. It looks like this:

![Broken gravitron pattern](https://user-images.githubusercontent.com/59748578/119043284-ba1d7a80-b96d-11eb-8302-3cf628ccb1d3.png)
<sup>How the pattern was intended - four descending squares, with two offscreen, and one more yet to spawn.</sup>

Unfortunately, due to an oversight, this pattern can only ever produce 1 square or 4 squares, which look out of place. So instead it currently looks like:

![Fixed gravitron pattern](https://user-images.githubusercontent.com/59748578/119043202-a540e700-b96d-11eb-873e-718efe2b4691.png)
<sup>There is only one square on the left, then it immediately goes to a different pattern (two sets of two squares vertically opposite each other).</sup>

Both gravitrons are state machines (of course). States 20 and 21 in the Super Gravitron are this staircase pattern (state 20 spawns the squares on the left, state 21 spawns the squares on the right).

The only way states 20 and 21 can be reached is through state 1, and the only way state 1 can be reached is through state 3. The only way state 3 can be reached is through states 28, 29, 30, and 31.

In states 20 and 21, the variable used to keep track of the amount of squares spawned is `swnstate4`. However, states 28, 29, 30, and 31 all end up using swnstate4, and at the end of states 28 and 29, `swnstate4` will be 7, and at the end of states 30 and 31, `swnstate4` will be 3. This means if we go to states 20 and 21 after coming from states 28 and 29, we will only get 1 square, and if we go to states 20 and 21 after coming from states 30 and 31, we will only get 4 squares.

This can be clearly filed under a failure to reset appropriate state.

What's the solution here? Just reset `swnstate4` in state 3, so there will be 7 squares, as intended. This also fixes the bug for state 22 as well, which is affected in the same manner.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
