### PR TITLE
Unhardcoded minimap markers

### DIFF
--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -995,7 +995,7 @@ bool customlevelclass::load(std::string _path)
     tinyxml2::XMLElement* pElem;
 
     map.markers.clear();
-    std::map<std::string, std::vector<point> > markerLocations;
+    std::map<std::string, std::vector<MarkerRoom> > markerLocations;
 
     reset();
 #ifndef NO_EDITOR
@@ -1410,6 +1410,8 @@ next:
                     marker.flip_hidden_id = marker.hidden_id;
                     markerElement->QueryIntAttribute("flip_visited_id", &marker.flip_visited_id);
                     markerElement->QueryIntAttribute("flip_hidden_id", &marker.flip_hidden_id);
+                    markerElement->QueryBoolAttribute("show_hidden", &marker.show_hidden);
+                    markerElement->QueryBoolAttribute("show_visited", &marker.show_visited);
 
                     const char* name = "";
                     markerElement->QueryStringAttribute("name", &name);
@@ -1425,16 +1427,22 @@ next:
                 {
                     int x = 0;
                     int y = 0;
+                    int trinket_id = -1;
+                    int flag = -1;
                     const char* name = "";
                     markerElement->QueryStringAttribute("name", &name);
                     markerElement->QueryIntAttribute("x", &x);
                     markerElement->QueryIntAttribute("y", &y);
+                    markerElement->QueryIntAttribute("trinket_id", &trinket_id);
+                    markerElement->QueryIntAttribute("flag", &flag);
 
-                    point coords;
-                    coords.x = x;
-                    coords.y = y;
+                    MarkerRoom room;
+                    room.coords.x = x;
+                    room.coords.y = y;
+                    room.trinket_id = trinket_id;
+                    room.flag = flag;
 
-                    markerLocations[name].push_back(coords);
+                    markerLocations[name].push_back(room);
                 }
             }
         }
@@ -1443,26 +1451,10 @@ next:
     for (size_t i = 0; i < map.markers.size(); i++)
     {
         MapMarker marker = map.markers[i];
+
         if (markerLocations.count(marker.name) != 0)
         {
-            for (size_t j = 0; j < markerLocations[marker.name].size(); j++)
-            {
-                point p = markerLocations[marker.name][j];
-                // Check if the point isn't already in the vector...
-                bool found = false;
-                for (size_t j = 0; j < map.markers[i].rooms.size(); j++)
-                {
-                    if (map.markers[i].rooms[j].x == p.x && map.markers[i].rooms[j].y == p.y)
-                    {
-                        found = true;
-                        break;
-                    }
-                }
-                if (!found)
-                {
-                    map.markers[i].rooms.push_back(p);
-                }
-            }
+            map.markers[i].rooms = markerLocations[marker.name];
         }
     }
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5260,7 +5260,7 @@ void Game::readmaingamesave(const char* savename, tinyxml2::XMLDocument& doc)
         }
         else if (SDL_strcmp(pKey, "showtargets") == 0)
         {
-            map.showtargets = help.Int(pText);
+            map.set_targets_visible(help.Int(pText));
         }
 
     }
@@ -5279,11 +5279,9 @@ void Game::readmaingamesave(const char* savename, tinyxml2::XMLDocument& doc)
         map.final_colorframe = 1;
     }
 
-    map.showteleporters = true;
-    if(obj.flags[12]) map.showtargets = true;
+    map.set_teleporters_visible(true);
+    if (obj.flags[12]) map.set_targets_visible(true);
     if (obj.flags[42]) map.showtrinkets = true;
-
-
 }
 
 void Game::customloadquick(const std::string& savfile)
@@ -5553,8 +5551,8 @@ void Game::customloadquick(const std::string& savfile)
         }
     }
 
