### PR TITLE
Fix minor visual issue in int1yellow_5

### DIFF
--- a/desktop_version/src/Scripts.cpp
+++ b/desktop_version/src/Scripts.cpp
@@ -2724,7 +2724,7 @@ bool scriptclass::load(const std::string& name)
         "speak_active",
 
         "squeak(yellow)",
-        "changedir(yellow,0)",
+        "changeai(yellow,faceleft)", // changedir(yellow,0) doesn't work
         "text(yellow,0,0,3)",
         "We shouldn't really be able",
         "to move between dimensions",
@@ -2733,7 +2733,6 @@ bool scriptclass::load(const std::string& name)
         "speak_active",
 
         "squeak(yellow)",
-        "changedir(yellow,0)",
         "text(yellow,0,0,2)",
         "Maybe this isn't a proper",
         "dimension at all?",
@@ -2741,7 +2740,6 @@ bool scriptclass::load(const std::string& name)
         "speak_active",
 
         "squeak(yellow)",
-        "changedir(yellow,0)",
         "text(yellow,0,0,4)",
         "Maybe it's some kind of",
         "polar dimension? Something",
@@ -2751,7 +2749,7 @@ bool scriptclass::load(const std::string& name)
         "speak_active",
 
         "squeak(yellow)",
-        "changedir(yellow,1)",
+        "changeai(yellow,0)", // Make him face right again
         "text(yellow,0,0,2)",
         "I can't wait to get back to the",
         "ship. I have a lot of tests to run!",


### PR DESCRIPTION
## Changes:

Originally the `changedir` command was used here, making Vitellary look left and then immediately snap back to looking right on the next frame, almost certainly unintended for how the cutscene should look. Now the `changeai` command is used instead to make him actually look left, and then look back to the right on his last textbox.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
