### PR TITLE
Super Gravitron #define

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -19,6 +19,12 @@ option(OFFICIAL_BUILD "Compile an official build of the game" OFF)
 
 option(MAKEANDPLAY "Compile a version of the game without the main campaign (provided for convenience; consider modifying MakeAndPlay.h instead" OFF)
 
+option(SUPER_GRAV "Compile a version of the game with only the Super Gravitron" OFF)
+
+if(SUPER_GRAV)
+    set(CUSTOM_LEVEL_SUPPORT DISABLED)
+endif()
+
 if(OFFICIAL_BUILD AND NOT MAKEANDPLAY)
     set(STEAM ON)
     set(GOG ON)
@@ -162,6 +168,10 @@ if(STEAM)
 endif()
 if(GOG)
     target_compile_definitions(VVVVVV PRIVATE -DGOG_NETWORK)
+endif()
+
+if(SUPER_GRAV)
+    target_compile_definitions(VVVVVV PRIVATE -DSUPER_GRAV)
 endif()
 
 set(XML2_SRC

--- a/desktop_version/src/Finalclass.cpp
+++ b/desktop_version/src/Finalclass.cpp
@@ -15,7 +15,7 @@ const short* finalclass::loadlevel(int rx, int ry)
 
     switch(t)
     {
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
     case rn(50,52):
     {
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4027,7 +4027,7 @@ void Game::deletestats(void)
         swnrecord = 0;
         swnbestrank = 0;
         bestgamedeaths = -1;
-#ifndef MAKEANDPLAY
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
         graphics.setflipmode = false;
 #endif
         stat_trinkets = 0;
@@ -4044,7 +4044,7 @@ void Game::deletesettings(void)
 
 void Game::unlocknum( int t )
 {
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
     if (map.custommode)
     {
         //Don't let custom levels unlock things!
@@ -5925,14 +5925,18 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
             SDL_assert(0 && "Entering main menu from in-game options!");
             break;
         }
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
         option("play");
+#endif
+#if defined(SUPER_GRAV)
+        option("play game");
+        option("about vvvvvv");
 #endif
 #if !defined(NO_CUSTOM_LEVELS)
         option("levels");
 #endif
         option("options");
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
         option("credits");
 #endif
         option("quit");
@@ -6075,7 +6079,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         menuyoff = -20;
         break;
     case Menu::gameplayoptions:
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
         if (ingame_titlemode && unlock[18])
 #endif
         {
@@ -6196,7 +6200,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         maxspacing = 15;
         break;
     case Menu::accessibility:
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
         option("unlock play modes");
 #endif
         option("invincibility", !ingame_titlemode || !incompetitive());
@@ -6286,6 +6290,19 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
     case Menu::credits6:
         option("first page");
         option("previous page");
+        option("return");
+        menuyoff = 64;
+        break;
+    case Menu::gravabout1:
+    case Menu::gravabout2:
+    case Menu::gravabout3:
+    case Menu::gravabout4:
+    case Menu::gravabout5:
+        option("next page");
+        option("return");
+        menuyoff = 64;
+        break;
+    case Menu::gravabout6:
         option("return");
         menuyoff = 64;
         break;
@@ -6902,7 +6919,7 @@ void Game::returntoingame(void)
 }
 
 void Game::unlockAchievement(const char *name) {
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
     if (!map.custommode) NETWORK_unlockAchievement(name);
 #endif
 }

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -94,7 +94,13 @@ namespace Menu
         timetrialcomplete,
         timetrialcomplete2,
         timetrialcomplete3,
-        gamecompletecontinue
+        gamecompletecontinue,
+        gravabout1,
+        gravabout2,
+        gravabout3,
+        gravabout4,
+        gravabout5,
+        gravabout6
     };
 }
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3398,6 +3398,7 @@ bool Graphics::reloadresources(void)
     images.push_back(grphx.im_image2);
     images.push_back(grphx.im_image3);
     images.push_back(grphx.im_image4);
+#if !defined(SUPER_GRAV)
     images.push_back(grphx.im_image5);
     images.push_back(grphx.im_image6);
 
@@ -3407,6 +3408,7 @@ bool Graphics::reloadresources(void)
     images.push_back(grphx.im_image10);
     images.push_back(grphx.im_image11);
     images.push_back(grphx.im_image12);
+#endif
 
     gameScreen.LoadIcon();
 

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -86,6 +86,7 @@ void GraphicsResources::init(void)
     im_bfont =        LoadImage("graphics/font.png");
     im_teleporter =        LoadImage("graphics/teleporter.png");
 
+#if !defined(SUPER_GRAV)
     im_image0 =        LoadImage("graphics/levelcomplete.png");
     im_image1 =        LoadImage("graphics/minimap.png");
     im_image2 =        LoadImage("graphics/covered.png");
@@ -99,6 +100,13 @@ void GraphicsResources::init(void)
     im_image10 =        LoadImage("graphics/ending.png");
     im_image11 =        LoadImage("graphics/site4.png");
     im_image12 =        LoadImage("graphics/minimap.png");
+#else
+    im_image0 = LoadImage("graphics/supergrav.png");
+    im_image1 = LoadImage("graphics/vvvvvv1.png");
+    im_image2 = LoadImage("graphics/vvvvvv2.png");
+    im_image3 = LoadImage("graphics/vvvvvv3.png");
+    im_image4 = LoadImage("graphics/vvvvvv4.png");
+#endif
 }
 
 
@@ -122,6 +130,7 @@ void GraphicsResources::destroy(void)
     CLEAR(im_image2);
     CLEAR(im_image3);
     CLEAR(im_image4);
+#if !defined(SUPER_GRAV)
     CLEAR(im_image5);
     CLEAR(im_image6);
     CLEAR(im_image7);
@@ -130,5 +139,6 @@ void GraphicsResources::destroy(void)
     CLEAR(im_image10);
     CLEAR(im_image11);
     CLEAR(im_image12);
+#endif
 #undef CLEAR
 }

