### PR TITLE
Per-room altstate system

### DIFF
--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -376,7 +376,7 @@ const int* customlevelclass::loadlevel( int rxi, int ryi )
 
     int state = getroomprop(rxi, ryi)->altstate;
    
-    if (state > altstates[rxi + maxwidth * ryi].size())
+    if (state < 0 || state > altstates[rxi + maxwidth * ryi].size())
     {
         state = 0;
         setroomaltstate(rxi, ryi, 0);

--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -8,7 +8,6 @@
 #include <string>
 #include <tinyxml2.h>
 #include <utf8/unchecked.h>
-#include <array>
 
 #include "Constants.h"
 #include "Editor.h"
@@ -1141,7 +1140,8 @@ bool customlevelclass::load(std::string& _path)
                     pText2 = "";
                 }
 
-                std::array<int, 40 * 30> tiles;
+                std::vector<int> tiles;
+                tiles.resize(30 * 40, 0);
 
                 char buffer[16];
                 size_t start = 0;
@@ -1149,7 +1149,7 @@ bool customlevelclass::load(std::string& _path)
                 int tile = 0;
                 while (next_split_s(buffer, sizeof(buffer), &start, pText2, ','))
                 {
-                    if (INBOUNDS_ARR(tile, tiles))
+                    if (INBOUNDS_VEC(tile, tiles))
                     {
                         tiles[tile] = help.Int(buffer);
                     }

--- a/desktop_version/src/CustomLevels.h
+++ b/desktop_version/src/CustomLevels.h
@@ -7,7 +7,6 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <array>
 
 class CustomEntity
 {
@@ -162,7 +161,7 @@ public:
     Uint32 getonewaycol(void);
     bool onewaycol_override;
 
-    std::vector<std::array<int, 40 * 30>> altstates[numrooms];
+    std::vector<std::vector<int>> altstates[numrooms];
 };
 
 #ifndef CL_DEFINITION

--- a/desktop_version/src/CustomLevels.h
+++ b/desktop_version/src/CustomLevels.h
@@ -6,6 +6,8 @@
 #include <SDL.h>
 #include <string>
 #include <vector>
+#include <map>
+#include <array>
 
 class CustomEntity
 {
@@ -32,7 +34,8 @@ public:
     FOREACH_PROP(enemyx2, int) \
     FOREACH_PROP(enemyy2, int) \
     FOREACH_PROP(enemytype, int) \
-    FOREACH_PROP(directmode, int)
+    FOREACH_PROP(directmode, int) \
+    FOREACH_PROP(altstate, int)
 
 class RoomProperty
 {
@@ -158,6 +161,8 @@ public:
     Uint32 getonewaycol(const int rx, const int ry);
     Uint32 getonewaycol(void);
     bool onewaycol_override;
+
+    std::vector<std::array<int, 40 * 30>> altstates[numrooms];
 };
 
 #ifndef CL_DEFINITION

--- a/desktop_version/src/CustomLevels.h
+++ b/desktop_version/src/CustomLevels.h
@@ -161,7 +161,7 @@ public:
     Uint32 getonewaycol(void);
     bool onewaycol_override;
 
-    std::vector<std::vector<int>> altstates[numrooms];
+    std::vector<std::vector<int> > altstates[numrooms];
 };
 
 #ifndef CL_DEFINITION

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -2235,9 +2235,18 @@ void mapclass::twoframedelayfix(void)
 
 void mapclass::setaltstate(int x, int y, int state)
 {
-    cl.setroomaltstate(x, y, state);
-    if (game.roomx - 100 == x && game.roomy - 100 == y)
+#if !defined(NO_CUSTOM_LEVELS)
+    if (custommode)
     {
-        gotoroom(x + 100, y + 100);
+        cl.setroomaltstate(x, y, state);
+        if (game.roomx - 100 == x && game.roomy - 100 == y)
+        {
+            gotoroom(x + 100, y + 100);
+        }
+    }
+    else
+#endif
+    {
+        obj.altstates = state;
     }
 }

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -2232,3 +2232,12 @@ void mapclass::twoframedelayfix(void)
     game.statedelay = 0;
     script.load(game.newscript);
 }
+
+void mapclass::setaltstate(int x, int y, int state)
+{
+    cl.setroomaltstate(x, y, state);
+    if (game.roomx - 100 == x && game.roomy - 100 == y)
+    {
+        gotoroom(x + 100, y + 100);
+    }
+}

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -89,6 +89,8 @@ public:
 
     void twoframedelayfix(void);
 
