### PR TITLE
Update c-hashmap submodule

### DIFF
--- a/desktop_version/src/Font.cpp
+++ b/desktop_version/src/Font.cpp
@@ -465,7 +465,7 @@ static bool find_font_by_name(FontContainer* container, const char* name, uint8_
     }
 
     uintptr_t i;
-    if (hashmap_get(container->map_name_idx, (char*) name, SDL_strlen(name), &i))
+    if (hashmap_get(container->map_name_idx, name, SDL_strlen(name), &i))
     {
         *idx = i;
         return true;

--- a/desktop_version/src/Localization.cpp
+++ b/desktop_version/src/Localization.cpp
@@ -162,7 +162,7 @@ const TextboxFormat* gettext_cutscene(const std::string& script_id, const std::s
     }
 
     uintptr_t ptr_cutscene_map;
-    bool found = hashmap_get(map, (void*) map_script_key, SDL_strlen(map_script_key), &ptr_cutscene_map);
+    bool found = hashmap_get(map, map_script_key, SDL_strlen(map_script_key), &ptr_cutscene_map);
     hashmap* cutscene_map = (hashmap*) ptr_cutscene_map;
 
     if (!found || cutscene_map == NULL)
@@ -178,7 +178,7 @@ const TextboxFormat* gettext_cutscene(const std::string& script_id, const std::s
     }
 
     uintptr_t ptr_format;
-    found = hashmap_get(cutscene_map, (void*) key, alloc_len-1, &ptr_format);
+    found = hashmap_get(cutscene_map, key, alloc_len-1, &ptr_format);
     const TextboxFormat* format = (TextboxFormat*) ptr_format;
 
     VVV_free(key);
@@ -294,7 +294,7 @@ bool is_cutscene_translated(const std::string& script_id)
     }
 
     uintptr_t ptr_unused;
-    return hashmap_get(map, (void*) map_script_key, SDL_strlen(map_script_key), &ptr_unused);
+    return hashmap_get(map, map_script_key, SDL_strlen(map_script_key), &ptr_unused);
 }
 
 uint32_t toupper_ch(uint32_t ch)

--- a/desktop_version/src/LocalizationMaint.cpp
+++ b/desktop_version/src/LocalizationMaint.cpp
@@ -244,7 +244,7 @@ static void sync_lang_file(const std::string& langcode)
             hashmap* map = map_translation_cutscene;
 
             uintptr_t ptr_cutscene_map;
-            bool found = hashmap_get(map, (void*) cutscene_id, SDL_strlen(cutscene_id), &ptr_cutscene_map);
+            bool found = hashmap_get(map, cutscene_id, SDL_strlen(cutscene_id), &ptr_cutscene_map);
             hashmap* cutscene_map = (hashmap*) ptr_cutscene_map;
             if (!found || cutscene_map == NULL)
             {
@@ -271,7 +271,7 @@ static void sync_lang_file(const std::string& langcode)
                 }
 
                 uintptr_t ptr_format;
-                found = hashmap_get(cutscene_map, (void*) eng_prefixed, alloc_len-1, &ptr_format);
+                found = hashmap_get(cutscene_map, eng_prefixed, alloc_len-1, &ptr_format);
                 const TextboxFormat* format = (TextboxFormat*) ptr_format;
 
                 VVV_free(eng_prefixed);

--- a/desktop_version/src/LocalizationStorage.cpp
+++ b/desktop_version/src/LocalizationStorage.cpp
@@ -129,7 +129,7 @@ static void map_store_translation(Textbook* textbook, hashmap* map, const char* 
         return;
     }
 
-    hashmap_set(map, (void*) tb_eng, SDL_strlen(tb_eng), (uintptr_t) tb_tra);
+    hashmap_set(map, tb_eng, SDL_strlen(tb_eng), (uintptr_t) tb_tra);
 }
 
 unsigned char form_for_count(int n)
@@ -643,7 +643,7 @@ static void loadtext_cutscenes(bool custom_level)
         hashmap* cutscene_map = hashmap_create();
         hashmap_set_free(
             map,
-            (void*) script_id,
+            script_id,
             SDL_strlen(script_id),
             (uintptr_t) cutscene_map,
             callback_free_map_value,
@@ -704,7 +704,7 @@ static void loadtext_cutscenes(bool custom_level)
             {
                 continue;
             }
-            hashmap_set(cutscene_map, (void*) tb_eng, SDL_strlen(tb_eng), (uintptr_t) tb_format);
+            hashmap_set(cutscene_map, tb_eng, SDL_strlen(tb_eng), (uintptr_t) tb_format);
         }
     }
 }
@@ -1072,7 +1072,7 @@ void loadlanguagelist(void)
 const char* map_lookup_text(hashmap* map, const char* eng, const char* fallback)
 {
     uintptr_t ptr_tra;
-    bool found = hashmap_get(map, (void*) eng, SDL_strlen(eng), &ptr_tra);
+    bool found = hashmap_get(map, eng, SDL_strlen(eng), &ptr_tra);
     const char* tra = (const char*) ptr_tra;
 
     if (found && tra != NULL && tra[0] != '\0')


### PR DESCRIPTION
## Changes:

- Hashmap keys are now const everywhere except in callbacks, meaning we don't need (char*) and (void*) casts whenever passing a const pointer anymore - so I cleaned up all these casts. (Guess C is a lot less strict with const than C++ is, and string literals aren't even const-qualified in C, but the reason hashmap keys aren't just const everywhere is because you may want to free a key based on a hashmap iteration).
- "no newline at end of file" warnings on macOS are fixed (for some reason, specifically macOS complained about that)
- "'return': conversion from 'uint64_t' to 'uint32_t', possible loss of data" warning on Windows is fixed (though Windows gives lots of these warnings, I guess /W4 is a bit too much...)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
