### PR TITLE
Support for OpenBSD

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -25,6 +25,7 @@ Contributors
 * Thomas Sänger (@HorayNarea)
 * Info Teddy (@InfoTeddy)
 * Pierre-Alain TORET (@daftaupe)
+* Jules de Sartiges (@strikersh)
 * leo60228 (@leo60228)
 * Emmanuel Vadot (@evadot)
 * Rémi Verschelde (@akien-mga)

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -148,8 +148,8 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath)
 
 	if (basePath == NULL)
 	{
-		puts("Unable to get base path!");
-		return 0;
+		puts("Unable to determine base path, falling back to current directory");
+		basePath = SDL_strdup("./");
 	}
 
 	/* Mount the stock content last */

--- a/third_party/tinyxml2/tinyxml2.cpp
+++ b/third_party/tinyxml2/tinyxml2.cpp
@@ -103,7 +103,7 @@ distribution.
 #if defined(_WIN64)
 	#define TIXML_FSEEK _fseeki64
 	#define TIXML_FTELL _ftelli64
-#elif defined(__APPLE__) || (__FreeBSD__)
+#elif defined(__APPLE__) || (__FreeBSD__) || (__OpenBSD__)
 	#define TIXML_FSEEK fseeko
 	#define TIXML_FTELL ftello
 #elif defined(__unix__) && defined(__x86_64__)


### PR DESCRIPTION
## Changes:

- use fseeko and ftello like FreeBSD in tinyxml2
- use current directory as basePath if NULL (OpenBSD doesn't actually support this feature it is disabled via a patch in their ports)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
