### PR TITLE
General bug fixes

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -283,7 +283,7 @@ static void startmode(const int mode)
     gotomode = mode;
     graphics.fademode = 2; /* fading out */
     fadetomode = true;
-    fadetomodedelay = 16;
+    fadetomodedelay = 19;
 }
 
 static int* user_changing_volume = NULL;
@@ -2531,7 +2531,7 @@ static void mapmenuactionpress(const bool version2_2)
         if (!version2_2)
         {
             game.fadetomenu = true;
-            game.fadetomenudelay = 16;
+            game.fadetomenudelay = 19;
         }
         music.playef(11);
         break;
@@ -2549,7 +2549,7 @@ static void mapmenuactionpress(const bool version2_2)
         if (!version2_2)
         {
             game.fadetolab = true;
-            game.fadetolabdelay = 16;
+            game.fadetolabdelay = 19;
         }
         music.playef(11);
         break;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -653,8 +653,8 @@ static void menurender(void)
             if (game.showingametimer)
             {
                 graphics.Print(-1, 65, "In Game Timer is ON", tr, tg, tb, true);
-            } 
-            else 
+            }
+            else
             {
                 graphics.Print(-1, 65, "In Game Timer is OFF", tr / 2, tg / 2, tb / 2, true);
             }
@@ -1686,7 +1686,7 @@ void gamerender(void)
         }
     }
 
-    if (graphics.fademode==0 && !game.intimetrial && !game.isingamecompletescreen() && game.swngame != 1 && game.showingametimer) 
+    if (graphics.fademode==0 && !game.intimetrial && !game.isingamecompletescreen() && game.swngame != 1 && game.showingametimer)
     {
         graphics.bprint(6, 6, "TIME:",  255,255,255);
         graphics.bprint(46, 6, game.timestring(),  196, 196, 196);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2714,7 +2714,11 @@ void maprender(void)
     // We need to draw the black screen above the menu in order to disguise it
     // being jankily brought down in glitchrunner mode when exiting to the title
     // Otherwise, there's no reason to obscure the menu
-    if (GlitchrunnerMode_less_than_or_equal(Glitchrunner2_2) || graphics.fademode == 3 || graphics.fademode == 5)
+    if (GlitchrunnerMode_less_than_or_equal(Glitchrunner2_2)
+    || graphics.fademode == 3
+    || graphics.fademode == 5
+    || game.fadetomenu
+    || game.fadetolab)
     {
         graphics.drawfade();
     }


### PR DESCRIPTION
This is because the fade delay did not last long enough.

I was under the mistaken impression that the fade animation lasts for 15 frames. However, this does not account for the fact that the offset of each fade bar is dependent on RNG, and the worst case scenario is that they have an offset of 96 pixels (in the opposite direction of the fade).

The actual fade animation timer accounts for the worst case scenario, so the fade animation actually lasts for (320 pixels plus 96 pixels is 416 pixels, 416 pixels divided by 24 pixels per frame equals 17.333... frames, but since the actual timer keeps adding/subtracting 24 pixels per frame until it passes the 416-pixel threshold, that gets rounded up to...) 18 frames.

And an extra frame to make it so deltaframe interpolation doesn't suddenly stop on the last deltaframes before the screen is completely black.

I also need to draw the screen black on the map screen when glitchrunner mode is off, if there's a fadeout going on. Else that would introduce yet another frame flicker.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
