### PR TITLE
Supercrewmate interaction fixes

### DIFF
--- a/desktop_version/src/Ent.h
+++ b/desktop_version/src/Ent.h
@@ -43,6 +43,7 @@ public:
     int onentity;
     bool harmful;
     int onwall, onxwall, onywall;
+    bool scm;
 
     //Platforming specific
     bool gravity;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2766,23 +2766,23 @@ bool entityclass::updateentities( int i )
                 entities[i].state = 2;
 
                 music.playef(8);
-                
-                auto thing = entities[i];
 
                 bool flipped = (game.gravitycontrol != 0);
 
+                int entity = getplayer();
+
                 if (entities[i].para == 1)
                 {
-                    int scm = getscm();
-                    if (entities[scm].rule == 6)
+                    entity = getscm();
+                    if (entities[entity].rule == 6)
                     {
                         flipped = false;
-                        entities[scm].rule = 7;
+                        entities[entity].rule = 7;
                     }
                     else
                     {
                         flipped = true;
-                        entities[scm].rule = 6;
+                        entities[entity].rule = 6;
                     }
                 }
                 else
@@ -2793,11 +2793,11 @@ bool entityclass::updateentities( int i )
 
                 if (flipped)
                 {
-                    if (entities[i].vy < 3) entities[i].vy = 3;
+                    if (entities[entity].vy < 3) entities[entity].vy = 3;
                 }
                 else
                 {
-                    if (entities[i].vy > -3) entities[i].vy = -3;
+                    if (entities[entity].vy > -3) entities[entity].vy = -3;
                 }
             }
             else if (entities[i].state == 2)

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -3733,26 +3733,26 @@ void entityclass::animateentities( int _i )
         case 55:
         case 14: //Crew member! Very similar to hero
             entities[_i].framedelay--;
-            if(entities[_i].dir==1)
+            if (entities[_i].dir == 1)
             {
-                entities[_i].drawframe=entities[_i].tile;
+                entities[_i].drawframe = entities[_i].tile;
             }
             else
             {
-                entities[_i].drawframe=entities[_i].tile+3;
+                entities[_i].drawframe = entities[_i].tile+3;
             }
 
-            if(entities[_i].visualonground>0 || entities[_i].visualonroof>0)
+            if (entities[_i].visualonground > 0 || entities[_i].visualonroof > 0)
             {
                 if(entities[_i].vx > 0.0000f || entities[_i].vx < -0.000f)
                 {
                     //Walking
-                    if(entities[_i].framedelay<=0)
+                    if(entities[_i].framedelay <= 0)
                     {
-                        entities[_i].framedelay=4;
+                        entities[_i].framedelay = 4;
                         entities[_i].walkingframe++;
                     }
-                    if (entities[_i].walkingframe >=2) entities[_i].walkingframe=0;
+                    if (entities[_i].walkingframe >= 2) entities[_i].walkingframe = 0;
                     entities[_i].drawframe += entities[_i].walkingframe + 1;
                 }
 
@@ -3760,7 +3760,7 @@ void entityclass::animateentities( int _i )
             }
             else
             {
-                entities[_i].drawframe ++;
+                entities[_i].drawframe++;
                 if (entities[_i].rule == 7) {
                     entities[_i].drawframe += 6;
                 }
@@ -3768,7 +3768,7 @@ void entityclass::animateentities( int _i )
 
             if (game.deathseq > -1)
             {
-                entities[_i].drawframe=13;
+                entities[_i].drawframe = 13;
                 if (entities[_i].dir == 1) entities[_i].drawframe = 12;
                 if (entities[_i].rule == 7) entities[_i].drawframe += 2;
             }

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4484,7 +4484,7 @@ bool entityclass::testwallsx( int t, int tx, int ty, const bool skipdirblocks )
     bool skipblocks = entities[t].rule < 2 || entities[t].type == 14;
     float dx = 0;
     float dy = 0;
-    if (entities[t].rule == 0) dx = entities[t].vx;
+    if (entities[t].rule == 0 || entities[t].type == 14) dx = entities[t].vx;
     int dr = entities[t].rule;
 
     const bool invincible = map.invincibility && entities[t].ishumanoid();
@@ -4531,7 +4531,7 @@ bool entityclass::testwallsy( int t, int tx, int ty )
 
     float dx = 0;
     float dy = 0;
-    if (entities[t].rule == 0) dy = entities[t].vy;
+    if (entities[t].rule == 0 || entities[t].type == 14) dy = entities[t].vy;
     int dr = entities[t].rule;
 
     const bool invincible = map.invincibility && entities[t].ishumanoid();

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2636,13 +2636,16 @@ bool entityclass::updateentities( int i )
                 if (entities[i].scm)
                 {
                     int scm = getscm();
-                    if (entities[scm].rule == 6)
+                    if (INBOUNDS_VEC(scm, entities))
                     {
-                        entities[scm].rule = 7;
-                    }
-                    else
-                    {
-                        entities[scm].rule = 6;
+                        if (entities[scm].rule == 6)
+                        {
+                            entities[scm].rule = 7;
+                        }
+                        else
+                        {
+                            entities[scm].rule = 6;
+                        }
                     }
                 }
                 else
@@ -2774,15 +2777,18 @@ bool entityclass::updateentities( int i )
                 if (entities[i].para == 1)
                 {
                     entity = getscm();
-                    if (entities[entity].rule == 6)
+                    if (INBOUNDS_VEC(entity, entities))
                     {
-                        flipped = false;
-                        entities[entity].rule = 7;
-                    }
-                    else
-                    {
-                        flipped = true;
-                        entities[entity].rule = 6;
+                        if (entities[entity].rule == 6)
+                        {
+                            flipped = false;
+                                entities[entity].rule = 7;
+                        }
+                        else
+                        {
+                            flipped = true;
+                                entities[entity].rule = 6;
+                        }
                     }
                 }
                 else
@@ -2793,11 +2799,11 @@ bool entityclass::updateentities( int i )
 
                 if (flipped)
                 {
-                    if (entities[entity].vy < 3) entities[entity].vy = 3;
+                    if (INBOUNDS_VEC(entity, entities) && entities[entity].vy < 3) entities[entity].vy = 3;
                 }
                 else
                 {
-                    if (entities[entity].vy > -3) entities[entity].vy = -3;
+                    if (INBOUNDS_VEC(entity, entities) && entities[entity].vy > -3) entities[entity].vy = -3;
                 }
             }
             else if (entities[i].state == 2)

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -860,6 +860,23 @@ void gamelogic(void)
                         obj.entitymapcollision(i);
                     }
                 }
+                // what about a supercrewmate?
+                i = obj.getscm();
+                j = obj.entitycollideplatformfloor(i);
+                if (INBOUNDS_VEC(i, obj.entities) && j > -1000)
+                {
+                    obj.entities[i].newxp = obj.entities[i].xp + j;
+                    obj.entitymapcollision(i);
+                }
+                else
+                {
+                    j = obj.entitycollideplatformroof(i);
+                    if (INBOUNDS_VEC(i, obj.entities) && j > -1000)
+                    {
+                        obj.entities[i].newxp = obj.entities[i].xp + j;
+                        obj.entitymapcollision(i);
+                    }
+                }
             }
 
             for (int ie = obj.entities.size() - 1; ie >= 0;  ie--)


### PR DESCRIPTION
## Changes:

Supercrewmates now interact with gravity lines, gravity tokens and oneways correctly. They're now moved by horizontal moving platforms and conveyors.

Closes #901.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
