### PR TITLE
Actually have p1/p2/p3/p4 defaults for createentity() command

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -38,6 +38,8 @@ void scriptclass::clearcustom(void)
 	customscripts.clear();
 }
 
+static bool argexists[NUM_SCRIPT_ARGS];
+
 void scriptclass::tokenize( const std::string& t )
 {
 	j = 0;
@@ -71,9 +73,15 @@ void scriptclass::tokenize( const std::string& t )
 		}
 	}
 
-	if (tempword != "" && j < (int) SDL_arraysize(words))
+	SDL_zeroa(argexists);
+
+	if (j < (int) NUM_SCRIPT_ARGS)
 	{
-		words[j] = tempword;
+		argexists[j] = tempword != "";
+		if (argexists[j])
+		{
+			words[j] = tempword;
+		}
 	}
 }
 
@@ -756,10 +764,10 @@ void scriptclass::run(void)
 				std::string word7 = words[7];
 				std::string word8 = words[8];
 				std::string word9 = words[9];
-				if (words[6] == "") words[6] = "0";
-				if (words[7] == "") words[7] = "0";
-				if (words[8] == "") words[8] = "320";
-				if (words[9] == "") words[9] = "240";
+				if (!argexists[6]) words[6] = "0";
+				if (!argexists[7]) words[7] = "0";
+				if (!argexists[8]) words[8] = "320";
+				if (!argexists[9]) words[9] = "240";
 				obj.createentity(
 					ss_toi(words[1]),
 					ss_toi(words[2]),

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -15,6 +15,8 @@ struct Script
     std::vector<std::string> contents;
 };
 
+#define NUM_SCRIPT_ARGS 40
+
 class scriptclass
 {
 public:
@@ -47,7 +49,7 @@ public:
 
     //Script contents
     std::vector<std::string> commands;
-    std::string words[40];
+    std::string words[NUM_SCRIPT_ARGS];
     std::vector<std::string> txt;
     std::string scriptname;
     int position;


### PR DESCRIPTION
Since `createentity()` started accepting `p1`/`p2`/`p3`/`p4` arguments, it now unconditionally passes in whatever arguments were present there previously, when there weren't any before.

This can lead to unexpected behavior when selectively using and then omitting `p1`/`p2`/`p3`/`p4` arguments.

Also, plenty of existing levels already only use the 5-argument version of `createentity()`. And `createcrewman()` can take up to 6 arguments at once. It's not far-fetched that an existing level could `createentity()` right after doing a 6-argument `createcrewman()`, which would lead to a different behavior than in 2.2 and previous.

So instead, instead of checking if `words[index]` is an empty string (it only sets the string to be empty if there are enough argument separators on the line), *actually* check if it's empty. I've added a static array (no need for it to be exported) that keeps track of this. `createentity()` now checks for that instead of `words`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
