### PR TITLE
Disable final color animations if screen effects off

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -475,11 +475,29 @@ int mapclass::finalat(int x, int y)
 		//Special case: animated tiles
 		if (final_mapcol == 1)
 		{
-			return 737 + (int(fRandom() * 11) * 40);
+			int offset;
+			if (game.noflashingmode)
+			{
+				offset = 0;
+			}
+			else
+			{
+				offset = int(fRandom() * 11) * 40;
+			}
+			return 737 + offset;
 		}
 		else
 		{
-			return contents[x + vmult[y]] - (final_mapcol * 3) + (final_aniframe * 40);
+			int offset;
+			if (game.noflashingmode)
+			{
+				offset = 0;
+			}
+			else
+			{
+				offset = final_aniframe * 40;
+			}
+			return contents[x + vmult[y]] - (final_mapcol * 3) + offset;
 		}
 	}
 	else if (contents[x + vmult[y]] >= 80)


### PR DESCRIPTION
Similar to disabling the elephant flashiness, at least one photosensitive person has told me the flashy color animation makes their
eyes kind of hurt a little bit. Also it screws up the compression really badly when they record (especially the green noisy tiles!).

The colors will still cycle, but the individual animations within each color will be completely static.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
