### PR TITLE
Move the game off of surfaces, and use the render system instead

### DIFF
--- a/desktop_version/CONTRIBUTORS.txt
+++ b/desktop_version/CONTRIBUTORS.txt
@@ -3,9 +3,9 @@ Contributors
 
 (Ordered alphabetically by first name.)
 
+* Alexandra Fox
 * AlexApps99 (@AlexApps99)
 * Allison Fleischer (AllisonFleischer)
-* AllyTally (@AllyTally)
 * Brian Callahan (@ibara)
 * Charlie Bruce (@charliebruce)
 * Christoph Böhmwalder (@chrboe)

--- a/desktop_version/src/Credits.h
+++ b/desktop_version/src/Credits.h
@@ -85,9 +85,9 @@ static const char* patrons[] = {
 /* CONTRIBUTORS.txt, again listed alphabetically (according to `sort`) by first name
  * Misa is special; she gets to be listed in C++ credits alongside Ethan */
 static const char* githubfriends[] = {
+    "Alexandra Fox",
     "AlexApps99",
     "Allison Fleischer",
-    "AllyTally",
     "Brian Callahan",
     "Charlie Bruce",
     "Christoph Böhmwalder",

--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -21,6 +21,7 @@
 #include "Localization.h"
 #include "LocalizationStorage.h"
 #include "Map.h"
+#include "Screen.h"
 #include "Script.h"
 #include "UtilityClass.h"
 #include "Vlogging.h"
@@ -1539,7 +1540,11 @@ void customlevelclass::generatecustomminimap(void)
     map.custommmxsize = 240 - (map.custommmxoff * 2);
     map.custommmysize = 180 - (map.custommmyoff * 2);
 
-    FillRect(graphics.images[12], graphics.getRGB(0, 0, 0));
+    // Start drawing the minimap
+
+    SDL_Texture* target = SDL_GetRenderTarget(gameScreen.m_renderer);
+    graphics.set_render_target(graphics.images[IMAGE_CUSTOMMINIMAP]);
+    graphics.clear();
 
     // Scan over the map size
     for (int j2 = 0; j2 < mapheight; j2++)
@@ -1587,12 +1592,10 @@ void customlevelclass::generatecustomminimap(void)
                     if (tile >= 1)
                     {
                         // Fill in this pixel
-                        FillRect(
-                            graphics.images[12],
+                        graphics.fill_rect(
                             (i2 * 12 * map.customzoom) + i,
                             (j2 * 9 * map.customzoom) + j,
-                            1,
-                            1,
+                            1, 1,
                             graphics.getRGB(tm, tm, tm)
                         );
                     }
@@ -1600,6 +1603,8 @@ void customlevelclass::generatecustomminimap(void)
             }
         }
     }
+
+    graphics.set_render_target(target);
 }
 
 // Return a graphics-ready color based off of the given tileset and tilecol

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4785,7 +4785,8 @@ void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
                 colpoint2.y = entities[j].yp;
                 int drawframe1 = entities[i].collisiondrawframe;
                 int drawframe2 = entities[j].drawframe;
-                std::vector<SDL_Surface*>& spritesvec = graphics.flipmode ? graphics.flipsprites : graphics.sprites;
+
+                std::vector<SDL_Surface*>& spritesvec = graphics.flipmode ? graphics.flipsprites_surf : graphics.sprites_surf;
                 if (INBOUNDS_VEC(drawframe1, spritesvec) && INBOUNDS_VEC(drawframe2, spritesvec)
                 && graphics.Hitest(spritesvec[drawframe1],
                                  colpoint1, spritesvec[drawframe2], colpoint2))

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -21,6 +21,24 @@ enum FadeBars
     FADE_FADING_IN
 };
 
+enum ImageNames
+{
+    IMAGE_LEVELCOMPLETE,
+    IMAGE_MINIMAP,
+    IMAGE_COVERED,
+    IMAGE_ELEPHANT,
+    IMAGE_GAMECOMPLETE,
+    IMAGE_FLIPLEVELCOMPLETE,
+    IMAGE_FLIPGAMECOMPLETE,
+    IMAGE_SITE,
+    IMAGE_SITE2,
+    IMAGE_SITE3,
+    IMAGE_ENDING,
+    IMAGE_SITE4,
+    IMAGE_CUSTOMMINIMAP,
+    NUM_IMAGES
+};
+
 #define FADEMODE_IS_FADING(mode) ((mode) != FADE_NONE && (mode) != FADE_FULLY_BLACK)
 
 class Graphics
@@ -29,7 +47,7 @@ public:
     void init(void);
     void destroy(void);
 
-    void create_buffers(const SDL_PixelFormat* fmt);
+    void create_buffers(void);
     void destroy_buffers(void);
 
     GraphicsResources grphx;
@@ -39,17 +57,12 @@ public:
 
     bool Makebfont(void);
 
-    void drawhuetile(int x, int y, int t, SDL_Color ct);
     SDL_Color huetilegetcol(int t);
     SDL_Color bigchunkygetcol(int t);
 
     void drawgravityline(int t);
 
-    bool MakeTileArray(void);
-
     bool MakeSpriteArray(void);
-
-    bool maketelearray(void);
 
     void drawcoloredtile(int x, int y, int t, int r, int g, int b);
 
@@ -134,16 +147,62 @@ public:
 
     void drawimagecol(int t, int xp, int yp, SDL_Color ct, bool cent= false);
 
+    void draw_texture(SDL_Texture* image, int x, int y);
+
+    void draw_texture_part(SDL_Texture* image, int x, int y, int x2, int y2, int w, int h, int scalex, int scaley);
+
+    void draw_grid_tile(SDL_Texture* texture, int t, int x, int y, int width, int height, int scalex, int scaley);
+    void draw_grid_tile(SDL_Texture* texture, int t, int x, int y, int width, int height);
+    void draw_grid_tile(SDL_Texture* texture, int t, int x, int y, int width, int height, int r, int g, int b, int a, int scalex, int scaley);
+    void draw_grid_tile(SDL_Texture* texture, int t, int x, int y, int width, int height, int r, int g, int b, int a);
+    void draw_grid_tile(SDL_Texture* texture, int t, int x, int y, int width, int height, int r, int g, int b, int scalex, int scaley);
+    void draw_grid_tile(SDL_Texture* texture, int t, int x, int y, int width, int height, int r, int g, int b);
+    void draw_grid_tile(SDL_Texture* texture, int t, int x, int y, int width, int height, SDL_Color color, int scalex, int scaley);
+    void draw_grid_tile(SDL_Texture* texture, int t, int x, int y, int width, int height, SDL_Color color);
+
     void updatetextboxes(void);
     void drawgui(void);
 
-    void drawsprite(int x, int y, int t, int r, int g, int b);
-    void drawsprite(int x, int y, int t, SDL_Color color);
+    void draw_sprite(int x, int y, int t, int r, int g, int b);
+    void draw_sprite(int x, int y, int t, SDL_Color color);
+
+    void scroll_texture(SDL_Texture* texture, int x, int y);
 
     void printcrewname(int x, int y, int t);
     void printcrewnamedark(int x, int y, int t);
 
     void printcrewnamestatus(int x, int y, int t, bool rescued);
