### PR TITLE
Potential Steam Deck UX enhancements for first-time users

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4317,10 +4317,12 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, struct ScreenSett
     if (controllerButton_map.size() < 1)
     {
         controllerButton_map.push_back(SDL_CONTROLLER_BUTTON_Y);
+        controllerButton_map.push_back(SDL_CONTROLLER_BUTTON_START);
     }
     if (controllerButton_esc.size() < 1)
     {
         controllerButton_esc.push_back(SDL_CONTROLLER_BUTTON_B);
+        controllerButton_esc.push_back(SDL_CONTROLLER_BUTTON_BACK);
     }
     if (controllerButton_restart.size() < 1)
     {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -26,6 +26,9 @@
 #include "Vlogging.h"
 #include "XMLUtils.h"
 
+static std::vector<SDL_GameControllerButton> defaultGameControllerMenuAccept;
+static std::vector<SDL_GameControllerButton> defaultGameControllerMenuBack;
+
 static std::vector<SDL_GameControllerButton> defaultGameControllerFlip;
 static std::vector<SDL_GameControllerButton> defaultGameControllerMap;
 static std::vector<SDL_GameControllerButton> defaultGameControllerEsc;
@@ -33,6 +36,9 @@ static std::vector<SDL_GameControllerButton> defaultGameControllerRestart;
 static std::vector<SDL_GameControllerButton> defaultGameControllerInteract;
 
 static void initDefaultGameControllerButtons() {
+    defaultGameControllerMenuAccept.push_back(SDL_CONTROLLER_BUTTON_A);
+    defaultGameControllerMenuBack.push_back(SDL_CONTROLLER_BUTTON_B);
+
     defaultGameControllerFlip.push_back(SDL_CONTROLLER_BUTTON_A);
 
     defaultGameControllerMap.push_back(SDL_CONTROLLER_BUTTON_Y);
@@ -46,6 +52,16 @@ static void initDefaultGameControllerButtons() {
 }
 
 void Game::applyDefaultGameControllerButtons() {
+    if (controllerButton_menuAccept.size() < 1) {
+        for (size_t i = 0; i < defaultGameControllerMenuAccept.size(); ++i) {
+            controllerButton_menuAccept.push_back(defaultGameControllerMenuAccept[i]);
+        }
+    }
+    if (controllerButton_menuBack.size() < 1) {
+        for (size_t i = 0; i < defaultGameControllerMenuBack.size(); ++i) {
+            controllerButton_menuBack.push_back(defaultGameControllerMenuBack[i]);
+        }
+    }
     if (controllerButton_flip.size() < 1)
     {
         for (size_t i = 0; i < defaultGameControllerFlip.size(); ++i) {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -26,6 +26,58 @@
 #include "Vlogging.h"
 #include "XMLUtils.h"
 
+static std::vector<SDL_GameControllerButton> defaultGameControllerFlip;
+static std::vector<SDL_GameControllerButton> defaultGameControllerMap;
+static std::vector<SDL_GameControllerButton> defaultGameControllerEsc;
+static std::vector<SDL_GameControllerButton> defaultGameControllerRestart;
+static std::vector<SDL_GameControllerButton> defaultGameControllerInteract;
+
+static void initDefaultGameControllerButtons() {
+    defaultGameControllerFlip.push_back(SDL_CONTROLLER_BUTTON_A);
+
+    defaultGameControllerMap.push_back(SDL_CONTROLLER_BUTTON_Y);
+    defaultGameControllerMap.push_back(SDL_CONTROLLER_BUTTON_START);
+
+    defaultGameControllerEsc.push_back(SDL_CONTROLLER_BUTTON_B);
+    defaultGameControllerEsc.push_back(SDL_CONTROLLER_BUTTON_BACK);
+
+    defaultGameControllerRestart.push_back(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER);
+    defaultGameControllerInteract.push_back(SDL_CONTROLLER_BUTTON_X);
+}
+
+void Game::applyDefaultGameControllerButtons() {
+    if (controllerButton_flip.size() < 1)
+    {
+        for (size_t i = 0; i < defaultGameControllerFlip.size(); ++i) {
+            controllerButton_flip.push_back(defaultGameControllerFlip[i]);
+        }
+    }
+    if (controllerButton_map.size() < 1)
+    {
+        for (size_t i = 0; i < defaultGameControllerMap.size(); ++i) {
+            controllerButton_map.push_back(defaultGameControllerMap[i]);
+        }
+    }
+    if (controllerButton_esc.size() < 1)
+    {
+        for (size_t i = 0; i < defaultGameControllerEsc.size(); ++i) {
+            controllerButton_esc.push_back(defaultGameControllerEsc[i]);
+        }
+    }
+    if (controllerButton_restart.size() < 1)
+    {
+        for (size_t i = 0; i < defaultGameControllerRestart.size(); ++i) {
+            controllerButton_restart.push_back(defaultGameControllerRestart[i]);
+        }
+    }
+    if (controllerButton_interact.size() < 1)
+    {
+        for (size_t i = 0; i < defaultGameControllerInteract.size(); ++i) {
+            controllerButton_interact.push_back(defaultGameControllerInteract[i]);
+        }
+    }
+}
+
 static bool GetButtonFromString(const char *pText, SDL_GameControllerButton *button)
 {
     if (*pText == '0' ||
@@ -367,6 +419,9 @@ void Game::init(void)
     disableaudiopause = false;
     disabletemporaryaudiopause = true;
     inputdelay = false;
+
+    initDefaultGameControllerButtons();
+    applyDefaultGameControllerButtons();
 }
 
 void Game::lifesequence(void)
@@ -4310,28 +4365,17 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, struct ScreenSett
 
     }
 
-    if (controllerButton_flip.size() < 1)
-    {
-        controllerButton_flip.push_back(SDL_CONTROLLER_BUTTON_A);
-    }
-    if (controllerButton_map.size() < 1)
-    {
-        controllerButton_map.push_back(SDL_CONTROLLER_BUTTON_Y);
-        controllerButton_map.push_back(SDL_CONTROLLER_BUTTON_START);
-    }
-    if (controllerButton_esc.size() < 1)
-    {
-        controllerButton_esc.push_back(SDL_CONTROLLER_BUTTON_B);
-        controllerButton_esc.push_back(SDL_CONTROLLER_BUTTON_BACK);
-    }
-    if (controllerButton_restart.size() < 1)
-    {
-        controllerButton_restart.push_back(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER);
-    }
-    if (controllerButton_interact.size() < 1)
-    {
-        controllerButton_interact.push_back(SDL_CONTROLLER_BUTTON_X);
-    }
+    applyDefaultGameControllerButtons();
+}
+
+void Game::resetdefaultgamecontrollerbuttons() {
+    controllerButton_flip.clear();
+    controllerButton_map.clear();
+    controllerButton_esc.clear();
+    controllerButton_restart.clear();
+    controllerButton_interact.clear();
+
+    applyDefaultGameControllerButtons();
 }
 
 bool Game::savestats(bool sync /*= true*/)
@@ -6180,6 +6224,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         break;
     case Menu::controller:
         option("analog stick sensitivity");
+        option("reset bindings");
         option("bind flip");
         option("bind enter");
         option("bind menu");

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6184,7 +6184,9 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option("bind enter");
         option("bind menu");
         option("bind restart");
-        option("bind interact");
+        if (separate_interact) {
+            option("bind interact");
+        }
         option("return");
         menuyoff = 0;
         maxspacing = 10;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -174,6 +174,8 @@ public:
 
     void serializesettings(tinyxml2::XMLElement* dataNode, const struct ScreenSettings* screen_settings);
 
+    void resetdefaultgamecontrollerbuttons();
+
     void loadsettings(struct ScreenSettings* screen_settings);
 
     bool savesettings(const struct ScreenSettings* screen_settings);
@@ -487,6 +489,9 @@ public:
     bool disableaudiopause;
     bool disabletemporaryaudiopause;
     bool inputdelay;
+
+private:
+    void applyDefaultGameControllerButtons();
 };
 
 #ifndef GAME_DEFINITION

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -436,6 +436,9 @@ public:
     std::vector<CustomLevelStat> customlevelstats;
 
 
+    std::vector<SDL_GameControllerButton> controllerButton_menuAccept;
+    std::vector<SDL_GameControllerButton> controllerButton_menuBack;
+
     std::vector<SDL_GameControllerButton> controllerButton_map;
     std::vector<SDL_GameControllerButton> controllerButton_flip;
     std::vector<SDL_GameControllerButton> controllerButton_esc;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1515,6 +1515,16 @@ static void menuactionpress(void)
             game.savestatsandsettings_menu();
             break;
 
+        case 5:
+            // if separate_interact has been enabled in the speedrunner options then the interact option will be in this position
+            // if not it's return, so fallthrough to the return option
+            if (game.separate_interact) {
+                break;
+            }
+            music.playef(11);
+            game.returnmenu();
+            map.nexttowercolour();
+            break;
         case 6:
             music.playef(11);
             game.returnmenu();
@@ -1971,7 +1981,13 @@ void titleinput(void)
         }
         if (    game.currentmenuname == Menu::controller &&
                 game.currentmenuoption > 0 &&
-                game.currentmenuoption < 6 &&
+                (
+                // if separate_interact has been enabled in the speedrunner options then the interact option will in position 5
+                // if not position 5 will be return
+                 game.separate_interact
+                    ? game.currentmenuoption < 6
+                    : game.currentmenuoption < 5
+                ) &&
                 key.controllerButtonDown()      )
         {
             updatebuttonmappings(game.currentmenuoption);

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1886,24 +1886,24 @@ void titleinput(void)
             game.press_right = true;
         }
     }
-    if (key.isDown(KEYBOARD_z) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v) || key.isDown(game.controllerButton_flip)) game.press_action = true;
+    if (key.isDown(KEYBOARD_z) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v) || key.isDown(game.controllerButton_menuAccept)) game.press_action = true;
     //|| key.isDown(KEYBOARD_UP) || key.isDown(KEYBOARD_DOWN)) game.press_action = true; //on menus, up and down don't work as action
     if (key.isDown(KEYBOARD_ENTER)) game.press_map = true;
 
     //In the menu system, all keypresses are single taps rather than holds. Therefore this test has to be done for all presses
