### PR TITLE
Deduplicate map rendering code

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2172,7 +2172,7 @@ void rendermapcursor(bool flashing)
     }
     else if (map.cursorstate == 1 && (int(map.cursordelay / 4) % 2 == 0))
     {
-        graphics.drawrect(40 + ((game.roomx - 100) * 12 * mapzoom) + mapxoff, 21 + ((game.roomy - 100) * 9) + mapyoff, 12 * mapzoom, 9 * mapzoom, 255, 255, 255);
+        graphics.drawrect(40 + ((game.roomx - 100) * 12 * mapzoom) + mapxoff, 21 + ((game.roomy - 100) * 9 * mapzoom) + mapyoff, 12 * mapzoom, 9 * mapzoom, 255, 255, 255);
         graphics.drawrect(40 + ((game.roomx - 100) * 12 * mapzoom) + 2 + mapxoff, 21 + ((game.roomy - 100) * 9 * mapzoom) + 2 + mapyoff, (12 * mapzoom) - 4, (9 * mapzoom) - 4, 255, 255, 255);
     }
 }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2189,7 +2189,7 @@ void maprender(void)
     //Menubar:
     graphics.drawtextbox( -10, 212, 43, 3, 65, 185, 207);
 
-    // Draw the selected page name at the bottomtele
+    // Draw the selected page name at the bottom
     // menupage 0 - 3 is the pause screen
     if (script.running && game.menupage == 3)
     {

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2040,24 +2040,22 @@ static void draw_roomname_menu(void)
  * the same in Flip Mode. */
 #define FLIP(y, h) (graphics.flipmode ? 220 - (y) - (h) : (y))
 
-void rendermap(void)
+static void rendermap(void)
 {
 #ifndef NO_CUSTOM_LEVELS
     if (map.custommode)
     {
-        //draw the map image
         graphics.drawpixeltextbox(35 + map.custommmxoff, 16 + map.custommmyoff, map.custommmxsize + 10, map.custommmysize + 10, 65, 185, 207);
         graphics.drawpartimage(graphics.minimap_mounted ? 1 : 12, 40 + map.custommmxoff, 21 + map.custommmyoff, map.custommmxsize, map.custommmysize);
         return;
      }
 #endif /* NO_CUSTOM_LEVELS */
 
-    //draw the map image
     graphics.drawpixeltextbox(35, 16, 250, 190, 65, 185, 207);
     graphics.drawimage(1, 40, 21, false);
 }
 
-void rendermapfog(void)
+static void rendermapfog(void)
 {
     int mapwidth = map.custommode ? map.customwidth : 20;
     int mapheight = map.custommode ? map.customheight : 20;
@@ -2065,7 +2063,6 @@ void rendermapfog(void)
     int mapxoff = map.custommode ? map.custommmxoff : 0;
     int mapyoff = map.custommode ? map.custommmyoff : 0;
 
-    // Draw the fog of war
     for (int j = 0; j < mapheight; j++)
     {
         for (int i = 0; i < mapwidth; i++)
@@ -2085,7 +2082,7 @@ void rendermapfog(void)
     }
 }
 
-void rendermaplegend(void)
+static void rendermaplegend(void)
 {
     // Draw the map legend, aka teleports/targets/trinkets
 
@@ -2095,21 +2092,21 @@ void rendermaplegend(void)
 
     switch (zoom_mult)
     {
-        case 4:
-            zoom_offset_x = 60;
-            zoom_offset_y = 35;
-            break;
-        case 2:
-            zoom_offset_x = 48;
-            zoom_offset_y = 26;
-            break;
-        default:
-            zoom_offset_x = 43;
-            zoom_offset_y = 22;
-            break;
+    case 4:
+        zoom_offset_x = 60;
+        zoom_offset_y = 35;
+        break;
+    case 2:
+        zoom_offset_x = 48;
+        zoom_offset_y = 26;
+        break;
+    default:
+        zoom_offset_x = 43;
+        zoom_offset_y = 22;
+        break;
     }
 
-    int tile_offset = graphics.flipmode ? 3 : 0;
+    const int tile_offset = graphics.flipmode ? 3 : 0;
 
     for (size_t i = 0; i < map.teleporters.size(); i++)
     {
@@ -2135,7 +2132,7 @@ void rendermaplegend(void)
     }
 }
 
-void rendermapcursor(bool flashing)
+static void rendermapcursor(const bool flashing)
 {
     int mapwidth = map.custommode ? map.customwidth : 20;
     int mapheight = map.custommode ? map.customheight : 20;
@@ -2157,7 +2154,6 @@ void rendermapcursor(bool flashing)
                 graphics.drawrect(40 + ((game.roomx - 100) * 12), 21, 12, 180, 255, 255, 255);
                 graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + 2, 12 - 4, 180 - 4, 255, 255, 255);
             }