+
+    int set_render_target(SDL_Texture* texture);
+
+    int set_texture_color_mod(SDL_Texture* texture, Uint8 r, Uint8 g, Uint8 b);
+
+    int set_texture_alpha_mod(SDL_Texture* texture, Uint8 alpha);
+
+    int query_texture(SDL_Texture* texture, Uint32* format, int* access, int* w, int* h);
+
+    int set_blendmode(SDL_BlendMode blendmode);
+    int set_blendmode(SDL_Texture* texture, SDL_BlendMode blendmode);
+
+    int clear(int r, int g, int b, int a);
+    int clear();
+
+    int copy_texture(SDL_Texture* texture, const SDL_Rect* src, const SDL_Rect* dest);
+    int copy_texture(SDL_Texture* texture, const SDL_Rect* src, const SDL_Rect* dest, double angle, const SDL_Point* center, SDL_RendererFlip flip);
+
+    int set_color(Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+    int set_color(Uint8 r, Uint8 g, Uint8 b);
+    int set_color(SDL_Color color);
+
+    int fill_rect(const SDL_Rect* rect, int r, int g, int b, int a);
+    int fill_rect(int x, int y, int w, int h, int r, int g, int b, int a);
+    int fill_rect(int x, int y, int w, int h, int r, int g, int b);
+    int fill_rect(int r, int g, int b, int a);
+    int fill_rect(const SDL_Rect* rect, int r, int g, int b);
+    int fill_rect(int r, int g, int b);
+    int fill_rect(const SDL_Rect* rect, SDL_Color color);
+    int fill_rect(int x, int y, int w, int h, SDL_Color color);
+    int fill_rect(SDL_Color color);
 
     void map_tab(int opt, const char* text, bool selected = false);
 
@@ -261,28 +320,22 @@ public:
 
     int m;
 
-    std::vector <SDL_Surface*> images;
+    std::vector <SDL_Surface*> sprites_surf;
+    std::vector <SDL_Surface*> flipsprites_surf;
 
-    std::vector <SDL_Surface*> tele;
-    std::vector <SDL_Surface*> tiles;
-    std::vector <SDL_Surface*> tiles2;
-    std::vector <SDL_Surface*> tiles3;
-    std::vector <SDL_Surface*> entcolours;
-    std::vector <SDL_Surface*> sprites;
-    std::vector <SDL_Surface*> flipsprites;
-    std::vector <SDL_Surface*> bfont;
-    std::vector <SDL_Surface*> flipbfont;
+    SDL_Texture* images[NUM_IMAGES];
 
     bool flipmode;
     bool setflipmode;
     bool notextoutline;
-    //buffer objects. //TODO refactor buffer objects
-    SDL_Surface* backBuffer;
-    SDL_Surface* menubuffer;
-    SDL_Surface* foregroundBuffer;
-    SDL_Surface* menuoffbuffer;
-    SDL_Surface* warpbuffer;
-    SDL_Surface* warpbuffer_lerp;
+
+    SDL_Texture* gameTexture;
+    SDL_Texture* tempTexture;
+    SDL_Texture* gameplayTexture;
+    SDL_Texture* menuTexture;
+    SDL_Texture* ghostTexture;
+    SDL_Texture* backgroundTexture;
+    SDL_Texture* foregroundTexture;
 
     TowerBG towerbg;
     TowerBG titlebg;
@@ -291,11 +344,9 @@ public:
     SDL_Rect sprites_rect;
     SDL_Rect line_rect;
     SDL_Rect tele_rect;
-    SDL_Rect towerbuffer_rect;
 
     SDL_Rect prect;
     SDL_Rect footerrect;
-    SDL_Surface* footerbuffer;
 
     int linestate, linedelay;
     int backoffset;
@@ -339,8 +390,6 @@ public:
     bool translucentroomname;
 
     std::map<int, int> font_positions;
-
-    SDL_Surface* ghostbuffer;
 
 #ifndef GAME_DEFINITION
     float inline lerp(const float v0, const float v1)

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -2,7 +2,9 @@
 
 #include "Alloc.h"
 #include "FileSystemUtils.h"
+#include "GraphicsUtil.h"
 #include "Vlogging.h"
+#include "Screen.h"
 
 // Used to load PNG data
 extern "C"
@@ -17,19 +19,15 @@ extern "C"
     extern const char* lodepng_error_text(unsigned code);
 }
 
-/* Don't declare `static`, this is used elsewhere */
-SDL_Surface* LoadImage(const char *filename)
+static SDL_Surface* LoadImageRaw(const char* filename, unsigned char** data)
 {
     //Temporary storage for the image that's loaded
     SDL_Surface* loadedImage = NULL;
-    //The optimized image that will be used
-    SDL_Surface* optimizedImage = NULL;
 
-    unsigned char *data;
     unsigned int width, height;
     unsigned int error;
 
-    unsigned char *fileIn;
+    unsigned char* fileIn;
     size_t length;
     FILESYSTEM_loadAssetToMemory(filename, &fileIn, &length, false);
     if (fileIn == NULL)
@@ -37,7 +35,7 @@ SDL_Surface* LoadImage(const char *filename)
         SDL_assert(0 && "Image file missing!");
         return NULL;
     }
-    error = lodepng_decode32(&data, &width, &height, fileIn, length);
+    error = lodepng_decode32(data, &width, &height, fileIn, length);
     VVV_free(fileIn);
 
     if (error != 0)
@@ -47,7 +45,7 @@ SDL_Surface* LoadImage(const char *filename)
     }
 
     loadedImage = SDL_CreateRGBSurfaceWithFormatFrom(
-        data,
+        *data,
         width,
         height,
         32,
@@ -55,61 +53,260 @@ SDL_Surface* LoadImage(const char *filename)
         SDL_PIXELFORMAT_ABGR8888
     );
 
