### PR TITLE
Explore all rooms when entering Secret Lab 

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2840,14 +2840,9 @@ void scriptclass::startgamemode( int t )
 		game.jumpheld = true;
 
 		//Secret lab, so reveal the map, give them all 20 trinkets
-		for (int j = 0; j < 20; j++)
-		{
-			obj.collect[j] = true;
-			for (i = 0; i < 20; i++)
-			{
-				map.setexplored(i, j, true);
-			}
-		}
+		SDL_memset(obj.collect, true, sizeof(obj.collect[0]) * 20);
+		SDL_memset(map.explored, true, sizeof(map.explored));
+		i = 400; /* previously a nested for-loop set this */
 		game.insecretlab = true;
 		map.showteleporters = true;
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1515,6 +1515,7 @@ void scriptclass::run(void)
 			{
 				game.unlocknum(8);
 				game.insecretlab = true;
+				SDL_memset(map.explored, true, sizeof(map.explored));
 			}
 			else if (words[0] == "leavesecretlab")
 			{


### PR DESCRIPTION
If you enter the Secret Lab from the title screen, all rooms will be explored. However, if you enter the Secret Lab via the Secret Lab
entrance cutscene (epilogue), not all rooms will be explored, which is inconsistent.

To do this, just do an `SDL_memset()` for the `entersecretlab` script command.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
