### PR TITLE
Gravity Token additions

### DIFF
--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -671,6 +671,10 @@ static void draw_entities(void)
                 font::print(PR_FONT_8X8, x, y, "////", 255 - help.glow, 255 - help.glow, 255 - help.glow);
                 graphics.draw_rect(x, y, 32, 8, graphics.getRGB(255, 255, 255));
                 break;
+            case 5: // Gravity Tokens
+                graphics.draw_sprite(x, y, 68 + entity->p1, graphics.getcol(entity->p2));
+                graphics.draw_rect(x, y, 16, 16, graphics.getRGB(255, 164, 164));
+                break;
             case 9: // Shiny Trinkets
                 graphics.draw_sprite(x, y, 22, 196, 196, 196);
                 graphics.draw_rect(x, y, 16, 16, graphics.getRGB(255, 164, 164));

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1480,13 +1480,14 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.rule = 3;
         entity.type = 4;
         entity.size = 0;
-        entity.tile = 11;
+        entity.tile = 68 + meta1;
+        entity.colour = meta2;
         entity.w = 16;
         entity.h = 16;
-        entity.behave = meta1;
-        entity.para = meta2;
+        entity.behave = p2;
+        entity.para = p3;
         entity.onentity = 1;
-        entity.animate = 100;
+        entity.animate = (p1 >= 1) ? 1 : -1;
         break;
     case 6: //Decorative particles
         entity.rule = 2;
@@ -2634,8 +2635,22 @@ bool entityclass::updateentities( int i )
             {
                 game.gravitycontrol = (game.gravitycontrol + 1) % 2;
                 ++game.totalflips;
-                return disableentity(i);
-
+                music.playef(8 + entities[i].behave);
+                entities[i].invis = true;
+                entities[i].state = 2;
+                // Removes collision
+                entities[i].onentity = 0;
+            }
+            else if (entities[i].state == 2)
+            {
+                // Wait until recharged!
+            }
+            else if (entities[i].state == 3)
+            {
+                // Respawn!
+                entities[i].invis = false;
+                entities[i].state = 0;
+                entities[i].onentity = 1;
             }
             break;
         case 5:  //Particle sprays
@@ -3475,6 +3490,7 @@ void entityclass::animateentities( int _i )
             }
             break;
         case 1:
+        case 4:
         case 23:
             //Variable animation
             switch(entities[_i].animate)

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -417,6 +417,11 @@ void gamelogic(void)
                 }
                 if (!entitygone) obj.entities[i].state = 4;
             }
+            else if (obj.entities[i].type == 4 && obj.entities[i].state == 2)
+            {
+                // Flip token: Give a signal to respawn
+                obj.entities[i].state = 3;
+            }
             else if (obj.entities[i].type == 23 && game.swnmode && game.deathseq<15)
             {
                 //if playing SWN, get the enemies offscreen.

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -419,7 +419,7 @@ void gamelogic(void)
             }
             else if (obj.entities[i].type == 4 && obj.entities[i].state == 2)
             {
-                // Flip token: Give a signal to respawn
+                // Gravity token: Give a signal to respawn
                 obj.entities[i].state = 3;
             }
             else if (obj.entities[i].type == 23 && game.swnmode && game.deathseq<15)

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1872,6 +1872,9 @@ void mapclass::loadlevel(int rx, int ry)
             case 3: // Disappearing platforms
                 obj.createentity(ex, ey, 3);
                 break;
+            case 5: // Gravity tokens
+                obj.createentity(ex, ey, 5, ent.p1, ent.p2, ent.p3, ent.p4);
+                break;
             case 9: // Trinkets
                 obj.createentity(ex, ey, 9, cl.findtrinket(edi));
                 break;


### PR DESCRIPTION
## Changes:

Gravity tokens are interesting. They were added in the mechanics test, but were never used after. You can assume they became gravity lines, but they're still pretty interesting.

This PR freshens them up a little -- a better default sprite, a sound when you touch them, and making them respawn on death.

Additionally, a few createentity arguments have been added:

- `meta1` is a sprite ID offset
- `meta2` is the colour
- `p1` is if the entity animates or not (0 is doesn't animate)
- `p2` is a sound ID offset

Of course, these additions shouldn't affect gameplay, other than respawning on death which is just convenience (you can just leave and reenter the room to respawn them otherwise), so these changes are solely visual and auditory. Hopefully this breathes some life into the unused entity.

~~(Who knows, maybe we could even get an edentity later when more of those are added due to the main-game-as-custom-level goal...?)~~ I have now added an edentity for consistency, however this means this PR now affects gameplay.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
