### PR TITLE
Add support for start position via level XML for CLI playtesting

### DIFF
--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -201,6 +201,15 @@ TAG_FINDER(find_desc2, "Desc2")
 TAG_FINDER(find_desc3, "Desc3")
 TAG_FINDER(find_website, "website")
 
+/* For CliPlaytestArgs */
+TAG_FINDER(find_playtest, "Playtest")
+TAG_FINDER(find_playx, "playx")
+TAG_FINDER(find_playy, "playy")
+TAG_FINDER(find_playrx, "playrx")
+TAG_FINDER(find_playry, "playry")
+TAG_FINDER(find_playgc, "playgc")
+TAG_FINDER(find_playmusic, "playmusic")
+
 #undef TAG_FINDER
 
 static void levelMetaDataCallback(const char* filename)
@@ -245,7 +254,7 @@ void customlevelclass::getDirectoryData(void)
     }
 
 }
-bool customlevelclass::getLevelMetaData(const std::string& _path, LevelMetaData& _data )
+bool customlevelclass::getLevelMetaDataAndPlaytestArgs(const std::string& _path, LevelMetaData& _data, CliPlaytestArgs* pt_args)
 {
     unsigned char *uMem;
     FILESYSTEM_loadFileToMemory(_path.c_str(), &uMem, NULL, true);
@@ -273,8 +282,32 @@ bool customlevelclass::getLevelMetaData(const std::string& _path, LevelMetaData&
     _data.Desc3 = find_desc3(buf);
     _data.website = find_website(buf);
 
+    if (pt_args != NULL)
+    {
+        const std::string playtest = find_playtest(buf);
+        if (playtest == "")
+        {
+            pt_args->valid = false;
+        }
+        else
+        {
+            pt_args->valid = true;
+            pt_args->x = help.Int(find_playx(playtest).c_str());
+            pt_args->y = help.Int(find_playy(playtest).c_str());
+            pt_args->rx = help.Int(find_playrx(playtest).c_str());
+            pt_args->ry = help.Int(find_playry(playtest).c_str());
+            pt_args->gc = help.Int(find_playgc(playtest).c_str());
+            pt_args->music = help.Int(find_playmusic(playtest).c_str());
+        }
+    }
+
     _data.filename = _path;
     return true;
+}
+
+bool customlevelclass::getLevelMetaData(const std::string& _path, LevelMetaData& _data)
+{
+    return getLevelMetaDataAndPlaytestArgs(_path, _data, NULL);
 }
 
 void customlevelclass::reset(void)

--- a/desktop_version/src/CustomLevels.h
+++ b/desktop_version/src/CustomLevels.h
@@ -60,6 +60,17 @@ struct LevelMetaData
     int version;
 };
 
+struct CliPlaytestArgs
+{
+    int x;
+    int y;
+    int rx;
+    int ry;
+    int gc;
+    int music;
+    bool valid;
+};
+
 
 extern std::vector<CustomEntity> customentities;
 
@@ -80,7 +91,8 @@ public:
 
     void loadZips(void);
     void getDirectoryData(void);
-    bool getLevelMetaData(const std::string& filename, LevelMetaData& _data );
+    bool getLevelMetaDataAndPlaytestArgs(const std::string& filename, LevelMetaData& _data, CliPlaytestArgs* pt_args);
+    bool getLevelMetaData(const std::string& filename, LevelMetaData& _data);
 
     void reset(void);
     const int* loadlevel(int rxi, int ryi);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -634,18 +634,30 @@ int main(int argc, char *argv[])
         game.menustart = true;
 
         LevelMetaData meta;
-        if (cl.getLevelMetaData(playtestname, meta)) {
+        CliPlaytestArgs pt_args;
+        if (cl.getLevelMetaDataAndPlaytestArgs(playtestname, meta, &pt_args)) {
             cl.ListOfMetaData.clear();
             cl.ListOfMetaData.push_back(meta);
         } else {
             cl.loadZips();
-            if (cl.getLevelMetaData(playtestname, meta)) {
+            if (cl.getLevelMetaDataAndPlaytestArgs(playtestname, meta, &pt_args)) {
                 cl.ListOfMetaData.clear();
                 cl.ListOfMetaData.push_back(meta);
             } else {
                 vlog_error("Level not found");
                 VVV_exit(1);
             }
+        }
+
+        if (pt_args.valid)
+        {
+            savefileplaytest = true;
+            savex = pt_args.x;
+            savey = pt_args.y;
+            saverx = pt_args.rx;
+            savery = pt_args.ry;
+            savegc = pt_args.gc;
+            savemusic = pt_args.music;
         }
 
         game.loadcustomlevelstats();


### PR DESCRIPTION
## Changes:

As already described in cc61194bed324e9fbf51847915357d613a94ff47, as well as Ved's commits from the last almost two weeks, starting VVVVVV from Ved for playtesting could be made a lot faster by "preloading" the game - letting it do all its asset loading in the background without creating a window - and then waiting until the level is passed in via stdin. There's only one problem left with this approach: VVVVVV currently expects the starting position to be passed via command line arguments, which isn't known yet at the time we'd like to start VVVVVV. Therefore, this commit allows passing the starting position via the level XML, instead of via arguments.

The extra XML looks like this, and is added next to the `<Data>` tag:

```xml
    <Playtest>
        <playx>214</playx>
        <playy>112</playy>
        <playrx>100</playrx>
        <playry>100</playry>
        <playgc>0</playgc>
        <playmusic>4</playmusic>
    </Playtest>
```

This is handled similarly to how the equivalent arguments are handled: when the level metadata is loaded for CLI playtesting, we also try to find this tag, and if it exists, it sets the same variables that the arguments would have otherwise set.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
