### PR TITLE
Fix wrong bounds check when colliding with activity zones

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1599,7 +1599,7 @@ void gamelogic(void)
     game.activeactivity = obj.checkactivity();
 
     if (game.hascontrol && !script.running
-    && INBOUNDS_VEC(game.activeactivity, obj.entities))
+    && INBOUNDS_VEC(game.activeactivity, obj.blocks))
     {
         game.activity_lastprompt = obj.blocks[game.activeactivity].prompt;
         game.activity_r = obj.blocks[game.activeactivity].r;


### PR DESCRIPTION
I am so stupid.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
