### PR TITLE
Fix font .txt files not being null-terminated

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -741,6 +741,12 @@ void FILESYSTEM_loadFileToMemory(
         goto fail;
     }
 
+    if (len == NULL && !addnull)
+    {
+        vlog_warn("%s is loaded with len == NULL && !addnull", name);
+        SDL_assert(0 && "Are you sure you don't want a null terminator to be added to these loaded file contents?");
+    }
+
     /* FIXME: Dumb hack to use `special/stdin.vvvvvv` here...
      * This is also checked elsewhere... grep for `special/stdin`! */
     if (SDL_strcmp(name, "levels/special/stdin.vvvvvv") == 0)

--- a/desktop_version/src/Font.cpp
+++ b/desktop_version/src/Font.cpp
@@ -346,7 +346,7 @@ static uint8_t load_font(FontContainer* container, const char* name)
     unsigned char* charmap = NULL;
     if (FILESYSTEM_areAssetsInSameRealDir(name_png, name_txt))
     {
-        FILESYSTEM_loadAssetToMemory(name_txt, &charmap, NULL, false);
+        FILESYSTEM_loadAssetToMemory(name_txt, &charmap, NULL, true);
     }
     if (charmap != NULL)
     {


### PR DESCRIPTION
## Changes:

This was an oversight when we migrated to the new UTF-8 system - it expects a null-terminated string, but the utfcpp implementation worked with a pointer to the end of the file instead.

I also added an assert in FILESYSTEM_loadFileToMemory() so this is less likely to happen again - because there should be no valid reason to have a NULL pointer for the total file size, as well as not wanting a null terminator to be added at the end of the file.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
