### PR TITLE
Play Viridian squeak when editing level desc fields

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3828,11 +3828,11 @@ static void editormenuactionpress(void)
             key.keybuffer=ed.website;
             break;
         case 4:
-            music.playef(11);
             game.returnmenu();
             map.nexttowercolour();
             break;
         }
+        music.playef(11);
         break;
     case Menu::ed_settings:
         switch (game.currentmenuoption)
@@ -4047,6 +4047,7 @@ void editorinput(void)
             ed.desc3mod=false;
             ed.websitemod=false;
             ed.creatormod=false;
+            music.playef(11);
 
             ed.shiftmenu=false;
             ed.shiftkey=false;
@@ -4499,6 +4500,7 @@ void editorinput(void)
                     key.enabletextentry();
                     key.keybuffer=ed.Desc3;
                 }
+                music.playef(11);
             }
         }
     }


### PR DESCRIPTION
For consistency, the Viridian squeak will now play whenever you start editing a level description field, or finish editing it (either by pressing Esc or Enter).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
