### PR TITLE
Add in-game timer option

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -12,6 +12,7 @@ Contributors
 * Dav999 (Dav999-v)
 * Allison Fleischer (AllisonFleischer)
 * Malte Grimm (@trelbutate)
+* KyoZM (@lsaa)
 * Daniel Lee (@ddm999)
 * Fredrik Ljungdahl (@FredrIQ)
 * Nichole Mattera (@NicholeMattera)

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -380,6 +380,7 @@ void Game::init(void)
     fadetolabdelay = 0;
 
     over30mode = true;
+    showingametimer = false;
 
     ingame_titlemode = false;
 #if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6103,7 +6103,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("input delay");
         option("interact button");
         option("fake load screen");
-        option("show in game timer");
+        option("toggle in game timer");
         option("return");
         menuyoff = 0;
         maxspacing = 15;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -125,7 +125,6 @@ void Game::init(void)
     edteleportent = 0; //Added in the port!
     companion = 0;
     roomchange = false;
-    isingamecompletescreen = false;
 
 
     quickrestartkludge = false;
@@ -2591,7 +2590,6 @@ void Game::updatestate(void)
             break;
         case 3501:
             //Game complete!
-            isingamecompletescreen = true;
             unlockAchievement("vvvvvvgamecomplete");
             unlocknum(5);
             crewstats[0] = true;
@@ -2807,7 +2805,6 @@ void Game::updatestate(void)
             map.finalstretch = false;
 
             graphics.setbars(320);
-            isingamecompletescreen = false;
 
             teleport_to_new_area = true;
             teleportscript = "gamecomplete";
@@ -2815,7 +2812,6 @@ void Game::updatestate(void)
 
         case 3520:
             //NO DEATH MODE COMPLETE JESUS
-            isingamecompletescreen = true;
             hascontrol = false;
             crewstats[0] = true;
 
@@ -2826,7 +2822,6 @@ void Game::updatestate(void)
             if(graphics.fademode == 1)	state++;
             break;
         case 3522:
-            isingamecompletescreen = false;
             copyndmresults();
             quittomenu();
             createmenu(Menu::nodeathmodecomplete);
@@ -6908,4 +6903,9 @@ bool Game::incompetitive(void)
 bool Game::nocompetitive(void)
 {
     return slowdown < 30 || map.invincibility;
+}
+
+bool Game::isingamecompletescreen()
+{
+    return (state >= 3501 && state <= 3518) || (state >= 3520 && state <= 3522);
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -125,7 +125,7 @@ void Game::init(void)
     edteleportent = 0; //Added in the port!
     companion = 0;
     roomchange = false;
-	isingamecompletescreen = false;
+    isingamecompletescreen = false;
 
 
     quickrestartkludge = false;
@@ -2591,7 +2591,7 @@ void Game::updatestate(void)
             break;
         case 3501:
             //Game complete!
-			isingamecompletescreen = true;
+            isingamecompletescreen = true;
             unlockAchievement("vvvvvvgamecomplete");
             unlocknum(5);
             crewstats[0] = true;
@@ -2807,7 +2807,7 @@ void Game::updatestate(void)
             map.finalstretch = false;
 
             graphics.setbars(320);
-			isingamecompletescreen = false;
+            isingamecompletescreen = false;
 
             teleport_to_new_area = true;
             teleportscript = "gamecomplete";
@@ -2815,7 +2815,7 @@ void Game::updatestate(void)
 
         case 3520:
             //NO DEATH MODE COMPLETE JESUS
-			isingamecompletescreen = true;
+            isingamecompletescreen = true;
             hascontrol = false;
             crewstats[0] = true;
 
@@ -2826,7 +2826,7 @@ void Game::updatestate(void)
             if(graphics.fademode == 1)	state++;
             break;
         case 3522:
-			isingamecompletescreen = false;
+            isingamecompletescreen = false;
             copyndmresults();
             quittomenu();
             createmenu(Menu::nodeathmodecomplete);
@@ -4217,7 +4217,7 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* s
             GlitchrunnerMode_set(GlitchrunnerMode_string_to_enum(pText));
         }
 
-		if (SDL_strcmp(pKey, "showingametimer") == 0)
+        if (SDL_strcmp(pKey, "showingametimer") == 0)
         {
             showingametimer = help.Int(pText);
         }
@@ -6103,7 +6103,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("input delay");
         option("interact button");
         option("fake load screen");
-		option("show in game timer");
+        option("show in game timer");
         option("return");
         menuyoff = 0;
         maxspacing = 15;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -125,6 +125,7 @@ void Game::init(void)
     edteleportent = 0; //Added in the port!
     companion = 0;
     roomchange = false;
+	isingamecompletescreen = false;
 
 
     quickrestartkludge = false;
