### PR TITLE
Fix regression with chunky pixels being the wrong color

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2988,9 +2988,9 @@ Uint32 Graphics::bigchunkygetcol(int t)
 	switch (t)
 	{
 	case 1:
-		return getRGB((fRandom() * 64), 10, 10);
+		return getBGR((fRandom() * 64), 10, 10);
 	case 2:
-		return getRGB(int(160- help.glow/2 - (fRandom()*20)),  200- help.glow/2, 220 - help.glow);
+		return getBGR(int(160- help.glow/2 - (fRandom()*20)),  200- help.glow/2, 220 - help.glow);
 	}
 	return 0x00000000;
 }


### PR DESCRIPTION
Since colors going into `FillRect()` need to be in BGR format, we need to use `getBGR` instead. (Well, actually, it gets passed in RGB, but then at some point the order gets switched around, and, really, this game's masks are all over the place, I'm going to fix that in 2.4.)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
