### PR TITLE
Unhardcoded glitchy and changing roomnames

### DIFF
--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -391,6 +391,7 @@ void customlevelclass::reset(void)
     onewaycol_override = false;
 
     customcolours.clear();
+    map.specialroomnames.clear();
 }
 
 const int* customlevelclass::loadlevel( int rxi, int ryi )
@@ -1314,6 +1315,71 @@ next:
                         customcolours[name] = colour;
                     }
                 }
+            }
+        }
+
+        if (SDL_strcmp(pKey, "SpecialRoomnames") == 0)
+        {
+            for (tinyxml2::XMLElement* roomnameElement = pElem->FirstChildElement(); roomnameElement; roomnameElement = roomnameElement->NextSiblingElement())
+            {
+                const char* roomnameType = roomnameElement->Value();
+                Roomname name;
+                name.x = 0;
+                name.y = 0;
+                name.flag = -1;
+                name.loop = false;
+                name.type = STATIC;
+                name.progress = 0;
+                name.delay = 0;
+                if (SDL_strcmp(roomnameType, "transform") == 0)
+                {
+                    name.type = TRANSFORM;
+                    name.delay = 2;
+                }
+                else if (SDL_strcmp(roomnameType, "glitch") == 0)
+                {
+                    name.type = GLITCH;
+                    name.progress = 1;
+                    name.delay = -1;
+                }
+
+                name.text.clear();
+
+                roomnameElement->QueryIntAttribute("x", &name.x);
+                roomnameElement->QueryIntAttribute("y", &name.y);
+                roomnameElement->QueryIntAttribute("flag", &name.flag);
+
+                roomnameElement->QueryBoolAttribute("loop", &name.loop);
+
+                if (name.type == STATIC)
+                {
+                    const char* text = roomnameElement->GetText();
+                    if (text != NULL)
+                    {
+                        name.text.push_back(std::string(text));
+                    }
+                }
+                else
+                {
+                    // Does it have children?
+                    if (roomnameElement->FirstChildElement() == NULL)
+                    {
+                        continue;
+                    }
+                    for (tinyxml2::XMLElement* textElement = roomnameElement->FirstChildElement(); textElement; textElement = textElement->NextSiblingElement())
+                    {
+                        if (SDL_strcmp(textElement->Value(), "text") == 0)
+                        {
+                            const char* text = textElement->GetText();
+                            if (text != NULL)
+                            {
+                                name.text.push_back(std::string(text));
+                            }
+                        }
+                    }
+                }
+
+                map.specialroomnames.push_back(name);
             }
         }
     }

--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -1328,17 +1328,17 @@ next:
                 name.y = 0;
                 name.flag = -1;
                 name.loop = false;
-                name.type = STATIC;
+                name.type = RoomnameType_STATIC;
                 name.progress = 0;
                 name.delay = 0;
                 if (SDL_strcmp(roomnameType, "transform") == 0)
                 {
-                    name.type = TRANSFORM;
+                    name.type = RoomnameType_TRANSFORM;
                     name.delay = 2;
                 }
                 else if (SDL_strcmp(roomnameType, "glitch") == 0)
                 {
-                    name.type = GLITCH;
+                    name.type = RoomnameType_GLITCH;
                     name.progress = 1;
                     name.delay = -1;
                 }
@@ -1351,7 +1351,11 @@ next:
 
                 roomnameElement->QueryBoolAttribute("loop", &name.loop);
 
