### PR TITLE
Fix inconsistencies with controller keybind options

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1840,6 +1840,7 @@ void titleinput(void)
                 key.controllerButtonDown()      )
         {
             updatebuttonmappings(game.currentmenuoption);
+            music.playef(11);
             game.savestatsandsettings_menu();
         }
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1840,6 +1840,7 @@ void titleinput(void)
                 key.controllerButtonDown()      )
         {
             updatebuttonmappings(game.currentmenuoption);
+            game.savestatsandsettings_menu();
         }
 
     }


### PR DESCRIPTION
Settings are now saved after updating controller keybinds, and Viridian squeaks are played when using the controller keybind options.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
