### PR TITLE
Fix screenshake not clearing the gameplay cache

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3578,6 +3578,13 @@ void Graphics::screenshake(void)
     set_render_target(gameTexture);
     clear();
 
+    // Clear the gameplay texture so blackout() is actually black after a screenshake
+    if (game.gamestate == GAMEMODE)
+    {
+        set_render_target(gameplayTexture);
+        clear();
+    }
+
     set_render_target(NULL);
     copy_texture(tempTexture, NULL, NULL);
 }


### PR DESCRIPTION
## Changes:

The renderer branch had a last-minute fix for screenshaking, and I didn't fully think out the interactions between screenshaking and other features (or, well, the other feature) like `blackout()`. This fixes screenshaking not clearing the gameplay texture, which `blackout()` relies on for some weird reason.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