-                if (name.type == STATIC)
+                // Rooms start at (100, 100) instead of (0, 0), so offset the coordinates
+                name.x += 100;
+                name.y += 100;
+
+                if (name.type == RoomnameType_STATIC)
                 {
                     const char* text = roomnameElement->GetText();
                     if (text != NULL)

--- a/desktop_version/src/Finalclass.cpp
+++ b/desktop_version/src/Finalclass.cpp
@@ -157,7 +157,7 @@ const short* finalclass::loadlevel(int rx, int ry)
         obj.createentity(192, 116, 11, 64);  // (horizontal gravity line)
 
         warpy = true;
-        roomname = "glitch";
+        roomname = "The Untouchables";
         roomname_special = true;
         result = contents;
         break;
@@ -208,7 +208,7 @@ const short* finalclass::loadlevel(int rx, int ry)
         obj.createentity(32, 48, 10, 1, 51481);  // (savepoint)
 
         warpy = true;
-        roomname = "glitch";
+        roomname = "On the Waterfront";
         roomname_special = true;
         result = contents;
         break;
@@ -257,7 +257,7 @@ const short* finalclass::loadlevel(int rx, int ry)
         obj.createentity(128, 56, 10, 1, 51471);  // (savepoint)
 
         warpy = true;
-        roomname = "change";
+        roomname = "Gvnsmoke";
         roomname_special = true;
         result = contents;
         break;
@@ -308,7 +308,7 @@ const short* finalclass::loadlevel(int rx, int ry)
         obj.createentity(288, 120, 1, 2, 4);  // Enemy
 
         warpy = true;
-        roomname = "change";
+        roomname = "Vwitched";
         roomname_special = true;
         result = contents;
         break;
@@ -356,7 +356,7 @@ const short* finalclass::loadlevel(int rx, int ry)
         obj.createentity(176, 96, 10, 0, 51451);  // (savepoint)
 
         warpy = true;
-        roomname = "change";
+        roomname = "Television Newsveel";
         roomname_special = true;
         result = contents;
         break;
@@ -514,7 +514,7 @@ const short* finalclass::loadlevel(int rx, int ry)
         obj.createentity(24, 148, 11, 120);  // (horizontal gravity line)
 
         warpy = true;
-        roomname = "glitch";
+        roomname = "Rear Window";
         roomname_special = true;
         result = contents;
         break;
@@ -961,7 +961,7 @@ const short* finalclass::loadlevel(int rx, int ry)
         obj.createentity(120 + 4, 160 - 4, 1, 1, 5);  // Enemy
 
         warpx = true;
-        roomname = "change";
+        roomname = "Please enjoy these repeats";
         roomname_special = true;
         result = contents;
         break;
@@ -1012,7 +1012,7 @@ const short* finalclass::loadlevel(int rx, int ry)
         obj.createentity(224, 52, 11, 80);  // (horizontal gravity line)
 
         warpx = true;
-        roomname = "change";
+        roomname = "Try Jiggling the Antenna";
         roomname_special = true;
         result = contents;
         break;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -3042,6 +3042,7 @@ void Game::updatestate(void)
             map.final_mapcol = 0;
             map.final_colorframe = 0;
             map.finalstretch = false;
+            obj.flags[72] = false;
 
             graphics.setbars(320);
 
@@ -4179,33 +4180,14 @@ void Game::gethardestroom(void)
     if (currentroomdeaths > hardestroomdeaths)
     {
         hardestroomdeaths = currentroomdeaths;
-        hardestroom = loc::gettext_roomname(map.custommode, roomx, roomy, map.roomname, map.roomname_special);
-        if (SDL_strcmp(map.roomname, "glitch") == 0)
-        {
-            if (roomx == 42 && roomy == 51)
-            {
-                hardestroom = loc::gettext_roomname_special("Rear Vindow");
-            }
-            else if (roomx == 48 && roomy == 51)
-            {
-                hardestroom = loc::gettext_roomname_special("On the Vaterfront");
-            }
-            else if (roomx == 49 && roomy == 51)
-            {
-                hardestroom = loc::gettext_roomname_special("The Untouchavles");
-            }
-        }
-        else if (SDL_strcmp(map.roomname, "change") == 0)
-        {
-            if (roomx == 45 && roomy == 51) hardestroom = loc::gettext_roomname_special(map.specialnames[3]);
-            if (roomx == 46 && roomy == 51) hardestroom = loc::gettext_roomname_special(map.specialnames[4]);
-            if (roomx == 47 && roomy == 51) hardestroom = loc::gettext_roomname_special(map.specialnames[5]);
-            if (roomx == 50 && roomy == 53) hardestroom = loc::gettext_roomname_special(map.specialnames[6]);
-            if (roomx == 50 && roomy == 54) hardestroom = loc::gettext_roomname_special(map.specialnames[7]);
-        }
-        else if (map.roomname[0] == '\0')
+
+        if (map.roomname[0] == '\0')
         {
             hardestroom = loc::gettext_roomname_special(map.hiddenname);
+        }
+        else
+        {
+            hardestroom = map.roomname;
         }
     }
 }
@@ -5978,6 +5960,15 @@ bool Game::customsavequick(const std::string& savfile)
     if (map.roomnameset)
     {
         xml::update_tag(msgs, "roomname", map.roomname);
+    }
+    else
+    {
+        // If there's roomname tags, remove them. There will probably only always be one, but just in case...
+        tinyxml2::XMLElement* element;
+        while ((element = msgs->FirstChildElement("roomname")) != NULL)
+        {
+            doc.DeleteNode(element);
+        }
     }
 
     std::string summary = savearea + ", " + timestring();

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5496,7 +5496,12 @@ void Game::customloadquick(const std::string& savfile)
         {
             map.showtrinkets = help.Int(pText);
         }
-
+        else if (SDL_strcmp(pKey, "roomname") == 0)
+        {
+            map.setroomname(pText);
+            map.roomnameset = true;
+            map.roomname_special = true;
+        }
     }
 
     map.showteleporters = true;
@@ -5969,6 +5974,11 @@ bool Game::customsavequick(const std::string& savfile)
     xml::update_tag(msgs, "disabletemporaryaudiopause", (int) disabletemporaryaudiopause);
 
     xml::update_tag(msgs, "showtrinkets", (int) map.showtrinkets);
