### PR TITLE
Be more user-friendly if levels have asset/zip issues

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -470,7 +470,9 @@ void FILESYSTEM_loadZip(const char* filename)
 	}
 }
 
-void FILESYSTEM_mountAssets(const char* path)
+void FILESYSTEM_unmountAssets(void);
+
+bool FILESYSTEM_mountAssets(const char* path)
 {
 	char filename[MAX_PATH];
 	char zip_data[MAX_PATH];
@@ -501,10 +503,10 @@ void FILESYSTEM_mountAssets(const char* path)
 
 		if (!FILESYSTEM_mountAssetsFrom(zip_data))
 		{
-			return;
+			return false;
 		}
 
-		graphics.reloadresources();
+		MAYBE_FAIL(graphics.reloadresources());
 	}
 	else if (zip_normal != NULL && endsWith(zip_normal, ".zip"))
 	{
@@ -512,10 +514,10 @@ void FILESYSTEM_mountAssets(const char* path)
 
 		if (!FILESYSTEM_mountAssetsFrom(zip_normal))
 		{
-			return;
+			return false;
 		}
 
-		graphics.reloadresources();
+		MAYBE_FAIL(graphics.reloadresources());
 	}
 	else if (FILESYSTEM_exists(dir))
 	{
@@ -523,15 +525,21 @@ void FILESYSTEM_mountAssets(const char* path)
 
 		if (!FILESYSTEM_mountAssetsFrom(dir))
 		{
-			return;
+			return false;
 		}
 
-		graphics.reloadresources();
+		MAYBE_FAIL(graphics.reloadresources());
 	}
 	else
 	{
 		puts("Custom asset directory does not exist");
 	}
+
+	return true;
+
+fail:
+	FILESYSTEM_unmountAssets();
+	return false;
 }
 
 void FILESYSTEM_unmountAssets(void)

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -19,7 +19,7 @@ bool FILESYSTEM_isFile(const char* filename);
 bool FILESYSTEM_isMounted(const char* filename);
 
 void FILESYSTEM_loadZip(const char* filename);
-void FILESYSTEM_mountAssets(const char *path);
+bool FILESYSTEM_mountAssets(const char *path);
 void FILESYSTEM_unmountAssets(void);
 bool FILESYSTEM_isAssetMounted(const char* filename);
 

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -40,6 +40,10 @@ bool FILESYSTEM_loadTiXml2Document(const char *name, tinyxml2::XMLDocument& doc)
 
 void FILESYSTEM_enumerateLevelDirFileNames(void (*callback)(const char* filename));
 
+bool FILESYSTEM_levelDirHasError(void);
+void FILESYSTEM_clearLevelDirError(void);
+const char* FILESYSTEM_getLevelDirError(void);
+
 bool FILESYSTEM_openDirectoryEnabled(void);
 bool FILESYSTEM_openDirectory(const char *dname);
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6468,6 +6468,9 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("silence");
         menuyoff = 10;
         break;
+    case Menu::errorloadinglevel:
+        option("ok");
+        break;
     }
 
     // Automatically center the menu. We must check the width of the menu with the initial horizontal spacing.

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6469,7 +6469,9 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         menuyoff = 10;
         break;
     case Menu::errorloadinglevel:
+    case Menu::warninglevellist:
         option("ok");
+        menuyoff = 50;
         break;
     }
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -35,6 +35,7 @@ namespace Menu
         youwannaquit,
         errornostart,
         errorsavingsettings,
+        errorloadinglevel,
         graphicoptions,
         ed_settings,
         ed_desc,

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -36,6 +36,7 @@ namespace Menu
         errornostart,
         errorsavingsettings,
         errorloadinglevel,
+        warninglevellist,
         graphicoptions,
         ed_settings,
         ed_desc,

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -515,6 +515,119 @@ void Graphics::PrintAlpha( int _x, int _y, std::string _s, int r, int g, int b, 
     }
 }
 