-    map.showteleporters = true;
-    if(obj.flags[12]) map.showtargets = true;
+    map.set_teleporters_visible(true);
+    if (obj.flags[12]) map.set_targets_visible(true);
 
 }
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5488,7 +5488,7 @@ void Game::customloadquick(const std::string& savfile)
         }
         else if (SDL_strcmp(pKey, "markers") == 0)
         {
-            // loop through all the markers and save their 
+            // loop through all the markers and save their data
             for (tinyxml2::XMLElement* pElem2 = pElem->FirstChildElement(); pElem2 != NULL; pElem2 = pElem2->NextSiblingElement())
             {
                 const char* pKey2 = pElem2->Value();
@@ -5514,9 +5514,13 @@ void Game::customloadquick(const std::string& savfile)
                     const char* name = "";
                     int x = 0;
                     int y = 0;
+                    int flag = -1;
+                    int trinket_id = -1;
                     pElem2->QueryStringAttribute("name", &name);
                     pElem2->QueryIntAttribute("x", &x);
                     pElem2->QueryIntAttribute("y", &y);
+                    pElem2->QueryIntAttribute("flag", &flag);
+                    pElem2->QueryIntAttribute("trinket_id", &trinket_id);
                     for (size_t i = 0; i < map.markers.size(); i++)
                     {
                         if (map.markers[i].name == name)
@@ -5525,7 +5529,8 @@ void Game::customloadquick(const std::string& savfile)
                             bool found = false;
                             for (size_t j = 0; j < map.markers[i].rooms.size(); j++)
                             {
-                                if (map.markers[i].rooms[j].x == x && map.markers[i].rooms[j].y == y)
+                                MarkerRoom room = map.markers[i].rooms[j];
+                                if (room.coords.x == x && room.coords.y == y && room.flag == flag && room.trinket_id == trinket_id)
                                 {
                                     found = true;
                                     break;
@@ -5533,8 +5538,13 @@ void Game::customloadquick(const std::string& savfile)
                             }
                             if (!found)
                             {
-                                SDL_Point p = { x, y };
-                                map.markers[i].rooms.push_back(p);
+                                MarkerRoom room;
+                                room.coords.x = x;
+                                room.coords.y = y;
+                                room.flag = flag;
+                                room.trinket_id = trinket_id;
+
+                                map.markers[i].rooms.push_back(room);
                             }
                         }
                     }
@@ -6044,8 +6054,10 @@ bool Game::customsavequick(const std::string& savfile)
             tinyxml2::XMLElement* room_el;
             room_el = doc.NewElement("room");
             room_el->SetAttribute("name", map.markers[i].name.c_str());
-            room_el->SetAttribute("x", map.markers[i].rooms[j].x);
-            room_el->SetAttribute("y", map.markers[i].rooms[j].y);
+            room_el->SetAttribute("x", map.markers[i].rooms[j].coords.x);
+            room_el->SetAttribute("y", map.markers[i].rooms[j].coords.y);
+            room_el->SetAttribute("flag", map.markers[i].rooms[j].flag);
+            room_el->SetAttribute("trinket_id", map.markers[i].rooms[j].trinket_id);
             msg->LinkEndChild(room_el);
         }
     }

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -165,17 +165,20 @@ void mapclass::setteleporter(int x, int y)
     teleporters.push_back(temp);
 }
 
-void mapclass::settrinket(int x, int y)
+void mapclass::settrinket(const int id, const int x, const int y)
 {
     if (x < 0 || x >= getwidth() || y < 0 || y >= getheight())
     {
         return;
     }
 
-    SDL_Point temp;
-    temp.x = x;
-    temp.y = y;
-    shinytrinkets.push_back(temp);
+    MarkerRoom room;
+    room.coords.x = x;
+    room.coords.y = y;
+    room.flag = -1;
+    room.trinket_id = id;
+
+    shinytrinkets.rooms.push_back(room);
 }
 
 void mapclass::setroomname(const char* name)
