### PR TITLE
Custom levels: only count inbounds trinkets and crewmates

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -5895,12 +5895,21 @@ Uint32 editorclass::getonewaycol(void)
     return graphics.getRGB(255, 255, 255);
 }
 
+static bool inbounds(const edentities* entity)
+{
+    extern editorclass ed;
+    return entity->x >= 0
+    && entity->y >= 0
+    && entity->x < ed.mapwidth * 40
+    && entity->y < ed.mapheight * 30;
+}
+
 int editorclass::numtrinkets(void)
 {
     int temp = 0;
     for (size_t i = 0; i < edentity.size(); i++)
     {
-        if (edentity[i].t == 9)
+        if (edentity[i].t == 9 && inbounds(&edentity[i]))
         {
             temp++;
         }
@@ -5913,7 +5922,7 @@ int editorclass::numcrewmates(void)
     int temp = 0;
     for (size_t i = 0; i < edentity.size(); i++)
     {
-        if (edentity[i].t == 15)
+        if (edentity[i].t == 15 && inbounds(&edentity[i]))
         {
             temp++;
         }


### PR DESCRIPTION
In the past, people have reported having glitched levels where they can't get the trinket star or can't complete the level because the number of trinkets or crewmates is one higher than what can be obtained in the level.

How did this happen? Well, it turns out that if you place an entity, and then resize the level to be smaller, that entity still exists. This is inconsequential for most entities, but if the entity is a trinket or crewmate, that entity is still counted towards the number of trinkets or crewmates in the level.

One fix would be to just remove entities whenever the level is downsized, but then if someone accidentally downsizes the level and wants to go back, that entity will be gone. Plus, it would be inconsistent with tiles, because tiles don't get removed when you downsize the level. Also, it wouldn't fix existing levels where people have managed to place trinkets or crewmates out of bounds.

So instead, `ed.numtrinkets()` and `ed.numcrewmates()` should simply ignore trinkets and crewmates that are outside the playable area. That way, levels with glitched trinkets and crewmates can still be completed, and can still be completed with the trinket star.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
