### PR TITLE
Outline text outline text and draw backing

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -5,6 +5,7 @@
 #include "Entity.h"
 #include "FileSystemUtils.h"
 #include "Graphics.h"
+#include "GraphicsUtil.h"
 #include "KeyPoll.h"
 #include "MakeAndPlay.h"
 #include "Map.h"
@@ -710,18 +711,27 @@ static void menurender(void)
             }
             break;
         case OFFSET+4:
+        {
+            const char* text;
+
             graphics.bigprint(-1, 40, "Text Outline", tr, tg, tb, true);
             graphics.Print(-1, 75, "Disables outline on game text.", tr, tg, tb, true);
-            // FIXME: Maybe do an outlined print instead? -flibit
+
+            FillRect(graphics.backBuffer, 0, 84, 320, 10, tr, tg, tb);
+
             if (!graphics.notextoutline)
             {
-                graphics.Print(-1, 85, "Text outlines are ON.", tr, tg, tb, true);
+                text = "Text outlines are ON.";
             }
             else
             {
-                graphics.Print(-1, 85, "Text outlines are OFF.", tr / 2, tg / 2, tb / 2, true);
+                text = "Text outlines are OFF.";
             }
+
+            graphics.bprint(-1, 85, text, 255, 255, 255, true);
             break;
+        }
+
         }
         break;
 


### PR DESCRIPTION
In order to help players spot the difference between outlined text and non-outlined text, we now outline the text outline text itself (if text outline is enabled, of course). But drawing the outline alone doesn't stand out enough, so we have to draw a solid backing against the text as well, in order to properly show the contrast.

Outline enabled:
![Outline enabled](https://user-images.githubusercontent.com/59748578/121790418-0dad6d80-cb94-11eb-93b2-756ed41dee18.png)

Outline disabled:
![Outline disabled](https://user-images.githubusercontent.com/59748578/121790402-f3738f80-cb93-11eb-82a4-4768e3fbb888.png)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
