### PR TITLE
Clarify submodules in desktop_version/README.md

### DIFF
--- a/desktop_version/README.md
+++ b/desktop_version/README.md
@@ -14,6 +14,11 @@ respective repositories, and macOS developers should compile and install from so
 [see here](https://github.com/TerryCavanagh/VVVVVV/issues/618#issuecomment-968338212)
 for workarounds.)
 
+Since VVVVVV 2.4, git submodules are used for the
+[third party libraries](https://github.com/TerryCavanagh/VVVVVV/tree/master/third_party).
+After cloning, run `git submodule update --init` to set all of these up.
+You can also use this command whenever the submodules need to be updated.
+
 Steamworks support is included and the DLL is loaded dynamically, you do not
 need the SDK headers and there is no special Steam or non-Steam version. The
 current implementation has been tested with Steamworks SDK v1.46.


### PR DESCRIPTION
VVVVVV uses submodules now, so you need to know how to initialize them.

I'm explicitly not including `git clone --recurse-submodules`. Usage of submodules in git projects is kinda rare in my experience, so people are used to doing simple clones, and that instruction would just result in people being annoyed thinking they have to delete the repo they already cloned, and clone it again except slightly differently.

It also doesn't help you if you need submodules that aren't in the master branch (for example, if you clone my fork recursively and then checkout the localization branch, you won't have C-HashMap and you'll need the update command anyway). And you also need it whenever VVVVVV updates its submodules. So teaching people just the update command is better.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
