### PR TITLE
Add new UTF-8 library, remove utfcpp submodule, fix UTF-8 fixme in next_wrap()

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "third_party/tinyxml2"]
 	path = third_party/tinyxml2
 	url = https://github.com/leethomason/tinyxml2/
-[submodule "third_party/utfcpp"]
-	path = third_party/utfcpp
-	url = https://github.com/nemtrif/utfcpp
 [submodule "third_party/FAudio"]
 	path = third_party/FAudio
 	url = https://github.com/FNA-XNA/FAudio

--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -147,7 +147,6 @@ if(BUNDLE_DEPENDENCIES)
         ../third_party/physfs/src
         ../third_party/physfs/extras
         ../third_party/lodepng
-        ../third_party/utfcpp/source
         ../third_party/c-hashmap
         ../third_party/FAudio/include
         ../third_party/FAudio/src

--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -111,6 +111,7 @@ set(VVV_SRC
     src/Network.c
     src/Textbook.c
     src/ThirdPartyDeps.c
+    src/UTF8.c
     src/VFormat.c
     src/Vlogging.c
     src/Xoshiro.c

--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <string>
 #include <tinyxml2.h>
-#include <utf8/unchecked.h>
 
 #include "Alloc.h"
 #include "Constants.h"
@@ -24,6 +23,7 @@
 #include "Map.h"
 #include "Screen.h"
 #include "Script.h"
+#include "UTF8.h"
 #include "UtilityClass.h"
 #include "Vlogging.h"
 #include "XMLUtils.h"
@@ -208,10 +208,7 @@ static std::string find_tag(const std::string& buf, const std::string& start, co
         {
             SDL_sscanf(number.c_str(), "%" SCNu32, &character);
         }
-        uint32_t utf32[] = {character, 0};
-        std::string utf8;
-        utf8::unchecked::utf32to8(utf32, utf32 + 1, std::back_inserter(utf8));
-        value.replace(start_pos, end - start_pos + 1, utf8);
+        value.replace(start_pos, end - start_pos + 1, UTF8_encode(character).bytes);
     }
 
     return value;

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -4,7 +4,6 @@
 #include "Editor.h"
 
 #include <string>
-#include <utf8/unchecked.h>
 
 #include "Constants.h"
 #include "CustomLevels.h"
@@ -21,6 +20,7 @@
 #include "Music.h"
 #include "Screen.h"
 #include "Script.h"
+#include "UTF8.h"
 #include "UtilityClass.h"
 #include "VFormat.h"
 #include "Vlogging.h"
@@ -2292,7 +2292,7 @@ void editorinput(void)
                         ed.sby--;
                     }
                     key.keybuffer=ed.sb[ed.pagey+ed.sby];
-                    ed.sbx = utf8::unchecked::distance(ed.sb[ed.pagey+ed.sby].begin(), ed.sb[ed.pagey+ed.sby].end());
+                    ed.sbx = UTF8_total_codepoints(ed.sb[ed.pagey+ed.sby].c_str());
                     music.playef(11);
                 }
             }
@@ -2382,7 +2382,7 @@ void editorinput(void)
             }}
 
             ed.sb[ed.pagey+ed.sby]=key.keybuffer;
-            ed.sbx = utf8::unchecked::distance(ed.sb[ed.pagey+ed.sby].begin(), ed.sb[ed.pagey+ed.sby].end());
+            ed.sbx = UTF8_total_codepoints(ed.sb[ed.pagey+ed.sby].c_str());
 
             if(!game.press_map && !key.isDown(27)) game.mapheld=false;
             if (!game.mapheld)
@@ -2400,7 +2400,7 @@ void editorinput(void)
                             ed.sby--;
                         }
                         key.keybuffer=ed.sb[ed.pagey+ed.sby];
