### PR TITLE
Don't take editor input when fading out

### DIFF
--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -3974,6 +3974,10 @@ static void editormenuactionpress(void)
 void editorinput(void)
 {
     extern editorclass ed;
+    if (graphics.fademode == 3 /* fading out */)
+    {
+        return;
+    }
     game.mx = (float) key.mx;
     game.my = (float) key.my;
     ed.tilex=(game.mx - (game.mx%8))/8;


### PR DESCRIPTION
This fixes being able to re-trigger the fadeout while a fadeout is already happening. It also fixes being able to enter playtesting during the fadeout, which means the level now has a fadeout you normally can't do in actual gameplay.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
