### PR TITLE
Fix -Wformat-security warnings

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -306,7 +306,7 @@ static int setLevelDirError(const char* text, ...)
     retval = SDL_vsnprintf(levelDirError, sizeof(levelDirError), text, list);
     va_end(list);
 
-    vlog_error(levelDirError);
+    vlog_error("%s", levelDirError);
 
     return retval;
 }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -321,7 +321,7 @@ void Graphics::updatetitlecolours(void)
         SDL_snprintf(error, sizeof(error), error_fmt, #tilesheet, tile_square); \
         SDL_snprintf(error_title, sizeof(error_title), error_title_fmt, #tilesheet); \
         \
-        vlog_error(error); \
+        vlog_error("%s", error); \
         \
         return false; \
     }


### PR DESCRIPTION
## Changes:

In two places, `vlog_error` is fed a string, even though it takes a format string. This causes warnings for me:
```
FileSystemUtils.cpp:309:16: warning: format not a string literal and no format arguments [-Wformat-security]
  309 |     vlog_error(levelDirError);
      |                ^~~~~~~~~~~~~
```

And this one is repeated several times:
```
Graphics.cpp:324:20: warning: format not a string literal and no format arguments [-Wformat-security]
  324 |         vlog_error(error); \
      |                    ^~~~~
```

The fix is to change these into `vlog_error("%s", levelDirError)` and `vlog_error("%s", error)`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