@@ -2590,6 +2591,7 @@ void Game::updatestate(void)
             break;
         case 3501:
             //Game complete!
+			isingamecompletescreen = true;
             unlockAchievement("vvvvvvgamecomplete");
             unlocknum(5);
             crewstats[0] = true;
@@ -2805,6 +2807,7 @@ void Game::updatestate(void)
             map.finalstretch = false;
 
             graphics.setbars(320);
+			isingamecompletescreen = false;
 
             teleport_to_new_area = true;
             teleportscript = "gamecomplete";
@@ -2812,6 +2815,7 @@ void Game::updatestate(void)
 
         case 3520:
             //NO DEATH MODE COMPLETE JESUS
+			isingamecompletescreen = true;
             hascontrol = false;
             crewstats[0] = true;
 
@@ -2822,6 +2826,7 @@ void Game::updatestate(void)
             if(graphics.fademode == 1)	state++;
             break;
         case 3522:
+			isingamecompletescreen = false;
             copyndmresults();
             quittomenu();
             createmenu(Menu::nodeathmodecomplete);
@@ -4212,6 +4217,11 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* s
             GlitchrunnerMode_set(GlitchrunnerMode_string_to_enum(pText));
         }
 
+		if (SDL_strcmp(pKey, "showingametimer") == 0)
+        {
+            showingametimer = help.Int(pText);
+        }
+
         if (SDL_strcmp(pKey, "vsync") == 0)
         {
             screen_settings->useVsync = help.Int(pText);
@@ -4476,6 +4486,8 @@ void Game::serializesettings(tinyxml2::XMLElement* dataNode, const ScreenSetting
         "glitchrunnermode",
         GlitchrunnerMode_enum_to_string(GlitchrunnerMode_get())
     );
+
+    xml::update_tag(dataNode, "showingametimer", (int) showingametimer);
 
     xml::update_tag(dataNode, "vsync", (int) screen_settings->useVsync);
 
@@ -6091,6 +6103,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("input delay");
         option("interact button");
         option("fake load screen");
+		option("show in game timer");
         option("return");
         menuyoff = 0;
         maxspacing = 15;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -229,6 +229,7 @@ public:
     bool hascontrol, jumpheld;
     int jumppressed;
     int gravitycontrol;
+	bool isingamecompletescreen;
 
     bool muted;
     int mutebutton;
@@ -460,6 +461,7 @@ public:
     bool nocompetitive(void);
 
     bool over30mode;
+	bool showingametimer;
 
     bool ingame_titlemode;
 #if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -229,7 +229,7 @@ public:
     bool hascontrol, jumpheld;
     int jumppressed;
     int gravitycontrol;
-    bool isingamecompletescreen;
+    bool isingamecompletescreen();
 
     bool muted;
     int mutebutton;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -229,7 +229,7 @@ public:
     bool hascontrol, jumpheld;
     int jumppressed;
     int gravitycontrol;
-	bool isingamecompletescreen;
+    bool isingamecompletescreen;
 
     bool muted;
     int mutebutton;
@@ -461,7 +461,7 @@ public:
     bool nocompetitive(void);
 
     bool over30mode;
-	bool showingametimer;
+    bool showingametimer;
 
     bool ingame_titlemode;
 #if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -684,7 +684,7 @@ static void menuactionpress(void)
             game.savestatsandsettings_menu();
             music.playef(11);
             break;
-		case 4:
+        case 4:
             // toggle in game timer
             game.showingametimer = !game.showingametimer;
             game.savestatsandsettings_menu();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -684,6 +684,12 @@ static void menuactionpress(void)
             game.savestatsandsettings_menu();
             music.playef(11);
             break;
+		case 4:
+            // toggle in game timer
+            game.showingametimer = !game.showingametimer;
+            game.savestatsandsettings_menu();
+            music.playef(11);
+            break;
         default:
             //back
             music.playef(11);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -648,14 +648,14 @@ static void menurender(void)
             else
                 graphics.Print(-1, 65, "Fake loading screen is ON", tr, tg, tb, true);
             break;
-		case 4:
+        case 4:
             graphics.bigprint(-1, 30, "In Game Timer", tr, tg, tb, true);
             if (game.showingametimer)
-				graphics.Print(-1, 65, "In Game Timer is ON", tr, tg, tb, true);
+                graphics.Print(-1, 65, "In Game Timer is ON", tr, tg, tb, true);
             else
-				graphics.Print(-1, 65, "In Game Timer is OFF", tr / 2, tg / 2, tb / 2, true);
+                graphics.Print(-1, 65, "In Game Timer is OFF", tr / 2, tg / 2, tb / 2, true);
             break;
-		}
+        }
         break;
     case Menu::setglitchrunner:
         graphics.bigprint(-1, 30, "Glitchrunner Mode", tr, tg, tb, true);
