### PR TITLE
Allow multiple lines and wordwrapping in activity zone prompts

### DIFF
--- a/desktop_version/lang/ca/strings.xml
+++ b/desktop_version/lang/ca/strings.xml
@@ -489,16 +489,16 @@
     <string english="Press {button} to activate terminal" translation="Prem {button} per a activar el terminal" explanation="keyboard key (E or ENTER) or controller button glyph is filled in for {button}. max is when displayed" max="37"/>
     <string english="Press {button} to activate terminals" translation="{button} per a activar els terminals" explanation="keyboard key (E or ENTER) or controller button glyph is filled in for {button}. max is when displayed. there are 3 next to each other in the ship" max="37"/>
     <string english="Press {button} to interact" translation="Prem {button} per a interaccionar" explanation="keyboard key (E or ENTER) or controller button glyph is filled in for {button}. max is when displayed" max="37"/>
-    <string english="Passion for Exploring" translation="Passió per l’exploració" explanation="song name should probably not be translated" max="37"/>
-    <string english="Pushing Onwards" translation="Prement sempre endavant" explanation="song name should probably not be translated" max="37"/>
-    <string english="Positive Force" translation="Positivitat en la força" explanation="song name should probably not be translated" max="37"/>
-    <string english="Presenting VVVVVV" translation="Presentació de VVVVVV" explanation="song name should probably not be translated" max="37"/>
-    <string english="Potential for Anything" translation="Potencial per a qualsevol cosa" explanation="song name should probably not be translated" max="37"/>
-    <string english="Predestined Fate" translation="Predestinació atzarosa" explanation="song name should probably not be translated" max="37"/>
-    <string english="Pipe Dream" translation="Pretensió impossible" explanation="song name should probably not be translated" max="37"/>
-    <string english="Popular Potpourri" translation="Popurri popular" explanation="song name should probably not be translated" max="37"/>
-    <string english="Pressure Cooker" translation="Pressió dins l’olla" explanation="song name should probably not be translated" max="37"/>
-    <string english="ecroF evitisoP" translation="açrof al ne tativitisoP" explanation="song name should probably not be translated" max="37"/>
+    <string english="Passion for Exploring" translation="Passió per l’exploració" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Pushing Onwards" translation="Prement sempre endavant" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Positive Force" translation="Positivitat en la força" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Presenting VVVVVV" translation="Presentació de VVVVVV" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Potential for Anything" translation="Potencial per a qualsevol cosa" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Predestined Fate" translation="Predestinació atzarosa" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Pipe Dream" translation="Pretensió impossible" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Popular Potpourri" translation="Popurri popular" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Pressure Cooker" translation="Pressió dins l’olla" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="ecroF evitisoP" translation="açrof al ne tativitisoP" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
     <string english="Map Settings" translation="Opcions del mapa" explanation="title, editor, Level Settings, map is kinda inconsistent with everything else" max="20"/>
     <string english="edit scripts" translation="edita els scripts" explanation="level editor menu option"/>
     <string english="change music" translation="canvia la música" explanation="level editor menu option"/>

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -489,16 +489,16 @@
     <string english="Press {button} to activate terminal" translation="" explanation="keyboard key (E or ENTER) or controller button glyph is filled in for {button}. max is when displayed" max="37"/>
     <string english="Press {button} to activate terminals" translation="" explanation="keyboard key (E or ENTER) or controller button glyph is filled in for {button}. max is when displayed. there are 3 next to each other in the ship" max="37"/>
     <string english="Press {button} to interact" translation="" explanation="keyboard key (E or ENTER) or controller button glyph is filled in for {button}. max is when displayed" max="37"/>
