### PR TITLE
Fix music changes between areas

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -357,6 +357,7 @@ end:
             FAudioSourceVoice_FlushSourceBuffers(musicVoice);
             FAudioVoice_DestroyVoice(musicVoice);
             musicVoice = NULL;
+            paused = true;
         }
     }
 
@@ -370,7 +371,13 @@ end:
         if (!IsHalted())
         {
             FAudioSourceVoice_Stop(musicVoice, 0, FAUDIO_COMMIT_NOW);
+            paused = true;
         }
+    }
+
+    static bool IsPaused()
+    {
+        return paused || IsHalted();
     }
 
     static void Resume()
@@ -378,6 +385,7 @@ end:
         if (!IsHalted())
         {
             FAudioSourceVoice_Start(musicVoice, 0, FAUDIO_COMMIT_NOW);
+            paused = false;
         }
     }
 
@@ -406,6 +414,7 @@ end:
     bool shouldloop;
     bool valid;
 
+    static bool paused;
     static FAudioSourceVoice* musicVoice;
 
     static void refillReserve(FAudioVoiceCallback* callback, void* ctx)
@@ -560,7 +569,7 @@ end:
         return (result * 60 + val) * samplerate_hz;
     }
 };
-
+bool MusicTrack::paused = false;
 FAudioSourceVoice* MusicTrack::musicVoice = NULL;
 
 musicclass::musicclass(void)
@@ -1130,7 +1139,7 @@ void musicclass::resumeef(void)
 
 bool musicclass::halted(void)
 {
-    return MusicTrack::IsHalted();
+    return MusicTrack::IsPaused();
 }
 
 void musicclass::updatemutestate(void)


### PR DESCRIPTION
## Changes:
Missed a Bug in #869.
When changing Areas, [this](https://github.com/TerryCavanagh/VVVVVV/blob/master/desktop_version/src/Music.cpp#L1010) line checks if Music is halted before playing the next track. However, it was never being halted, just paused.

Changing `haltdasmusik` to actually halt `MusicTrack` fixes it, but given the comment placed I wonder if this is the right approach. Could also check if Music is paused at the original location.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
