### PR TITLE
Call FS.syncfs on Emscripten

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -879,7 +879,14 @@ bool FILESYSTEM_saveTiXml2Document(const char *name, tinyxml2::XMLDocument& doc)
 	PHYSFS_close(handle);
 
 #ifdef __EMSCRIPTEN__
-	EM_ASM(FS.syncfs(false, function(err) { if (err) abort(err); }));
+	EM_ASM(FS.syncfs(false, function(err)
+	{
+		if (err)
+		{
+			console.warn("Error saving:", err);
+			alert("Error saving. Check console for more information.");
+		}
+	}));
 #endif
 
 	return true;

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -25,7 +25,12 @@ int mkdir(char* path, int mode)
 	MultiByteToWideChar(CP_UTF8, 0, path, -1, utf16_path, MAX_PATH);
 	return CreateDirectoryW(utf16_path, NULL);
 }
-#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__HAIKU__) || defined(__DragonFly__) || defined(__EMSCRIPTEN__) || defined(__unix__)
+#elif defined(__EMSCRIPTEN__)
+#include <limits.h>
+#include <sys/stat.h>
+#include <emscripten.h>
+#define MAX_PATH PATH_MAX
+#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__HAIKU__) || defined(__DragonFly__) || defined(__unix__)
 #include <limits.h>
 #include <sys/stat.h>
 #define MAX_PATH PATH_MAX
@@ -872,6 +877,11 @@ bool FILESYSTEM_saveTiXml2Document(const char *name, tinyxml2::XMLDocument& doc)
 	}
 	PHYSFS_writeBytes(handle, printer.CStr(), printer.CStrSize() - 1); // subtract one because CStrSize includes terminating null
 	PHYSFS_close(handle);
+
+#ifdef __EMSCRIPTEN__
+	EM_ASM(FS.syncfs(false, function(err) { if (err) abort(err); }));
+#endif
+
 	return true;
 }
 

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -865,7 +865,7 @@ fail:
 	return true;
 }
 
-bool FILESYSTEM_saveTiXml2Document(const char *name, tinyxml2::XMLDocument& doc)
+bool FILESYSTEM_saveTiXml2Document(const char *name, tinyxml2::XMLDocument& doc, bool sync /*= true*/)
 {
 	/* XMLDocument.SaveFile doesn't account for Unicode paths, PHYSFS does */
 	tinyxml2::XMLPrinter printer;
@@ -879,14 +879,17 @@ bool FILESYSTEM_saveTiXml2Document(const char *name, tinyxml2::XMLDocument& doc)
 	PHYSFS_close(handle);
 
 #ifdef __EMSCRIPTEN__
-	EM_ASM(FS.syncfs(false, function(err)
+	if (sync)
 	{
-		if (err)
+		EM_ASM(FS.syncfs(false, function(err)
 		{
-			console.warn("Error saving:", err);
-			alert("Error saving. Check console for more information.");
-		}
-	}));
+			if (err)
+			{
+				console.warn("Error saving:", err);
+				alert("Error saving. Check console for more information.");
+			}
+		}));
+	}
 #endif
 
 	return true;

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -35,7 +35,7 @@ void FILESYSTEM_freeMemory(unsigned char **mem);
 
 bool FILESYSTEM_loadBinaryBlob(binaryBlob* blob, const char* filename);
 
-bool FILESYSTEM_saveTiXml2Document(const char *name, tinyxml2::XMLDocument& doc);
+bool FILESYSTEM_saveTiXml2Document(const char *name, tinyxml2::XMLDocument& doc, bool sync = true);
 bool FILESYSTEM_loadTiXml2Document(const char *name, tinyxml2::XMLDocument& doc);
 
 void FILESYSTEM_enumerateLevelDirFileNames(void (*callback)(const char* filename));

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4338,7 +4338,7 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, ScreenSettings* s
     }
 }
 
-bool Game::savestats(void)
+bool Game::savestats(bool sync /*= true*/)
 {
     if (graphics.screenbuffer == NULL)
     {
@@ -4348,10 +4348,10 @@ bool Game::savestats(void)
     ScreenSettings screen_settings;
     graphics.screenbuffer->GetSettings(&screen_settings);
 
-    return savestats(&screen_settings);
+    return savestats(&screen_settings, sync);
 }
 
-bool Game::savestats(const ScreenSettings* screen_settings)
+bool Game::savestats(const ScreenSettings* screen_settings, bool sync /*= true*/)
 {
     tinyxml2::XMLDocument doc;
     bool already_exists = FILESYSTEM_loadTiXml2Document("saves/unlock.vvv", doc);
@@ -4427,12 +4427,12 @@ bool Game::savestats(const ScreenSettings* screen_settings)
 
     serializesettings(dataNode, screen_settings);
 
-    return FILESYSTEM_saveTiXml2Document("saves/unlock.vvv", doc);
+    return FILESYSTEM_saveTiXml2Document("saves/unlock.vvv", doc, sync);
 }
 
 bool Game::savestatsandsettings(void)
 {
-    const bool stats_saved = savestats();
+    const bool stats_saved = savestats(false);
 
     const bool settings_saved = savesettings();
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -156,8 +156,8 @@ public:
 
     void loadstats(ScreenSettings* screen_settings);
 
-    bool savestats(const ScreenSettings* screen_settings);
-    bool savestats(void);
+    bool savestats(const ScreenSettings* screen_settings, bool sync = true);
+    bool savestats(bool sync = true);
 
     void deletestats(void);
 


### PR DESCRIPTION
## Changes:

While thinking about #835, I realized that I can sidestep asyncify entirely by directly calling the relevant functions via inline JS.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
