### PR TITLE
Don't open the map in the editor

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2379,6 +2379,10 @@ void gameinput(void)
     {
         //Do nothing if we're in a Time Trial but a fade animation is playing
     }
+    else if (map.custommode && !map.custommodeforreal)
+    {
+        // We're playtesting in the editor so don't do anything
+    }
     else
     {
         //Normal map screen, do transition later


### PR DESCRIPTION
## Changes:

In editor playtesting, If you die while in a teleporter activity zone and you press ENTER, you open the map screen. This can lead to a crash viewing the CREW tab due to data not being initialized. This PR simply makes sure you can't open the map in the editor.

This does NOT fix the glitchy map when using a teleporter in the editor, that'll be fixed in #898 shortly.

Fixes #892.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
