### PR TITLE
Save showtargets to main game save files

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4971,6 +4971,10 @@ void Game::readmaingamesave(tinyxml2::XMLDocument& doc)
                 music.play(song);
             }
         }
+        else if (SDL_strcmp(pKey, "showtargets") == 0)
+        {
+            map.showtargets = help.Int(pText);
+        }
 
     }
 
@@ -5494,6 +5498,8 @@ std::string Game::writemaingamesave(tinyxml2::XMLDocument& doc)
     {
         xml::update_tag(msgs, "currentsong", music.currentsong);
     }
+
+    xml::update_tag(msgs, "showtargets", (int) map.showtargets);
 
     xml::update_tag(msgs, "teleportscript", teleportscript.c_str());
     xml::update_tag(msgs, "companion", companion);


### PR DESCRIPTION
This fixes an oversight that could lead to confusion by the player.

`showtargets` is the variable that shows all unexplored teleporters on the map as a question mark, so players know where to head to to make progress. However, it previously was not directly saved to the main game file. Instead, it would be set to true if flag 12 was turned on in the save file.

How well does flag 12 correlate with `showtargets`?

Well, the script that turns on `showtargets` (`bigopenworld` and `bigopenworldskip`) doesn't turn it on. Neither does completing Space Station 1.

This flag is only turned on when the player activates Violet's activity zone for the first time.

Therefore, it's entirely possible that a new player could complete Space Station 1, then save their game, and come back to resume playing later. When they do come back, the question marks that Violet told them about won't show up on the minimap, and they'll be confused. They may not know where to go.

And it is completely unintuitive for them to know that in order to get the question marks to show up again, they have to not only talk to Violet, but then save the game again, and reload the save. Especially since the question marks only show up after you reload the save, and not when you talk to Violet (because flag 12 is only a proxy for `showtargets`, not the actual variable itself).

So what's the solution? Just save `showtargets` to the save file directly.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