-    <string english="Passion for Exploring" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="Pushing Onwards" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="Positive Force" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="Presenting VVVVVV" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="Potential for Anything" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="Predestined Fate" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="Pipe Dream" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="Popular Potpourri" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="Pressure Cooker" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="ecroF evitisoP" translation="" explanation="song name should probably not be translated" max="37"/>
+    <string english="Passion for Exploring" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Pushing Onwards" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Positive Force" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Presenting VVVVVV" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Potential for Anything" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Predestined Fate" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Pipe Dream" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Popular Potpourri" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Pressure Cooker" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="ecroF evitisoP" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
     <string english="Map Settings" translation="" explanation="title, editor, Level Settings, map is kinda inconsistent with everything else" max="20"/>
     <string english="edit scripts" translation="" explanation="level editor menu option"/>
     <string english="change music" translation="" explanation="level editor menu option"/>

--- a/desktop_version/lang/eo/strings.xml
+++ b/desktop_version/lang/eo/strings.xml
@@ -489,16 +489,16 @@
     <string english="Press {button} to activate terminal" translation="Premu {button} por aktivigi terminalon" explanation="keyboard key (E or ENTER) or controller button glyph is filled in for {button}. max is when displayed" max="37"/>
     <string english="Press {button} to activate terminals" translation="Premu {button} por aktivigi terminalojn" explanation="keyboard key (E or ENTER) or controller button glyph is filled in for {button}. max is when displayed. there are 3 next to each other in the ship" max="37"/>
     <string english="Press {button} to interact" translation="Premu {button} por interagi" explanation="keyboard key (E or ENTER) or controller button glyph is filled in for {button}. max is when displayed" max="37"/>
-    <string english="Passion for Exploring" translation="Passion for Exploring" explanation="song name should probably not be translated" max="37"/>
-    <string english="Pushing Onwards" translation="Pushing Onwards" explanation="song name should probably not be translated" max="37"/>
-    <string english="Positive Force" translation="Positive Force" explanation="song name should probably not be translated" max="37"/>
-    <string english="Presenting VVVVVV" translation="Presenting VVVVVV" explanation="song name should probably not be translated" max="37"/>
-    <string english="Potential for Anything" translation="Potential for Anything" explanation="song name should probably not be translated" max="37"/>
-    <string english="Predestined Fate" translation="Predestined Fate" explanation="song name should probably not be translated" max="37"/>
-    <string english="Pipe Dream" translation="Pipe Dream" explanation="song name should probably not be translated" max="37"/>
-    <string english="Popular Potpourri" translation="Popular Potpourri" explanation="song name should probably not be translated" max="37"/>
-    <string english="Pressure Cooker" translation="Pressure Cooker" explanation="song name should probably not be translated" max="37"/>
-    <string english="ecroF evitisoP" translation="ecroF evitisoP" explanation="song name should probably not be translated" max="37"/>
+    <string english="Passion for Exploring" translation="Passion for Exploring" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Pushing Onwards" translation="Pushing Onwards" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Positive Force" translation="Positive Force" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Presenting VVVVVV" translation="Presenting VVVVVV" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Potential for Anything" translation="Potential for Anything" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Predestined Fate" translation="Predestined Fate" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Pipe Dream" translation="Pipe Dream" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Popular Potpourri" translation="Popular Potpourri" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Pressure Cooker" translation="Pressure Cooker" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="ecroF evitisoP" translation="ecroF evitisoP" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
     <string english="Map Settings" translation="Mapagordoj" explanation="title, editor, Level Settings, map is kinda inconsistent with everything else" max="20"/>
     <string english="edit scripts" translation="redakti skriptojn" explanation="level editor menu option"/>
     <string english="change music" translation="ŝanĝi muzikon" explanation="level editor menu option"/>

--- a/desktop_version/lang/es/strings.xml
+++ b/desktop_version/lang/es/strings.xml
@@ -489,16 +489,16 @@
     <string english="Press {button} to activate terminal" translation="" explanation="keyboard key (E or ENTER) or controller button glyph is filled in for {button}. max is when displayed" max="37"/>
     <string english="Press {button} to activate terminals" translation="" explanation="keyboard key (E or ENTER) or controller button glyph is filled in for {button}. max is when displayed. there are 3 next to each other in the ship" max="37"/>
     <string english="Press {button} to interact" translation="" explanation="keyboard key (E or ENTER) or controller button glyph is filled in for {button}. max is when displayed" max="37"/>
