### PR TITLE
Don't show next/previous page options if only one page

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5996,21 +5996,24 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
                     option(text);
                 }
             }
-            if((size_t) ((levelpage*8)+8) <ed.ListOfMetaData.size())
+            if (ed.ListOfMetaData.size() > 8)
             {
-                option("next page");
-            }
-            else
-            {
-                option("first page");
-            }
-            if (levelpage == 0)
-            {
-                option("last page");
-            }
-            else
-            {
-                option("previous page");
+                if((size_t) ((levelpage*8)+8) <ed.ListOfMetaData.size())
+                {
+                    option("next page");
+                }
+                else
+                {
+                    option("first page");
+                }
+                if (levelpage == 0)
+                {
+                    option("last page");
+                }
+                else
+                {
+                    option("previous page");
+                }
             }
             option("return to menu");
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -412,12 +412,14 @@ static void menuactionpress(void)
         break;
 #if !defined(NO_CUSTOM_LEVELS)
     case Menu::levellist:
+    {
+        const bool nextlastoptions = ed.ListOfMetaData.size() > 8;
         if(game.currentmenuoption==(int)game.menuoptions.size()-1){
             //go back to menu
             music.playef(11);
             game.returnmenu();
             map.nexttowercolour();
-        }else if(game.currentmenuoption==(int)game.menuoptions.size()-2){
+        }else if(nextlastoptions && game.currentmenuoption==(int)game.menuoptions.size()-2){
             //previous page
             music.playef(11);
             if(game.levelpage==0){
@@ -428,7 +430,7 @@ static void menuactionpress(void)
             game.createmenu(Menu::levellist, true);
             game.currentmenuoption=game.menuoptions.size()-2;
             map.nexttowercolour();
-        }else if(game.currentmenuoption==(int)game.menuoptions.size()-3){
+        }else if(nextlastoptions && game.currentmenuoption==(int)game.menuoptions.size()-3){
             //next page
             music.playef(11);
             if((size_t) ((game.levelpage*8)+8) >= ed.ListOfMetaData.size()){
@@ -457,6 +459,7 @@ static void menuactionpress(void)
             }
         }
         break;
+    }
 #endif
     case Menu::quickloadlevel:
         switch (game.currentmenuoption)

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -173,8 +173,9 @@ static void menurender(void)
       }
       int tmp=game.currentmenuoption+(game.levelpage*8);
       if(INBOUNDS_VEC(tmp, ed.ListOfMetaData)){
+        const bool nextlastoptions = ed.ListOfMetaData.size() > 8;
         //Don't show next/previous page or return to menu options here!
-        if(game.menuoptions.size() - game.currentmenuoption<=3){
+        if(nextlastoptions && game.menuoptions.size() - game.currentmenuoption<=3){
 
         }else{
           graphics.bigprint( -1, 15, ed.ListOfMetaData[tmp].title, tr, tg, tb, true);


### PR DESCRIPTION
It's possible to get one page of levels by removing all the built-ins, either by removing them directly from `data.zip` or by putting files with the same filenames as them in your level folder that don't contain nothing.

And hey, there's already a check for if no levels exist at all, so why not check for this too?

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