--- a/desktop_version/src/GraphicsResources.h
+++ b/desktop_version/src/GraphicsResources.h
@@ -22,6 +22,7 @@ public:
     SDL_Surface* im_image2;
     SDL_Surface* im_image3;
     SDL_Surface* im_image4;
+#if !defined(SUPER_GRAV)
     SDL_Surface* im_image5;
     SDL_Surface* im_image6;
     SDL_Surface* im_image7;
@@ -30,6 +31,7 @@ public:
     SDL_Surface* im_image10;
     SDL_Surface* im_image11;
     SDL_Surface* im_image12;
+#endif
 };
 
 #endif /* GRAPHICSRESOURCES_H */

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -370,19 +370,26 @@ static void menuactionpress(void)
 #define MPOFFSET 0
 #endif
 
+#if defined(SUPER_GRAV)
+#define SGOFFSET 1
+#else
+#define SGOFFSET 0
+#endif
+
 #if defined(NO_CUSTOM_LEVELS)
 #define NOCUSTOMSOFFSET -1
 #else
 #define NOCUSTOMSOFFSET 0
 #endif
 
-#define OFFSET (MPOFFSET+NOCUSTOMSOFFSET)
+#define OFFSET (MPOFFSET+NOCUSTOMSOFFSET+SGOFFSET)
 
         switch (game.currentmenuoption)
         {
 #if !defined(MAKEANDPLAY)
         case 0:
             //Play
+#if !defined(SUPER_GRAV)
             if (!game.save_exists() && !game.anything_unlocked())
             {
                 //No saves exist, just start a new game
@@ -396,6 +403,17 @@ static void menuactionpress(void)
                 game.createmenu(Menu::play);
                 map.nexttowercolour();
             }
+#else
+            music.playef(11);
+            startmode(11);
+#endif
+            break;
+#endif
+#if defined(SUPER_GRAV)
+        case 1:
+            music.playef(11);
+            game.createmenu(Menu::gravabout1);
+            map.settowercolour(0);
             break;
 #endif
 #if !defined(NO_CUSTOM_LEVELS)
@@ -412,7 +430,7 @@ static void menuactionpress(void)
             game.createmenu(Menu::options);
             map.nexttowercolour();
             break;
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
         case OFFSET+3:
             //Credits
             music.playef(11);
@@ -420,8 +438,13 @@ static void menuactionpress(void)
             map.nexttowercolour();
             break;
 #else
- #undef MPOFFSET
- #define MPOFFSET -2
+ #if defined (MAKEANDPLAY)
+  #undef MPOFFSET
+  #define MPOFFSET -2
+ #else
+  #undef SGOFFSET
+  #define SGOFFSET 0
+ #endif
 #endif
         case OFFSET+4:
             music.playef(11);
@@ -431,8 +454,93 @@ static void menuactionpress(void)
 #undef OFFSET
 #undef NOCUSTOMSOFFSET
 #undef MPOFFSET
+#undef SGOFFSET
         }
         break;