+    return loadedImage;
+}
+
+static SDL_Surface* LoadSurfaceFromRaw(SDL_Surface* loadedImage)
+{
+    SDL_Surface* optimizedImage = SDL_ConvertSurfaceFormat(
+        loadedImage,
+        SDL_PIXELFORMAT_ARGB8888,
+        0
+    );
+    SDL_SetSurfaceBlendMode(optimizedImage, SDL_BLENDMODE_BLEND);
+    return optimizedImage;
+}
+
+/* Can't be static, used in Screen.h */
+SDL_Surface* LoadImageSurface(const char* filename)
+{
+    unsigned char* data;
+
+    SDL_Surface* loadedImage = LoadImageRaw(filename, &data);
+
+    SDL_Surface* optimizedImage = LoadSurfaceFromRaw(loadedImage);
     if (loadedImage != NULL)
     {
-        optimizedImage = SDL_ConvertSurfaceFormat(
-            loadedImage,
-            SDL_PIXELFORMAT_ARGB8888,
-            0
-        );
         VVV_freefunc(SDL_FreeSurface, loadedImage);
-        VVV_free(data);
-        SDL_SetSurfaceBlendMode(optimizedImage, SDL_BLENDMODE_BLEND);
-        return optimizedImage;
     }
-    else
+
+    VVV_free(data);
+
+    if (optimizedImage == NULL)
     {
         VVV_free(data);
         vlog_error("Image not found: %s", filename);
         SDL_assert(0 && "Image not found! See stderr.");
+    }
+
+    return optimizedImage;
+}
+
+static SDL_Texture* LoadTextureFromRaw(const char* filename, SDL_Surface* loadedImage, const TextureLoadType loadtype)
+{
+    if (loadedImage == NULL)
+    {
         return NULL;
     }
+
+    // Modify the surface with the load type.
+    // This could be done in LoadImageRaw, however currently, surfaces are only used for
+    // pixel perfect collision (which will be changed later) and the window icon.
+
+    switch (loadtype)
+    {
+    case TEX_WHITE:
+        SDL_LockSurface(loadedImage);
+        for (int y = 0; y < loadedImage->h; y++)
+        {
+            for (int x = 0; x < loadedImage->w; x++)
+            {
+                SDL_Color color = ReadPixel(loadedImage, x, y);
+                color.r = 255;
+                color.g = 255;
+                color.b = 255;
+                DrawPixel(loadedImage, x, y, color);
+            }
+        }
+        SDL_UnlockSurface(loadedImage);
+        break;
+    case TEX_GRAYSCALE:
+        SDL_LockSurface(loadedImage);
+        for (int y = 0; y < loadedImage->h; y++)
+        {
+            for (int x = 0; x < loadedImage->w; x++)
+            {
+                SDL_Color color = ReadPixel(loadedImage, x, y);
+
+                // Magic numbers used for grayscaling (eyes perceive certain colors brighter than others)
+                Uint8 r = color.r * 0.299;
+                Uint8 g = color.g * 0.587;
+                Uint8 b = color.b * 0.114;
+
+                const double gray = SDL_floor(r + g + b + 0.5);
+
+                color.r = gray;
+                color.g = gray;
+                color.b = gray;
+
+                DrawPixel(loadedImage, x, y, color);
+            }
+        }
+        SDL_UnlockSurface(loadedImage);
+        break;
+    default:
+        break;
+    }
+
+    //Create texture from surface pixels
+    SDL_Texture* texture = SDL_CreateTextureFromSurface(gameScreen.m_renderer, loadedImage);
+    if (texture == NULL)
+    {
+        vlog_error("Failed creating texture: %s. SDL error: %s\n", filename, SDL_GetError());
+    }
+
+    return texture;
+}
+
+static SDL_Texture* LoadImage(const char *filename, const TextureLoadType loadtype)
+{
+    unsigned char* data;
+
+    SDL_Surface* loadedImage = LoadImageRaw(filename, &data);
+
+    SDL_Texture* texture = LoadTextureFromRaw(filename, loadedImage, loadtype);
+
+    if (loadedImage != NULL)
+    {
+        VVV_freefunc(SDL_FreeSurface, loadedImage);
+    }
+
+    VVV_free(data);
+
+    if (texture == NULL)
+    {
+        vlog_error("Image not found: %s", filename);
+        SDL_assert(0 && "Image not found! See stderr.");
+    }
+
+    return texture;
+}
+
+static SDL_Texture* LoadImage(const char* filename)
+{
+    return LoadImage(filename, TEX_COLOR);
+}
+
+/* Any unneeded variants can be NULL */
+static void LoadVariants(const char* filename, SDL_Texture** colored, SDL_Texture** white, SDL_Texture** grayscale)
+{
+    unsigned char* data;
+    SDL_Surface* loadedImage = LoadImageRaw(filename, &data);
+
+    if (colored != NULL)
+    {
+        *colored = LoadTextureFromRaw(filename, loadedImage, TEX_COLOR);
+        if (*colored == NULL)
+        {
+            vlog_error("Image not found: %s", filename);
+            SDL_assert(0 && "Image not found! See stderr.");
+        }
+    }
+
+    if (grayscale != NULL)
+    {
+        *grayscale = LoadTextureFromRaw(filename, loadedImage, TEX_GRAYSCALE);
+        if (*grayscale == NULL)
+        {
+            vlog_error("Image not found: %s", filename);
+            SDL_assert(0 && "Image not found! See stderr.");
+        }
+    }
+
+    if (white != NULL)
+    {
+        *white = LoadTextureFromRaw(filename, loadedImage, TEX_WHITE);
+        if (*white == NULL)
+        {
+            vlog_error("Image not found: %s", filename);
+            SDL_assert(0 && "Image not found! See stderr.");
+        }
+    }
+
+    if (loadedImage != NULL)
+    {
+        VVV_freefunc(SDL_FreeSurface, loadedImage);
+    }
+
+    VVV_free(data);
+}
+
+/* The pointers `texture` and `surface` cannot be NULL */
+static void LoadSprites(const char* filename, SDL_Texture** texture, SDL_Surface** surface)
+{
+    unsigned char* data;
+    SDL_Surface* loadedImage = LoadImageRaw(filename, &data);
+
+    *texture = LoadTextureFromRaw(filename, loadedImage, TEX_WHITE);
+    if (*texture == NULL)
+    {
+        vlog_error("Image not found: %s", filename);
+        SDL_assert(0 && "Image not found! See stderr.");
+    }
+
+    *surface = LoadSurfaceFromRaw(loadedImage);
+    if (*surface == NULL)
+    {
+        vlog_error("Image not found: %s", filename);
+        SDL_assert(0 && "Image not found! See stderr.");
+    }
+
+    if (loadedImage != NULL)
+    {
+        VVV_freefunc(SDL_FreeSurface, loadedImage);
+    }
+
+    VVV_free(data);
 }
 
 void GraphicsResources::init(void)
 {
-    im_tiles =        LoadImage("graphics/tiles.png");
-    im_tiles2 =        LoadImage("graphics/tiles2.png");
-    im_tiles3 =        LoadImage("graphics/tiles3.png");
-    im_entcolours =        LoadImage("graphics/entcolours.png");
-    im_sprites =        LoadImage("graphics/sprites.png");
-    im_flipsprites =    LoadImage("graphics/flipsprites.png");
-    im_bfont =        LoadImage("graphics/font.png");
-    im_teleporter =        LoadImage("graphics/teleporter.png");
+    LoadVariants("graphics/tiles.png", &im_tiles, &im_tiles_white, &im_tiles_tint);
+    LoadVariants("graphics/tiles2.png", &im_tiles2, NULL, &im_tiles2_tint);
+    LoadVariants("graphics/entcolours.png", &im_entcolours, NULL, &im_entcolours_tint);
 
-    im_image0 =        LoadImage("graphics/levelcomplete.png");
-    im_image1 =        LoadImage("graphics/minimap.png");
-    im_image2 =        LoadImage("graphics/covered.png");
-    im_image3 =        LoadImage("graphics/elephant.png");
-    im_image4 =        LoadImage("graphics/gamecomplete.png");
-    im_image5 =        LoadImage("graphics/fliplevelcomplete.png");
-    im_image6 =        LoadImage("graphics/flipgamecomplete.png");
-    im_image7 =        LoadImage("graphics/site.png");
-    im_image8 =        LoadImage("graphics/site2.png");
-    im_image9 =        LoadImage("graphics/site3.png");
-    im_image10 =        LoadImage("graphics/ending.png");
-    im_image11 =        LoadImage("graphics/site4.png");
-    im_image12 =        LoadImage("graphics/minimap.png");
+    LoadSprites("graphics/sprites.png", &im_sprites, &im_sprites_surf);
+    LoadSprites("graphics/flipsprites.png", &im_flipsprites, &im_flipsprites_surf);
+
+    im_tiles3 = LoadImage("graphics/tiles3.png");
+    im_bfont = LoadImage("graphics/font.png", TEX_WHITE);
+    im_teleporter = LoadImage("graphics/teleporter.png", TEX_WHITE);
+
+    im_image0 = LoadImage("graphics/levelcomplete.png");
+    im_image1 = LoadImage("graphics/minimap.png");
+    im_image2 = LoadImage("graphics/covered.png");
+    im_image3 = LoadImage("graphics/elephant.png", TEX_WHITE);
+    im_image4 = LoadImage("graphics/gamecomplete.png");
+    im_image5 = LoadImage("graphics/fliplevelcomplete.png");
+    im_image6 = LoadImage("graphics/flipgamecomplete.png");
+    im_image7 = LoadImage("graphics/site.png", TEX_WHITE);
+    im_image8 = LoadImage("graphics/site2.png", TEX_WHITE);
+    im_image9 = LoadImage("graphics/site3.png", TEX_WHITE);
+    im_image10 = LoadImage("graphics/ending.png");
+    im_image11 = LoadImage("graphics/site4.png", TEX_WHITE);
+
+    im_image12 = SDL_CreateTexture(gameScreen.m_renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET, 240, 180);
+
+    if (im_image12 == NULL)
+    {
+        vlog_error("Failed to create minimap texture: %s", SDL_GetError());
+        SDL_assert(0 && "Failed to create minimap texture! See stderr.");
+        return;
+    }
 }
 
 
 void GraphicsResources::destroy(void)
 {
-#define CLEAR(img) VVV_freefunc(SDL_FreeSurface, img)
+#define CLEAR(img) VVV_freefunc(SDL_DestroyTexture, img)
     CLEAR(im_tiles);
+    CLEAR(im_tiles_white);
+    CLEAR(im_tiles_tint);
     CLEAR(im_tiles2);
+    CLEAR(im_tiles2_tint);
     CLEAR(im_tiles3);
     CLEAR(im_entcolours);
+    CLEAR(im_entcolours_tint);
     CLEAR(im_sprites);
     CLEAR(im_flipsprites);
     CLEAR(im_bfont);
@@ -129,4 +326,7 @@ void GraphicsResources::destroy(void)
     CLEAR(im_image11);
     CLEAR(im_image12);
 #undef CLEAR
+
+    VVV_freefunc(SDL_FreeSurface, im_sprites_surf);
+    VVV_freefunc(SDL_FreeSurface, im_flipsprites_surf);
 }