-    <string english="Passion for Exploring" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="Pushing Onwards" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="Positive Force" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="Presenting VVVVVV" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="Potential for Anything" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="Predestined Fate" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="Pipe Dream" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="Popular Potpourri" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="Pressure Cooker" translation="" explanation="song name should probably not be translated" max="37"/>
-    <string english="ecroF evitisoP" translation="" explanation="song name should probably not be translated" max="37"/>
+    <string english="Passion for Exploring" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Pushing Onwards" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Positive Force" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Presenting VVVVVV" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Potential for Anything" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Predestined Fate" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Pipe Dream" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Popular Potpourri" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Pressure Cooker" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="ecroF evitisoP" translation="" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
     <string english="Map Settings" translation="" explanation="title, editor, Level Settings, map is kinda inconsistent with everything else" max="20"/>
     <string english="edit scripts" translation="scripts editados" explanation="level editor menu option"/>
     <string english="change music" translation="cambiar musica" explanation="level editor menu option"/>

--- a/desktop_version/lang/nl/strings.xml
+++ b/desktop_version/lang/nl/strings.xml
@@ -489,16 +489,16 @@
     <string english="Press {button} to activate terminal" translation="{button}: Terminal activeren" explanation="keyboard key (E or ENTER) or controller button glyph is filled in for {button}. max is when displayed" max="37"/>
     <string english="Press {button} to activate terminals" translation="{button}: Terminals activeren" explanation="keyboard key (E or ENTER) or controller button glyph is filled in for {button}. max is when displayed. there are 3 next to each other in the ship" max="37"/>
     <string english="Press {button} to interact" translation="{button}: Interactie" explanation="keyboard key (E or ENTER) or controller button glyph is filled in for {button}. max is when displayed" max="37"/>
-    <string english="Passion for Exploring" translation="Passion for Exploring" explanation="song name should probably not be translated" max="37"/>
-    <string english="Pushing Onwards" translation="Pushing Onwards" explanation="song name should probably not be translated" max="37"/>
-    <string english="Positive Force" translation="Positive Force" explanation="song name should probably not be translated" max="37"/>
-    <string english="Presenting VVVVVV" translation="Presenting VVVVVV" explanation="song name should probably not be translated" max="37"/>
-    <string english="Potential for Anything" translation="Potential for Anything" explanation="song name should probably not be translated" max="37"/>
-    <string english="Predestined Fate" translation="Predestined Fate" explanation="song name should probably not be translated" max="37"/>
-    <string english="Pipe Dream" translation="Pipe Dream" explanation="song name should probably not be translated" max="37"/>
-    <string english="Popular Potpourri" translation="Popular Potpourri" explanation="song name should probably not be translated" max="37"/>
-    <string english="Pressure Cooker" translation="Pressure Cooker" explanation="song name should probably not be translated" max="37"/>
-    <string english="ecroF evitisoP" translation="ecroF evitisoP" explanation="song name should probably not be translated" max="37"/>
+    <string english="Passion for Exploring" translation="Passion for Exploring" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Pushing Onwards" translation="Pushing Onwards" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Positive Force" translation="Positive Force" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Presenting VVVVVV" translation="Presenting VVVVVV" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Potential for Anything" translation="Potential for Anything" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Predestined Fate" translation="Predestined Fate" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Pipe Dream" translation="Pipe Dream" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Popular Potpourri" translation="Popular Potpourri" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="Pressure Cooker" translation="Pressure Cooker" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
+    <string english="ecroF evitisoP" translation="ecroF evitisoP" explanation="jukebox prompt. song name should probably not be translated" max="37*2"/>
     <string english="Map Settings" translation="Levelinstellingen" explanation="title, editor, Level Settings, map is kinda inconsistent with everything else" max="20"/>
     <string english="edit scripts" translation="scripts bewerken" explanation="level editor menu option"/>
     <string english="change music" translation="muziek wijzigen" explanation="level editor menu option"/>

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2222,17 +2222,13 @@ void gamerender(void)
             game.activity_lastprompt.c_str()
         );
 
