### PR TITLE
Fix generateBase36 generating more than base 36

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -251,8 +251,8 @@ static void generateBase36(char* string, const size_t string_size)
 	for (i = 0; i < string_size - 1; ++i)
 	{
 		/* a-z0-9 */
-		char randchar = fRandom() * 36;
-		if (randchar <= 26)
+		char randchar = fRandom() * 35;
+		if (randchar < 26)
 		{
 			randchar += 'a';
 		}


### PR DESCRIPTION
Two problems: the `fRandom()` range was from 0..36, but that's 37 characters, not 36. And the check to sort the lower 26 values into the Latin alphabet used a 'lesser-than-or-equal-to 26' check, even though that checks for the range of values of 0..26, which is 27 letters, even though the alphabet only has 26 letters. So just drop the equals sign from that check.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