@@ -1682,10 +1682,10 @@ void gamerender(void)
         }
     }
 
-	if (graphics.fademode==0 && !game.intimetrial && !game.isingamecompletescreen && game.swngame != 1 && game.showingametimer) {
-		graphics.bprint(6, 6, "TIME :",  255,255,255);
-		graphics.bprint(56, 6, game.timestring(),  196, 196, 196);
-	}
+    if (graphics.fademode==0 && !game.intimetrial && !game.isingamecompletescreen && game.swngame != 1 && game.showingametimer) {
+        graphics.bprint(6, 6, "TIME :",  255,255,255);
+        graphics.bprint(56, 6, game.timestring(),  196, 196, 196);
+    }
 
     if(map.extrarow==0 || (map.custommode && map.roomname!=""))
     {

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -648,7 +648,14 @@ static void menurender(void)
             else
                 graphics.Print(-1, 65, "Fake loading screen is ON", tr, tg, tb, true);
             break;
-        }
+		case 4:
+            graphics.bigprint(-1, 30, "In Game Timer", tr, tg, tb, true);
+            if (game.showingametimer)
+				graphics.Print(-1, 65, "In Game Timer is ON", tr, tg, tb, true);
+            else
+				graphics.Print(-1, 65, "In Game Timer is OFF", tr / 2, tg / 2, tb / 2, true);
+            break;
+		}
         break;
     case Menu::setglitchrunner:
         graphics.bigprint(-1, 30, "Glitchrunner Mode", tr, tg, tb, true);
@@ -1674,6 +1681,11 @@ void gamerender(void)
             graphics.drawtowerspikes();
         }
     }
+
+	if (graphics.fademode==0 && !game.intimetrial && !game.isingamecompletescreen && game.swngame != 1 && game.showingametimer) {
+		graphics.bprint(6, 6, "TIME :",  255,255,255);
+		graphics.bprint(56, 6, game.timestring(),  196, 196, 196);
+	}
 
     if(map.extrarow==0 || (map.custommode && map.roomname!=""))
     {

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -651,9 +651,13 @@ static void menurender(void)
         case 4:
             graphics.bigprint(-1, 30, "In Game Timer", tr, tg, tb, true);
             if (game.showingametimer)
+            {
                 graphics.Print(-1, 65, "In Game Timer is ON", tr, tg, tb, true);
-            else
+            } 
+            else 
+            {
                 graphics.Print(-1, 65, "In Game Timer is OFF", tr / 2, tg / 2, tb / 2, true);
+            }
             break;
         }
         break;
@@ -1682,8 +1686,9 @@ void gamerender(void)
         }
     }
 
-    if (graphics.fademode==0 && !game.intimetrial && !game.isingamecompletescreen && game.swngame != 1 && game.showingametimer) {
-        graphics.bprint(6, 6, "TIME :",  255,255,255);
+    if (graphics.fademode==0 && !game.intimetrial && !game.isingamecompletescreen && game.swngame != 1 && game.showingametimer) 
+    {
+        graphics.bprint(6, 6, "TIME:",  255,255,255);
         graphics.bprint(56, 6, game.timestring(),  196, 196, 196);
     }
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1686,7 +1686,7 @@ void gamerender(void)
         }
     }
 
-    if (graphics.fademode==0 && !game.intimetrial && !game.isingamecompletescreen && game.swngame != 1 && game.showingametimer) 
+    if (graphics.fademode==0 && !game.intimetrial && !game.isingamecompletescreen() && game.swngame != 1 && game.showingametimer) 
     {
         graphics.bprint(6, 6, "TIME:",  255,255,255);
         graphics.bprint(56, 6, game.timestring(),  196, 196, 196);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1689,7 +1689,7 @@ void gamerender(void)
     if (graphics.fademode==0 && !game.intimetrial && !game.isingamecompletescreen() && game.swngame != 1 && game.showingametimer) 
     {
         graphics.bprint(6, 6, "TIME:",  255,255,255);
-        graphics.bprint(56, 6, game.timestring(),  196, 196, 196);
+        graphics.bprint(46, 6, game.timestring(),  196, 196, 196);
     }
 
     if(map.extrarow==0 || (map.custommode && map.roomname!=""))


### PR DESCRIPTION
## Changes:
Since the game's speedruns are timed based on the IGT it would be useful to display it during gameplay.

How it looks:
![Hello](https://i.imgur.com/cLAiv2W.png)

It displays behind textboxes and the cutscene screen border effect, doesn't display on super gravitron and the game complete screen
![Render Order](https://files.catbox.moe/zkbw82.gif)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
