### PR TITLE
Attempt to make the Windows CI again a bit faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,20 +125,19 @@ jobs:
         submodules: true
 
     - name: Cache SDL
-      uses: actions/cache@v2
+      id: cache-windows-sdl
+      uses: actions/cache@v3
       env:
         cache-name: cache-sdl
       with:
-        path: C:\SDL
-        key: ${{ runner.os }}-build-${{ env.cache-name }}
+        path: C:\SDL2-*
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.SDL_VERSION }}
 
-    - name: Download SDL if not cached
+    - if: ${{ steps.cache-windows-sdl.outputs.cache-hit != 'true' }}
+      name: Download SDL if not cached
       run: |
-        if (-Not (Test-Path C:\SDL))
-        {
-          Invoke-WebRequest "https://github.com/libsdl-org/SDL/releases/download/release-$env:SDL_VERSION/SDL2-devel-$env:SDL_VERSION-VC.zip" -o C:\SDL.zip
-          Expand-Archive C:\SDL.zip -DestinationPath C:\
-        }
+        Invoke-WebRequest "https://github.com/libsdl-org/SDL/releases/download/release-$env:SDL_VERSION/SDL2-devel-$env:SDL_VERSION-VC.zip" -o C:\SDL.zip
+        Expand-Archive C:\SDL.zip -DestinationPath C:\
 
     - name: CMake configure (default version)
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,9 @@ jobs:
       env:
         cache-name: cache-windows-build-folder-VS2022
       with:
-        path: desktop_version/build
+        path: |
+          desktop_version/build
+          desktop_version/CMakeLists.txt
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('desktop_version/CMakeLists.txt') }}-SDL${{ env.SDL_VERSION }}
 
     - if: ${{ steps.cache-windows-build-folder.outputs.cache-hit != 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,17 @@ jobs:
         Invoke-WebRequest "https://github.com/libsdl-org/SDL/releases/download/release-$env:SDL_VERSION/SDL2-devel-$env:SDL_VERSION-VC.zip" -o C:\SDL.zip
         Expand-Archive C:\SDL.zip -DestinationPath C:\
 
-    - name: CMake configure (default version)
+    - name: Cache build folder for this CMakeLists.txt
+      id: cache-windows-build-folder
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-windows-build-folder-VS2022
+      with:
+        path: desktop_version/build
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('desktop_version/CMakeLists.txt') }}-SDL${{ env.SDL_VERSION }}
+
+    - if: ${{ steps.cache-windows-build-folder.outputs.cache-hit != 'true' }}
+      name: CMake initial configure/generate
       run: |
         mkdir $env:SRC_DIR_PATH/build
         cd $env:SRC_DIR_PATH/build
@@ -147,6 +157,11 @@ jobs:
         cmake -G "Visual Studio 17 2022" -A Win32 `
               -DSDL2_INCLUDE_DIRS="C:\SDL2-$env:SDL_VERSION\include" `
               -DSDL2_LIBRARIES="SDL2;SDL2main" ..
+
+    - name: CMake configure (default version)
+      run: |
+        cd $env:SRC_DIR_PATH/build
+        cmake ..
     - name: Build (default version)
       run: |
         cd $env:SRC_DIR_PATH/build


### PR DESCRIPTION
## Changes:

Apart from the CI seemingly liking to randomly twiddle its fingers for dozens of seconds or even minutes (are Windows shared runners overloaded or something?) and CMake (and probably also Visual Studio) still spending a lot of time rebuilding things no matter what I try, I've made some more changes to improve the Windows CI:
- The SDL cache action is now upgraded from `cache@v2` to `cache@v3` (removing a Node.js 12 deprecation warning)
- It now caches the correct SDL folder (it was caching 30 bytes before, I don't know what those 30 bytes were)
- The "Download SDL" step is now fully skipped (with the cache hit return value) instead of using `Test-Path` to check for the folder
- The build folder is now cached, to avoid the initial `cmake -G -A -D -D ..` which often takes really long. It really depends on the CI's mood though - sometimes the next `cmake ..` completes in 5 seconds (success!), sometimes it decides to completely start over anyway, without saying why. And then the first build will still take the longest, even though subsequent builds can all be done in as fast as 11 seconds (I even tried splitting the build folder into one for each build type, but the pattern would stay the exact same unfortunately - first build in the run takes 50+ seconds, subsequent builds, in their own separate folders, are less than 20)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
