### PR TITLE
Change text to accommodate button glyphs

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -71,6 +71,7 @@ endif()
 set(VVV_SRC
     src/BinaryBlob.cpp
     src/BlockV.cpp
+    src/ButtonGlyphs.cpp
     src/CWrappers.cpp
     src/Ent.cpp
     src/Entity.cpp

--- a/desktop_version/lang/ca/cutscenes.xml
+++ b/desktop_version/lang/ca/cutscenes.xml
@@ -76,10 +76,11 @@
     <cutscene id="bigopenworldskip" explanation="">
         <dialogue speaker="purple" english="I&apos;ll be right here if you need any help!" translation="Si necessites ajuda, seré aquí!"/>
     </cutscene>
-    <cutscene id="talkpurple_intro" explanation="">
+    <cutscene id="talkpurple_intro" explanation="***ENTER is OUTDATED***">
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Tot això m’aclapara una mica, doctora."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Per on començo?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Recorda que pots prémer Retorn per a veure on ets del mapa!"/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Cerca zones on pugui haver-hi altres tripulants..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Si et perds, pots tornar a la nau a partir de qualsevol teletransportador."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="I no pateixis! Segur que trobarem tothom!"/>

--- a/desktop_version/lang/ca/strings.xml
+++ b/desktop_version/lang/ca/strings.xml
@@ -213,6 +213,8 @@
     <string english="Toggle whether you interact with prompts using ENTER or E." translation="Commuta si s’interacciona|fent servir Retorn o E." explanation="prompts: see the `Press {button} to talk to .../activate terminal/teleport` below" max="38*3"/>
     <string english="E" translation="E" explanation="keyboard key E. Speedrunner options menu"/>
     <string english="ENTER" translation="Retorn" explanation="keyboard key ENTER. Speedrunner options menu"/>
+    <string english="ESC" translation="" explanation="keyboard key ESC"/>
+    <string english="ACTION" translation="" explanation="the ACTION key is either the SPACE key, Z or V (this is explained on the title screen). It&apos;s used in strings like `Press ACTION to advance text`"/>
     <string english="Interact button: {button}" translation="Botó d’interacció: {button}" explanation="keyboard key (E or ENTER) is filled in for {button}. Speedrunner options menu" max="38*2"/>
     <string english="fake load screen" translation="pantalla de càrrega" explanation="menu option"/>
     <string english="Fake Load Screen" translation="Pantalla de càrrega" explanation="title, allows the loading screen which counts to 100% to be turned off" max="20"/>
@@ -418,11 +420,15 @@
     <string english="To install new player levels, copy the .vvvvvv files to the levels folder." translation="Per a instal·lar nous nivells,|copia els fitxers .vvvvvv|a la carpeta de nivells." explanation="" max="38*3"/>
     <string english="Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming." translation="Segur que vols mostrar el camí|de la carpeta de nivells?|Si estàs emetent en directe, pot ser|que es mostri informació delicada." explanation="" max="38*4"/>
     <string english="The levels path is:" translation="El camí dels nivells és:" explanation="" max="40"/>
-    <string english="[ Press ACTION to Start ]" translation="[ Prem Acció per a començar ]" explanation="title screen" max="38*2"/>
+    <string english="[ Press ACTION to Start ]" translation="[ Prem Acció per a començar ]" explanation="***OUTDATED***" max="38*2"/>
+    <string english="[ Press {button} to Start ]" translation="" explanation="title screen. Expect `ACTION`" max="38*2"/>
     <string english="ACTION = Space, Z, or V" translation="Acció = Espai, Z o V" explanation="title screen" max="38*3"/>
-    <string english="[Press ENTER to return to editor]" translation="[Prem Retorn per a tornar a l’editor]" explanation="`to editor` is sorta redundant" max="40"/>
-    <string english="- Press ACTION to advance text -" translation="- Prem Acció per a avançar el text -" explanation="to dismiss a textbox" max="40"/>
-    <string english="Press ACTION to continue" translation="Prem Acció per a continuar" explanation="" max="34"/>
+    <string english="[Press ENTER to return to editor]" translation="[Prem Retorn per a tornar a l’editor]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to return to editor]" translation="" explanation="`to editor` is sorta redundant" max="40"/>
+    <string english="- Press ACTION to advance text -" translation="- Prem Acció per a avançar el text -" explanation="***OUTDATED***" max="40"/>
+    <string english="- Press {button} to advance text -" translation="" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
+    <string english="Press ACTION to continue" translation="Prem Acció per a continuar" explanation="***OUTDATED***" max="34"/>
+    <string english="Press {button} to continue" translation="" explanation="Expect `ACTION`" max="34"/>
     <string english="Current Time" translation="Temps actual" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="Millor temps" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="Pròxim trofeu a 5 segons" explanation="" max="38*2"/>
@@ -434,7 +440,8 @@
     <string english="All Trophies collected!" translation="Has obtingut tots els trofeus!" explanation="" max="38*2"/>
     <string english="New Record!" translation="Nou rècord!" explanation="" max="20"/>
     <string english="New Trophy!" translation="Nou trofeu!" explanation="" max="20"/>
-    <string english="[Press ENTER to stop]" translation="[Prem Retorn per a aturar-lo]" explanation="stop super gravitron" max="40"/>
+    <string english="[Press ENTER to stop]" translation="[Prem Retorn per a aturar-lo]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to stop]" translation="" explanation="stop super gravitron" max="40"/>
     <string english="SUPER GRAVITRON" translation="SUPERGRAVITRÓ" explanation="" max="20"/>
     <string english="SUPER GRAVITRON HIGHSCORE" translation="PUNTUACIÓ MÀXIMA AL SUPERGRAVITRÓ" explanation="" max="38*4"/>
     <string english="MAP" translation="MAPA" explanation="in-game menu" max="8"/>
@@ -447,7 +454,8 @@
     <string english="[ QUIT ]" translation="[ SURT ]" explanation="in-game menu" max="40"/>
     <string english="[ GRAVITRON ]" translation="[ GRAVITRÓ ]" explanation="in-game menu" max="40"/>
     <string english="NO SIGNAL" translation="NO HI HA SENYAL" explanation="map screen. So like a TV/computer monitor" max="29"/>
-    <string english="Press ACTION to warp to the ship." translation="Prem Acció per a teletransportar-te|a la nau" explanation="spaceship. Warp = teleport" max="38*7"/>
+    <string english="Press ACTION to warp to the ship." translation="Prem Acció per a teletransportar-te|a la nau" explanation="***OUTDATED***" max="38*7"/>
+    <string english="Press {button} to warp to the ship." translation="" explanation="spaceship. Warp = teleport. Expect `ACTION`" max="38*7"/>
     <string english="Missing..." translation="No hi és..." case="1" explanation="this male crew member is missing" max="15"/>
     <string english="Missing..." translation="No hi és..." case="2" explanation="this female crew member is missing" max="15"/>
     <string english="Missing..." translation="No hi és..." case="3" explanation="Viridian is missing (final level). You could even fill in something like `Uh-oh...` here if you really have to specify gender otherwise - everyone else is rescued, but the player is missing" max="15"/>
@@ -461,7 +469,8 @@
     <string english="ERROR: Could not save game!" translation="ERROR: No s’ha pogut desar la partida!" explanation="in-game menu" max="34*2"/>
     <string english="ERROR: Could not save settings file!" translation="ERROR: No s’ha pogut desar|el fitxer de configuració!" explanation="" max="38*2"/>
     <string english="Game saved ok!" translation="La partida s’ha desat!" explanation="in-game menu" max="38*2"/>
-    <string english="[Press ACTION to save your game]" translation="[Prem Acció per a desar la partida]" explanation="in-game menu" max="40"/>
+    <string english="[Press ACTION to save your game]" translation="[Prem Acció per a desar la partida]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to save your game]" translation="" explanation="in-game menu. Expect `ACTION`" max="40"/>
     <string english="(Note: The game is autosaved at every teleporter.)" translation="(Nota: La partida es desa automàticament a cada teletransportador.)" explanation="in-game menu" max="38*3"/>
     <string english="Last Save:" translation="Desada per darrera vegada a:" explanation="in-game menu" max="40"/>
     <string english="Return to main menu?" translation="Vols tornar al menú principal?" explanation="in-game menu" max="38*4"/>
@@ -652,8 +661,11 @@
     <string english="All crewmates rescued!" translation="Has rescatat tothom!" explanation="" max="32"/>
     <string english="Game Saved" translation="S’ha desat la partida" explanation="" max="30"/>
     <string english="Press arrow keys or WASD to move" translation="Prem les tecles de fletxa o WASD per a moure’t" explanation="" max="32*2"/>
-    <string english="Press ACTION to flip" translation="Prem Acció per a invertir-te" explanation="" max="32*3"/>
-    <string english="Press ENTER to view map and quicksave" translation="Prem Retorn per a veure el mapa|i desar ràpidament" explanation="" max="32*3"/>
+    <string english="Press left/right to move" translation="" explanation="" max="32*2"/>
+    <string english="Press ACTION to flip" translation="Prem Acció per a invertir-te" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to flip" translation="" explanation="expect `ACTION`" max="32*3"/>
+    <string english="Press ENTER to view map and quicksave" translation="Prem Retorn per a veure el mapa|i desar ràpidament" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to view map and quicksave" translation="" explanation="" max="32*3"/>
     <string english="If you prefer, you can press UP or DOWN instead of ACTION to flip." translation="Si ho prefereixes, pots prémer ↑ o ↓ en lloc d’Acció per a invertir-te." explanation="" max="34*3"/>
     <string english="Help! Can anyone hear this message?" translation="Ajuda! Algú sent aquest missatge?" explanation="Violet speaking via Comms Relay" max="25*4"/>
     <string english="Verdigris? Are you out there? Are you ok?" translation="Verdet? Ets allà fora? Estàs bé?" explanation="Violet speaking via Comms Relay" max="25*4"/>

--- a/desktop_version/lang/de/cutscenes.xml
+++ b/desktop_version/lang/de/cutscenes.xml
@@ -76,10 +76,11 @@
     <cutscene id="bigopenworldskip" explanation="">
         <dialogue speaker="purple" english="I&apos;ll be right here if you need any help!" translation="Ich bin hier, wenn du Hilfe brauchst!"/>
     </cutscene>
-    <cutscene id="talkpurple_intro" explanation="">
+    <cutscene id="talkpurple_intro" explanation="***ENTER is OUTDATED***">
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Ich fühle mich ein bisschen überfordert, Doktor."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Wo soll ich anfangen?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Denk dran, dass du ENTER drücken kannst, um zu sehen, wo du auf der Karte bist!"/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Halte Ausschau nach Bereichen, in denen der Rest der Crew sein könnte..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Wenn du dich verirrst, kannst du von jedem Teleporter aus zum Schiff zurückkehren."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="Und mach dir keine Sorgen! Wir werden alle finden!"/>

--- a/desktop_version/lang/de/strings.xml
+++ b/desktop_version/lang/de/strings.xml
@@ -213,6 +213,8 @@
     <string english="Toggle whether you interact with prompts using ENTER or E." translation="Schalte um, ob du mit ENTER oder E zum Interagieren verwendest." explanation="prompts: see the `Press {button} to talk to .../activate terminal/teleport` below" max="38*3"/>
     <string english="E" translation="E" explanation="keyboard key E. Speedrunner options menu"/>
     <string english="ENTER" translation="ENTER" explanation="keyboard key ENTER. Speedrunner options menu"/>
+    <string english="ESC" translation="" explanation="keyboard key ESC"/>
+    <string english="ACTION" translation="" explanation="the ACTION key is either the SPACE key, Z or V (this is explained on the title screen). It&apos;s used in strings like `Press ACTION to advance text`"/>
     <string english="Interact button: {button}" translation="Handlungstaste: {button}" explanation="keyboard key (E or ENTER) is filled in for {button}. Speedrunner options menu" max="38*2"/>
     <string english="fake load screen" translation="falscher ladebildschirm" explanation="menu option"/>
     <string english="Fake Load Screen" translation="Ladebildschirm" explanation="title, allows the loading screen which counts to 100% to be turned off" max="20"/>
@@ -418,11 +420,15 @@
     <string english="To install new player levels, copy the .vvvvvv files to the levels folder." translation="Kopiere die .vvvvvv-Dateien in den Level-Ordner, um neue Spielerlevel zu installieren." explanation="" max="38*3"/>
     <string english="Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming." translation="Bist du sicher, dass du den Level-Pfad anzeigen willst? Das könnte sensible Informationen preisgeben, wenn du streamst." explanation="" max="38*4"/>
     <string english="The levels path is:" translation="Der Levelpfad ist:" explanation="" max="40"/>
-    <string english="[ Press ACTION to Start ]" translation="[ Drücke HANDLUNG zum Starten ]" explanation="title screen" max="38*2"/>
+    <string english="[ Press ACTION to Start ]" translation="[ Drücke HANDLUNG zum Starten ]" explanation="***OUTDATED***" max="38*2"/>
+    <string english="[ Press {button} to Start ]" translation="" explanation="title screen. Expect `ACTION`" max="38*2"/>
     <string english="ACTION = Space, Z, or V" translation="HANDLUNG = Leertaste, Z oder V" explanation="title screen" max="38*3"/>
-    <string english="[Press ENTER to return to editor]" translation="[Kehre mit ENTER zum Editor zurück]" explanation="`to editor` is sorta redundant" max="40"/>
-    <string english="- Press ACTION to advance text -" translation="- Drücke HANDLUNG zum Fortsetzen -" explanation="to dismiss a textbox" max="40"/>
-    <string english="Press ACTION to continue" translation="Drücke HANDLUNG zum Fortsetzen" explanation="" max="34"/>
+    <string english="[Press ENTER to return to editor]" translation="[Kehre mit ENTER zum Editor zurück]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to return to editor]" translation="" explanation="`to editor` is sorta redundant" max="40"/>
+    <string english="- Press ACTION to advance text -" translation="- Drücke HANDLUNG zum Fortsetzen -" explanation="***OUTDATED***" max="40"/>
+    <string english="- Press {button} to advance text -" translation="" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
+    <string english="Press ACTION to continue" translation="Drücke HANDLUNG zum Fortsetzen" explanation="***OUTDATED***" max="34"/>
+    <string english="Press {button} to continue" translation="" explanation="Expect `ACTION`" max="34"/>
     <string english="Current Time" translation="Aktuelle Zeit" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="Beste Zeit" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="Nächste Trophäe bei 5 Sekunden" explanation="" max="38*2"/>
@@ -434,7 +440,8 @@
     <string english="All Trophies collected!" translation="Alle Trophäen erhalten!" explanation="" max="38*2"/>
     <string english="New Record!" translation="Neuer Rekord!" explanation="" max="20"/>
     <string english="New Trophy!" translation="Neue Trophäe!" explanation="" max="20"/>
-    <string english="[Press ENTER to stop]" translation="[Drücke ENTER zum Anhalten]" explanation="stop super gravitron" max="40"/>
+    <string english="[Press ENTER to stop]" translation="[Drücke ENTER zum Anhalten]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to stop]" translation="" explanation="stop super gravitron" max="40"/>
     <string english="SUPER GRAVITRON" translation="SUPER GRAVITRON" explanation="" max="20"/>
     <string english="SUPER GRAVITRON HIGHSCORE" translation="SUPER GRAVITRON HIGHSCORE" explanation="" max="38*4"/>
     <string english="MAP" translation="KARTE" explanation="in-game menu" max="8"/>
@@ -447,7 +454,8 @@
     <string english="[ QUIT ]" translation="[ ENDE ]" explanation="in-game menu" max="40"/>
     <string english="[ GRAVITRON ]" translation="[ GRAVITRON ]" explanation="in-game menu" max="40"/>
     <string english="NO SIGNAL" translation="KEIN SIGNAL" explanation="map screen. So like a TV/computer monitor" max="29"/>
-    <string english="Press ACTION to warp to the ship." translation="Drücke HANDLUNG, um zum Schiff zu warpen." explanation="spaceship. Warp = teleport" max="38*7"/>
+    <string english="Press ACTION to warp to the ship." translation="Drücke HANDLUNG, um zum Schiff zu warpen." explanation="***OUTDATED***" max="38*7"/>
+    <string english="Press {button} to warp to the ship." translation="" explanation="spaceship. Warp = teleport. Expect `ACTION`" max="38*7"/>
     <string english="Missing..." translation="Vermisst..." case="1" explanation="this male crew member is missing" max="15"/>
     <string english="Missing..." translation="Vermisst..." case="2" explanation="this female crew member is missing" max="15"/>
     <string english="Missing..." translation="Vermisst..." case="3" explanation="Viridian is missing (final level). You could even fill in something like `Uh-oh...` here if you really have to specify gender otherwise - everyone else is rescued, but the player is missing" max="15"/>
@@ -461,7 +469,8 @@
     <string english="ERROR: Could not save game!" translation="FEHLER: Konnte das Spiel nicht speichern!" explanation="in-game menu" max="34*2"/>
     <string english="ERROR: Could not save settings file!" translation="FEHLER: Konnte die eingestellten Optionen nicht speichern!" explanation="" max="38*2"/>
     <string english="Game saved ok!" translation="Spiel gespeichert!" explanation="in-game menu" max="38*2"/>
-    <string english="[Press ACTION to save your game]" translation="[Speichere mit HANDLUNG das Spiel]" explanation="in-game menu" max="40"/>
+    <string english="[Press ACTION to save your game]" translation="[Speichere mit HANDLUNG das Spiel]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to save your game]" translation="" explanation="in-game menu. Expect `ACTION`" max="40"/>
     <string english="(Note: The game is autosaved at every teleporter.)" translation="(Hinweis: Das Spiel wird bei jedem Teleporter automatisch gespeichert)." explanation="in-game menu" max="38*3"/>
     <string english="Last Save:" translation="Letzter Spielstand:" explanation="in-game menu" max="40"/>
     <string english="Return to main menu?" translation="Zurück zum Hauptmenü?" explanation="in-game menu" max="38*4"/>
@@ -652,8 +661,11 @@
     <string english="All crewmates rescued!" translation="Alle Crewmitglieder gerettet!" explanation="" max="32"/>
     <string english="Game Saved" translation="Spiel gespeichert" explanation="" max="30"/>
     <string english="Press arrow keys or WASD to move" translation="Drücke die Pfeiltasten oder WASD zum Bewegen" explanation="" max="32*2"/>
-    <string english="Press ACTION to flip" translation="Drücke HANDLUNG zum Flippen" explanation="" max="32*3"/>
-    <string english="Press ENTER to view map and quicksave" translation="Drücke ENTER, um die Karte anzuzeigen und zum Schnellspeichern" explanation="" max="32*3"/>
+    <string english="Press left/right to move" translation="" explanation="" max="32*2"/>
+    <string english="Press ACTION to flip" translation="Drücke HANDLUNG zum Flippen" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to flip" translation="" explanation="expect `ACTION`" max="32*3"/>
+    <string english="Press ENTER to view map and quicksave" translation="Drücke ENTER, um die Karte anzuzeigen und zum Schnellspeichern" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to view map and quicksave" translation="" explanation="" max="32*3"/>
     <string english="If you prefer, you can press UP or DOWN instead of ACTION to flip." translation="Du kannst statt HANDLUNG auch HOCH oder RUNTER drücken, um zu flippen." explanation="" max="34*3"/>
     <string english="Help! Can anyone hear this message?" translation="Hilfe! Kann mich irgendjemand hören?" explanation="Violet speaking via Comms Relay" max="25*4"/>
     <string english="Verdigris? Are you out there? Are you ok?" translation="Verdigris? Bist du da draußen? Geht es dir gut?" explanation="Violet speaking via Comms Relay" max="25*4"/>

--- a/desktop_version/lang/en/cutscenes.xml
+++ b/desktop_version/lang/en/cutscenes.xml
@@ -76,10 +76,11 @@
     <cutscene id="bigopenworldskip" explanation="">
         <dialogue speaker="purple" english="I&apos;ll be right here if you need any help!" translation=""/>
     </cutscene>
-    <cutscene id="talkpurple_intro" explanation="">
+    <cutscene id="talkpurple_intro" explanation="***ENTER is OUTDATED***">
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation=""/>
         <dialogue speaker="player" english="Where do I begin?" translation=""/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation=""/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation=""/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation=""/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation=""/>

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -213,6 +213,7 @@
     <string english="Toggle whether you interact with prompts using ENTER or E." translation="" explanation="prompts: see the `Press {button} to talk to .../activate terminal/teleport` below" max="38*3"/>
     <string english="E" translation="" explanation="keyboard key E. Speedrunner options menu"/>
     <string english="ENTER" translation="" explanation="keyboard key ENTER. Speedrunner options menu"/>
+    <string english="ESC" translation="" explanation="keyboard key ESC"/>
     <string english="ACTION" translation="" explanation="the ACTION key is either the SPACE key, Z or V (this is explained on the title screen). It's used in strings like `Press ACTION to advance text`"/>
     <string english="Interact button: {button}" translation="" explanation="keyboard key (E or ENTER) is filled in for {button}. Speedrunner options menu" max="38*2"/>
     <string english="fake load screen" translation="" explanation="menu option"/>

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -213,6 +213,7 @@
     <string english="Toggle whether you interact with prompts using ENTER or E." translation="" explanation="prompts: see the `Press {button} to talk to .../activate terminal/teleport` below" max="38*3"/>
     <string english="E" translation="" explanation="keyboard key E. Speedrunner options menu"/>
     <string english="ENTER" translation="" explanation="keyboard key ENTER. Speedrunner options menu"/>
+    <string english="ACTION" translation="" explanation="the ACTION key is either the SPACE key, Z or V (this is explained on the title screen). It's used in strings like `Press ACTION to advance text`"/>
     <string english="Interact button: {button}" translation="" explanation="keyboard key (E or ENTER) is filled in for {button}. Speedrunner options menu" max="38*2"/>
     <string english="fake load screen" translation="" explanation="menu option"/>
     <string english="Fake Load Screen" translation="" explanation="title, allows the loading screen which counts to 100% to be turned off" max="20"/>
@@ -418,12 +419,15 @@
     <string english="To install new player levels, copy the .vvvvvv files to the levels folder." translation="" explanation="" max="38*3"/>
     <string english="Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming." translation="" explanation="" max="38*4"/>
     <string english="The levels path is:" translation="" explanation="" max="40"/>
-    <string english="[ Press ACTION to Start ]" translation="" explanation="title screen" max="38*2"/>
+    <string english="[ Press ACTION to Start ]" translation="" explanation="***OUTDATED***" max="38*2"/>
+    <string english="[ Press {button} to Start ]" translation="" explanation="title screen. Expect `ACTION`" max="38*2"/>
     <string english="ACTION = Space, Z, or V" translation="" explanation="title screen" max="38*3"/>
     <string english="[Press ENTER to return to editor]" translation="" explanation="***OUTDATED***" max="40"/>
     <string english="[Press {button} to return to editor]" translation="" explanation="`to editor` is sorta redundant" max="40"/>
-    <string english="- Press ACTION to advance text -" translation="" explanation="to dismiss a textbox" max="40"/>
-    <string english="Press ACTION to continue" translation="" explanation="" max="34"/>
+    <string english="- Press ACTION to advance text -" translation="" explanation="***OUTDATED***" max="40"/>
+    <string english="- Press {button} to advance text -" translation="" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
+    <string english="Press ACTION to continue" translation="" explanation="***OUTDATED***" max="34"/>
+    <string english="Press {button} to continue" translation="" explanation="Expect `ACTION`" max="34"/>
     <string english="Current Time" translation="" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="" explanation="" max="38*2"/>
@@ -449,7 +453,8 @@
     <string english="[ QUIT ]" translation="" explanation="in-game menu" max="40"/>
     <string english="[ GRAVITRON ]" translation="" explanation="in-game menu" max="40"/>
     <string english="NO SIGNAL" translation="" explanation="map screen. So like a TV/computer monitor" max="29"/>
-    <string english="Press ACTION to warp to the ship." translation="" explanation="spaceship. Warp = teleport" max="38*7"/>
+    <string english="Press ACTION to warp to the ship." translation="" explanation="***OUTDATED***" max="38*7"/>
+    <string english="Press {button} to warp to the ship." translation="" explanation="spaceship. Warp = teleport. Expect `ACTION`" max="38*7"/>
     <string english="Missing..." translation="" case="1" explanation="this male crew member is missing" max="15"/>
     <string english="Missing..." translation="" case="2" explanation="this female crew member is missing" max="15"/>
     <string english="Missing..." translation="" case="3" explanation="Viridian is missing (final level). You could even fill in something like `Uh-oh...` here if you really have to specify gender otherwise - everyone else is rescued, but the player is missing" max="15"/>
@@ -463,7 +468,8 @@
     <string english="ERROR: Could not save game!" translation="" explanation="in-game menu" max="34*2"/>
     <string english="ERROR: Could not save settings file!" translation="" explanation="" max="38*2"/>
     <string english="Game saved ok!" translation="" explanation="in-game menu" max="38*2"/>
-    <string english="[Press ACTION to save your game]" translation="" explanation="in-game menu" max="40"/>
+    <string english="[Press ACTION to save your game]" translation="" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to save your game]" translation="" explanation="in-game menu. Expect `ACTION`" max="40"/>
     <string english="(Note: The game is autosaved at every teleporter.)" translation="" explanation="in-game menu" max="38*3"/>
     <string english="Last Save:" translation="" explanation="in-game menu" max="40"/>
     <string english="Return to main menu?" translation="" explanation="in-game menu" max="38*4"/>
