### PR TITLE
Custom textbox colors

### DIFF
--- a/desktop_version/src/BlockV.cpp
+++ b/desktop_version/src/BlockV.cpp
@@ -2,6 +2,7 @@
 
 #include <SDL_stdinc.h>
 
+#include "CustomLevels.h"
 #include "Font.h"
 
 blockclass::blockclass(void)
@@ -48,6 +49,15 @@ void blockclass::rectset(const int xi, const int yi, const int wi, const int hi)
 
 void blockclass::setblockcolour(const char* col)
 {
+#ifndef NO_CUSTOM_LEVELS
+    if (cl.customcolours.count(col) != 0)
+    {
+        r = cl.customcolours[col].r;
+        g = cl.customcolours[col].g;
+        b = cl.customcolours[col].b;
+    }
+    else // Turn the if into an else if so we don't run the default colour processing
+#endif
     if (SDL_strcmp(col, "cyan") == 0)
     {
         r = 164;

--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -389,6 +389,8 @@ void customlevelclass::reset(void)
     script.clearcustom();
 
     onewaycol_override = false;
+
+    customcolours.clear();
 }
 
 const int* customlevelclass::loadlevel( int rxi, int ryi )
@@ -1283,6 +1285,35 @@ next:
             if (headerfound)
             {
                 script.customscripts.push_back(script_);
+            }
+        }
+
+        if (SDL_strcmp(pKey, "TextboxColours") == 0)
+        {
+            for (tinyxml2::XMLElement* textColourElement = pElem->FirstChildElement(); textColourElement; textColourElement = textColourElement->NextSiblingElement())
+            {
+                if (SDL_strcmp(textColourElement->Value(), "colour") == 0)
+                {
+                    int r = 255;
+                    int g = 255;
+                    int b = 255;
+
+                    textColourElement->QueryIntAttribute("r", &r);
+                    textColourElement->QueryIntAttribute("g", &g);
+                    textColourElement->QueryIntAttribute("b", &b);
+
+                    const char* name = textColourElement->Attribute("name");
+
+                    if (name != NULL)
+                    {
+                        SDL_Colour colour;
+                        colour.r = r;
+                        colour.g = g;
+                        colour.b = b;
+
+                        customcolours[name] = colour;
+                    }
+                }
             }
         }
     }

--- a/desktop_version/src/CustomLevels.h
+++ b/desktop_version/src/CustomLevels.h
@@ -6,6 +6,7 @@
 #include <SDL.h>
 #include <string>
 #include <vector>
+#include <map>
 
 class CustomEntity
 {
@@ -169,6 +170,8 @@ public:
     SDL_Color getonewaycol(int rx, int ry);
     SDL_Color getonewaycol(void);
     bool onewaycol_override;
+
+    std::map<std::string, SDL_Color> customcolours;
 };
 
 std::string translate_title(const std::string& title, bool* is_gettext);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -442,6 +442,15 @@ void scriptclass::run(void)
             {
                 //oh boy
                 //first word is the colour.
+#ifndef NO_CUSTOM_LEVELS
+                if (cl.customcolours.count(words[1]) != 0)
+                {
+                    r = cl.customcolours[words[1]].r;
+                    g = cl.customcolours[words[1]].g;
+                    b = cl.customcolours[words[1]].b;
+                }
+                else // Turn the if into an else if so we don't run the default colour processing
+#endif
                 if (words[1] == "cyan")
                 {
                     r = 164;


### PR DESCRIPTION
## Changes:

Textbox colors are also hardcoded, this loads them from XML, this is a visual change.

```xml
  <TextboxColours>
      <colour r="170" g="47" b="88" name="test"></colour>
  </TextboxColours>
  ```

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
