### PR TITLE
Update project generation snippet to reference SDL2 2.0.14

### DIFF
--- a/desktop_version/README.md
+++ b/desktop_version/README.md
@@ -22,7 +22,7 @@ To generate the projects on Windows:
 # Put your SDL2/SDL2_mixer folders somewhere nice!
 mkdir flibitBuild
 cd flibitBuild
-cmake -G "Visual Studio 10 2010" .. -DSDL2_INCLUDE_DIRS="C:\SDL2-2.0.10\include;C:\SDL2_mixer-2.0.4\include" -DSDL2_LIBRARIES="C:\SDL2-2.0.10\lib\x86\SDL2;C:\SDL2-2.0.10\lib\x86\SDL2main;C:\SDL2_mixer-2.0.4\lib\x86\SDL2_mixer"
+cmake -G "Visual Studio 10 2010" .. -DSDL2_INCLUDE_DIRS="C:\SDL2-2.0.14\include;C:\SDL2_mixer-2.0.4\include" -DSDL2_LIBRARIES="C:\SDL2-2.0.14\lib\x86\SDL2;C:\SDL2-2.0.14\lib\x86\SDL2main;C:\SDL2_mixer-2.0.4\lib\x86\SDL2_mixer"
 ```
 
 Note that on some systems, the `SDL2_LIBRARIES` list on Windows may need


### PR DESCRIPTION

## Changes:

Update the desktop project generation code snippet currently, as it still references SDL2 2.0.10 even though building now requires 2.0.14.
Just a minor nitpick on my part.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
