### PR TITLE
Add mapexplored(), mapreveal() commands

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5566,6 +5566,10 @@ void Game::customloadquick(const std::string& savfile)
         {
             map.customshowmm = help.Int(pText);
         }
+        else if (SDL_strcmp(pKey, "mapreveal") == 0)
+        {
+            map.revealmap = help.Int(pText);
+        }
         else if (SDL_strcmp(pKey, "disabletemporaryaudiopause") == 0)
         {
             disabletemporaryaudiopause = help.Int(pText);
@@ -6044,6 +6048,8 @@ bool Game::customsavequick(const std::string& savfile)
     xml::update_tag(msgs, "hardestroomdeaths", hardestroomdeaths);
 
     xml::update_tag(msgs, "showminimap", (int) map.customshowmm);
+
+    xml::update_tag(msgs, "mapreveal", (int) map.revealmap);
 
     xml::update_tag(msgs, "disabletemporaryaudiopause", (int) disabletemporaryaudiopause);
 

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -55,6 +55,7 @@ mapclass::mapclass(void)
     custommmxoff=0; custommmyoff=0; custommmxsize=0; custommmysize=0;
     customzoom=0;
     customshowmm=true;
+    revealmap = true;
 
     rcol = 0;
 
@@ -200,6 +201,12 @@ void mapclass::resetmap(void)
 {
     //clear the explored area of the map
     SDL_memset(explored, 0, sizeof(explored));
+}
+
+void mapclass::fullmap(void)
+{
+    //mark the whole map as explored
+    SDL_memset(explored, 1, sizeof(explored));
 }
 
 void mapclass::updateroomnames(void)
@@ -1304,12 +1311,15 @@ static void copy_short_to_int(int* dest, const short* src, const size_t size)
 void mapclass::loadlevel(int rx, int ry)
 {
     int t;
-    if (!finalmode)
+    if (revealmap)
     {
-        setexplored(rx - 100, ry - 100, true);
-        if (rx == 109 && !custommode)
+        if (!finalmode)
         {
-            exploretower();
+            setexplored(rx - 100, ry - 100, true);
+            if (rx == 109 && !custommode)
+            {
+                exploretower();
+            }
         }
     }
 

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -57,6 +57,8 @@ public:
 
     void resetmap(void);
 
+    void fullmap(void);
+
     void updateroomnames(void);
 
     void initmapdata(void);
@@ -123,6 +125,8 @@ public:
 
     bool isexplored(const int rx, const int ry);
     void setexplored(const int rx, const int ry, const bool status);
+
+    bool revealmap;
 
     int background;
     int rcol;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1276,6 +1276,28 @@ void scriptclass::run(void)
                 map.setexplored(19, 7, false);
                 map.setexplored(19, 8, false);
             }
+            else if (words[0] == "mapexplored")
+            {
+                if (words[1] == "none")
+                {
+                    map.resetmap();
+                }
+                else if (words[1] == "all")
+                {
+                    map.fullmap();
+                }
+            }
+            else if (words[0] == "mapreveal")
+            {
+                if (words[1] == "on")
+                {
+                    map.revealmap = true;
+                }
+                else if (words[1] == "off")
+                {
+                    map.revealmap = false;
+                }
+            }
             else if (words[0] == "showteleporters")
             {
                 map.showteleporters = true;
@@ -2814,6 +2836,7 @@ void scriptclass::startgamemode(const enum StartMode mode)
         map.custommode = true;
         map.custommodeforreal = false;
         map.customshowmm = true;
+        map.revealmap = true;
 
         if (cl.levmusic > 0)
         {
@@ -2841,6 +2864,7 @@ void scriptclass::startgamemode(const enum StartMode mode)
         cl.findstartpoint();
 
         map.customshowmm = true;
+        map.revealmap = true;
 
         music.fadeout();
         game.customstart();
@@ -3218,7 +3242,8 @@ void scriptclass::hardreset(void)
     map.cameraseekframe = 0;
     map.resumedelay = 0;
     graphics.towerbg.scrolldir = 0;
-    map.customshowmm=true;
+    map.customshowmm = true;
+    map.revealmap = true;
 
     SDL_memset(map.roomdeaths, 0, sizeof(map.roomdeaths));
     SDL_memset(map.roomdeathsfinal, 0, sizeof(map.roomdeathsfinal));


### PR DESCRIPTION
## Changes:

This pull request adds the commands `mapexplored(x)` and `mapreveal(x)`, which give level creators more control over revealing and hiding rooms on the minimap.

`mapexplored(x)`'s argument is either `all`, which shows every room on the minimap, or `none`, which hides all rooms on the minimap.

`mapreveal(x)` can be toggled either `on` or `off`, which enables or disables to automatic revealing of rooms on the minimap.

Here's a demonstration video:
https://user-images.githubusercontent.com/19874772/198907911-1398fa93-fb43-4274-9b50-2ccfe5625c23.mp4


Forwards compatibility should not be an issue, as this only affects how the map visually displays and won't affect gameplay (besides the player's ability to navigate, maybe)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
