### PR TITLE
Terminal edentity tweaks

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1918,9 +1918,14 @@ void mapclass::loadlevel(int rx, int ry)
                 }
 
                 obj.createentity(ex, usethisy + 8, 20 + SDL_clamp(ent.p2, 0, 1), usethistile);
-                if (obj.customscript != "")
+
+                for (size_t i = 0; i < script.customscripts.size(); i++)
                 {
-                    obj.createblock(ACTIVITY, ex - 8, usethisy + 8, 20, 16, 35);
+                    if (script.customscripts[i].name == obj.customscript)
+                    {
+                        obj.createblock(ACTIVITY, ex - 8, usethisy + 8, 20, 16, 35);
+                        break;
+                    }
                 }
                 break;
             }

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1917,8 +1917,11 @@ void mapclass::loadlevel(int rx, int ry)
                     usethisy -= 8;
                 }
 
-                obj.createentity(ex, usethisy + 8, 20, usethistile);
-                obj.createblock(ACTIVITY, ex - 8, usethisy + 8, 20, 16, 35);
+                obj.createentity(ex, usethisy + 8, 20 + SDL_clamp(ent.p2, 0, 1), usethistile);
+                if (obj.customscript != "")
+                {
+                    obj.createblock(ACTIVITY, ex - 8, usethisy + 8, 20, 16, 35);
+                }
                 break;
             }
             case 19: //Script Box


### PR DESCRIPTION
## Changes:

If `p2` is >= 1, the spawned terminal will be entity 21 instead of 20. If the entered script does not exist, don't bother spawning the activity zone.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
