### PR TITLE
Fix textboxes fully fading out during blackout

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1967,11 +1967,12 @@ void gamerender(void)
     graphics.cutscenebars();
     graphics.drawfade();
 
+    graphics.drawgui();
+
     graphics.set_render_target(graphics.gameTexture);
 
     graphics.copy_texture(graphics.gameplayTexture, NULL, NULL);
 
-    graphics.drawgui();
     if (graphics.flipmode)
     {
         if (game.advancetext) font::print(PR_CEN | PR_BOR, -1, 228, loc::gettext("- Press ACTION to advance text -"), 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));


### PR DESCRIPTION
## Changes:

When `blackout` is active, the screen (to simplify) stops getting drawn to. The excecption is textboxes, which draw anyway. But since the screen isn't being cleared, removed textboxes stay on screen, since that texture isn't being cleared. In the SDL_Renderer PR, I accidentally broke this behavior, so this commit fixes it.

Fixes #951.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
