### PR TITLE
Do not close game if fallback character is missing

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -258,8 +258,8 @@ int Graphics::font_idx(uint32_t ch)
             iter = font_positions.find('?');
             if (iter == font_positions.end())
             {
-                puts("font.txt missing fallback character!");
-                VVV_exit(1);
+                WHINE_ONCE("font.txt missing fallback character!");
+                return -1;
             }
         }
         return iter->second;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -760,7 +760,7 @@ void Graphics::drawtile( int x, int y, int t )
 {
     if (!INBOUNDS_VEC(t, tiles))
     {
-        WHINE_ONCE("drawtile() out-of-bounds!")
+        WHINE_ONCE("drawtile() out-of-bounds!");
         return;
     }
 
@@ -784,7 +784,7 @@ void Graphics::drawtile2( int x, int y, int t )
 {
     if (!INBOUNDS_VEC(t, tiles2))
     {
-        WHINE_ONCE("drawtile2() out-of-bounds!")
+        WHINE_ONCE("drawtile2() out-of-bounds!");
         return;
     }
 
@@ -810,7 +810,7 @@ void Graphics::drawtile3( int x, int y, int t, int off, int height_subtract /*= 
     t += off * 30;
     if (!INBOUNDS_VEC(t, tiles3))
     {
-        WHINE_ONCE("drawtile3() out-of-bounds!")
+        WHINE_ONCE("drawtile3() out-of-bounds!");
         return;
     }
     SDL_Rect src_rect = { 0, 0, tiles_rect.w, tiles_rect.h - height_subtract };
@@ -822,7 +822,7 @@ void Graphics::drawtowertile( int x, int y, int t )
 {
     if (!INBOUNDS_VEC(t, tiles2))
     {
-        WHINE_ONCE("drawtowertile() out-of-bounds!")
+        WHINE_ONCE("drawtowertile() out-of-bounds!");
         return;
     }
     x += 8;
@@ -837,7 +837,7 @@ void Graphics::drawtowertile3( int x, int y, int t, TowerBG& bg_obj )
     t += bg_obj.colstate*30;
     if (!INBOUNDS_VEC(t, tiles3))
     {
-        WHINE_ONCE("drawtowertile3() out-of-bounds!")
+        WHINE_ONCE("drawtowertile3() out-of-bounds!");
         return;
     }
     x += 8;
@@ -3286,7 +3286,7 @@ void Graphics::drawforetile(int x, int y, int t)
 {
 	if (!INBOUNDS_VEC(t, tiles))
 	{
-		WHINE_ONCE("drawforetile() out-of-bounds!")
+		WHINE_ONCE("drawforetile() out-of-bounds!");
 		return;
 	}
 
@@ -3310,7 +3310,7 @@ void Graphics::drawforetile2(int x, int y, int t)
 {
 	if (!INBOUNDS_VEC(t, tiles2))
 	{
-		WHINE_ONCE("drawforetile2() out-of-bounds!")
+		WHINE_ONCE("drawforetile2() out-of-bounds!");
 		return;
 	}
 
@@ -3335,7 +3335,7 @@ void Graphics::drawforetile3(int x, int y, int t, int off)
 	t += off * 30;
 	if (!INBOUNDS_VEC(t, tiles3))
 	{
-		WHINE_ONCE("drawforetile3() out-of-bounds!")
+		WHINE_ONCE("drawforetile3() out-of-bounds!");
 		return;
 	}
 	SDL_Rect rect;

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -43,7 +43,8 @@ void VVV_fillstring(
     { \
         whine = false; \
         puts(message); \
-    }
+    } \
+    do { } while (false)
 
 /* Don't call this directly; use the VVV_between macro. */
 void _VVV_between(


### PR DESCRIPTION
It's quite rude to close the game. Especially if the user does not use the console. They won't know why the game closed.

Instead, just return -1. All usages of `font_idx()` should be and are bounds checked anyways. This will result in missing characters, but, it's not like the characters had a font image in the first place, otherwise we wouldn't be here. And if the user sees a bunch of
characters missing in their font, they'll probably work out what the problem is even without having a console. And it's still far better than abruptly closing the game.

And use `WHINE_ONCE` to prevent spamming the console.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
