### PR TITLE
Allow 26 textbox lines

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1347,6 +1347,17 @@ void Graphics::addline( const std::string& t )
     textboxes[m].addline(t);
 }
 
+void Graphics::setlarge(bool large)
+{
+    if (!INBOUNDS_VEC(m, textboxes))
+    {
+        vlog_error("setlarge() out-of-bounds!");
+        return;
+    }
+
+    textboxes[m].large = large;
+}
+
 void Graphics::textboxadjust(void)
 {
     if (!INBOUNDS_VEC(m, textboxes))

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -117,6 +117,8 @@ public:
 
     void addline(const std::string& t);
 
+    void setlarge(bool large);
+
     void textboxtimer(int t);
 
     void textboxremove(void);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -520,9 +520,8 @@ void scriptclass::run(void)
                 textx = ss_toi(words[2]);
                 texty = ss_toi(words[3]);
 
-                // If words[4] ends with L, set large to true.
-                textlarge = (words[4].size() > 0 && words[4][words[4].size() - 1] == 'l');
-                int lines = ss_toi(words[4].substr(0, words[4].size() - (textlarge ? 1 : 0)));
+                textlarge = endsWith(words[4].c_str(), "l") || endsWith(words[4].c_str(), "L");
+                int lines = ss_toi(words[4]);
 
                 //Number of lines for the textbox!
                 txt.clear();
@@ -3523,7 +3522,7 @@ bool scriptclass::loadcustom(const std::string& t)
                     add("text(blue,0,0,"+words[1]+")");
                 break;
             }
-            int ti = ss_toi(words[1].c_str());
+            int ti = ss_toi(words[1]);
             int nti = ti >= 0 ? ti : 1;
             for (int ti2 = 0; ti2 < nti; ti2++)
             {

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -48,6 +48,7 @@ scriptclass::scriptclass(void)
     textpad_right = 0;
     textpadtowidth = 0;
     textcase = 1;
+    textlarge = false;
 }
 
 void scriptclass::clearcustom(void)
@@ -519,9 +520,13 @@ void scriptclass::run(void)
                 textx = ss_toi(words[2]);
                 texty = ss_toi(words[3]);
 
+                // If words[4] ends with L, set large to true.
+                textlarge = (words[4].size() > 0 && words[4][words[4].size() - 1] == 'l');
+                int lines = ss_toi(words[4].substr(0, words[4].size() - (textlarge ? 1 : 0)));
+
                 //Number of lines for the textbox!
                 txt.clear();
-                for (int i = 0; i < ss_toi(words[4]); i++)
+                for (int i = 0; i < lines; i++)
                 {
                     position++;
                     if (INBOUNDS_VEC(position, commands))
@@ -714,6 +719,10 @@ void scriptclass::run(void)
                 }
                 graphics.createtextboxreal(txt[0], textx, texty, r, g, b, textflipme);
                 textflipme = false;
+
+                graphics.setlarge(textlarge);
+                textlarge = false;
+
                 if ((int) txt.size() > 1)
                 {
                     for (i = 1; i < (int) txt.size(); i++)
@@ -3514,11 +3523,13 @@ bool scriptclass::loadcustom(const std::string& t)
                     add("text(blue,0,0,"+words[1]+")");
                 break;
             }
-            int ti=help.Int(words[1].c_str());
-            int nti = ti>=0 ? ti : 1;
-            for(int ti2=0; ti2<nti; ti2++){
+            int ti = ss_toi(words[1].c_str());
+            int nti = ti >= 0 ? ti : 1;
+            for (int ti2 = 0; ti2 < nti; ti2++)
+            {
                 i++;
-                if(INBOUNDS_VEC(i, lines)){
+                if (INBOUNDS_VEC(i, lines))
+                {
                     add(lines[i]);
                 }
             }

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -111,6 +111,7 @@ public:
     size_t textpad_right;
     size_t textpadtowidth;
     char textcase;
+    bool textlarge;
 
     //Misc
     int i, j, k;

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -24,6 +24,8 @@ textboxclass::textboxclass(void)
 
     rand = 0;
 
+    large = false;
+
     print_flags = PR_FONT_LEVEL;
 }
 
@@ -117,7 +119,10 @@ void textboxclass::addline(const std::string& t)
 {
     lines.push_back(t);
     resize();
-    if ((int) lines.size() >= 12) lines.clear();
+    if ((int)lines.size() > (large ? 26 : 11))
+    {
+        lines.clear();
+    }
 }
 
 void textboxclass::pad(size_t left_pad, size_t right_pad)

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -49,6 +49,8 @@ public:
 
     int rand;
 
+    bool large;
+
     uint32_t print_flags;
 };
 


### PR DESCRIPTION
## Changes:

For some reason, textboxes can only have 11 lines added before the line list gets cleared. This changes that behavior, allowing a total of 26 lines before *ignoring* extra lines added. 26 is the maximum amount of lines that the screen can display vertically without the textbox going off-screen. As far as I can tell, this is only visual, and doesn't affect any used glitches.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