@@ -655,7 +661,8 @@
     <string english="Game Saved" translation="" explanation="" max="30"/>
     <string english="Press arrow keys or WASD to move" translation="" explanation="" max="32*2"/>
     <string english="Press left/right to move" translation="" explanation="" max="32*2"/>
-    <string english="Press ACTION to flip" translation="" explanation="" max="32*3"/>
+    <string english="Press ACTION to flip" translation="" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to flip" translation="" explanation="expect `ACTION`" max="32*3"/>
     <string english="Press ENTER to view map and quicksave" translation="" explanation="***OUTDATED***" max="32*3"/>
     <string english="Press {button} to view map and quicksave" translation="" explanation="" max="32*3"/>
     <string english="If you prefer, you can press UP or DOWN instead of ACTION to flip." translation="" explanation="" max="34*3"/>

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -420,7 +420,8 @@
     <string english="The levels path is:" translation="" explanation="" max="40"/>
     <string english="[ Press ACTION to Start ]" translation="" explanation="title screen" max="38*2"/>
     <string english="ACTION = Space, Z, or V" translation="" explanation="title screen" max="38*3"/>
-    <string english="[Press ENTER to return to editor]" translation="" explanation="`to editor` is sorta redundant" max="40"/>
+    <string english="[Press ENTER to return to editor]" translation="" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to return to editor]" translation="" explanation="`to editor` is sorta redundant" max="40"/>
     <string english="- Press ACTION to advance text -" translation="" explanation="to dismiss a textbox" max="40"/>
     <string english="Press ACTION to continue" translation="" explanation="" max="34"/>
     <string english="Current Time" translation="" explanation="super gravitron, stopwatch time" max="20"/>
@@ -434,7 +435,8 @@
     <string english="All Trophies collected!" translation="" explanation="" max="38*2"/>
     <string english="New Record!" translation="" explanation="" max="20"/>
     <string english="New Trophy!" translation="" explanation="" max="20"/>
-    <string english="[Press ENTER to stop]" translation="" explanation="stop super gravitron" max="40"/>
+    <string english="[Press ENTER to stop]" translation="" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to stop]" translation="" explanation="stop super gravitron" max="40"/>
     <string english="SUPER GRAVITRON" translation="" explanation="" max="20"/>
     <string english="SUPER GRAVITRON HIGHSCORE" translation="" explanation="" max="38*4"/>
     <string english="MAP" translation="" explanation="in-game menu" max="8"/>
@@ -652,8 +654,10 @@
     <string english="All crewmates rescued!" translation="" explanation="" max="32"/>
     <string english="Game Saved" translation="" explanation="" max="30"/>
     <string english="Press arrow keys or WASD to move" translation="" explanation="" max="32*2"/>
+    <string english="Press left/right to move" translation="" explanation="" max="32*2"/>
     <string english="Press ACTION to flip" translation="" explanation="" max="32*3"/>
-    <string english="Press ENTER to view map and quicksave" translation="" explanation="" max="32*3"/>
+    <string english="Press ENTER to view map and quicksave" translation="" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to view map and quicksave" translation="" explanation="" max="32*3"/>
     <string english="If you prefer, you can press UP or DOWN instead of ACTION to flip." translation="" explanation="" max="34*3"/>
     <string english="Help! Can anyone hear this message?" translation="" explanation="Violet speaking via Comms Relay" max="25*4"/>
     <string english="Verdigris? Are you out there? Are you ok?" translation="" explanation="Violet speaking via Comms Relay" max="25*4"/>

--- a/desktop_version/lang/eo/cutscenes.xml
+++ b/desktop_version/lang/eo/cutscenes.xml
@@ -76,10 +76,11 @@
     <cutscene id="bigopenworldskip" explanation="">
         <dialogue speaker="purple" english="I&apos;ll be right here if you need any help!" translation="Mi estos ĉi tie, se vi helpon bezonas!"/>
     </cutscene>
-    <cutscene id="talkpurple_intro" explanation="">
+    <cutscene id="talkpurple_intro" explanation="***ENTER is OUTDATED***">
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Mi sentas min iom superŝarĝita, Doktoro."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Kie mi komencu?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Memoru, ke vi povas premi ENTER por kontroli, kie vi estas sur la mapo!"/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Serĉu areojn, kie eble estas la skipanoj..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Se vi perdiĝas, vi povas reveni al la ŝipo per iu ajn teleportilo."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="Kaj ne ĉagreniĝu! Ni ĉiujn trovos!"/>

--- a/desktop_version/lang/eo/strings.xml
+++ b/desktop_version/lang/eo/strings.xml
@@ -213,6 +213,8 @@
     <string english="Toggle whether you interact with prompts using ENTER or E." translation="Baskuligi ĉu interagi al invitoj per aŭ ENTER aŭ E." explanation="prompts: see the `Press {button} to talk to .../activate terminal/teleport` below" max="38*3"/>
     <string english="E" translation="E" explanation="keyboard key E. Speedrunner options menu"/>
     <string english="ENTER" translation="ENTER" explanation="keyboard key ENTER. Speedrunner options menu"/>
+    <string english="ESC" translation="" explanation="keyboard key ESC"/>
+    <string english="ACTION" translation="" explanation="the ACTION key is either the SPACE key, Z or V (this is explained on the title screen). It&apos;s used in strings like `Press ACTION to advance text`"/>
     <string english="Interact button: {button}" translation="Interaga butono: {button}" explanation="keyboard key (E or ENTER) is filled in for {button}. Speedrunner options menu" max="38*2"/>
     <string english="fake load screen" translation="falsa ŝargekrano" explanation="menu option"/>
     <string english="Fake Load Screen" translation="Falsa ŝarĝekrano" explanation="title, allows the loading screen which counts to 100% to be turned off" max="20"/>
@@ -418,11 +420,15 @@
     <string english="To install new player levels, copy the .vvvvvv files to the levels folder." translation="Por instali novajn nivelojn, kopiu la dosierojn .vvvvvv al la nivel-dosierujo." explanation="" max="38*3"/>
     <string english="Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming." translation="Ĉu vi vere volas montri la dosierindikon? Tio eble malkaŝos konfidencajn informojn se vi elsendas." explanation="" max="38*4"/>
     <string english="The levels path is:" translation="La nivela dosierindiko estas:" explanation="" max="40"/>
-    <string english="[ Press ACTION to Start ]" translation="[ Premu AGOKLAVON por komenci ]" explanation="title screen" max="38*2"/>
+    <string english="[ Press ACTION to Start ]" translation="[ Premu AGOKLAVON por komenci ]" explanation="***OUTDATED***" max="38*2"/>
+    <string english="[ Press {button} to Start ]" translation="" explanation="title screen. Expect `ACTION`" max="38*2"/>
     <string english="ACTION = Space, Z, or V" translation="AGOKLAVO = Spaceto, Z aŭ V" explanation="title screen" max="38*3"/>
-    <string english="[Press ENTER to return to editor]" translation="[Premu ENTER por reveni al redaktilo]" explanation="`to editor` is sorta redundant" max="40"/>
-    <string english="- Press ACTION to advance text -" translation="- Premu AGOKLAVON por daŭrigi -" explanation="to dismiss a textbox" max="40"/>
-    <string english="Press ACTION to continue" translation="Premu AGOKLAVON por daŭrigi" explanation="" max="34"/>
+    <string english="[Press ENTER to return to editor]" translation="[Premu ENTER por reveni al redaktilo]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to return to editor]" translation="" explanation="`to editor` is sorta redundant" max="40"/>
+    <string english="- Press ACTION to advance text -" translation="- Premu AGOKLAVON por daŭrigi -" explanation="***OUTDATED***" max="40"/>
+    <string english="- Press {button} to advance text -" translation="" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
+    <string english="Press ACTION to continue" translation="Premu AGOKLAVON por daŭrigi" explanation="***OUTDATED***" max="34"/>
+    <string english="Press {button} to continue" translation="" explanation="Expect `ACTION`" max="34"/>
     <string english="Current Time" translation="Nuna tempo" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="Plej bona tempo" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="Sekva trofeo je 5 sekundoj" explanation="" max="38*2"/>
@@ -434,7 +440,8 @@
     <string english="All Trophies collected!" translation="Ĉiuj trofeoj kolektiĝis!" explanation="" max="38*2"/>
     <string english="New Record!" translation="Nova rekordo!" explanation="" max="20"/>
     <string english="New Trophy!" translation="Nova trofeo!" explanation="" max="20"/>
-    <string english="[Press ENTER to stop]" translation="[Premu ENTER por eliri]" explanation="stop super gravitron" max="40"/>
+    <string english="[Press ENTER to stop]" translation="[Premu ENTER por eliri]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to stop]" translation="" explanation="stop super gravitron" max="40"/>
     <string english="SUPER GRAVITRON" translation="SUPERGRAVITRONO" explanation="" max="20"/>
     <string english="SUPER GRAVITRON HIGHSCORE" translation="ALTPOENTARO DE SUPERGRAVITRONO" explanation="" max="38*4"/>
     <string english="MAP" translation="MAPO" explanation="in-game menu" max="8"/>
@@ -447,7 +454,8 @@
     <string english="[ QUIT ]" translation="[ ELIRI ]" explanation="in-game menu" max="40"/>
     <string english="[ GRAVITRON ]" translation="[ GRAVITRONO ]" explanation="in-game menu" max="40"/>
     <string english="NO SIGNAL" translation="SENSIGNALE" explanation="map screen. So like a TV/computer monitor" max="29"/>
-    <string english="Press ACTION to warp to the ship." translation="Premu AGOKLAVON por teleportiĝi al la ŝipo." explanation="spaceship. Warp = teleport" max="38*7"/>
+    <string english="Press ACTION to warp to the ship." translation="Premu AGOKLAVON por teleportiĝi al la ŝipo." explanation="***OUTDATED***" max="38*7"/>
+    <string english="Press {button} to warp to the ship." translation="" explanation="spaceship. Warp = teleport. Expect `ACTION`" max="38*7"/>
     <string english="Missing..." translation="Mankas..." case="1" explanation="this male crew member is missing" max="15"/>
     <string english="Missing..." translation="Mankas..." case="2" explanation="this female crew member is missing" max="15"/>
     <string english="Missing..." translation="Mankas..." case="3" explanation="Viridian is missing (final level). You could even fill in something like `Uh-oh...` here if you really have to specify gender otherwise - everyone else is rescued, but the player is missing" max="15"/>
@@ -461,7 +469,8 @@
     <string english="ERROR: Could not save game!" translation="ERARO: Ne eblis konservi ludon!" explanation="in-game menu" max="34*2"/>
     <string english="ERROR: Could not save settings file!" translation="ERARO: Ne eblis konservi agordodosieron!" explanation="" max="38*2"/>
     <string english="Game saved ok!" translation="Ludo konserviĝis sukcese!" explanation="in-game menu" max="38*2"/>
-    <string english="[Press ACTION to save your game]" translation="[Premu AGOKLAVON por konservi la ludon]" explanation="in-game menu" max="40"/>
+    <string english="[Press ACTION to save your game]" translation="[Premu AGOKLAVON por konservi la ludon]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to save your game]" translation="" explanation="in-game menu. Expect `ACTION`" max="40"/>
     <string english="(Note: The game is autosaved at every teleporter.)" translation="(Notu: la ludo aŭtomate konserviĝas ĉe ĉiu teleportilo.)" explanation="in-game menu" max="38*3"/>
     <string english="Last Save:" translation="Lasta konservo:" explanation="in-game menu" max="40"/>
     <string english="Return to main menu?" translation="Ĉu reveni al ĉefa menuo?" explanation="in-game menu" max="38*4"/>
@@ -652,8 +661,11 @@
     <string english="All crewmates rescued!" translation="Ĉiuj skipanoj estas savitaj!" explanation="" max="32"/>
     <string english="Game Saved" translation="Ludo konserviĝis" explanation="" max="30"/>
     <string english="Press arrow keys or WASD to move" translation="Premu ←/→ aŭ WASD por moviĝi" explanation="" max="32*2"/>
-    <string english="Press ACTION to flip" translation="Premu AGOKLAVON por renversiĝi" explanation="" max="32*3"/>
-    <string english="Press ENTER to view map and quicksave" translation="Premu ENTER por vidi la mapon kaj rapidkonservi" explanation="" max="32*3"/>
+    <string english="Press left/right to move" translation="" explanation="" max="32*2"/>
+    <string english="Press ACTION to flip" translation="Premu AGOKLAVON por renversiĝi" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to flip" translation="" explanation="expect `ACTION`" max="32*3"/>
+    <string english="Press ENTER to view map and quicksave" translation="Premu ENTER por vidi la mapon kaj rapidkonservi" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to view map and quicksave" translation="" explanation="" max="32*3"/>
     <string english="If you prefer, you can press UP or DOWN instead of ACTION to flip." translation="Se vi preferas, eblas premi ↑/↓ por renversiĝi." explanation="" max="34*3"/>
     <string english="Help! Can anyone hear this message?" translation="Helpu! Ĉu iu ajn povas aŭdi ĉi tiun mesaĝon?" explanation="Violet speaking via Comms Relay" max="25*4"/>
     <string english="Verdigris? Are you out there? Are you ok?" translation="Verdigriso? Ĉu vi estas? Ĉu vi enordas?" explanation="Violet speaking via Comms Relay" max="25*4"/>

--- a/desktop_version/lang/es/cutscenes.xml
+++ b/desktop_version/lang/es/cutscenes.xml
@@ -76,10 +76,11 @@
     <cutscene id="bigopenworldskip" explanation="">
         <dialogue speaker="purple" english="I&apos;ll be right here if you need any help!" translation="¡Si necesitas ayuda, aquí me tienes!"/>
     </cutscene>
-    <cutscene id="talkpurple_intro" explanation="">
+    <cutscene id="talkpurple_intro" explanation="***ENTER is OUTDATED***">
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Me siento un poco abrumado, doctora."/>
         <dialogue speaker="player" english="Where do I begin?" translation="¿Por dónde empiezo?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="¡Recuerda que puedes pulsar la tecla ENTRAR para comprobar dónde te encuentras en el mapa!"/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Busca zonas donde pueda estar el resto de la tripulación..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Si te pierdes, puedes volver a la nave desde cualquier teletransportador."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="¡Y no te preocupes! ¡Encontraremos a todo el mundo!"/>

--- a/desktop_version/lang/es/strings.xml
+++ b/desktop_version/lang/es/strings.xml
@@ -213,6 +213,8 @@
     <string english="Toggle whether you interact with prompts using ENTER or E." translation="Cambia el botón de interacción entre las teclas ENTRAR o E." explanation="prompts: see the `Press {button} to talk to .../activate terminal/teleport` below" max="38*3"/>
     <string english="E" translation="E" explanation="keyboard key E. Speedrunner options menu"/>
     <string english="ENTER" translation="ENTRAR" explanation="keyboard key ENTER. Speedrunner options menu"/>
+    <string english="ESC" translation="" explanation="keyboard key ESC"/>
+    <string english="ACTION" translation="" explanation="the ACTION key is either the SPACE key, Z or V (this is explained on the title screen). It&apos;s used in strings like `Press ACTION to advance text`"/>
     <string english="Interact button: {button}" translation="Botón de interacción: {button}" explanation="keyboard key (E or ENTER) is filled in for {button}. Speedrunner options menu" max="38*2"/>
     <string english="fake load screen" translation="pantalla de carga" explanation="menu option"/>
     <string english="Fake Load Screen" translation="Pantalla de carga" explanation="title, allows the loading screen which counts to 100% to be turned off" max="20"/>
@@ -418,11 +420,15 @@
     <string english="To install new player levels, copy the .vvvvvv files to the levels folder." translation="Para instalar nuevos niveles de jugador, copia los archivos .vvvvvv en la carpeta levels." explanation="" max="38*3"/>
     <string english="Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming." translation="¿Seguro que quieres mostrar la ruta de los niveles? Esto podría revelar información delicada si estás transmitiendo en directo." explanation="" max="38*4"/>
     <string english="The levels path is:" translation="La ruta de los niveles es:" explanation="" max="40"/>
