### PR TITLE
Play Viridian squeak when using return button in audio options

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -949,6 +949,7 @@ static void menuactionpress(void)
             /* Return */
             game.returnmenu();
             map.nexttowercolour();
+            music.playef(11);
         }
         break;
     case Menu::unlockmenutrials:


### PR DESCRIPTION
For some reason this button was missing the Viridian squeak.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
