### PR TITLE
Allow getting star if more trinkets than level trinkets

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1956,7 +1956,7 @@ void Game::updatestate(void)
             if(ed.numcrewmates()-crewmates()==0)
             {
                 //Finished level
-                if(ed.numtrinkets()-trinkets()==0)
+                if (trinkets() >= ed.numtrinkets())
                 {
                     //and got all the trinkets!
                     updatecustomlevelstats(customlevelfilename, 3);


### PR DESCRIPTION
Previously, you would only get the trinket completion star if you got the exact same amount of trinkets as there are custom entity trinkets in the level file. But if you got more (say, if the level spawned extra "bonus trinkets"), you wouldn't be able to get the star.

This is true of the custom crewmate case as well, but I've decided to not change that case, because there are still downsides to the resulting behavior and it's better to just leave it alone because it's rare for it to happen anyways.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