-    <string english="[ Press ACTION to Start ]" translation="[ Pulsa ACCIÓN para empezar ]" explanation="title screen" max="38*2"/>
+    <string english="[ Press ACTION to Start ]" translation="[ Pulsa ACCIÓN para empezar ]" explanation="***OUTDATED***" max="38*2"/>
+    <string english="[ Press {button} to Start ]" translation="" explanation="title screen. Expect `ACTION`" max="38*2"/>
     <string english="ACTION = Space, Z, or V" translation="ACCIÓN = Espacio, Z o V" explanation="title screen" max="38*3"/>
-    <string english="[Press ENTER to return to editor]" translation="[Pulsa ENTRAR para volver al editor]" explanation="`to editor` is sorta redundant" max="40"/>
-    <string english="- Press ACTION to advance text -" translation="- Pulsa ACCIÓN para avanzar el texto -" explanation="to dismiss a textbox" max="40"/>
-    <string english="Press ACTION to continue" translation="Pulsa ACCIÓN para continuar" explanation="" max="34"/>
+    <string english="[Press ENTER to return to editor]" translation="[Pulsa ENTRAR para volver al editor]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to return to editor]" translation="" explanation="`to editor` is sorta redundant" max="40"/>
+    <string english="- Press ACTION to advance text -" translation="- Pulsa ACCIÓN para avanzar el texto -" explanation="***OUTDATED***" max="40"/>
+    <string english="- Press {button} to advance text -" translation="" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
+    <string english="Press ACTION to continue" translation="Pulsa ACCIÓN para continuar" explanation="***OUTDATED***" max="34"/>
+    <string english="Press {button} to continue" translation="" explanation="Expect `ACTION`" max="34"/>
     <string english="Current Time" translation="Tiempo actual" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="Mejor tiempo" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="Siguiente trofeo en 5 segundos" explanation="" max="38*2"/>
@@ -434,7 +440,8 @@
     <string english="All Trophies collected!" translation="¡Has conseguido todos los trofeos!" explanation="" max="38*2"/>
     <string english="New Record!" translation="¡Nuevo récord!" explanation="" max="20"/>
     <string english="New Trophy!" translation="¡Nuevo trofeo!" explanation="" max="20"/>
-    <string english="[Press ENTER to stop]" translation="[Pulsa ENTRAR para parar]" explanation="stop super gravitron" max="40"/>
+    <string english="[Press ENTER to stop]" translation="[Pulsa ENTRAR para parar]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to stop]" translation="" explanation="stop super gravitron" max="40"/>
     <string english="SUPER GRAVITRON" translation="SUPERGRAVITRÓN" explanation="" max="20"/>
     <string english="SUPER GRAVITRON HIGHSCORE" translation="PUNTUACIÓN MÁXIMA EN SUPERGRAVITRÓN" explanation="" max="38*4"/>
     <string english="MAP" translation="MAPA" explanation="in-game menu" max="8"/>
@@ -447,7 +454,8 @@
     <string english="[ QUIT ]" translation="[ SALIR ]" explanation="in-game menu" max="40"/>
     <string english="[ GRAVITRON ]" translation="[ GRAVITRÓN ]" explanation="in-game menu" max="40"/>
     <string english="NO SIGNAL" translation="SIN SEÑAL" explanation="map screen. So like a TV/computer monitor" max="29"/>
-    <string english="Press ACTION to warp to the ship." translation="Pulsa ACCIÓN para teletransportarte a la nave." explanation="spaceship. Warp = teleport" max="38*7"/>
+    <string english="Press ACTION to warp to the ship." translation="Pulsa ACCIÓN para teletransportarte a la nave." explanation="***OUTDATED***" max="38*7"/>
+    <string english="Press {button} to warp to the ship." translation="" explanation="spaceship. Warp = teleport. Expect `ACTION`" max="38*7"/>
     <string english="Missing..." translation="No está..." case="1" explanation="this male crew member is missing" max="15"/>
     <string english="Missing..." translation="No está..." case="2" explanation="this female crew member is missing" max="15"/>
     <string english="Missing..." translation="No está..." case="3" explanation="Viridian is missing (final level). You could even fill in something like `Uh-oh...` here if you really have to specify gender otherwise - everyone else is rescued, but the player is missing" max="15"/>
@@ -461,7 +469,8 @@
     <string english="ERROR: Could not save game!" translation="ERROR: ¡No se ha podido guardar el juego!" explanation="in-game menu" max="34*2"/>
     <string english="ERROR: Could not save settings file!" translation="ERROR: ¡No se ha podido guardar el archivo de ajustes!" explanation="" max="38*2"/>
     <string english="Game saved ok!" translation="¡Partida guardada correctamente!" explanation="in-game menu" max="38*2"/>
-    <string english="[Press ACTION to save your game]" translation="[Pulsa ACCIÓN para guardar la partida]" explanation="in-game menu" max="40"/>
+    <string english="[Press ACTION to save your game]" translation="[Pulsa ACCIÓN para guardar la partida]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to save your game]" translation="" explanation="in-game menu. Expect `ACTION`" max="40"/>
     <string english="(Note: The game is autosaved at every teleporter.)" translation="(Nota: La partida se guarda automáticamente en cada teletransportador)." explanation="in-game menu" max="38*3"/>
     <string english="Last Save:" translation="Último guardado:" explanation="in-game menu" max="40"/>
     <string english="Return to main menu?" translation="¿Volver al menú principal?" explanation="in-game menu" max="38*4"/>
@@ -652,8 +661,11 @@
     <string english="All crewmates rescued!" translation="¡Has rescatado a todos!" explanation="" max="32"/>
     <string english="Game Saved" translation="Partida guardada" explanation="" max="30"/>
     <string english="Press arrow keys or WASD to move" translation="Pulsa las teclas de dirección o WASD para moverte" explanation="" max="32*2"/>
-    <string english="Press ACTION to flip" translation="Pulsa ACCIÓN para girar" explanation="" max="32*3"/>
-    <string english="Press ENTER to view map and quicksave" translation="Pulsa ENTRAR para ver el mapa y hacer un guardado rápido" explanation="" max="32*3"/>
+    <string english="Press left/right to move" translation="" explanation="" max="32*2"/>
+    <string english="Press ACTION to flip" translation="Pulsa ACCIÓN para girar" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to flip" translation="" explanation="expect `ACTION`" max="32*3"/>
+    <string english="Press ENTER to view map and quicksave" translation="Pulsa ENTRAR para ver el mapa y hacer un guardado rápido" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to view map and quicksave" translation="" explanation="" max="32*3"/>
     <string english="If you prefer, you can press UP or DOWN instead of ACTION to flip." translation="Si lo prefieres, puedes pulsar ARRIBA o ABAJO en lugar de ACCIÓN para girar." explanation="" max="34*3"/>
     <string english="Help! Can anyone hear this message?" translation="¡Ayuda! ¿Puede alguien oír este mensaje?" explanation="Violet speaking via Comms Relay" max="25*4"/>
     <string english="Verdigris? Are you out there? Are you ok?" translation="¿Verdigrís? ¿Estás ahí? ¿Estás bien?" explanation="Violet speaking via Comms Relay" max="25*4"/>

--- a/desktop_version/lang/fr/cutscenes.xml
+++ b/desktop_version/lang/fr/cutscenes.xml
@@ -76,10 +76,11 @@
     <cutscene id="bigopenworldskip" explanation="">
         <dialogue speaker="purple" english="I&apos;ll be right here if you need any help!" translation="Si vous avez besoin d&apos;aide, je serai là !"/>
     </cutscene>
-    <cutscene id="talkpurple_intro" explanation="">
+    <cutscene id="talkpurple_intro" explanation="***ENTER is OUTDATED***">
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Je ne sais plus où donner de la tête, Docteure..."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Par où commencer ?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Souvenez-vous que vous pouvez appuyer sur ENTRÉE pour vérifier votre position sur la carte !"/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Cherchez des endroits où le reste de l&apos;équipage pourrait se trouver..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Si vous vous perdez, vous pourrez regagner le vaisseau à partir de n&apos;importe quel téléporteur."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="Et ne vous en faites pas ! Nous allons tous les retrouver  !"/>

--- a/desktop_version/lang/fr/strings.xml
+++ b/desktop_version/lang/fr/strings.xml
@@ -213,6 +213,8 @@
     <string english="Toggle whether you interact with prompts using ENTER or E." translation="Choisissez d&apos;interagir|avec ENTRÉE ou avec E." explanation="prompts: see the `Press {button} to talk to .../activate terminal/teleport` below" max="38*3"/>
     <string english="E" translation="E" explanation="keyboard key E. Speedrunner options menu"/>
     <string english="ENTER" translation="ENTRÉE" explanation="keyboard key ENTER. Speedrunner options menu"/>
+    <string english="ESC" translation="" explanation="keyboard key ESC"/>
+    <string english="ACTION" translation="" explanation="the ACTION key is either the SPACE key, Z or V (this is explained on the title screen). It&apos;s used in strings like `Press ACTION to advance text`"/>
     <string english="Interact button: {button}" translation="Bouton d&apos;interaction : {button}" explanation="keyboard key (E or ENTER) is filled in for {button}. Speedrunner options menu" max="38*2"/>
     <string english="fake load screen" translation="écran de chargement" explanation="menu option"/>
     <string english="Fake Load Screen" translation="Écran de chargement" explanation="title, allows the loading screen which counts to 100% to be turned off" max="20"/>
@@ -418,11 +420,15 @@
     <string english="To install new player levels, copy the .vvvvvv files to the levels folder." translation="Pour installer de nouveaux niveaux de joueurs, copiez les fichiers .vvvvvv dans le dossier « Levels »." explanation="" max="38*3"/>
     <string english="Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming." translation="Souhaitez-vous vraiment afficher le chemin des niveaux ? Ceci pourrait révéler des informations sensibles si vous êtes en train de streamer..." explanation="" max="38*4"/>
     <string english="The levels path is:" translation="Le chemin des niveaux est :" explanation="" max="40"/>
-    <string english="[ Press ACTION to Start ]" translation="[ Appuyez sur ACTION pour commencer ]" explanation="title screen" max="38*2"/>
+    <string english="[ Press ACTION to Start ]" translation="[ Appuyez sur ACTION pour commencer ]" explanation="***OUTDATED***" max="38*2"/>
+    <string english="[ Press {button} to Start ]" translation="" explanation="title screen. Expect `ACTION`" max="38*2"/>
     <string english="ACTION = Space, Z, or V" translation="ACTION = espace, Z ou V" explanation="title screen" max="38*3"/>
-    <string english="[Press ENTER to return to editor]" translation="[ENTRÉE pour retourner à l&apos;éditeur]" explanation="`to editor` is sorta redundant" max="40"/>
-    <string english="- Press ACTION to advance text -" translation="- ACTION pour faire avancer le texte -" explanation="to dismiss a textbox" max="40"/>
-    <string english="Press ACTION to continue" translation="Appuyez sur ACTION pour continuer" explanation="" max="34"/>
+    <string english="[Press ENTER to return to editor]" translation="[ENTRÉE pour retourner à l&apos;éditeur]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to return to editor]" translation="" explanation="`to editor` is sorta redundant" max="40"/>
+    <string english="- Press ACTION to advance text -" translation="- ACTION pour faire avancer le texte -" explanation="***OUTDATED***" max="40"/>
+    <string english="- Press {button} to advance text -" translation="" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
+    <string english="Press ACTION to continue" translation="Appuyez sur ACTION pour continuer" explanation="***OUTDATED***" max="34"/>
+    <string english="Press {button} to continue" translation="" explanation="Expect `ACTION`" max="34"/>
     <string english="Current Time" translation="Temps actuel" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="Meilleur temps" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="Prochain trophée à 5 secondes" explanation="" max="38*2"/>
@@ -434,7 +440,8 @@
     <string english="All Trophies collected!" translation="Tous les trophées ont été obtenus !" explanation="" max="38*2"/>
     <string english="New Record!" translation="Nouveau record !" explanation="" max="20"/>
     <string english="New Trophy!" translation="Nouveau trophée !" explanation="" max="20"/>
-    <string english="[Press ENTER to stop]" translation="[Appuyez sur ENTRÉE pour arrêter]" explanation="stop super gravitron" max="40"/>
+    <string english="[Press ENTER to stop]" translation="[Appuyez sur ENTRÉE pour arrêter]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to stop]" translation="" explanation="stop super gravitron" max="40"/>
     <string english="SUPER GRAVITRON" translation="SUPER GRAVITRON" explanation="" max="20"/>
     <string english="SUPER GRAVITRON HIGHSCORE" translation="MEILLEUR SCORE SUPER GRAVITRON" explanation="" max="38*4"/>
     <string english="MAP" translation="CARTE" explanation="in-game menu" max="8"/>
@@ -447,7 +454,8 @@
     <string english="[ QUIT ]" translation="[ QUITTER ]" explanation="in-game menu" max="40"/>
     <string english="[ GRAVITRON ]" translation="[ GRAVITRON ]" explanation="in-game menu" max="40"/>
     <string english="NO SIGNAL" translation="PAS DE SIGNAL" explanation="map screen. So like a TV/computer monitor" max="29"/>
-    <string english="Press ACTION to warp to the ship." translation="Appuyez sur ACTION pour vous téléporter à bord du vaisseau" explanation="spaceship. Warp = teleport" max="38*7"/>
+    <string english="Press ACTION to warp to the ship." translation="Appuyez sur ACTION pour vous téléporter à bord du vaisseau" explanation="***OUTDATED***" max="38*7"/>
+    <string english="Press {button} to warp to the ship." translation="" explanation="spaceship. Warp = teleport. Expect `ACTION`" max="38*7"/>
     <string english="Missing..." translation="Manquant..." case="1" explanation="this male crew member is missing" max="15"/>
     <string english="Missing..." translation="Manquante..." case="2" explanation="this female crew member is missing" max="15"/>
     <string english="Missing..." translation="Euh..." case="3" explanation="Viridian is missing (final level). You could even fill in something like `Uh-oh...` here if you really have to specify gender otherwise - everyone else is rescued, but the player is missing" max="15"/>
@@ -461,7 +469,8 @@
     <string english="ERROR: Could not save game!" translation="ERREUR : sauvegarde impossible !" explanation="in-game menu" max="34*2"/>
     <string english="ERROR: Could not save settings file!" translation="ERREUR : enregistrement de la configuration impossible !" explanation="" max="38*2"/>
     <string english="Game saved ok!" translation="Sauvegarde réussie !" explanation="in-game menu" max="38*2"/>
-    <string english="[Press ACTION to save your game]" translation="[ACTION pour sauvegarder votre partie]" explanation="in-game menu" max="40"/>
+    <string english="[Press ACTION to save your game]" translation="[ACTION pour sauvegarder votre partie]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to save your game]" translation="" explanation="in-game menu. Expect `ACTION`" max="40"/>
     <string english="(Note: The game is autosaved at every teleporter.)" translation="(Note : votre partie est sauvegardée automatiquement à chaque téléporteur.)" explanation="in-game menu" max="38*3"/>
     <string english="Last Save:" translation="Dernière sauvegarde :" explanation="in-game menu" max="40"/>
     <string english="Return to main menu?" translation="Retourner au menu principal ?" explanation="in-game menu" max="38*4"/>
@@ -652,8 +661,11 @@
     <string english="All crewmates rescued!" translation="Tous l&apos;équipage a été sauvé !" explanation="" max="32"/>
     <string english="Game Saved" translation="Partie sauvegardée" explanation="" max="30"/>
     <string english="Press arrow keys or WASD to move" translation="Utilisez les flèches ou ZQSD pour vous déplacer" explanation="" max="32*2"/>
-    <string english="Press ACTION to flip" translation="Appuyez sur ACTION pour renverser" explanation="" max="32*3"/>
-    <string english="Press ENTER to view map and quicksave" translation="Appuyez sur ENTRÉE pour la carte et la sauvegarde rapide" explanation="" max="32*3"/>
+    <string english="Press left/right to move" translation="" explanation="" max="32*2"/>
+    <string english="Press ACTION to flip" translation="Appuyez sur ACTION pour renverser" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to flip" translation="" explanation="expect `ACTION`" max="32*3"/>
+    <string english="Press ENTER to view map and quicksave" translation="Appuyez sur ENTRÉE pour la carte et la sauvegarde rapide" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to view map and quicksave" translation="" explanation="" max="32*3"/>
     <string english="If you prefer, you can press UP or DOWN instead of ACTION to flip." translation="Vous pouvez aussi utiliser HAUT ou BAS plutôt qu&apos;ACTION pour le renversement." explanation="" max="34*3"/>
     <string english="Help! Can anyone hear this message?" translation="À l&apos;aide ! Est-ce que quelqu&apos;un me reçoit ?" explanation="Violet speaking via Comms Relay" max="25*4"/>
     <string english="Verdigris? Are you out there? Are you ok?" translation="Vert-de-gris ? Vous êtes là ? Tout va bien ?" explanation="Violet speaking via Comms Relay" max="25*4"/>

--- a/desktop_version/lang/it/cutscenes.xml
+++ b/desktop_version/lang/it/cutscenes.xml
@@ -76,10 +76,11 @@
     <cutscene id="bigopenworldskip" explanation="">
         <dialogue speaker="purple" english="I&apos;ll be right here if you need any help!" translation="Se ha bisogno d&apos;aiuto, io sono qui!"/>
     </cutscene>
-    <cutscene id="talkpurple_intro" explanation="">
+    <cutscene id="talkpurple_intro" explanation="***ENTER is OUTDATED***">
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Non so se mi sento all&apos;altezza del compito, dottoressa."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Da dove comincio?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Ricordi: può premere INVIO per controllare la sua posizione sulla mappa!"/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Cerchi le zone in cui potrebbe trovarsi il resto dell&apos;equipaggio..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Se si perde, può tornare alla nave da qualsiasi teletrasporto."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="E non si preoccupi! Troveremo tutti!"/>

--- a/desktop_version/lang/it/strings.xml
+++ b/desktop_version/lang/it/strings.xml
@@ -213,6 +213,8 @@
     <string english="Toggle whether you interact with prompts using ENTER or E." translation="Scegli se interagire con i messaggi utilizzando INVIO o E." explanation="prompts: see the `Press {button} to talk to .../activate terminal/teleport` below" max="38*3"/>
     <string english="E" translation="E" explanation="keyboard key E. Speedrunner options menu"/>
     <string english="ENTER" translation="INVIO" explanation="keyboard key ENTER. Speedrunner options menu"/>
+    <string english="ESC" translation="" explanation="keyboard key ESC"/>
+    <string english="ACTION" translation="" explanation="the ACTION key is either the SPACE key, Z or V (this is explained on the title screen). It&apos;s used in strings like `Press ACTION to advance text`"/>
     <string english="Interact button: {button}" translation="Pulsante Interagisci: {button}" explanation="keyboard key (E or ENTER) is filled in for {button}. Speedrunner options menu" max="38*2"/>
     <string english="fake load screen" translation="finto caricamento" explanation="menu option"/>
     <string english="Fake Load Screen" translation="Finto caricamento" explanation="title, allows the loading screen which counts to 100% to be turned off" max="20"/>
@@ -418,11 +420,15 @@
     <string english="To install new player levels, copy the .vvvvvv files to the levels folder." translation="Per installare nuovi livelli giocatore, copia i file .vvvvvv nella cartella dei livelli." explanation="" max="38*3"/>
     <string english="Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming." translation="Vuoi davvero mostrare il percorso dei livelli? Potrebbe rivelare informazioni sensibili durante lo streaming." explanation="" max="38*4"/>
     <string english="The levels path is:" translation="Il percorso dei livelli è:" explanation="" max="40"/>
-    <string english="[ Press ACTION to Start ]" translation="[ Premi AZIONE per iniziare ]" explanation="title screen" max="38*2"/>
+    <string english="[ Press ACTION to Start ]" translation="[ Premi AZIONE per iniziare ]" explanation="***OUTDATED***" max="38*2"/>
+    <string english="[ Press {button} to Start ]" translation="" explanation="title screen. Expect `ACTION`" max="38*2"/>
     <string english="ACTION = Space, Z, or V" translation="AZIONE = Spazio, Z o V" explanation="title screen" max="38*3"/>
-    <string english="[Press ENTER to return to editor]" translation="[Premi INVIO per tornare all&apos;editor]" explanation="`to editor` is sorta redundant" max="40"/>
-    <string english="- Press ACTION to advance text -" translation="- Premi AZIONE per scorrere il testo -" explanation="to dismiss a textbox" max="40"/>
-    <string english="Press ACTION to continue" translation="Premi AZIONE per continuare" explanation="" max="34"/>
+    <string english="[Press ENTER to return to editor]" translation="[Premi INVIO per tornare all&apos;editor]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to return to editor]" translation="" explanation="`to editor` is sorta redundant" max="40"/>
+    <string english="- Press ACTION to advance text -" translation="- Premi AZIONE per scorrere il testo -" explanation="***OUTDATED***" max="40"/>
+    <string english="- Press {button} to advance text -" translation="" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
+    <string english="Press ACTION to continue" translation="Premi AZIONE per continuare" explanation="***OUTDATED***" max="34"/>
+    <string english="Press {button} to continue" translation="" explanation="Expect `ACTION`" max="34"/>
     <string english="Current Time" translation="Tempo attuale" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="Miglior tempo" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="Prossimo trofeo a 5 secondi" explanation="" max="38*2"/>