@@ -258,6 +261,15 @@ void mapclass::updateroomnames(void)
 
 void mapclass::initmapdata(void)
 {
+    shinytrinkets.rooms.clear();
+    shinytrinkets.name = "trinkets";
+    shinytrinkets.visited_id = 1086;
+    shinytrinkets.hidden_id = 1086;
+    shinytrinkets.flip_visited_id = 1089;
+    shinytrinkets.flip_hidden_id = 1089;
+    shinytrinkets.show_visited = true;
+    shinytrinkets.show_hidden = true;
+
     if (custommode)
     {
         initcustommapdata();
@@ -265,9 +277,8 @@ void mapclass::initmapdata(void)
     }
 
     teleporters.clear();
-    shinytrinkets.clear();
 
-    //Set up static map information like teleporters and shiny trinkets.
+    // Set up static map information like teleporters and shiny trinkets.
     setteleporter(0, 0);
     setteleporter(0, 16);
     setteleporter(2, 4);
@@ -286,24 +297,26 @@ void mapclass::initmapdata(void)
     setteleporter(18, 1);
     setteleporter(18, 7);
 
-    settrinket(14, 4);
-    settrinket(13, 6);
-    settrinket(11, 12);
-    settrinket(15, 12);
-    settrinket(14, 11);
-    settrinket(18, 14);
-    settrinket(11, 7);
-    settrinket(9, 2);
-    settrinket(9, 16);
-    settrinket(2, 18);
-    settrinket(7, 18);
-    settrinket(6, 1);
-    settrinket(17, 3);
-    settrinket(10, 19);
-    settrinket(5, 15);
-    settrinket(1, 10);
-    settrinket(3, 2);
-    settrinket(10, 8);
+    settrinket(0, 14, 4);
+    settrinket(1, 13, 6);
+    settrinket(2, 11, 12);
+    settrinket(3, 15, 12);
+    settrinket(4, 14, 11);
+    settrinket(5, 18, 14);
+    settrinket(6, 11, 7);
+    settrinket(7, 9, 2);
+    settrinket(8, 9, 16);
+    settrinket(9, 2, 18);
+    settrinket(10, 7, 18);
+    settrinket(11, 6, 1);
+    settrinket(12, 17, 3);
+    settrinket(13, 10, 19);
+    settrinket(14, 5, 15);
+    settrinket(15, 1, 10);
+    settrinket(16, 3, 2);
+    settrinket(17, 10, 8);
+
+    markers.push_back(shinytrinkets);
 
     //Special room names
     specialroomnames.clear();
@@ -419,9 +432,8 @@ void mapclass::roomnamechange(const int x, const int y, const char** lines, cons
 
 void mapclass::initcustommapdata(void)
 {
-    shinytrinkets.clear();
-
 #if !defined(NO_CUSTOM_LEVELS)
+    int trinkets = 0;
     for (size_t i = 0; i < customentities.size(); i++)
     {
         const CustomEntity& ent = customentities[i];
@@ -432,8 +444,7 @@ void mapclass::initcustommapdata(void)
 
         const int rx = ent.x / 40;
         const int ry = ent.y / 30;
-
-        settrinket(rx, ry);
+        settrinket(trinkets++, rx, ry);
     }
 #endif
 }

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -29,9 +29,9 @@ mapclass::mapclass(void)
     warpy = false;
     extrarow = 0;
 
-    showteleporters = false;
-    showtargets = false;
     showtrinkets = false;
+    set_targets_visible(false);
+    set_targets_visible(false);
 
     finalmode = false;
     finalstretch = false;
@@ -152,6 +152,30 @@ int mapclass::intpol(int a, int b, float c)
     return static_cast<int>(a + ((b - a) * c));
 }
 
+void mapclass::set_targets_visible(const bool visible)
+{
+    showtargets = visible;
+    for (size_t i = 0; i < markers.size(); ++i)
+    {
+        if (markers[i].name == "teleporters")
+        {
+            markers[i].show_hidden = visible;
+        }
+    }
+}
+
+void mapclass::set_teleporters_visible(const bool visible)
+{
+    showteleporters = visible;
+    for (size_t i = 0; i < markers.size(); ++i)
+    {
+        if (markers[i].name == "teleporters")
+        {
+            markers[i].show_visited = visible;
+        }
+    }
+}
+
 void mapclass::setteleporter(int x, int y)
 {
     if (x < 0 || x >= getwidth() || y < 0 || y >= getheight())
@@ -163,6 +187,13 @@ void mapclass::setteleporter(int x, int y)
     temp.x = x;
     temp.y = y;
     teleporters.push_back(temp);
+
+    MarkerRoom room;
+    room.coords = temp;
+    room.flag = -1;
+    room.trinket_id = -1;
+
+    teleporter_markers.rooms.push_back(room);
 }
 
 void mapclass::settrinket(const int id, const int x, const int y)
@@ -270,9 +301,21 @@ void mapclass::initmapdata(void)
     shinytrinkets.show_visited = true;
     shinytrinkets.show_hidden = true;
 
+    teleporter_markers.rooms.clear();
+    teleporter_markers.name = "teleporters";
+    teleporter_markers.visited_id = 1127;
+    teleporter_markers.hidden_id = 1126;
+    teleporter_markers.flip_visited_id = 1129;
+    teleporter_markers.flip_hidden_id = 1128;
+    teleporter_markers.show_visited = showteleporters;
+    teleporter_markers.show_hidden = showtargets;
+
     if (custommode)
     {
         initcustommapdata();
+
+        markers.push_back(shinytrinkets);
+        markers.push_back(teleporter_markers);
         return;
     }
 
@@ -317,6 +360,7 @@ void mapclass::initmapdata(void)
     settrinket(17, 10, 8);
 
     markers.push_back(shinytrinkets);
+    markers.push_back(teleporter_markers);
 
     //Special room names
     specialroomnames.clear();

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -67,6 +67,7 @@ mapclass::mapclass(void)
     SDL_memset(roomdeaths, 0, sizeof(roomdeaths));
     SDL_memset(roomdeathsfinal, 0, sizeof(roomdeathsfinal));
     resetmap();
+    markers.clear();
 
     setroomname("");
     hiddenname = "";

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -37,6 +37,18 @@ struct Roomname
     int delay;
 };
 
