### PR TITLE
Make Violet's button dialogue work in cutscene test

### DIFF
--- a/desktop_version/lang/ca/cutscenes.xml
+++ b/desktop_version/lang/ca/cutscenes.xml
@@ -80,7 +80,7 @@
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Tot això m’aclapara una mica, doctora."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Per on començo?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Recorda que pots prémer Retorn per a veure on ets del mapa!"/>
-        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="" buttons="1"/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Cerca zones on pugui haver-hi altres tripulants..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Si et perds, pots tornar a la nau a partir de qualsevol teletransportador."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="I no pateixis! Segur que trobarem tothom!"/>

--- a/desktop_version/lang/de/cutscenes.xml
+++ b/desktop_version/lang/de/cutscenes.xml
@@ -80,7 +80,7 @@
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Ich fühle mich ein bisschen überfordert, Doktor."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Wo soll ich anfangen?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Denk dran, dass du ENTER drücken kannst, um zu sehen, wo du auf der Karte bist!"/>
-        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="" buttons="1"/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Halte Ausschau nach Bereichen, in denen der Rest der Crew sein könnte..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Wenn du dich verirrst, kannst du von jedem Teleporter aus zum Schiff zurückkehren."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="Und mach dir keine Sorgen! Wir werden alle finden!"/>

--- a/desktop_version/lang/en/cutscenes.xml
+++ b/desktop_version/lang/en/cutscenes.xml
@@ -80,7 +80,7 @@
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation=""/>
         <dialogue speaker="player" english="Where do I begin?" translation=""/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation=""/>
-        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="" buttons="1"/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation=""/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation=""/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation=""/>

--- a/desktop_version/lang/eo/cutscenes.xml
+++ b/desktop_version/lang/eo/cutscenes.xml
@@ -80,7 +80,7 @@
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Mi sentas min iom superŝarĝita, Doktoro."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Kie mi komencu?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Memoru, ke vi povas premi ENTER por kontroli, kie vi estas sur la mapo!"/>
-        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="" buttons="1"/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Serĉu areojn, kie eble estas la skipanoj..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Se vi perdiĝas, vi povas reveni al la ŝipo per iu ajn teleportilo."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="Kaj ne ĉagreniĝu! Ni ĉiujn trovos!"/>

--- a/desktop_version/lang/es/cutscenes.xml
+++ b/desktop_version/lang/es/cutscenes.xml
@@ -80,7 +80,7 @@
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Me siento un poco abrumado, doctora."/>
         <dialogue speaker="player" english="Where do I begin?" translation="¿Por dónde empiezo?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="¡Recuerda que puedes pulsar la tecla ENTRAR para comprobar dónde te encuentras en el mapa!"/>
-        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="" buttons="1"/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Busca zonas donde pueda estar el resto de la tripulación..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Si te pierdes, puedes volver a la nave desde cualquier teletransportador."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="¡Y no te preocupes! ¡Encontraremos a todo el mundo!"/>

--- a/desktop_version/lang/fr/cutscenes.xml
+++ b/desktop_version/lang/fr/cutscenes.xml
@@ -80,7 +80,7 @@
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Je ne sais plus où donner de la tête, Docteure..."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Par où commencer ?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Souvenez-vous que vous pouvez appuyer sur ENTRÉE pour vérifier votre position sur la carte !"/>
-        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="" buttons="1"/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Cherchez des endroits où le reste de l&apos;équipage pourrait se trouver..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Si vous vous perdez, vous pourrez regagner le vaisseau à partir de n&apos;importe quel téléporteur."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="Et ne vous en faites pas ! Nous allons tous les retrouver  !"/>

--- a/desktop_version/lang/it/cutscenes.xml
+++ b/desktop_version/lang/it/cutscenes.xml
@@ -80,7 +80,7 @@
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Non so se mi sento all&apos;altezza del compito, dottoressa."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Da dove comincio?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Ricordi: può premere INVIO per controllare la sua posizione sulla mappa!"/>
-        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="" buttons="1"/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Cerchi le zone in cui potrebbe trovarsi il resto dell&apos;equipaggio..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Se si perde, può tornare alla nave da qualsiasi teletrasporto."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="E non si preoccupi! Troveremo tutti!"/>

--- a/desktop_version/lang/nl/cutscenes.xml
+++ b/desktop_version/lang/nl/cutscenes.xml
@@ -80,7 +80,7 @@
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Ik voel me een beetje overdonderd, Doctor."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Waar begin ik?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Onthoud dat je op ENTER kunt drukken om te zien waar je je op de kaart bevindt!"/>
-        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="Onthoud dat je op {b_map} kunt drukken om te zien waar je je op de kaart bevindt!"/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="Onthoud dat je op {b_map} kunt drukken om te zien waar je je op de kaart bevindt!" buttons="1"/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Zoek naar gebieden waar de rest van de bemanning zou kunnen zijn..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Als je verdwaald raakt kun je terug naar het schip met welke teleport dan ook."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="En maak je geen zorgen! We gaan iedereen vinden!"/>