+
+    if (map.roomnameset)
+    {
+        xml::update_tag(msgs, "roomname", map.roomname);
+    }
 
     std::string summary = savearea + ", " + timestring();
     xml::update_tag(msgs, "summary", summary.c_str());

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -68,10 +68,15 @@ mapclass::mapclass(void)
     SDL_memset(roomdeathsfinal, 0, sizeof(roomdeathsfinal));
     resetmap();
 
+    setroomname("");
+    hiddenname = "";
+
+    roomname_special = false;
+    specialroomnames.clear();
+    roomnameset = false;
+
     tileset = 0;
     initmapdata();
-
-    resetnames();
 
     ypos = 0;
     oldypos = 0;
@@ -83,13 +88,6 @@ mapclass::mapclass(void)
     roomtexton = false;
 
     nexttowercolour_set = false;
-
-    setroomname("");
-    hiddenname = "";
-
-    roomname_special = false;
-    specialroomnames.clear();
-    roomnameset = false;
 }
 
 static char roomname_static[SCREEN_WIDTH_CHARS];
@@ -204,200 +202,6 @@ void mapclass::resetmap(void)
     SDL_memset(explored, 0, sizeof(explored));
 }
 
-void mapclass::resetnames(void)
-{
-    //Reset all the special names
-    specialnames[0] = "Rear Window";
-    specialnames[1] = "On the Waterfront";
-    specialnames[2] = "The Untouchables";
-    specialnames[3] = "Television Newsveel";
-    specialnames[4] = "Vwitched";
-    specialnames[5] = "Gvnsmoke";
-    specialnames[6] = "Please enjoy these repeats";
-    specialnames[7] = "Try Jiggling the Antenna";
-
-    glitchmode = 0;
-    glitchdelay = 0;
-}
-
-void mapclass::transformname(int t)
-{
-    //transform special names into new ones, one step at a time
-
-    glitchdelay--;
-    if(glitchdelay<=0)
-    {
-        switch(t)
-        {
-        case 3:
-            //Television Newsveel -> The 9 O'Clock News
-            if (SDL_strcmp(specialnames[3], "Television Newsveel") == 0)
-            {
-                specialnames[3] = "Television Newsvel";
-            }
-            else if (SDL_strcmp(specialnames[3], "Television Newsvel") == 0)
-            {
-                specialnames[3] = "TelevisvonvNewsvel";
-            }
-            else if (SDL_strcmp(specialnames[3], "TelevisvonvNewsvel") == 0)
-            {
-                specialnames[3] = "TvlvvvsvonvNevsvel";
-            }
-            else if (SDL_strcmp(specialnames[3], "TvlvvvsvonvNevsvel") == 0)
-            {
-                specialnames[3] = "vvvvvvsvovvNe svel";
-            }
-            else if (SDL_strcmp(specialnames[3], "vvvvvvsvovvNe svel") == 0)
-            {
-                specialnames[3] = "vhv vvv'vvovv vevl";
-            }
-            else if (SDL_strcmp(specialnames[3], "vhv vvv'vvovv vevl") == 0)
-            {
-                specialnames[3] = "vhv V v'Cvovv vewv";
-            }
-            else if (SDL_strcmp(specialnames[3], "vhv V v'Cvovv vewv") == 0)
-            {
-                specialnames[3] = "vhe 9 v'Cvovv vewv";
-            }
-            else if (SDL_strcmp(specialnames[3], "vhe 9 v'Cvovv vewv") == 0)
-            {
-                specialnames[3] = "vhe 9 v'Cvovv Newv";
-            }
-            else if (SDL_strcmp(specialnames[3], "vhe 9 v'Cvovv Newv") == 0)
-            {
-                specialnames[3] = "The 9 O'Cvovk Newv";
-            }
-            else if (SDL_strcmp(specialnames[3], "The 9 O'Cvovk Newv") == 0)
-            {
-                specialnames[3] = "The 9 O'Clock News";
-            }
-            break;
-        case 4:
-            //Vwitched -> Dial M for Murder
-            if (SDL_strcmp(specialnames[4], "Vwitched") == 0)
-            {
-                specialnames[4] = "Vwitvhed";
-            }
-            else if (SDL_strcmp(specialnames[4], "Vwitvhed") == 0)
-            {
-                specialnames[4] = "vVwivcvedv";
-            }
-            else if (SDL_strcmp(specialnames[4], "vVwivcvedv") == 0)
-            {
-                specialnames[4] = "vvvwMvcvMdvv";
-            }
-            else if (SDL_strcmp(specialnames[4], "vvvwMvcvMdvv") == 0)
-            {
-                specialnames[4] = "DvvvwMvfvvMdvvv";
-            }
-            else if (SDL_strcmp(specialnames[4], "DvvvwMvfvvMdvvv") == 0)
-            {
-                specialnames[4] = "Dvav Mvfvr Mdvvvv";
-            }
-            else if (SDL_strcmp(specialnames[4], "Dvav Mvfvr Mdvvvv") == 0)
-            {
-                specialnames[4] = "Diav M for Mdrver";
-            }
-            else if (SDL_strcmp(specialnames[4], "Diav M for Mdrver") == 0)
-            {
-                specialnames[4] = "Dial M for Murder";
-            }
-            break;
-        case 5:
-            //Gvnsmoke -> Gunsmoke 1966
-            if (SDL_strcmp(specialnames[5], "Gvnsmoke") == 0)
-            {
-                specialnames[5] = "Gvnsmove";
-            }
-            else if (SDL_strcmp(specialnames[5], "Gvnsmove") == 0)
-            {
-                specialnames[5] = "Gvnvmovevv";
-            }
-            else if (SDL_strcmp(specialnames[5], "Gvnvmovevv") == 0)
-            {
-                specialnames[5] = "Gunvmove1vv6";
-            }
-            else if (SDL_strcmp(specialnames[5], "Gunvmove1vv6") == 0)
-            {
-                specialnames[5] = "Vunsmoke 19v6";
-            }
-            else if (SDL_strcmp(specialnames[5], "Vunsmoke 19v6") == 0)
-            {
-                specialnames[5] = "Gunsmoke 1966";
-            }
-            break;
-        case 6:
-            //Please enjoy these repeats -> In the Margins
-            if (SDL_strcmp(specialnames[6], "Please enjoy these repeats") == 0)
-            {
-                specialnames[6] = "Please envoy theve repeats";
-            }
-            else if (SDL_strcmp(specialnames[6], "Please envoy theve repeats") == 0)
-            {
-                specialnames[6] = "Plse envoy tse rvpvas";
-            }
-            else if (SDL_strcmp(specialnames[6], "Plase envoy these rvpeas") == 0)
-            {
-                specialnames[6] = "Plse envoy tse rvpvas";
-            }
-            else if (SDL_strcmp(specialnames[6], "Plse envoy tse rvpvas") == 0)
-            {
-                specialnames[6] = "Vl envoy te rvevs";
-            }
-            else if (SDL_strcmp(specialnames[6], "Vl envoy te rvevs") == 0)
-            {
-                specialnames[6] = "Vv evo tv vevs";
-            }
-            else if (SDL_strcmp(specialnames[6], "Vv evo tv vevs") == 0)
-            {
-                specialnames[6] = "Iv vhv Mvrvivs";
-            }
-            else if (SDL_strcmp(specialnames[6], "Iv vhv Mvrvivs") == 0)
-            {
-                specialnames[6] = "In the Margins";
-            }
-            break;
-        case 7:
-            //Try Jiggling the Antenna -> Heaven's Gate
-            if (SDL_strcmp(specialnames[7], "Try Jiggling the Antenna") == 0)
-            {
-                specialnames[7] = "Try Viggling the Antenna";
-            }
-            else if (SDL_strcmp(specialnames[7], "Try Viggling the Antenna") == 0)
-            {
-                specialnames[7] = "TryJivglvng theAvtevna";
-            }
-            else if (SDL_strcmp(specialnames[7], "TryJivglvng theAvtevna") == 0)
-            {
-                specialnames[7] = "Tvvivglvng thAvtvvv";
-            }
-            else if (SDL_strcmp(specialnames[7], "Tvvivglvng thAvtvvv") == 0)
-            {
-                specialnames[7] = "Vvvgglvnv tvnvva";
-            }
-            else if (SDL_strcmp(specialnames[7], "Vvvgglvnv tvnvva") == 0)
-            {
-                specialnames[7] = "Vvavvnvs vvtv";
-            }
-            else if (SDL_strcmp(specialnames[7], "Vvavvnvs vvtv") == 0)
-            {
-                specialnames[7] = "Veavvn's Gvte";
-            }
-            else if (SDL_strcmp(specialnames[7], "Veavvn's Gvte") == 0)
-            {
-                specialnames[7] = "Heaven's Gate";
-            }
-            break;
-
-        }
-        glitchdelay = 5;
-    }
-    else
-    {
-        glitchdelay--;
-    }
-}
-
 void mapclass::updateroomnames(void)
 {
     if (roomnameset)
@@ -405,115 +209,50 @@ void mapclass::updateroomnames(void)
         return;
     }
 
