### PR TITLE
Set visualonroof/visualonground to 1 on vertically-moving platforms

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4508,14 +4508,14 @@ void entityclass::movingplatformfix( int t, int j )
                     entities[j].yp = entities[t].yp + entities[t].h;
                     entities[j].vy = 0;
                     entities[j].onroof = 2;
-                    entities[j].visualonroof = entities[j].onroof;
+                    entities[j].visualonroof = 1;
                 }
                 else
                 {
                     entities[j].yp = entities[t].yp - entities[j].h-entities[j].cy;
                     entities[j].vy = 0;
                     entities[j].onground = 2;
-                    entities[j].visualonground = entities[j].onground;
+                    entities[j].visualonground = 1;
                 }
             }
             else


### PR DESCRIPTION
This fixes one of two desyncs in my Nova TAS.

The problem is that by adding two frames of edge-flipping to vertically moving platforms, Viridian's framedelay is updated for one extra frame after they step off of a vertically-moving platform. This then messes up Viridian's drawframe for the rest of the TAS until they die in a drawframe-sensitive trick.

The solution here is to only set the visual `onroof`/`onground` to 1 instead. The logical `onroof`/`onground` is still 2, so players still have two frames of edge-flipping off of vertically-moving platforms - it just won't really look like it (not that you could easily tell anyway).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
