### PR TITLE
Interpolate gravitron square indicators

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2033,7 +2033,7 @@ void Graphics::drawentity(const int i, const int yoff)
         {
             if (obj.entities[i].xp < -100)
             {
-                tpoint.x = -5 + (int(( -obj.entities[i].xp) / 10));
+                tpoint.x = -5 + (int(( -xp) / 10));
             }
             else
             {
@@ -2056,7 +2056,7 @@ void Graphics::drawentity(const int i, const int yoff)
         {
             if (obj.entities[i].xp > 420)
             {
-                tpoint.x = 320 - (int(( obj.entities[i].xp-320) / 10));
+                tpoint.x = 320 - (int(( xp-320) / 10));
             }
             else
             {


### PR DESCRIPTION
This is more future-proofing than anything else. The position of the indicators is just the x-position of the gravitron square divided by 10, but the gravitron squares will always only ever move at 7 pixels per frame - so the distance an indicator travels on each frame will only ever be at most 1 pixel. But just in case in the future gravitron squares become faster than 10 pixels per frame, their indicators will be interpolated as well.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
