### PR TITLE
Fix screen shake during flip mode not flipping the screen

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3200,7 +3200,10 @@ void Graphics::screenshake(void)
     }
 
     set_render_target(NULL);
-    copy_texture(tempTexture, NULL, NULL);
+    set_blendmode(SDL_BLENDMODE_NONE);
+    clear();
+
+    copy_texture(tempTexture, NULL, NULL, 0, NULL, flipmode ? SDL_FLIP_VERTICAL : SDL_FLIP_NONE);
 }
 
 void Graphics::updatescreenshake(void)


### PR DESCRIPTION
## Changes:

This fixes a regression introduced by #923 where flip mode no longer flips the screen while the screen is shaking.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
