### PR TITLE
Use hiddenname for hardestroom if roomname is empty

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -3962,7 +3962,7 @@ void Game::gethardestroom(void)
         }
         else if (map.roomname == "")
         {
-            hardestroom = "Dimension VVVVVV";
+            hardestroom = map.hiddenname;
         }
     }
 }


### PR DESCRIPTION
In earlier 2.3, if the roomname was empty, Dimension VVVVVV was used instead. However, instead of doing that, it's better to just use the hiddenname instead. Both because it's less hardcoded, and some rooms have hidden names that aren't Dimension VVVVVV.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
