### PR TITLE
Save stats when setting stat_trinkets

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2643,6 +2643,7 @@ bool entityclass::updateentities( int i )
                     if (game.trinkets() > game.stat_trinkets && !map.custommode)
                     {
                         game.stat_trinkets = game.trinkets();
+                        game.savestatsandsettings();
                     }
                 }
 


### PR DESCRIPTION
This ensures that if the game crashes afterwards, the new `stat_trinkets` value won't be lost.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