-    const int rx = game.roomx - 100;
-    const int ry = game.roomy - 100;
+    const int rx = game.roomx;
+    const int ry = game.roomy;
 
     for (int i = specialroomnames.size() - 1; i >= 0; i--)
     {
-        Roomname &roomname = specialroomnames[i];
-        if (rx == roomname.x && ry == roomname.y && (roomname.flag == -1 || (INBOUNDS_ARR(roomname.flag, obj.flags) && obj.flags[roomname.flag])))
+        Roomname* roomname = &specialroomnames[i];
+        if (rx == roomname->x && ry == roomname->y && (roomname->flag == -1 || (INBOUNDS_ARR(roomname->flag, obj.flags) && obj.flags[roomname->flag])))
         {
             roomname_special = true;
-            if (roomname.type == STATIC)
+            if (roomname->type == RoomnameType_STATIC)
             {
-                setroomname(roomname.text[0].c_str());
+                setroomname(roomname->text[0].c_str());
             }
-            if (roomname.type == GLITCH)
+            if (roomname->type == RoomnameType_GLITCH)
             {
-                roomname.delay--;
-                if (roomname.delay <= 0)
+                roomname->delay--;
+                if (roomname->delay <= 0)
                 {
-                    roomname.progress = (roomname.progress + 1) % 2;
-                    roomname.delay = 5;
-                    if (roomname.progress == 0)
+                    roomname->progress = (roomname->progress + 1) % 2;
+                    roomname->delay = 5;
+                    if (roomname->progress == 0)
                     {
-                        roomname.delay = 25 + (int) (fRandom() * 10);
+                        roomname->delay = 25 + (int) (fRandom() * 10);
                     }
                 }
-                setroomname(roomname.text[roomname.progress].c_str());
+                setroomname(roomname->text[roomname->progress].c_str());
             }
-            if (roomname.type == TRANSFORM)
+            if (roomname->type == RoomnameType_TRANSFORM)
             {
-                roomname.delay--;
-                if (roomname.delay <= 0)
+                roomname->delay--;
+                if (roomname->delay <= 0)
                 {
-                    roomname.progress++;
-                    roomname.delay = 2;
-                    if (roomname.progress >= roomname.text.size())
+                    roomname->progress++;
+                    roomname->delay = 2;
+                    if ((size_t) roomname->progress >= roomname->text.size())
                     {
-                        roomname.progress = roomname.loop ? 0 : roomname.text.size() - 1;
+                        roomname->progress = roomname->loop ? 0 : roomname->text.size() - 1;
                     }
                 }
-                setroomname(roomname.text[roomname.progress].c_str());
+                setroomname(roomname->text[roomname->progress].c_str());
             }
             break;
         }
     }
