### PR TITLE
Fix rebinding "menu" (esc) bindings to different actions

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2210,6 +2210,18 @@ void titleinput(void)
             game.jumpheld = true;
         }
 
+        if (    game.currentmenuname == Menu::controller &&
+                game.currentmenuoption > 0 &&
+                game.currentmenuoption < 6 &&
+                (game.separate_interact || game.currentmenuoption < 5) &&
+                key.controllerButtonDown()      )
+        {
+            updatebuttonmappings(game.currentmenuoption);
+            music.playef(11);
+            game.savestatsandsettings_menu();
+            return;
+        }
+
         if (game.menustart
         && game.menucountdown <= 0
         && (key.isDown(27) || key.isDown(game.controllerButton_esc)))
@@ -2363,17 +2375,6 @@ void titleinput(void)
                 menuactionpress();
             }
         }
-        if (    game.currentmenuname == Menu::controller &&
-                game.currentmenuoption > 0 &&
-                game.currentmenuoption < 6 &&
-                (game.separate_interact || game.currentmenuoption < 5) &&
-                key.controllerButtonDown()      )
-        {
-            updatebuttonmappings(game.currentmenuoption);
-            music.playef(11);
-            game.savestatsandsettings_menu();
-        }
-
     }
 
     if (fadetomode)


### PR DESCRIPTION
## Changes:

Ever since 2.3, if you bind a controller button to the "menu" action (i.e. back/escape) you won't be able to change that button to any other action, because pressing it anywhere in the binding menu will exit to the previous menu, without applying the binding.

I know action sets will overhaul everything, but 2.4 may (probably "should") come out before we have action sets. This part is very broken, and the fix is very easy: just move the bind-assigning code to above the menu-return-on-esc code, and add a return.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
