### PR TITLE
Fix setactivityposition still taking two arguments

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1683,7 +1683,7 @@ void scriptclass::run(void)
             }
             else if (words[0] == "setactivityposition")
             {
-                obj.customactivitypositiony = ss_toi(words[2]);
+                obj.customactivitypositiony = ss_toi(words[1]);
             }
             else if (words[0] == "createrescuedcrew")
             {


### PR DESCRIPTION
## Changes:

This command was changed from setactivityposition(x,y) to setactivityposition(y) in acca4747f73f066e002a74db5dd2edaacc8ea8d2, but there's a small problem here:

```diff
             else if (words[0] == "setactivityposition")
             {
-                obj.customactivitypositionx = ss_toi(words[1]);
                 obj.customactivitypositiony = ss_toi(words[2]);
             }
```

This meant that the function still took two arguments, the first of which was unused and the second of which was the Y position of the activity zone. This is now fixed.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