@@ -434,7 +440,8 @@
     <string english="All Trophies collected!" translation="Tutti i trofei raccolti!" explanation="" max="38*2"/>
     <string english="New Record!" translation="Nuovo record!" explanation="" max="20"/>
     <string english="New Trophy!" translation="Nuovo trofeo!" explanation="" max="20"/>
-    <string english="[Press ENTER to stop]" translation="[Premi INVIO per fermarti]" explanation="stop super gravitron" max="40"/>
+    <string english="[Press ENTER to stop]" translation="[Premi INVIO per fermarti]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to stop]" translation="" explanation="stop super gravitron" max="40"/>
     <string english="SUPER GRAVITRON" translation="SUPER GRAVITRONE" explanation="" max="20"/>
     <string english="SUPER GRAVITRON HIGHSCORE" translation="RECORD SUPER GRAVITRONE" explanation="" max="38*4"/>
     <string english="MAP" translation="MAPPA" explanation="in-game menu" max="8"/>
@@ -447,7 +454,8 @@
     <string english="[ QUIT ]" translation="[ ESCI ]" explanation="in-game menu" max="40"/>
     <string english="[ GRAVITRON ]" translation="[ GRAVITRONE ]" explanation="in-game menu" max="40"/>
     <string english="NO SIGNAL" translation="NESSUN SEGNALE" explanation="map screen. So like a TV/computer monitor" max="29"/>
-    <string english="Press ACTION to warp to the ship." translation="Premi AZIONE per teletrasportarti alla nave." explanation="spaceship. Warp = teleport" max="38*7"/>
+    <string english="Press ACTION to warp to the ship." translation="Premi AZIONE per teletrasportarti alla nave." explanation="***OUTDATED***" max="38*7"/>
+    <string english="Press {button} to warp to the ship." translation="" explanation="spaceship. Warp = teleport. Expect `ACTION`" max="38*7"/>
     <string english="Missing..." translation="Disperso..." case="1" explanation="this male crew member is missing" max="15"/>
     <string english="Missing..." translation="Dispersa..." case="2" explanation="this female crew member is missing" max="15"/>
     <string english="Missing..." translation="Oh oh..." case="3" explanation="Viridian is missing (final level). You could even fill in something like `Uh-oh...` here if you really have to specify gender otherwise - everyone else is rescued, but the player is missing" max="15"/>
@@ -461,7 +469,8 @@
     <string english="ERROR: Could not save game!" translation="ERRORE: Impossibile salvare la partita." explanation="in-game menu" max="34*2"/>
     <string english="ERROR: Could not save settings file!" translation="ERRORE: Impossibile salvare il file delle impostazioni." explanation="" max="38*2"/>
     <string english="Game saved ok!" translation="Partita salvata!" explanation="in-game menu" max="38*2"/>
-    <string english="[Press ACTION to save your game]" translation="[Premi AZIONE per salvare la partita]" explanation="in-game menu" max="40"/>
+    <string english="[Press ACTION to save your game]" translation="[Premi AZIONE per salvare la partita]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to save your game]" translation="" explanation="in-game menu. Expect `ACTION`" max="40"/>
     <string english="(Note: The game is autosaved at every teleporter.)" translation="(Nota: la partita viene salvata automaticamente a ogni teletrasporto)" explanation="in-game menu" max="38*3"/>
     <string english="Last Save:" translation="Ultimo salvataggio:" explanation="in-game menu" max="40"/>
     <string english="Return to main menu?" translation="Tornare al menu principale?" explanation="in-game menu" max="38*4"/>
@@ -652,8 +661,11 @@
     <string english="All crewmates rescued!" translation="Hai salvato tutti i compagni!" explanation="" max="32"/>
     <string english="Game Saved" translation="Partita salvata" explanation="" max="30"/>
     <string english="Press arrow keys or WASD to move" translation="Premi i tasti freccia o WASD per muoverti" explanation="" max="32*2"/>
-    <string english="Press ACTION to flip" translation="Premi AZIONE per capovolgerti" explanation="" max="32*3"/>
-    <string english="Press ENTER to view map and quicksave" translation="Premi INVIO per visualizzare la mappa e per il salvataggio rapido" explanation="" max="32*3"/>
+    <string english="Press left/right to move" translation="" explanation="" max="32*2"/>
+    <string english="Press ACTION to flip" translation="Premi AZIONE per capovolgerti" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to flip" translation="" explanation="expect `ACTION`" max="32*3"/>
+    <string english="Press ENTER to view map and quicksave" translation="Premi INVIO per visualizzare la mappa e per il salvataggio rapido" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to view map and quicksave" translation="" explanation="" max="32*3"/>
     <string english="If you prefer, you can press UP or DOWN instead of ACTION to flip." translation="Se preferisci, puoi premere SU o GIÙ invece di AZIONE per capovolgerti." explanation="" max="34*3"/>
     <string english="Help! Can anyone hear this message?" translation="Aiuto! Qualcuno mi sente?" explanation="Violet speaking via Comms Relay" max="25*4"/>
     <string english="Verdigris? Are you out there? Are you ok?" translation="Verdigris? È in ascolto? Tutto bene?" explanation="Violet speaking via Comms Relay" max="25*4"/>

--- a/desktop_version/lang/nl/cutscenes.xml
+++ b/desktop_version/lang/nl/cutscenes.xml
@@ -76,10 +76,11 @@
     <cutscene id="bigopenworldskip" explanation="">
         <dialogue speaker="purple" english="I&apos;ll be right here if you need any help!" translation="Ik blijf hier als je hulp nodig hebt!"/>
     </cutscene>
-    <cutscene id="talkpurple_intro" explanation="">
+    <cutscene id="talkpurple_intro" explanation="***ENTER is OUTDATED***">
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Ik voel me een beetje overdonderd, Doctor."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Waar begin ik?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Onthoud dat je op ENTER kunt drukken om te zien waar je je op de kaart bevindt!"/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="Onthoud dat je op {b_map} kunt drukken om te zien waar je je op de kaart bevindt!"/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Zoek naar gebieden waar de rest van de bemanning zou kunnen zijn..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Als je verdwaald raakt kun je terug naar het schip met welke teleport dan ook."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="En maak je geen zorgen! We gaan iedereen vinden!"/>

--- a/desktop_version/lang/nl/strings.xml
+++ b/desktop_version/lang/nl/strings.xml
@@ -213,6 +213,8 @@
     <string english="Toggle whether you interact with prompts using ENTER or E." translation="Wijzig of interacties met bemanningsleden en objecten werken met ENTER of E." explanation="prompts: see the `Press {button} to talk to .../activate terminal/teleport` below" max="38*3"/>
     <string english="E" translation="E" explanation="keyboard key E. Speedrunner options menu"/>
     <string english="ENTER" translation="ENTER" explanation="keyboard key ENTER. Speedrunner options menu"/>
+    <string english="ESC" translation="ESC" explanation="keyboard key ESC"/>
+    <string english="ACTION" translation="ACTIE" explanation="the ACTION key is either the SPACE key, Z or V (this is explained on the title screen). It&apos;s used in strings like `Press ACTION to advance text`"/>
     <string english="Interact button: {button}" translation="Interactie-knop: {button}" explanation="keyboard key (E or ENTER) is filled in for {button}. Speedrunner options menu" max="38*2"/>
     <string english="fake load screen" translation="nep-laadscherm" explanation="menu option"/>
     <string english="Fake Load Screen" translation="Nep-laadscherm" explanation="title, allows the loading screen which counts to 100% to be turned off" max="20"/>
@@ -418,11 +420,15 @@
     <string english="To install new player levels, copy the .vvvvvv files to the levels folder." translation="Kopieer .vvvvvv-bestanden naar de levelsmap om nieuwe spelerlevels te installeren." explanation="" max="38*3"/>
     <string english="Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming." translation="Weet je zeker dat je het levelspad wil laten zien? Dit kan gevoelige informatie onthullen als je aan het streamen bent." explanation="" max="38*4"/>
     <string english="The levels path is:" translation="Het levelspad is:" explanation="" max="40"/>
-    <string english="[ Press ACTION to Start ]" translation="[ Druk op ACTIE om te beginnen ]" explanation="title screen" max="38*2"/>
+    <string english="[ Press ACTION to Start ]" translation="[ Druk op ACTIE om te beginnen ]" explanation="***OUTDATED***" max="38*2"/>
+    <string english="[ Press {button} to Start ]" translation="[ Druk op {button} om te beginnen ]" explanation="title screen. Expect `ACTION`" max="38*2"/>
     <string english="ACTION = Space, Z, or V" translation="ACTIE = Spatie, Z, of V" explanation="title screen" max="38*3"/>
-    <string english="[Press ENTER to return to editor]" translation="[Druk op ENTER om terug te gaan]" explanation="`to editor` is sorta redundant" max="40"/>
-    <string english="- Press ACTION to advance text -" translation="- Druk op ACTIE om verder te gaan -" explanation="to dismiss a textbox" max="40"/>
-    <string english="Press ACTION to continue" translation="Druk op ACTIE om verder te gaan" explanation="" max="34"/>
+    <string english="[Press ENTER to return to editor]" translation="[Druk op ENTER om terug te gaan]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to return to editor]" translation="[Druk op {button} om terug te gaan]" explanation="`to editor` is sorta redundant" max="40"/>
+    <string english="- Press ACTION to advance text -" translation="- Druk op ACTIE om verder te gaan -" explanation="***OUTDATED***" max="40"/>
+    <string english="- Press {button} to advance text -" translation="- Druk op {button} om verder te gaan -" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
+    <string english="Press ACTION to continue" translation="Druk op ACTIE om verder te gaan" explanation="***OUTDATED***" max="34"/>
+    <string english="Press {button} to continue" translation="Druk op {button} om verder te gaan" explanation="Expect `ACTION`" max="34"/>
     <string english="Current Time" translation="Huidige tijd" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="Beste tijd" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="Volgende trofee bij 5 seconden" explanation="" max="38*2"/>
@@ -434,7 +440,8 @@
     <string english="All Trophies collected!" translation="Alle trofeeën behaald!" explanation="" max="38*2"/>
     <string english="New Record!" translation="Nieuw record!" explanation="" max="20"/>
     <string english="New Trophy!" translation="Nieuwe trofee!" explanation="" max="20"/>
-    <string english="[Press ENTER to stop]" translation="[Druk op ENTER om te stoppen]" explanation="stop super gravitron" max="40"/>
+    <string english="[Press ENTER to stop]" translation="[Druk op ENTER om te stoppen]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to stop]" translation="[Druk op {button} om te stoppen]" explanation="stop super gravitron" max="40"/>
     <string english="SUPER GRAVITRON" translation="SUPERGRAVITRON" explanation="" max="20"/>
     <string english="SUPER GRAVITRON HIGHSCORE" translation="HIGHSCORE SUPERGRAVITRON" explanation="" max="38*4"/>
     <string english="MAP" translation="KAART" explanation="in-game menu" max="8"/>
@@ -447,7 +454,8 @@
     <string english="[ QUIT ]" translation="[ STOPPEN ]" explanation="in-game menu" max="40"/>
     <string english="[ GRAVITRON ]" translation="[ GRAVITRON ]" explanation="in-game menu" max="40"/>
     <string english="NO SIGNAL" translation="GEEN SIGNAAL" explanation="map screen. So like a TV/computer monitor" max="29"/>
-    <string english="Press ACTION to warp to the ship." translation="Druk op ACTIE om naar het schip te teleporteren." explanation="spaceship. Warp = teleport" max="38*7"/>
+    <string english="Press ACTION to warp to the ship." translation="Druk op ACTIE om naar het schip te teleporteren." explanation="***OUTDATED***" max="38*7"/>
+    <string english="Press {button} to warp to the ship." translation="Druk op {button} om naar het schip te teleporteren." explanation="spaceship. Warp = teleport. Expect `ACTION`" max="38*7"/>
     <string english="Missing..." translation="Vermist..." case="1" explanation="this male crew member is missing" max="15"/>
     <string english="Missing..." translation="Vermist..." case="2" explanation="this female crew member is missing" max="15"/>
     <string english="Missing..." translation="Vermist..." case="3" explanation="Viridian is missing (final level). You could even fill in something like `Uh-oh...` here if you really have to specify gender otherwise - everyone else is rescued, but the player is missing" max="15"/>
@@ -461,7 +469,8 @@
     <string english="ERROR: Could not save game!" translation="FOUT: Kon spel niet opslaan!" explanation="in-game menu" max="34*2"/>
     <string english="ERROR: Could not save settings file!" translation="FOUT: Kon instellingenbestand niet opslaan!" explanation="" max="38*2"/>
     <string english="Game saved ok!" translation="Spel opgeslagen!" explanation="in-game menu" max="38*2"/>
-    <string english="[Press ACTION to save your game]" translation="[Druk op ACTIE om je spel op te slaan]" explanation="in-game menu" max="40"/>
+    <string english="[Press ACTION to save your game]" translation="[Druk op ACTIE om je spel op te slaan]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to save your game]" translation="[Druk op {button} om je spel op te slaan]" explanation="in-game menu. Expect `ACTION`" max="40"/>
     <string english="(Note: The game is autosaved at every teleporter.)" translation="(Opmerking: het spel wordt automatisch opgeslagen bij elke teleport.)" explanation="in-game menu" max="38*3"/>
     <string english="Last Save:" translation="Laatst opgeslagen:" explanation="in-game menu" max="40"/>
     <string english="Return to main menu?" translation="Terug naar het hoofdmenu?" explanation="in-game menu" max="38*4"/>
@@ -652,8 +661,11 @@
     <string english="All crewmates rescued!" translation="Alle bemanningsleden gered!" explanation="" max="32"/>
     <string english="Game Saved" translation="Spel opgeslagen" explanation="" max="30"/>
     <string english="Press arrow keys or WASD to move" translation="Druk op de pijltjestoetsen of WASD om te bewegen" explanation="" max="32*2"/>
-    <string english="Press ACTION to flip" translation="Druk op ACTIE om je zwaartekracht om te keren" explanation="" max="32*3"/>
-    <string english="Press ENTER to view map and quicksave" translation="Druk op ENTER om de kaart te bekijken en om op te slaan" explanation="" max="32*3"/>
+    <string english="Press left/right to move" translation="Druk op links/rechts om te bewegen" explanation="" max="32*2"/>
+    <string english="Press ACTION to flip" translation="Druk op ACTIE om je zwaartekracht om te keren" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to flip" translation="Druk op {button} om je zwaartekracht om te keren" explanation="expect `ACTION`" max="32*3"/>
+    <string english="Press ENTER to view map and quicksave" translation="Druk op ENTER voor kaart en opslaan" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to view map and quicksave" translation="Druk op {button} voor kaart en opslaan" explanation="" max="32*3"/>
     <string english="If you prefer, you can press UP or DOWN instead of ACTION to flip." translation="Je kunt ook op OMHOOG of OMLAAG drukken in plaats van ACTIE om je zwaartekracht om te keren." explanation="" max="34*3"/>
     <string english="Help! Can anyone hear this message?" translation="Help! Kan iemand dit horen?" explanation="Violet speaking via Comms Relay" max="25*4"/>
     <string english="Verdigris? Are you out there? Are you ok?" translation="Verdigris? Ben je daar ergens? Ben je in orde?" explanation="Violet speaking via Comms Relay" max="25*4"/>

--- a/desktop_version/lang/pt_BR/cutscenes.xml
+++ b/desktop_version/lang/pt_BR/cutscenes.xml
@@ -76,10 +76,11 @@
     <cutscene id="bigopenworldskip" explanation="">
         <dialogue speaker="purple" english="I&apos;ll be right here if you need any help!" translation="Vou estar aqui se precisar de ajuda!"/>
     </cutscene>
-    <cutscene id="talkpurple_intro" explanation="">
+    <cutscene id="talkpurple_intro" explanation="***ENTER is OUTDATED***">
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Eu tô me sentindo um pouco sobrecarregado, Doutora."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Por onde começo?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Lembre-se: você pode pressionar ENTER para verificar onde você está no mapa!"/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Procure áreas onde o resto da equipe pode estar..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Se você se perder, pode voltar para a nave a partir de qualquer teletransportador."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="E não se preocupa! Vamos encontrar todos!"/>

--- a/desktop_version/lang/pt_BR/strings.xml
+++ b/desktop_version/lang/pt_BR/strings.xml
@@ -213,6 +213,8 @@
     <string english="Toggle whether you interact with prompts using ENTER or E." translation="Alterne se você interage com prompts usando ENTER ou E." explanation="prompts: see the `Press {button} to talk to .../activate terminal/teleport` below" max="38*3"/>
     <string english="E" translation="E" explanation="keyboard key E. Speedrunner options menu"/>
     <string english="ENTER" translation="ENTER" explanation="keyboard key ENTER. Speedrunner options menu"/>
+    <string english="ESC" translation="" explanation="keyboard key ESC"/>
+    <string english="ACTION" translation="" explanation="the ACTION key is either the SPACE key, Z or V (this is explained on the title screen). It&apos;s used in strings like `Press ACTION to advance text`"/>
     <string english="Interact button: {button}" translation="Botão Interagir: {button}" explanation="keyboard key (E or ENTER) is filled in for {button}. Speedrunner options menu" max="38*2"/>
     <string english="fake load screen" translation="tela de carregamento falsa" explanation="menu option"/>
     <string english="Fake Load Screen" translation="Tela de carregamento falsa" explanation="title, allows the loading screen which counts to 100% to be turned off" max="20"/>
@@ -418,11 +420,15 @@
     <string english="To install new player levels, copy the .vvvvvv files to the levels folder." translation="Para instalar novos níveis de jogadores, copie os arquivos .vvvvvv para a pasta de níveis." explanation="" max="38*3"/>
     <string english="Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming." translation="Quer mesmo mostrar o caminho dos níveis? Isso pode revelar informações confidenciais se você estiver transmitindo em vídeo." explanation="" max="38*4"/>
     <string english="The levels path is:" translation="O caminho dos níveis é:" explanation="" max="40"/>
-    <string english="[ Press ACTION to Start ]" translation="[ Pressione AÇÃO para começar ]" explanation="title screen" max="38*2"/>
+    <string english="[ Press ACTION to Start ]" translation="[ Pressione AÇÃO para começar ]" explanation="***OUTDATED***" max="38*2"/>
+    <string english="[ Press {button} to Start ]" translation="" explanation="title screen. Expect `ACTION`" max="38*2"/>
     <string english="ACTION = Space, Z, or V" translation="AÇÃO = Espaço, Z ou V" explanation="title screen" max="38*3"/>
-    <string english="[Press ENTER to return to editor]" translation="[Pressione ENTER para retornar ao editor]" explanation="`to editor` is sorta redundant" max="40"/>
-    <string english="- Press ACTION to advance text -" translation="- Pressione AÇÃO para avançar o texto -" explanation="to dismiss a textbox" max="40"/>
-    <string english="Press ACTION to continue" translation="Pressione AÇÃO para continuar" explanation="" max="34"/>
+    <string english="[Press ENTER to return to editor]" translation="[Pressione ENTER para retornar ao editor]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to return to editor]" translation="" explanation="`to editor` is sorta redundant" max="40"/>
+    <string english="- Press ACTION to advance text -" translation="- Pressione AÇÃO para avançar o texto -" explanation="***OUTDATED***" max="40"/>
+    <string english="- Press {button} to advance text -" translation="" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
+    <string english="Press ACTION to continue" translation="Pressione AÇÃO para continuar" explanation="***OUTDATED***" max="34"/>
+    <string english="Press {button} to continue" translation="" explanation="Expect `ACTION`" max="34"/>
     <string english="Current Time" translation="Tempo atual" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="Melhor Tempo" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="Próximo Troféu em 5 segundos" explanation="" max="38*2"/>
@@ -434,7 +440,8 @@
     <string english="All Trophies collected!" translation="Todos os troféus coletados!" explanation="" max="38*2"/>
     <string english="New Record!" translation="Novo recorde!" explanation="" max="20"/>
     <string english="New Trophy!" translation="Novo Troféu!" explanation="" max="20"/>
-    <string english="[Press ENTER to stop]" translation="[Pressione ENTER para parar]" explanation="stop super gravitron" max="40"/>
+    <string english="[Press ENTER to stop]" translation="[Pressione ENTER para parar]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to stop]" translation="" explanation="stop super gravitron" max="40"/>
     <string english="SUPER GRAVITRON" translation="SUPER GRAVITRON" explanation="" max="20"/>
     <string english="SUPER GRAVITRON HIGHSCORE" translation="PONTUAÇÃO MÁXIMA NO SUPER GRAVITRON" explanation="" max="38*4"/>
     <string english="MAP" translation="MAPA" explanation="in-game menu" max="8"/>