--- a/desktop_version/src/GraphicsResources.h
+++ b/desktop_version/src/GraphicsResources.h
@@ -3,33 +3,47 @@
 
 #include <SDL.h>
 
+enum TextureLoadType
+{
+    TEX_COLOR,
+    TEX_WHITE,
+    TEX_GRAYSCALE
+};
+
 class GraphicsResources
 {
 public:
     void init(void);
     void destroy(void);
 
-    SDL_Surface* im_tiles;
-    SDL_Surface* im_tiles2;
-    SDL_Surface* im_tiles3;
-    SDL_Surface* im_entcolours;
-    SDL_Surface* im_sprites;
-    SDL_Surface* im_flipsprites;
-    SDL_Surface* im_bfont;
-    SDL_Surface* im_teleporter;
-    SDL_Surface* im_image0;
-    SDL_Surface* im_image1;
-    SDL_Surface* im_image2;
-    SDL_Surface* im_image3;
-    SDL_Surface* im_image4;
-    SDL_Surface* im_image5;
-    SDL_Surface* im_image6;
-    SDL_Surface* im_image7;
-    SDL_Surface* im_image8;
-    SDL_Surface* im_image9;
-    SDL_Surface* im_image10;
-    SDL_Surface* im_image11;
-    SDL_Surface* im_image12;
+    SDL_Surface* im_sprites_surf;
+    SDL_Surface* im_flipsprites_surf;
+
+    SDL_Texture* im_tiles;
+    SDL_Texture* im_tiles_white;
+    SDL_Texture* im_tiles_tint;
+    SDL_Texture* im_tiles2;
+    SDL_Texture* im_tiles2_tint;
+    SDL_Texture* im_tiles3;
+    SDL_Texture* im_entcolours;
+    SDL_Texture* im_entcolours_tint;
+    SDL_Texture* im_sprites;
+    SDL_Texture* im_flipsprites;
+    SDL_Texture* im_bfont;
+    SDL_Texture* im_teleporter;
+    SDL_Texture* im_image0;
+    SDL_Texture* im_image1;
+    SDL_Texture* im_image2;
+    SDL_Texture* im_image3;
+    SDL_Texture* im_image4;
+    SDL_Texture* im_image5;
+    SDL_Texture* im_image6;
+    SDL_Texture* im_image7;
+    SDL_Texture* im_image8;
+    SDL_Texture* im_image9;
+    SDL_Texture* im_image10;
+    SDL_Texture* im_image11;
+    SDL_Texture* im_image12;
 };
 
 #endif /* GRAPHICSRESOURCES_H */

--- a/desktop_version/src/GraphicsUtil.h
+++ b/desktop_version/src/GraphicsUtil.h
@@ -7,36 +7,11 @@ void setRect(SDL_Rect& _r, int x, int y, int w, int h);
 
 SDL_Surface* GetSubSurface( SDL_Surface* metaSurface, int x, int y, int width, int height );
 
+void DrawPixel(SDL_Surface* surface, int x, int y, SDL_Color color);
+
 SDL_Color ReadPixel(const SDL_Surface* surface, int x, int y);
 
-SDL_Surface * ScaleSurface( SDL_Surface *Surface, int Width, int Height, SDL_Surface * Dest = NULL );
-
-void BlitSurfaceStandard( SDL_Surface* _src, SDL_Rect* _srcRect, SDL_Surface* _dest, SDL_Rect* _destRect );
-
-void BlitSurfaceColoured(SDL_Surface* src, const SDL_Rect* src_rect, SDL_Surface* dest, SDL_Rect* dest_rect, SDL_Color color);
-
-void BlitSurfaceTinted(SDL_Surface* src, const SDL_Rect* src_rect, SDL_Surface* dest, SDL_Rect* dest_rect, SDL_Color color);
-
-void FillRect( SDL_Surface* surface, const int x, const int y, const int w, const int h, const int r, int g, int b );
-
-void FillRect( SDL_Surface* surface, const int r, int g, int b );
-
-void FillRect( SDL_Surface* surface, SDL_Rect& rect, const int r, int g, int b );
-
-void FillRect(SDL_Surface* surface, SDL_Rect rect, SDL_Color color);
-
-void FillRect(SDL_Surface* surface, SDL_Color color);
-
-void FillRect(SDL_Surface* surface, int x, int y, int w, int h, SDL_Color color);
-
-void FillRect(SDL_Surface* surface, int r, int g, int b, int a);
-
-void ClearSurface(SDL_Surface* surface);
-
-void ScrollSurface(SDL_Surface* _src, int pX, int py);
-
-SDL_Surface * FlipSurfaceVerticle(SDL_Surface* _src);
 void UpdateFilter(void);
