### PR TITLE
Cycle tower color if loading level has error

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2648,6 +2648,7 @@ void scriptclass::resetgametomenu(void)
 static void gotoerrorloadinglevel(void)
 {
 	game.createmenu(Menu::errorloadinglevel);
+	map.nexttowercolour();
 	graphics.fademode = 4; /* start fade in */
 	music.currentsong = -1; /* otherwise music.play won't work */
 	music.play(6); /* title screen music */


### PR DESCRIPTION
For consistency.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