+#if defined(SUPER_GRAV)
+    case Menu::gravabout1:
+    {
+        music.playef(11);
+        if (game.currentmenuoption == 0)
+        {
+            map.settowercolour(5);
+            game.createmenu(Menu::gravabout2);
+        }
+        else
+        {
+            game.createmenu(Menu::mainmenu);
+            map.nexttowercolour();
+        }
+        break;
+    }
+    case Menu::gravabout2:
+    {
+        music.playef(11);
+        if (game.currentmenuoption == 0)
+        {
+            map.settowercolour(3);
+            game.createmenu(Menu::gravabout3);
+        }
+        else
+        {
+            game.createmenu(Menu::mainmenu);
+            map.nexttowercolour();
+        }
+        break;
+    }
+    case Menu::gravabout3:
+    {
+        music.playef(11);
+        if (game.currentmenuoption == 0)
+        {
+            map.settowercolour(1);
+            game.createmenu(Menu::gravabout4);
+        }
+        else
+        {
+            game.createmenu(Menu::mainmenu);
+            map.nexttowercolour();
+        }
+        break;
+    }
+    case Menu::gravabout4:
+    {
+        music.playef(11);
+        if (game.currentmenuoption == 0)
+        {
+            map.settowercolour(2);
+            game.createmenu(Menu::gravabout5);
+    }
+        else
+        {
+            game.createmenu(Menu::mainmenu);
+            map.nexttowercolour();
+        }
+        break;
+    }
+    case Menu::gravabout5:
+    {
+        music.playef(11);
+        if (game.currentmenuoption == 0)
+        {
+            map.settowercolour(3);
+            game.createmenu(Menu::gravabout6);
+        }
+        else
+        {
+            game.createmenu(Menu::mainmenu);
+            map.nexttowercolour();
+        }
+        break;
+    }
+    case Menu::gravabout6:
+    {
+        music.playef(11);
+        game.createmenu(Menu::mainmenu);
+        map.nexttowercolour();
+        break;
+    }
+#endif
 #if !defined(NO_CUSTOM_LEVELS)
     case Menu::levellist:
     {
@@ -823,7 +931,7 @@ static void menuactionpress(void)
     case Menu::accessibility:
     {
         int accessibilityoffset = 0;
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
         accessibilityoffset = 1;
         if (game.currentmenuoption == 0) {
             //unlock play options
@@ -907,7 +1015,7 @@ static void menuactionpress(void)
     case Menu::gameplayoptions:
     {
         int gameplayoptionsoffset = 0;
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
         if (game.ingame_titlemode && game.unlock[18])
 #endif
         {
@@ -2362,10 +2470,22 @@ void gameinput(void)
         //quitting the super gravitron
         game.mapheld = true;
         //Quit menu, same conditions as in game menu
+#if !defined(SUPER_GRAV)
         game.mapmenuchange(MAPMODE, true);
         game.gamesaved = false;
         game.gamesavefailed = false;
         game.menupage = 20; // The Map Page
+#else
+        if (graphics.fademode == FADE_NONE)
+        {
+            game.swnmode = false;
+            graphics.fademode = FADE_START_FADEOUT;
+            music.fadeout();
+            game.fadetolab = true;
+            game.fadetolabdelay = 16;
+            game.state = 80;
+        }
+#endif
     }
     else if (game.intimetrial && graphics.fademode == FADE_NONE)
     {

--- a/desktop_version/src/Labclass.cpp
+++ b/desktop_version/src/Labclass.cpp
@@ -28,7 +28,7 @@ const short* labclass::loadlevel(int rx, int ry)
 
     switch(t)
     {
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
 
     case rn(50,50):
     {

--- a/desktop_version/src/Network.c
+++ b/desktop_version/src/Network.c
@@ -3,7 +3,7 @@
 #include "MakeAndPlay.h"
 #include "Unused.h"
 
-#ifdef MAKEANDPLAY
+#if defined(MAKEANDPLAY) || defined(SUPER_GRAV)
     #ifdef STEAM_NETWORK
         #undef STEAM_NETWORK
     #endif

--- a/desktop_version/src/Otherlevel.cpp
+++ b/desktop_version/src/Otherlevel.cpp
@@ -19,7 +19,7 @@ const short* otherlevelclass::loadlevel(int rx, int ry)
 
     switch(t)
     {
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
     case rn(0,0):
     {
 
@@ -9131,7 +9131,8 @@ const short* otherlevelclass::loadlevel(int rx, int ry)
         break;
     }
 
-
+#endif
+#if !defined(MAKEANDPLAY)
     case rn(19, 8):
     {
         //The SUPER GRAVITRON

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -136,12 +136,17 @@ static void menurender(void)
     switch (game.currentmenuname)
     {
     case Menu::mainmenu:
+#if !defined(SUPER_GRAV)
         graphics.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
         graphics.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
         graphics.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
         graphics.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
         graphics.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
         graphics.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
+#else
+        graphics.setcolreal(graphics.getRGB(tr, tg, tb));
+        graphics.drawimagecol(0, -1, 46, true);
+#endif
 #if defined(MAKEANDPLAY)
         graphics.Print(-1,temp+35,"     MAKE AND PLAY EDITION",tr, tg, tb, true);
 #endif
@@ -155,6 +160,65 @@ static void menurender(void)
             graphics.Print( 10, 230, "[MMMMMM Mod Installed]", tr/2, tg/2, tb/2);
         }
         break;
+#if defined(SUPER_GRAV)
+    case Menu::gravabout1:
+        graphics.drawimage(1, -1, 10, true);
+        graphics.Print(-1, 150, "Hello! My name's Terry and I made", tr, tg, tb, true);
+        graphics.Print(-1, 160, "the Super Gravitron!", tr, tg, tb, true);
+        graphics.Print(-1, 175, "Thank you for playing it!", tr, tg, tb, true);
+        break;
+    case Menu::gravabout2:
+        graphics.drawimage(2, -1, 10, true);
+        graphics.Print(-1, 145, "DID YOU KNOW?", tr, tg, tb, true);
+        graphics.Print(-1, 160, "Super Gravitron is actually a small", tr, tg, tb, true);
+        graphics.Print(-1, 170, "part of a different game that I made", tr, tg, tb, true);
+        graphics.Print(-1, 180, "years ago, called VVVVVV!", tr, tg, tb, true);
+        break;
+    case Menu::gravabout3:
+        graphics.Print(-1, 10, "Years before I made", tr, tg, tb, true);
+        graphics.Print(-1, 20, "Super Hexagon, VVVVVV was my", tr, tg, tb, true);
+        graphics.Print(-1, 30, "first commercial game.", tr, tg, tb, true);
+        graphics.drawimage(3, -1, 50, true);
+        graphics.Print(-1, 135, "It's an 80's inspired platformer,", tr, tg, tb, true);
+        graphics.Print(-1, 145, "built around exploring a single", tr, tg, tb, true);
+        graphics.Print(-1, 155, "game mechanic as far as I could:", tr, tg, tb, true);
+        graphics.Print(-1, 170, "What if, instead of jumping,", tr, tg, tb, true);
+        graphics.Print(-1, 180, "you flipped gravity?", tr, tg, tb, true);
+        break;
+    case Menu::gravabout4:
+        graphics.Print(-1, 20, "I'm very proud of VVVVVV, and I'm", tr, tg, tb, true);
+        graphics.Print(40, 30, "glad that other people like it too!", tr, tg, tb, true);
+        graphics.Print(40, 50, "When the original version was released", tr, tg, tb, true);
+        graphics.Print(40, 60, "in 2010, it won an award at Indiecade", tr, tg, tb, true);
+        graphics.Print(40, 70, "for most Fun Game, and showed up in", tr, tg, tb, true);
+        graphics.Print(40, 80, "lots of game of the year lists! Here's", tr, tg, tb, true);
+        graphics.Print(40, 90, "what some people have said about it:", tr, tg, tb, true);
+        graphics.Print(40, 130, "\"One of the best platformers", tr * 0.8, tg * 0.8, tb * 0.8, true);
+        graphics.Print(40, 140, "I\'ve ever played.\"", tr * 0.8, tg * 0.8, tb * 0.8, true);
+        graphics.Print(40, 155, "                      Anthony Burch", tr * 0.5, tg * 0.5, tb * 0.5, true);
+        graphics.Print(40, 165, "                  Destructoid 10/10", tr * 0.5, tg * 0.5, tb * 0.5, true);
+        break;
+    case Menu::gravabout5:
+        graphics.Print(40, 15, "\"I haven't felt as good with a", tr, tg, tb, true);
+        graphics.Print(40, 25, "videogame, in that direct\"", tr, tg, tb, true);
+        graphics.Print(40, 35, "physical way, for quite a while.\"", tr, tg, tb, true);
+        graphics.Print(40, 50, "                      Kieron Gillen", tr * 0.8, tg * 0.8, tb * 0.8, true);
+        graphics.Print(40, 60, "               Rock, Paper, Shotgun", tr * 0.8, tg * 0.8, tb * 0.8, true);
+        graphics.Print(40, 85, "\"This game is incredible.\"", tr, tg, tb, true);
+        graphics.Print(40, 100, "                      Michael Rose", tr * 0.8, tg * 0.8, tb * 0.8, true);
+        graphics.Print(40, 110, "                    Indiegames.com", tr * 0.8, tg * 0.8, tb * 0.8, true);
+        graphics.Print(40, 135, "\"When game design is taught in", tr, tg, tb, true);
+        graphics.Print(40, 145, "most universities, VVVVVV will", tr, tg, tb, true);
+        graphics.Print(40, 155, "be on every syllabus.\"", tr, tg, tb, true);
+        graphics.Print(40, 170, "                    Filipe Salgado", tr * 0.8, tg * 0.8, tb * 0.8, true);
+        graphics.Print(40, 180, "          Kill Screen Best of 2010", tr * 0.8, tg * 0.8, tb * 0.8, true);
+        break;
+    case Menu::gravabout6:
+        graphics.drawimage(4, -1, 10, true);
+        graphics.Print(-1, 140, "If you'd like to try it, VVVVVV is", tr, tg, tb, true);
+        graphics.Print(-1, 150, "now available for android!", tr, tg, tb, true);
+        break;
+#endif
 #if !defined(NO_CUSTOM_LEVELS)
     case Menu::levellist:
     {
@@ -186,7 +250,7 @@ static void menurender(void)
     case Menu::gameplayoptions:
     {
         int gameplayoptionsoffset = 0;
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
         if (game.ingame_titlemode && game.unlock[18])
 #endif
         {
@@ -722,7 +786,7 @@ static void menurender(void)
 
         switch (game.currentmenuoption)
         {
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
         case 0:
             graphics.bigprint(-1, 30, "Unlock Play Modes", tr, tg, tb, true);
             graphics.Print(-1, 65, "Unlock parts of the game normally", tr, tg, tb, true);
@@ -1418,6 +1482,7 @@ void titlerender(void)
         tg = graphics.col_tg;
         tb = graphics.col_tb;
 
+#if !defined(SUPER_GRAV)
         int temp = 50;
         graphics.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
         graphics.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
@@ -1425,6 +1490,10 @@ void titlerender(void)
         graphics.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
         graphics.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
         graphics.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
+#else
+    graphics.setcolreal(graphics.getRGB(tr, tg, tb));
+    graphics.drawimagecol(0, -1, 46, true);
+#endif
 #if defined(MAKEANDPLAY)
         graphics.Print(-1,temp+35,"     MAKE AND PLAY EDITION",tr, tg, tb, true);
 #endif

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2596,7 +2596,13 @@ void scriptclass::startgamemode( int t )
         map.resetplayer();
         map.gotoroom(game.saverx, game.savery);
         map.initmapdata();
+#if !defined(SUPER_GRAV)
         music.play(11);
+#else
+        map.warpto(119, 108, obj.getplayer(), 19, 10);
+        game.state = 9;
+        game.statedelay = 0;
+#endif
         graphics.fademode = FADE_START_FADEIN;
         break;
     case 12:

--- a/desktop_version/src/Spacestation2.cpp
+++ b/desktop_version/src/Spacestation2.cpp
@@ -20,7 +20,7 @@ const short* spacestation2class::loadlevel(int rx, int ry)
 
     switch(t)
     {
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
     case rn(50,50):
     {
 

--- a/desktop_version/src/Tower.cpp
+++ b/desktop_version/src/Tower.cpp
@@ -81,7 +81,7 @@ int towerclass::miniat(int xp, int yp, int yoff)
 void towerclass::loadminitower1(void)
 {
     //Loads the first minitower into the array.
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
     static const short tmap[] = {
     12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,
     12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,
@@ -191,7 +191,7 @@ void towerclass::loadminitower1(void)
 
 void towerclass::loadminitower2(void)
 {
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
     static const short tmap[] = {
     12,12,21,10,0,0,0,0,0,0,0,0,0,0,0,0,11,20,21,10,0,20,21,28,28,20,21,28,28,20,12,12,12,12,12,12,12,12,12,12,
     12,12,21,10,0,0,0,0,0,0,0,0,0,0,0,0,11,20,21,10,0,20,21,28,28,20,21,28,28,20,12,12,12,12,12,12,12,12,12,12,
@@ -431,7 +431,7 @@ void towerclass::loadbackground(void)
 void towerclass::loadmap(void)
 {
     //Loads the map into the array.
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
     static const short tmap[] = {
     12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,
     12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,

--- a/desktop_version/src/WarpClass.cpp
+++ b/desktop_version/src/WarpClass.cpp
@@ -23,7 +23,7 @@ const short* warpclass::loadlevel(int rx, int ry)
 
     switch(t)
     {
-#if !defined(MAKEANDPLAY)
+#if !defined(MAKEANDPLAY) && !defined(SUPER_GRAV)
     case rn(50,50):
     {
         static const short contents[] = {


### PR DESCRIPTION
## Changes:

As requested in #832, this adds a define for Super Gravitron. Super Gravitron is a version of the mobile VVVVVV port, which only contains the Super Gravitron. This PR ports it to the native version. This doesn't do any changes to the options menu however, meaning you can still activate flip mode and stuff, however I don't think it's that big of a deal... (that is to say, I'm tired of working on this PR)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