@@ -447,7 +454,8 @@
     <string english="[ QUIT ]" translation="[ SAIR ]" explanation="in-game menu" max="40"/>
     <string english="[ GRAVITRON ]" translation="[GRAVITRON]" explanation="in-game menu" max="40"/>
     <string english="NO SIGNAL" translation="SEM SINAL" explanation="map screen. So like a TV/computer monitor" max="29"/>
-    <string english="Press ACTION to warp to the ship." translation="Pressione AÇÃO para teletransportar para a nave." explanation="spaceship. Warp = teleport" max="38*7"/>
+    <string english="Press ACTION to warp to the ship." translation="Pressione AÇÃO para teletransportar para a nave." explanation="***OUTDATED***" max="38*7"/>
+    <string english="Press {button} to warp to the ship." translation="" explanation="spaceship. Warp = teleport. Expect `ACTION`" max="38*7"/>
     <string english="Missing..." translation="Ausente..." case="1" explanation="this male crew member is missing" max="15"/>
     <string english="Missing..." translation="Ausente..." case="2" explanation="this female crew member is missing" max="15"/>
     <string english="Missing..." translation="Ausente..." case="3" explanation="Viridian is missing (final level). You could even fill in something like `Uh-oh...` here if you really have to specify gender otherwise - everyone else is rescued, but the player is missing" max="15"/>
@@ -461,7 +469,8 @@
     <string english="ERROR: Could not save game!" translation="ERRO: não foi possível salvar o jogo!" explanation="in-game menu" max="34*2"/>
     <string english="ERROR: Could not save settings file!" translation="ERRO: não foi possível salvar o arquivo de configurações!" explanation="" max="38*2"/>
     <string english="Game saved ok!" translation="Jogo salvo ok!" explanation="in-game menu" max="38*2"/>
-    <string english="[Press ACTION to save your game]" translation="[Pressione AÇÃO para salvar seu jogo]" explanation="in-game menu" max="40"/>
+    <string english="[Press ACTION to save your game]" translation="[Pressione AÇÃO para salvar seu jogo]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to save your game]" translation="" explanation="in-game menu. Expect `ACTION`" max="40"/>
     <string english="(Note: The game is autosaved at every teleporter.)" translation="(Observação: o jogo é salvo automaticamente em cada teletransportador.)" explanation="in-game menu" max="38*3"/>
     <string english="Last Save:" translation="Último salvamento:" explanation="in-game menu" max="40"/>
     <string english="Return to main menu?" translation="Voltar ao menu principal?" explanation="in-game menu" max="38*4"/>
@@ -652,8 +661,11 @@
     <string english="All crewmates rescued!" translation="Todos os membros resgatados!" explanation="" max="32"/>
     <string english="Game Saved" translation="Jogo salvo" explanation="" max="30"/>
     <string english="Press arrow keys or WASD to move" translation="Pressione as setas ou WASD para mover" explanation="" max="32*2"/>
-    <string english="Press ACTION to flip" translation="Pressione AÇÃO para inverter" explanation="" max="32*3"/>
-    <string english="Press ENTER to view map and quicksave" translation="Pressione ENTER para ver o mapa e salvar rapidamente" explanation="" max="32*3"/>
+    <string english="Press left/right to move" translation="" explanation="" max="32*2"/>
+    <string english="Press ACTION to flip" translation="Pressione AÇÃO para inverter" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to flip" translation="" explanation="expect `ACTION`" max="32*3"/>
+    <string english="Press ENTER to view map and quicksave" translation="Pressione ENTER para ver o mapa e salvar rapidamente" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to view map and quicksave" translation="" explanation="" max="32*3"/>
     <string english="If you prefer, you can press UP or DOWN instead of ACTION to flip." translation="Se preferir, você pode pressionar CIMA ou BAIXO em vez de AÇÃO para inverter." explanation="" max="34*3"/>
     <string english="Help! Can anyone hear this message?" translation="Ajuda! Alguém pode ouvir esta mensagem?" explanation="Violet speaking via Comms Relay" max="25*4"/>
     <string english="Verdigris? Are you out there? Are you ok?" translation="Verdete? Você está aí fora? Tudo bem?" explanation="Violet speaking via Comms Relay" max="25*4"/>

--- a/desktop_version/lang/pt_PT/cutscenes.xml
+++ b/desktop_version/lang/pt_PT/cutscenes.xml
@@ -76,10 +76,11 @@
     <cutscene id="bigopenworldskip" explanation="">
         <dialogue speaker="purple" english="I&apos;ll be right here if you need any help!" translation="Fico por aqui, se precisares de algo!"/>
     </cutscene>
-    <cutscene id="talkpurple_intro" explanation="">
+    <cutscene id="talkpurple_intro" explanation="***ENTER is OUTDATED***">
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Doutora, já tenho a cabeça a andar à roda..."/>
         <dialogue speaker="player" english="Where do I begin?" translation="É melhor começar por onde?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Não te esqueças que podes premir ENTER para verificar a tua localização no mapa!"/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Investiga áreas onde o resto da tripulação possa estar..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Se te perderes, basta usar um teletransporte para regressar à nave."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="E não te preocupes, tenho a certeza que encontraremos toda a gente!"/>

--- a/desktop_version/lang/pt_PT/strings.xml
+++ b/desktop_version/lang/pt_PT/strings.xml
@@ -213,6 +213,8 @@
     <string english="Toggle whether you interact with prompts using ENTER or E." translation="Define se usas E ou ENTER para interações." explanation="prompts: see the `Press {button} to talk to .../activate terminal/teleport` below" max="38*3"/>
     <string english="E" translation="E" explanation="keyboard key E. Speedrunner options menu"/>
     <string english="ENTER" translation="ENTER" explanation="keyboard key ENTER. Speedrunner options menu"/>
+    <string english="ESC" translation="" explanation="keyboard key ESC"/>
+    <string english="ACTION" translation="" explanation="the ACTION key is either the SPACE key, Z or V (this is explained on the title screen). It&apos;s used in strings like `Press ACTION to advance text`"/>
     <string english="Interact button: {button}" translation="Botão de Interação: {button}" explanation="keyboard key (E or ENTER) is filled in for {button}. Speedrunner options menu" max="38*2"/>
     <string english="fake load screen" translation="carregamento simulado" explanation="menu option"/>
     <string english="Fake Load Screen" translation="Carregam. Simulado" explanation="title, allows the loading screen which counts to 100% to be turned off" max="20"/>
@@ -418,11 +420,15 @@
     <string english="To install new player levels, copy the .vvvvvv files to the levels folder." translation="Copia os ficheiros .vvvvvv para a pasta de níveis para instalar novos níveis jogáveis." explanation="" max="38*3"/>
     <string english="Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming." translation="De certeza que queres mostrar o caminho dos níveis? Isto poderá revelar dados sensíveis durante transmissões." explanation="" max="38*4"/>
     <string english="The levels path is:" translation="Caminho dos níveis:" explanation="" max="40"/>
-    <string english="[ Press ACTION to Start ]" translation="[ Prime AÇÃO para iniciar ]" explanation="title screen" max="38*2"/>
+    <string english="[ Press ACTION to Start ]" translation="[ Prime AÇÃO para iniciar ]" explanation="***OUTDATED***" max="38*2"/>
+    <string english="[ Press {button} to Start ]" translation="" explanation="title screen. Expect `ACTION`" max="38*2"/>
     <string english="ACTION = Space, Z, or V" translation="AÇÃO: Barra de Espaços, Z ou V" explanation="title screen" max="38*3"/>
-    <string english="[Press ENTER to return to editor]" translation="[Prime ENTER para voltar ao editor]" explanation="`to editor` is sorta redundant" max="40"/>
-    <string english="- Press ACTION to advance text -" translation="- Prime AÇÃO para avançar o texto -" explanation="to dismiss a textbox" max="40"/>
-    <string english="Press ACTION to continue" translation="Prime AÇÃO para continuar" explanation="" max="34"/>
+    <string english="[Press ENTER to return to editor]" translation="[Prime ENTER para voltar ao editor]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to return to editor]" translation="" explanation="`to editor` is sorta redundant" max="40"/>
+    <string english="- Press ACTION to advance text -" translation="- Prime AÇÃO para avançar o texto -" explanation="***OUTDATED***" max="40"/>
+    <string english="- Press {button} to advance text -" translation="" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
+    <string english="Press ACTION to continue" translation="Prime AÇÃO para continuar" explanation="***OUTDATED***" max="34"/>
+    <string english="Press {button} to continue" translation="" explanation="Expect `ACTION`" max="34"/>
     <string english="Current Time" translation="Tempo Atual" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="Recorde" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="Troféu seguinte aos cinco segundos" explanation="" max="38*2"/>
@@ -434,7 +440,8 @@
     <string english="All Trophies collected!" translation="Recebeste todos os troféus!" explanation="" max="38*2"/>
     <string english="New Record!" translation="Novo recorde!" explanation="" max="20"/>
     <string english="New Trophy!" translation="Novo troféu!" explanation="" max="20"/>
-    <string english="[Press ENTER to stop]" translation="[Prime ENTER para parar]" explanation="stop super gravitron" max="40"/>
+    <string english="[Press ENTER to stop]" translation="[Prime ENTER para parar]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to stop]" translation="" explanation="stop super gravitron" max="40"/>
     <string english="SUPER GRAVITRON" translation="SUPERGRAVITRÃO" explanation="" max="20"/>
     <string english="SUPER GRAVITRON HIGHSCORE" translation="RECORDE DO SUPERGRAVITRÃO" explanation="" max="38*4"/>
     <string english="MAP" translation="MAPA" explanation="in-game menu" max="8"/>
@@ -447,7 +454,8 @@
     <string english="[ QUIT ]" translation="[ SAIR ]" explanation="in-game menu" max="40"/>
     <string english="[ GRAVITRON ]" translation="[ GRAVITRÃO ]" explanation="in-game menu" max="40"/>
     <string english="NO SIGNAL" translation="SEM SINAL" explanation="map screen. So like a TV/computer monitor" max="29"/>
-    <string english="Press ACTION to warp to the ship." translation="Prime AÇÃO para te teletransportares para a nave." explanation="spaceship. Warp = teleport" max="38*7"/>
+    <string english="Press ACTION to warp to the ship." translation="Prime AÇÃO para te teletransportares para a nave." explanation="***OUTDATED***" max="38*7"/>
+    <string english="Press {button} to warp to the ship." translation="" explanation="spaceship. Warp = teleport. Expect `ACTION`" max="38*7"/>
     <string english="Missing..." translation="Desaparecido" case="1" explanation="this male crew member is missing" max="15"/>
     <string english="Missing..." translation="Desaparecida" case="2" explanation="this female crew member is missing" max="15"/>
     <string english="Missing..." translation="Desapareceu" case="3" explanation="Viridian is missing (final level). You could even fill in something like `Uh-oh...` here if you really have to specify gender otherwise - everyone else is rescued, but the player is missing" max="15"/>
@@ -461,7 +469,8 @@
     <string english="ERROR: Could not save game!" translation="ERRO: Não foi possível guardar o jogo!" explanation="in-game menu" max="34*2"/>
     <string english="ERROR: Could not save settings file!" translation="ERRO: Não foi possível guardar as definições!" explanation="" max="38*2"/>
     <string english="Game saved ok!" translation="Jogo guardado!" explanation="in-game menu" max="38*2"/>
-    <string english="[Press ACTION to save your game]" translation="[Prime AÇÃO para guardar o jogo]" explanation="in-game menu" max="40"/>
+    <string english="[Press ACTION to save your game]" translation="[Prime AÇÃO para guardar o jogo]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to save your game]" translation="" explanation="in-game menu. Expect `ACTION`" max="40"/>
     <string english="(Note: The game is autosaved at every teleporter.)" translation="(Nota: O jogo é guardado automaticamente nos teletransportes.)" explanation="in-game menu" max="38*3"/>
     <string english="Last Save:" translation="Última gravação:" explanation="in-game menu" max="40"/>
     <string english="Return to main menu?" translation="Voltar ao menu principal?" explanation="in-game menu" max="38*4"/>
@@ -652,8 +661,11 @@
     <string english="All crewmates rescued!" translation="Resgataste todos os tripulantes!" explanation="" max="32"/>
     <string english="Game Saved" translation="Jogo guardado" explanation="" max="30"/>
     <string english="Press arrow keys or WASD to move" translation="Prime as teclas WASD para te moveres" explanation="" max="32*2"/>
-    <string english="Press ACTION to flip" translation="Prime AÇÃO para inverter" explanation="" max="32*3"/>
-    <string english="Press ENTER to view map and quicksave" translation="Prime ENTER para consultar o mapa e fazer gravações rápidas" explanation="" max="32*3"/>
+    <string english="Press left/right to move" translation="" explanation="" max="32*2"/>
+    <string english="Press ACTION to flip" translation="Prime AÇÃO para inverter" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to flip" translation="" explanation="expect `ACTION`" max="32*3"/>
+    <string english="Press ENTER to view map and quicksave" translation="Prime ENTER para consultar o mapa e fazer gravações rápidas" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to view map and quicksave" translation="" explanation="" max="32*3"/>
     <string english="If you prefer, you can press UP or DOWN instead of ACTION to flip." translation="Também podes fazer inversões com as teclas ↑ e ↓." explanation="" max="34*3"/>
     <string english="Help! Can anyone hear this message?" translation="Socorro! Alguém recebeu esta mensagem?" explanation="Violet speaking via Comms Relay" max="25*4"/>
     <string english="Verdigris? Are you out there? Are you ok?" translation="Verdusco? Safaste-te? Estás bem?" explanation="Violet speaking via Comms Relay" max="25*4"/>

--- a/desktop_version/lang/ru/cutscenes.xml
+++ b/desktop_version/lang/ru/cutscenes.xml
@@ -76,10 +76,11 @@
     <cutscene id="bigopenworldskip" explanation="">
         <dialogue speaker="purple" english="I&apos;ll be right here if you need any help!" translation="Я буду здесь, если вдруг понадобится помощь!"/>
     </cutscene>
-    <cutscene id="talkpurple_intro" explanation="">
+    <cutscene id="talkpurple_intro" explanation="***ENTER is OUTDATED***">
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Я чувствую себя как-то подавленно, доктор. Просто... глаза разбегаются."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Где мне начать?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Помни, что нажав ENTER, ты можешь посмотреть, где ты находишься на карте!"/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Ищи места, где могут находиться остальные члены экипажа..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Если потеряешься, то помни, что можешь вернуться на корабль с помощью любого телепорта."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="И не волнуйся! Мы обязательно всех найдём!"/>

--- a/desktop_version/lang/ru/strings.xml
+++ b/desktop_version/lang/ru/strings.xml
@@ -213,6 +213,8 @@
     <string english="Toggle whether you interact with prompts using ENTER or E." translation="Выберите, хотите ли вы взаимодействовать с объектами при помощи клавиши ENTER или E." explanation="prompts: see the `Press {button} to talk to .../activate terminal/teleport` below" max="38*3"/>
     <string english="E" translation="E" explanation="keyboard key E. Speedrunner options menu"/>
     <string english="ENTER" translation="ENTER" explanation="keyboard key ENTER. Speedrunner options menu"/>
+    <string english="ESC" translation="" explanation="keyboard key ESC"/>
+    <string english="ACTION" translation="" explanation="the ACTION key is either the SPACE key, Z or V (this is explained on the title screen). It&apos;s used in strings like `Press ACTION to advance text`"/>
     <string english="Interact button: {button}" translation="Клавиша взаимодействия: {button}" explanation="keyboard key (E or ENTER) is filled in for {button}. Speedrunner options menu" max="38*2"/>
     <string english="fake load screen" translation="фальшивый экран загрузки" explanation="menu option"/>
     <string english="Fake Load Screen" translation="Экран загрузки" explanation="title, allows the loading screen which counts to 100% to be turned off" max="20"/>
@@ -418,11 +420,15 @@
     <string english="To install new player levels, copy the .vvvvvv files to the levels folder." translation="Чтобы установить новые пользовательские уровни, скопируйте файлы .vvvvvv в папку с уровнями." explanation="" max="38*3"/>
     <string english="Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming." translation="Вы уверены, что хотите показать путь к папке с уровнями? Это может раскрыть конфиденциальную информацию, если вы стримите в данный момент." explanation="" max="38*4"/>
     <string english="The levels path is:" translation="Путь к уровням:" explanation="" max="40"/>
-    <string english="[ Press ACTION to Start ]" translation="[ Нажмите ДЕЙСТВИЕ, чтобы начать ]" explanation="title screen" max="38*2"/>
+    <string english="[ Press ACTION to Start ]" translation="[ Нажмите ДЕЙСТВИЕ, чтобы начать ]" explanation="***OUTDATED***" max="38*2"/>
+    <string english="[ Press {button} to Start ]" translation="" explanation="title screen. Expect `ACTION`" max="38*2"/>
     <string english="ACTION = Space, Z, or V" translation="ДЕЙСТВИЕ = Пробел, Z или V" explanation="title screen" max="38*3"/>
-    <string english="[Press ENTER to return to editor]" translation="[ENTER - вернуться к редактору]" explanation="`to editor` is sorta redundant" max="40"/>
-    <string english="- Press ACTION to advance text -" translation="- Нажмите ДЕЙСТВИЕ, чтобы продолжить -" explanation="to dismiss a textbox" max="40"/>
-    <string english="Press ACTION to continue" translation="Нажмите ДЕЙСТВИЕ, чтобы продолжить" explanation="" max="34"/>
+    <string english="[Press ENTER to return to editor]" translation="[ENTER - вернуться к редактору]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to return to editor]" translation="" explanation="`to editor` is sorta redundant" max="40"/>
+    <string english="- Press ACTION to advance text -" translation="- Нажмите ДЕЙСТВИЕ, чтобы продолжить -" explanation="***OUTDATED***" max="40"/>
+    <string english="- Press {button} to advance text -" translation="" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
+    <string english="Press ACTION to continue" translation="Нажмите ДЕЙСТВИЕ, чтобы продолжить" explanation="***OUTDATED***" max="34"/>
+    <string english="Press {button} to continue" translation="" explanation="Expect `ACTION`" max="34"/>
     <string english="Current Time" translation="Текущее время" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="Лучшее время" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="След. трофей на 5 секундах" explanation="" max="38*2"/>
@@ -434,7 +440,8 @@
     <string english="All Trophies collected!" translation="Все трофеи собраны!" explanation="" max="38*2"/>
     <string english="New Record!" translation="Новый рекорд!" explanation="" max="20"/>
     <string english="New Trophy!" translation="Новый трофей!" explanation="" max="20"/>
-    <string english="[Press ENTER to stop]" translation="[Нажмите ENTER, чтобы закончить]" explanation="stop super gravitron" max="40"/>
+    <string english="[Press ENTER to stop]" translation="[Нажмите ENTER, чтобы закончить]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to stop]" translation="" explanation="stop super gravitron" max="40"/>
     <string english="SUPER GRAVITRON" translation="СУПЕР ГРАВИТРОН" explanation="" max="20"/>
     <string english="SUPER GRAVITRON HIGHSCORE" translation="РЕКОРД В СУПЕР ГРАВИТРОНЕ" explanation="" max="38*4"/>
     <string english="MAP" translation="КАРТА" explanation="in-game menu" max="8"/>
@@ -447,7 +454,8 @@
     <string english="[ QUIT ]" translation="[ ВЫЙТИ ]" explanation="in-game menu" max="40"/>
     <string english="[ GRAVITRON ]" translation="[ ГРАВИТРОН ]" explanation="in-game menu" max="40"/>
     <string english="NO SIGNAL" translation="НЕТ СИГНАЛА" explanation="map screen. So like a TV/computer monitor" max="29"/>
-    <string english="Press ACTION to warp to the ship." translation="Нажмите ДЕЙСТВИЕ, чтобы телепортироваться на корабль." explanation="spaceship. Warp = teleport" max="38*7"/>
+    <string english="Press ACTION to warp to the ship." translation="Нажмите ДЕЙСТВИЕ, чтобы телепортироваться на корабль." explanation="***OUTDATED***" max="38*7"/>
+    <string english="Press {button} to warp to the ship." translation="" explanation="spaceship. Warp = teleport. Expect `ACTION`" max="38*7"/>
     <string english="Missing..." translation="Пропал..." case="1" explanation="this male crew member is missing" max="15"/>
     <string english="Missing..." translation="Пропала..." case="2" explanation="this female crew member is missing" max="15"/>
     <string english="Missing..." translation="Без вести..." case="3" explanation="Viridian is missing (final level). You could even fill in something like `Uh-oh...` here if you really have to specify gender otherwise - everyone else is rescued, but the player is missing" max="15"/>