-SDL_Surface* ApplyFilter( SDL_Surface* _src );
+void ApplyFilter(void);
 
 #endif /* GRAPHICSUTIL_H */

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -3072,9 +3072,6 @@ static void mapmenuactionpress(const bool version2_2)
     case 11:
         //quit to menu
 
-        //Kill contents of offset render buffer, since we do that for some reason.
-        //This fixes an apparent frame flicker.
-        ClearSurface(graphics.menuoffbuffer);
         graphics.fademode = FADE_START_FADEOUT;
         music.fadeout();
         map.nexttowercolour();

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -361,6 +361,7 @@ void KeyPoll::Poll(void)
                     }
                 }
                 SDL_DisableScreenSaver();
+                gameScreen.recacheTextures();
                 break;
             case SDL_WINDOWEVENT_FOCUS_LOST:
                 if (!game.disablepause)

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1406,15 +1406,18 @@ void gamelogic(void)
     if (map.finalmode && map.final_colormode)
     {
         map.final_aniframedelay--;
-        if(map.final_aniframedelay==0)
+        if (map.final_aniframedelay == 0)
         {
-            graphics.foregrounddrawn=false;
+            graphics.foregrounddrawn = false;
         }
-        if (map.final_aniframedelay <= 0) {
+        if (map.final_aniframedelay <= 0)
+        {
             map.final_aniframedelay = 2;
             map.final_aniframe++;
             if (map.final_aniframe >= 4)
+            {
                 map.final_aniframe = 0;
+            }
         }
     }
 

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1085,7 +1085,7 @@ void mapclass::gotoroom(int rx, int ry)
     //Do we need to reload the background?
     bool redrawbg = game.roomx != game.prevroomx || game.roomy != game.prevroomy;
 
-    if(redrawbg)
+    if (redrawbg)
     {
         graphics.backgrounddrawn = false; //Used for background caching speedup
     }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -147,12 +147,12 @@ static void menurender(void)
     case Menu::mainmenu:
     {
         const int temp = 50;
-        graphics.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
-        graphics.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
-        graphics.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
-        graphics.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
-        graphics.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
-        graphics.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
 #if defined(MAKEANDPLAY)
         const char* editionlabel = loc::gettext("MAKE AND PLAY EDITION");
         graphics.Print(264-graphics.len(editionlabel),temp+35,editionlabel,tr, tg, tb);
@@ -435,16 +435,16 @@ static void menurender(void)
         graphics.Print( -1, 50, loc::gettext("VVVVVV is a game by"), tr, tg, tb, true);
         graphics.bigprint( 40, 65, "Terry Cavanagh", tr, tg, tb, true, 2);
 
-        graphics.drawimagecol(7, -1, 86, graphics.getRGB(tr, tg, tb), true);
+        graphics.drawimagecol(IMAGE_SITE, -1, 86, graphics.getRGB(tr, tg, tb), true);
 
         graphics.Print( -1, 120, loc::gettext("and features music by"), tr, tg, tb, true);
         graphics.bigprint( 40, 135, "Magnus Pålsson", tr, tg, tb, true, 2);
-        graphics.drawimagecol(8, -1, 156, graphics.getRGB(tr, tg, tb), true);
+        graphics.drawimagecol(IMAGE_SITE2, -1, 156, graphics.getRGB(tr, tg, tb), true);
         break;
     case Menu::credits2:
         graphics.Print( -1, 50, loc::gettext("Roomnames are by"), tr, tg, tb, true);
         graphics.bigprint( 40, 65, "Bennett Foddy", tr, tg, tb, true);
-        graphics.drawimagecol(9, -1, 86, graphics.getRGB(tr, tg, tb), true);
+        graphics.drawimagecol(IMAGE_SITE3, -1, 86, graphics.getRGB(tr, tg, tb), true);
         graphics.Print( -1, 110, loc::gettext("C++ version by"), tr, tg, tb, true);
         graphics.bigprint( 40, 125, "Simon Roth", tr, tg, tb, true);
         graphics.bigprint( 40, 145, "Ethan Lee", tr, tg, tb, true);
@@ -713,7 +713,7 @@ static void menurender(void)
 
             int box_x = SDL_min(10, (320-overflow.max_w_px)/2);
             int box_h = overflow.max_h_px - SDL_max(0, 10-loc::get_langmeta()->font_h);
-            FillRect(graphics.backBuffer, box_x-1, 30-1, overflow.max_w_px+2, box_h+2, tr/3, tg/3, tb/3);
+            graphics.fill_rect(box_x-1, 30-1, overflow.max_w_px+2, box_h+2, tr/3, tg/3, tb/3);
 
             int wraplimit;
             if (overflow.multiline)
@@ -1029,7 +1029,7 @@ static void menurender(void)
             graphics.bigprint(-1, 30, loc::gettext("Text Outline"), tr, tg, tb, true);
             int next_y = graphics.PrintWrap(-1, 65, loc::gettext("Disables outline on game text."), tr, tg, tb, true);
 
-            FillRect(graphics.backBuffer, 0, next_y-4, 320, 16, tr, tg, tb);
+            graphics.fill_rect(0, next_y-4, 320, 16, tr, tg, tb);
 
             if (!graphics.notextoutline)
             {
@@ -1142,8 +1142,8 @@ static void menurender(void)
             );
             graphics.Print(262-graphics.len(buffer), 132-20, buffer, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-            graphics.drawsprite(34, 126-20, 50, graphics.col_clock);
-            graphics.drawsprite(270, 126-20, 22, graphics.col_trinket);
+            graphics.draw_sprite(34, 126-20, 50, graphics.col_clock);
+            graphics.draw_sprite(270, 126-20, 22, graphics.col_trinket);
             break;
         }
         case 1:
@@ -1166,8 +1166,8 @@ static void menurender(void)
             );
             graphics.Print(262-graphics.len(buffer), 132-20, buffer, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
-            graphics.drawsprite(34, 126-20, 50, graphics.col_clock);
-            graphics.drawsprite(270, 126-20, 22, graphics.col_trinket);
+            graphics.draw_sprite(34, 126-20, 50, graphics.col_clock);
+            graphics.draw_sprite(270, 126-20, 22, graphics.col_trinket);
             break;
         }
         }