-    if (!game.press_action && !game.press_left && !game.press_right && !key.isDown(27) && !key.isDown(game.controllerButton_esc)) game.jumpheld = false;
+    if (!game.press_action && !game.press_left && !game.press_right && !key.isDown(27) && !key.isDown(game.controllerButton_menuBack)) game.jumpheld = false;
     if (!game.press_map) game.mapheld = false;
 
     if (!game.jumpheld && graphics.fademode==0)
     {
-        if (game.press_action || game.press_left || game.press_right || game.press_map || key.isDown(27) || key.isDown(game.controllerButton_esc))
+        if (game.press_action || game.press_left || game.press_right || game.press_map || key.isDown(27) || key.isDown(game.controllerButton_menuBack))
         {
             game.jumpheld = true;
         }
 
         if (game.menustart
         && game.menucountdown <= 0
-        && (key.isDown(27) || key.isDown(game.controllerButton_esc)))
+        && (key.isDown(27) || key.isDown(game.controllerButton_menuBack)))
         {
             music.playef(11);
             if (game.currentmenuname == Menu::mainmenu)
@@ -2526,7 +2526,7 @@ void mapinput(void)
         {
             game.press_right = true;
         }
-        if (key.isDown(KEYBOARD_z) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v) || key.isDown(game.controllerButton_flip))
+        if (key.isDown(KEYBOARD_z) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v) || key.isDown(game.controllerButton_menuAccept))
         {
             game.press_action = true;
         }

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -30,7 +30,7 @@ static void updatebuttonmappings(int bind)
             bool dupe = false;
             switch (bind)
             {
-            case 1:
+            case 2:
             {
                 size_t j;
                 for (j = 0; j < game.controllerButton_flip.size(); j += 1)
@@ -75,7 +75,7 @@ static void updatebuttonmappings(int bind)
                 }
                 break;
             }