@@ -461,7 +469,8 @@
     <string english="ERROR: Could not save game!" translation="ОШИБКА: Не удалось сохранить игру!" explanation="in-game menu" max="34*2"/>
     <string english="ERROR: Could not save settings file!" translation="ОШИБКА: Не удалось сохранить файл настроек!" explanation="" max="38*2"/>
     <string english="Game saved ok!" translation="Сохранение успешно!" explanation="in-game menu" max="38*2"/>
-    <string english="[Press ACTION to save your game]" translation="[Нажмите ДЕЙСТВИЕ, чтобы сохраниться]" explanation="in-game menu" max="40"/>
+    <string english="[Press ACTION to save your game]" translation="[Нажмите ДЕЙСТВИЕ, чтобы сохраниться]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to save your game]" translation="" explanation="in-game menu. Expect `ACTION`" max="40"/>
     <string english="(Note: The game is autosaved at every teleporter.)" translation="(Игра автоматически сохраняется на каждом телепорте.)" explanation="in-game menu" max="38*3"/>
     <string english="Last Save:" translation="Последнее сохранение:" explanation="in-game menu" max="40"/>
     <string english="Return to main menu?" translation="Вернуться в главное меню?" explanation="in-game menu" max="38*4"/>
@@ -652,8 +661,11 @@
     <string english="All crewmates rescued!" translation="Все члены экипажа спасены!" explanation="" max="32"/>
     <string english="Game Saved" translation="Игра сохранена" explanation="" max="30"/>
     <string english="Press arrow keys or WASD to move" translation="Используйте клавиши со стрелками или WASD, чтобы передвигаться" explanation="" max="32*2"/>
-    <string english="Press ACTION to flip" translation="Нажмите ДЕЙСТВИЕ, чтобы перевернуться" explanation="" max="32*3"/>
-    <string english="Press ENTER to view map and quicksave" translation="Нажмите ENTER, чтобы открыть карту или сделать быстрое сохранение" explanation="" max="32*3"/>
+    <string english="Press left/right to move" translation="" explanation="" max="32*2"/>
+    <string english="Press ACTION to flip" translation="Нажмите ДЕЙСТВИЕ, чтобы перевернуться" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to flip" translation="" explanation="expect `ACTION`" max="32*3"/>
+    <string english="Press ENTER to view map and quicksave" translation="Нажмите ENTER, чтобы открыть карту или сделать быстрое сохранение" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to view map and quicksave" translation="" explanation="" max="32*3"/>
     <string english="If you prefer, you can press UP or DOWN instead of ACTION to flip." translation="Если хотите, вы можете нажимать ВВЕРХ или ВНИЗ вместо ДЕЙСТВИЯ, чтобы перевернуться." explanation="" max="34*3"/>
     <string english="Help! Can anyone hear this message?" translation="Помогите! Кто-нибудь слышит это сообщение?" explanation="Violet speaking via Comms Relay" max="25*4"/>
     <string english="Verdigris? Are you out there? Are you ok?" translation="Вердигри? Где ты? Ты в порядке?" explanation="Violet speaking via Comms Relay" max="25*4"/>

--- a/desktop_version/lang/tr/cutscenes.xml
+++ b/desktop_version/lang/tr/cutscenes.xml
@@ -76,10 +76,11 @@
     <cutscene id="bigopenworldskip" explanation="">
         <dialogue speaker="purple" english="I&apos;ll be right here if you need any help!" translation="Yardımıma ihtiyacınız olursa burada olacağım!"/>
     </cutscene>
-    <cutscene id="talkpurple_intro" explanation="">
+    <cutscene id="talkpurple_intro" explanation="***ENTER is OUTDATED***">
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Tüm bunlar bana biraz fazla geldi doktor."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Nereden başlamalıyım?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Haritadaki yerinizi görmek için ENTER tuşuna basabileceğinizi unutmayın!"/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Mürettebatın geri kalanının olabileceğin bölgeleri arayın..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Kaybolursanız herhangi bir ışınlayıcıdan gemiye geri dönebilirsiniz."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="Merak etmeyin! Herkesi bulacağız!"/>

--- a/desktop_version/lang/tr/strings.xml
+++ b/desktop_version/lang/tr/strings.xml
@@ -213,6 +213,8 @@
     <string english="Toggle whether you interact with prompts using ENTER or E." translation="Etkileşim için ENTER tuşunun mu|E tuşunun mu kullanılacağını seç." explanation="prompts: see the `Press {button} to talk to .../activate terminal/teleport` below" max="38*3"/>
     <string english="E" translation="E" explanation="keyboard key E. Speedrunner options menu"/>
     <string english="ENTER" translation="ENTER" explanation="keyboard key ENTER. Speedrunner options menu"/>
+    <string english="ESC" translation="" explanation="keyboard key ESC"/>
+    <string english="ACTION" translation="" explanation="the ACTION key is either the SPACE key, Z or V (this is explained on the title screen). It&apos;s used in strings like `Press ACTION to advance text`"/>
     <string english="Interact button: {button}" translation="Etkileşim düğmesi: {button}" explanation="keyboard key (E or ENTER) is filled in for {button}. Speedrunner options menu" max="38*2"/>
     <string english="fake load screen" translation="sahte yükleme ekranı" explanation="menu option"/>
     <string english="Fake Load Screen" translation="Sahte Yükleme Ekranı" explanation="title, allows the loading screen which counts to 100% to be turned off" max="20"/>
@@ -418,11 +420,15 @@
     <string english="To install new player levels, copy the .vvvvvv files to the levels folder." translation=".vvvvvv dosyalarını &quot;levels&quot; klasörüne kopyalayarak oyuncuların hazırladığı yeni bölümleri yükleyebilirsin." explanation="" max="38*3"/>
     <string english="Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming." translation="&quot;levels&quot; klasörünün yolunu göstermek istediğinden emin misin? Bu işlem, yayın yapıyorsan hassas bilgilerin görünmesine neden olabilir." explanation="" max="38*4"/>
     <string english="The levels path is:" translation="&quot;levels&quot; klasörünün yolu:" explanation="" max="40"/>
-    <string english="[ Press ACTION to Start ]" translation="[ Başlamak için AKSİYON tuşuna bas ]" explanation="title screen" max="38*2"/>
+    <string english="[ Press ACTION to Start ]" translation="[ Başlamak için AKSİYON tuşuna bas ]" explanation="***OUTDATED***" max="38*2"/>
+    <string english="[ Press {button} to Start ]" translation="" explanation="title screen. Expect `ACTION`" max="38*2"/>
     <string english="ACTION = Space, Z, or V" translation="AKSİYON = Boşluk, Z veya V" explanation="title screen" max="38*3"/>
-    <string english="[Press ENTER to return to editor]" translation="[Düzenleyiciye dönmek için ENTER&apos;a bas]" explanation="`to editor` is sorta redundant" max="40"/>
-    <string english="- Press ACTION to advance text -" translation="- Metni geçmek için AKSİYON tuşuna bas -" explanation="to dismiss a textbox" max="40"/>
-    <string english="Press ACTION to continue" translation="AKSİYON tuşuna basarak devam et" explanation="" max="34"/>
+    <string english="[Press ENTER to return to editor]" translation="[Düzenleyiciye dönmek için ENTER&apos;a bas]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to return to editor]" translation="" explanation="`to editor` is sorta redundant" max="40"/>
+    <string english="- Press ACTION to advance text -" translation="- Metni geçmek için AKSİYON tuşuna bas -" explanation="***OUTDATED***" max="40"/>
+    <string english="- Press {button} to advance text -" translation="" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
+    <string english="Press ACTION to continue" translation="AKSİYON tuşuna basarak devam et" explanation="***OUTDATED***" max="34"/>
+    <string english="Press {button} to continue" translation="" explanation="Expect `ACTION`" max="34"/>
     <string english="Current Time" translation="Mevcut Süre" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="En İyi Süre" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="Sıradaki Ödüle 5 Saniye" explanation="" max="38*2"/>
@@ -434,7 +440,8 @@
     <string english="All Trophies collected!" translation="Tüm Ödülleri topladın!" explanation="" max="38*2"/>
     <string english="New Record!" translation="Yeni Rekor!" explanation="" max="20"/>
     <string english="New Trophy!" translation="Yeni Ödül!" explanation="" max="20"/>
-    <string english="[Press ENTER to stop]" translation="[Durdurmak için ENTER tuşuna bas]" explanation="stop super gravitron" max="40"/>
+    <string english="[Press ENTER to stop]" translation="[Durdurmak için ENTER tuşuna bas]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to stop]" translation="" explanation="stop super gravitron" max="40"/>
     <string english="SUPER GRAVITRON" translation="SÜPER GRAVITRON" explanation="" max="20"/>
     <string english="SUPER GRAVITRON HIGHSCORE" translation="SÜPER GRAVITRON - EN İYİ SKOR" explanation="" max="38*4"/>
     <string english="MAP" translation="HARİTA" explanation="in-game menu" max="8"/>
@@ -447,7 +454,8 @@
     <string english="[ QUIT ]" translation="[ ÇIK ]" explanation="in-game menu" max="40"/>
     <string english="[ GRAVITRON ]" translation="[ GRAVITRON ]" explanation="in-game menu" max="40"/>
     <string english="NO SIGNAL" translation="SİNYAL YOK" explanation="map screen. So like a TV/computer monitor" max="29"/>
-    <string english="Press ACTION to warp to the ship." translation="Gemiyi ışınlamak için AKSİYON tuşuna bas." explanation="spaceship. Warp = teleport" max="38*7"/>
+    <string english="Press ACTION to warp to the ship." translation="Gemiyi ışınlamak için AKSİYON tuşuna bas." explanation="***OUTDATED***" max="38*7"/>
+    <string english="Press {button} to warp to the ship." translation="" explanation="spaceship. Warp = teleport. Expect `ACTION`" max="38*7"/>
     <string english="Missing..." translation="Kayıp..." case="1" explanation="this male crew member is missing" max="15"/>
     <string english="Missing..." translation="Kayıp..." case="2" explanation="this female crew member is missing" max="15"/>
     <string english="Missing..." translation="Kayıp..." case="3" explanation="Viridian is missing (final level). You could even fill in something like `Uh-oh...` here if you really have to specify gender otherwise - everyone else is rescued, but the player is missing" max="15"/>
@@ -461,7 +469,8 @@
     <string english="ERROR: Could not save game!" translation="HATA: Oyun kaydedilemedi!" explanation="in-game menu" max="34*2"/>
     <string english="ERROR: Could not save settings file!" translation="HATA: Ayarlar dosyası kaydedilemedi!" explanation="" max="38*2"/>
     <string english="Game saved ok!" translation="Oyun başarıyla kaydedildi!" explanation="in-game menu" max="38*2"/>
-    <string english="[Press ACTION to save your game]" translation="[AKSİYON tuşuna basarak kaydet]" explanation="in-game menu" max="40"/>
+    <string english="[Press ACTION to save your game]" translation="[AKSİYON tuşuna basarak kaydet]" explanation="***OUTDATED***" max="40"/>
+    <string english="[Press {button} to save your game]" translation="" explanation="in-game menu. Expect `ACTION`" max="40"/>
     <string english="(Note: The game is autosaved at every teleporter.)" translation="(Not: Işınlayıcılarda otomatik kaydedilir.)" explanation="in-game menu" max="38*3"/>
     <string english="Last Save:" translation="Son Kayıt:" explanation="in-game menu" max="40"/>
     <string english="Return to main menu?" translation="Ana menüye dönülsün mü?" explanation="in-game menu" max="38*4"/>
@@ -652,8 +661,11 @@
     <string english="All crewmates rescued!" translation="Tüm ekip üyelerini kurtardın!" explanation="" max="32"/>
     <string english="Game Saved" translation="Oyun Kaydedildi" explanation="" max="30"/>
     <string english="Press arrow keys or WASD to move" translation="Hareket etmek için ok ya da WASD tuşlarını kullan" explanation="" max="32*2"/>
-    <string english="Press ACTION to flip" translation="Ters dönmek için AKSİYON tuşuna bas" explanation="" max="32*3"/>
-    <string english="Press ENTER to view map and quicksave" translation="Haritayı görüntüleyip oyunu hızlı kaydetmek için ENTER tuşuna bas" explanation="" max="32*3"/>
+    <string english="Press left/right to move" translation="" explanation="" max="32*2"/>
+    <string english="Press ACTION to flip" translation="Ters dönmek için AKSİYON tuşuna bas" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to flip" translation="" explanation="expect `ACTION`" max="32*3"/>
+    <string english="Press ENTER to view map and quicksave" translation="Haritayı görüntüleyip oyunu hızlı kaydetmek için ENTER tuşuna bas" explanation="***OUTDATED***" max="32*3"/>
+    <string english="Press {button} to view map and quicksave" translation="" explanation="" max="32*3"/>
     <string english="If you prefer, you can press UP or DOWN instead of ACTION to flip." translation="Dilersen ters dönmek için AKSİYON yerine YUKARI ya da AŞAĞI tuşlarını kullanabilirsin." explanation="" max="34*3"/>
     <string english="Help! Can anyone hear this message?" translation="Yardım edin! Bu mesajı duyan var mı?" explanation="Violet speaking via Comms Relay" max="25*4"/>
     <string english="Verdigris? Are you out there? Are you ok?" translation="Verdigris? Orada mısın? İyi misin?" explanation="Violet speaking via Comms Relay" max="25*4"/>

--- a/desktop_version/src/ActionSets.h
+++ b/desktop_version/src/ActionSets.h
@@ -53,7 +53,9 @@ typedef enum
 {
     Action_InGame_ACTION,
     Action_InGame_Interact,
-    Action_InGame_Map
+    Action_InGame_Map,
+    Action_InGame_Restart,
+    Action_InGame_Esc
 }
 Action_InGame;
 

--- a/desktop_version/src/ActionSets.h
+++ b/desktop_version/src/ActionSets.h
@@ -24,7 +24,7 @@ extern "C"
 typedef enum
 {
     //ActionSet_Global,
-    //ActionSet_Menu,
+    ActionSet_Menu,
     ActionSet_InGame
     //ActionSet_Editor
 }
@@ -45,6 +45,13 @@ Action_Global;
 
 typedef enum
 {
+    Action_Menu_Accept
+}
+Action_Menu;
+
+typedef enum
+{
+    Action_InGame_ACTION,
     Action_InGame_Interact,
     Action_InGame_Map
 }
@@ -67,6 +74,7 @@ typedef union
 {
     int intval;
     //Action_Global Global;
+    Action_Menu Menu;
     Action_InGame InGame;
     //Action_Editor Editor;
 }

--- a/desktop_version/src/ActionSets.h
+++ b/desktop_version/src/ActionSets.h
@@ -1,0 +1,80 @@
+/* For now, this isn't really a foundation for action sets yet; button glyphs
+ * just need to be able to identify actions that are printed in text like
+ * "Press ENTER to teleport". Thus, this currently ONLY contains identifiers
+ * for the actions that button glyphs are needed for.
+ *
+ * Based on this comment:
+ * https://github.com/TerryCavanagh/VVVVVV/issues/834#issuecomment-1015692161
+ */
+
+
+#ifndef ACTIONSETS_H
+#define ACTIONSETS_H
+
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+/*----------------------------------------*
+ * List of all action sets (all "states") *
+ *----------------------------------------*/
+typedef enum
+{
+    //ActionSet_Global,
+    //ActionSet_Menu,
+    ActionSet_InGame
+    //ActionSet_Editor
+}
+ActionSet;
+
+
+/*----------------------------------------------------------*
+ * An enum for each actionset, with the actions in that set *
+ *----------------------------------------------------------*/
+/*
+typedef enum
+{
+    Action_Global_Mute,
+    Action_Global_MuteMusic
+}
+Action_Global;
+*/
+
+typedef enum
+{
+    Action_InGame_Interact,
+    Action_InGame_Map
+}
+Action_InGame;
+
+/*
+typedef enum
+{
+    //Action_Editor_PrevTool,
+    //Action_Editor_NextTool
+}
+Action_Editor;
+*/
+
+
+/*-----------------------------------------*
+ * A union to represent any actionset enum *
+ *-----------------------------------------*/
+typedef union
+{
+    int intval;
+    //Action_Global Global;
+    Action_InGame InGame;
+    //Action_Editor Editor;
+}
+Action;
+
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // ACTIONSETS_H

--- a/desktop_version/src/ButtonGlyphs.cpp
+++ b/desktop_version/src/ButtonGlyphs.cpp
@@ -68,6 +68,74 @@ ButtonGlyphKey;
 
 static char glyph[GLYPH_TOTAL][5];
 
+typedef enum
+{
+    LAYOUT_NINTENDO_SWITCH_PRO,
+    LAYOUT_NINTENDO_SWITCH_JOYCON_L,
+    LAYOUT_NINTENDO_SWITCH_JOYCON_R,
+    LAYOUT_DECK,
+    LAYOUT_PLAYSTATION,
+    LAYOUT_XBOX,
+    LAYOUT_GENERIC,
+
+    LAYOUT_TOTAL
+}
+ButtonGlyphLayout;
+
+/* SDL provides Xbox buttons, we'd like to show the correct
+ * (controller-specific) glyphs or labels for those... */
+static const char* glyph_layout[LAYOUT_TOTAL][SDL_CONTROLLER_BUTTON_RIGHTSHOULDER + 1] = {
+    { // NINTENDO_SWITCH_PRO
+        glyph[GLYPH_NINTENDO_DECK_B], glyph[GLYPH_NINTENDO_DECK_A],
+        glyph[GLYPH_NINTENDO_DECK_Y], glyph[GLYPH_NINTENDO_DECK_X],
+        glyph[GLYPH_NINTENDO_MINUS], "HOME", glyph[GLYPH_NINTENDO_PLUS],
+        glyph[GLYPH_NINTENDO_XBOX_LSTICK], glyph[GLYPH_NINTENDO_XBOX_RSTICK],
+        glyph[GLYPH_NINTENDO_L], glyph[GLYPH_NINTENDO_R]
+    },
+    { // NINTENDO_SWITCH_JOYCON_L
+        glyph[GLYPH_NINTENDO_GENERIC_ACTIONDOWN], glyph[GLYPH_NINTENDO_GENERIC_ACTIONRIGHT],
+        glyph[GLYPH_NINTENDO_GENERIC_ACTIONLEFT], glyph[GLYPH_NINTENDO_GENERIC_ACTIONUP],
+        "CAPTURE", "GUIDE", glyph[GLYPH_NINTENDO_MINUS],
+        glyph[GLYPH_NINTENDO_GENERIC_STICK], glyph[GLYPH_NINTENDO_XBOX_RSTICK],
+        glyph[GLYPH_NINTENDO_SL], glyph[GLYPH_NINTENDO_SR]
+    },
+    { // NINTENDO_SWITCH_JOYCON_R
+        glyph[GLYPH_NINTENDO_GENERIC_ACTIONDOWN], glyph[GLYPH_NINTENDO_GENERIC_ACTIONRIGHT],
+        glyph[GLYPH_NINTENDO_GENERIC_ACTIONLEFT], glyph[GLYPH_NINTENDO_GENERIC_ACTIONUP],
+        "HOME", "GUIDE", glyph[GLYPH_NINTENDO_PLUS],
+        glyph[GLYPH_NINTENDO_GENERIC_STICK], glyph[GLYPH_NINTENDO_XBOX_RSTICK],
+        glyph[GLYPH_NINTENDO_SL], glyph[GLYPH_NINTENDO_SR]
+    },
+    { // DECK
+        glyph[GLYPH_NINTENDO_DECK_A], glyph[GLYPH_NINTENDO_DECK_B],
+        glyph[GLYPH_NINTENDO_DECK_X], glyph[GLYPH_NINTENDO_DECK_Y],
+        glyph[GLYPH_XBOX_DECK_VIEW], "GUIDE", glyph[GLYPH_XBOX_DECK_MENU],
+        glyph[GLYPH_PLAYSTATION_DECK_L3], glyph[GLYPH_PLAYSTATION_DECK_R3],
+        glyph[GLYPH_PLAYSTATION_DECK_L1], glyph[GLYPH_PLAYSTATION_DECK_R1]
+    },
+    { // PLAYSTATION
+        glyph[GLYPH_PLAYSTATION_CROSS], glyph[GLYPH_PLAYSTATION_CIRCLE],
+        glyph[GLYPH_PLAYSTATION_SQUARE], glyph[GLYPH_PLAYSTATION_TRIANGLE],
+        glyph[GLYPH_PLAYSTATION_OPTIONS], "PS", glyph[GLYPH_PLAYSTATION_START],
+        glyph[GLYPH_PLAYSTATION_DECK_L3], glyph[GLYPH_PLAYSTATION_DECK_R3],
+        glyph[GLYPH_PLAYSTATION_DECK_L1], glyph[GLYPH_PLAYSTATION_DECK_R1]
+    },
+    { // XBOX
+        glyph[GLYPH_XBOX_A], glyph[GLYPH_XBOX_B],
+        glyph[GLYPH_XBOX_X], glyph[GLYPH_XBOX_Y],
+        glyph[GLYPH_XBOX_DECK_VIEW], "GUIDE", glyph[GLYPH_XBOX_DECK_MENU],
+        glyph[GLYPH_NINTENDO_XBOX_LSTICK], glyph[GLYPH_NINTENDO_XBOX_RSTICK],
+        glyph[GLYPH_XBOX_LB], glyph[GLYPH_XBOX_RB]
+    },
+    { // GENERIC
+        glyph[GLYPH_NINTENDO_GENERIC_ACTIONDOWN], glyph[GLYPH_NINTENDO_GENERIC_ACTIONRIGHT],
+        glyph[GLYPH_NINTENDO_GENERIC_ACTIONLEFT], glyph[GLYPH_NINTENDO_GENERIC_ACTIONUP],
+        "SELECT", "GUIDE", "START",
+        glyph[GLYPH_NINTENDO_XBOX_LSTICK], glyph[GLYPH_NINTENDO_XBOX_RSTICK],
+        glyph[GLYPH_GENERIC_L], glyph[GLYPH_GENERIC_R]
+    }
+};
+
 void BUTTONGLYPHS_init(void)
 {
     /* Set glyph array to strings for all the button glyph codepoints (U+EBxx) */
@@ -101,18 +169,57 @@ const char* BUTTONGLYPHS_get_wasd_text(void)
     return loc::gettext("Press left/right to move");
 }
 
