### PR TITLE
Change `font::len`, `font::print` and `font::print_wrap` text argument from `std::string` to `const char*`

### DIFF
--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -1181,7 +1181,7 @@ void editorrender(void)
         graphics.fill_rect(0,238-textheight,320,240, graphics.getRGB(32,32,32));
         graphics.fill_rect(0,239-textheight,320,240, graphics.getRGB(0,0,0));
 
-        font::print_wrap(0, 4, 240-textheight, message, 255,255,255, 8, 312);
+        font::print_wrap(0, 4, 240-textheight, message.c_str(), 255,255,255, 8, 312);
     }
     else if(ed.scripteditmod)
     {
@@ -1283,7 +1283,7 @@ void editorrender(void)
 
         graphics.fill_rect(0, 238-textheight, 320, 240, graphics.getRGB(32, 32, 32));
         graphics.fill_rect(0, 239-textheight, 320, 240, graphics.getRGB(0, 0, 0));
-        font::print_wrap(0, 4, 240-textheight, wrapped, 255, 255, 255, 8, 312);
+        font::print_wrap(0, 4, 240-textheight, wrapped.c_str(), 255, 255, 255, 8, 312);
         std::string input = key.keybuffer;
         if (ed.entframe < 2)
         {
@@ -1640,7 +1640,7 @@ void editorrender(void)
         float alpha = graphics.lerp(ed.oldnotedelay, ed.notedelay);
         graphics.fill_rect(0, banner_y, 320, 10+textheight, graphics.getRGB(92,92,92));
         graphics.fill_rect(0, banner_y+1, 320, 8+textheight, graphics.getRGB(0,0,0));
-        font::print_wrap(PR_CEN, -1,banner_y+5, wrapped, 196-((45.0f-alpha)*4), 196-((45.0f-alpha)*4), 196-((45.0f-alpha)*4));
+        font::print_wrap(PR_CEN, -1,banner_y+5, wrapped.c_str(), 196-((45.0f-alpha)*4), 196-((45.0f-alpha)*4), 196-((45.0f-alpha)*4));
     }
 
     graphics.drawfade();

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -790,7 +790,7 @@ void editorrender(void)
                 }
                 else
                 {
-                    fillboxabs((customentities[i].x*8)-(ed.levx*40*8), (customentities[i].y*8)-(ed.levy*30*8), font::len(PR_FONT_LEVEL, customentities[i].scriptname), font::height(PR_FONT_LEVEL), graphics.getRGB(96,96,96));
+                    fillboxabs((customentities[i].x*8)-(ed.levx*40*8), (customentities[i].y*8)-(ed.levy*30*8), font::len(PR_FONT_LEVEL, customentities[i].scriptname.c_str()), font::height(PR_FONT_LEVEL), graphics.getRGB(96,96,96));
                 }
                 font::print(PR_FONT_LEVEL | PR_CJK_LOW, (customentities[i].x*8)-(ed.levx*40*8), (customentities[i].y*8)-(ed.levy*30*8), customentities[i].scriptname, 196, 196, 255 - help.glow);
                 break;
@@ -1245,7 +1245,7 @@ void editorrender(void)
             //Draw cursor
             if(ed.entframe<2)
             {
-                font::print(PR_FONT_LEVEL | PR_CJK_LOW, 16+font::len(PR_FONT_LEVEL, ed.sb[ed.pagey+ed.sby]),20+(ed.sby*font_height),"_",123, 111, 218);
+                font::print(PR_FONT_LEVEL | PR_CJK_LOW, 16+font::len(PR_FONT_LEVEL, ed.sb[ed.pagey+ed.sby].c_str()),20+(ed.sby*font_height),"_",123, 111, 218);
             }
             break;
         }

