### PR TITLE
Port to FAudio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         submodules: true
 
     - name: Install dependencies
-      run: brew install ninja sdl2 sdl2_mixer
+      run: brew install ninja sdl2
 
     - name: CMake configure (default version)
       run: |
@@ -118,7 +118,6 @@ jobs:
 
     env:
       SDL_VERSION: 2.0.20
-      SDL_MIXER_VERSION: 2.0.4
 
     steps:
     - uses: actions/checkout@v1
@@ -133,14 +132,6 @@ jobs:
         path: C:\SDL
         key: ${{ runner.os }}-build-${{ env.cache-name }}
 
-    - name: Cache SDL_mixer
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-sdl-mixer
-      with:
-        path: C:\SDL_mixer
-        key: ${{ runner.os }}-build-${{ env.cache-name }}
-
     - name: Download SDL if not cached
       run: |
         if (-Not (Test-Path C:\SDL))
@@ -149,23 +140,14 @@ jobs:
           Expand-Archive C:\SDL.zip -DestinationPath C:\
         }
 
-    - name: Download SDL_mixer if not cached
-      run: |
-        if (-Not (Test-Path C:\SDL_mixer))
-        {
-          Invoke-WebRequest "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-$env:SDL_MIXER_VERSION-VC.zip" -o C:\SDL_mixer.zip
-          Expand-Archive C:\SDL_mixer.zip -DestinationPath C:\
-        }
-
     - name: CMake configure (default version)
       run: |
         mkdir $env:SRC_DIR_PATH/build
         cd $env:SRC_DIR_PATH/build
         $env:LDFLAGS =  "/LIBPATH:C:\SDL2-$env:SDL_VERSION\lib\x86 "