+    void setaltstate(int x, int y, int state);
+
 
     int roomdeaths[20 * 20];
     int roomdeathsfinal[20 * 20];

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1694,9 +1694,13 @@ void scriptclass::run(void)
             {
                 game.savecolour = getcolorfromname(words[1]);
             }
-            else if (words[0] == "altstates")
+            else if (words[0] == "altstate")
             {
-                obj.altstates = ss_toi(words[1]);
+                int room_x = game.roomx - 100;
+                int room_y = game.roomy - 100;
+                if (ss_toi(words[1]) != -1) room_x = ss_toi(words[1]);
+                if (ss_toi(words[2]) != -1) room_y = ss_toi(words[2]);
+                map.setaltstate(room_x, room_y, ss_toi(words[3]));
             }
             else if (words[0] == "activeteleporter")
             {
@@ -3247,6 +3251,15 @@ void scriptclass::hardreset(void)
     SDL_memset(map.roomdeaths, 0, sizeof(map.roomdeaths));
     SDL_memset(map.roomdeathsfinal, 0, sizeof(map.roomdeathsfinal));
     map.resetmap();
+
+    for (int j = 0; j < cl.maxheight; j++)
+    {
+        for (int i = 0; i < cl.maxwidth; i++)
+        {
+            cl.setroomaltstate(j, i, 0);
+        }
+    }
+
     //entityclass
     obj.nearelephant = false;
     obj.upsetmode = false;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3252,6 +3252,7 @@ void scriptclass::hardreset(void)
     SDL_memset(map.roomdeathsfinal, 0, sizeof(map.roomdeathsfinal));
     map.resetmap();
 
+#if !defined(NO_CUSTOM_LEVELS)
     for (int j = 0; j < cl.maxheight; j++)
     {
         for (int i = 0; i < cl.maxwidth; i++)
@@ -3259,6 +3260,7 @@ void scriptclass::hardreset(void)
             cl.setroomaltstate(j, i, 0);
         }
     }
+#endif
 
     //entityclass
     obj.nearelephant = false;

--- a/desktop_version/src/Scripts.cpp
+++ b/desktop_version/src/Scripts.cpp
@@ -6332,7 +6332,7 @@ void scriptclass::load(const std::string& name)
         "rescued(green)",
         "rescued(yellow)",
         "missing(blue)",
-        "altstates(1)",
+        "altstate(-1,-1,1)",
 
         "fadeout()",
         "untilfade()",
@@ -6592,7 +6592,7 @@ void scriptclass::load(const std::string& name)
         "flash(10)",
         "shake(20)",
         "playef(23)",
-        "altstates(2)",
+        "altstate(-1,-1,2)",
         "gotoroom(17,6)",
 
         "delay(20)",
@@ -6601,7 +6601,7 @@ void scriptclass::load(const std::string& name)
         "flash(10)",
         "shake(20)",
         "playef(23)",
-        "altstates(0)",
+        "altstate(-1,-1,0)",
         "gotoroom(17,6)",
 
         "delay(20)",


### PR DESCRIPTION
## Changes:

VVVVVV has this interesting system called altstates. It's where a room can have multiple sets of tiles which can be switched between by using `altstates(ID)` in a script. This is only used in the pre-secret lab cutscene.

This works by the entity class having an `altstates` variable, which is 0 most of the time. Then when loading a room, it checks if that variable is a certain number, and switches out the set of tiles to load.

This is very hardcoded.

Like a couple of my other PRs (ex. #897, #905), this PR helps with the goal of reducing the split between custom levels and the main game. This gives the custom level system the ability to load alternate sets of tiles. To make it a bit more useful, it's per-room, instead of a global "altstate".

So, `altstates(ID)` has been stripped out -- it's not very useful when altstates are now per-room. Instead, `altstate(x, y, ID)` has taken it's place. `x` and `y` can be `-1` to target the current x/y. The command changes the altstate and reloads the room. Altstates are stored separately from normal rooms in the level file, and this is because every single tile in levels are just one huge list... so altstates they're stored like so:

```xml
        <altstates>
            <state x="0" y="0">244,244,244,244,244,244,244,[...]</state> <!-- altstate 1 for 0, 0 -->
            <state x="0" y="0">244,244,244,244,244,244,244,[...]</state> <!-- altstate 2 for 0, 0 -->
        </altstates>
```

Like #897, this PR does NOT replace the current system used in the main game, as that should be done when the main game is overhauled to use a better format. However, laying down the systems for future use is the way to get there.

Also like #897, this doesn't add any editor support. In the future, I might make a PR to add some missing editor features, however I'm not sure yet. I'd love input on this decision. Additionally, if editor support for altstates is requested alone, I can do that in this PR as well.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
