### PR TITLE
Play Viridian squeak when pressing Esc in teleporter menu

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2603,6 +2603,7 @@ void teleporterinput(void)
                 // Close teleporter menu
                 graphics.resumegamemode = true;
             }
+            music.playef(11);
         }
     }
     else


### PR DESCRIPTION
For consistency, this should be done to match pressing Esc on the map screen.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