+        uint8_t text_r, text_g, text_b;
+
         if (game.activity_r == 0 && game.activity_g == 0 && game.activity_b == 0)
         {
-            font::print(
-                game.activity_print_flags | PR_BRIGHTNESS(act_alpha*255) | PR_CEN,
-                -1,
-                game.activity_y + 12,
-                final_string,
-                196,
-                196,
-                255 - help.glow
-            );
+            text_r = 196;
+            text_g = 196;
+            text_b = 255 - help.glow;
         }
         else
         {
@@ -2245,16 +2241,21 @@ void gamerender(void)
                 game.activity_g*act_alpha,
                 game.activity_b*act_alpha
             );
-            font::print(
-                game.activity_print_flags | PR_BRIGHTNESS(act_alpha*255) | PR_CJK_LOW | PR_CEN,
-                -1,
-                game.activity_y + 12,
-                final_string,
-                game.activity_r,
-                game.activity_g,
-                game.activity_b
-            );
+
+            text_r = game.activity_r;
+            text_g = game.activity_g;
+            text_b = game.activity_b;
         }
+
+        font::print(
+            game.activity_print_flags | PR_BRIGHTNESS(act_alpha*255) | PR_CJK_LOW | PR_CEN,
+            -1,
+            game.activity_y + 12,
+            final_string,
+            text_r,
+            text_g,
+            text_b
+        );
     }
 
     if (obj.trophytext > 0 || obj.oldtrophytext > 0)

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2223,6 +2223,7 @@ void gamerender(void)
         );
 
         uint8_t text_r, text_g, text_b;
+        uint32_t text_flags = game.activity_print_flags | PR_BRIGHTNESS(act_alpha*255) | PR_CJK_LOW | PR_CEN;
 
         if (game.activity_r == 0 && game.activity_g == 0 && game.activity_b == 0)
         {
@@ -2232,11 +2233,14 @@ void gamerender(void)
         }
         else
         {
+            short lines;
+            font::string_wordwrap(text_flags, final_string, 37*8, &lines);
+
             graphics.drawpixeltextbox(
                 4,
                 game.activity_y + 4,
                 39*8,
-                16 + font::height(game.activity_print_flags),
+                16 + font::height(text_flags)*lines,
                 game.activity_r*act_alpha,
                 game.activity_g*act_alpha,
                 game.activity_b*act_alpha
@@ -2247,14 +2251,16 @@ void gamerender(void)
             text_b = game.activity_b;
         }
 
-        font::print(
-            game.activity_print_flags | PR_BRIGHTNESS(act_alpha*255) | PR_CJK_LOW | PR_CEN,
+        font::print_wrap(
+            text_flags,
             -1,
             game.activity_y + 12,
             final_string,
             text_r,
             text_g,
-            text_b
+            text_b,
+            8,
+            37*8
         );
     }
 


### PR DESCRIPTION
## Changes:

Activity zone prompts have always been limited to a single line, because the text box had a hardcoded size. A translator requested for the possibility to add a subtitle under music names for the jukebox, and the easiest solution is to make it possible to translate a prompt with multiple lines. This is possible now, and the textbox even wordwraps automatically (using the normal `font::print_wrap`).

![music subtitle](https://user-images.githubusercontent.com/44736680/220240566-be25b0a0-e00b-4808-9d69-999a8f89e183.png)

(I wouldn't really like to see translations using multiple lines for stuff like "Press ENTER to talk to Vitellary", especially if it wraps with one name and not with another, but if a string is too long, wordwrapping will look better than text running out of the box.)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