-}
-
-const char* mapclass::getglitchname(int x, int y)
-{
-    //Returns the name in the final area.
-    if (SDL_strcmp(roomname, "glitch") == 0)
-    {
-        //8 Cases!
-        //First, the three "glitches"
-        glitchdelay--;
-        if (glitchdelay <= -5)
-        {
-            glitchmode = (glitchmode + 1) % 2;
-            glitchdelay = 0;
-            if (glitchmode == 0) glitchdelay = 20 +int(fRandom() * 10);
-        }
-
-        if (x == 42 && y == 51)
-        {
-            if (glitchmode == 0)
-            {
-                return specialnames[0];
-            }
-            else return "Rear Vindow";
-        }
-        else if (x == 48 && y == 51)
-        {
-            if (glitchmode == 0)
-            {
-                return specialnames[1];
-            }
-            else return "On the Vaterfront";
-        }
-        else if (x == 49 && y == 51)
-        {
-            if (glitchmode == 0)
-            {
-                return specialnames[2];
-            }
-            else return "The Untouchavles";
-        }
-    }
-    else if (SDL_strcmp(roomname, "change") == 0)
-    {
-        if (finalstretch)
-        {
-            if (x == 45 && y == 51) transformname(3);
-            if (x == 46 && y == 51) transformname(4);
-            if (x == 47 && y == 51) transformname(5);
-            if (x == 50 && y == 53) transformname(6);
-            if (x == 50 && y == 54) transformname(7);
-        }
-
-        if (x == 45 && y == 51) return specialnames[3];
-        if (x == 46 && y == 51) return specialnames[4];
-        if (x == 47 && y == 51) return specialnames[5];
-        if (x == 50 && y == 53) return specialnames[6];
-        if (x == 50 && y == 54) return specialnames[7];
-        return roomname;
-    }
-    else
-    {
-        return roomname;
-    }
-    return roomname;
 }
 
 void mapclass::initmapdata(void)
@@ -564,6 +303,117 @@ void mapclass::initmapdata(void)
     settrinket(1, 10);
     settrinket(3, 2);
     settrinket(10, 8);
