### PR TITLE
Region system

### DIFF
--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -1678,35 +1678,7 @@ bool customlevelclass::save(const std::string& _path)
 
 void customlevelclass::generatecustomminimap(void)
 {
-    map.customzoom = 1;
-    if (mapwidth <= 10 && mapheight <= 10)
-    {
-        map.customzoom = 2;
-    }
-    if (mapwidth <= 5 && mapheight <= 5)
-    {
-        map.customzoom = 4;
-    }
-
-    // Set minimap offsets
-    switch (map.customzoom)
-    {
-    case 4:
-        map.custommmxoff = 24 * (5 - mapwidth);
-        map.custommmyoff = 18 * (5 - mapheight);
-        break;
-    case 2:
-        map.custommmxoff = 12 * (10 - mapwidth);
-        map.custommmyoff = 9 * (10 - mapheight);
-        break;
-    default:
-        map.custommmxoff = 6 * (20 - mapwidth);
-        map.custommmyoff = int(4.5 * (20 - mapheight));
-        break;
-    }
-
-    map.custommmxsize = 240 - (map.custommmxoff * 2);
-    map.custommmysize = 180 - (map.custommmyoff * 2);
+    const MapRenderData data = map.get_render_data();
 
     // Start drawing the minimap
 
@@ -1715,9 +1687,9 @@ void customlevelclass::generatecustomminimap(void)
     graphics.clear();
 
     // Scan over the map size
-    for (int j2 = 0; j2 < mapheight; j2++)
+    for (int j2 = data.starty; j2 < data.starty + data.height; j2++)
     {
-        for (int i2 = 0; i2 < mapwidth; i2++)
+        for (int i2 = data.startx; i2 < data.startx + data.width; i2++)
         {
             std::vector<SDL_Point> dark_points;
             std::vector<SDL_Point> light_points;
@@ -1725,12 +1697,12 @@ void customlevelclass::generatecustomminimap(void)
             bool dark = getroomprop(i2, j2)->tileset == 1;
 
             // Ok, now scan over each square
-            for (int j = 0; j < 9 * map.customzoom; j++)
+            for (int j = 0; j < 9 * data.zoom; j++)
             {
-                for (int i = 0; i < 12 * map.customzoom; i++)
+                for (int i = 0; i < 12 * data.zoom; i++)
                 {
                     int tile;
-                    switch (map.customzoom)
+                    switch (data.zoom)
                     {
                     case 4:
                         tile = absfree(
@@ -1755,7 +1727,7 @@ void customlevelclass::generatecustomminimap(void)
                     if (tile >= 1)
                     {
                         // Add this pixel
-                        SDL_Point point = { (i2 * 12 * map.customzoom) + i, (j2 * 9 * map.customzoom) + j };
+                        SDL_Point point = { ((i2 - data.startx) * 12 * data.zoom) + i, ((j2 - data.starty) * 9 * data.zoom) + j };
                         if (dark)
                         {
                             dark_points.push_back(point);

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5921,7 +5921,6 @@ void Game::customloadquick(const std::string& savfile)
         {
             map.currentregion = help.Int(pText);
         }
-#if !defined(NO_CUSTOM_LEVELS)
         else if (SDL_strcmp(pKey, "regions") == 0)
         {
             tinyxml2::XMLElement* pElem2;
@@ -5960,7 +5959,6 @@ void Game::customloadquick(const std::string& savfile)
                 map.setregion(thisid, thisrx, thisry, thisrx2, thisry2);
             }
         }
-#endif
     }
 }
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -228,16 +228,6 @@ void Game::init(void)
 
     customcol=0;
 
-    map.currentregion = 0;
-    for (size_t i = 0; i < SDL_arraysize(map.region); i++)
-    {
-        map.region[i].isvalid = false;
-        map.region[i].rx = 0;
-        map.region[i].ry = 0;
-        map.region[i].rx2 = 0;
-        map.region[i].ry2 = 0;
-    }
-
     SDL_memset(crewstats, false, sizeof(crewstats));
     SDL_memset(ndmresultcrewstats, false, sizeof(ndmresultcrewstats));
     SDL_memset(besttimes, -1, sizeof(besttimes));

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -228,6 +228,16 @@ void Game::init(void)
 
     customcol=0;
 
+    map.currentregion = 0;
+    for (size_t i = 0; i < SDL_arraysize(map.region); i++)
+    {
+        map.region[i].isvalid = false;
+        map.region[i].rx = 0;
+        map.region[i].ry = 0;
+        map.region[i].rx2 = 0;
+        map.region[i].ry2 = 0;
+    }
+
     SDL_memset(crewstats, false, sizeof(crewstats));
     SDL_memset(ndmresultcrewstats, false, sizeof(ndmresultcrewstats));
     SDL_memset(besttimes, -1, sizeof(besttimes));
@@ -5907,6 +5917,50 @@ void Game::customloadquick(const std::string& savfile)
             map.roomnameset = true;
             map.roomname_special = true;
         }
+        else if (SDL_strcmp(pKey, "currentregion") == 0)
+        {
+            map.currentregion = help.Int(pText);
+        }
+#if !defined(NO_CUSTOM_LEVELS)
+        else if (SDL_strcmp(pKey, "regions") == 0)
+        {
+            tinyxml2::XMLElement* pElem2;
+            for (pElem2 = pElem->FirstChildElement(); pElem2 != NULL; pElem2 = pElem2->NextSiblingElement())
+            {
+                int thisid = 0;
+                int thisrx = 0;
+                int thisry = 0;
+                int thisrx2 = (cl.mapwidth - 1);
+                int thisry2 = (cl.mapheight - 1);
+                if (pElem2->Attribute("id"))
+                {
+                    thisid = help.Int(pElem2->Attribute("id"));
+                }
+
+                for (tinyxml2::XMLElement* pElem3 = pElem2->FirstChildElement(); pElem3 != NULL; pElem3 = pElem3->NextSiblingElement())
+                {
+                    if (SDL_strcmp(pElem3->Value(), "rx") == 0 && pElem3->GetText() != NULL)
+                    {
+                        thisrx = help.Int(pElem3->GetText());
+                    }
+                    if (SDL_strcmp(pElem3->Value(), "ry") == 0 && pElem3->GetText() != NULL)
+                    {
+                        thisry = help.Int(pElem3->GetText());
+                    }
+                    if (SDL_strcmp(pElem3->Value(), "rx2") == 0 && pElem3->GetText() != NULL)
+                    {
+                        thisrx2 = help.Int(pElem3->GetText());
+                    }
+                    if (SDL_strcmp(pElem3->Value(), "ry2") == 0 && pElem3->GetText() != NULL)
+                    {
+                        thisry2 = help.Int(pElem3->GetText());
+                    }
+                }
+
+                map.setregion(thisid, thisrx, thisry, thisrx2, thisry2);
+            }
+        }
+#endif
     }
 }
 
@@ -6291,6 +6345,41 @@ bool Game::customsavequick(const std::string& savfile)
 
     xml::update_tag(msgs, "crewmates", crewmates());
 
+    xml::update_tag(msgs, "currentregion", map.currentregion);
+
+    tinyxml2::XMLElement* msg = xml::update_element_delete_contents(msgs, "regions");
+    for (size_t i = 0; i < SDL_arraysize(map.region); i++)
+    {
+        if (map.region[i].isvalid)
+        {
+            tinyxml2::XMLElement* region_el;
+            region_el = doc.NewElement("region");
+
+            region_el->SetAttribute("id", (help.String(i).c_str()));
+
+            tinyxml2::XMLElement* rx_el;
+            rx_el = doc.NewElement("rx");
+            rx_el->LinkEndChild(doc.NewText(help.String(map.region[i].rx).c_str()));
+            region_el->LinkEndChild(rx_el);
+
+            tinyxml2::XMLElement* ry_el;
+            ry_el = doc.NewElement("ry");
+            ry_el->LinkEndChild(doc.NewText(help.String(map.region[i].ry).c_str()));
+            region_el->LinkEndChild(ry_el);
+
+            tinyxml2::XMLElement* rx2_el;
+            rx2_el = doc.NewElement("rx2");
+            rx2_el->LinkEndChild(doc.NewText(help.String(map.region[i].rx2).c_str()));
+            region_el->LinkEndChild(rx2_el);
+
+            tinyxml2::XMLElement* ry2_el;
+            ry2_el = doc.NewElement("ry2");
+            ry2_el->LinkEndChild(doc.NewText(help.String(map.region[i].ry2).c_str()));
+            region_el->LinkEndChild(ry2_el);
+
+            msg->LinkEndChild(region_el);
+        }
+    }
 
     //Special stats
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1270,6 +1270,15 @@ void Graphics::draw_grid_tile(
     draw_grid_tile(texture, t, x, y, width, height, color, 1, 1);
 }
 
+void Graphics::draw_region_image(int t, int xp, int yp, int wp, int hp)
+{
+    if (!INBOUNDS_ARR(t, customminimaps) || customminimaps[t] == NULL)
+    {
+        return;
+    }
+    draw_texture_part(customminimaps[t], xp, yp, 0, 0, wp, hp, 1, 1);
+}
+
 void Graphics::cutscenebars(void)
 {
     const int usethispos = lerp(oldcutscenebarspos, cutscenebarspos);

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -172,6 +172,8 @@ public:
     void draw_grid_tile(SDL_Texture* texture, int t, int x, int y, int width, int height, SDL_Color color, int scalex, int scaley);
     void draw_grid_tile(SDL_Texture* texture, int t, int x, int y, int width, int height, SDL_Color color);
 
+    void draw_region_image(int t, int xp, int yp, int wp, int hp);
+
     void updatetextboxes(void);
     const char* textbox_line(char* buffer, size_t buffer_len, size_t textbox_i, size_t line_i);
     void drawgui(void);
@@ -336,6 +338,8 @@ public:
     std::vector <SDL_Surface*> flipsprites_surf;
 
     SDL_Texture* images[NUM_IMAGES];
+
+    SDL_Texture* customminimaps[401];
 
     bool flipmode;
     bool setflipmode;

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -442,6 +442,28 @@ void GraphicsResources::init(void)
         SDL_assert(0 && "Failed to create minimap texture! See stderr.");
         return;
     }
+
+    SDL_zeroa(graphics.customminimaps);
+
+    EnumHandle handle = {};
+    const char* item;
+    char full_item[73];
+    while ((item = FILESYSTEM_enumerateAssets("graphics", &handle)) != NULL)
+    {
+        if (SDL_strncmp(item, "region", 6) != 0)
+        {
+            continue;
+        }
+        char* end;
+        int i = SDL_strtol(&item[6], &end, 10);
+        if (item == end || SDL_strcmp(end, ".png") != 0)
+        {
+            continue;
+        }
+        SDL_snprintf(full_item, sizeof(full_item), "graphics/%s", item);
+        graphics.customminimaps[i] = LoadImage(full_item);
+    }
+    FILESYSTEM_freeEnumerate(&handle);
 }
 
 
@@ -476,6 +498,14 @@ void GraphicsResources::destroy(void)
 
     CLEAR(im_sprites_translated);
     CLEAR(im_flipsprites_translated);
+
+    for (size_t i = 0; i < SDL_arraysize(graphics.customminimaps); i++)
+    {
+        if (graphics.customminimaps[i] != NULL)
+        {
+            CLEAR(graphics.customminimaps[i]);
+        }
+    }
 #undef CLEAR
 
     VVV_freefunc(SDL_FreeSurface, im_sprites_surf);

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -501,10 +501,7 @@ void GraphicsResources::destroy(void)
 
     for (size_t i = 0; i < SDL_arraysize(graphics.customminimaps); i++)
     {
-        if (graphics.customminimaps[i] != NULL)
-        {
-            CLEAR(graphics.customminimaps[i]);
-        }
+        CLEAR(graphics.customminimaps[i]);
     }
 #undef CLEAR
 

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -447,7 +447,7 @@ void GraphicsResources::init(void)
 
     EnumHandle handle = {};
     const char* item;
-    char full_item[73];
+    char full_item[64];
     while ((item = FILESYSTEM_enumerateAssets("graphics", &handle)) != NULL)
     {
         if (SDL_strncmp(item, "region", 6) != 0)
@@ -456,6 +456,11 @@ void GraphicsResources::init(void)
         }
         char* end;
         int i = SDL_strtol(&item[6], &end, 10);
+        // make sure the region id is actually in bounds!
+        if (i < 1 || i > 400)
+        {
+            continue;
+        }
         if (item == end || SDL_strcmp(end, ".png") != 0)
         {
             continue;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -2296,6 +2296,20 @@ void mapclass::setregion(int id, int rx, int ry, int rx2, int ry2)
 {
     if (INBOUNDS_ARR(id, region) && id > 0)
     {
+        // swap the variables if they're entered in the wrong order
+        if (rx2 > rx)
+        {
+            int temp = rx;
+            rx = rx2;
+            rx2 = temp;
+        }
+        if (ry2 > ry)
+        {
+            int temp = ry;
+            ry = ry2;
+            ry2 = temp;
+        }
+        
         region[id].isvalid = true;
         region[id].rx = SDL_clamp(rx, 0, cl.mapwidth - 1);
         region[id].ry = SDL_clamp(ry, 0, cl.mapheight - 1);

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -2297,7 +2297,7 @@ void mapclass::setregion(int id, int rx, int ry, int rx2, int ry2)
     if (INBOUNDS_ARR(id, region) && id > 0)
     {
         // swap the variables if they're entered in the wrong order
-        if (rx2 > rx)
+        if (rx2 < rx)
         {
             int temp = rx;
             rx = rx2;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -2291,7 +2291,6 @@ MapRenderData mapclass::get_render_data(void)
 
 void mapclass::setregion(int id, int rx, int ry, int rx2, int ry2)
 {
-#if !defined(NO_CUSTOM_LEVELS)
     if (INBOUNDS_ARR(id, region))
     {
         region[id].isvalid = true;
@@ -2300,30 +2299,21 @@ void mapclass::setregion(int id, int rx, int ry, int rx2, int ry2)
         region[id].rx2 = SDL_clamp(rx2, 0, cl.mapwidth - 1);
         region[id].ry2 = SDL_clamp(ry2, 0, cl.mapheight - 1);
     }
-#endif
 }
 
 void mapclass::removeregion(int id)
 {
-#if !defined(NO_CUSTOM_LEVELS)
     if (INBOUNDS_ARR(id, region))
     {
-        region[id].isvalid = false;
-        region[id].rx = 0;
-        region[id].ry = 0;
-        region[id].rx2 = 0;
-        region[id].ry2 = 0;
+        SDL_zero(region[id]);
     }
-#endif
 }
 
 void mapclass::changeregion(int id)
 {
-#if !defined(NO_CUSTOM_LEVELS)
     if (INBOUNDS_ARR(id, region))
     {
         currentregion = id;
         cl.generatecustomminimap();
     }
-#endif
 }

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -86,6 +86,9 @@ mapclass::mapclass(void)
     roomtexton = false;
 
     nexttowercolour_set = false;
+
+    currentregion = 0;
+    SDL_zeroa(region);
 }
 
 static char roomname_static[SCREEN_WIDTH_CHARS];
@@ -2291,21 +2294,31 @@ MapRenderData mapclass::get_render_data(void)
 
 void mapclass::setregion(int id, int rx, int ry, int rx2, int ry2)
 {
-    if (INBOUNDS_ARR(id, region))
+    if (INBOUNDS_ARR(id, region) && id > 0)
     {
         region[id].isvalid = true;
         region[id].rx = SDL_clamp(rx, 0, cl.mapwidth - 1);
         region[id].ry = SDL_clamp(ry, 0, cl.mapheight - 1);
         region[id].rx2 = SDL_clamp(rx2, 0, cl.mapwidth - 1);
         region[id].ry2 = SDL_clamp(ry2, 0, cl.mapheight - 1);
+
+        if (id == currentregion)
+        {
+            cl.generatecustomminimap();
+        }
     }
 }
 
 void mapclass::removeregion(int id)
 {
-    if (INBOUNDS_ARR(id, region))
+    if (INBOUNDS_ARR(id, region) && id > 0)
     {
         SDL_zero(region[id]);
+
+        if (id == currentregion)
+        {
+            cl.generatecustomminimap();
+        }
     }
 }
 

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -2303,7 +2303,7 @@ void mapclass::setregion(int id, int rx, int ry, int rx2, int ry2)
             rx = rx2;
             rx2 = temp;
         }
-        if (ry2 > ry)
+        if (ry2 < ry)
         {
             int temp = ry;
             ry = ry2;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -52,8 +52,6 @@ mapclass::mapclass(void)
 
     custommode=false;
     custommodeforreal=false;
-    custommmxoff=0; custommmyoff=0; custommmxsize=0; custommmysize=0;
-    customzoom=0;
     customshowmm=true;
 
     rcol = 0;
@@ -2195,16 +2193,16 @@ void mapclass::twoframedelayfix(void)
     // A bit kludge-y, but it's the least we can do without changing the frame ordering.
 
     if (GlitchrunnerMode_less_than_or_equal(Glitchrunner2_2)
-    || !custommode
-    || game.deathseq != -1)
+        || !custommode
+        || game.deathseq != -1)
         return;
 
     int block_idx = -1;
     // obj.checktrigger() sets block_idx
     int activetrigger = obj.checktrigger(&block_idx);
     if (activetrigger <= -1
-    || !INBOUNDS_VEC(block_idx, obj.blocks)
-    || activetrigger < 300)
+        || !INBOUNDS_VEC(block_idx, obj.blocks)
+        || activetrigger < 300)
     {
         return;
     }
@@ -2214,4 +2212,118 @@ void mapclass::twoframedelayfix(void)
     game.setstate(0);
     game.setstatedelay(0);
     script.load(game.newscript);
+}
+
+MapRenderData mapclass::get_render_data(void)
+{
+    MapRenderData data;
+    data.width = getwidth();
+    data.height = getheight();
+
+    data.startx = 0;
+    data.starty = 0;
+
+    // Region handling
+    if (region[currentregion].isvalid)
+    {
+        data.startx = region[currentregion].rx;
+        data.starty = region[currentregion].ry;
+        data.width = ((region[currentregion].rx2 - data.startx) + 1);
+        data.height = ((region[currentregion].ry2 - data.starty) + 1);
+    }
+
+    data.zoom = 1;
+
+    if (data.width <= 10 && data.height <= 10)
+    {
+        data.zoom = 2;
+    }
+    if (data.width <= 5 && data.height <= 5)
+    {
+        data.zoom = 4;
+    }
+
+    data.xoff = 0;
+    data.yoff = 0;
+
+    // Set minimap offsets
+    switch (data.zoom)
+    {
+    case 4:
+        data.xoff = 24 * (5 - data.width);
+        data.yoff = 18 * (5 - data.height);
+        break;
+    case 2:
+        data.xoff = 12 * (10 - data.width);
+        data.yoff = 9 * (10 - data.height);
+        break;
+    default:
+        data.xoff = 6 * (20 - data.width);
+        data.yoff = (int)(4.5 * (20 - data.height));
+        break;
+    }
+
+    data.pixelsx = 240 - (data.xoff * 2);
+    data.pixelsy = 180 - (data.yoff * 2);
+
+    data.legendxoff = 40 + data.xoff;
+    data.legendyoff = 21 + data.yoff;
+
+    // Magic numbers for centering legend tiles.
+    switch (data.zoom)
+    {
+    case 4:
+        data.legendxoff += 21;
+        data.legendyoff += 16;
+        break;
+    case 2:
+        data.legendxoff += 9;
+        data.legendyoff += 5;
+        break;
+    default:
+        data.legendxoff += 3;
+        data.legendyoff += 1;
+        break;
+    }
+
+    return data;
+}
+
+void mapclass::setregion(int id, int rx, int ry, int rx2, int ry2)
+{
+#if !defined(NO_CUSTOM_LEVELS)
+    if (INBOUNDS_ARR(id, region))
+    {
+        region[id].isvalid = true;
+        region[id].rx = SDL_clamp(rx, 0, cl.mapwidth - 1);
+        region[id].ry = SDL_clamp(ry, 0, cl.mapheight - 1);
+        region[id].rx2 = SDL_clamp(rx2, 0, cl.mapwidth - 1);
+        region[id].ry2 = SDL_clamp(ry2, 0, cl.mapheight - 1);
+    }
+#endif
+}
+
+void mapclass::removeregion(int id)
+{
+#if !defined(NO_CUSTOM_LEVELS)
+    if (INBOUNDS_ARR(id, region))
+    {
+        region[id].isvalid = false;
+        region[id].rx = 0;
+        region[id].ry = 0;
+        region[id].rx2 = 0;
+        region[id].ry2 = 0;
+    }
+#endif
+}
+
+void mapclass::changeregion(int id)
+{
+#if !defined(NO_CUSTOM_LEVELS)
+    if (INBOUNDS_ARR(id, region))
+    {
+        currentregion = id;
+        cl.generatecustomminimap();
+    }
+#endif
 }

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -12,6 +12,21 @@
 #include "TowerBG.h"
 #include "WarpClass.h"
 
+struct MapRenderData
+{
+    int zoom;
+    int xoff;
+    int yoff;
+    int legendxoff;
+    int legendyoff;
+    int startx;
+    int starty;
+    int width;
+    int height;
+    int pixelsx;
+    int pixelsy;
+};
+
 struct Roomtext
 {
     int x, y;
@@ -159,8 +174,6 @@ public:
     //Variables for playing custom levels
     bool custommode;
     bool custommodeforreal;
-    int custommmxoff, custommmyoff, custommmxsize, custommmysize;
-    int customzoom;
     bool customshowmm;
 
     //final level colour cycling stuff
@@ -194,6 +207,25 @@ public:
 
     //Map cursor
     int cursorstate, cursordelay;
+
+    //Region system
+    struct regionstruct
+    {
+        bool isvalid;
+        int rx;
+        int ry;
+        int rx2;
+        int ry2;
+    };
+    struct regionstruct region[401];
+    void setregion(int id, int rx, int ry, int rx2, int ry2);
+    void removeregion(int id);
+    void changeregion(int id);
+    int currentregion;
+    int regionx, regiony;
+    int regionwidth, regionheight;
+
+    MapRenderData get_render_data(void);
 };
 
 #ifndef MAP_DEFINITION

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -209,7 +209,7 @@ public:
     int cursorstate, cursordelay;
 
     //Region system
-    struct regionstruct
+    struct Region
     {
         bool isvalid;
         int rx;
@@ -217,7 +217,7 @@ public:
         int rx2;
         int ry2;
     };
-    struct regionstruct region[401];
+    struct Region region[401];
     void setregion(int id, int rx, int ry, int rx2, int ry2);
     void removeregion(int id);
     void changeregion(int id);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3237,6 +3237,8 @@ void scriptclass::hardreset(void)
     SDL_memset(map.roomdeaths, 0, sizeof(map.roomdeaths));
     SDL_memset(map.roomdeathsfinal, 0, sizeof(map.roomdeathsfinal));
     map.resetmap();
+    map.currentregion = 0;
+    SDL_zeroa(map.region);
     //entityclass
     obj.nearelephant = false;
     obj.upsetmode = false;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -371,6 +371,23 @@ void scriptclass::run(void)
                     map.customshowmm=false;
                 }
             }
+            else if (words[0] == "setregion")
+            {
+                map.setregion(
+                    ss_toi(words[1]),
+                    ss_toi(words[2]),
+                    ss_toi(words[3]),
+                    ss_toi(words[4]),
+                    ss_toi(words[5]));
+            }
+            else if (words[0] == "removeregion")
+            {
+                map.removeregion(ss_toi(words[1]));
+            }
+            else if (words[0] == "changeregion")
+            {
+                map.changeregion(ss_toi(words[1]));
+            }
             if (words[0] == "delay")
             {
                 //USAGE: delay(frames)


### PR DESCRIPTION
## Changes:

This PR adds a map region system. Regions allow the minimap to display only part of a level even if the level has larger bounds (for example, a 5x5 region in a 20x16 level). Regions can also have custom images. If region`id`.png is present in /graphics, then the minimap will display that image when the current region is `id`. The default region is `0`, and in region `0` the map will display minimap.png (instead of region0.png) if it is present, in order to maintain forwards compatibility. There are a maximum of 401 regions, from `0` to `400`.
It adds three commands to manage them:
`setregion(id,x,y,x2,y2)` - sets region `id` from `x,y` to `x2,y2`.
`changeregion(id)` - sets the current region to `id`. If region `id` doesn't exist, then it will act as if you aren't in any region at all.
`removeregion(id)` - removes region `id` from the array.

Here is a demonstration video:

https://github.com/TerryCavanagh/VVVVVV/assets/19874772/64f2c254-51bd-4b19-9cf0-7ba828d46a55


This PR will not break forwards compatibility. Playing a level which uses this system with an older version of the game probably won't even affect their ability to navigate, although they might end up seeing rooms on the minimap that the level creator intended to be outside of the bounds of the displayed map.

Regions are saved to and loaded from a level's save file, as well as what the current region is. The map cursor and icons for trinkets and teleporters will display properly - if the player/a trinket/a teleporter is outside the bounds of the current region, it won't render on the map screen.

This also cleans up a lot of map code, moving more things into `MapRenderData`. Thanks to Ally and Dav999 for help with this!!!

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