@@ -1597,9 +1597,7 @@ static void menurender(void)
 
 void titlerender(void)
 {
-
-    ClearSurface(graphics.backBuffer);
-
+    graphics.clear();
     if (!game.menustart)
     {
         tr = graphics.col_tr;
@@ -1607,12 +1605,12 @@ void titlerender(void)
         tb = graphics.col_tb;
 
         int temp = 50;
-        graphics.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
-        graphics.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
-        graphics.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
-        graphics.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
-        graphics.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
-        graphics.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
 #if defined(MAKEANDPLAY)
         const char* editionlabel = loc::gettext("MAKE AND PLAY EDITION");
         graphics.Print(264-graphics.len(editionlabel),temp+35,editionlabel,tr, tg, tb);
@@ -1650,7 +1648,7 @@ void titlerender(void)
 
 void gamecompleterender(void)
 {
-    ClearSurface(graphics.backBuffer);
+    graphics.clear();
 
     if(!game.colourblindmode) graphics.drawtowerbackground(graphics.titlebg);
 
@@ -1665,12 +1663,12 @@ void gamecompleterender(void)
     if (graphics.onscreen(220 + position))
     {
         int temp = 220 + position;
-        graphics.drawsprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
-        graphics.drawsprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
-        graphics.drawsprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
-        graphics.drawsprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
-        graphics.drawsprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
-        graphics.drawsprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 0 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 1 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 2 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 3 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 4 * 32, temp, 23, tr, tg, tb);
+        graphics.draw_sprite((160 - 96) + 5 * 32, temp, 23, tr, tg, tb);
     }
 
     if (graphics.onscreen(290 + position)) graphics.bigprint( -1, 290 + position, loc::gettext("Starring"), tr, tg, tb, true, 2);
@@ -1802,9 +1800,9 @@ void gamecompleterender(void)
 
 void gamecompleterender2(void)
 {
-    ClearSurface(graphics.backBuffer);
+    graphics.clear();
 
-    graphics.drawimage(10, 0, 0);
+    graphics.drawimage(IMAGE_ENDING, 0, 0);
 
     for (int j = 0; j < 30; j++)
     {
@@ -1814,18 +1812,18 @@ void gamecompleterender2(void)
             {
                 if (i > game.creditposx)
                 {
-                    FillRect(graphics.backBuffer, i * 8, j * 8, 8, 8, 0, 0, 0);
+                    graphics.fill_rect(i * 8, j * 8, 8, 8, 0, 0, 0);
                 }
             }
 
             if (j > game.creditposy)
             {
-                FillRect(graphics.backBuffer, i * 8, j * 8, 8, 8, 0, 0, 0);
+                graphics.fill_rect(i * 8, j * 8, 8, 8, 0, 0, 0);
             }
         }
     }
 
-    FillRect(graphics.backBuffer, graphics.lerp(game.oldcreditposx * 8, game.creditposx * 8) + 8, game.creditposy * 8, 8, 8, 0, 0, 0);
+    graphics.fill_rect(graphics.lerp(game.oldcreditposx * 8, game.creditposx * 8) + 8, game.creditposy * 8, 8, 8, 0, 0, 0);
 
     graphics.drawfade();
 
@@ -1855,12 +1853,11 @@ static const char* interact_prompt(
 
 void gamerender(void)
 {
-
-
+    graphics.set_render_target(graphics.gameplayTexture);
+    graphics.set_color(0, 0, 0, 255);
 
     if(!game.blackout)
     {
-
         if (map.towermode)
         {
             if (!game.colourblindmode)
@@ -1869,7 +1866,7 @@ void gamerender(void)
             }
             else
             {
-                ClearSurface(graphics.backBuffer);
+                graphics.clear();
             }
             graphics.drawtowermap();
         }
@@ -1881,7 +1878,7 @@ void gamerender(void)
             }
             else
             {
-                ClearSurface(graphics.backBuffer);
+                graphics.clear();
             }
             if ((map.finalmode || map.custommode) && map.final_colormode)
             {
@@ -1962,7 +1959,10 @@ void gamerender(void)
 
     graphics.cutscenebars();
     graphics.drawfade();
-    BlitSurfaceStandard(graphics.backBuffer, NULL, graphics.menuoffbuffer, NULL);
+
+    graphics.set_render_target(graphics.gameTexture);
+
+    graphics.copy_texture(graphics.gameplayTexture, NULL, NULL);
 
     graphics.drawgui();
     if (graphics.flipmode)
@@ -2280,13 +2280,13 @@ static void rendermap(void)
     if (map.custommode && map.customshowmm)
     {
         graphics.drawpixeltextbox(35 + map.custommmxoff, 16 + map.custommmyoff, map.custommmxsize + 10, map.custommmysize + 10, 65, 185, 207);
-        graphics.drawpartimage(graphics.minimap_mounted ? 1 : 12, 40 + map.custommmxoff, 21 + map.custommmyoff, map.custommmxsize, map.custommmysize);
+        graphics.drawpartimage(graphics.minimap_mounted ? IMAGE_MINIMAP : IMAGE_CUSTOMMINIMAP, 40 + map.custommmxoff, 21 + map.custommmyoff, map.custommmxsize, map.custommmysize);
         return;
      }
 #endif /* NO_CUSTOM_LEVELS */
 
     graphics.drawpixeltextbox(35, 16, 250, 190, 65, 185, 207);
-    graphics.drawimage(1, 40, 21, false);
+    graphics.drawimage(IMAGE_MINIMAP, 40, 21, false);
 }
 
 static void rendermapfog(void)
@@ -2304,7 +2304,7 @@ static void rendermapfog(void)
                 {
                     for (int y = 0; y < data.zoom; y++)
                     {
-                        graphics.drawimage(2, data.xoff + 40 + (x * 12) + (i * (12 * data.zoom)), data.yoff + 21 + (y * 9) + (j * (9 * data.zoom)), false);
+                        graphics.drawimage(IMAGE_COVERED, data.xoff + 40 + (x * 12) + (i * (12 * data.zoom)), data.yoff + 21 + (y * 9) + (j * (9 * data.zoom)), false);
                     }
                 }
             }
@@ -2383,12 +2383,13 @@ static void rendermapcursor(const bool flashing)
 
 void maprender(void)
 {
-    ClearSurface(graphics.backBuffer);
+    graphics.set_render_target(graphics.menuTexture);
+    graphics.clear();
 
     draw_roomname_menu();
 
     //Background color
-    FillRect(graphics.backBuffer,0, 12, 320, 240, 10, 24, 26 );
+    graphics.fill_rect(0, 12, 320, 240, 10, 24, 26 );
 
     //Menubar:
     graphics.drawtextbox( -10, 212, 43, 3, 65, 185, 207);
@@ -2458,7 +2459,7 @@ void maprender(void)
             {
                 for (int i = 0; i < 20; i++)
                 {
-                    graphics.drawimage(2, 40 + (i * 12), 21 + (j * 9), false);
+                    graphics.drawimage(IMAGE_COVERED, 40 + (i * 12), 21 + (j * 9), false);
                 }
             }
             graphics.bprint(-1, 105, loc::gettext("NO SIGNAL"), 245, 245, 245, true);
@@ -2746,8 +2747,8 @@ void maprender(void)
         );
         graphics.Print(262 - graphics.len(buffer), FLIP(132, 8), buffer, 255 - help.glow/2, 255 - help.glow/2, 255 - help.glow/2);
 
-        graphics.drawsprite(34, FLIP(126, 17), 50, graphics.col_clock);
-        graphics.drawsprite(270, FLIP(126, 17), 22, graphics.col_trinket);
+        graphics.draw_sprite(34, FLIP(126, 17), 50, graphics.col_clock);
+        graphics.draw_sprite(270, FLIP(126, 17), 22, graphics.col_trinket);
         break;
     }
     case 10:
@@ -2851,19 +2852,7 @@ void maprender(void)
 
     }
 