--- a/desktop_version/lang/pt_BR/cutscenes.xml
+++ b/desktop_version/lang/pt_BR/cutscenes.xml
@@ -80,7 +80,7 @@
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Eu tô me sentindo um pouco sobrecarregado, Doutora."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Por onde começo?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Lembre-se: você pode pressionar ENTER para verificar onde você está no mapa!"/>
-        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="" buttons="1"/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Procure áreas onde o resto da equipe pode estar..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Se você se perder, pode voltar para a nave a partir de qualquer teletransportador."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="E não se preocupa! Vamos encontrar todos!"/>

--- a/desktop_version/lang/pt_PT/cutscenes.xml
+++ b/desktop_version/lang/pt_PT/cutscenes.xml
@@ -80,7 +80,7 @@
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Doutora, já tenho a cabeça a andar à roda..."/>
         <dialogue speaker="player" english="Where do I begin?" translation="É melhor começar por onde?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Não te esqueças que podes premir ENTER para verificar a tua localização no mapa!"/>
-        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="" buttons="1"/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Investiga áreas onde o resto da tripulação possa estar..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Se te perderes, basta usar um teletransporte para regressar à nave."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="E não te preocupes, tenho a certeza que encontraremos toda a gente!"/>

--- a/desktop_version/lang/ru/cutscenes.xml
+++ b/desktop_version/lang/ru/cutscenes.xml
@@ -80,7 +80,7 @@
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Я чувствую себя как-то подавленно, доктор. Просто... глаза разбегаются."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Где мне начать?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Помни, что нажав ENTER, ты можешь посмотреть, где ты находишься на карте!"/>
-        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="" buttons="1"/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Ищи места, где могут находиться остальные члены экипажа..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Если потеряешься, то помни, что можешь вернуться на корабль с помощью любого телепорта."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="И не волнуйся! Мы обязательно всех найдём!"/>

--- a/desktop_version/lang/tr/cutscenes.xml
+++ b/desktop_version/lang/tr/cutscenes.xml
@@ -80,7 +80,7 @@
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Tüm bunlar bana biraz fazla geldi doktor."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Nereden başlamalıyım?"/>
         <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="Haritadaki yerinizi görmek için ENTER tuşuna basabileceğinizi unutmayın!"/>
-        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation=""/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="" buttons="1"/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Mürettebatın geri kalanının olabileceğin bölgeleri arayın..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Kaybolursanız herhangi bir ışınlayıcıdan gemiye geri dönebilirsiniz."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="Merak etmeyin! Herkesi bulacağız!"/>

--- a/desktop_version/src/LocalizationMaint.cpp
+++ b/desktop_version/src/LocalizationMaint.cpp
@@ -289,6 +289,9 @@ static void sync_lang_file(const std::string& langcode)
                 subElem->DeleteAttribute("pad_right");
                 subElem->DeleteAttribute("padtowidth");
 
+                bool buttons = subElem->BoolAttribute("buttons", false);
+                subElem->DeleteAttribute("buttons"); // we want this at the end...
+
                 if (format->text != NULL)
                     subElem->SetAttribute("translation", format->text);
                 if (format->tt)
@@ -310,6 +313,8 @@ static void sync_lang_file(const std::string& langcode)
                 }
                 if (format->padtowidth != 0)
                     subElem->SetAttribute("padtowidth", format->padtowidth);
+                if (buttons)
+                    subElem->SetAttribute("buttons", 1);
             }
         }
 
@@ -546,7 +551,8 @@ bool populate_cutscene_test(const char* script_id)
                 script.add_test_line(
                     speaker,
                     eng,
-                    subElem->UnsignedAttribute("case", 1)
+                    subElem->UnsignedAttribute("case", 1),
+                    subElem->BoolAttribute("buttons", false)
                 );
             }
         }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3608,8 +3608,12 @@ void scriptclass::loadalts(const std::string& processed, const std::string& raw)
     }
 }
 
-void scriptclass::add_test_line(const std::string& speaker, const std::string& english, char textcase)
-{
+void scriptclass::add_test_line(
+    const std::string& speaker,
+    const std::string& english,
+    const char textcase,
+    const bool textbuttons
+) {
     if (speaker == "gray")
     {
         add("squeak(terminal)");
@@ -3622,6 +3626,10 @@ void scriptclass::add_test_line(const std::string& speaker, const std::string& e
     add("text("+speaker+",0,0,1)");
     add(english);
     add("position(center)");
+    if (textbuttons)
+    {
+        add("textbuttons()");
+    }
     add("speak_active");
 }
 

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -68,7 +68,7 @@ public:
     bool loadcustom(const std::string& t);
     void loadalts(const std::string& processed, const std::string& raw);
 
-    void add_test_line(const std::string& speaker, const std::string& english, char textcase);
+    void add_test_line(const std::string& speaker, const std::string& english, char textcase, bool textbuttons);
     void loadtest(const std::string& name);
 
     void inline add(const std::string& t)


### PR DESCRIPTION
## Changes:

This was easier than I expected - just add an optional buttons="1" attribute to cutscenes.xml. It's treated like the speaker attribute - it's only there as context for the translator, and for the cutscene test.

Before:

![öb_mapÁ](https://user-images.githubusercontent.com/44736680/227031950-760933f1-a2a5-4973-9384-c5354e0afc8f.png)

After:

![SELECT](https://user-images.githubusercontent.com/44736680/227031828-7450f9b3-244e-4539-a99d-dc4337c7372a.png)



## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
