### PR TITLE
Fix box placement in editor

### DIFF
--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -2948,7 +2948,7 @@ void editorinput(void)
                     }
                 }
             }
-            else
+            else if (!key.leftbutton)
             {
                 ed.lclickdelay = 0;
             }


### PR DESCRIPTION
## Changes:

Boxes could be placed by just holding down the left button. This PR adds a missing `!key.leftbutton` check, fixing this behavior.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
