### PR TITLE
Don't draw texture onto itself for scrolling

### DIFF
--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -162,7 +162,7 @@ public:
     void draw_sprite(int x, int y, int t, int r, int g, int b);
     void draw_sprite(int x, int y, int t, SDL_Color color);
 
-    void scroll_texture(SDL_Texture* texture, int x, int y);
+    void scroll_texture(SDL_Texture* texture, SDL_Texture* temp, int x, int y);
 
     void printcrewname(int x, int y, int t);
     void printcrewnamedark(int x, int y, int t);
@@ -314,6 +314,7 @@ public:
     SDL_Texture* ghostTexture;
     SDL_Texture* backgroundTexture;
     SDL_Texture* foregroundTexture;
+    SDL_Texture* tempScrollingTexture;
 
     TowerBG towerbg;
     TowerBG titlebg;


### PR DESCRIPTION
Drawing a texture onto itself seems to produce issues on Metal.

To fix this, use a temporary texture instead, that then gets drawn onto the original texture.

Fixes #927.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
