### PR TITLE
Don't print redundant zip structure failure message if .vvvvvv file not found

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -365,6 +365,7 @@ static bool checkZipStructure(const char* filename)
 	char check_path[MAX_PATH];
 	char random_str[6 + 1];
 	bool success;
+	bool file_exists;
 	struct ArchiveState zip_state;
 
 	if (real_dir == NULL)
@@ -408,7 +409,8 @@ static bool checkZipStructure(const char* filename)
 		base_name_suffixed
 	);
 
-	success = PHYSFS_exists(check_path);
+	file_exists = PHYSFS_exists(check_path);
+	success = file_exists;
 
 	SDL_zero(zip_state);
 	zip_state.filename = base_name_suffixed;
@@ -429,7 +431,8 @@ static bool checkZipStructure(const char* filename)
 	success &= !zip_state.other_level_files;
 
 	/* ...But if other .vvvvvv file(s), do print warning. */
-	if (zip_state.other_level_files)
+	/* This message is redundant if the correct file already DOESN'T exist. */
+	if (file_exists && zip_state.other_level_files)
 	{
 		/* FIXME: How do we print this for non-terminal users? */
 		printf(


### PR DESCRIPTION
Let's say you have a zip named `LEVELNAME.zip`, but the only `.vvvvvv` file it contains is `NOTLEVELNAME.vvvvvv`. This zip would end up printing both the '`LEVELNAME.vvvvvv` is missing' and 'It has `.vvvvvv` file(s) other than `LEVELNAME.vvvvvv`' messages, even though we already know there's something wrong with the zip, and the 'other level files' message is redundant, since in this case the problem here is simply just the `.vvvvvv` file being named the wrong way.

The 'other level files' message is only intended to be printed when `LEVELNAME.vvvvvv` *does* exist, but there's additional `.vvvvvv` files in the zip on top of that, so don't print this message if `LEVELNAME.vvvvvv` exists.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
