### PR TITLE
Don't lerp when drawing all-sides warp background

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2325,7 +2325,7 @@ void Graphics::drawbackground( int t )
 
         for (int i = 10 ; i >= 0; i--)
         {
-            temp = (i << 4) + lerp(backoffset - 1, backoffset);
+            temp = (i << 4) + backoffset;
             setwarprect(160 - temp, 120 - temp, temp * 2, temp * 2);
             if (i % 2 == warpskip)
             {


### PR DESCRIPTION
There's nothing to interpolate. It moves at one pixel per frame. And interpolating sometimes results in the box being short by 1 pixel to cover the whole screen on deltaframes, so if you stand on the right edge of the screen and have a translucent sprite, it will quickly draw over itself many times, and it looks glitchy. This commit fixes that bug.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