+struct MapMarker
+{
+    std::string name;
+    bool show_hidden;
+    bool show_visited;
+    std::vector<SDL_Point> rooms;
+    int hidden_id;
+    int visited_id;
+    int flip_hidden_id;
+    int flip_visited_id;
+};
+
 class mapclass
 {
 public:
@@ -174,6 +186,9 @@ public:
     std::vector<SDL_Point> shinytrinkets;
 
     bool showteleporters, showtargets, showtrinkets;
+
+    // Custom markers!
+    std::vector<MapMarker> markers;
 
     //Roomtext
     bool roomtexton;

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -37,12 +37,19 @@ struct Roomname
     int delay;
 };
 
+struct MarkerRoom
+{
+    SDL_Point coords;
+    int flag;
+    int trinket_id;
+};
+
 struct MapMarker
 {
     std::string name;
     bool show_hidden;
     bool show_visited;
-    std::vector<SDL_Point> rooms;
+    std::vector<MarkerRoom> rooms;
     int hidden_id;
     int visited_id;
     int flip_hidden_id;
@@ -63,7 +70,7 @@ public:
 
     void setteleporter(int x, int y);
 
-    void settrinket(int x, int y);
+    void settrinket(int id, int x, int y);
 
     void setroomname(const char* name);
 
@@ -181,9 +188,10 @@ public:
     int final_aniframedelay;
     int final_colorframe, final_colorframedelay;
 
-    //Teleporters and Trinkets on the map
+    // Teleporters
     std::vector<SDL_Point> teleporters;
-    std::vector<SDL_Point> shinytrinkets;
+
+    MapMarker shinytrinkets;
 
     bool showteleporters, showtargets, showtrinkets;
 

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -68,6 +68,9 @@ public:
 
     int intpol(int a, int b, float c);
 
+    void set_targets_visible(bool visible);
+    void set_teleporters_visible(bool visible);
+
     void setteleporter(int x, int y);
 
     void settrinket(int id, int x, int y);
@@ -192,6 +195,7 @@ public:
     std::vector<SDL_Point> teleporters;
 
     MapMarker shinytrinkets;
+    MapMarker teleporter_markers;
 
     bool showteleporters, showtargets, showtrinkets;
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2372,29 +2372,31 @@ static void rendermaplegend(void)
         }
     }
 
