### PR TITLE
Update SDL version to 2.0.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     name: Build (CentOS 7)
 
     runs-on: ubuntu-latest
-    container: ghcr.io/infoteddy/vvvvvv-build@sha256:641092ceb715783183ff3cb6ec4932aecfa2161d135195c29e72c2ad665a4619
+    container: ghcr.io/infoteddy/vvvvvv-build@sha256:2965b59331026ce108836e5226cfda5e08a8c8440156b58944dff0fe5cf93f94
 
     env:
       CXXFLAGS: -I/usr/local/include/SDL2
@@ -117,7 +117,7 @@ jobs:
     runs-on: windows-latest
 
     env:
-      SDL_VERSION: 2.0.20
+      SDL_VERSION: 2.0.22
 
     steps:
     - uses: actions/checkout@v1

--- a/desktop_version/Dockerfile
+++ b/desktop_version/Dockerfile
@@ -2,9 +2,9 @@ FROM centos:7
 
 # run first to improve caching (other things update more often than SDL2)
 WORKDIR /tmp
-RUN curl -O https://www.libsdl.org/release/SDL2-2.0.20.tar.gz
-RUN tar -xf SDL2-2.0.20.tar.gz
-RUN mkdir SDL2-2.0.20/build
+RUN curl -LJO https://github.com/libsdl-org/SDL/releases/download/release-2.0.22/SDL2-2.0.22.tar.gz
+RUN tar -xf SDL2-2.0.22.tar.gz
+RUN mkdir SDL2-2.0.22/build
 
 # add EPEL (for SDL2)
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
@@ -20,12 +20,12 @@ RUN yum-builddep -y SDL2
 
 RUN yum clean all
 
-WORKDIR /tmp/SDL2-2.0.20/build
+WORKDIR /tmp/SDL2-2.0.22/build
 RUN ../configure
 RUN make -j $(nproc)
 RUN make install
 
 WORKDIR /tmp
-RUN rm -rf SDL2-2.0.20.tar.gz SDL2-2.0.20/
+RUN rm -rf SDL2-2.0.22.tar.gz SDL2-2.0.22/
 
 WORKDIR /

--- a/desktop_version/README.md
+++ b/desktop_version/README.md
@@ -6,7 +6,7 @@ VVVVVV's official desktop versions are built with the following environments:
 - macOS: Xcode CLT, currently targeting 10.9 SDK
 - GNU/Linux: CentOS 7
 
-The engine depends solely on [SDL2](https://libsdl.org/) 2.0.20+. All other dependencies
+The engine depends solely on [SDL2](https://libsdl.org/) 2.0.22+. All other dependencies
 are statically linked into the engine. The development libraries for Windows can
 be downloaded from SDL's website, Linux developers can find the dev libraries from their
 respective repositories, and macOS developers should compile and install from source.
@@ -23,7 +23,7 @@ To generate the projects on Windows:
 # Put your SDL2 folders somewhere nice!
 mkdir flibitBuild
 cd flibitBuild
-cmake -A Win32 -G "Visual Studio 10 2010" .. -DSDL2_INCLUDE_DIRS="C:\SDL2-2.0.20\include" -DSDL2_LIBRARIES="C:\SDL2-2.0.20\lib\x86\SDL2;C:\SDL2-2.0.20\lib\x86\SDL2main"
+cmake -A Win32 -G "Visual Studio 10 2010" .. -DSDL2_INCLUDE_DIRS="C:\SDL2-2.0.22\include" -DSDL2_LIBRARIES="C:\SDL2-2.0.22\lib\x86\SDL2;C:\SDL2-2.0.22\lib\x86\SDL2main"
 ```
 
 Note that on some systems, the `SDL2_LIBRARIES` list on Windows may need


### PR DESCRIPTION
2.0.22 just released 40 minutes ago.

This also updates the `Dockerfile` to use the URL from the GitHub releases page, instead of SDL's servers.

I've also pushed a new Docker container to `ghcr.io/infoteddy/vvvvvv-build`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