+bool Graphics::next_wrap(
+    size_t* start,
+    size_t* len,
+    const char* str,
+    const int maxwidth
+) {
+    /* This function is UTF-8 aware. But start/len still are bytes. */
+    size_t idx = 0;
+    size_t lenfromlastspace = 0;
+    size_t lastspace = 0;
+    int linewidth = 0;
+    *len = 0;
+
+    if (str[idx] == '\0')
+    {
+        return false;
+    }
+
+    while (true)
+    {
+        /* FIXME: This only checks one byte, not multiple! */
+        if ((str[idx] & 0xC0) == 0x80)
+        {
+            /* Skip continuation byte. */
+            goto next;
+        }
+
+        linewidth += bfontlen(str[idx]);
+
+        switch (str[idx])
+        {
+        case ' ':
+            lenfromlastspace = idx;
+            lastspace = *start;
+            break;
+        case '\n':
+            *start += 1;
+            fallthrough;
+        case '\0':
+            return true;
+        }
+
+        if (linewidth > maxwidth)
+        {
+            if (lenfromlastspace != 0)
+            {
+                *len = lenfromlastspace;
+                *start = lastspace + 1;
+            }
+            return true;
+        }
+
+next:
+        idx += 1;
+        *start += 1;
+        *len += 1;
+    }
+}
+
+bool Graphics::next_wrap_s(
+    char buffer[],
+    const size_t buffer_size,
+    size_t* start,
+    const char* str,
+    const int maxwidth
+) {
+    size_t len = 0;
+    const size_t prev_start = *start;
+
+    const bool retval = next_wrap(start, &len, &str[*start], maxwidth);
+
+    if (retval)
+    {
+        /* Like next_split_s(), don't use SDL_strlcpy() here. */
+        const size_t length = VVV_min(buffer_size - 1, len);
+        SDL_memcpy(buffer, &str[prev_start], length);
+        buffer[length] = '\0';
+    }
+
+    return retval;
+}
+
+void Graphics::PrintWrap(
+    const int x,
+    int y,
+    const char* str,
+    const int r,
+    const int g,
+    const int b,
+    const bool cen,
+    const int linespacing,
+    const int maxwidth
+) {
+    /* Screen width is 320 pixels. The shortest a char can be is 6 pixels wide.
+     * 320 / 6 is 54, rounded up. 4 bytes per char. */
+    char buffer[54*4 + 1];
+    size_t start = 0;
+
+    while (next_wrap_s(buffer, sizeof(buffer), &start, str, maxwidth))
+    {
+        Print(x, y, buffer, r, g, b, cen);
+
+        if (flipmode)
+        {
+            y -= linespacing;
+        }
+        else
+        {
+            y += linespacing;
+        }
+    }
+}
+
 
 void Graphics::bigprint(  int _x, int _y, std::string _s, int r, int g, int b, bool cen, int sc )
 {

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -136,6 +136,12 @@ public:
 
 	void PrintAlpha(int _x, int _y, std::string _s, int r, int g, int b, int a, bool cen = false);
 
+	bool next_wrap(size_t* start, size_t* len, const char* str, int maxwidth);
+
+	bool next_wrap_s(char buffer[], size_t buffer_size, size_t* start, const char* str, int maxwidth);
+
+	void PrintWrap(int x, int y, const char* str, int r, int g, int b, bool cen, int linespacing, int maxwidth);
+
 	void PrintOffAlpha(int _x, int _y, std::string _s, int r, int g, int b, int a, bool cen = false);
 
 	void bprint(int x, int y, std::string t, int r, int g, int b, bool cen = false);

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -26,7 +26,7 @@ public:
 	int bfontlen(uint32_t ch);
 	int font_idx(uint32_t ch);
 
-	void Makebfont(void);
+	bool Makebfont(void);
 
 	void drawhuetile(int x, int y, int t);
 	void huetilesetcol(int t);
@@ -34,11 +34,11 @@ public:
 
 	void drawgravityline(int t);
 
-	void MakeTileArray(void);
+	bool MakeTileArray(void);
 
-	void MakeSpriteArray(void);
+	bool MakeSpriteArray(void);
 
-	void maketelearray(void);
+	bool maketelearray(void);
 
 	void drawcoloredtile(int x, int y, int t, int r, int g, int b);
 
@@ -222,7 +222,7 @@ public:
 
 	bool onscreen(int t);
 
-	void reloadresources(void);
+	bool reloadresources(void);
 #ifndef NO_CUSTOM_LEVELS
 	bool tiles1_mounted;
 	bool tiles2_mounted;
@@ -357,6 +357,9 @@ public:
 	bool kludgeswnlinewidth;
 
 	Uint32 crewcolourreal(int t);
+
+	char error[128];
+	char error_title[128]; /* for SDL_ShowSimpleMessageBox */
 };
 
 #ifndef GRAPHICS_DEFINITION

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -492,6 +492,10 @@ static void menuactionpress(void)
             ed.getDirectoryData();
             game.loadcustomlevelstats(); //Should only load a file if it's needed
             game.createmenu(Menu::levellist);