+
+    //Special room names
+    specialroomnames.clear();
+
+    {
+        static const char* lines[] = {
+            "Television Newsvel",
+            "TelevisvonvNewsvel",
+            "TvlvvvsvonvNevsvel",
+            "vvvvvvsvovvNe svel",
+            "vhv vvv'vvovv vevl",
+            "vhv V v'Cvovv vewv",
+            "vhe 9 v'Cvovv vewv",
+            "vhe 9 v'Cvovv Newv",
+            "The 9 O'Cvovk Newv",
+            "The 9 O'Clock News"
+        };
+
+        roomnamechange(45, 51, lines, SDL_arraysize(lines));
+    }
+
+    {
+        static const char* lines[] = {
+            "Vwitvhed",
+            "vVwivcvedv",
+            "vvvwMvcvMdvv",
+            "DvvvwMvfvvMdvvv",
+            "Dvav Mvfvr Mdvvvv",
+            "Diav M for Mdrver",
+            "Dial M for Murder"
+        };
+
+        roomnamechange(46, 51, lines, SDL_arraysize(lines));
+    }
+
+    {
+        static const char* lines[] = {
+            "Gvnsmove",
+            "Gvnvmovevv",
+            "Gunvmove1vv6",
+            "Vunsmoke 19v6",
+            "Gunsmoke 1966"
+        };
+
+        roomnamechange(47, 51, lines, SDL_arraysize(lines));
+    }
+
+    {
+        static const char* lines[] = {
+            "Please envoy theve repeats",
+            "Plse envoy tse rvpvas",
+            "Plse envoy tse rvpvas",
+            "Vl envoy te rvevs",
+            "Vv evo tv vevs",
+            "Iv vhv Mvrvivs",
+            "In the Margins"
+        };
+
+        roomnamechange(50, 53, lines, SDL_arraysize(lines));
+    }
+
+    {
+        static const char* lines[] = {
+            "Try Viggling the Antenna",
+            "TryJivglvng theAvtevna",
+            "Tvvivglvng thAvtvvv",
+            "Vvvgglvnv tvnvva",
+            "Vvavvnvs vvtv",
+            "Veavvn's Gvte",
+            "Heaven's Gate"
+        };
+
+        roomnamechange(50, 54, lines, SDL_arraysize(lines));
+    }
+
+    roomnameglitch(42, 51, "Rear Window", "Rear Vindow");
+    roomnameglitch(48, 51, "On the Waterfront", "On the Vaterfront");
+    roomnameglitch(49, 51, "The Untouchables", "The Untouchavles");
+}
+
+void mapclass::roomnameglitch(int x, int y, const char* name, const char* text)
+{
+    Roomname roomname;
+    roomname.x = x;
+    roomname.y = y;
+    roomname.type = RoomnameType_GLITCH;
+    roomname.flag = -1;
+    roomname.loop = false;
+    roomname.progress = 1;
+    roomname.delay = -1;
+
+    roomname.text.push_back(name);
+    roomname.text.push_back(text);
+
+    specialroomnames.push_back(roomname);
+}
+
+void mapclass::roomnamechange(const int x, const int y, const char** lines, const size_t size)
+{
+    Roomname roomname;
+    roomname.x = x;
+    roomname.y = y;
+    roomname.type = RoomnameType_TRANSFORM;
+    roomname.flag = 72; // Flag 72 is synced with finalstretch
+    roomname.loop = false;
+    roomname.progress = 0;
+    roomname.delay = 2;
+
+    roomname.text.insert(roomname.text.end(), lines, lines + size);
+
+    specialroomnames.push_back(roomname);
 }
 
 void mapclass::initcustommapdata(void)

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -88,6 +88,8 @@ mapclass::mapclass(void)
     hiddenname = "";
 
     roomname_special = false;
+    specialroomnames.clear();
+    roomnameset = false;
 }
 
 static char roomname_static[SCREEN_WIDTH_CHARS];
@@ -393,6 +395,59 @@ void mapclass::transformname(int t)
     else
     {
         glitchdelay--;
+    }
+}
+
+void mapclass::updateroomnames(void)
+{
+    if (roomnameset)
+    {
+        return;
+    }
+
+    const int rx = game.roomx - 100;
+    const int ry = game.roomy - 100;
+
+    for (int i = specialroomnames.size() - 1; i >= 0; i--)
+    {
+        Roomname &roomname = specialroomnames[i];
+        if (rx == roomname.x && ry == roomname.y && (roomname.flag == -1 || (INBOUNDS_ARR(roomname.flag, obj.flags) && obj.flags[roomname.flag])))
+        {
+            roomname_special = true;
+            if (roomname.type == STATIC)
+            {
+                setroomname(roomname.text[0].c_str());
+            }
+            if (roomname.type == GLITCH)
+            {
+                roomname.delay--;
+                if (roomname.delay <= 0)
+                {
+                    roomname.progress = (roomname.progress + 1) % 2;
+                    roomname.delay = 5;
+                    if (roomname.progress == 0)
+                    {
+                        roomname.delay = 25 + (int) (fRandom() * 10);
+                    }
+                }
+                setroomname(roomname.text[roomname.progress].c_str());
+            }
+            if (roomname.type == TRANSFORM)
+            {
+                roomname.delay--;
+                if (roomname.delay <= 0)
+                {
+                    roomname.progress++;
+                    roomname.delay = 2;
+                    if (roomname.progress >= roomname.text.size())
+                    {
+                        roomname.progress = roomname.loop ? 0 : roomname.text.size() - 1;
+                    }
+                }
+                setroomname(roomname.text[roomname.progress].c_str());
+            }
+            break;
+        }
     }
 }
 
