### PR TITLE
Update VS2019 to VS2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         cd $env:SRC_DIR_PATH
         $env:LDFLAGS =  "/LIBPATH:C:\SDL2-$env:SDL_VERSION\lib\x86 "
         $env:LDFLAGS += "/LIBPATH:C:\SDL2_mixer-$env:SDL_MIXER_VERSION\lib\x86"
-        cmake -G "Visual Studio 16 2019" -A Win32 `
+        cmake -G "Visual Studio 17 2022" -A Win32 `
               -DSDL2_INCLUDE_DIRS="C:\SDL2-$env:SDL_VERSION\include;C:\SDL2_mixer-$env:SDL_MIXER_VERSION\include" `
               -DSDL2_LIBRARIES="SDL2;SDL2main;SDL2_mixer" .
     - name: Build (default version)


### PR DESCRIPTION
Required for Actions workflow due to windows-latest Version Change
(Alternatively, pin Windows to 2019)

## Changes:

I was having build issues on my fork, turns out the Github Actions [windows-latest version change](https://github.com/actions/virtual-environments/issues/4856) breaks the CMake Generator used atm.
Update it to keep compatibility with windows-latest.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