-    if (map.showtrinkets)
-    {
-        for (size_t i = 0; i < map.shinytrinkets.size(); i++)
-        {
-            if (!obj.collect[i])
-            {
-                graphics.drawtile(data.legendxoff + (map.shinytrinkets[i].x * 12 * data.zoom), data.legendyoff + (map.shinytrinkets[i].y * 9 * data.zoom), 1086 + tile_offset);
-            }
-        }
-    }
-
     for (size_t i = 0; i < map.markers.size(); i++)
     {
-        MapMarker marker = map.markers[i];
+        const MapMarker marker = map.markers[i];
         for (size_t j = 0; j < marker.rooms.size(); j++)
         {
-            if (marker.show_visited && map.isexplored(marker.rooms[j].x, marker.rooms[j].y))
+            const MarkerRoom room = marker.rooms[j];
+
+            // If it doesn't have a flag, or if the flag is true...
+            if (room.flag == -1 || (INBOUNDS_ARR(room.flag, obj.flags) && obj.flags[room.flag]))
             {
-                graphics.drawtile(data.legendxoff + (marker.rooms[j].x * 12 * data.zoom), data.legendyoff + (marker.rooms[j].y * 9 * data.zoom), graphics.flipmode ? marker.flip_visited_id : marker.visited_id);
-            }
-            else if (marker.show_hidden && !map.isexplored(marker.rooms[j].x, marker.rooms[j].y))
-            {
-                graphics.drawtile(data.legendxoff + (marker.rooms[j].x * 12 * data.zoom), data.legendyoff + (marker.rooms[j].y * 9 * data.zoom), graphics.flipmode ? marker.flip_hidden_id : marker.hidden_id);
+                // If it doesn't have a trinket, or if the trinket isn't collected yet...
+                if (room.trinket_id == -1 || (map.showtrinkets && INBOUNDS_ARR(room.trinket_id, obj.collect) && !obj.collect[room.trinket_id]))
+                {
+                    // Draw the markers
+                    const int x = data.legendxoff + (room.coords.x * 12 * data.zoom);
+                    const int y = data.legendyoff + (room.coords.y * 9 * data.zoom);
+                    if (marker.show_visited && map.isexplored(room.coords.x, room.coords.y))
+                    {
+                        graphics.drawtile(x, y, graphics.flipmode ? marker.flip_visited_id : marker.visited_id);
+                    }
+                    else if (marker.show_hidden && !map.isexplored(room.coords.x, room.coords.y))
+                    {
+                        graphics.drawtile(x, y, graphics.flipmode ? marker.flip_hidden_id : marker.hidden_id);
+                    }
+                }
             }
         }
     }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2354,7 +2354,7 @@ static void rendermapfog(void)
 
 static void rendermaplegend(void)
 {
-    // Draw the map legend, aka teleports/targets/trinkets
+    // Draw the map legend, aka teleporters/targets/trinkets/markers
 
     const MapRenderData data = getmaprenderdata();
 
@@ -2379,6 +2379,22 @@ static void rendermaplegend(void)
             if (!obj.collect[i])
             {
                 graphics.drawtile(data.legendxoff + (map.shinytrinkets[i].x * 12 * data.zoom), data.legendyoff + (map.shinytrinkets[i].y * 9 * data.zoom), 1086 + tile_offset);
+            }
+        }
+    }
+
+    for (size_t i = 0; i < map.markers.size(); i++)
+    {
+        MapMarker marker = map.markers[i];
+        for (size_t j = 0; j < marker.rooms.size(); j++)
+        {
+            if (marker.show_visited && map.isexplored(marker.rooms[j].x, marker.rooms[j].y))
+            {
+                graphics.drawtile(data.legendxoff + (marker.rooms[j].x * 12 * data.zoom), data.legendyoff + (marker.rooms[j].y * 9 * data.zoom), graphics.flipmode ? marker.flip_visited_id : marker.visited_id);
+            }
+            else if (marker.show_hidden && !map.isexplored(marker.rooms[j].x, marker.rooms[j].y))
+            {
+                graphics.drawtile(data.legendxoff + (marker.rooms[j].x * 12 * data.zoom), data.legendyoff + (marker.rooms[j].y * 9 * data.zoom), graphics.flipmode ? marker.flip_hidden_id : marker.hidden_id);
             }
         }
     }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2358,20 +2358,6 @@ static void rendermaplegend(void)
 
     const MapRenderData data = getmaprenderdata();
 
