### PR TITLE
Fix being able to see box corners on map screen with custom graphics

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1931,7 +1931,7 @@ void maprender(void)
 
 
     //Menubar:
-    graphics.drawtextbox( -10, 212, 42, 3, 65, 185, 207);
+    graphics.drawtextbox( -10, 212, 43, 3, 65, 185, 207);
 
     // Draw the selected page name at the bottom
     // menupage 0 - 3 is the pause screen


### PR DESCRIPTION
The text box drawn at the bottom of the map screen isn't wide enough, so it's possible to see the corners on the right side of the text box if you have custom graphics like I do.

![Right-side corners visible](https://user-images.githubusercontent.com/59748578/121768352-aa2f2b80-cb12-11eb-9eba-c42ec221d69e.png)

The solution is to increase the width of the text box by one tile.

![Right-side corners fixed](https://user-images.githubusercontent.com/59748578/121768384-cd59db00-cb12-11eb-9be1-a5f902257cbb.png)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
