### PR TITLE
Save showtrinkets to custom level quicksaves

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5198,6 +5198,10 @@ void Game::customloadquick(std::string savfile)
         {
             disabletemporaryaudiopause = help.Int(pText);
         }
+        else if (SDL_strcmp(pKey, "showtrinkets") == 0)
+        {
+            map.showtrinkets = help.Int(pText);
+        }
 
     }
 
@@ -5680,6 +5684,8 @@ bool Game::customsavequick(std::string savfile)
     xml::update_tag(msgs, "showminimap", (int) map.customshowmm);
 
     xml::update_tag(msgs, "disabletemporaryaudiopause", (int) disabletemporaryaudiopause);
+
+    xml::update_tag(msgs, "showtrinkets", (int) map.showtrinkets);
 
     std::string summary = savearea + ", " + timestring();
     xml::update_tag(msgs, "summary", summary.c_str());


### PR DESCRIPTION
Since custom levels have gained the functionality to show trinkets on the minimap, it's nice to just save the `showtrinkets` variable directly to the save file, without having to make level makers handle it themselves.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
