### PR TITLE
Fix cycling title BG more than once per frame

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -82,6 +82,8 @@ mapclass::mapclass(void)
 	cameraseek = 0;
 	minitowermode = false;
 	roomtexton = false;
+
+	nexttowercolour_set = false;
 }
 
 //Areamap starts at 100,100 and extends 20x20
@@ -631,6 +633,13 @@ void mapclass::updatetowerglow(TowerBG& bg_obj)
 
 void mapclass::nexttowercolour(void)
 {
+	/* Prevent cycling title BG more than once per frame. */
+	if (nexttowercolour_set)
+	{
+		return;
+	}
+	nexttowercolour_set = true;
+
 	graphics.titlebg.colstate+=5;
 	if (graphics.titlebg.colstate >= 30) graphics.titlebg.colstate = 0;
 

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -55,6 +55,7 @@ public:
     void updatetowerglow(TowerBG& bg_obj);
 
     void nexttowercolour(void);
+    bool nexttowercolour_set;
 
     void settowercolour(int t);
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -724,7 +724,7 @@ static void unfocused_run(void)
 
 static void focused_begin(void)
 {
-    /* no-op. */
+    map.nexttowercolour_set = false;
 }
 
 static void focused_end(void)


### PR DESCRIPTION
This can happen if you select an option in a menu that (A) returns to the previous menu and (B) saves settings. If the settings save fails, this will create another menu on the same frame that cycles the tower BG after it's already been cycled for that frame. Examples are the slowdown and glitchrunner menus.

I could fix this by creating a new function that copy-pastes all of `Game::savestatsandsettings_menu()` except for the `map.nexttowercolour()` at the end. But that's copy-pasting code.

Instead what I've done is added a variable to signal if the color has already been cycled this frame, so we don't cycle it again. This also covers cases of possible double-cycling in the future as well.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