-                        ed.sbx = utf8::unchecked::distance(ed.sb[ed.pagey+ed.sby].begin(), ed.sb[ed.pagey+ed.sby].end());
+                        ed.sbx = UTF8_total_codepoints(ed.sb[ed.pagey+ed.sby].c_str());
                     }
                     else
                     {

--- a/desktop_version/src/Font.cpp
+++ b/desktop_version/src/Font.cpp
@@ -789,14 +789,10 @@ static bool next_wrap(
 
     while (true)
     {
-        /* FIXME: This only checks one byte, not multiple! */
-        if ((str[idx] & 0xC0) == 0x80)
-        {
-            /* Skip continuation byte. */
-            goto next;
-        }
+        uint8_t codepoint_nbytes;
+        uint32_t codepoint = UTF8_peek_next(&str[idx], &codepoint_nbytes);
 
-        switch (str[idx])
+        switch (codepoint)
         {
         case ' ':
             if (loc::get_langmeta()->autowordwrap)
@@ -813,7 +809,7 @@ static bool next_wrap(
             return true;
         }
 
-        linewidth += get_advance(f, str[idx]);
+        linewidth += get_advance(f, codepoint);
 
         if (linewidth > maxwidth)
         {
@@ -831,10 +827,9 @@ static bool next_wrap(
             return true;
         }
 
-next:
-        idx += 1;
-        *start += 1;
-        *len += 1;
+        idx += codepoint_nbytes;
+        *start += codepoint_nbytes;
+        *len += codepoint_nbytes;
     }
 }
 

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2,7 +2,6 @@
 #include "Graphics.h"
 
 #include <SDL.h>
-#include <utf8/unchecked.h>
 
 #include "Alloc.h"
 #include "Constants.h"

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -2,7 +2,6 @@
 #include "KeyPoll.h"
 
 #include <string.h>
-#include <utf8/unchecked.h>
 
 #include "Alloc.h"
 #include "Exit.h"
@@ -13,6 +12,7 @@
 #include "LocalizationStorage.h"
 #include "Music.h"
 #include "Screen.h"
+#include "UTF8.h"
 #include "Vlogging.h"
 
 int inline KeyPoll::getThreshold(void)
@@ -178,9 +178,7 @@ void KeyPoll::Poll(void)
             {
                 if (evt.key.keysym.sym == SDLK_BACKSPACE && !keybuffer.empty())
                 {
-                    std::string::iterator iter = keybuffer.end();
-                    utf8::unchecked::prior(iter);
-                    keybuffer = keybuffer.substr(0, iter - keybuffer.begin());
+                    keybuffer.erase(UTF8_backspace(keybuffer.c_str(), keybuffer.length()));
                     if (keybuffer.empty())
                     {
                         linealreadyemptykludge = true;

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -1,9 +1,9 @@
 #include "Textbox.h"
 
 #include <SDL.h>
-#include <utf8/unchecked.h>
 
 #include "Font.h"
+#include "UTF8.h"
 
 textboxclass::textboxclass(void)
 {
@@ -145,7 +145,7 @@ void textboxclass::padtowidth(size_t new_w)
     size_t chars_w = SDL_max(w-16, new_w) / glyph_w;
     for (size_t iter = 0; iter < lines.size(); iter++)
     {
-        size_t n_glyphs = utf8::unchecked::distance(lines[iter].begin(), lines[iter].end());
+        size_t n_glyphs = UTF8_total_codepoints(lines[iter].c_str());
         signed int padding_needed = chars_w - n_glyphs;
         if (padding_needed < 0)
         {

--- a/desktop_version/src/UTF8.c
+++ b/desktop_version/src/UTF8.c
@@ -1,0 +1,202 @@
+#include "UTF8.h"
+
+#define STARTS_0(byte) ((byte & 0x80) == 0x00)
+#define STARTS_10(byte) ((byte & 0xC0) == 0x80)
+#define STARTS_110(byte) ((byte & 0xE0) == 0xC0)
+#define STARTS_1110(byte) ((byte & 0xF0) == 0xE0)
+#define STARTS_11110(byte) ((byte & 0xF8) == 0xF0)
+#define TAKE(byte, nbits) (byte & ((1 << nbits)-1))
+
+static inline bool is_illegal(uint32_t codepoint)
+{
+    return (codepoint >= 0xD800 && codepoint <= 0xDFFF) || codepoint > 0x10FFFF;
+}
+
+uint32_t UTF8_peek_next(const char* s_str, uint8_t* codepoint_nbytes)
+{
+    /* Get the next codepoint from a string, but instead of advancing the
+     * pointer, give the number of bytes the index will need to advance. */
+    if (s_str == NULL)
+    {
+        return 0;
+    }
+
+    // Pointer conversion to avoid all those brilliant signedness plot twists...
+    const unsigned char* str = (const unsigned char*) s_str;
+    uint32_t codepoint;
+    *codepoint_nbytes = 1;
+
+    if (STARTS_0(str[0]))
+    {
+        // 0xxx xxxx - ASCII
+        codepoint = str[0];
+    }
+    else if (STARTS_10(str[0]))
+    {
+        // 10xx xxxx - unexpected continuation byte
+        codepoint = 0xFFFD;
+    }
+    else if (STARTS_110(str[0]))
+    {
+        // 110x xxxx - 2-byte sequence
+        if (!STARTS_10(str[1]))
+        {
+            codepoint = 0xFFFD;
+        }
+        else
+        {
+            codepoint =
+                (TAKE(str[0], 5) << 6) |
+                (TAKE(str[1], 6));
+            *codepoint_nbytes = 2;
+        }
+    }
+    else if (STARTS_1110(str[0]))
+    {
+        // 1110 xxxx - 3-byte sequence
+        if (!STARTS_10(str[1]) || !STARTS_10(str[2]))
+        {
+            codepoint = 0xFFFD;
+        }
+        else
+        {
+            codepoint =
+                (TAKE(str[0], 4) << 12) |
+                (TAKE(str[1], 6) << 6) |
+                (TAKE(str[2], 6));
+            *codepoint_nbytes = 3;
+        }
+    }
+    else if (STARTS_11110(str[0]))
+    {
+        // 1111 0xxx - 4-byte sequence
+        if (!STARTS_10(str[1]) || !STARTS_10(str[2]) || !STARTS_10(str[3]))
+        {
+            codepoint = 0xFFFD;
+        }
+        else
+        {
+            codepoint =
+                (TAKE(str[0], 3) << 18) |
+                (TAKE(str[1], 6) << 12) |
+                (TAKE(str[2], 6) << 6) |
+                (TAKE(str[3], 6));
+            *codepoint_nbytes = 4;
+        }
+    }
+    else
+    {
+        // 1111 1xxx - invalid
+        codepoint = 0xFFFD;
+    }
+
+    // Overlong sequence?
+    if (
+        (codepoint <= 0x7F && *codepoint_nbytes > 1) ||
+        (codepoint > 0x7F && codepoint <= 0x7FF && *codepoint_nbytes > 2) ||
+        (codepoint > 0x7FF && codepoint <= 0xFFFF && *codepoint_nbytes > 3)
+    ) {
+        codepoint = 0xFFFD;
+    }
+
+    // UTF-16 surrogates are invalid, so are codepoints after 10FFFF
+    if (is_illegal(codepoint))
+    {
+        codepoint = 0xFFFD;
+    }
+
+    return codepoint;
+}
+
+uint32_t UTF8_next(const char** p_str)
+{
+    /* Get the next codepoint from a string, and advance the pointer.
+     * Example usage:
+     *
+     *  const char* str = "asdf";
+     *  uint32_t codepoint;
+     *  while ((codepoint = UTF8_next(&str)))
+     *  {
+     *      // you have a codepoint congrats
+     *  }
+     */
+    if (p_str == NULL)
+    {
+        return 0;
+    }
+
+    uint8_t codepoint_nbytes;
+    uint32_t codepoint = UTF8_peek_next(*p_str, &codepoint_nbytes);
+    *p_str += codepoint_nbytes;
+    return codepoint;
+}
+
+UTF8_encoding UTF8_encode(uint32_t codepoint)
+{
+    UTF8_encoding enc = {0};
+
+    // Pretend the bytes array is unsigned...
+    unsigned char* bytes = (unsigned char*) &enc.bytes;
+
+    if (is_illegal(codepoint))
+    {
+        codepoint = 0xFFFD;
+        enc.error = true;
+    }
+
+    if (codepoint <= 0x7F)
+    {
+        enc.nbytes = 1;
+        bytes[0] = codepoint;
+    }
+    else if (codepoint <= 0x7FF)
+    {
+        enc.nbytes = 2;
+        bytes[0] = 0xC0 | (codepoint >> 6);
+        bytes[1] = 0x80 | (codepoint & 0x3F);
+    }
+    else if (codepoint <= 0xFFFF)
+    {
+        enc.nbytes = 3;
+        bytes[0] = 0xE0 | (codepoint >> 12);
+        bytes[1] = 0x80 | ((codepoint >> 6) & 0x3F);
+        bytes[2] = 0x80 | (codepoint & 0x3F);
+    }
+    else
+    {
+        enc.nbytes = 4;
+        bytes[0] = 0xF0 | (codepoint >> 18);
+        bytes[1] = 0x80 | ((codepoint >> 12) & 0x3F);
+        bytes[2] = 0x80 | ((codepoint >> 6) & 0x3F);
+        bytes[3] = 0x80 | (codepoint & 0x3F);
+    }
+
+    return enc;
+}
+
+size_t UTF8_total_codepoints(const char* str)
+{
+    size_t total = 0;
+    while (UTF8_next(&str))
+    {
+        total++;
+    }
+    return total;
+}
+
+size_t UTF8_backspace(const char* str, size_t len)
+{
+    /* Given a string of length len,
+     * give the new length after removing the last character.
+     * In other words, the index at which to write a \0 byte. */
+
+    for (len -= 1; len > 0; len--)
+    {
+        if (!STARTS_10(str[len]))
+        {
+            break;
+        }
+    }
+
+    return len;
+}

--- a/desktop_version/src/UTF8.h
+++ b/desktop_version/src/UTF8.h
@@ -1,0 +1,35 @@
+#ifndef UTF8_H
+#define UTF8_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef struct
+{
+    char bytes[5];
+    uint8_t nbytes;
+    bool error;
+}
+UTF8_encoding;
+
+
+uint32_t UTF8_peek_next(const char* s_str, uint8_t* codepoint_nbytes);
+
+uint32_t UTF8_next(const char** p_str);
+UTF8_encoding UTF8_encode(uint32_t codepoint);
+
+size_t UTF8_total_codepoints(const char* str);
+size_t UTF8_backspace(const char* str, size_t len);
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif // UTF8_H


### PR DESCRIPTION
## Changes:

This adds a small library I wrote to handle UTF-8.

Usage is meant to be as simple as possible - see for example decoding a UTF-8 string:

```c
const char* str = "asdf";
uint32_t codepoint;
while ((codepoint = UTF8_next(&str)))
{
    // you have a codepoint congrats
}
```

Or encoding a single codepoint to add it to a string:

```cpp
std::string result;
result.append(UTF8_encode(0x1234).bytes);
```

There are some other functions (`UTF8_total_codepoints()` to get the total number of codepoints in a string, `UTF8_backspace()` to get the length of a string after backspacing one character, and `UTF8_peek_next()` as a slightly less fancy version of `UTF8_next()`), but more functions could always be added if we need them.

This allows us to replace utfcpp (utf8::unchecked) - which is also done in this PR - and also fix some less-than-ideal code:
- Some places had to resort to ignoring UTF-8 (`next_wrap`) or using UCS-4→UTF-8 functions (VFormat had to use PHYSFS ones, and one other place had four lines of code including a `std::back_inserter` just for one character)
- The iterator stuff is kinda confusing and verbose anyway.

The reason why I'm doing this now is also because my next button glyphs PR will most likely need it to encode the characters used for the button glyphs (and because `next_wrap` being incomplete might matter for localization).


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
