### PR TITLE
Add audiopause(on/off) command

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -391,6 +391,7 @@ void Game::init(void)
 
     disablepause = false;
     disableaudiopause = false;
+    disabletemporaryaudiopause = true;
     inputdelay = false;
 }
 
@@ -5193,6 +5194,10 @@ void Game::customloadquick(std::string savfile)
         {
             map.customshowmm = help.Int(pText);
         }
+        else if (SDL_strcmp(pKey, "disabletemporaryaudiopause") == 0)
+        {
+            disabletemporaryaudiopause = help.Int(pText);
+        }
 
     }
 
@@ -5673,6 +5678,8 @@ bool Game::customsavequick(std::string savfile)
     xml::update_tag(msgs, "hardestroomdeaths", hardestroomdeaths);
 
     xml::update_tag(msgs, "showminimap", (int) map.customshowmm);
+
+    xml::update_tag(msgs, "disabletemporaryaudiopause", (int) disabletemporaryaudiopause);
 
     std::string summary = savearea + ", " + timestring();
     xml::update_tag(msgs, "summary", summary.c_str());

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -475,6 +475,7 @@ public:
 
     bool disablepause;
     bool disableaudiopause;
+    bool disabletemporaryaudiopause;
     bool inputdelay;
 };
 

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -327,7 +327,7 @@ void KeyPoll::Poll(void)
 				if (!game.disablepause)
 				{
 					isActive = true;
-					if (!game.disableaudiopause)
+					if (!game.disableaudiopause || !game.disabletemporaryaudiopause)
 					{
 						music.resume();
 						music.resumeef();
@@ -350,7 +350,7 @@ void KeyPoll::Poll(void)
 				if (!game.disablepause)
 				{
 					isActive = false;
-					if (!game.disableaudiopause)
+					if (!game.disableaudiopause || !game.disabletemporaryaudiopause)
 					{
 						music.pause();
 						music.pauseef();

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -326,6 +326,17 @@ void scriptclass::run(void)
 			{
 				graphics.showcutscenebars = false;
 			}
+			if (words[0] == "audiopause")
+			{
+				if (words[1] == "on")
+				{
+					game.disabletemporaryaudiopause = false;
+				}
+				else if (words[1] == "off")
+				{
+					game.disabletemporaryaudiopause = true;
+				}
+			}
 			if (words[0] == "untilbars")
 			{
 				if (graphics.showcutscenebars)
@@ -3464,6 +3475,8 @@ void scriptclass::hardreset(void)
 
 	game.activeactivity = -1;
 	game.act_fade = 5;
+
+	game.disabletemporaryaudiopause = true;
 
 	//dwgraphicsclass
 	graphics.backgrounddrawn = false;


### PR DESCRIPTION
## Changes:
If you have unfocus pause off, and unfocus audio pause off, then this command will go into effect. When it's set to on, the audio will pause when you unfocus the game. When it's set to off, the audio will not. This is different from the setting, and gets saved to the save file.
This was created in response to #799 being merged.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