+            if (FILESYSTEM_levelDirHasError())
+            {
+                game.createmenu(Menu::warninglevellist);
+            }
             map.nexttowercolour();
             break;
  #if !defined(NO_EDITOR)
@@ -1722,6 +1726,7 @@ static void menuactionpress(void)
         map.nexttowercolour();
         break;
     case Menu::errorloadinglevel:
+    case Menu::warninglevellist:
         music.playef(11);
         game.returnmenu();
         map.nexttowercolour();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1721,6 +1721,11 @@ static void menuactionpress(void)
         game.returnmenu();
         map.nexttowercolour();
         break;
+    case Menu::errorloadinglevel:
+        music.playef(11);
+        game.returnmenu();
+        map.nexttowercolour();
+        break;
     default:
         break;
     }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1374,6 +1374,10 @@ static void menurender(void)
     case Menu::errorsavingsettings:
         graphics.Print( -1, 95, "ERROR: Could not save settings file!", tr, tg, tb, true);
         break;
+    case Menu::errorloadinglevel:
+        graphics.bigprint(-1, 45, "ERROR", tr, tg, tb, true);
+        graphics.PrintWrap(-1, 65, graphics.error, tr, tg, tb, true, 10, 304);
+        break;
     default:
         break;
     }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1378,6 +1378,10 @@ static void menurender(void)
         graphics.bigprint(-1, 45, "ERROR", tr, tg, tb, true);
         graphics.PrintWrap(-1, 65, graphics.error, tr, tg, tb, true, 10, 304);
         break;
+    case Menu::warninglevellist:
+        graphics.bigprint(-1, 45, "WARNING", tr, tg, tb, true);
+        graphics.PrintWrap(-1, 65, FILESYSTEM_getLevelDirError(), tr, tg, tb, true, 10, 304);
+        break;
     default:
         break;
     }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2634,6 +2634,14 @@ void scriptclass::resetgametomenu(void)
 	game.createmenu(Menu::gameover);
 }
 