@@ -1414,6 +1469,7 @@ void mapclass::loadlevel(int rx, int ry)
 
     roomtexton = false;
     roomtext.clear();
+    roomnameset = false;
 
     obj.platformtile = 0;
     obj.customplatformtile=0;

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -2,6 +2,7 @@
 #define MAPGAME_H
 
 #include <vector>
+#include <string>
 
 #include "Finalclass.h"
 #include "Labclass.h"
@@ -15,6 +16,25 @@ struct Roomtext
 {
     int x, y;
     const char* text;
+};
+
+enum RoomnameType
+{
+    STATIC,
+    GLITCH,
+    TRANSFORM
+};
+
+struct Roomname
+{
+    int x;
+    int y;
+    bool loop;
+    int flag;
+    RoomnameType type;
+    std::vector<std::string> text;
+    int progress;
+    int delay;
 };
 
 class mapclass
@@ -38,6 +58,8 @@ public:
     void resetmap(void);
 
     void resetnames(void);
+
+    void updateroomnames(void);
 
     void transformname(int t);
 
@@ -114,7 +136,10 @@ public:
 
     const char* roomname;
     bool roomname_special;
+    bool roomnameset;
     const char* hiddenname;
+
+    std::vector<Roomname> specialroomnames;
 
     //Special tower stuff
     bool towermode;

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -20,9 +20,9 @@ struct Roomtext
 
 enum RoomnameType
 {
-    STATIC,
-    GLITCH,
-    TRANSFORM
+    RoomnameType_STATIC,
+    RoomnameType_GLITCH,
+    RoomnameType_TRANSFORM
 };
 
 struct Roomname
@@ -57,16 +57,13 @@ public:
 
     void resetmap(void);
 
-    void resetnames(void);
-
     void updateroomnames(void);
-
-    void transformname(int t);
-
-    const char* getglitchname(int x, int y);
 
     void initmapdata(void);
     void initcustommapdata(void);
+
+    void roomnamechange(int x, int y, const char** lines, size_t size);
+    void roomnameglitch(int x, int y, const char* name, const char* glitch);
 
     int finalat(int x, int y);
 
@@ -164,11 +161,6 @@ public:
     int custommmxoff, custommmyoff, custommmxsize, custommmysize;
     int customzoom;
     bool customshowmm;
-
-    const char* specialnames[8];
-    int glitchmode;
-    int glitchdelay;
-    const char* glitchname;
 
     //final level colour cycling stuff
     bool final_colormode;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1933,16 +1933,7 @@ void gamerender(void)
 
     if ((map.extrarow==0 || (map.custommode && map.roomname[0] != '\0')) && !force_roomname_hidden)
     {
-        const char* roomname;
-
-        if (map.finalmode)
-        {
-            roomname = loc::gettext_roomname(map.custommode, game.roomx, game.roomy, map.glitchname, map.roomname_special);
-        }
-        else
-        {
-            roomname = loc::gettext_roomname(map.custommode, game.roomx, game.roomy, map.roomname, map.roomname_special);
-        }
+        const char* roomname = loc::gettext_roomname(map.custommode, game.roomx, game.roomy, map.roomname, map.roomname_special);
 
         graphics.render_roomname(
             roomname_untranslated ? PR_FONT_8X8 : PR_FONT_LEVEL,
@@ -2273,10 +2264,6 @@ static void draw_roomname_menu(void)
     if (map.hiddenname[0] != '\0')
     {
         name = loc::gettext_roomname_special(map.hiddenname);
-    }
-    else if (map.finalmode)
-    {
-        name = loc::gettext_roomname(map.custommode, game.roomx, game.roomy, map.glitchname, map.roomname_special);
     }
     else
     {

--- a/desktop_version/src/RenderFixed.cpp
+++ b/desktop_version/src/RenderFixed.cpp
@@ -116,11 +116,6 @@ void gamerenderfixed(void)
 
     map.updateroomnames();
 
-    if (map.finalmode)
-    {
-        map.glitchname = map.getglitchname(game.roomx, game.roomy);
-    }
-
 #if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
     ed.oldreturneditoralpha = ed.returneditoralpha;
     if (map.custommode && !map.custommodeforreal && ed.returneditoralpha > 0)
@@ -248,11 +243,6 @@ void maprenderfixed(void)
     }
 
     map.updateroomnames();
-
-    if (map.finalmode)
-    {
-        map.glitchname = map.getglitchname(game.roomx, game.roomy);
-    }
 }
 
 void teleporterrenderfixed(void)

--- a/desktop_version/src/RenderFixed.cpp
+++ b/desktop_version/src/RenderFixed.cpp
@@ -114,6 +114,8 @@ void gamerenderfixed(void)
         obj.entities[i].updatecolour();
     }
 