-
-
-
-    // We need to draw the black screen above the menu in order to disguise it
-    // being jankily brought down in glitchrunner mode when exiting to the title
-    // Otherwise, there's no reason to obscure the menu
-    if (GlitchrunnerMode_less_than_or_equal(Glitchrunner2_2)
-    || FADEMODE_IS_FADING(graphics.fademode)
-    || game.fadetomenu
-    || game.fadetolab)
-    {
-        graphics.drawfade();
-    }
+    graphics.set_render_target(graphics.gameTexture);
 
     if (graphics.resumegamemode || graphics.menuoffset > 0 || graphics.oldmenuoffset > 0)
     {
@@ -2871,22 +2860,38 @@ void maprender(void)
     }
     else
     {
-        graphics.renderwithscreeneffects();
+        graphics.copy_texture(graphics.menuTexture, NULL, NULL);
     }
+
+    // We need to draw the black screen above the menu in order to disguise it
+    // being jankily brought down in glitchrunner mode when exiting to the title
+    // Otherwise, there's no reason to obscure the menu
+    if (GlitchrunnerMode_less_than_or_equal(Glitchrunner2_2)
+        || FADEMODE_IS_FADING(graphics.fademode)
+        || game.fadetomenu
+        || game.fadetolab)
+    {
+        graphics.drawfade();
+    }
+
+
+    graphics.renderwithscreeneffects();
 }
 
 #undef FLIP
 
 void teleporterrender(void)
 {
-    ClearSurface(graphics.backBuffer);
+    graphics.set_render_target(graphics.menuTexture);
+    graphics.clear();
+
     const int telex = map.teleporters[game.teleport_to_teleporter].x;
     const int teley = map.teleporters[game.teleport_to_teleporter].y;
 
     draw_roomname_menu();
 
     //Background color
-    FillRect(graphics.backBuffer, 0, 12, 320, 240, 10, 24, 26);
+    graphics.fill_rect(0, 12, 320, 240, 10, 24, 26);
 
     rendermap();
     rendermapfog();
@@ -2944,6 +2949,7 @@ void teleporterrender(void)
         if (game.advancetext) graphics.bprint(5, 5, loc::gettext("- Press ACTION to advance text -"), 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2), true);
     }
 
+    graphics.set_render_target(graphics.gameTexture);
 
     if (graphics.resumegamemode || graphics.menuoffset > 0 || graphics.oldmenuoffset > 0)
     {
@@ -2951,6 +2957,8 @@ void teleporterrender(void)
     }
     else
     {
-        graphics.render();
+        graphics.copy_texture(graphics.menuTexture, NULL, NULL);
     }
+
+    graphics.render();
 }

--- a/desktop_version/src/RoomnameTranslator.cpp
+++ b/desktop_version/src/RoomnameTranslator.cpp
@@ -3,6 +3,7 @@
 #include "Constants.h"
 #include "Game.h"
 #include "Graphics.h"
+#include "GraphicsUtil.h"
 #include "KeyPoll.h"
 #include "Localization.h"
 #include "LocalizationMaint.h"
@@ -54,7 +55,9 @@ namespace roomname_translator
             fullscreen_rect.y = 0;
             fullscreen_rect.w = 320;
             fullscreen_rect.h = 240;