-    const int tile_offset = graphics.flipmode ? 3 : 0;
-
-    for (size_t i = 0; i < map.teleporters.size(); i++)
-    {
-        if (map.showteleporters && map.isexplored(map.teleporters[i].x, map.teleporters[i].y))
-        {
-            graphics.drawtile(data.legendxoff + (map.teleporters[i].x * 12 * data.zoom), data.legendyoff + (map.teleporters[i].y * 9 * data.zoom), 1127 + tile_offset);
-        }
-        else if (map.showtargets && !map.isexplored(map.teleporters[i].x, map.teleporters[i].y))
-        {
-            graphics.drawtile(data.legendxoff + (map.teleporters[i].x * 12 * data.zoom), data.legendyoff + (map.teleporters[i].y * 9 * data.zoom), 1126 + tile_offset);
-        }
-    }
-
     for (size_t i = 0; i < map.markers.size(); i++)
     {
         const MapMarker marker = map.markers[i];

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1359,15 +1359,19 @@ void scriptclass::run(void)
                 {
                     if (map.markers[i].name == words[1])
                     {
-                        point p;
-                        p.x = ss_toi(words[2]);
-                        p.y = ss_toi(words[3]);
+                        MarkerRoom current;
+                        current.coords.x = ss_toi(words[2]);
+                        current.coords.y = ss_toi(words[3]);
+                        current.flag = argexists[4] ? ss_toi(words[4]) : -1;
+                        current.trinket_id = argexists[5] ? ss_toi(words[5]) : -1;
 
                         // Check if the point isn't already in the vector...
                         bool found = false;
                         for (size_t j = 0; j < map.markers[i].rooms.size(); j++)
                         {
-                            if (map.markers[i].rooms[j].x == p.x && map.markers[i].rooms[j].y == p.y)
+                            MarkerRoom room = map.markers[i].rooms[j];
+                            if (room.coords.x == current.coords.x && room.coords.y == current.coords.y &&
+                                room.flag == current.flag && room.trinket_id == current.trinket_id)
                             {
                                 found = true;
                                 break;
@@ -1375,9 +1379,9 @@ void scriptclass::run(void)
                         }
                         if (!found)
                         {
-                            map.markers[i].rooms.push_back(p);
+                            map.markers[i].rooms.push_back(current);
                         }
-                        
+
                         break;
                     }
                 }
@@ -1388,12 +1392,18 @@ void scriptclass::run(void)
                 {
                     if (map.markers[i].name == words[1])
                     {
-                        point p;
-                        p.x = ss_toi(words[2]);
-                        p.y = ss_toi(words[3]);
+                        SDL_Point coords = {ss_toi(words[2]), ss_toi(words[3])};
+                        int flag = argexists[4] ? ss_toi(words[4]) : -1;
+                        int trinket_id = argexists[5] ? ss_toi(words[5]) : -1;
+
                         for (size_t j = 0; j < map.markers[i].rooms.size(); j++)
                         {
-                            if (map.markers[i].rooms[j].x == p.x && map.markers[i].rooms[j].y == p.y)
+                            bool flagcheck = (map.markers[i].rooms[j].flag == flag);
+                            bool trinketcheck = (map.markers[i].rooms[j].trinket_id == trinket_id);
+
+                            MarkerRoom room = map.markers[i].rooms[j];
+
+                            if (room.coords.x == coords.x && room.coords.y == coords.y && flagcheck && trinketcheck)
                             {
                                 map.markers[i].rooms.erase(map.markers[i].rooms.begin() + j);
                                 // Don't break here in case there's duplicates for whatever reason

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1334,6 +1334,75 @@ void scriptclass::run(void)
             {
                 map.showtrinkets = false;
             }
+            else if (words[0] == "showmarker" || words[0] == "hidemarker")
+            {
+                // Show or hide markers
+                for (size_t i = 0; i < map.markers.size(); i++)
+                {
+                    if (map.markers[i].name == words[1])
+                    {
+                        if (words[2] == "visited" || words[2] == "both")
+                        {
+                            map.markers[i].show_visited = (words[0] == "showmarker");
+                        }
+                        if (words[2] == "hidden" || words[2] == "both")
+                        {
+                            map.markers[i].show_hidden = (words[0] == "showmarker");
+                        }
+                        break;
+                    }
+                }
+            }
+            else if (words[0] == "placemarker")
+            {
+                for (size_t i = 0; i < map.markers.size(); i++)
+                {
+                    if (map.markers[i].name == words[1])
+                    {
+                        point p;
+                        p.x = ss_toi(words[2]);
+                        p.y = ss_toi(words[3]);
+
+                        // Check if the point isn't already in the vector...
+                        bool found = false;
+                        for (size_t j = 0; j < map.markers[i].rooms.size(); j++)
+                        {
+                            if (map.markers[i].rooms[j].x == p.x && map.markers[i].rooms[j].y == p.y)
+                            {
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (!found)
+                        {
+                            map.markers[i].rooms.push_back(p);
+                        }
+                        
+                        break;
+                    }
+                }
+            }
+            else if (words[0] == "removemarker")
+            {
+                for (size_t i = 0; i < map.markers.size(); i++)
+                {
+                    if (map.markers[i].name == words[1])
+                    {
+                        point p;
+                        p.x = ss_toi(words[2]);
+                        p.y = ss_toi(words[3]);
+                        for (size_t j = 0; j < map.markers[i].rooms.size(); j++)
+                        {
+                            if (map.markers[i].rooms[j].x == p.x && map.markers[i].rooms[j].y == p.y)
+                            {
+                                map.markers[i].rooms.erase(map.markers[i].rooms.begin() + j);
+                                // Don't break here in case there's duplicates for whatever reason
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
             else if (words[0] == "hideplayer")
             {
                 int player = obj.getplayer();

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1312,11 +1312,11 @@ void scriptclass::run(void)
             }
             else if (words[0] == "showteleporters")
             {
-                map.showteleporters = true;
+                map.set_teleporters_visible(true);
             }
             else if (words[0] == "showtargets")
             {
-                map.showtargets = true;
+                map.set_targets_visible(true);
             }
             else if (words[0] == "showtrinkets")
             {
@@ -1324,11 +1324,11 @@ void scriptclass::run(void)
             }
             else if (words[0] == "hideteleporters")
             {
-                map.showteleporters = false;
+                map.set_teleporters_visible(false);
             }
             else if (words[0] == "hidetargets")
             {
-                map.showtargets = false;
+                map.set_targets_visible(false);
             }
             else if (words[0] == "hidetrinkets")
             {
@@ -2814,7 +2814,7 @@ void scriptclass::startgamemode(const enum StartMode mode)
         SDL_memset(map.explored, true, sizeof(map.explored));
         i = 400; /* previously a nested for-loop set this */
         game.insecretlab = true;
-        map.showteleporters = true;
+        map.set_teleporters_visible(true);
 
         music.play(11);
         graphics.fademode = FADE_START_FADEIN;
@@ -3290,8 +3290,6 @@ void scriptclass::hardreset(void)
     //mapclass
     map.warpx = false;
     map.warpy = false;
-    map.showteleporters = false;
-    map.showtargets = false;
     map.showtrinkets = false;
     map.finalmode = false;
     map.finalstretch = false;
@@ -3304,6 +3302,8 @@ void scriptclass::hardreset(void)
     map.rcol = 0;
     map.custommode=false;
     map.custommodeforreal=false;
+    map.set_targets_visible(false);
+    map.set_teleporters_visible(true);
     if (!version2_2)
     {
         // Ironically, resetting more variables makes the janky fadeout system even more glitchy


### PR DESCRIPTION
## Changes:

Unhardcodes the very hardcoded map legend, also allowing for custom markers.

Level file sample XML:
```xml
<Markers>
    <marker visited_id="1087" hidden_id="1126" name="core" />
    <room name="core" x="0" y="0"/>
    <room name="core" x="1" y="0"/>
    <room name="core" x="2" y="0"/>
</Markers>
````

The bare minimum a marker tag requires is a `visited_id` property and a `name` property. `hidden_id` defaults to `visited_id` if it's missing. There's also flip mode properties as well, since teleporters use different graphics in flip mode as well. These are saved and loaded to/from the save file as well.

`showmarker(name,visited)` - Show `name` markers in visited rooms
`showmarker(name,hidden)` - Show `name` markers in unvisited rooms
`showmarker(name,both)` - Show `name` markers
`hidemarker` exists as well, used in the same way.

`placemarker(name, x, y)` - Places a marker at those coordinates
`removemarker(name, x, y)` - Removes a marker at those coordinates

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