-        $env:LDFLAGS += "/LIBPATH:C:\SDL2_mixer-$env:SDL_MIXER_VERSION\lib\x86"
         cmake -G "Visual Studio 17 2022" -A Win32 `
-              -DSDL2_INCLUDE_DIRS="C:\SDL2-$env:SDL_VERSION\include;C:\SDL2_mixer-$env:SDL_MIXER_VERSION\include" `
-              -DSDL2_LIBRARIES="SDL2;SDL2main;SDL2_mixer" ..
+              -DSDL2_INCLUDE_DIRS="C:\SDL2-$env:SDL_VERSION\include" `
+              -DSDL2_LIBRARIES="SDL2;SDL2main" ..
     - name: Build (default version)
       run: |
         cd $env:SRC_DIR_PATH/build

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "third_party/utfcpp"]
 	path = third_party/utfcpp
 	url = https://github.com/nemtrif/utfcpp
+[submodule "third_party/FAudio"]
+	path = third_party/FAudio
+	url = https://github.com/FNA-XNA/FAudio

--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -135,6 +135,8 @@ if(BUNDLE_DEPENDENCIES)
         ../third_party/physfs/extras
         ../third_party/lodepng
         ../third_party/utfcpp/source
+        ../third_party/FAudio/include
+        ../third_party/FAudio/src
     )
 else()
     target_include_directories(
@@ -142,6 +144,7 @@ else()
         src
         ../third_party/lodepng
         ../third_party/physfs/extras
+        ../third_party/FAudio/src
     )
 endif()
 
@@ -158,6 +161,13 @@ endif()
 
 set(XML2_SRC
     ../third_party/tinyxml2/tinyxml2.cpp
+)
+set(FAUDIO_SRC
+    ../third_party/FAudio/src/FAudio.c
+    ../third_party/FAudio/src/FAudio_internal.c
+    ../third_party/FAudio/src/FAudio_internal_simd.c
+    ../third_party/FAudio/src/FAudio_operationset.c
+    ../third_party/FAudio/src/FAudio_platform_sdl2.c
 )
 set(PFS_SRC
     ../third_party/physfs/src/physfs.c
@@ -289,12 +299,17 @@ if(BUNDLE_DEPENDENCIES)
     target_compile_definitions(physfs-static PRIVATE
         -DPHYSFS_SUPPORTS_DEFAULT=0 -DPHYSFS_SUPPORTS_ZIP=1
     )
+    add_library(faudio-static STATIC ${FAUDIO_SRC})
+    target_include_directories(
+        faudio-static PRIVATE
+        ../third_party/FAudio/include
+    )
 
-    target_link_libraries(VVVVVV physfs-static tinyxml2-static lodepng-static)
+    target_link_libraries(VVVVVV physfs-static tinyxml2-static lodepng-static faudio-static)
 else()
     find_package(utf8cpp CONFIG)
 
-    target_link_libraries(VVVVVV physfs tinyxml2 utf8cpp lodepng-static)
+    target_link_libraries(VVVVVV physfs tinyxml2 utf8cpp lodepng-static FAudio)
 endif()
 
 # SDL2 Dependency (Detection pulled from FAudio)
@@ -302,24 +317,41 @@ if(DEFINED SDL2_INCLUDE_DIRS AND DEFINED SDL2_LIBRARIES)
     message(STATUS "Using pre-defined SDL2 variables SDL2_INCLUDE_DIRS and SDL2_LIBRARIES")
     target_include_directories(VVVVVV SYSTEM PRIVATE "$<BUILD_INTERFACE:${SDL2_INCLUDE_DIRS}>")
     target_link_libraries(VVVVVV ${SDL2_LIBRARIES})
+    if(BUNDLE_DEPENDENCIES)
+        target_include_directories(faudio-static SYSTEM PRIVATE "$<BUILD_INTERFACE:${SDL2_INCLUDE_DIRS}>")
+        target_link_libraries(faudio-static ${SDL2_LIBRARIES})
+    endif()
 elseif (EMSCRIPTEN)
     message(STATUS "Using Emscripten SDL2")
-    target_compile_options(VVVVVV PUBLIC -sUSE_SDL=2 -sUSE_SDL_MIXER=2)
-    target_link_libraries(VVVVVV -sUSE_SDL=2 -sUSE_SDL_MIXER=2)
+    target_compile_options(VVVVVV PUBLIC -sUSE_SDL=2)
+    target_link_libraries(VVVVVV -sUSE_SDL=2)
+    if(BUNDLE_DEPENDENCIES)
+        target_compile_options(faudio-static PUBLIC -sUSE_SDL=2)
+        target_link_libraries(faudio-static -sUSE_SDL=2)
+    endif()
 else()
     # Only try to autodetect if both SDL2 variables aren't explicitly set
     find_package(SDL2 CONFIG)
     if(TARGET SDL2::SDL2)
         message(STATUS "Using TARGET SDL2::SDL2")
-        target_link_libraries(VVVVVV SDL2::SDL2 SDL2_mixer)
+        target_link_libraries(VVVVVV SDL2::SDL2)
+        if(BUNDLE_DEPENDENCIES)
+            target_link_libraries(faudio-static SDL2::SDL2)
+        endif()
     elseif(TARGET SDL2)
         message(STATUS "Using TARGET SDL2")
-        target_link_libraries(VVVVVV SDL2 SDL2_mixer)
+        target_link_libraries(VVVVVV SDL2)
+        if(BUNDLE_DEPENDENCIES)
+            target_link_libraries(faudio-static SDL2)
+        endif()
     else()
         message(STATUS "No TARGET SDL2::SDL2, or SDL2, using variables")
-        find_path(SDL2_MIXER_INCLUDE_DIRS NAMES SDL_mixer.h PATH_SUFFIXES SDL2)
-        target_include_directories(VVVVVV SYSTEM PRIVATE "$<BUILD_INTERFACE:${SDL2_INCLUDE_DIRS}>" ${SDL2_MIXER_INCLUDE_DIRS})
-        target_link_libraries(VVVVVV ${SDL2_LIBRARIES} SDL2_mixer)
+        target_include_directories(VVVVVV SYSTEM PRIVATE "$<BUILD_INTERFACE:${SDL2_INCLUDE_DIRS}>")
+        target_link_libraries(VVVVVV ${SDL2_LIBRARIES})
+        if(BUNDLE_DEPENDENCIES)
+            target_include_directories(faudio-static SYSTEM PRIVATE "$<BUILD_INTERFACE:${SDL2_INCLUDE_DIRS}>")
+            target_link_libraries(faudio-static ${SDL2_LIBRARIES})
+        endif()
     endif()
 endif()
 

--- a/desktop_version/Dockerfile
+++ b/desktop_version/Dockerfile
@@ -5,9 +5,6 @@ WORKDIR /tmp
 RUN curl -O https://www.libsdl.org/release/SDL2-2.0.20.tar.gz
 RUN tar -xf SDL2-2.0.20.tar.gz
 RUN mkdir SDL2-2.0.20/build
-RUN curl -O https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.4.tar.gz
-RUN tar -xf SDL2_mixer-2.0.4.tar.gz
-RUN mkdir SDL2_mixer-2.0.4/build
 
 # add EPEL (for SDL2)
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
@@ -30,12 +27,7 @@ RUN ../configure
 RUN make -j $(nproc)
 RUN make install
 
-WORKDIR /tmp/SDL2_mixer-2.0.4/build
-RUN ../configure
-RUN make -j $(nproc)
-RUN make install
-
 WORKDIR /tmp
-RUN rm -rf SDL2-2.0.20.tar.gz SDL2-2.0.20/ SDL2_mixer-2.0.4.tar.gz SDL2_mixer-2.0.4/
+RUN rm -rf SDL2-2.0.20.tar.gz SDL2-2.0.20/
 
 WORKDIR /

--- a/desktop_version/README.md
+++ b/desktop_version/README.md
@@ -6,8 +6,7 @@ VVVVVV's official desktop versions are built with the following environments:
 - macOS: Xcode CLT, currently targeting 10.9 SDK
 - GNU/Linux: CentOS 7
 
-The engine depends solely on [SDL2](https://libsdl.org/) 2.0.20+ and
-[SDL2_mixer](https://www.libsdl.org/projects/SDL_mixer/). All other dependencies
+The engine depends solely on [SDL2](https://libsdl.org/) 2.0.20+. All other dependencies
 are statically linked into the engine. The development libraries for Windows can
 be downloaded from their respective websites, Linux developers can find the dev
 libraries from their respective repositories, and macOS developers should
@@ -22,14 +21,14 @@ current implementation has been tested with Steamworks SDK v1.46.
 
 To generate the projects on Windows:
 ```
