### PR TITLE
Fix centering of translated "Level Complete!" and "Game Complete!"

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -881,7 +881,7 @@ void Graphics::drawgui(void)
                 {
                     y = 240 - y - 8*sc;
                 }
-                font::print(sc==2 ? PR_2X : PR_1X | PR_CEN, -1, y, translation, 164, 164, 255);
+                font::print((sc==2 ? PR_2X : PR_1X) | PR_CEN, -1, y, translation, 164, 164, 255);
             }
             else
             {
@@ -917,7 +917,7 @@ void Graphics::drawgui(void)
                 {
                     y = 240 - y - 8*sc;
                 }
-                font::print(sc==2 ? PR_2X : PR_1X | PR_CEN, -1, y, translation, 196, 196, 243);
+                font::print((sc==2 ? PR_2X : PR_1X) | PR_CEN, -1, y, translation, 196, 196, 243);
             }
             else
             {


### PR DESCRIPTION
## Changes:

Operator precedence meant that `sc == 2 ? PR_2X : PR_1X | PR_CEN` didn't work how I expected it to.

![oops left](https://user-images.githubusercontent.com/44736680/221332244-0ba19d0b-55f2-4f61-9e0a-8fdb5342e542.png)

So I added some parentheses.

![oops centered](https://user-images.githubusercontent.com/44736680/221332268-ae622dd9-f862-4d69-bb47-902dbd316e40.png)



## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