-            SDL_BlitSurface(dimbuffer, NULL, graphics.backBuffer, &fullscreen_rect);
+            graphics.set_blendmode(SDL_BLENDMODE_BLEND);
+            graphics.fill_rect(0, 0, 0, 96);
+            graphics.set_blendmode(SDL_BLENDMODE_NONE);
             if (help_screen)
             {
                 graphics.bprint(0, 0, "=== Room name translation mode help ===", 255,255,255);

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -19,15 +19,14 @@ public:
     void ResizeToNearestMultiple(void);
     void GetWindowSize(int* x, int* y);
 
-    void UpdateScreen(SDL_Surface* buffer, SDL_Rect* rect);
-    void FlipScreen(bool flipmode);
-
-    const SDL_PixelFormat* GetFormat(void);
+    void RenderPresent();
 
     void toggleFullScreen(void);
     void toggleScalingMode(void);
     void toggleLinearFilter(void);
     void toggleVSync(void);
+
+    void recacheTextures(void);
 
     bool isForcedFullscreen(void);
 
@@ -39,8 +38,6 @@ public:
 
     SDL_Window *m_window;
     SDL_Renderer *m_renderer;
-    SDL_Texture *m_screenTexture;
-    SDL_Surface* m_screen;
 };
 
 #ifndef GAMESCREEN_DEFINITION

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -175,41 +175,54 @@ void scriptclass::run(void)
 #if !defined(NO_CUSTOM_LEVELS)
             if (words[0] == "warpdir")
             {
-                int temprx=ss_toi(words[1])-1;
-                int tempry=ss_toi(words[2])-1;
+                int temprx = ss_toi(words[1]) - 1;
+                int tempry = ss_toi(words[2]) - 1;
                 const RoomProperty* room;
                 cl.setroomwarpdir(temprx, tempry, ss_toi(words[3]));
 
                 room = cl.getroomprop(temprx, tempry);
 
                 //Do we update our own room?
-                if(game.roomx-100==temprx && game.roomy-100==tempry){
+                if (game.roomx - 100 == temprx && game.roomy - 100 == tempry)
+                {
                     //If screen warping, then override all that:
                     graphics.backgrounddrawn = false;
-                    map.warpx=false; map.warpy=false;
-                    if(room->warpdir==0){
+                    map.warpx = false;
+                    map.warpy = false;
+                    if (room->warpdir == 0)
+                    {
                         map.background = 1;
                         //Be careful, we could be in a Lab or Warp Zone room...
-                        if(room->tileset==2){
+                        if (room->tileset == 2)
+                        {
                             //Lab
                             map.background = 2;
                             graphics.rcol = room->tilecol;
-                        }else if(room->tileset==3){
+                        }
+                        else if (room->tileset == 3)
+                        {
                             //Warp Zone
                             map.background = 6;
                         }
-                    }else if(room->warpdir==1){
-                        map.warpx=true;
-                        map.background=3;
-                        graphics.rcol = cl.getwarpbackground(temprx,tempry);
-                    }else if(room->warpdir==2){
-                        map.warpy=true;
-                        map.background=4;
-                        graphics.rcol = cl.getwarpbackground(temprx,tempry);
-                    }else if(room->warpdir==3){
-                        map.warpx=true; map.warpy=true;
+                    }
+                    else if (room->warpdir == 1)
+                    {
+                        map.warpx = true;
+                        map.background = 3;
+                        graphics.rcol = cl.getwarpbackground(temprx, tempry);
+                    }
+                    else if (room->warpdir == 2)
+                    {
+                        map.warpy = true;
+                        map.background = 4;
+                        graphics.rcol = cl.getwarpbackground(temprx, tempry);
+                    }
+                    else if (room->warpdir == 3)
+                    {
+                        map.warpx = true;
+                        map.warpy = true;
                         map.background = 5;
-                        graphics.rcol = cl.getwarpbackground(temprx,tempry);
+                        graphics.rcol = cl.getwarpbackground(temprx, tempry);
                     }
                 }
             }

--- a/desktop_version/src/TowerBG.h
+++ b/desktop_version/src/TowerBG.h
@@ -5,8 +5,7 @@
 
 struct TowerBG
 {
-    SDL_Surface* buffer;
-    SDL_Surface* buffer_lerp;
+    SDL_Texture* texture;
     bool tdrawback;
     int bypos;
     int bscroll;

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -46,6 +46,15 @@ void VVV_fillstring(
     } \
     do { } while (false)
 
+#define WHINE_ONCE_ARGS(args) \
+    static bool whine = true; \
+    if (whine) \
+    { \
+        whine = false; \
+        vlog_error args; \
+    } \
+    do { } while (false)
+
 /* Don't call this directly; use the VVV_between macro. */
 void _VVV_between(
     const char* original,

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -584,33 +584,11 @@ int main(int argc, char *argv[])
     vlog_info("\t\t");
     vlog_info("\t\t");
 
-    //Set up screen
-
-
-
-
-    // Load Ini
-
-
+    // Set up screen
     graphics.init();
 
     game.init();
     game.seed_use_sdl_getticks = seed_use_sdl_getticks;
-
-    // This loads music too...
-    if (!graphics.reloadresources())
-    {
-        /* Something wrong with the default assets? We can't use them to
-         * display the error message, and we have to bail. */
-        SDL_ShowSimpleMessageBox(
-            SDL_MESSAGEBOX_ERROR,
-            graphics.error_title,
-            graphics.error,
-            NULL
-        );
-
-        VVV_exit(1);
-    }
 
     game.gamestate = PRELOADER;
 
@@ -636,11 +614,26 @@ int main(int argc, char *argv[])
         gameScreen.init(&screen_settings);
     }
 
+    // This loads music too...
+    if (!graphics.reloadresources())
+    {
+        /* Something wrong with the default assets? We can't use them to
+         * display the error message, and we have to bail. */
+        SDL_ShowSimpleMessageBox(
+            SDL_MESSAGEBOX_ERROR,
+            graphics.error_title,
+            graphics.error,
+            NULL
+        );
+
+        VVV_exit(1);
+    }
+
     loc::loadtext(false);
     loc::loadlanguagelist();
     game.createmenu(Menu::mainmenu);
 
-    graphics.create_buffers(gameScreen.GetFormat());
+    graphics.create_buffers();
 
     if (game.skipfakeload)
         game.gamestate = TITLEMODE;
@@ -790,9 +783,10 @@ static void cleanup(void)
     {
         game.savestatsandsettings();
     }
-    gameScreen.destroy();
+
     graphics.grphx.destroy();
     graphics.destroy_buffers();
+    gameScreen.destroy();
     graphics.destroy();
     music.destroy();
     map.destroy();
@@ -849,9 +843,13 @@ static void inline deltaloop(void)
 
         if (implfunc->type == Func_delta && implfunc->func != NULL)
         {
+            graphics.clear();
+
+            graphics.set_render_target(graphics.gameTexture);
+
             implfunc->func();
 
-            gameScreen.FlipScreen(graphics.flipmode);
+            gameScreen.RenderPresent();
         }
     }
 }
@@ -873,7 +871,7 @@ static void unfocused_run(void)
 {
     if (!game.blackout)
     {
-        ClearSurface(graphics.backBuffer);
+        graphics.fill_rect(0, 0, 0);
 #define FLIP(YPOS) graphics.flipmode ? 232 - YPOS : YPOS
         graphics.bprint(5, FLIP(110), loc::gettext("Game paused"), 196 - help.glow, 255 - help.glow, 196 - help.glow, true);
         graphics.bprint(5, FLIP(120), loc::gettext("[click to resume]"), 196 - help.glow, 255 - help.glow, 196 - help.glow, true);

--- a/desktop_version/src/preloader.cpp
+++ b/desktop_version/src/preloader.cpp
@@ -95,15 +95,15 @@ void preloaderrender(void)
       pre_temprecty = (i * 16)- pre_offset;
       if (i % 2 == 0)
       {
-        FillRect(graphics.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, pre_lightcol);
+        graphics.fill_rect(pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, pre_lightcol);
       }
       else
       {
-        FillRect(graphics.backBuffer, pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, pre_darkcol);
+        graphics.fill_rect(pre_temprectx, pre_temprecty, pre_temprectw,pre_temprecth, pre_darkcol);
       }
     }
 
-    FillRect(graphics.backBuffer, pre_frontrectx, pre_frontrecty, pre_frontrectw,pre_frontrecth, graphics.getRGB(0x3E,0x31,0xA2));
+    graphics.fill_rect(pre_frontrectx, pre_frontrecty, pre_frontrectw,pre_frontrecth, graphics.getRGB(0x3E,0x31,0xA2));
 
     print_percentage = true;
 
@@ -114,12 +114,12 @@ void preloaderrender(void)
   }else if (pre_transition <= -10) {
     //Switch to TITLEMODE (handled by preloaderrenderfixed)
   }else if (pre_transition < 5) {
-    ClearSurface(graphics.backBuffer);
+    graphics.fill_rect(0, 0, 0);
   }else if (pre_transition < 20) {
     pre_temprecty = 0;
     pre_temprecth = 240;
-    ClearSurface(graphics.backBuffer);
-    FillRect(graphics.backBuffer, pre_frontrectx, pre_frontrecty, pre_frontrectw,pre_frontrecth, graphics.getRGB(0x3E,0x31,0xA2));
+    graphics.fill_rect(0, 0, 0);
+    graphics.fill_rect(pre_frontrectx, pre_frontrecty, pre_frontrectw,pre_frontrecth, graphics.getRGB(0x3E,0x31,0xA2));
 
     print_percentage = true;
   }


### PR DESCRIPTION
## Changes:

This is quite a big PR.

Ever since VVVVVV was initially ported to C++ in 2.0, it has used surfaces from SDL. The downside is, that's all software rendering. This PR moves most things off of surfaces, and all into GPU, by using textures and SDL_Renderer.

Pixel-perfect collision has been kept by keeping a copy of sprites as surfaces. There's plans for pixel-perfect collision to use masks instead of reading pixel data directly, but that's out of scope for this PR.

Everything has been ported over, and from a bit of playtesting, I see no visual differences between the old system and the new one. This PR should help make the code more understandable and easier to mess with, while also providing a fair framerate boost, cutting down on CPU, and it maybe even cuts down on memory a bit.

Also as a quick note, `graphics.reloadresources()` in `main` now gets called _after_ the renderer is created, because textures cannot be created without a renderer.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
