### PR TITLE
tokenize(): Check all arguments

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -73,15 +73,16 @@ void scriptclass::tokenize( const std::string& t )
 		}
 	}
 
+	if (tempword != "" && j < (int) SDL_arraysize(words))
+	{
+		words[j] = tempword;
+	}
+
 	SDL_zeroa(argexists);
 
-	if (j < (int) NUM_SCRIPT_ARGS)
+	for (size_t ii = 0; ii < NUM_SCRIPT_ARGS; ++ii)
 	{
-		argexists[j] = tempword != "";
-		if (argexists[j])
-		{
-			words[j] = tempword;
-		}
+		argexists[ii] = words[ii] != "";
 	}
 }
 


### PR DESCRIPTION
63a487d20df72e5ed64d1625217fb4257a3cc668 only checked for the last argument, not for all arguments.

Fixes #822.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