-            if (map.cursordelay > 30) map.cursorstate = 2;
         }
         else if (map.cursorstate == 2 && (int(map.cursordelay / 15) % 2 == 0))
         {
@@ -2256,7 +2252,9 @@ void maprender(void)
                 }
             }
             graphics.bprint(-1, 105, "NO SIGNAL", 245, 245, 245, true);
-        } else {
+        }
+        else
+        {
             rendermapfog();
             rendermapcursor(true);
             rendermaplegend();
@@ -2719,7 +2717,7 @@ void teleporterrender(void)
 
     tempx = map.teleporters[game.teleport_to_teleporter].x;
     tempy = map.teleporters[game.teleport_to_teleporter].y;
-    if (game.useteleporter && ((help.slowsine % 16) > 8))
+    if (game.useteleporter && help.slowsine % 16 > 8)
     {
         graphics.drawtile(zoom_offset_x + mapxoff + (tempx * 12 * mapzoom), zoom_offset_y + mapyoff + (tempy * 9 * mapzoom), 1128 + (graphics.flipmode ? 3 : 0));
     }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -24,7 +24,8 @@ static int tr;
 static int tg;
 static int tb;
 
-struct MapRenderData {
+struct MapRenderData
+{
     int width;
     int height;
     int zoom;
@@ -2096,7 +2097,7 @@ static void rendermap(void)
 
 static void rendermapfog(void)
 {
-    MapRenderData data = getmaprenderdata();
+    const MapRenderData data = getmaprenderdata();
 
     for (int j = 0; j < data.height; j++)
     {
@@ -2121,7 +2122,7 @@ static void rendermaplegend(void)
 {
     // Draw the map legend, aka teleports/targets/trinkets
 
-    MapRenderData data = getmaprenderdata();
+    const MapRenderData data = getmaprenderdata();
 
     const int tile_offset = graphics.flipmode ? 3 : 0;
 
@@ -2151,7 +2152,7 @@ static void rendermaplegend(void)
 
 static void rendermapcursor(const bool flashing)
 {
-    MapRenderData data = getmaprenderdata();
+    const MapRenderData data = getmaprenderdata();
 
     if (!map.custommode && game.roomx == 109)
     {
@@ -2686,7 +2687,7 @@ void teleporterrender(void)
 
     // Draw a box around the currently selected teleporter
 
-    MapRenderData data = getmaprenderdata();
+    const MapRenderData data = getmaprenderdata();
 
     if (game.useteleporter)
     {

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2059,7 +2059,7 @@ void rendermap(void)
 
 void rendermapfog(void)
 {
-    int mapwidth = map.custommode ? map.customheight : 20;
+    int mapwidth = map.custommode ? map.customwidth : 20;
     int mapheight = map.custommode ? map.customheight : 20;
     int mapzoom = map.custommode ? map.customzoom : 1;
     int mapxoff = map.custommode ? map.custommmxoff : 0;
@@ -2137,7 +2137,7 @@ void rendermaplegend(void)
 
 void rendermapcursor(bool flashing)
 {
-    int mapwidth = map.custommode ? map.customheight : 20;
+    int mapwidth = map.custommode ? map.customwidth : 20;
     int mapheight = map.custommode ? map.customheight : 20;
     int mapzoom = map.custommode ? map.customzoom : 1;
     int mapxoff = map.custommode ? map.custommmxoff : 0;
@@ -2675,7 +2675,7 @@ void teleporterrender(void)
 
     // Draw a box around the currently selected teleporter
 
-    int mapwidth = map.custommode ? map.customheight : 20;
+    int mapwidth = map.custommode ? map.customwidth : 20;
     int mapheight = map.custommode ? map.customheight : 20;
     int mapzoom = map.custommode ? map.customzoom : 1;
     int mapxoff = map.custommode ? map.custommmxoff : 0;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2060,20 +2060,23 @@ static MapRenderData getmaprenderdata()
     data.zoom = map.custommode ? map.customzoom : 1;
     data.xoff = map.custommode ? map.custommmxoff : 0;
     data.yoff = map.custommode ? map.custommmyoff : 0;
+    data.legendxoff = 40 + data.xoff;
+    data.legendyoff = 21 + data.yoff;
 
+    // Magic numbers for centering legend tiles.
     switch (data.zoom)
     {
     case 4:
-        data.legendxoff = 60;
-        data.legendyoff = 35;
+        data.legendxoff += 21;
+        data.legendyoff += 16;
         break;
     case 2:
-        data.legendxoff = 48;
-        data.legendyoff = 26;
+        data.legendxoff += 9;
+        data.legendyoff += 5;
         break;
     default:
-        data.legendxoff = 43;
-        data.legendyoff = 22;
+        data.legendxoff += 3;
+        data.legendyoff += 1;
         break;
     }
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2166,37 +2166,14 @@ void rendermapcursor(bool flashing)
         return;
     }
 
-    if (mapzoom == 4) {
-        if (!flashing || (map.cursorstate == 2 && int(map.cursordelay / 15) % 2 == 0)) {
-            graphics.drawrect(40 + ((game.roomx - 100) * 48) + 2 + mapxoff, 21 + ((game.roomy - 100) * 36) + 2 + mapyoff, 48 - 4, 36 - 4, 16, 245 - (help.glow), 245 - (help.glow));
-        }
-        else if (map.cursorstate == 1 && (int(map.cursordelay / 4) % 2 == 0))
-        {
-            graphics.drawrect(40 + ((game.roomx - 100) * 48) + mapxoff, 21 + ((game.roomy - 100) * 36) + mapyoff, 48, 36, 255, 255, 255);
-            graphics.drawrect(40 + ((game.roomx - 100) * 48) + 2 + mapxoff, 21 + ((game.roomy - 100) * 36) + 2 + mapyoff, 48 - 4, 36 - 4, 255, 255, 255);
-        }
+    if (!flashing || (map.cursorstate == 2 && int(map.cursordelay / 15) % 2 == 0))
+    {
+        graphics.drawrect(40 + ((game.roomx - 100) * 12 * mapzoom) + 2 + mapxoff, 21 + ((game.roomy - 100) * 9 * mapzoom) + 2 + mapyoff, (12 * mapzoom) - 4, (9 * mapzoom) - 4, 16, 245 - (help.glow), 245 - (help.glow));
     }
-    else if (mapzoom == 2) {
-        if (!flashing || (map.cursorstate == 2 && int(map.cursordelay / 15) % 2 == 0))
-        {
-            graphics.drawrect(40 + ((game.roomx - 100) * 24) + 2 + mapxoff, 21 + ((game.roomy - 100) * 18) + 2 + mapyoff, 24 - 4, 18 - 4, 16, 245 - (help.glow), 245 - (help.glow));
-        }
-        else if (map.cursorstate == 1 && (int(map.cursordelay / 4) % 2 == 0))
-        {
-            graphics.drawrect(40 + ((game.roomx - 100) * 24) + mapxoff, 21 + ((game.roomy - 100) * 18) + mapyoff, 24, 18, 255, 255, 255);
-            graphics.drawrect(40 + ((game.roomx - 100) * 24) + 2 + mapxoff, 21 + ((game.roomy - 100) * 18) + 2 + mapyoff, 24 - 4, 18 - 4, 255, 255, 255);
-        }
-    }
-    else {
-        if (!flashing || (map.cursorstate == 2 && int(map.cursordelay / 15) % 2 == 0))
-        {
-            graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2 + mapxoff, 21 + ((game.roomy - 100) * 9) + 2 + mapyoff, 12 - 4, 9 - 4, 16, 245 - (help.glow), 245 - (help.glow));
-        }
-        else if (map.cursorstate == 1 && (int(map.cursordelay / 4) % 2 == 0))
-        {
-            graphics.drawrect(40 + ((game.roomx - 100) * 12) + mapxoff, 21 + ((game.roomy - 100) * 9) + mapyoff, 12, 9, 255, 255, 255);
-            graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2 + mapxoff, 21 + ((game.roomy - 100) * 9) + 2 + mapyoff, 12 - 4, 9 - 4, 255, 255, 255);
-        }
+    else if (map.cursorstate == 1 && (int(map.cursordelay / 4) % 2 == 0))
+    {
+        graphics.drawrect(40 + ((game.roomx - 100) * 12 * mapzoom) + mapxoff, 21 + ((game.roomy - 100) * 9) + mapyoff, 12 * mapzoom, 9 * mapzoom, 255, 255, 255);
+        graphics.drawrect(40 + ((game.roomx - 100) * 12 * mapzoom) + 2 + mapxoff, 21 + ((game.roomy - 100) * 9 * mapzoom) + 2 + mapyoff, (12 * mapzoom) - 4, (9 * mapzoom) - 4, 255, 255, 255);
     }
 }
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2889,7 +2889,6 @@ void scriptclass::startgamemode( int t )
         map.gotoroom(game.saverx, game.savery);
         map.initmapdata();
 
-
         cl.generatecustomminimap();
         map.customshowmm = true;
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2857,6 +2857,10 @@ void scriptclass::startgamemode( int t )
         map.resetplayer();
         map.gotoroom(game.saverx, game.savery);
         map.initmapdata();
+
+        cl.generatecustomminimap();
+        map.customshowmm = true;
+
         graphics.fademode = FADE_START_FADEIN;
         break;
     case 21:  //play custom level (in editor)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2857,10 +2857,6 @@ void scriptclass::startgamemode( int t )
         map.resetplayer();
         map.gotoroom(game.saverx, game.savery);
         map.initmapdata();
-
-        cl.generatecustomminimap();
-        map.customshowmm = true;
-
         graphics.fademode = FADE_START_FADEIN;
         break;
     case 21:  //play custom level (in editor)
@@ -2892,10 +2888,18 @@ void scriptclass::startgamemode( int t )
         map.resetplayer();
         map.gotoroom(game.saverx, game.savery);
         map.initmapdata();
-        if(cl.levmusic>0){
+
+
+        cl.generatecustomminimap();
+        map.customshowmm = true;
+
+        if (cl.levmusic > 0)
+        {
             music.play(cl.levmusic);
-        }else{
-            music.currentsong=-1;
+        }
+        else
+        {
+            music.currentsong = -1;
         }
         break;
 # endif /* NO_EDITOR */


### PR DESCRIPTION
## Changes:

This PR deduplicates a lot of map rendering code, as it's cloned a few times for the following reasons:
- Main game map
- Teleporter screen map
- Custom level map

This splits a lot of map rendering features into smaller functions, instead of a bunch of slightly different copy-pasted huge functions. This also allows the teleporter screen to work properly in custom levels with smaller map sizes, and with showing the legend (trinkets, teleporters, targets) in those as well.

This also cleans up some bad code such as fog rendering, so it uses a small for loop instead of 30+ lines of code...

**NOTE:** One of these changes means the teleporter screen in custom levels no longer always shows `minimap.png` -- it shows the map that custom levels are supposed to show. This is a _fix_, but I thought I'd mention it.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