-            case 2:
+            case 3:
             {
                 size_t j;
                 for (j = 0; j < game.controllerButton_map.size(); j += 1)
@@ -120,7 +120,7 @@ static void updatebuttonmappings(int bind)
                 }
                 break;
             }
-            case 3:
+            case 4:
             {
                 size_t j;
                 for (j = 0; j < game.controllerButton_esc.size(); j += 1)
@@ -165,7 +165,7 @@ static void updatebuttonmappings(int bind)
                 }
                 break;
             }
-            case 4:
+            case 5:
             {
                 size_t j;
                 for (j = 0; j < game.controllerButton_restart.size(); j += 1)
@@ -210,7 +210,7 @@ static void updatebuttonmappings(int bind)
                 }
                 break;
             }
-            case 5:
+            case 6:
             {
                 size_t j;
                 for (j = 0; j < game.controllerButton_interact.size(); j += 1)
@@ -1514,8 +1514,12 @@ static void menuactionpress(void)
             }
             game.savestatsandsettings_menu();
             break;
+        case 1:
+            // reset bindings
+            game.resetdefaultgamecontrollerbuttons();
+            break;
 
-        case 5:
+        case 6:
             // if separate_interact has been enabled in the speedrunner options then the interact option will be in this position
             // if not it's return, so fallthrough to the return option
             if (game.separate_interact) {
@@ -1525,7 +1529,7 @@ static void menuactionpress(void)
             game.returnmenu();
             map.nexttowercolour();
             break;
-        case 6:
+        case 7:
             music.playef(11);
             game.returnmenu();
             map.nexttowercolour();
@@ -1980,13 +1984,13 @@ void titleinput(void)
             }
         }
         if (    game.currentmenuname == Menu::controller &&
-                game.currentmenuoption > 0 &&
+                game.currentmenuoption > 1 &&
                 (
-                // if separate_interact has been enabled in the speedrunner options then the interact option will in position 5
-                // if not position 5 will be return
+                // if separate_interact has been enabled in the speedrunner options then the interact option will in position 6
+                // if not position 6 will be return
                  game.separate_interact
-                    ? game.currentmenuoption < 6
-                    : game.currentmenuoption < 5
+                    ? game.currentmenuoption < 7
+                    : game.currentmenuoption < 6
                 ) &&
                 key.controllerButtonDown()      )
         {

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -589,9 +589,10 @@ static void menurender(void)
         case 3:
         case 4:
         case 5:
+        case 6:
             // if separate_interact has been enabled in the speedrunner options then the interact option will in position 5
             // if not position 5 will be return
-            if (game.currentmenuoption == 5 && !game.separate_interact) {
+            if (game.currentmenuoption == 6 && !game.separate_interact) {
                 break;
             }
             graphics.Print( -1, 75, "Flip is bound to: " + std::string(help.GCString(game.controllerButton_flip)) , tr, tg, tb, true);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -589,11 +589,18 @@ static void menurender(void)
         case 3:
         case 4:
         case 5:
+            // if separate_interact has been enabled in the speedrunner options then the interact option will in position 5
+            // if not position 5 will be return
+            if (game.currentmenuoption == 5 && !game.separate_interact) {
+                break;
+            }
             graphics.Print( -1, 75, "Flip is bound to: " + std::string(help.GCString(game.controllerButton_flip)) , tr, tg, tb, true);
             graphics.Print( -1, 85, "Enter is bound to: "  + std::string(help.GCString(game.controllerButton_map)), tr, tg, tb, true);
             graphics.Print( -1, 95, "Menu is bound to: " + std::string(help.GCString(game.controllerButton_esc)) , tr, tg, tb, true);
             graphics.Print( -1, 105, "Restart is bound to: " + std::string(help.GCString(game.controllerButton_restart)) , tr, tg, tb, true);
-            graphics.Print( -1, 115, "Interact is bound to: " + std::string(help.GCString(game.controllerButton_interact)) , tr, tg, tb, true);
+            if (game.separate_interact) {
+                graphics.Print( -1, 115, "Interact is bound to: " + std::string(help.GCString(game.controllerButton_interact)) , tr, tg, tb, true);
+            }
             break;
         }
 


### PR DESCRIPTION



## Changes:

I have a few modifications I made to the code that would address some of the issues (linked below) for first-time Steam Deck users. The issues specifically that these modifications address are:

* Add Back and Start buttons to default Menu and Enter bindings, respectively.
* Hide Interact binding in controller menu if separate_interact is not set to true.
* Add reset bindings option to controller menu that will reset bindings back to default.
* Apply controller bindings on first load when no settings.vvv exists.
* Decouple in-game flip/menu actions from in-menu accept/back actions.

Related to:

https://github.com/TerryCavanagh/VVVVVV/issues/875

---

I see in the issues that there is a desire to rework the game controller functionality via Action Sets. However given that the Steam Deck is out and in people's hands now, maybe it makes sense to make a some small tweaks in a less clean way within the existing codebase? Or does it just make more sense to wait and perform a more wholistic rewrite? I don't know the answer to that question of course. But I wanted to submit these modifications in a draft form as potential fixes and/or to facilitate discussion.




## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
