### PR TITLE
Disable more flashing elements if a11y is on

### DIFF
--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -623,7 +623,7 @@ void entclass::updatecolour(void)
         realcol = graphics.bigchunkygetcol(colour);
         break;
     case 4: // Small pickups
-        realcol = graphics.huetilegetcol(colour);
+        realcol = graphics.huetilegetcol();
         break;
     case 11: // The fucking elephant
         if (game.noflashingmode)

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -3738,7 +3738,7 @@ void entityclass::animateentities( int _i )
             }
             break;
         case 100: //the teleporter!
-            if (entities[_i].tile == 1)
+            if (entities[_i].tile == 1 || game.noflashingmode)
             {
                 //it's inactive
                 entities[_i].drawframe = entities[_i].tile;
@@ -3748,10 +3748,10 @@ void entityclass::animateentities( int _i )
                 entities[_i].drawframe = entities[_i].tile;
 
                 entities[_i].framedelay--;
-                if(entities[_i].framedelay<=0)
+                if (entities[_i].framedelay <= 0)
                 {
                     entities[_i].framedelay = 1;
-                    entities[_i].walkingframe = int(fRandom() * 6);
+                    entities[_i].walkingframe = (int) (fRandom() * 6);
                     if (entities[_i].walkingframe >= 4)
                     {
                         entities[_i].walkingframe = -1;
@@ -3768,10 +3768,10 @@ void entityclass::animateentities( int _i )
                 entities[_i].drawframe = entities[_i].tile;
 
                 entities[_i].framedelay--;
-                if(entities[_i].framedelay<=0)
+                if (entities[_i].framedelay <= 0)
                 {
                     entities[_i].framedelay = 2;
-                    entities[_i].walkingframe = int(fRandom() * 6);
+                    entities[_i].walkingframe = (int) (fRandom() * 6);
                     if (entities[_i].walkingframe >= 4)
                     {
                         entities[_i].walkingframe = -5;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -400,7 +400,7 @@ void Game::lifesequence(void)
         if (lifeseq > 5) gravitycontrol = savegc;
 
         lifeseq--;
-        if (INBOUNDS_VEC(i, obj.entities) && lifeseq <= 0)
+        if (INBOUNDS_VEC(i, obj.entities) && (lifeseq <= 0 || noflashingmode))
         {
             obj.entities[i].invis = false;
         }
@@ -5009,7 +5009,7 @@ void Game::deathsequence(void)
         }
         deathcounts++;
         music.playef(2);
-        if (INBOUNDS_VEC(i, obj.entities))
+        if (INBOUNDS_VEC(i, obj.entities) && !noflashingmode)
         {
             obj.entities[i].invis = true;
         }
@@ -5030,7 +5030,7 @@ void Game::deathsequence(void)
             }
         }
     }
-    if (INBOUNDS_VEC(i, obj.entities))
+    if (INBOUNDS_VEC(i, obj.entities) && !noflashingmode)
     {
         if (deathseq == 25) obj.entities[i].invis = true;
         if (deathseq == 20) obj.entities[i].invis = true;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1727,6 +1727,12 @@ void Graphics::drawgravityline( int t )
 
     if (obj.entities[t].life == 0)
     {
+        if (game.noflashingmode)
+        {
+            fill_rect(&line_rect, getRGB(200 - 20, 200 - 20, 200 - 20));
+            return;
+        }
+
         switch(linestate)
         {
         case 0:
@@ -2878,6 +2884,7 @@ void Graphics::updatetowerbackground(TowerBG& bg_obj)
     set_render_target(target);
 }
 
+#define GETCOL_RANDOM (game.noflashingmode ? 0.5 : fRandom())
 SDL_Color Graphics::getcol( int t )
 {
     //Setup predefinied colours as per our zany palette
@@ -2885,39 +2892,39 @@ SDL_Color Graphics::getcol( int t )
     {
         //Player Normal
     case 0:
-        return getRGB(160 - help.glow/2 - (fRandom() * 20), 200 - help.glow/2, 220 - help.glow);
+        return getRGB(160 - help.glow/2 - (GETCOL_RANDOM * 20), 200 - help.glow/2, 220 - help.glow);
         //Player Hurt
     case 1:
-        return getRGB(196 - (fRandom() * 64), 10, 10);
+        return getRGB(196 - (GETCOL_RANDOM * 64), 10, 10);
         //Enemies and stuff
     case 2:
         return getRGB(225 - (help.glow / 2), 75, 30);
     case 3: //Trinket
         if (!trinketcolset)
         {
-            trinketr = 200 - (fRandom() * 64);
-            trinketg = 200 - (fRandom() * 128);
-            trinketb = 164 + (fRandom() * 60);
+            trinketr = 200 - (GETCOL_RANDOM * 64);
+            trinketg = 200 - (GETCOL_RANDOM * 128);
+            trinketb = 164 + (GETCOL_RANDOM * 60);
             trinketcolset = true;
         }
         return getRGB(trinketr, trinketg, trinketb);
     case 4: //Inactive savepoint
     {
-        const int temp = (help.glow / 2) + (fRandom() * 8);
+        const int temp = (help.glow / 2) + (GETCOL_RANDOM * 8);
         return getRGB(80 + temp, 80 + temp, 80 + temp);
     }
     case 5: //Active savepoint
-        return getRGB(164 + (fRandom() * 64), 164 + (fRandom() * 64), 255 - (fRandom() * 64));
+        return getRGB(164 + (GETCOL_RANDOM * 64), 164 + (GETCOL_RANDOM * 64), 255 - (GETCOL_RANDOM * 64));
     case 6: //Enemy : Red
         return getRGB(250 - help.glow/2, 60- help.glow/2, 60 - help.glow/2);
     case 7: //Enemy : Green
-        return getRGB(100 - help.glow/2 - (fRandom() * 30), 250 - help.glow/2, 100 - help.glow/2 - (fRandom() * 30));
+        return getRGB(100 - help.glow/2 - (GETCOL_RANDOM * 30), 250 - help.glow/2, 100 - help.glow/2 - (GETCOL_RANDOM * 30));
     case 8: //Enemy : Purple
-        return getRGB(250 - help.glow/2, 20, 128 - help.glow/2 + (fRandom() * 30));
+        return getRGB(250 - help.glow/2, 20, 128 - help.glow/2 + (GETCOL_RANDOM * 30));
     case 9: //Enemy : Yellow
         return getRGB(250 - help.glow/2, 250 - help.glow/2, 20);
     case 10: //Warp point (white)
-        return getRGB(255 - (fRandom() * 64), 255 - (fRandom() * 64), 255 - (fRandom() * 64));
+        return getRGB(255 - (GETCOL_RANDOM * 64), 255 - (GETCOL_RANDOM * 64), 255 - (GETCOL_RANDOM * 64));
     case 11: //Enemy : Cyan
         return getRGB(20, 250 - help.glow/2, 250 - help.glow/2);
     case 12: //Enemy : Blue
@@ -2925,16 +2932,16 @@ SDL_Color Graphics::getcol( int t )
         //Crew Members
         //green
     case 13:
-        return getRGB(120 - help.glow/4 - (fRandom() * 20), 220 - help.glow/4, 120 - help.glow/4);
+        return getRGB(120 - help.glow/4 - (GETCOL_RANDOM * 20), 220 - help.glow/4, 120 - help.glow/4);
         //Yellow
     case 14:
-        return getRGB(220 - help.glow/4 - (fRandom() * 20), 210 - help.glow/4, 120 - help.glow/4);
+        return getRGB(220 - help.glow/4 - (GETCOL_RANDOM * 20), 210 - help.glow/4, 120 - help.glow/4);
         //pink
     case 15:
         return getRGB(255 - help.glow/8, 70 - help.glow/4, 70 - help.glow / 4);
         //Blue
     case 16:
-        return getRGB(75, 75, 255 - help.glow/4 - (fRandom() * 20));
+        return getRGB(75, 75, 255 - help.glow/4 - (GETCOL_RANDOM * 20));
 
 
     case 17: //Enemy : Orange
@@ -2945,14 +2952,14 @@ SDL_Color Graphics::getcol( int t )
         return getRGB(60 - help.glow/8, 60 - help.glow/8, 60 - help.glow/8);
         //Purple
     case 20:
-        return getRGB(220 - help.glow/4 - (fRandom() * 20), 120 - help.glow/4, 210 - help.glow/4);
+        return getRGB(220 - help.glow/4 - (GETCOL_RANDOM * 20), 120 - help.glow/4, 210 - help.glow/4);
 
     case 21: //Enemy : Light Gray
         return getRGB(180 - help.glow/2, 180 - help.glow/2, 180 - help.glow/2);
     case 22: //Enemy : Indicator Gray
         return getRGB(230 - help.glow/2, 230- help.glow/2, 230 - help.glow/2);
     case 23: //Enemy : Indicator Gray
-        return getRGB(255 - help.glow/2 - (fRandom() * 40) , 255 - help.glow/2 - (fRandom() * 40), 255 - help.glow/2 - (fRandom() * 40));
+        return getRGB(255 - help.glow/2 - (GETCOL_RANDOM * 40) , 255 - help.glow/2 - (GETCOL_RANDOM * 40), 255 - help.glow/2 - (GETCOL_RANDOM * 40));
 
         //Trophies
         //cyan
@@ -2979,9 +2986,9 @@ SDL_Color Graphics::getcol( int t )
     case 37: //Trinket
         if (!trinketcolset)
         {
-            trinketr = 200 - (fRandom() * 64);
-            trinketg = 200 - (fRandom() * 128);
-            trinketb = 164 + (fRandom() * 60);
+            trinketr = 200 - (GETCOL_RANDOM * 64);
+            trinketg = 200 - (GETCOL_RANDOM * 128);
+            trinketb = 164 + (GETCOL_RANDOM * 60);
             trinketcolset = true;
         }
         return RGBf(trinketr, trinketg, trinketb);
@@ -2994,56 +3001,67 @@ SDL_Color Graphics::getcol( int t )
         //Awesome
     case 40: //Teleporter in action!
     {
-        const int temp = fRandom() * 150;
-        if(temp<33)
+        if (game.noflashingmode)
         {
-            return RGBf(255 - (fRandom() * 64), 64 + (fRandom() * 64), 64 + (fRandom() * 64));
+            return getRGB(196, 196, 223);
+        }
+
+        const int temp = GETCOL_RANDOM * 150;
+        if (temp < 33)
+        {
+            return RGBf(255 - (GETCOL_RANDOM * 64), 64 + (GETCOL_RANDOM * 64), 64 + (GETCOL_RANDOM * 64));
         }
         else if (temp < 66)
         {
-            return RGBf(64 + (fRandom() * 64), 255 - (fRandom() * 64), 64 + (fRandom() * 64));
+            return RGBf(64 + (GETCOL_RANDOM * 64), 255 - (GETCOL_RANDOM * 64), 64 + (GETCOL_RANDOM * 64));
         }
         else if (temp < 100)
         {
-            return RGBf(64 + (fRandom() * 64), 64 + (fRandom() * 64), 255 - (fRandom() * 64));
+            return RGBf(64 + (GETCOL_RANDOM * 64), 64 + (GETCOL_RANDOM * 64), 255 - (GETCOL_RANDOM * 64));
         }
         else
         {
-            return RGBf(164 + (fRandom() * 64), 164 + (fRandom() * 64), 255 - (fRandom() * 64));
+            return RGBf(164 + (GETCOL_RANDOM * 64), 164 + (GETCOL_RANDOM * 64), 255 - (GETCOL_RANDOM * 64));
         }
     }
 
     case 100: //Inactive Teleporter
     {
-        const int temp = (help.glow / 2) + (fRandom() * 8);
+        const int temp = (help.glow / 2) + (GETCOL_RANDOM * 8);
         return getRGB(42 + temp, 42 + temp, 42 + temp);
     }
     case 101: //Active Teleporter
-        return getRGB(164 + (fRandom() * 64), 164 + (fRandom() * 64), 255 - (fRandom() * 64));
+        return getRGB(164 + (GETCOL_RANDOM * 64), 164 + (GETCOL_RANDOM * 64), 255 - (GETCOL_RANDOM * 64));
     case 102: //Teleporter in action!
     {
-        const int temp = fRandom() * 150;
+        if (game.noflashingmode)
+        {
+            return getRGB(196, 196, 223);
+        }
+
+        const int temp = GETCOL_RANDOM * 150;
         if (temp < 33)
         {
-            return getRGB(255 - (fRandom() * 64), 64 + (fRandom() * 64), 64 + (fRandom() * 64));
+            return getRGB(255 - (GETCOL_RANDOM * 64), 64 + (GETCOL_RANDOM * 64), 64 + (GETCOL_RANDOM * 64));
         }
         else if (temp < 66)
         {
-            return getRGB(64 + (fRandom() * 64), 255 - (fRandom() * 64), 64 + (fRandom() * 64));
+            return getRGB(64 + (GETCOL_RANDOM * 64), 255 - (GETCOL_RANDOM * 64), 64 + (GETCOL_RANDOM * 64));
         }
         else if (temp < 100)
         {
-            return getRGB(64 + (fRandom() * 64), 64 + (fRandom() * 64), 255 - (fRandom() * 64));
+            return getRGB(64 + (GETCOL_RANDOM * 64), 64 + (GETCOL_RANDOM * 64), 255 - (GETCOL_RANDOM * 64));
         }
         else
         {
-            return getRGB(164 + (fRandom() * 64), 164 + (fRandom() * 64), 255 - (fRandom() * 64));
+            return getRGB(164 + (GETCOL_RANDOM * 64), 164 + (GETCOL_RANDOM * 64), 255 - (GETCOL_RANDOM * 64));
         }
     }
     }
 
     return getRGB(255, 255, 255);
 }
+#undef GETCOL_RANDOM
 
 void Graphics::menuoffrender(void)
 {
@@ -3061,28 +3079,27 @@ void Graphics::menuoffrender(void)
     }
 }
 
-SDL_Color Graphics::huetilegetcol(const int t)
+SDL_Color Graphics::huetilegetcol()
 {
-    switch (t)
+    if (game.noflashingmode)
     {
-    case 0:
-        return getRGB(250-int(fRandom()*32), 250-int(fRandom()*32), 10);
-    case 1:
-        return getRGB(250-int(fRandom()*32), 250-int(fRandom()*32), 10);
-    default:
-        return getRGB(250-int(fRandom()*32), 250-int(fRandom()*32), 10);
+        return getRGB(234, 234, 10);
     }
+
+    return getRGB(250 - int(fRandom() * 32), 250 - int(fRandom() * 32), 10);
 }
 
 SDL_Color Graphics::bigchunkygetcol(int t)
 {
-    //A seperate index of colours, for simplicity
+    // A seperate index of colours, for simplicity
+    float random = game.noflashingmode ? 0.5 : fRandom();
+
     switch (t)
     {
     case 1:
-        return getRGB((fRandom() * 64), 10, 10);
+        return getRGB(random * 64, 10, 10);
     case 2:
-        return getRGB(int(160- help.glow/2 - (fRandom()*20)),  200- help.glow/2, 220 - help.glow);
+        return getRGB(160 - help.glow / 2 - random * 20, 200 - help.glow / 2, 220 - help.glow);
     }
     const SDL_Color color = {0, 0, 0, 0};
     return color;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -51,7 +51,7 @@ public:
 
     GraphicsResources grphx;
 
-    SDL_Color huetilegetcol(int t);
+    SDL_Color huetilegetcol();
     SDL_Color bigchunkygetcol(int t);
 
     void drawgravityline(int t);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2460,7 +2460,7 @@ static void rendermapcursor(const bool flashing)
     if (!map.custommode && game.roomx == 109)
     {
         // Draw the tower specially
-        if (!flashing)
+        if (!flashing || game.noflashingmode)
         {
             graphics.drawrect(40 + ((game.roomx - 100) * 12) + 2, 21 + 2, 12 - 4, 180 - 4, 16, 245 - (help.glow * 2), 245 - (help.glow * 2));
         }
@@ -2479,11 +2479,11 @@ static void rendermapcursor(const bool flashing)
         return;
     }
 
-    if (!flashing || (map.cursorstate == 2 && int(map.cursordelay / 15) % 2 == 0))
+    if (!flashing || ((map.cursorstate == 2 && int(map.cursordelay / 15) % 2 == 0) || game.noflashingmode))
     {
         graphics.drawrect(40 + ((game.roomx - 100) * 12 * data.zoom) + 2 + data.xoff, 21 + ((game.roomy - 100) * 9 * data.zoom) + 2 + data.yoff, (12 * data.zoom) - 4, (9 * data.zoom) - 4, 16, 245 - (help.glow), 245 - (help.glow));
     }
-    else if (map.cursorstate == 1 && (int(map.cursordelay / 4) % 2 == 0))
+    else if (map.cursorstate == 1 && int(map.cursordelay / 4) % 2 == 0)
     {
         graphics.drawrect(40 + ((game.roomx - 100) * 12 * data.zoom) + data.xoff, 21 + ((game.roomy - 100) * 9 * data.zoom) + data.yoff, 12 * data.zoom, 9 * data.zoom, 255, 255, 255);
         graphics.drawrect(40 + ((game.roomx - 100) * 12 * data.zoom) + 2 + data.xoff, 21 + ((game.roomy - 100) * 9 * data.zoom) + 2 + data.yoff, (12 * data.zoom) - 4, (9 * data.zoom) - 4, 255, 255, 255);
@@ -3041,7 +3041,7 @@ void teleporterrender(void)
 
     // Highlight the currently selected teleporter
 
-    if (game.useteleporter && help.slowsine % 16 > 8)
+    if (game.useteleporter && (help.slowsine % 16 > 8 || game.noflashingmode))
     {
         graphics.drawtile(data.legendxoff + data.xoff + (telex * 12 * data.zoom), data.legendyoff + data.yoff + (teley * 9 * data.zoom), 1128 + (graphics.flipmode ? 3 : 0));
     }


### PR DESCRIPTION
## Changes:

For some reason, the accessibility option that was meant to disable flashes doesn't disable ALL flashes, only screen flashes and screen shaking. This commit disables a lot more, most importantly randomness in colors, the player flashing on death/respawn, and teleporters flashing.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
