### PR TITLE
Show correct button glyph for interact if Enter/E are not split

### DIFF
--- a/desktop_version/src/ButtonGlyphs.cpp
+++ b/desktop_version/src/ButtonGlyphs.cpp
@@ -244,7 +244,13 @@ const char* BUTTONGLYPHS_get_button(const ActionSet actionset, const Action acti
         case Action_InGame_Interact:
             if (show_controller)
             {
-                return glyph_for_vector(game.controllerButton_interact, binding);
+                /* FIXME: this really does depend on the Enter/E speedrunner option...
+                 * This is messy, but let's not show the wrong thing here... */
+                if (game.separate_interact)
+                {
+                    return glyph_for_vector(game.controllerButton_interact, binding);
+                }
+                return glyph_for_vector(game.controllerButton_map, binding);
             }
             if (game.separate_interact)
             {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6531,7 +6531,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option(loc::gettext("bind enter"));
         option(loc::gettext("bind menu"));
         option(loc::gettext("bind restart"));
-        option(loc::gettext("bind interact"));
+        option(loc::gettext("bind interact"), separate_interact);
         option(loc::gettext("return"));
         menuyoff = 0;
         maxspacing = 10;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2366,6 +2366,7 @@ void titleinput(void)
         if (    game.currentmenuname == Menu::controller &&
                 game.currentmenuoption > 0 &&
                 game.currentmenuoption < 6 &&
+                (game.separate_interact || game.currentmenuoption < 5) &&
                 key.controllerButtonDown()      )
         {
             updatebuttonmappings(game.currentmenuoption);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -631,7 +631,7 @@ static void menurender(void)
                 loc::gettext("Interact is bound to: "),
                 BUTTONGLYPHS_get_all_gamepad_buttons(buffer_b, sizeof(buffer_b), ActionSet_InGame, Action_InGame_Interact)
             );
-            font::print(PR_CEN, -1, 115, buffer_a, tr, tg, tb);
+            font::print(PR_CEN | PR_BRIGHTNESS(game.separate_interact ? 255 : 128), -1, 115, buffer_a, tr, tg, tb);
             break;
         }
         }


### PR DESCRIPTION
## Changes:

I thought 2.2 already had separate map and interact gamepad bindings, and they simply got neglected and broken with 2.3's split Enter/E key option. But actually, the new split Enter/E option also applied to gamepad buttons, and a separate interact binding was added, without really indicating anything if Enter and E are not split. And I guess using the same button for map and interact by default also makes sense for simplicity...

![Press left action button to talk to Vitellary, which should be top action button](https://user-images.githubusercontent.com/44736680/227754187-e912c640-4191-4512-ab7b-906d7da0b873.png)

This commit makes sure the button glyph displayed in-game is at least the correct button. The gamepad bindings menu is also slightly modified to darken the interact option - the button glyphs code now automatically causes them to show equal buttons anyway, so it wasn't too big of a change to also darken the line and disable the binding option. To me this says: "the interact key is fixed to be the same as enter right now, but there is a way to change it."

![gamepad menu](https://user-images.githubusercontent.com/44736680/227754168-b9989306-882d-4766-852f-5bbf3cf16683.png)

It's still not ideal of course, and I know a similar change to the gamepad menu to hide the interact option was rejected a year ago because action sets would already fix it, but it's a year later now, and showing misleading button glyphs should be fixed in 2.4, whether it will already have action sets or not (And at this point I think the plan already is to keep the existing input system for 2.4)

And it's a 3 line diff to darken and disable the option, compared to fully hiding the option.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
