### PR TITLE
Add button glyphs support to selection hint on language screen

### DIFF
--- a/desktop_version/lang/ca/meta.xml
+++ b/desktop_version/lang/ca/meta.xml
@@ -11,6 +11,9 @@
     <!-- On the language screen, hard limit 40 8x8 characters. Space/Z/V sets this as the language -->
     <action_hint>Prem Espai, Z o V per a seleccionar</action_hint>
 
+    <!-- Same as above, but for a gamepad button (hard limit 40 8x8 characters) -->
+    <gamepad_hint>Press {button} to select</gamepad_hint>
+
     <!-- Enable automatic word wrapping instead of having to manually insert newlines -->
     <autowordwrap>1</autowordwrap>
 

--- a/desktop_version/lang/de/meta.xml
+++ b/desktop_version/lang/de/meta.xml
@@ -11,6 +11,9 @@
     <!-- On the language screen, hard limit 40 8x8 characters. Space/Z/V sets this as the language -->
     <action_hint>Drücke die Leertaste, Z oder V zur Auswahl</action_hint>
 
+    <!-- Same as above, but for a gamepad button (hard limit 40 8x8 characters) -->
+    <gamepad_hint>Press {button} to select</gamepad_hint>
+
     <!-- Enable automatic word wrapping instead of having to manually insert newlines -->
     <autowordwrap>1</autowordwrap>
 

--- a/desktop_version/lang/en/meta.xml
+++ b/desktop_version/lang/en/meta.xml
@@ -11,6 +11,9 @@
     <!-- On the language screen, hard limit 40 8x8 characters. Space/Z/V sets this as the language -->
     <action_hint>Press Space, Z, or V to select</action_hint>
 
+    <!-- Same as above, but for a gamepad button (hard limit 40 8x8 characters) -->
+    <gamepad_hint>Press {button} to select</gamepad_hint>
+
     <!-- Enable automatic word wrapping instead of having to manually insert newlines -->
     <autowordwrap>1</autowordwrap>
 

--- a/desktop_version/lang/eo/meta.xml
+++ b/desktop_version/lang/eo/meta.xml
@@ -11,6 +11,9 @@
     <!-- On the language screen, hard limit 40 8x8 characters. Space/Z/V sets this as the language -->
     <action_hint>Premu spaceton, Z aŭ V por elekti</action_hint>
 
+    <!-- Same as above, but for a gamepad button (hard limit 40 8x8 characters) -->
+    <gamepad_hint>Press {button} to select</gamepad_hint>
+
     <!-- Enable automatic word wrapping instead of having to manually insert newlines -->
     <autowordwrap>1</autowordwrap>
 

--- a/desktop_version/lang/es/meta.xml
+++ b/desktop_version/lang/es/meta.xml
@@ -11,6 +11,9 @@
     <!-- On the language screen, hard limit 40 8x8 characters. Space/Z/V sets this as the language -->
     <action_hint>Pulsa Espacio, Z, o V para seleccionar</action_hint>
 
+    <!-- Same as above, but for a gamepad button (hard limit 40 8x8 characters) -->
+    <gamepad_hint>Press {button} to select</gamepad_hint>
+
     <!-- Enable automatic word wrapping instead of having to manually insert newlines -->
     <autowordwrap>1</autowordwrap>
 

--- a/desktop_version/lang/fr/meta.xml
+++ b/desktop_version/lang/fr/meta.xml
@@ -11,6 +11,9 @@
     <!-- On the language screen, hard limit 40 8x8 characters. Space/Z/V sets this as the language -->
     <action_hint>Espace, Z ou V pour sélectionner</action_hint>
 
+    <!-- Same as above, but for a gamepad button (hard limit 40 8x8 characters) -->
+    <gamepad_hint>Press {button} to select</gamepad_hint>
+
     <!-- Enable automatic word wrapping instead of having to manually insert newlines -->
     <autowordwrap>1</autowordwrap>
 

--- a/desktop_version/lang/it/meta.xml
+++ b/desktop_version/lang/it/meta.xml
@@ -11,6 +11,9 @@
     <!-- On the language screen, hard limit 40 8x8 characters. Space/Z/V sets this as the language -->
     <action_hint>Premi spazio, Z, or V per selezionare</action_hint>
 
+    <!-- Same as above, but for a gamepad button (hard limit 40 8x8 characters) -->
+    <gamepad_hint>Press {button} to select</gamepad_hint>
+
     <!-- Enable automatic word wrapping instead of having to manually insert newlines -->
     <autowordwrap>1</autowordwrap>
 

--- a/desktop_version/lang/nl/meta.xml
+++ b/desktop_version/lang/nl/meta.xml
@@ -11,6 +11,9 @@
     <!-- On the language screen, hard limit 40 8x8 characters. Space/Z/V sets this as the language -->
     <action_hint>Druk op spatie, Z, of V om te kiezen</action_hint>
 
+    <!-- Same as above, but for a gamepad button (hard limit 40 8x8 characters) -->
+    <gamepad_hint>Druk op {button} om te kiezen</gamepad_hint>
+
     <!-- Enable automatic word wrapping instead of having to manually insert newlines -->
     <autowordwrap>1</autowordwrap>
 

--- a/desktop_version/lang/pt_BR/meta.xml
+++ b/desktop_version/lang/pt_BR/meta.xml
@@ -11,6 +11,9 @@
     <!-- On the language screen, hard limit 40 8x8 characters. Space/Z/V sets this as the language -->
     <action_hint></action_hint>
 
+    <!-- Same as above, but for a gamepad button (hard limit 40 8x8 characters) -->
+    <gamepad_hint>Press {button} to select</gamepad_hint>
+
     <!-- Enable automatic word wrapping instead of having to manually insert newlines -->
     <autowordwrap>1</autowordwrap>
 