+static void gotoerrorloadinglevel(void)
+{
+	game.createmenu(Menu::errorloadinglevel);
+	graphics.fademode = 4; /* start fade in */
+	music.currentsong = -1; /* otherwise music.play won't work */
+	music.play(6); /* title screen music */
+}
+
 void scriptclass::startgamemode( int t )
 {
 	switch(t)
@@ -3152,7 +3160,11 @@ void scriptclass::startgamemode( int t )
 		//Initilise the level
 		//First up, find the start point
 		std::string filename = std::string(ed.ListOfMetaData[game.playcustomlevel].filename);
-		ed.load(filename);
+		if (!ed.load(filename))
+		{
+			gotoerrorloadinglevel();
+			break;
+		}
 		ed.findstartpoint();
 
 		game.gamestate = GAMEMODE;
@@ -3190,7 +3202,11 @@ void scriptclass::startgamemode( int t )
 		//Initilise the level
 		//First up, find the start point
 		std::string filename = std::string(ed.ListOfMetaData[game.playcustomlevel].filename);
-		ed.load(filename);
+		if (!ed.load(filename))
+		{
+			gotoerrorloadinglevel();
+			break;
+		}
 		ed.findstartpoint();
 
 		game.gamestate = GAMEMODE;

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -77,6 +77,15 @@ void _VVV_between(
 #   define fallthrough do { } while (false) /* fallthrough */
 #endif
 
+#define MAYBE_FAIL(expr) \
+    do \
+    { \
+        if (!expr) \
+        { \
+            goto fail; \
+        } \
+    } \
+    while (false)
 
 //helperClass
 class UtilityClass

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -67,6 +67,16 @@ void _VVV_between(
         sizeof(middle) \
     )
 
+#ifndef __has_attribute
+#   define __has_attribute(x) 0
+#endif
+
+#if __has_attribute(__fallthrough__)
+#   define fallthrough __attribute__((__fallthrough__))
+#else
+#   define fallthrough do { } while (false) /* fallthrough */
+#endif
+
 
 //helperClass
 class UtilityClass

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -1748,6 +1748,11 @@ void editorclass::switch_enemy(const bool reversed /*= false*/)
 
 bool editorclass::load(std::string& _path)
 {
+    tinyxml2::XMLDocument doc;
+    tinyxml2::XMLHandle hDoc(&doc);
+    tinyxml2::XMLElement* pElem;
+    tinyxml2::XMLHandle hRoot(NULL);
+
     reset();
 
     static const char *levelDir = "levels/";
@@ -1759,14 +1764,13 @@ bool editorclass::load(std::string& _path)
     FILESYSTEM_unmountAssets();
     if (game.cliplaytest && game.playassets != "")
     {
-        FILESYSTEM_mountAssets(game.playassets.c_str());
+        MAYBE_FAIL(FILESYSTEM_mountAssets(game.playassets.c_str()));
     }
     else
     {
-        FILESYSTEM_mountAssets(_path.c_str());
+        MAYBE_FAIL(FILESYSTEM_mountAssets(_path.c_str()));
     }
 
-    tinyxml2::XMLDocument doc;
     if (!FILESYSTEM_loadTiXml2Document(_path.c_str(), doc))
     {
         printf("No level %s to load :(\n", _path.c_str());
@@ -1775,9 +1779,6 @@ bool editorclass::load(std::string& _path)
 
     loaded_filepath = _path;
 
-    tinyxml2::XMLHandle hDoc(&doc);
-    tinyxml2::XMLElement* pElem;
-    tinyxml2::XMLHandle hRoot(NULL);
     version = 0;
 
     {
@@ -2040,6 +2041,9 @@ next:
     version=2;
 
     return true;
+
+fail:
+    return false;
 }
 
 bool editorclass::save(std::string& _path)

--- a/desktop_version/src/editor.cpp
+++ b/desktop_version/src/editor.cpp
@@ -229,6 +229,8 @@ void editorclass::getDirectoryData(void)
 
     ListOfMetaData.clear();
 
+    FILESYSTEM_clearLevelDirError();
+
     loadZips();
 
     FILESYSTEM_enumerateLevelDirFileNames(levelMetaDataCallback);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -483,7 +483,19 @@ int main(int argc, char *argv[])
     game.init();
 
     // This loads music too...
-    graphics.reloadresources();
+    if (!graphics.reloadresources())
+    {
+        /* Something wrong with the default assets? We can't use them to
+         * display the error message, and we have to bail. */
+        SDL_ShowSimpleMessageBox(
+            SDL_MESSAGEBOX_ERROR,
+            graphics.error_title,
+            graphics.error,
+            NULL
+        );
+
+        VVV_exit(1);
+    }
 
     game.gamestate = PRELOADER;
 


### PR DESCRIPTION
This PR does the following:

1. Gracefully handles a custom level having an asset issue after its assets are loaded, by returning to the title screen and printing the error for the player.
2. Displays a message warning about improperly-structured zips, if there are any, when the levels list is loaded.

They both make it so users don't need a console in order to be notified of what's wrong with their levels. This is good, because not everyone uses a console.

Also, it's a bit rude to close the game and bail completely if a level has an issue with its assets, so I've fixed that too.

![Bad level asset](https://user-images.githubusercontent.com/59748578/128591705-e6e4db88-ac51-4a0d-a5b6-4e0eae3144cc.png)

![Bad zip structure](https://user-images.githubusercontent.com/59748578/128591707-e1cc0ecc-61c6-4ab1-95a5-666da21c25bf.png)

Both of these depend on some new text wrapping functions, which is why they're both in this PR.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
