### PR TITLE
Prevent losing level data with rollcredits

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1567,9 +1567,20 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "rollcredits")
 			{
-				game.gamestate = GAMECOMPLETE;
-				graphics.fademode = 4;
-				game.creditposition = 0;
+#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
+				if (map.custommode && !map.custommodeforreal)
+				{
+					game.returntoeditor();
+					ed.note = "Rolled credits";
+					ed.notedelay = 45;
+				}
+				else
+#endif
+				{
+					game.gamestate = GAMECOMPLETE;
+					graphics.fademode = 4;
+					game.creditposition = 0;
+				}
 			}
 			else if (words[0] == "finalmode")
 			{


### PR DESCRIPTION
When `rollcredits` is ran during in-editor playtesting, all unsaved data is lost. To prevent this, just return to the editor if `rollcredits` is ran, with a note saying "Rolled credits".

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
