### PR TITLE
Fix being able to start flipped in time trials

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1950,6 +1950,7 @@ void gameinput(void)
         script.startgamemode(game.timetriallevel + 3);
         game.deathseq = -1;
         game.completestop = false;
+        game.hascontrol = false;
     }
 
     //Returning to editor mode must always be possible


### PR DESCRIPTION
This fixes a regression where you're able to start flipped by restarting and then holding ACTION.

This happens because when the game resets all variables, it turns `hascontrol` back on (because of `hardreset()`). However, this is handled in the input function, and it's handled before player input is handled, so the player is able to get 1 frame of being able to flip after a time trial resets.

Why didn't this happen in 2.2? Because `resetplayer()` in 2.2 would set `lifeseq` to 10, as if the player had died. However, this is inconsistent, because loading in to the game for the first time would not result in a `lifeseq` of 10. So, in 2.2, restarting the time trial would remove that 1 frame of being able to flip because of `lifeseq`, while 2.3 doesn't set `lifeseq` because the player hasn't died.

I could have fixed this by setting `lifeseq` in the time trial restart code, but I decided to just set `hascontrol` to false instead.

Fixes #770.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
