### PR TITLE
Refactor colors in internal commands

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2856,7 +2856,7 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 11)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                int j=getcrewman(PURPLE); //purple
+                int j=getcrewman(PURPLE);
                 if (INBOUNDS_VEC(j, entities))
                 {
                     if (entities[j].xp > entities[i].xp + 5)
@@ -2881,7 +2881,7 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 12)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                int j=getcrewman(YELLOW); //yellow
+                int j=getcrewman(YELLOW);
                 if (INBOUNDS_VEC(j, entities))
                 {
                     if (entities[j].xp > entities[i].xp + 5)
@@ -2906,7 +2906,7 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 13)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                int j=getcrewman(RED); //red
+                int j=getcrewman(RED);
                 if (INBOUNDS_VEC(j, entities))
                 {
                     if (entities[j].xp > entities[i].xp + 5)
@@ -2931,7 +2931,7 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 14)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                int j=getcrewman(GREEN); //green
+                int j=getcrewman(GREEN);
                 if (INBOUNDS_VEC(j, entities))
                 {
                     if (entities[j].xp > entities[i].xp + 5)
@@ -2956,7 +2956,7 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 15)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                int j=getcrewman(BLUE); //blue
+                int j=getcrewman(BLUE);
                 if (INBOUNDS_VEC(j, entities))
                 {
                     if (entities[j].xp > entities[i].xp + 5)

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1199,33 +1199,6 @@ bool entityclass::gridmatch( int p1, int p2, int p3, int p4, int p11, int p21, i
     return false;
 }
 
-int entityclass::crewcolour( int t )
-{
-    //Return the colour of the indexed crewmate
-    switch(t)
-    {
-    case 0:
-        return 0;
-        break;
-    case 1:
-        return 20;
-        break;
-    case 2:
-        return 14;
-        break;
-    case 3:
-        return 15;
-        break;
-    case 4:
-        return 13;
-        break;
-    case 5:
-        return 16;
-        break;
-    }
-    return 0;
-}
-
 static void entityclonefix(entclass* entity)
 {
     if (entity->behave == 10 || entity->behave == 12)
@@ -2033,7 +2006,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         }else{
           entity.tile = 0;
         }
-        entity.colour = crewcolour(meta2);
+        entity.colour = graphics.crewcolour(meta2);
         entity.cx = 6;
         entity.cy = 2;
         entity.w = 12;
@@ -2883,7 +2856,7 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 11)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                int j=getcrewman(1); //purple
+                int j=getcrewman(PURPLE); //purple
                 if (INBOUNDS_VEC(j, entities))
                 {
                     if (entities[j].xp > entities[i].xp + 5)
@@ -2908,7 +2881,7 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 12)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                int j=getcrewman(2); //yellow
+                int j=getcrewman(YELLOW); //yellow
                 if (INBOUNDS_VEC(j, entities))
                 {
                     if (entities[j].xp > entities[i].xp + 5)
@@ -2933,7 +2906,7 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 13)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                int j=getcrewman(3); //red
+                int j=getcrewman(RED); //red
                 if (INBOUNDS_VEC(j, entities))
                 {
                     if (entities[j].xp > entities[i].xp + 5)
@@ -2958,7 +2931,7 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 14)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                int j=getcrewman(4); //green
+                int j=getcrewman(GREEN); //green
                 if (INBOUNDS_VEC(j, entities))
                 {
                     if (entities[j].xp > entities[i].xp + 5)
@@ -2983,7 +2956,7 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 15)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                int j=getcrewman(5); //blue
+                int j=getcrewman(BLUE); //blue
                 if (INBOUNDS_VEC(j, entities))
                 {
                     if (entities[j].xp > entities[i].xp + 5)
@@ -3939,15 +3912,9 @@ int entityclass::getlineat( int t )
     return 0;
 }
 
-int entityclass::getcrewman( int t )
+int entityclass::getcrewman( int t, int fallback /*= 0*/ )
 {
     //Returns the index of the crewman with colour index given by t
-    if (t == 0) t = 0;
-    if (t == 1) t = 20;
-    if (t == 2) t = 14;
-    if (t == 3) t = 15;
-    if (t == 4) t = 13;
-    if (t == 5) t = 16;
 
     for (size_t i = 0; i < entities.size(); i++)
     {
@@ -3961,7 +3928,7 @@ int entityclass::getcrewman( int t )
         }
     }
 
-    return 0;
+    return fallback;
 }
 
 int entityclass::getcustomcrewman( int t )

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -20,6 +20,18 @@ enum
     ACTIVITY = 5
 };
 
