### PR TITLE
Add zip structure checks for user friendliness

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -11,6 +11,7 @@
 #include "Exit.h"
 #include "Graphics.h"
 #include "Maths.h"
+#include "Unused.h"
 #include "UtilityClass.h"
 
 /* These are needed for PLATFORM_* crap */
@@ -309,9 +310,147 @@ static bool FILESYSTEM_mountAssetsFrom(const char *fname)
 	return true;
 }
 
+struct ArchiveState
+{
+	const char* filename;
+	bool has_extension;
+	bool other_level_files;
+};
+
+static PHYSFS_EnumerateCallbackResult zipCheckCallback(
+	void* data,
+	const char* origdir,
+	const char* filename
+) {
+	struct ArchiveState* state = (struct ArchiveState*) data;
+	const bool has_extension = endsWith(filename, ".vvvvvv");
+	UNUSED(origdir);
+
+	if (!state->has_extension)
+	{
+		state->has_extension = has_extension;
+	}
+	if (!state->other_level_files && has_extension)
+	{
+		state->other_level_files = SDL_strcmp(
+			state->filename,
+			filename
+		) != 0;
+	}
+
+	if (state->has_extension && state->other_level_files)
+	{
+		/* We don't need to check any more files. */
+		return PHYSFS_ENUM_STOP;
+	}
+	return PHYSFS_ENUM_OK;
+}
+
+/* For technical reasons, the level file inside a zip named LEVELNAME.zip must
+ * be named LEVELNAME.vvvvvv, else its custom assets won't work;
+ * if there are .vvvvvv files other than LEVELNAME.vvvvvv, they would be loaded
+ * too but they won't load any assets
+ *
+ * For user-friendliness, we check this upfront and reject all zips that don't
+ * conform to this (regardless of them containing assets or not) - otherwise a
+ * level zip with assets can be played but its assets mysteriously won't work
+ */
+static bool checkZipStructure(const char* filename)
+{
+	const char* real_dir = PHYSFS_getRealDir(filename);
+	char base_name[MAX_PATH];
+	char real_path[MAX_PATH];
+	char mount_path[MAX_PATH];
+	char check_path[MAX_PATH];
+	char random_str[6 + 1];
+	bool success;
+	struct ArchiveState zip_state;
+
+	if (real_dir == NULL)
+	{
+		printf(
+			"Could not check %s: real directory doesn't exist\n",
+			filename
+		);
+		return false;
+	}
+
+	SDL_snprintf(real_path, sizeof(real_path), "%s/%s", real_dir, filename);
+
+	generateBase36(random_str, sizeof(random_str));
+	SDL_snprintf(mount_path, sizeof(mount_path), ".vvv-mnt-temp-%s/", random_str);
+
+	if (!PHYSFS_mount(real_path, mount_path, 1))
+	{
+		printf(
+			"Error mounting and checking %s: %s\n",
+			filename,
+			PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
+		);
+		return false;
+	}
+
+	VVV_between(filename, "levels/", base_name, ".zip");
+
+	SDL_snprintf(
+		check_path,
+		sizeof(check_path),
+		"%s%s.vvvvvv",
+		mount_path,
+		base_name
+	);
+
+	success = PHYSFS_exists(check_path);
+
+	SDL_zero(zip_state);
+	zip_state.filename = check_path;
+
+	PHYSFS_enumerate(mount_path, zipCheckCallback, (void*) &zip_state);
+
+	/* If no .vvvvvv files in zip, don't print warning. */
+	if (!success && zip_state.has_extension)
+	{
+		/* FIXME: How do we print this for non-terminal users? */
+		printf(
+			"%s.zip is not structured correctly! It is missing %s.vvvvvv.\n",
+			base_name,
+			base_name
+		);
+	}
+
+	success &= !zip_state.other_level_files;
+
+	/* ...But if other .vvvvvv file(s), do print warning. */
+	if (zip_state.other_level_files)
+	{
+		/* FIXME: How do we print this for non-terminal users? */
+		printf(
+			"%s.zip is not structured correctly! It has .vvvvvv file(s) other than %s.vvvvvv.\n",
+			base_name,
+			base_name
+		);
+	}
+
+	if (!PHYSFS_unmount(real_path))
+	{
+		printf(
+			"Could not unmount %s: %s\n",
+			mount_path,
+			PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())
+		);
+	}
+
+	return success;
+}
+
 void FILESYSTEM_loadZip(const char* filename)
 {
 	PHYSFS_File* zip = PHYSFS_openRead(filename);
+
+	if (!checkZipStructure(filename))
+	{
+		return;
+	}
 
 	if (!PHYSFS_mountHandle(zip, filename, "levels", 1))
 	{

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -244,13 +244,12 @@ static bool FILESYSTEM_exists(const char *fname)
 	return PHYSFS_exists(fname);
 }
 
-static void generateVirtualMountPath(char* path, const size_t path_size)
+static void generateBase36(char* string, const size_t string_size)
 {
-	char random[6 + 1] = {'\0'};
 	size_t i;
-	for (i = 0; i < SDL_arraysize(random) - 1; ++i)
+	for (i = 0; i < string_size - 1; ++i)
 	{
-		/* Generate a-z0-9 (base 36) */
+		/* a-z0-9 */
 		char randchar = fRandom() * 36;
 		if (randchar <= 26)
 		{
@@ -261,13 +260,20 @@ static void generateVirtualMountPath(char* path, const size_t path_size)
 			randchar -= 26;
 			randchar += '0';
 		}
-		random[i] = randchar;
+		string[i] = randchar;
 	}
+	string[string_size - 1] = '\0';
+}
+
+static void generateVirtualMountPath(char* path, const size_t path_size)
+{
+	char random_str[6 + 1];
+	generateBase36(random_str, sizeof(random_str));
 	SDL_snprintf(
 		path,
 		path_size,
 		".vvv-mnt-virtual-%s/custom-assets/",
-		random
+		random_str
 	);
 }
 

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -325,25 +325,12 @@ void FILESYSTEM_loadZip(const char* filename)
 
 void FILESYSTEM_mountAssets(const char* path)
 {
-	const size_t path_size = SDL_strlen(path);
 	char filename[MAX_PATH];
 	char zip_data[MAX_PATH];
 	const char* zip_normal;
 	char dir[MAX_PATH];
 
-	/* path is going to look like "levels/LEVELNAME.vvvvvv".
-	 * We want LEVELNAME, which entails starting from index 7
-	 * (which is how long "levels/" is)
-	 * and then grabbing path_size-14 characters
-	 * (14 chars because "levels/" and ".vvvvvv" are both 7 chars).
-	 * We also add 1 when calculating the amount of bytes to grab
-	 * to account for the null terminator.
-	 */
-	SDL_strlcpy(
-		filename,
-		&path[7],
-		VVV_min((path_size - 14) + 1, sizeof(filename))
-	);
+	VVV_between(path, "levels/", filename, ".vvvvvv");
 
 	SDL_snprintf(
 		zip_data,

--- a/desktop_version/src/Network.c
+++ b/desktop_version/src/Network.c
@@ -1,8 +1,7 @@
 #include <stdint.h>
 
 #include "MakeAndPlay.h"
-
-#define UNUSED(expr) (void)(expr)
+#include "Unused.h"
 
 #ifdef MAKEANDPLAY
 	#ifdef STEAM_NETWORK

--- a/desktop_version/src/Unused.h
+++ b/desktop_version/src/Unused.h
@@ -1,0 +1,6 @@
+#ifndef UNUSED_H
+#define UNUSED_H
+
+#define UNUSED(expr) (void)(expr)
+
+#endif /* UNUSED_H */

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -344,3 +344,18 @@ void VVV_fillstring(
 	SDL_memset(buffer, fillchar, buffer_size - 1);
 	buffer[buffer_size - 1] = '\0';
 }
+void _VVV_between(
+	const char* original,
+	const size_t left_length,
+	char* middle,
+	const size_t right_length,
+	const size_t middle_size
+) {
+	size_t middle_length = SDL_strlen(original);
+	middle_length -= left_length + right_length;
+	SDL_strlcpy(
+		middle,
+		&original[left_length],
+		VVV_min(middle_length + 1, middle_size)
+	);
+}

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -45,6 +45,28 @@ void VVV_fillstring(
         puts(message); \
     }
 
+/* Don't call this directly; use the VVV_between macro. */
+void _VVV_between(
+    const char* original,
+    const size_t left_length,
+    char* middle,
+    const size_t right_length,
+    const size_t middle_size
+);
+
+/* If original is "LEFTMIDDLERIGHT", VVV_between(original, "LEFT", buffer, "RIGHT")
+ * will put "MIDDLE" into buffer - assuming that sizeof(buffer) refers to length
+ * of buffer and not length of pointer to buffer.
+ */
+#define VVV_between(original, left, middle, right) \
+    _VVV_between( \
+        original, \
+        SDL_arraysize(left) - 1, \
+        middle, \
+        SDL_arraysize(right) - 1, \
+        sizeof(middle) \
+    )
+
 
 //helperClass
 class UtilityClass


### PR DESCRIPTION
If a level zip is named `LEVELNAME.zip`, the level file inside it must also be named `LEVELNAME.vvvvvv`, else custom assets won't work.

This is because when we mount the zip file, we simply add `LEVELNAME.vvvvvv` to the levels directory. Then whenever we load `LEVELNAME.vvvvvv`, we look at the filename, remove the extension, and look for the assets inside the zip of the same name, `LEVELNAME.zip`.

As a result, if someone were to make a level zip with assets but mismatch the filename, the assets wouldn't load. Furthermore, if someone were to add extra levels in the same zip, they wouldn't have any assets load for them as well, which could be confusing.

To make things crystal-clear to the user, we now filter out any zips that have incorrect structures like that, and print a message to the terminal. Unfortunately nothing gets shown for non-terminal users, but at least doing this and filtering out the zips is less confusing than letting them through but with the issues mentioned above.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
