### PR TITLE
Fix lab background's "backboxint" array only using the first generated value

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1,8 +1,8 @@
 #define GRAPHICS_DEFINITION
 #include "Graphics.h"
 
-#include <SDL.h>
 #include <algorithm>
+#include <SDL.h>
 
 #include "Alloc.h"
 #include "Constants.h"

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -2,6 +2,7 @@
 #include "Graphics.h"
 
 #include <SDL.h>
+#include <algorithm>
 
 #include "Alloc.h"
 #include "Constants.h"
@@ -80,6 +81,8 @@ void Graphics::init(void)
         backboxvy[i] = bvy;
         backboxint[i] = bint;
     }
+    std::sort(&backboxint[0], &backboxint[numbackboxes]);
+
     backoffset = 0;
     foregrounddrawn = false;
     backgrounddrawn = false;
@@ -2326,62 +2329,62 @@ void Graphics::drawbackground( int t )
             {
                 //Akward ordering to match tileset
             case 0:
-                bcol = getRGB(16, 128*backboxint[0], 128*backboxint[0]);
+                bcol = getRGB(16, 128*backboxint[i], 128*backboxint[i]);
                 break; //Cyan
             case 1:
-                bcol = getRGB(128*backboxint[0], 16, 16);
+                bcol = getRGB(128*backboxint[i], 16, 16);
                 break;  //Red
             case 2:
-                bcol = getRGB(128*backboxint[0], 16, 128*backboxint[0]);
+                bcol = getRGB(128*backboxint[i], 16, 128*backboxint[i]);
                 break; //Purple
             case 3:
-                bcol = getRGB(16, 16, 128*backboxint[0]);
+                bcol = getRGB(16, 16, 128*backboxint[i]);
                 break;  //Blue
             case 4:
-                bcol = getRGB(128*backboxint[0], 128*backboxint[0], 16);
+                bcol = getRGB(128*backboxint[i], 128*backboxint[i], 16);
                 break; //Yellow
             case 5:
-                bcol = getRGB(16, 128 * backboxint[0], 16);
+                bcol = getRGB(16, 128 * backboxint[i], 16);
                 break;  //Green
             case 6:
                 //crazy case
                 switch(spcol)
                 {
                 case 0:
-                    bcol = getRGB(16, 128*backboxint[0], 128*backboxint[0]);
+                    bcol = getRGB(16, 128*backboxint[i], 128*backboxint[i]);
                     break; //Cyan
                 case 1:
-                    bcol = getRGB(16, ((spcoldel+1)*8)*backboxint[0], 128*backboxint[0]);
+                    bcol = getRGB(16, ((spcoldel+1)*8)*backboxint[i], 128*backboxint[i]);
                     break; //Cyan
                 case 2:
-                    bcol = getRGB(16, 16, 128*backboxint[0]);
+                    bcol = getRGB(16, 16, 128*backboxint[i]);
                     break;  //Blue
                 case 3:
-                    bcol = getRGB((128-(spcoldel*8))*backboxint[0], 16, 128*backboxint[0]);
+                    bcol = getRGB((128-(spcoldel*8))*backboxint[i], 16, 128*backboxint[i]);
                     break;  //Blue
                 case 4:
-                    bcol = getRGB(128*backboxint[0], 16, 128*backboxint[0]);
+                    bcol = getRGB(128*backboxint[i], 16, 128*backboxint[i]);
                     break; //Purple
                 case 5:
-                    bcol = getRGB(128*backboxint[0], 16, ((spcoldel+1)*8)*backboxint[0]);
+                    bcol = getRGB(128*backboxint[i], 16, ((spcoldel+1)*8)*backboxint[i]);
                     break; //Purple
                 case 6:
-                    bcol = getRGB(128*backboxint[0], 16, 16);
+                    bcol = getRGB(128*backboxint[i], 16, 16);
                     break;  //Red
                 case 7:
-                    bcol = getRGB(128*backboxint[0], (128-(spcoldel*8))*backboxint[0], 16);
+                    bcol = getRGB(128*backboxint[i], (128-(spcoldel*8))*backboxint[i], 16);
                     break;  //Red
                 case 8:
-                    bcol = getRGB(128*backboxint[0], 128*backboxint[0], 16);
+                    bcol = getRGB(128*backboxint[i], 128*backboxint[i], 16);
                     break; //Yellow
                 case 9:
-                    bcol = getRGB(((spcoldel+1)*8)*backboxint[0], 128*backboxint[0], 16);
+                    bcol = getRGB(((spcoldel+1)*8)*backboxint[i], 128*backboxint[i], 16);
                     break; //Yellow
                 case 10:
-                    bcol = getRGB(16, 128 * backboxint[0], 16);
+                    bcol = getRGB(16, 128 * backboxint[i], 16);
                     break;  //Green
                 case 11:
-                    bcol = getRGB(16, 128 * backboxint[0], (128-(spcoldel*8))*backboxint[0]);
+                    bcol = getRGB(16, 128 * backboxint[i], (128-(spcoldel*8))*backboxint[i]);
                     break;  //Green
                 }
                 break;


### PR DESCRIPTION
## Changes:

This change makes boxes drawn in the background for The Lab have a slight variation in brightness to give a slight sense of depth similar to the starfield background. I assume that's what was intended, as the `backboxint` variable is used in that way but would only use the first value that is generated despite creating a value for each box. This change just makes it use the value corresponding to that box.

This change also sorts that array so that darker boxes will not appear over brighter ones. I'm not too sure if this is what would've been intended since it is unsorted in the original code, but this helps to give off that slight depth feeling (though I do feel like it's a very slight difference). The sorting shouldn't have too much of an affect on performance since it's only ran once during initialization and is only ran through for each box.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [X] My changes may be used in a future commercial release of VVVVVV
- [X] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
