### PR TITLE
Fix the game texture clearing during menu shaking

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3173,7 +3173,7 @@ void Graphics::screenshake(void)
     clear();
 
     // Clear the gameplay texture so blackout() is actually black after a screenshake
-    if (game.gamestate == GAMEMODE)
+    if (game.gamestate == GAMEMODE && game.blackout)
     {
         set_render_target(gameplayTexture);
         clear();


### PR DESCRIPTION
## Changes:

Because of how `blackout` works, screen shaking must clear the gameplay buffer. `blackout` simply pauses rendering, so if the gameplay buffer gets cleared, then the screen will just be black, otherwise it'll look like the game is "frozen". VVVVVV only uses `blackout` during screen shaking, so it works as intended. However, when reimplementing this behavior in the move to using the SDL_Renderer system, I failed to notice that since my implementation always clears the gameplay buffer when shaking, if you open the menu during a shake, instead of seeing gameplay during the transition animation, you only see black. This has been fixed with a simple `game.blackout` check before clearing the gameplay buffer.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
