### PR TITLE
Fix zip structure checks checking for wrong filename

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -359,6 +359,7 @@ static bool checkZipStructure(const char* filename)
 {
 	const char* real_dir = PHYSFS_getRealDir(filename);
 	char base_name[MAX_PATH];
+	char base_name_suffixed[MAX_PATH];
 	char real_path[MAX_PATH];
 	char mount_path[MAX_PATH];
 	char check_path[MAX_PATH];
@@ -393,17 +394,24 @@ static bool checkZipStructure(const char* filename)
 	VVV_between(filename, "levels/", base_name, ".zip");
 
 	SDL_snprintf(
+		base_name_suffixed,
+		sizeof(base_name_suffixed),
+		"%s.vvvvvv",
+		base_name
+	);
+
+	SDL_snprintf(
 		check_path,
 		sizeof(check_path),
-		"%s%s.vvvvvv",
+		"%s%s",
 		mount_path,
-		base_name
+		base_name_suffixed
 	);
 
 	success = PHYSFS_exists(check_path);
 
 	SDL_zero(zip_state);
-	zip_state.filename = check_path;
+	zip_state.filename = base_name_suffixed;
 
 	PHYSFS_enumerate(mount_path, zipCheckCallback, (void*) &zip_state);
 


### PR DESCRIPTION
It was checking for `.vvv-mnt-temp-XXXXXX/LEVELNAME.vvvvvv` instead of `LEVELNAME.vvvvvv`. When PhysFS enumerates the folder, it only gives us `LEVELNAME.vvvvvv`, and not `.vvv-mnt-temp-XXXXXX/LEVELNAME.vvvvvv`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
