### PR TITLE
Fix C/C++ standards being unset for VVVVVV target if CMake is >= 3.1.3

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -248,27 +248,9 @@ if(MSVC)
     target_compile_options(VVVVVV PRIVATE /wd4244)
 endif()
 
-if(${CMAKE_VERSION} VERSION_LESS "3.1.3")
-    message(WARNING "Your CMake version is too old; using workaround")
-
-    if(MSVC)
-        # MSVC doesn't have /std:c99 or /std:c++98 switches!
-    else()
-        string(REGEX REPLACE "-std=[a-z0-9]+" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
-
-        string(REGEX REPLACE "-std=[a-z0-9+]+" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98")
-    endif()
-else()
-    set(CMAKE_C_STANDARD 99)
-    set(CMAKE_C_EXTENSIONS OFF)
-
-    set(CMAKE_CXX_STANDARD 98)
-    set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-
 if(MSVC)
+    # MSVC doesn't have /std:c99 or /std:c++98 switches!
+
     # Disable exceptions
     string(REGEX REPLACE "/EH[a-z]+" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
@@ -277,6 +259,12 @@ if(MSVC)
     string(REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
 else()
+    string(REGEX REPLACE "-std=[a-z0-9]+" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+
+    string(REGEX REPLACE "-std=[a-z0-9+]+" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98")
+
     # Disable exceptions
     string(REPLACE "-fexceptions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")


### PR DESCRIPTION
## Changes:

So, it turns out we weren't quite done fighting CMake yet...

To accommodate #869 (and actually also #272), the C standard was raised from C90 to C99. This turned out to require a bit of a fight with the CentOS CI's CMake version to get it to set the flags we wanted (and to not overwrite them later). Eventually the fix was to move the block that sets the standards to later in the file, which was done in 24353a54bb40665b64a93faebfb2ebd96cd0f6b5.

However, in [this comment](https://github.com/TerryCavanagh/VVVVVV/pull/869#pullrequestreview-917605059), I saw this screenshot:

> ![2022-03-22_10-21-52](https://user-images.githubusercontent.com/59748578/159538971-19a0e6ca-5a02-49d3-8854-6eb03ddd4218.png)

Where's the `--std=c++98` now?

As it apparently turns out, if your CMake is at least 3.1.3 and `CMAKE_<LANG>_STANDARD` is used instead of the workaround, the standard setting now has an effect on the third party libraries, but not on VVVVVV itself. The cause is (probably) the phrase "if it is set when a target is created" in the CMake documentation - the `CMAKE_<LANG>_STANDARD` values have to come before the VVVVVV target is defined. In other words, the compiler's default C/C++ standard will be used, probably something like C17 and C++17. As I can confirm with `__cplusplus` and `__STDC_VERSION__` with my recent-enough CMake. If I force the pre-3.1.3 workaround to be used, everything is compiled with C99/C++98 as expected; and the `-fno-exceptions` `-fno-rtti` flags appear everywhere regardless of version.

So my fix is to make the CMakeLists a little less complex by simplifying away the `CMAKE_<LANG>_STANDARD` and `CMAKE_<LANG>_EXTENSIONS`, and always using the workaround regardless of CMake version. There's nothing wrong with the workaround, the same thing is also done for `-fno-exceptions` `-fno-rtti`, and it's good to have a less complicated CMakeLists that doesn't do different and unexpected things for different versions.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
