### PR TITLE
Add unfocus audio pause option

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -390,6 +390,7 @@ void Game::init(void)
     slidermode = SLIDER_NONE;
 
     disablepause = false;
+    disableaudiopause = false;
     inputdelay = false;
 }
 
@@ -4198,6 +4199,11 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* s
             disablepause = help.Int(pText);
         }
 
+        if (SDL_strcmp(pKey, "disableaudiopause") == 0)
+        {
+            disableaudiopause = help.Int(pText);
+        }
+
         if (SDL_strcmp(pKey, "over30mode") == 0)
         {
             over30mode = help.Int(pText);
@@ -4468,6 +4474,8 @@ void Game::serializesettings(tinyxml2::XMLElement* dataNode, const ScreenSetting
     xml::update_tag(dataNode, "skipfakeload", (int) skipfakeload);
 
     xml::update_tag(dataNode, "disablepause", (int) disablepause);
+
+    xml::update_tag(dataNode, "disableaudiopause", (int) disableaudiopause);
 
     xml::update_tag(dataNode, "notextoutline", (int) graphics.notextoutline);
 
@@ -6118,6 +6126,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
     }
     case Menu::advancedoptions:
         option("unfocus pause");
+        option("unfocus audio pause");
         option("room name background");
         option("return");
         menuyoff = 0;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -472,6 +472,7 @@ public:
     void unlockAchievement(const char *name);
 
     bool disablepause;
+    bool disableaudiopause;
     bool inputdelay;
 };
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -715,6 +715,12 @@ static void menuactionpress(void)
             music.playef(11);
             break;
         case 1:
+            /* toggle unfocus music pause */
+            game.disableaudiopause = !game.disableaudiopause;
+            game.savestatsandsettings_menu();
+            music.playef(11);
+            break;
+        case 2:
             // toggle translucent roomname BG
             graphics.translucentroomname = !graphics.translucentroomname;
             game.savestatsandsettings_menu();

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -327,8 +327,11 @@ void KeyPoll::Poll(void)
 				if (!game.disablepause)
 				{
 					isActive = true;
-					music.resume();
-					music.resumeef();
+					if (!game.disableaudiopause)
+					{
+						music.resume();
+						music.resumeef();
+					}
 				}
 				if (SDL_strcmp(SDL_GetCurrentVideoDriver(), "x11") == 0)
 				{
@@ -347,8 +350,11 @@ void KeyPoll::Poll(void)
 				if (!game.disablepause)
 				{
 					isActive = false;
-					music.pause();
-					music.pauseef();
+					if (!game.disableaudiopause)
+					{
+						music.pause();
+						music.pauseef();
+					}
 				}
 				if (SDL_strcmp(SDL_GetCurrentVideoDriver(), "x11") == 0)
 				{

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -684,6 +684,19 @@ static void menurender(void)
             }
             break;
         case 1:
+            graphics.bigprint(-1, 30, "Unfocus Audio", tr, tg, tb, true);
+            graphics.Print(-1, 65, "Toggle if the audio will pause", tr, tg, tb, true);
+            graphics.Print(-1, 75, "when the window is unfocused.", tr, tg, tb, true);
+            if (game.disableaudiopause)
+            {
+                graphics.Print(-1, 95, "Unfocus audio pause is OFF", tr/2, tg/2, tb/2, true);
+            }
+            else
+            {
+                graphics.Print(-1, 95, "Unfocus audio pause is ON", tr, tg, tb, true);
+            }
+            break;
+        case 2:
             graphics.bigprint(-1, 30, "Room Name BG", tr, tg, tb, true);
             graphics.Print( -1, 65, "Lets you see through what is behind", tr, tg, tb, true);
             graphics.Print( -1, 75, "the name at the bottom of the screen.", tr, tg, tb, true);


### PR DESCRIPTION
Some people prefer the 2.2 behavior where unfocusing pauses the game, but the music still plays. One such person is Trinket9 on the VVVVVV Discord server, who wanted it that way.

The reason audio pausing was added in the first place was to prevent desyncing music in levels with cutscenes that synced to music. Rather than reverting it, let's add this option instead.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
