### PR TITLE
Fix hardestroom not being translated

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -4189,7 +4189,7 @@ void Game::gethardestroom(void)
         }
         else
         {
-            hardestroom = map.roomname;
+            hardestroom = loc::gettext_roomname(map.custommode, roomx, roomy, map.roomname, map.roomname_special);
         }
     }
 }


### PR DESCRIPTION
## Changes:

`hardestroom` currently stores the current roomname, but it was missing a call to get the translated string. This has been added, fixing the hardest room appearing as untranslated. This bug appeared in 5beaf973cefa0aa5a19655575d89b52febf21149.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
