### PR TITLE
Make textbuttons() work for transparent text boxes

### DIFF
--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -160,6 +160,7 @@ public:
     void draw_grid_tile(SDL_Texture* texture, int t, int x, int y, int width, int height, SDL_Color color);
 
     void updatetextboxes(void);
+    const char* textbox_line(char* buffer, size_t buffer_len, size_t textbox_i, size_t line_i);
     void drawgui(void);
 
     void draw_sprite(int x, int y, int t, int r, int g, int b);


### PR DESCRIPTION
## Changes:

Misa asked me if this should only work for non-transparent textboxes, and it shouldn't - that was kind of an oversight.

To make it work for transparent textboxes as well, I made a little restructuring to avoid duplicating the code - fill_buttons() is now called textbox_line(), and it replaces the direct accessing of the textbox lines in the printing loops. The code that checks the width of the textbox does not need to be copied, since the text box is naturally not drawn for transparent text boxes.

![Please press all these controller buttons](https://user-images.githubusercontent.com/44736680/228691097-eb1ca4b6-0f4f-45b6-9ee1-8c6b94c45c0f.png)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
