### PR TITLE
Add textboxtimer command

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -47,6 +47,7 @@ scriptclass::scriptclass(void)
     add_default_colours();
     textflipme = false;
     textcentertext = false;
+    textboxtimer = 0;
     textpad_left = 0;
     textpad_right = 0;
     textpadtowidth = 0;
@@ -503,6 +504,7 @@ void scriptclass::run(void)
                 textpad_left = 0;
                 textpad_right = 0;
                 textpadtowidth = 0;
+                textboxtimer = 0;
 
                 translate_dialogue();
             }
@@ -669,6 +671,10 @@ void scriptclass::run(void)
             {
                 game.backgroundtext = true;
             }
+            else if (words[0] == "textboxtimer")
+            {
+                textboxtimer = ss_toi(words[1]);
+            }
             else if (words[0] == "flipme")
             {
                 textflipme = !textflipme;
@@ -693,6 +699,11 @@ void scriptclass::run(void)
                     {
                         graphics.addline(txt[i]);
                     }
+                }
+
+                if (textboxtimer > 0)
+                {
+                    graphics.textboxtimer(textboxtimer);
                 }
 
                 // Some textbox formatting that can be set by translations...

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -122,6 +122,7 @@ public:
     char textcase;
     bool textbuttons;
     bool textlarge;
+    int textboxtimer;
 
     //Misc
     int i, j, k;


### PR DESCRIPTION
## Changes:

This PR simply adds the `textboxtimer` command. `textboxtimer` exists in code, and is used for gamestates, but the command for it has been missing. This PR adds it. This is a visual change.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