+enum
+{
+    CYAN = 0,
+    PURPLE = 20,
+    YELLOW = 14,
+    RED = 15,
+    GREEN = 13,
+    BLUE = 16,
+    GRAY = 19,
+    TELEPORTER = 102
+};
+
 class entityclass
 {
 public:
@@ -72,8 +84,6 @@ public:
 
     bool gridmatch(int p1, int p2, int p3, int p4, int p11, int p21, int p31, int p41);
 
-    int crewcolour(int t);
-
     void createentity(int xp, int yp, int t, int meta1, int meta2,
                       int p1, int p2, int p3, int p4);
     void createentity(int xp, int yp, int t, int meta1, int meta2,
@@ -98,7 +108,7 @@ public:
 
     int getlineat(int t);
 
-    int getcrewman(int t);
+    int getcrewman(int t, int fallback = 0);
     int getcustomcrewman(int t);
 
     int getteleporter(void);

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -3630,7 +3630,7 @@ void Game::updatestate(void)
                 }
                 obj.entities[i].invis = false;
                 obj.entities[i].dir = 1;
-                obj.entities[i].colour = obj.crewcolour(lastsaved);
+                obj.entities[i].colour = graphics.crewcolour(lastsaved);
 
                 obj.entities[i].ay = -6;
                 obj.entities[i].ax = 6;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3176,12 +3176,12 @@ void Graphics::textboxcentery(void)
 int Graphics::crewcolour(const int t)
 {
 	//given crewmate t, return colour in setcol
-	if (t == 0) return 0;
-	if (t == 1) return 20;
-	if (t == 2) return 14;
-	if (t == 3) return 15;
-	if (t == 4) return 13;
-	if (t == 5) return 16;
+	if (t == 0) return CYAN;
+	if (t == 1) return PURPLE;
+	if (t == 2) return YELLOW;
+	if (t == 3) return RED;
+	if (t == 4) return GREEN;
+	if (t == 5) return BLUE;
 	return 0;
 }
 

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -2005,7 +2005,7 @@ void mapclass::loadlevel(int rx, int ry)
 			{
 				//A slight varation - she's upside down
 				obj.createentity(249, 62, 18, 16, 0, 18);
-				int j = obj.getcrewman(5);
+				int j = obj.getcrewman(BLUE);
 				if (INBOUNDS_VEC(j, obj.entities))
 				{
 					obj.entities[j].rule = 7;

--- a/desktop_version/src/Otherlevel.cpp
+++ b/desktop_version/src/Otherlevel.cpp
@@ -8903,7 +8903,7 @@ const short* otherlevelclass::loadlevel(int rx, int ry)
 
 			//violet
 			obj.createentity(83, 126, 18, 20, 0, 18);
-			int crewman = obj.getcrewman(1);
+			int crewman = obj.getcrewman(PURPLE);
 			if (INBOUNDS_VEC(crewman, obj.entities))
 			{
 				obj.entities[crewman].rule = 7;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1799,7 +1799,7 @@ void scriptclass::run(void)
 			else if (words[0] == "createlastrescued")
 			{
 				r = graphics.crewcolour(game.lastsaved);
-				if (r <= 1)
+				if (r == 1 || r == PURPLE)
 				{
 					r = GRAY; // Default to gray if invalid color.
 				}

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -89,6 +89,33 @@ void scriptclass::tokenize( const std::string& t )
 	}
 }
 
+static int getcolorfromname(std::string name)
+{
+	if      (name == "player")     return CYAN;
+	else if (name == "cyan")       return CYAN;
+	else if (name == "red")        return RED;
+	else if (name == "green")      return GREEN;
+	else if (name == "yellow")     return YELLOW;
+	else if (name == "blue")       return BLUE;
+	else if (name == "purple")     return PURPLE;
+	else if (name == "customcyan") return CYAN;
+	else if (name == "gray")       return GRAY;
+	else if (name == "teleporter") return TELEPORTER;
+
+	int color = help.Int(name.c_str(), -1);
+	if (color < 0) return -1; // Not a number (or it's negative), so we give up
+	return color; // Last effort to give a valid color, maybe they just input the color?
+}
+
+static int getcrewmanfromname(std::string name)
+{
+	if (name == "player") return obj.getplayer(); //  Return the player
+	int color = getcolorfromname(name); // Maybe they passed in a crewmate name, or an id?
+	if (color == -1) return -1; // ...Nope, return -1
+	return obj.getcrewman(color);
+}
+
+
 void scriptclass::run(void)
 {
 	if (!running)
@@ -468,45 +495,7 @@ void scriptclass::run(void)
 				j = 0;
 
 				//the first word is the object to position relative to
-				if (words[1] == "player")
-				{
-					i = obj.getplayer();
-					if (INBOUNDS_VEC(i, obj.entities))
-					{
-						j = obj.entities[i].dir;
-					}
-				}
-				else if (words[1] == "cyan")
-				{
-					i = obj.getcrewman(0);
-					j = obj.entities[i].dir;
-				}
-				else if (words[1] == "purple")
-				{
-					i = obj.getcrewman(1);
-					j = obj.entities[i].dir;
-				}
-				else if (words[1] == "yellow")
-				{
-					i = obj.getcrewman(2);
-					j = obj.entities[i].dir;
-				}
-				else if (words[1] == "red")
-				{
-					i = obj.getcrewman(3);
-					j = obj.entities[i].dir;
-				}
-				else if (words[1] == "green")
-				{
-					i = obj.getcrewman(4);
-					j = obj.entities[i].dir;
-				}
-				else if (words[1] == "blue")
-				{
-					i = obj.getcrewman(5);
-					j = obj.entities[i].dir;
-				}
-				else if (words[1] == "centerx")
+				if (words[1] == "centerx")
 				{
 					words[2] = "donothing";
 					j = -1;
@@ -524,6 +513,14 @@ void scriptclass::run(void)
 					j = -1;
 					textx = -500;
 					texty = -500;
+				}
+				else // Well, are they asking for a crewmate...?
+				{
+				    i = getcrewmanfromname(words[1]);
+				    if (INBOUNDS_VEC(i, obj.entities))
+				    {
+				        j = obj.entities[i].dir;
+				    }
 				}
 
 				//next is whether to position above or below
@@ -797,38 +794,11 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "createcrewman")
 			{
-				if (words[3] == "cyan")
-				{
-					r=0;
-				}
-				else if (words[3] == "red")
-				{
-					r=15;
-				}
-				else if (words[3] == "green")
-				{
-					r=13;
-				}
-				else if (words[3] == "yellow")
-				{
-					r=14;
-				}
-				else if (words[3] == "blue")
-				{
-					r=16;
-				}
-				else if (words[3] == "purple")
-				{
-					r=20;
-				}
-				else if (words[3] == "gray")
-				{
-					r=19;
-				}
-				else
-				{
-					r = 19;
-				}
+				// Note: Do not change the "r" variable, it's used in custom levels
+				// to have glitchy textbox colors, where the game treats the value
+				// we set here as the red channel for the color.
+				r = getcolorfromname(words[3]);
+				if (r == -1) r = 19;
 
 				//convert the command to the right index
 				if (words[5] == "followplayer") words[5] = "10";
@@ -871,42 +841,8 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "changemood")
 			{
-				if (words[1] == "player")
-				{
-					i=obj.getplayer();
-				}
-				else if (words[1] == "cyan")
-				{
-					i=obj.getcrewman(0);
-				}
-				else if (words[1] == "customcyan")
-				{
-					i=obj.getcustomcrewman(0);
-				}
-				else if (words[1] == "red")
-				{
-					i=obj.getcrewman(3);
-				}
-				else if (words[1] == "green")
-				{
-					i=obj.getcrewman(4);
-				}
-				else if (words[1] == "yellow")
-				{
-					i=obj.getcrewman(2);
-				}
-				else if (words[1] == "blue")
-				{
-					i=obj.getcrewman(5);
-				}
-				else if (words[1] == "purple")
-				{
-					i=obj.getcrewman(1);
-				}
-				else if (words[1] == "pink")
-				{
-					i=obj.getcrewman(1);
-				}
+				int crewmate = getcrewmanfromname(words[1]);
+				if (crewmate != -1) i = crewmate; // Ensure AEM is kept
 
 				if (INBOUNDS_VEC(i, obj.entities) && ss_toi(words[2]) == 0)
 				{
@@ -976,34 +912,8 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "changetile")
 			{
-				if (words[1] == "player")
-				{
-					i=obj.getplayer();
-				}
-				else if (words[1] == "cyan")
-				{
-					i=obj.getcrewman(0);
-				}
-				else if (words[1] == "red")
-				{
-					i=obj.getcrewman(3);
-				}
-				else if (words[1] == "green")
-				{
-					i=obj.getcrewman(4);
-				}
-				else if (words[1] == "yellow")
-				{
-					i=obj.getcrewman(2);
-				}
-				else if (words[1] == "blue")
-				{
-					i=obj.getcrewman(5);
-				}
-				else if (words[1] == "purple")
-				{
-					i=obj.getcrewman(1);
-				}
+				int crewmate = getcrewmanfromname(words[1]);
+				if (crewmate != -1) i = crewmate; // Ensure AEM is kept
 
 				if (INBOUNDS_VEC(i, obj.entities))
 				{
@@ -1020,30 +930,8 @@ void scriptclass::run(void)
 				}
 				else
 				{
-					if (words[1] == "cyan")
-					{
-						i=obj.getcrewman(0);
-					}
-					else if (words[1] == "red")
-					{
-						i=obj.getcrewman(3);
-					}
-					else if (words[1] == "green")
-					{
-						i=obj.getcrewman(4);
-					}
-					else if (words[1] == "yellow")
-					{
-						i=obj.getcrewman(2);
-					}
-					else if (words[1] == "blue")
-					{
-						i=obj.getcrewman(5);
-					}
-					else if (words[1] == "purple")
-					{
-						i=obj.getcrewman(1);
-					}
+					int crewmate = getcrewmanfromname(words[1]);
+					if (crewmate != -1) i = crewmate; // Ensure AEM is kept
 
 					if (INBOUNDS_VEC(i, obj.entities) && obj.entities[i].rule == 7)
 					{
@@ -1060,34 +948,8 @@ void scriptclass::run(void)
 			else if (words[0] == "changegravity")
 			{
 				//not something I'll use a lot, I think. Doesn't need to be very robust!
-				if (words[1] == "player")
-				{
-					i=obj.getplayer();
-				}
-				else if (words[1] == "cyan")
-				{
-					i=obj.getcrewman(0);
-				}
-				else if (words[1] == "red")
-				{
-					i=obj.getcrewman(3);
-				}
-				else if (words[1] == "green")
-				{
-					i=obj.getcrewman(4);
-				}
-				else if (words[1] == "yellow")
-				{
-					i=obj.getcrewman(2);
-				}
-				else if (words[1] == "blue")
-				{
-					i=obj.getcrewman(5);
-				}
-				else if (words[1] == "purple")
-				{
-					i=obj.getcrewman(1);
-				}
+				int crewmate = getcrewmanfromname(words[1]);
+				if (crewmate != -1) i = crewmate; // Ensure AEM is kept
 
 				if (INBOUNDS_VEC(i, obj.entities))
 				{
@@ -1096,34 +958,8 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "changedir")
 			{
-				if (words[1] == "player")
-				{
-					i=obj.getplayer();
-				}
-				else if (words[1] == "cyan")
-				{
-					i=obj.getcrewman(0);
-				}
-				else if (words[1] == "red")
-				{
-					i=obj.getcrewman(3);
-				}
-				else if (words[1] == "green")
-				{
-					i=obj.getcrewman(4);
-				}
-				else if (words[1] == "yellow")
-				{
-					i=obj.getcrewman(2);
-				}
-				else if (words[1] == "blue")
-				{
-					i=obj.getcrewman(5);
-				}
-				else if (words[1] == "purple")
-				{
-					i=obj.getcrewman(1);
-				}
+				int crewmate = getcrewmanfromname(words[1]);
+				if (crewmate != -1) i = crewmate; // Ensure AEM is kept
 
 				if (INBOUNDS_VEC(i, obj.entities) && ss_toi(words[2]) == 0)
 				{
@@ -1145,34 +981,8 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "changeai")
 			{
-				if (words[1] == "player")
-				{
-					i=obj.getplayer();
-				}
-				else if (words[1] == "cyan")
-				{
-					i=obj.getcrewman(0);
-				}
-				else if (words[1] == "red")
-				{
-					i=obj.getcrewman(3);
-				}
-				else if (words[1] == "green")
-				{
-					i=obj.getcrewman(4);
-				}
-				else if (words[1] == "yellow")
-				{
-					i=obj.getcrewman(2);
-				}
-				else if (words[1] == "blue")
-				{
-					i=obj.getcrewman(5);
-				}
-				else if (words[1] == "purple")
-				{
-					i=obj.getcrewman(1);
-				}
+				int crewmate = getcrewmanfromname(words[1]);
+				if (crewmate != -1) i = crewmate; // Ensure AEM is kept
 
 				if (words[2] == "followplayer") words[2] = "10";
 				if (words[2] == "followpurple") words[2] = "11";
@@ -1218,65 +1028,12 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "changecolour")
 			{
-				if (words[1] == "player")
-				{
-					i=obj.getplayer();
-				}
-				else if (words[1] == "cyan")
-				{
-					i=obj.getcrewman(0);
-				}
-				else if (words[1] == "red")
-				{
-					i=obj.getcrewman(3);
-				}
-				else if (words[1] == "green")
-				{
-					i=obj.getcrewman(4);
-				}
-				else if (words[1] == "yellow")
-				{
-					i=obj.getcrewman(2);
-				}
-				else if (words[1] == "blue")
-				{
-					i=obj.getcrewman(5);
-				}
-				else if (words[1] == "purple")
-				{
-					i=obj.getcrewman(1);
-				}
+				int crewmate = getcrewmanfromname(words[1]);
+				if (crewmate != -1) i = crewmate; // Ensure AEM is kept
 
 				if (INBOUNDS_VEC(i, obj.entities))
 				{
-					if (words[2] == "cyan")
-					{
-						obj.entities[i].colour = 0;
-					}
-					else if (words[2] == "red")
-					{
-						obj.entities[i].colour = 15;
-					}
-					else if (words[2] == "green")
-					{
-						obj.entities[i].colour = 13;
-					}
-					else if (words[2] == "yellow")
-					{
-						obj.entities[i].colour = 14;
-					}
-					else if (words[2] == "blue")
-					{
-						obj.entities[i].colour = 16;
-					}
-					else if (words[2] == "purple")
-					{
-						obj.entities[i].colour = 20;
-					}
-					else if (words[2] == "teleporter")
-					{
-						obj.entities[i].colour = 102;
-					}
+					obj.entities[i].colour = getcolorfromname(words[2]);
 				}
 			}
 			else if (words[0] == "squeak")
@@ -1683,63 +1440,11 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "face")
 			{
-				if (words[1] == "player")
-				{
-					i=obj.getplayer();
-				}
-				else if (words[1] == "cyan")
-				{
-					i=obj.getcrewman(0);
-				}
-				else if (words[1] == "red")
-				{
-					i=obj.getcrewman(3);
-				}
-				else if (words[1] == "green")
-				{
-					i=obj.getcrewman(4);
-				}
-				else if (words[1] == "yellow")
-				{
-					i=obj.getcrewman(2);
-				}
-				else if (words[1] == "blue")
-				{
-					i=obj.getcrewman(5);
-				}
-				else if (words[1] == "purple")
-				{
-					i=obj.getcrewman(1);
-				}
+				int crewmate = getcrewmanfromname(words[1]);
+				if (crewmate != -1) i = crewmate; // Ensure AEM is kept
 
-				if (words[2] == "player")
-				{
-					j=obj.getplayer();
-				}
-				else if (words[2] == "cyan")
-				{
-					j=obj.getcrewman(0);
-				}
-				else if (words[2] == "red")
-				{
-					j=obj.getcrewman(3);
-				}
-				else if (words[2] == "green")
-				{
-					j=obj.getcrewman(4);
-				}
-				else if (words[2] == "yellow")
-				{
-					j=obj.getcrewman(2);
-				}
-				else if (words[2] == "blue")
-				{
-					j=obj.getcrewman(5);
-				}
-				else if (words[2] == "purple")
-				{
-					j=obj.getcrewman(1);
-				}
+				crewmate = getcrewmanfromname(words[2]);
+				if (crewmate != -1) j = crewmate; // Ensure AEM is kept
 
 				if (INBOUNDS_VEC(i, obj.entities) && INBOUNDS_VEC(j, obj.entities) && obj.entities[j].xp > obj.entities[i].xp + 5)
 				{
@@ -1872,29 +1577,35 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "createactivityzone")
 			{
+				int crew_color = i; // stay consistent with past behavior!
 				if (words[1] == "red")
 				{
-					i=3;
+					i = 3;
+					crew_color = RED;
 				}
 				else if (words[1] == "green")
 				{
-					i=4;
+					i = 4;
+					crew_color = GREEN;
 				}
 				else if (words[1] == "yellow")
 				{
-					i=2;
+					i = 2;
+					crew_color = YELLOW;
 				}
 				else if (words[1] == "blue")
 				{
-					i=5;
+					i = 5;
+					crew_color = BLUE;
 				}
 				else if (words[1] == "purple")
 				{
-					i=1;
+					i = 1;
+					crew_color = PURPLE;
 				}
 
-				int crewman = obj.getcrewman(i);
-				if (INBOUNDS_VEC(crewman, obj.entities) && i == 4)
+				int crewman = obj.getcrewman(crew_color);
+				if (INBOUNDS_VEC(crewman, obj.entities) && crew_color == GREEN)
 				{
 					obj.createblock(5, obj.entities[crewman].xp - 32, obj.entities[crewman].yp-20, 96, 60, i, "", (i == 35));
 				}
@@ -1955,34 +1666,7 @@ void scriptclass::run(void)
 
 				if (INBOUNDS_VEC(i, obj.entities))
 				{
-					if (words[1] == "cyan")
-					{
-						obj.entities[i].colour = 0;
-					}
-					else if (words[1] == "red")
-					{
-						obj.entities[i].colour = 15;
-					}
-					else if (words[1] == "green")
-					{
-						obj.entities[i].colour = 13;
-					}
-					else if (words[1] == "yellow")
-					{
-						obj.entities[i].colour = 14;
-					}
-					else if (words[1] == "blue")
-					{
-						obj.entities[i].colour = 16;
-					}
-					else if (words[1] == "purple")
-					{
-						obj.entities[i].colour = 20;
-					}
-					else if (words[1] == "teleporter")
-					{
-						obj.entities[i].colour = 102;
-					}
+					obj.entities[i].colour = getcolorfromname(words[1]);
 				}
 			}
 			else if (words[0] == "altstates")
@@ -2114,25 +1798,28 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "createlastrescued")
 			{
-				if (game.lastsaved==2)
+				int crew_color = 1;
+				switch (game.lastsaved)
 				{
-					r=14;
-				}
-				else if (game.lastsaved==3)
-				{
-					r=15;
-				}
-				else if (game.lastsaved==4)
-				{
-					r=13;
-				}
-				else if (game.lastsaved==5)
-				{
-					r=16;
-				}
-				else
-				{
+				case 2:
+					r = 14;
+					crew_color = YELLOW;
+					break;
+				case 3:
+					r = 15;
+					crew_color = RED;
+					break;
+				case 4:
+					r = 13;
+					crew_color = GREEN;
+					break;
+				case 5:
+					r = 16;
+					crew_color = BLUE;
+					break;
+				default:
 					r = 19;
+					break;
 				}
 
 				obj.createentity(200, 153, 18, r, 0, 19, 30);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1799,7 +1799,7 @@ void scriptclass::run(void)
 			else if (words[0] == "createlastrescued")
 			{
 				r = graphics.crewcolour(game.lastsaved);
-				if (r == 1 || r == PURPLE)
+				if (r == 0 || r == PURPLE)
 				{
 					r = GRAY; // Default to gray if invalid color.
 				}

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1798,28 +1798,10 @@ void scriptclass::run(void)
 			}
 			else if (words[0] == "createlastrescued")
 			{
-				int crew_color = 1;
-				switch (game.lastsaved)
+				r = graphics.crewcolour(game.lastsaved);
+				if (r <= 1)
 				{
-				case 2:
-					r = 14;
-					crew_color = YELLOW;
-					break;
-				case 3:
-					r = 15;
-					crew_color = RED;
-					break;
-				case 4:
-					r = 13;
-					crew_color = GREEN;
-					break;
-				case 5:
-					r = 16;
-					crew_color = BLUE;
-					break;
-				default:
-					r = 19;
-					break;
+					r = GRAY; // Default to gray if invalid color.
 				}
 
 				obj.createentity(200, 153, 18, r, 0, 19, 30);


### PR DESCRIPTION
## Changes:

Originally this started as a "deduplicate a bunch of duplicated code in script commands" PR, but as I was working on that, I discovered there's a lot more that needs to be done than just deduplication. Anything which needs a crewmate entity now calls `getcrewmanfromname(name)`, and anything which just needs the crewmate's color calls `getcolorfromname(name)`. This was done to make sure that everything works consistently and no copy/pasting is required. Next is the fallback; instead of giving up and doing various things when it can't find a specific color, it now attempts to treat the color name as an ID, and if it can't then it returns -1, where each individual command handles that return value. This means we can keep around AEM -- a bug used in custom levels -- by not doing anything with the return value if it's -1.

Also, for some reason, there were two `crewcolour` functions, so I stripped out the one in entityclass and left (and modified) the one in the graphics class, since the graphics class also has the `crewcolourreal` function.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