--- a/desktop_version/lang/pt_PT/meta.xml
+++ b/desktop_version/lang/pt_PT/meta.xml
@@ -11,6 +11,9 @@
     <!-- On the language screen, hard limit 40 8x8 characters. Space/Z/V sets this as the language -->
     <action_hint>Seleciona com Barra de Espaços, Z ou V</action_hint>
 
+    <!-- Same as above, but for a gamepad button (hard limit 40 8x8 characters) -->
+    <gamepad_hint>Press {button} to select</gamepad_hint>
+
     <!-- Enable automatic word wrapping instead of having to manually insert newlines -->
     <autowordwrap>1</autowordwrap>
 

--- a/desktop_version/lang/ru/meta.xml
+++ b/desktop_version/lang/ru/meta.xml
@@ -11,6 +11,9 @@
     <!-- On the language screen, hard limit 40 8x8 characters. Space/Z/V sets this as the language -->
     <action_hint>Нажмите Пробел, Z или V, чтобы выбрать</action_hint>
 
+    <!-- Same as above, but for a gamepad button (hard limit 40 8x8 characters) -->
+    <gamepad_hint>Press {button} to select</gamepad_hint>
+
     <!-- Enable automatic word wrapping instead of having to manually insert newlines -->
     <autowordwrap>1</autowordwrap>
 

--- a/desktop_version/lang/tr/meta.xml
+++ b/desktop_version/lang/tr/meta.xml
@@ -11,6 +11,9 @@
     <!-- On the language screen, hard limit 40 8x8 characters. Space/Z/V sets this as the language -->
     <action_hint>Boşluk, Z veya V tuşu ile seç</action_hint>
 
+    <!-- Same as above, but for a gamepad button (hard limit 40 8x8 characters) -->
+    <gamepad_hint>Press {button} to select</gamepad_hint>
+
     <!-- Enable automatic word wrapping instead of having to manually insert newlines -->
     <autowordwrap>1</autowordwrap>
 

--- a/desktop_version/src/Localization.h
+++ b/desktop_version/src/Localization.h
@@ -22,6 +22,7 @@ struct LangMeta
     std::string nativename;
     std::string credit;
     std::string action_hint;
+    std::string gamepad_hint;
     bool autowordwrap; // = true; enable automatic wordwrapping
     bool toupper; // = true; enable automatic full-caps for menu options
     bool toupper_i_dot; // = false; enable Turkish i mapping when uppercasing

--- a/desktop_version/src/LocalizationMaint.cpp
+++ b/desktop_version/src/LocalizationMaint.cpp
@@ -86,6 +86,8 @@ static void sync_lang_file(const std::string& langcode)
                 pElem->SetText(langmeta.credit.c_str());
             else if (SDL_strcmp(pKey, "action_hint") == 0)
                 pElem->SetText(langmeta.action_hint.c_str());
+            else if (SDL_strcmp(pKey, "gamepad_hint") == 0)
+                pElem->SetText(langmeta.gamepad_hint.c_str());
             else if (SDL_strcmp(pKey, "autowordwrap") == 0)
                 pElem->SetText((int) langmeta.autowordwrap);
             else if (SDL_strcmp(pKey, "toupper") == 0)

--- a/desktop_version/src/LocalizationStorage.cpp
+++ b/desktop_version/src/LocalizationStorage.cpp
@@ -93,6 +93,8 @@ static void loadmeta(LangMeta& meta, const std::string& langcode = lang)
             meta.credit = std::string(pText);
         else if (SDL_strcmp(pKey, "action_hint") == 0)
             meta.action_hint = std::string(pText);
+        else if (SDL_strcmp(pKey, "gamepad_hint") == 0)
+            meta.gamepad_hint = std::string(pText);
         else if (SDL_strcmp(pKey, "autowordwrap") == 0)
             meta.autowordwrap = help.Int(pText);
         else if (SDL_strcmp(pKey, "toupper") == 0)

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -646,7 +646,22 @@ static void menurender(void)
         else if ((unsigned)game.currentmenuoption < loc::languagelist.size())
         {
             font::print_wrap(PR_CEN, -1, 8, loc::languagelist[game.currentmenuoption].credit.c_str(), tr/2, tg/2, tb/2);
-            font::print(PR_CEN, -1, 230, loc::languagelist[game.currentmenuoption].action_hint, tr/2, tg/2, tb/2);
+            const char* select_hint;
+            char buffer[SCREEN_WIDTH_CHARS + 1];
+            if (BUTTONGLYPHS_keyboard_is_active())
+            {
+                select_hint = loc::languagelist[game.currentmenuoption].action_hint.c_str();
+            }
+            else
+            {
+                vformat_buf(buffer, sizeof(buffer),
+                    loc::languagelist[game.currentmenuoption].gamepad_hint.c_str(),
+                    "button:but",
+                    vformat_button(ActionSet_Menu, Action_Menu_Accept)
+                );
+                select_hint = buffer;
+            }
+            font::print(PR_CEN, -1, 230, select_hint, tr/2, tg/2, tb/2);
         }
         break;
     case Menu::translator_main:


### PR DESCRIPTION
## Changes:

The language screen has a "Press Space, Z, or V to select" hint, which I forgot to update for supporting button glyphs in #943, so this commit does.

```xml
    <action_hint>Press Space, Z, or V to select</action_hint>
    <gamepad_hint>Press {button} to select</gamepad_hint>
```

![Press (A) to select](https://user-images.githubusercontent.com/44736680/227796259-7d4b0cee-7e02-44c6-b708-27747ded45f4.png)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