-const char* BUTTONGLYPHS_get_button(const ActionSet actionset, const Action action)
+static const char* sdlbutton_to_glyph(const SDL_GameControllerButton button)
+{
+    if (button > SDL_CONTROLLER_BUTTON_RIGHTSHOULDER)
+    {
+        SDL_assert(0 && "Unhandled button!");
+        return glyph[GLYPH_UNKNOWN];
+    }
+
+    return glyph_layout[LAYOUT_PLAYSTATION][button];
+}
+
+static const char* glyph_for_vector(
+    const std::vector<SDL_GameControllerButton>& buttons,
+    const int index
+) {
+    if (index < 0 || index >= (int) buttons.size())
+    {
+        return NULL;
+    }
+
+    return sdlbutton_to_glyph(buttons[index]);
+}
+
+const char* BUTTONGLYPHS_get_button(const ActionSet actionset, const Action action, int binding)
 {
     /* Given a specific action (like INTERACT in-game),
      * return either a (localized) keyboard key string like "ENTER" or "E",
      * or a controller button glyph from the table above like glyph[GLYPH_XBOX_Y],
-     * to fill into strings like "Press {button} to activate terminal". */
+     * to fill into strings like "Press {button} to activate terminal".
+     *
+     * Normally, set binding = -1. This will return the best keyboard key OR controller glyph.
+     *
+     * If binding >= 0, select a specific CONTROLLER binding glyph,
+     * or NULL if the index is higher than the max binding index. */
+
+    bool show_controller = binding >= 0 || !BUTTONGLYPHS_keyboard_is_active();
+    if (binding < 0)
+    {
+        binding = 0;
+    }
+
     switch (actionset)
     {
     case ActionSet_Menu:
         switch (action.Menu)
         {
         case Action_Menu_Accept:
+            if (show_controller)
+            {
+                return glyph_for_vector(game.controllerButton_flip, binding);
+            }
             return loc::gettext("ACTION");
         }
         break;
@@ -120,22 +227,85 @@ const char* BUTTONGLYPHS_get_button(const ActionSet actionset, const Action acti
         switch (action.InGame)
         {
         case Action_InGame_ACTION:
+            if (show_controller)
+            {
+                return glyph_for_vector(game.controllerButton_flip, binding);
+            }
             return loc::gettext("ACTION");
 
         case Action_InGame_Interact:
+            if (show_controller)
+            {
+                return glyph_for_vector(game.controllerButton_interact, binding);
+            }
             if (game.separate_interact)
             {
                 return "E";
             }
             return loc::gettext("ENTER");
+
         case Action_InGame_Map:
+            if (show_controller)
+            {
+                return glyph_for_vector(game.controllerButton_map, binding);
+            }
             return loc::gettext("ENTER");
+
+        case Action_InGame_Esc:
+            if (show_controller)
+            {
+                return glyph_for_vector(game.controllerButton_esc, binding);
+            }
+            return loc::gettext("ESC");
+
+        case Action_InGame_Restart:
+            if (show_controller)
+            {
+                return glyph_for_vector(game.controllerButton_restart, binding);
+            }
+            return "R";
         }
         break;
     }
 
     SDL_assert(0 && "Trying to get label/glyph for unknown action!");
     return glyph[GLYPH_UNKNOWN];
+}
+
+char* BUTTONGLYPHS_get_all_gamepad_buttons(
+    char* buffer,
+    size_t buffer_len,
+    const ActionSet actionset,
+    const int action
+) {
+    /* Gives a list of all controller bindings, for in the menu */
+    Action union_action;
+    union_action.intval = action;
+    buffer[0] = '\0';
+    size_t cur = 0;
+    const char* glyph;
+    int binding = 0;
+    while ((glyph = BUTTONGLYPHS_get_button(actionset, union_action, binding)))
+    {
+        if (binding > 0 && buffer_len >= 1)
+        {
+            buffer[cur] = '/';
+            cur++;
+            buffer_len--;
+        }
+
+        size_t glyph_len = SDL_strlcpy(&buffer[cur], glyph, buffer_len);
+        if (glyph_len >= buffer_len)
+        {
+            // Truncation occurred, we're done
+            return buffer;
+        }
+        cur += glyph_len;
+        buffer_len -= glyph_len;
+
+        binding++;
+    }
+    return buffer;
 }
 
 } // extern "C"

--- a/desktop_version/src/ButtonGlyphs.cpp
+++ b/desktop_version/src/ButtonGlyphs.cpp
@@ -136,6 +136,9 @@ static const char* glyph_layout[LAYOUT_TOTAL][SDL_CONTROLLER_BUTTON_RIGHTSHOULDE
     }
 };
 
+static bool keyboard_is_active = true;
+static ButtonGlyphLayout layout = LAYOUT_GENERIC;
+
 void BUTTONGLYPHS_init(void)
 {
     /* Set glyph array to strings for all the button glyph codepoints (U+EBxx) */
@@ -156,7 +159,12 @@ bool BUTTONGLYPHS_keyboard_is_active(void)
 {
     /* Returns true if, not only do we have a keyboard available, but it's also the
      * active input method. (So, show keyboard keys, if false, show controller glyphs) */
-    return true;
+    return keyboard_is_active;
+}
+
+void BUTTONGLYPHS_keyboard_set_active(bool active)
+{
+    keyboard_is_active = active;
 }
 
 const char* BUTTONGLYPHS_get_wasd_text(void)
@@ -177,7 +185,7 @@ static const char* sdlbutton_to_glyph(const SDL_GameControllerButton button)
         return glyph[GLYPH_UNKNOWN];
     }
 
-    return glyph_layout[LAYOUT_PLAYSTATION][button];
+    return glyph_layout[layout][button];
 }
 
 static const char* glyph_for_vector(

--- a/desktop_version/src/ButtonGlyphs.cpp
+++ b/desktop_version/src/ButtonGlyphs.cpp
@@ -109,9 +109,19 @@ const char* BUTTONGLYPHS_get_button(const ActionSet actionset, const Action acti
      * to fill into strings like "Press {button} to activate terminal". */
     switch (actionset)
     {
+    case ActionSet_Menu:
+        switch (action.Menu)
+        {
+        case Action_Menu_Accept:
+            return loc::gettext("ACTION");
+        }
+        break;
     case ActionSet_InGame:
         switch (action.InGame)
         {
+        case Action_InGame_ACTION:
+            return loc::gettext("ACTION");
+
         case Action_InGame_Interact:
             if (game.separate_interact)
             {

--- a/desktop_version/src/ButtonGlyphs.cpp
+++ b/desktop_version/src/ButtonGlyphs.cpp
@@ -1,0 +1,131 @@
+#include "ButtonGlyphs.h"
+
+#include <SDL.h>
+
+#include "Game.h"
+#include "Localization.h"
+#include "UTF8.h"
+
+extern "C"
+{
+
+typedef enum
+{
+    GLYPH_NINTENDO_DECK_A, // Note that for the Deck, the icons are same as Nintendo but the layout is the same as Xbox
+    GLYPH_NINTENDO_DECK_B,
+    GLYPH_NINTENDO_DECK_X,
+    GLYPH_NINTENDO_DECK_Y,
+    GLYPH_NINTENDO_PLUS,
+    GLYPH_NINTENDO_MINUS,
+    GLYPH_NINTENDO_L,
+    GLYPH_NINTENDO_R,
+    GLYPH_NINTENDO_ZL,
+    GLYPH_NINTENDO_ZR,
+    GLYPH_NINTENDO_XBOX_LSTICK,
+    GLYPH_NINTENDO_XBOX_RSTICK,
+    GLYPH_NINTENDO_SL,
+    GLYPH_NINTENDO_SR,
+    GLYPH_GENERIC_L,
+    GLYPH_GENERIC_R,
+
+    GLYPH_PLAYSTATION_CIRCLE,
+    GLYPH_PLAYSTATION_CROSS,
+    GLYPH_PLAYSTATION_TRIANGLE,
+    GLYPH_PLAYSTATION_SQUARE,
+    GLYPH_PLAYSTATION_START,
+    GLYPH_PLAYSTATION_OPTIONS,
+    GLYPH_PLAYSTATION_DECK_L1,
+    GLYPH_PLAYSTATION_DECK_R1,
+    GLYPH_PLAYSTATION_DECK_L2,
+    GLYPH_PLAYSTATION_DECK_R2,
+    GLYPH_PLAYSTATION_DECK_L3,
+    GLYPH_PLAYSTATION_DECK_R3,
+    GLYPH_DECK_L4,
+    GLYPH_DECK_R4,
+    GLYPH_DECK_L5,
+    GLYPH_DECK_R5,
+
+    GLYPH_XBOX_B,
+    GLYPH_XBOX_A,
+    GLYPH_XBOX_Y,
+    GLYPH_XBOX_X,
+    GLYPH_XBOX_DECK_VIEW,
+    GLYPH_XBOX_DECK_MENU,
+    GLYPH_XBOX_LB,
+    GLYPH_XBOX_RB,
+    GLYPH_XBOX_LT,
+    GLYPH_XBOX_RT,
+    GLYPH_NINTENDO_GENERIC_ACTIONRIGHT,
+    GLYPH_NINTENDO_GENERIC_ACTIONDOWN,
+    GLYPH_NINTENDO_GENERIC_ACTIONUP,
+    GLYPH_NINTENDO_GENERIC_ACTIONLEFT,
+    GLYPH_NINTENDO_GENERIC_STICK,
+    GLYPH_UNKNOWN,
+
+    GLYPH_TOTAL
+}
+ButtonGlyphKey;
+
+static char glyph[GLYPH_TOTAL][5];
+
+void BUTTONGLYPHS_init(void)
+{
+    /* Set glyph array to strings for all the button glyph codepoints (U+EBxx) */
+    for (int i = 0; i < GLYPH_TOTAL; i++)
+    {
+        SDL_strlcpy(glyph[i], UTF8_encode(0xEB00+i).bytes, sizeof(glyph[i]));
+    }
+}
+
+bool BUTTONGLYPHS_keyboard_is_available(void)
+{
+    /* Returns true if it makes sense to show button hints that are only available
+     * on keyboards (like press M to mute), false if we're on a console. */
+    return true;
+}
+
+bool BUTTONGLYPHS_keyboard_is_active(void)
+{
+    /* Returns true if, not only do we have a keyboard available, but it's also the
+     * active input method. (So, show keyboard keys, if false, show controller glyphs) */
+    return true;
+}
+
+const char* BUTTONGLYPHS_get_wasd_text(void)
+{
+    /* Returns the string to use in Welcome Aboard */
+    if (BUTTONGLYPHS_keyboard_is_active())
+    {
+        return loc::gettext("Press arrow keys or WASD to move");
+    }
+    return loc::gettext("Press left/right to move");
+}
+
+const char* BUTTONGLYPHS_get_button(const ActionSet actionset, const Action action)
+{
+    /* Given a specific action (like INTERACT in-game),
+     * return either a (localized) keyboard key string like "ENTER" or "E",
+     * or a controller button glyph from the table above like glyph[GLYPH_XBOX_Y],
+     * to fill into strings like "Press {button} to activate terminal". */
+    switch (actionset)
+    {
+    case ActionSet_InGame:
+        switch (action.InGame)
+        {
+        case Action_InGame_Interact:
+            if (game.separate_interact)
+            {
+                return "E";
+            }
+            return loc::gettext("ENTER");
+        case Action_InGame_Map:
+            return loc::gettext("ENTER");
+        }
+        break;
+    }
+
+    SDL_assert(0 && "Trying to get label/glyph for unknown action!");
+    return glyph[GLYPH_UNKNOWN];
+}
+
+} // extern "C"

--- a/desktop_version/src/ButtonGlyphs.h
+++ b/desktop_version/src/ButtonGlyphs.h
@@ -1,0 +1,24 @@
+#ifndef BUTTONGLYPHS_H
+#define BUTTONGLYPHS_H
+
+#include <stdbool.h>
+
+#include "ActionSets.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+void BUTTONGLYPHS_init(void);
+
+bool BUTTONGLYPHS_keyboard_is_available(void);
+bool BUTTONGLYPHS_keyboard_is_active(void);
+const char* BUTTONGLYPHS_get_wasd_text(void);
+const char* BUTTONGLYPHS_get_button(ActionSet actionset, Action action);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // BUTTONGLYPHS_H

--- a/desktop_version/src/ButtonGlyphs.h
+++ b/desktop_version/src/ButtonGlyphs.h
@@ -1,6 +1,7 @@
 #ifndef BUTTONGLYPHS_H
 #define BUTTONGLYPHS_H
 
+#include <SDL.h>
 #include <stdbool.h>
 
 #include "ActionSets.h"
@@ -15,7 +16,14 @@ void BUTTONGLYPHS_init(void);
 bool BUTTONGLYPHS_keyboard_is_available(void);
 bool BUTTONGLYPHS_keyboard_is_active(void);
 const char* BUTTONGLYPHS_get_wasd_text(void);
-const char* BUTTONGLYPHS_get_button(ActionSet actionset, Action action);
+const char* BUTTONGLYPHS_get_button(ActionSet actionset, Action action, int binding);
+
+char* BUTTONGLYPHS_get_all_gamepad_buttons(
+    char* buffer,
+    size_t buffer_len,
+    ActionSet actionset,
+    int action
+);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/desktop_version/src/ButtonGlyphs.h
+++ b/desktop_version/src/ButtonGlyphs.h
@@ -15,6 +15,8 @@ void BUTTONGLYPHS_init(void);
 
 bool BUTTONGLYPHS_keyboard_is_available(void);
 bool BUTTONGLYPHS_keyboard_is_active(void);
+void BUTTONGLYPHS_keyboard_set_active(bool active);
+
 const char* BUTTONGLYPHS_get_wasd_text(void);
 const char* BUTTONGLYPHS_get_button(ActionSet actionset, Action action, int binding);
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <tinyxml2.h>
 
+#include "ButtonGlyphs.h"
 #include "Constants.h"
 #include "CustomLevels.h"
 #include "DeferCallbacks.h"
@@ -832,7 +833,7 @@ void Game::updatestate(void)
             break;
         case 4:
             //End of opening cutscene for now
-            graphics.createtextbox(loc::gettext("Press arrow keys or WASD to move"), -1, 195, 174, 174, 174);
+            graphics.createtextbox(BUTTONGLYPHS_get_wasd_text(), -1, 195, 174, 174, 174);
             graphics.textboxprintflags(PR_FONT_INTERFACE);
             graphics.textboxwrap(4);
             graphics.textboxcentertext();
@@ -864,7 +865,16 @@ void Game::updatestate(void)
             if (!obj.flags[13])
             {
                 obj.flags[13] = true;
-                graphics.createtextbox(loc::gettext("Press ENTER to view map and quicksave"), -1, 155, 174, 174, 174);
+
+                char buffer[SCREEN_WIDTH_CHARS*3 + 1];
+                vformat_buf(
+                    buffer, sizeof(buffer),
+                    loc::gettext("Press {button} to view map and quicksave"),
+                    "button:but",
+                    vformat_button(ActionSet_InGame, Action_InGame_Map)
+                );
+
+                graphics.createtextbox(buffer, -1, 155, 174, 174, 174);
                 graphics.textboxprintflags(PR_FONT_INTERFACE);
                 graphics.textboxwrap(4);
                 graphics.textboxcentertext();
@@ -1067,13 +1077,16 @@ void Game::updatestate(void)
         case 17:
             //Arrow key tutorial
             obj.removetrigger(17);
-            graphics.createtextbox(loc::gettext("If you prefer, you can press UP or DOWN instead of ACTION to flip."), -1, 187, 174, 174, 174);
-            graphics.textboxprintflags(PR_FONT_INTERFACE);
-            graphics.textboxwrap(2);
-            graphics.textboxcentertext();
-            graphics.textboxpad(1, 1);
-            graphics.textboxcenterx();
-            graphics.textboxtimer(100);
+            if (BUTTONGLYPHS_keyboard_is_active())
+            {
+                graphics.createtextbox(loc::gettext("If you prefer, you can press UP or DOWN instead of ACTION to flip."), -1, 187, 174, 174, 174);
+                graphics.textboxprintflags(PR_FONT_INTERFACE);
+                graphics.textboxwrap(2);
+                graphics.textboxcentertext();
+                graphics.textboxpad(1, 1);
+                graphics.textboxcenterx();
+                graphics.textboxtimer(100);
+            }
             setstate(0);
             break;
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -715,7 +715,14 @@ void Game::remaining_textbox(void)
 
 void Game::actionprompt_textbox(void)
 {
-    graphics.createtextboxflipme(loc::gettext("Press ACTION to continue"), -1, 196, 164, 164, 255);
+    char buffer[SCREEN_WIDTH_CHARS + 1];
+    vformat_buf(
+        buffer, sizeof(buffer),
+        loc::gettext("Press {button} to continue"),
+        "button:but",
+        vformat_button(ActionSet_InGame, Action_InGame_ACTION)
+    );
+    graphics.createtextboxflipme(buffer, -1, 196, 164, 164, 255);
     graphics.textboxprintflags(PR_FONT_INTERFACE);
     graphics.textboxpad(1, 1);
     graphics.textboxcenterx();
@@ -1114,7 +1121,15 @@ void Game::updatestate(void)
                 graphics.textboxremovefast();
                 obj.flags[3] = true;
                 setstate(0);
-                graphics.createtextbox(loc::gettext("Press ACTION to flip"), -1, 25, 174, 174, 174);
+
+                char buffer[SCREEN_WIDTH_CHARS*3 + 1];
+                vformat_buf(
+                    buffer, sizeof(buffer),
+                    loc::gettext("Press {button} to flip"),
+                    "button:but",
+                    vformat_button(ActionSet_InGame, Action_InGame_ACTION)
+                );
+                graphics.createtextbox(buffer, -1, 25, 174, 174, 174);
                 graphics.textboxprintflags(PR_FONT_INTERFACE);
                 graphics.textboxwrap(4);
                 graphics.textboxcentertext();

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -768,8 +768,10 @@ static void fill_buttons(char* buffer, const size_t buffer_len, const char* line
 {
     vformat_buf(buffer, buffer_len,
         line,
+        "b_act:but,"
         "b_int:but,"
         "b_map:but",
+        vformat_button(ActionSet_InGame, Action_InGame_ACTION),
         vformat_button(ActionSet_InGame, Action_InGame_Interact),
         vformat_button(ActionSet_InGame, Action_InGame_Map)
     );

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -770,10 +770,14 @@ static void fill_buttons(char* buffer, const size_t buffer_len, const char* line
         line,
         "b_act:but,"
         "b_int:but,"
-        "b_map:but",
+        "b_map:but,"
+        "b_res:but,"
+        "b_esc:but",
         vformat_button(ActionSet_InGame, Action_InGame_ACTION),
         vformat_button(ActionSet_InGame, Action_InGame_Interact),
-        vformat_button(ActionSet_InGame, Action_InGame_Map)
+        vformat_button(ActionSet_InGame, Action_InGame_Map),
+        vformat_button(ActionSet_InGame, Action_InGame_Restart),
+        vformat_button(ActionSet_InGame, Action_InGame_Esc)
     );
 }
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -111,6 +111,8 @@ public:
 
     void textboxprintflags(uint32_t flags);
 
+    void textboxbuttons(void);
+
     void textboxcommsrelay(void);
 
     void textboxadjust(void);

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include "Alloc.h"
+#include "ButtonGlyphs.h"
 #include "Exit.h"
 #include "Game.h"
 #include "GlitchrunnerMode.h"
@@ -174,6 +175,8 @@ void KeyPoll::Poll(void)
                 music.playef(4);
             }
 
+            BUTTONGLYPHS_keyboard_set_active(true);
+
             if (textentry())
             {
                 if (evt.key.keysym.sym == SDLK_BACKSPACE && !keybuffer.empty())
@@ -268,6 +271,7 @@ void KeyPoll::Poll(void)
         /* Controller Input */
         case SDL_CONTROLLERBUTTONDOWN:
             buttonmap[(SDL_GameControllerButton) evt.cbutton.button] = true;
+            BUTTONGLYPHS_keyboard_set_active(false);
             break;
         case SDL_CONTROLLERBUTTONUP:
             buttonmap[(SDL_GameControllerButton) evt.cbutton.button] = false;
@@ -300,6 +304,7 @@ void KeyPoll::Poll(void)
                 }
                 break;
             }
+            BUTTONGLYPHS_keyboard_set_active(false);
             break;
         }
         case SDL_CONTROLLERDEVICEADDED:
@@ -311,6 +316,7 @@ void KeyPoll::Poll(void)
                 SDL_GameControllerName(toOpen)
             );
             controllers[SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(toOpen))] = toOpen;
+            BUTTONGLYPHS_keyboard_set_active(false);
             break;
         }
         case SDL_CONTROLLERDEVICEREMOVED:
@@ -319,6 +325,10 @@ void KeyPoll::Poll(void)
             controllers.erase(evt.cdevice.which);
             vlog_info("Closing %s", SDL_GameControllerName(toClose));
             SDL_GameControllerClose(toClose);
+            if (controllers.empty())
+            {
+                BUTTONGLYPHS_keyboard_set_active(true);
+            }
             break;
         }
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1,5 +1,6 @@
 #include <SDL.h>
 
+#include "ActionSets.h"
 #include "Constants.h"
 #include "Credits.h"
 #include "CustomLevels.h"
@@ -1841,18 +1842,12 @@ static const char* interact_prompt(
     const size_t buffer_size,
     const char* raw
 ) {
-    const char* button;
-
-    if (game.separate_interact)
-    {
-        button = loc::gettext("E");
-    }
-    else
-    {
-        button = loc::gettext("ENTER");
-    }
-
-    vformat_buf(buffer, buffer_size, raw, "button:str", button);
+    vformat_buf(
+        buffer, buffer_size,
+        raw,
+        "button:but",
+        vformat_button(ActionSet_InGame, Action_InGame_Interact)
+    );
 
     return buffer;
 }
@@ -1958,7 +1953,14 @@ void gamerender(void)
 
         if (alpha > 100)
         {
-            font::print(PR_BRIGHTNESS(alpha) | PR_BOR, 5, 5, loc::gettext("[Press ENTER to return to editor]"), 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
+            char buffer[SCREEN_WIDTH_CHARS + 1];
+            vformat_buf(
+                buffer, sizeof(buffer),
+                loc::gettext("[Press {button} to return to editor]"),
+                "button:but",
+                vformat_button(ActionSet_InGame, Action_InGame_Map)
+            );
+            font::print(PR_BRIGHTNESS(alpha) | PR_BOR, 5, 5, buffer, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
         }
     }
 #endif
@@ -2077,7 +2079,14 @@ void gamerender(void)
                 }
             }
 
