### PR TITLE
Switch over to using `SDL_GetTicks64()`

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3087,7 +3087,12 @@ void scriptclass::hardreset(void)
 {
     const bool version2_2 = GlitchrunnerMode_less_than_or_equal(Glitchrunner2_2);
 
+#if SDL_VERSION_ATLEAST(2, 0, 17)
+    /* The RNG is 32-bit. We don't _really_ need 64-bit... */
+    xoshiro_seed((Uint32) SDL_GetTicks64());
+#else
     xoshiro_seed(SDL_GetTicks());
+#endif
 
     //Game:
     game.hascontrol = true;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -59,13 +59,13 @@ static std::string playassets;
 
 static std::string playtestname;
 
-static volatile Uint32 time_ = 0;
-static volatile Uint32 timePrev = 0;
+static volatile Uint64 time_ = 0;
+static volatile Uint64 timePrev = 0;
 static volatile Uint32 accumulator = 0;
 
 #ifndef __EMSCRIPTEN__
-static volatile Uint32 f_time = 0;
-static volatile Uint32 f_timePrev = 0;
+static volatile Uint64 f_time = 0;
+static volatile Uint64 f_timePrev = 0;
 #endif
 
 enum FuncType
@@ -358,7 +358,11 @@ static void cleanup(void);
 static void emscriptenloop(void)
 {
     timePrev = time_;
+#if SDL_VERSION_ATLEAST(2, 0, 17)
+    time_ = SDL_GetTicks64();
+#else
     time_ = SDL_GetTicks();
+#endif
     deltaloop();
 }
 #endif
@@ -670,20 +674,32 @@ int main(int argc, char *argv[])
 #else
     while (true)
     {
+#if SDL_VERSION_ATLEAST(2, 0, 17)
+        f_time = SDL_GetTicks64();
+#else
         f_time = SDL_GetTicks();
+#endif
 
-        const Uint32 f_timetaken = f_time - f_timePrev;
+        const Uint64 f_timetaken = f_time - f_timePrev;
         if (!game.over30mode && f_timetaken < 34)
         {
-            const volatile Uint32 f_delay = 34 - f_timetaken;
-            SDL_Delay(f_delay);
+            const volatile Uint64 f_delay = 34 - f_timetaken;
+            SDL_Delay((Uint32) f_delay);
+#if SDL_VERSION_ATLEAST(2, 0, 17)
+            f_time = SDL_GetTicks64();
+#else
             f_time = SDL_GetTicks();
+#endif
         }
 
         f_timePrev = f_time;
 
         timePrev = time_;
+#if SDL_VERSION_ATLEAST(2, 0, 17)
+        time_ = SDL_GetTicks64();
+#else
         time_ = SDL_GetTicks();
+#endif
 
         deltaloop();
     }


### PR DESCRIPTION
`SDL_GetTicks64()` is a function that got added in SDL 2.0.18, which is just an `SDL_GetTicks()` without a value that wraps every ~49 days, instead wrapping after the sun explodes and kills us all. Oh sorry, didn't mean to get existential.

For now, put this behind an `SDL_VERSION_ATLEAST` guard, which will be removed when SDL 2.0.18 officially releases and we can update to it.

Don't merge this until libsdl-org/SDL#4872 is merged into SDL 2.0.18.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