--- a/desktop_version/src/Font.cpp
+++ b/desktop_version/src/Font.cpp
@@ -1261,7 +1261,7 @@ int print_wrap(
     uint32_t flags,
     const int x,
     int y,
-    const std::string& text,
+    const char* text,
     const uint8_t r,
     const uint8_t g,
     const uint8_t b,
@@ -1292,7 +1292,6 @@ int print_wrap(
         flags &= ~PR_BOR;
     }
 
-    const char* str = text.c_str();
     // This could fit 64 non-BMP characters onscreen, should be plenty
     char buffer[256];
     size_t start = 0;
@@ -1301,7 +1300,7 @@ int print_wrap(
     {
         // Correct for the height of the resulting print.
         size_t len = 0;
-        while (next_wrap(pf.font_sel, &start, &len, &str[start], maxwidth))
+        while (next_wrap(pf.font_sel, &start, &len, &text[start], maxwidth))
         {
             y += linespacing;
         }
@@ -1309,7 +1308,7 @@ int print_wrap(
         start = 0;
     }
 
-    while (next_wrap_buf(pf.font_sel, buffer, sizeof(buffer), &start, str, maxwidth))
+    while (next_wrap_buf(pf.font_sel, buffer, sizeof(buffer), &start, text, maxwidth))
     {
         print(flags, x, y, buffer, r, g, b);
 

--- a/desktop_version/src/Font.cpp
+++ b/desktop_version/src/Font.cpp
@@ -1147,13 +1147,12 @@ bool glyph_dimensions(uint32_t flags, uint8_t* glyph_w, uint8_t* glyph_h)
     return true;
 }
 
-int len(const uint32_t flags, const std::string& t)
+int len(const uint32_t flags, const char* text)
 {
     PrintFlags pf = decode_print_flags(flags);
 
     int text_len = 0;
     uint32_t codepoint;
-    const char* text = t.c_str(); // TODO no std::string
     while ((codepoint = UTF8_next(&text)))
     {
         text_len += get_advance(pf.font_sel, codepoint);

--- a/desktop_version/src/Font.cpp
+++ b/desktop_version/src/Font.cpp
@@ -1176,7 +1176,7 @@ void print(
     const uint32_t flags,
     int x,
     int y,
-    const std::string& text,
+    const char* text,
     const uint8_t r,
     const uint8_t g,
     const uint8_t b
@@ -1239,9 +1239,8 @@ void print(
     }
 
     int position = 0;
-    const char* str = text.c_str(); // TODO no std::string
     uint32_t codepoint;
-    while ((codepoint = UTF8_next(&str)))
+    while ((codepoint = UTF8_next(&text)))
     {
         position += font::print_char(
             pf.font_sel,
@@ -1255,6 +1254,20 @@ void print(
             pf.brightness
         );
     }
+}
+
+void print(
+    const uint32_t flags,
+    int x,
+    int y,
+    const std::string& text,
+    const uint8_t r,
+    const uint8_t g,
+    const uint8_t b
+)
+{
+    // Just a std::string overload for now because it's more .c_str() to add than I'm comfortable with...
+    print(flags, x, y, text.c_str(), r, g, b);
 }
 
 int print_wrap(

--- a/desktop_version/src/Font.h
+++ b/desktop_version/src/Font.h
@@ -88,6 +88,15 @@ void print(
     uint32_t flags,
     int x,
     int y,
+    const char* text,
+    uint8_t r, uint8_t g, uint8_t b
+);
+
+// std::string overload for only font::print (use .c_str() for the others)
+void print(
+    uint32_t flags,
+    int x,
+    int y,
     const std::string& text,
     uint8_t r, uint8_t g, uint8_t b
 );

--- a/desktop_version/src/Font.h
+++ b/desktop_version/src/Font.h
@@ -96,7 +96,7 @@ int print_wrap(
     uint32_t flags,
     int x,
     int y,
-    const std::string& text,
+    const char* text,
     uint8_t r, uint8_t g, uint8_t b,
     int linespacing = -1,
     int maxwidth = -1

--- a/desktop_version/src/Font.h
+++ b/desktop_version/src/Font.h
@@ -81,7 +81,7 @@ std::string string_unwordwrap(const std::string& s);
 
 bool glyph_dimensions(uint32_t flags, uint8_t* glyph_w, uint8_t* glyph_h);
 
-int len(uint32_t flags, const std::string& t);
+int len(uint32_t flags, const char* text);
 int height(const uint32_t flags);
 
 void print(

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -468,7 +468,7 @@ void Graphics::print_level_creator(
      * - it makes sense to make it a face
      * - if anyone is sad about this decision, the happy face will cheer them up anyway :D */
     int width_for_face = 17;
-    int total_width = width_for_face + font::len(print_flags, creator);
+    int total_width = width_for_face + font::len(print_flags, creator.c_str());
     int face_x = (SCREEN_WIDTH_PIXELS-total_width)/2;
     set_texture_color_mod(grphx.im_sprites, r, g, b);
     draw_texture_part(grphx.im_sprites, face_x, y-1, 7, 2, 10, 10, 1, 1);
@@ -1366,7 +1366,7 @@ void Graphics::createtextboxreal(
         textboxclass text;
         text.lines.push_back(t);
         text.xp = xp;
-        if (xp == -1) text.xp = 160 - ((font::len(PR_FONT_LEVEL, t) / 2) + 8);
+        if (xp == -1) text.xp = 160 - ((font::len(PR_FONT_LEVEL, t.c_str()) / 2) + 8);
         text.yp = yp;
         text.initcol(r, g, b);
         text.flipme = flipme;
@@ -1567,7 +1567,7 @@ void Graphics::drawmenu(int cr, int cg, int cb, enum Menu::MenuName menu)
             vformat_buf(buffer, sizeof(buffer), loc::get_langmeta()->menu_select.c_str(), "label:str", opt_text.c_str());
 
             // Account for brackets
-            x -= (font::len(opt.print_flags, buffer)-font::len(opt.print_flags, opt_text))/2;
+            x -= (font::len(opt.print_flags, buffer)-font::len(opt.print_flags, opt_text.c_str()))/2;
         }
         else
         {

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -614,7 +614,7 @@ static void menurender(void)
         }
         else if ((unsigned)game.currentmenuoption < loc::languagelist.size())
         {
-            font::print_wrap(PR_CEN, -1, 8, loc::languagelist[game.currentmenuoption].credit, tr/2, tg/2, tb/2);
+            font::print_wrap(PR_CEN, -1, 8, loc::languagelist[game.currentmenuoption].credit.c_str(), tr/2, tg/2, tb/2);
             font::print(PR_CEN, -1, 230, loc::languagelist[game.currentmenuoption].action_hint, tr/2, tg/2, tb/2);
         }
         break;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1497,7 +1497,7 @@ static void menurender(void)
 
                 int w[4] = {
                     font::len(0, str_par_time),
-                    font::len(0, par_time),
+                    font::len(0, par_time.c_str()),
                     font::len(0, str_best_rank),
                     font::len(PR_2X, rank)
                 };
@@ -2189,7 +2189,7 @@ void gamerender(void)
             }
 
             std::string time = game.timetstring(game.timetrialpar);
-            label_len = font::len(0, time);
+            label_len = font::len(0, time.c_str());
             if(game.timetrialparlost)
             {
                 font::print(PR_BOR | PR_RIGHT, 307-label_len-8, 214, loc::gettext("PAR TIME:"),  80, 80, 80);

--- a/desktop_version/src/RoomnameTranslator.cpp
+++ b/desktop_version/src/RoomnameTranslator.cpp
@@ -186,7 +186,7 @@ namespace roomname_translator
                 {
                     *force_roomname_hidden = true;
                     graphics.render_roomname(PR_FONT_LEVEL, key.keybuffer.c_str(), 255,255,255);
-                    int name_w = font::len(PR_FONT_LEVEL, key.keybuffer);
+                    int name_w = font::len(PR_FONT_LEVEL, key.keybuffer.c_str());
                     font::print(PR_BOR | PR_FONT_LEVEL, (320-name_w)/2+name_w, 231, "_", 255,255,255);
                 }
                 else if (!roomname_is_translated)

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -106,7 +106,7 @@ void textboxclass::resize(void)
     int max = 0;
     for (size_t iter = 0; iter < lines.size(); iter++)
     {
-        int len = font::len(print_flags, lines[iter]);
+        int len = font::len(print_flags, lines[iter].c_str());
         if (len > max) max = len;
     }
 


### PR DESCRIPTION
## Changes:

Taking `const char*` instead of `const std::string&` means two things:
- If you already had a `const char*` (which is very common especially because `loc::gettext` gives them, and also string literals), your string is no longer converted into a `std::string` when calling `font::len`, `font::print` or `font::print_wrap`.
- If you had a `std::string` (for example due to string concatenation), you now need to call these functions with `.c_str()` (doesn't apply to `font::print` specifically).

In the case of `font::len` and `font::print_wrap`, they were pretty easy to change to taking only `const char*`. Any code that calls these functions needs to add `.c_str()` to any `std::string`s passed, and I didn't need to add them enough times to feel really worried about that (just 4 times for `font::print_wrap` out of the roughly 213 times this function is used, and 9 times for `font::len` out of the rougly 42 times).

On the other hand, `font::print` had so many calls that needed `.c_str()` to be added, that I decided to overload `font::print` instead. This means it can take either a `const char*` (the main function) or a `std::string` (a wrapper). This means C strings don't need to be needlessly converted into `std::string` objects, and existing `font::print` code doesn't need to be modified.

I don't have any metrics or really any idea whether this improves performance in any way and how much, but in my mind, I was imagining needless memory allocations and copying of data many times every frame (because I don't know if the compiler can optimize that away well enough), and now we can be sure that won't unnecessarily happen.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
