### PR TITLE
Set newxp/newyp when creating player

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1273,6 +1273,10 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.h = 21;
         entity.dir = 1;
 
+        /* Fix wrong y-position if spawning in on conveyor */
+        entity.newxp = xp;
+        entity.newyp = yp;
+
         if (meta1 == 1) entity.invis = true;
 
         entity.gravity = true;


### PR DESCRIPTION
This fixes a bug where the player's y-position would be incorrect if they loaded a save that was on a conveyor and it was their first time loading in since the game was opened.

This is because on the first load, the game creates a new player entity, but on subsequent loads, the game re-uses the player entity. Subsequent loads use `mapclass::resetplayer()`, which already has the `newxp`/`newyp` fix, but as for the first time, the game does not set `newxp`/`newyp`.

So just set `newxp`/`newyp`, like in `mapclass::resetplayer()`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
