### PR TITLE
Re-add playtesting passthrough code block for non-separate interact

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1960,8 +1960,18 @@ void gameinput(void)
     {
         if ((game.press_map || key.isDown(27)) && !game.mapheld)
         {
-            game.returntoeditor();
-            game.mapheld = true;
+            if (!game.separate_interact
+            && game.press_map
+            && (INBOUNDS_VEC(game.activeactivity, obj.blocks)
+            || (game.activetele && game.readytotele > 20)))
+            {
+                /* Pass, let code block below handle it */
+            }
+            else
+            {
+                game.returntoeditor();
+                game.mapheld = true;
+            }
         }
     }
 #endif


### PR DESCRIPTION
This fixes a regression where you're unable to activate activity zones in in-editor playtesting if your interact button is not separate from the map button.

When I originally did #743, I didn't have an option to set the bind to be non-separate, so I removed this logic without adding a `game.separate_interact` check. But when I added the option, I overlooked this code, and so this regression happened. Whoops.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