+    map.updateroomnames();
+
     if (map.finalmode)
     {
         map.glitchname = map.getglitchname(game.roomx, game.roomy);
@@ -244,6 +246,8 @@ void maprenderfixed(void)
     }else if (map.cursorstate == 2){
         map.cursordelay++;
     }
+
+    map.updateroomnames();
 
     if (map.finalmode)
     {

--- a/desktop_version/src/RoomnameTranslator.cpp
+++ b/desktop_version/src/RoomnameTranslator.cpp
@@ -160,7 +160,7 @@ namespace roomname_translator
                 print_explanation("This is a special room name, which cannot be translated in-game. Please see roomnames_special");
             }
         }
-        else if ((map.finalmode && map.glitchname[0] == '\0') || map.roomname[0] == '\0')
+        else if (map.roomname[0] == '\0')
         {
             // No room name at all, so no translation/explanation interface
             if (edit_mode)
@@ -176,15 +176,8 @@ namespace roomname_translator
 
             if (edit_mode)
             {
-                const char* english_roomname;
-                if (map.finalmode)
-                {
-                    english_roomname = map.glitchname;
-                }
-                else
-                {
-                    english_roomname = map.roomname;
-                }
+                const char* english_roomname = map.roomname;
+
                 font::print(PR_CEN | PR_BOR | PR_FONT_8X8, -1, 229-font::height(PR_FONT_LEVEL), english_roomname, 0,192,255);
 
                 print_explanation(loc::get_roomname_explanation(map.custommode, game.roomx, game.roomy));
@@ -414,10 +407,7 @@ namespace roomname_translator
 
             if (key_pressed_once(SDLK_RETURN, &held_return) || key_pressed_once(SDLK_e, &held_e))
             {
-                if (map.roomname_special
-                    || (map.finalmode && map.glitchname[0] == '\0')
-                    || (map.roomname[0] == '\0')
-                )
+                if (map.roomname_special || map.roomname[0] == '\0')
                 {
                     return true;
                 }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1403,7 +1403,6 @@ void scriptclass::run(void)
             }
             else if (words[0] == "resetgame")
             {
-                map.resetnames();
                 map.resetmap();
                 map.resetplayer();
                 graphics.towerbg.tdrawback = true;
@@ -3224,7 +3223,6 @@ void scriptclass::hardreset(void)
     map.final_aniframe = 0;
     map.final_aniframedelay = 0;
     map.rcol = 0;
-    map.resetnames();
     map.custommode=false;
     map.custommodeforreal=false;
     if (!version2_2)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -176,6 +176,16 @@ void scriptclass::run(void)
                 scriptdelay = 1;
             }
 #if !defined(NO_CUSTOM_LEVELS)
+            if (words[0] == "setroomname")
+            {
+                ++position;
+                if (INBOUNDS_VEC(position, commands))
+                {
+                    map.roomname_special = true;
+                    map.roomnameset = true;
+                    map.setroomname(commands[position].c_str());
+                }
+            }
             if (words[0] == "warpdir")
             {
                 int temprx = ss_toi(words[1]) - 1;


### PR DESCRIPTION
## Changes:

Roomname animations ("glitchy" and "changing" ones, used in the final level) are very hardcoded. Roomnames are solely visual, and some fun could be had with making them look cool.

Sample:

```xml
        <SpecialRoomnames>
            <static x="0" y="0" flag="2">This shows if flag 2 is on!</static>
            <glitch x="0" y="0" flag="1">
                <text>On the Waterfront</text>
                <text>On the Vaterfront</text>
            </glitch>
            <transform x="1" y="0" loop="0" flag="1">
                <text>Television Newsveel</text>
                <text>Television Newsvel</text>
                <text>TelevisvonvNewsvel</text>
                <text>TvlvvvsvonvNevsvel</text>
                <text>vvvvvvsvovvNe svel</text>
                <text>vhv vvv'vvovv vevl</text>
                <text>vhv V v'Cvovv vewv</text>
                <text>vhe 9 v'Cvovv vewv</text>
                <text>vhe 9 v'Cvovv Newv</text>
                <text>The 9 O'Cvovk Newv</text>
                <text>The 9 O'Clock News</text>
            </transform>
        </SpecialRoomnames>
```

Additionally, a `setroomname` command has been added, which sets the roomname temporarily to the next script line.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