-            font::print(PR_BOR | PR_CEN, -1, 228, loc::gettext("[Press ENTER to stop]"), 160 - (help.glow/2), 160 - (help.glow/2), 160 - (help.glow/2));
+            char buffer[SCREEN_WIDTH_CHARS + 1];
+            vformat_buf(
+                buffer, sizeof(buffer),
+                loc::gettext("[Press {button} to stop]"),
+                "button:but",
+                vformat_button(ActionSet_InGame, Action_InGame_Map)
+            );
+            font::print(PR_BOR | PR_CEN, -1, 228, buffer, 160 - (help.glow/2), 160 - (help.glow/2), 160 - (help.glow/2));
         }
         else if(game.swngame==2)
         {

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -599,12 +599,41 @@ static void menurender(void)
         case 3:
         case 4:
         case 5:
-            font::print(PR_CEN, -1, 75, loc::gettext("Flip is bound to: ") + std::string(help.GCString(game.controllerButton_flip)) , tr, tg, tb);
-            font::print(PR_CEN, -1, 85, loc::gettext("Enter is bound to: ")  + std::string(help.GCString(game.controllerButton_map)), tr, tg, tb);
-            font::print(PR_CEN, -1, 95, loc::gettext("Menu is bound to: ") + std::string(help.GCString(game.controllerButton_esc)) , tr, tg, tb);
-            font::print(PR_CEN, -1, 105, loc::gettext("Restart is bound to: ") + std::string(help.GCString(game.controllerButton_restart)) , tr, tg, tb);
-            font::print(PR_CEN, -1, 115, loc::gettext("Interact is bound to: ") + std::string(help.GCString(game.controllerButton_interact)) , tr, tg, tb);
+        {
+            char buffer_a[SCREEN_WIDTH_CHARS + 1];
+            char buffer_b[SCREEN_WIDTH_CHARS + 1];
+
+            SDL_snprintf(buffer_a, sizeof(buffer_a), "%s%s",
+                loc::gettext("Flip is bound to: "),
+                BUTTONGLYPHS_get_all_gamepad_buttons(buffer_b, sizeof(buffer_b), ActionSet_InGame, Action_InGame_ACTION)
+            );
+            font::print(PR_CEN, -1, 75, buffer_a, tr, tg, tb);
+
+            SDL_snprintf(buffer_a, sizeof(buffer_a), "%s%s",
+                loc::gettext("Enter is bound to: "),
+                BUTTONGLYPHS_get_all_gamepad_buttons(buffer_b, sizeof(buffer_b), ActionSet_InGame, Action_InGame_Map)
+            );
+            font::print(PR_CEN, -1, 85, buffer_a, tr, tg, tb);
+
+            SDL_snprintf(buffer_a, sizeof(buffer_a), "%s%s",
+                loc::gettext("Menu is bound to: "),
+                BUTTONGLYPHS_get_all_gamepad_buttons(buffer_b, sizeof(buffer_b), ActionSet_InGame, Action_InGame_Esc)
+            );
+            font::print(PR_CEN, -1, 95, buffer_a, tr, tg, tb);
+
+            SDL_snprintf(buffer_a, sizeof(buffer_a), "%s%s",
+                loc::gettext("Restart is bound to: "),
+                BUTTONGLYPHS_get_all_gamepad_buttons(buffer_b, sizeof(buffer_b), ActionSet_InGame, Action_InGame_Restart)
+            );
+            font::print(PR_CEN, -1, 105, buffer_a, tr, tg, tb);
+
+            SDL_snprintf(buffer_a, sizeof(buffer_a), "%s%s",
+                loc::gettext("Interact is bound to: "),
+                BUTTONGLYPHS_get_all_gamepad_buttons(buffer_b, sizeof(buffer_b), ActionSet_InGame, Action_InGame_Interact)
+            );
+            font::print(PR_CEN, -1, 115, buffer_a, tr, tg, tb);
             break;
+        }
         }
 
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1,6 +1,7 @@
 #include <SDL.h>
 
 #include "ActionSets.h"
+#include "ButtonGlyphs.h"
 #include "Constants.h"
 #include "Credits.h"
 #include "CustomLevels.h"
@@ -1623,8 +1624,18 @@ void titlerender(void)
         font::print(PR_RIGHT, 264, temp+35, loc::gettext("MAKE AND PLAY EDITION"), tr, tg, tb);
 #endif
 
-        font::print_wrap(PR_CEN, -1, 175, loc::gettext("[ Press ACTION to Start ]"), tr, tg, tb);
-        font::print_wrap(PR_CEN, -1, 195, loc::gettext("ACTION = Space, Z, or V"), int(tr*0.5f), int(tg*0.5f), int(tb*0.5f));
+        char buffer[SCREEN_WIDTH_CHARS*2 + 1];
+        vformat_buf(
+            buffer, sizeof(buffer),
+            loc::gettext("[ Press {button} to Start ]"),
+            "button:but",
+            vformat_button(ActionSet_Menu, Action_Menu_Accept)
+        );
+        font::print_wrap(PR_CEN, -1, 175, buffer, tr, tg, tb);
+        if (BUTTONGLYPHS_keyboard_is_active())
+        {
+            font::print_wrap(PR_CEN, -1, 195, loc::gettext("ACTION = Space, Z, or V"), int(tr*0.5f), int(tg*0.5f), int(tb*0.5f));
+        }
     }
     else
     {
@@ -1975,13 +1986,17 @@ void gamerender(void)
 
     graphics.copy_texture(graphics.gameplayTexture, NULL, NULL);
 
-    if (graphics.flipmode)
+    if (game.advancetext)
     {
-        if (game.advancetext) font::print(PR_CEN | PR_BOR, -1, 228, loc::gettext("- Press ACTION to advance text -"), 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
-    }
-    else
-    {
-        if (game.advancetext) font::print(PR_CEN | PR_BOR, -1, 5, loc::gettext("- Press ACTION to advance text -"), 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
+        char buffer_adv[SCREEN_WIDTH_CHARS + 1];
+        vformat_buf(
+            buffer_adv, sizeof(buffer_adv),
+            loc::gettext("- Press {button} to advance text -"),
+            "button:but",
+            vformat_button(ActionSet_InGame, Action_InGame_ACTION)
+        );
+
+        font::print(PR_CEN | PR_BOR, -1, graphics.flipmode ? 228 : 5, buffer_adv, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
     }
 
     if (game.readytotele > 100 || game.oldreadytotele > 100)
@@ -2593,7 +2608,14 @@ void maprender(void)
         }
         else if (obj.flags[67] && !map.custommode)
         {
-            font::print_wrap(PR_CEN, -1, 105, loc::gettext("Press ACTION to warp to the ship."), 196, 196, 255 - help.glow);
+            char buffer[SCREEN_WIDTH_CHARS + 1];
+            vformat_buf(
+                buffer, sizeof(buffer),
+                loc::gettext("Press {button} to warp to the ship."),
+                "button:but",
+                vformat_button(ActionSet_InGame, Action_InGame_ACTION)
+            );
+            font::print_wrap(PR_CEN, -1, 105, buffer, 196, 196, 255 - help.glow);
         }
 #if !defined(NO_CUSTOM_LEVELS)
         else if(map.custommode){
@@ -2755,7 +2777,15 @@ void maprender(void)
 
         if (!game.gamesaved)
         {
-            font::print(PR_CEN, -1, 80, loc::gettext("[Press ACTION to save your game]"), 255 - help.glow*2, 255 - help.glow*2, 255 - help.glow);
+            char buffer[SCREEN_WIDTH_CHARS + 1];
+            vformat_buf(
+                buffer, sizeof(buffer),
+                loc::gettext("[Press {button} to save your game]"),
+                "button:but",
+                vformat_button(ActionSet_InGame, Action_InGame_ACTION)
+            );
+
+            font::print(PR_CEN, -1, 80, buffer, 255 - help.glow*2, 255 - help.glow*2, 255 - help.glow);
 
             if (map.custommode || game.quicksummary == "")
             {
@@ -2991,13 +3021,17 @@ void teleporterrender(void)
 
     graphics.drawgui();
 
-    if (graphics.flipmode)
+    if (game.advancetext)
     {
-        if (game.advancetext) font::print(PR_CEN | PR_BOR, -1, 228, loc::gettext("- Press ACTION to advance text -"), 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
-    }
-    else
-    {
-        if (game.advancetext) font::print(PR_CEN | PR_BOR, -1, 5, loc::gettext("- Press ACTION to advance text -"), 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
+        char buffer_adv[SCREEN_WIDTH_CHARS + 1];
+        vformat_buf(
+            buffer_adv, sizeof(buffer_adv),
+            loc::gettext("- Press {button} to advance text -"),
+            "button:but",
+            vformat_button(ActionSet_InGame, Action_InGame_ACTION)
+        );
+
+        font::print(PR_CEN | PR_BOR, -1, graphics.flipmode ? 228 : 5, buffer_adv, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
     }
 
     graphics.set_render_target(graphics.gameTexture);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -4,6 +4,7 @@
 #include <limits.h>
 #include <SDL_timer.h>
 
+#include "Alloc.h"
 #include "Constants.h"
 #include "CustomLevels.h"
 #include "Editor.h"
@@ -48,6 +49,7 @@ scriptclass::scriptclass(void)
     textpad_right = 0;
     textpadtowidth = 0;
     textcase = 1;
+    textbuttons = false;
     textlarge = false;
 }
 
@@ -798,6 +800,12 @@ void scriptclass::run(void)
                         || key.isDown(KEYBOARD_UP) || key.isDown(KEYBOARD_DOWN)) game.jumpheld = true;
                 }
                 game.backgroundtext = false;
+
+                if (textbuttons)
+                {
+                    graphics.textboxbuttons();
+                }
+                textbuttons = false;
             }
             else if (words[0] == "endtext")
             {
@@ -2426,6 +2434,11 @@ void scriptclass::run(void)
                         position--;
                     }
                 }
+            }
+            else if (words[0] == "textbuttons")
+            {
+                // Parse buttons in the next textbox
+                textbuttons = true;
             }
             else if (words[0] == "textcase")
             {

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -111,6 +111,7 @@ public:
     size_t textpad_right;
     size_t textpadtowidth;
     char textcase;
+    bool textbuttons;
     bool textlarge;
 
     //Misc

--- a/desktop_version/src/Scripts.cpp
+++ b/desktop_version/src/Scripts.cpp
@@ -5054,9 +5054,10 @@ bool scriptclass::load(const std::string& name)
 
         "squeak(purple)",
         "text(purple,0,0,2)",
-        "Remember that you can press ENTER",
+        "Remember that you can press {b_map}",
         "to check where you are on the map!",
         "position(purple,above)",
+        "textbuttons()",
         "speak_active",
 
         "squeak(purple)",

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -27,6 +27,7 @@ textboxclass::textboxclass(void)
     large = false;
 
     print_flags = PR_FONT_LEVEL;
+    fill_buttons = false;
 }
 
 void textboxclass::centerx(void)

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -52,6 +52,7 @@ public:
     bool large;
 
     uint32_t print_flags;
+    bool fill_buttons;
 };
 
 #endif /* TEXTBOX_H */

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -9,38 +9,6 @@
 #include "Maths.h"
 #include "VFormat.h"
 
-static const char* GCChar(const SDL_GameControllerButton button)
-{
-    switch (button)
-    {
-    case SDL_CONTROLLER_BUTTON_A:
-        return "A";
-    case SDL_CONTROLLER_BUTTON_B:
-        return "B";
-    case SDL_CONTROLLER_BUTTON_X:
-        return "X";
-    case SDL_CONTROLLER_BUTTON_Y:
-        return "Y";
-    case SDL_CONTROLLER_BUTTON_BACK:
-        return "BACK";
-    case SDL_CONTROLLER_BUTTON_GUIDE:
-        return "GUIDE";
-    case SDL_CONTROLLER_BUTTON_START:
-        return "START";
-    case SDL_CONTROLLER_BUTTON_LEFTSTICK:
-        return "L3";
-    case SDL_CONTROLLER_BUTTON_RIGHTSTICK:
-        return "R3";
-    case SDL_CONTROLLER_BUTTON_LEFTSHOULDER:
-        return "LB";
-    case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER:
-        return "RB";
-    default:
-        SDL_assert(0 && "Unhandled button!");
-        return NULL;
-    }
-}
-
 int ss_toi(const std::string& str)
 {
     int retval = 0;
@@ -155,20 +123,6 @@ int UtilityClass::Int(const char* str, int fallback /*= 0*/)
     }
 
     return (int) SDL_strtol(str, NULL, 0);
-}
-
-std::string UtilityClass::GCString(const std::vector<SDL_GameControllerButton>& buttons)
-{
-    std::string retval = "";
-    for (size_t i = 0; i < buttons.size(); i += 1)
-    {
-        retval += GCChar(buttons[i]);
-        if ((i + 1) < buttons.size())
-        {
-            retval += ",";
-        }
-    }
-    return retval;
 }
 
 int UtilityClass::hms_to_seconds(int h, int m, int s)

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -3,7 +3,6 @@
 
 #include <SDL.h>
 #include <string>
-#include <vector>
 
 int ss_toi(const std::string& str);
 
@@ -101,8 +100,6 @@ public:
     static std::string String(int _v);
 
     static int Int(const char* str, int fallback = 0);
-
-    static std::string GCString(const std::vector<SDL_GameControllerButton>& buttons);
 
     int hms_to_seconds(int h, int m, int s);
 

--- a/desktop_version/src/VFormat.c
+++ b/desktop_version/src/VFormat.c
@@ -52,7 +52,7 @@ static inline void call_with_button(format_callback callback, void* userdata, in
     Action action;
     vformat_unbutton(&actionset, &action, vararg_value);
 
-    const char* button_text = BUTTONGLYPHS_get_button(actionset, action);
+    const char* button_text = BUTTONGLYPHS_get_button(actionset, action, -1);
     if (button_text == NULL)
     {
         callback(userdata, "[null]", 6);

--- a/desktop_version/src/VFormat.h
+++ b/desktop_version/src/VFormat.h
@@ -43,7 +43,7 @@
  * The valid types are:
  *  - int   Signed integer
  *  - str   const char*
- *  - but   Controller button icon
+ *  - but   Controller button icon: vformat_button(actionset, action)
  *
  * Special case: if an argument name is a single underscore (_), it matches
  * any name not found earlier in the list. This should normally not be needed.
@@ -75,12 +75,17 @@
 #include <stdarg.h>
 #include <stddef.h>
 
+#include "ActionSets.h"
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
 typedef void (*format_callback)(void* userdata, const char* string, size_t bytes);
+
+
+int vformat_button(ActionSet actionset, int action);
 
 
 void vformat_cb_valist(

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -4,6 +4,7 @@
 #include <emscripten/html5.h>
 #endif
 
+#include "ButtonGlyphs.h"
 #include "CustomLevels.h"
 #include "DeferCallbacks.h"
 #include "Editor.h"
@@ -649,6 +650,7 @@ int main(int argc, char *argv[])
         gameScreen.init(&screen_settings);
     }
 
+    BUTTONGLYPHS_init();
     font::load_main();
 
     // This loads music too...
@@ -915,9 +917,14 @@ static void unfocused_run(void)
          * a language changes the used language metadata but not the loaded strings... */
         uint32_t flags = PR_CEN | PR_BOR | PR_FONT_IDX(loc::langmeta.font_idx);
         font::print(flags | PR_CJK_HIGH, -1, FLIP(110), loc::gettext("Game paused"), 196 - help.glow, 255 - help.glow, 196 - help.glow);
-        font::print(flags | PR_CJK_LOW, -1, FLIP(120), loc::gettext("[click to resume]"), 196 - help.glow, 255 - help.glow, 196 - help.glow);
-        font::print(flags | PR_CJK_HIGH, -1, FLIP(220), loc::gettext("Press M to mute in game"), 164 - help.glow, 196 - help.glow, 164 - help.glow);
-        font::print(flags, -1, FLIP(230), loc::gettext("Press N to mute music only"), 164 - help.glow, 196 - help.glow, 164 - help.glow);
+
+        if (BUTTONGLYPHS_keyboard_is_available())
+        {
+            font::print(flags | PR_CJK_LOW, -1, FLIP(120), loc::gettext("[click to resume]"), 196 - help.glow, 255 - help.glow, 196 - help.glow);
+
+            font::print(flags | PR_CJK_HIGH, -1, FLIP(220), loc::gettext("Press M to mute in game"), 164 - help.glow, 196 - help.glow, 164 - help.glow);
+            font::print(flags, -1, FLIP(230), loc::gettext("Press N to mute music only"), 164 - help.glow, 196 - help.glow, 164 - help.glow);
+        }
 #undef FLIP
     }
     graphics.render();


### PR DESCRIPTION
## Changes:

This PR adds most of the remaining handling needed for #859.

This adds a function that converts an action (such as interacting in-game) to the corresponding button text ("ENTER", "E") or button glyph (PlayStation triangle, Steam Deck Y, etc).

To identify the actions that currently need to be displayed, this commit also adds the initial enums for action sets as described in https://github.com/TerryCavanagh/VVVVVV/issues/834#issuecomment-1015692161.

This also adds a `textbuttons()` scripting command to handle Violet's "Remember that you can press ENTER" dialogue.

Some screenshots to give an impression (again, with hardcoded mappings):

![Press (triangle) to talk to Vermilion](https://user-images.githubusercontent.com/44736680/223605336-4ae95cd1-67e3-40f8-8a1a-34798759d14e.png)

![Press (X) to Teleport](https://user-images.githubusercontent.com/44736680/223605432-99fd30eb-f38d-477c-a0f5-78566f0a6070.png)

![Remember that you can press (view) to check where you are on the map!](https://user-images.githubusercontent.com/44736680/223605495-9d75f3a3-ed43-42d1-b88e-25801541d935.png)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