-# Put your SDL2/SDL2_mixer folders somewhere nice!
+# Put your SDL2 folders somewhere nice!
 mkdir flibitBuild
 cd flibitBuild
-cmake -A Win32 -G "Visual Studio 10 2010" .. -DSDL2_INCLUDE_DIRS="C:\SDL2-2.0.20\include;C:\SDL2_mixer-2.0.4\include" -DSDL2_LIBRARIES="C:\SDL2-2.0.20\lib\x86\SDL2;C:\SDL2-2.0.20\lib\x86\SDL2main;C:\SDL2_mixer-2.0.4\lib\x86\SDL2_mixer"
+cmake -A Win32 -G "Visual Studio 10 2010" .. -DSDL2_INCLUDE_DIRS="C:\SDL2-2.0.20\include" -DSDL2_LIBRARIES="C:\SDL2-2.0.20\lib\x86\SDL2;C:\SDL2-2.0.20\lib\x86\SDL2main"
 ```
 
 Note that on some systems, the `SDL2_LIBRARIES` list on Windows may need
-SDL2/SDL2main/SDL2_mixer to have `.lib` at the end of them. The reason for this
+SDL2/SDL2main to have `.lib` at the end of them. The reason for this
 inconsistency is unknown.
 
 Also note that if you're using a Visual Studio later than 2010, you will need to


### PR DESCRIPTION
## Changes:

I was browsing the repo and saw #829, with the note that porting to FAudio should be "really easy" for someone else to do.
Answer is no it wasn't (tbf I never touched any audio stuff ever), but I tried nonetheless.

This should be functional, but buggy. I'm opening the PR to see if I should continue or just stop.
~~Thanks for looking at my awful code~~

CI is failing because I used a submodule for FAudio. I can either make CI clone recursive or just copy folder contents, will wait for feedback on that.
Had to increase C Standard Version due to stb_vorbis (90 -> 99). If someone has suggestions on how to avoid that please share.

Most Bugs revolve around tabbing in and out of the game. Sometimes there is no `Resume()` generated for some reason I think. For example, tabbing out during the intro sequence causes the game to stay mute until you do it again during gameplay. I think it might be because of `FAudio_StopEngine()` in `Pause()`, but as that was written in the comment I let it be.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
