### PR TITLE
Add magic string to the start of the `game` global

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -158,6 +158,8 @@ end:
 
 void Game::init(void)
 {
+    SDL_strlcpy(magic, "[vVvVvV]game", sizeof(magic));
+
     roomx = 0;
     roomy = 0;
     prevroomx = 0;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -132,6 +132,8 @@ struct CustomLevelStat
 
 class Game
 {
+    char magic[16];
+
 public:
     void init(void);
 


### PR DESCRIPTION
## Changes:

The `-addresses` command-line option added in 64be99d4 helps autosplitters on platforms where VVVVVV is not built as a position-independent executable. macOS has made it increasingly difficult, or impossible, to build binaries without PIE.

Adding an obvious string to search for will help tools that need to deal with versions of VVVVVV built with PIE. The bytestring to search for is `[vVvVvV]game`, followed by four null bytes (to avoid finding it in the program code section). This identifies the beginning of the game object; addresses to other objects can be figured out by relative offsets printed by `-addresses`, since ASLR can only change where the globals begin.

Partially f i x e s #928; it may still be advisable to figure out how to explicitly disable PIE on Windows/Linux.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
