### PR TITLE
Level debugger

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -85,6 +85,7 @@ set(VVV_SRC
     src/Input.cpp
     src/KeyPoll.cpp
     src/Labclass.cpp
+    src/LevelDebugger.cpp
     src/Localization.cpp
     src/LocalizationMaint.cpp
     src/LocalizationStorage.cpp

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -429,7 +429,7 @@
     <string english="- Press {button} to advance text -" translation="" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
     <string english="Press ACTION to continue" translation="" explanation="***OUTDATED***" max="34"/>
     <string english="Press {button} to continue" translation="" explanation="Expect `ACTION`" max="34"/>
-    <string english="[Press TAB to toggle movement]" translation="" explanation="Tab toggles whether the game is paused or not" max="39"/>
+    <string english="[Press TAB to toggle gameplay]" translation="" explanation="Tab toggles whether the game is paused or not" max="39"/>
     <string english="Current Time" translation="" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="" explanation="" max="38*2"/>

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -429,7 +429,7 @@
     <string english="- Press {button} to advance text -" translation="" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
     <string english="Press ACTION to continue" translation="" explanation="***OUTDATED***" max="34"/>
     <string english="Press {button} to continue" translation="" explanation="Expect `ACTION`" max="34"/>
-    <string english="[Press TAB to toggle gameplay]" translation="" explanation="Tab toggles whether the game is paused or not" max="39"/>
+    <string english="[Press {button} to toggle gameplay]" translation="" explanation="Tab toggles whether the game is paused or not" max="39"/>
     <string english="Current Time" translation="" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="" explanation="" max="38*2"/>

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -429,7 +429,7 @@
     <string english="- Press {button} to advance text -" translation="" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
     <string english="Press ACTION to continue" translation="" explanation="***OUTDATED***" max="34"/>
     <string english="Press {button} to continue" translation="" explanation="Expect `ACTION`" max="34"/>
-    <string english="[Press TAB to toggle movement]" translation="" explanation="Tab toggles whether the game is paused or not" max="40"/>
+    <string english="[Press TAB to toggle movement]" translation="" explanation="Tab toggles whether the game is paused or not" max="39"/>
     <string english="Current Time" translation="" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="" explanation="" max="38*2"/>

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -429,6 +429,7 @@
     <string english="- Press {button} to advance text -" translation="" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
     <string english="Press ACTION to continue" translation="" explanation="***OUTDATED***" max="34"/>
     <string english="Press {button} to continue" translation="" explanation="Expect `ACTION`" max="34"/>
+    <string english="[Press TAB to toggle movement]" translation="" explanation="Tab toggles whether the game is paused or not" max="40"/>
     <string english="Current Time" translation="" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="" explanation="" max="38*2"/>

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -17,6 +17,7 @@
 #include "Font.h"
 #include "GlitchrunnerMode.h"
 #include "Graphics.h"
+#include "LevelDebugger.h"
 #include "Localization.h"
 #include "LocalizationStorage.h"
 #include "KeyPoll.h"
@@ -7527,7 +7528,7 @@ int Game::get_timestep(void)
 
 bool Game::physics_frozen(void)
 {
-    return roomname_translator::is_pausing();
+    return roomname_translator::is_pausing() || level_debugger::is_pausing();
 }
 
 bool Game::incompetitive(void)

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2431,16 +2431,16 @@ void gameinput(void)
         }
     }
 
-    level_debugger::input();
-    if (level_debugger::is_pausing())
-    {
-        return;
-    }
-
     game.press_map = false;
     if (key.isDown(KEYBOARD_ENTER) || key.isDown(SDLK_KP_ENTER) || key.isDown(game.controllerButton_map)  )
     {
         game.press_map = true;
+    }
+
+    level_debugger::input();
+    if (level_debugger::is_pausing())
+    {
+        return;
     }
 
     if (game.advancetext)

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -12,6 +12,7 @@
 #include "Graphics.h"
 #include "GraphicsUtil.h"
 #include "KeyPoll.h"
+#include "LevelDebugger.h"
 #include "Localization.h"
 #include "LocalizationMaint.h"
 #include "LocalizationStorage.h"
@@ -2428,6 +2429,12 @@ void gameinput(void)
         {
             game.press_interact = true;
         }
+    }
+
+    level_debugger::input();
+    if (level_debugger::is_pausing())
+    {
+        return;
     }
 
     game.press_map = false;

--- a/desktop_version/src/LevelDebugger.cpp
+++ b/desktop_version/src/LevelDebugger.cpp
@@ -1,6 +1,7 @@
 #include "LevelDebugger.h"
 
 #include "Constants.h"
+#include "CustomLevels.h"
 #include "Entity.h"
 #include "Font.h"
 #include "Graphics.h"
@@ -345,6 +346,7 @@ namespace level_debugger
             line++;
 
             render_info(line++, "AEM Target", help.String(script.i));
+            render_info(line++, "Warp Background", help.String(cl.getroomprop(game.roomx % 100, game.roomy % 100)->warpdir));
 
             line++;
 

--- a/desktop_version/src/LevelDebugger.cpp
+++ b/desktop_version/src/LevelDebugger.cpp
@@ -440,6 +440,14 @@ namespace level_debugger
             }
         }
 
-        font::print(PR_BOR, 5, 14, loc::gettext("[Press TAB to toggle gameplay]"), 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
+        char buffer[SCREEN_WIDTH_CHARS + 1];
+        vformat_buf(
+            buffer, sizeof(buffer),
+            loc::gettext("[Press {button} to toggle gameplay]"),
+            "button:str",
+            "TAB"
+        );
+
+        font::print(PR_BOR, 5, 14, buffer, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
     }
 }

--- a/desktop_version/src/LevelDebugger.cpp
+++ b/desktop_version/src/LevelDebugger.cpp
@@ -45,7 +45,7 @@ namespace level_debugger
 
     bool mouse_within(SDL_Rect* rect)
     {
-        SDL_Point mouse = { key.mx, key.my };
+        SDL_Point mouse = { key.mousex, key.mousey };
         return SDL_PointInRect(&mouse, rect);
     }
 
@@ -110,8 +110,8 @@ namespace level_debugger
                     {
                         mouse_held = true;
                         held_entity = i;
-                        grabber_offset_x = key.mx - obj.entities[i].xp;
-                        grabber_offset_y = key.my - obj.entities[i].yp;
+                        grabber_offset_x = key.mousex - obj.entities[i].xp;
+                        grabber_offset_y = key.mousey - obj.entities[i].yp;
 
                         if (!key.keymap[SDLK_LSHIFT] && !key.keymap[SDLK_RSHIFT])
                         {
@@ -172,8 +172,8 @@ namespace level_debugger
                         {
                             mouse_held = true;
                             held_block = i;
-                            grabber_offset_x = key.mx - obj.blocks[i].rect.x;
-                            grabber_offset_y = key.my - obj.blocks[i].rect.y;
+                            grabber_offset_x = key.mousex - obj.blocks[i].rect.x;
+                            grabber_offset_y = key.mousey - obj.blocks[i].rect.y;
                         }
                         break;
                     }
@@ -192,8 +192,8 @@ namespace level_debugger
     {
         if (INBOUNDS_VEC(held_entity, obj.entities))
         {
-            int new_xp = key.mx - grabber_offset_x;
-            int new_yp = key.my - grabber_offset_y;
+            int new_xp = key.mousex - grabber_offset_x;
+            int new_yp = key.mousey - grabber_offset_y;
 
             if (key.isDown(SDLK_LSHIFT) || key.isDown(SDLK_RSHIFT))
             {
@@ -211,8 +211,8 @@ namespace level_debugger
 
         if (INBOUNDS_VEC(held_block, obj.blocks))
         {
-            int new_xp = key.mx - grabber_offset_x;
-            int new_yp = key.my - grabber_offset_y;
+            int new_xp = key.mousex - grabber_offset_x;
+            int new_yp = key.mousey - grabber_offset_y;
 
             if (key.isDown(SDLK_LSHIFT) || key.isDown(SDLK_RSHIFT))
             {
@@ -336,7 +336,7 @@ namespace level_debugger
         else if (hovered == -1)
         {
             render_coords(line++, "Room", game.roomx % 100, game.roomy % 100);
-            render_coords(line++, "Cursor", key.mx, key.my);
+            render_coords(line++, "Cursor", key.mousex, key.mousey);
             render_info(line++, "Entities", help.String(obj.entities.size()));
             line++;
 

--- a/desktop_version/src/LevelDebugger.cpp
+++ b/desktop_version/src/LevelDebugger.cpp
@@ -211,6 +211,11 @@ namespace level_debugger
         }
     }
 
+    void render_info(int y, const char* text)
+    {
+        font::print(PR_BOR | PR_FONT_8X8, 5, 32 + (10 * y), text, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
+    }
+
     void render_coords(int y, const char* text, int first, int second)
     {
         char buffer[SCREEN_WIDTH_CHARS + 1];
@@ -223,11 +228,6 @@ namespace level_debugger
         char buffer[SCREEN_WIDTH_CHARS + 1];
         vformat_buf(buffer, sizeof(buffer), "{text}: {value}", "text:str, value:str", text, value.c_str());
         render_info(y, buffer);
-    }
-
-    void render_info(int y, const char* text)
-    {
-        font::print(PR_BOR | PR_FONT_8X8, 5, 32 + (10 * y), text, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
     }
 
     void render(void)
@@ -289,7 +289,32 @@ namespace level_debugger
 
         int line = 0;
 
-        if (hovered == -1)
+        if (key.isDown(SDLK_u))
+        {
+            SDL_Color on = graphics.getRGB(220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
+            SDL_Color off = graphics.getRGB(220 / 2 - (help.glow), 220 / 2 - (help.glow), 255 / 2 - (help.glow / 2));
+
+            graphics.set_blendmode(SDL_BLENDMODE_BLEND);
+            graphics.fill_rect(NULL, 0, 0, 0, 127);
+            graphics.set_blendmode(SDL_BLENDMODE_NONE);
+
+            int x = 0;
+            int y = 0;
+
+            for (int i = 0; i < SDL_arraysize(obj.flags); i++)
+            {
+                SDL_Color color = obj.flags[i] ? on : off;
+                font::print(PR_BOR | PR_FONT_8X8, 5 + x, 32 + y, help.String(i), color.r, color.g, color.b);
+
+                x += 16 + 8;
+                if (x >= 300)
+                {
+                    x = 0;
+                    y += 16;
+                }
+            }
+        }
+        else if (hovered == -1)
         {
             render_coords(line++, "Room", game.roomx % 100, game.roomy % 100);
             render_coords(line++, "Cursor", key.mx, key.my);

--- a/desktop_version/src/LevelDebugger.cpp
+++ b/desktop_version/src/LevelDebugger.cpp
@@ -98,7 +98,7 @@ namespace level_debugger
         {
             SDL_Rect bounding_box = {
                 obj.entities[i].xp + obj.entities[i].cx,
-                obj.entities[i].yp + obj.entities[i].cy,
+                obj.entities[i].yp + obj.entities[i].cy - map.ypos,
                 obj.entities[i].w,
                 obj.entities[i].h
             };
@@ -160,7 +160,7 @@ namespace level_debugger
             {
                 SDL_Rect bounding_box = {
                     obj.blocks[i].rect.x,
-                    obj.blocks[i].rect.y,
+                    obj.blocks[i].rect.y - map.ypos,
                     obj.blocks[i].rect.w,
                     obj.blocks[i].rect.h
                 };
@@ -262,7 +262,7 @@ namespace level_debugger
         {
             SDL_Rect bounding_box = {
                 obj.entities[i].xp + obj.entities[i].cx,
-                obj.entities[i].yp + obj.entities[i].cy,
+                obj.entities[i].yp + obj.entities[i].cy - map.ypos,
                 obj.entities[i].w,
                 obj.entities[i].h
             };
@@ -292,7 +292,7 @@ namespace level_debugger
         {
             SDL_Rect bounding_box = {
                 obj.blocks[i].rect.x,
-                obj.blocks[i].rect.y,
+                obj.blocks[i].rect.y - map.ypos,
                 obj.blocks[i].rect.w,
                 obj.blocks[i].rect.h
             };
@@ -440,6 +440,6 @@ namespace level_debugger
             }
         }
 
-        font::print(PR_BOR, 5, 14, loc::gettext("[Press TAB to toggle movement]"), 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
+        font::print(PR_BOR, 5, 14, loc::gettext("[Press TAB to toggle gameplay]"), 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
     }
 }

--- a/desktop_version/src/LevelDebugger.cpp
+++ b/desktop_version/src/LevelDebugger.cpp
@@ -45,8 +45,8 @@ namespace level_debugger
 
     bool mouse_within(SDL_Rect* rect)
     {
-        return key.mx >= rect->x && key.mx < rect->x + rect->w &&
-            key.my >= rect->y && key.my < rect->y + rect->h;
+        SDL_Point mouse = { key.mx, key.my };
+        return SDL_PointInRect(&mouse, rect);
     }
 
     void set_forced(void)

--- a/desktop_version/src/LevelDebugger.cpp
+++ b/desktop_version/src/LevelDebugger.cpp
@@ -186,17 +186,27 @@ namespace level_debugger
                 }
             }
         }
+    }
 
+    void logic(void)
+    {
         if (INBOUNDS_VEC(held_entity, obj.entities))
         {
-            obj.entities[held_entity].xp = key.mx - grabber_offset_x;
-            obj.entities[held_entity].yp = key.my - grabber_offset_y;
+            int new_xp = key.mx - grabber_offset_x;
+            int new_yp = key.my - grabber_offset_y;
 
             if (key.isDown(SDLK_LSHIFT) || key.isDown(SDLK_RSHIFT))
             {
-                obj.entities[held_entity].xp -= obj.entities[held_entity].xp % 8;
-                obj.entities[held_entity].yp -= obj.entities[held_entity].yp % 8;
+                new_xp -= new_xp % 8;
+                new_yp -= new_yp % 8;
             }
+
+            obj.entities[held_entity].xp = new_xp;
+            obj.entities[held_entity].yp = new_yp;
+            obj.entities[held_entity].lerpoldxp = new_xp;
+            obj.entities[held_entity].lerpoldyp = new_yp;
+            obj.entities[held_entity].oldxp = new_xp;
+            obj.entities[held_entity].oldyp = new_yp;
         }
 
         if (INBOUNDS_VEC(held_block, obj.blocks))

--- a/desktop_version/src/LevelDebugger.cpp
+++ b/desktop_version/src/LevelDebugger.cpp
@@ -274,6 +274,17 @@ namespace level_debugger
             }
 
             graphics.draw_rect(bounding_box.x, bounding_box.y, bounding_box.w, bounding_box.h, graphics.getRGB(15, 90, 90));
+
+            // For gravity lines, show the true hitbox.
+            if (obj.entities[i].type == 9)
+            {
+                graphics.draw_rect(bounding_box.x - 1, bounding_box.y + 1, bounding_box.w + 2, bounding_box.h, graphics.getRGB(90, 90, 15));
+            }
+            else if (obj.entities[i].type == 10)
+            {
+                graphics.fill_rect(bounding_box.x - 2, bounding_box.y - 1, bounding_box.w + 1, bounding_box.h + 2, graphics.getRGB(90, 90, 15));
+            }
+
         }
 
         for (int i = 0; i < (int) obj.blocks.size(); i++)

--- a/desktop_version/src/LevelDebugger.cpp
+++ b/desktop_version/src/LevelDebugger.cpp
@@ -1,0 +1,306 @@
+#include "LevelDebugger.h"
+
+#include "Constants.h"
+#include "Entity.h"
+#include "Font.h"
+#include "Graphics.h"
+#include "KeyPoll.h"
+#include "Localization.h"
+#include "Map.h"
+#include "UtilityClass.h"
+#include "VFormat.h"
+
+namespace level_debugger
+{
+    bool active = false;
+    bool should_pause = true;
+    bool tab_held = false;
+    bool debug_held = false;
+
+    // Moving entities/blocks
+    bool mouse_held = false;
+    int held_entity = -1;
+    int held_block = -1;
+    int grabber_offset_x = 0;
+    int grabber_offset_y = 0;
+
+    bool is_pausing(void)
+    {
+        return active && should_pause;
+    }
+
+    bool is_active(void)
+    {
+        return active;
+    }
+
+    void toggle_active(void)
+    {
+        active = !active;
+    }
+
+    bool mouse_within(SDL_Rect* rect)
+    {
+        return key.mx >= rect->x && key.mx < rect->x + rect->w &&
+            key.my >= rect->y && key.my < rect->y + rect->h;
+    }
+
+    void input(void)
+    {
+        if (!map.custommode || map.custommodeforreal)
+        {
+            active = false;
+            return;
+        }
+
+        if (key.isDown(SDLK_y))
+        {
+            if (!debug_held)
+            {
+                debug_held = true;
+                active = !active;
+            }
+        }
+        else
+        {
+            debug_held = false;
+        }
+
+        if (!active)
+        {
+            return;
+        }
+
+        if (key.isDown(SDLK_TAB))
+        {
+            if (!tab_held)
+            {
+                tab_held = true;
+                should_pause = !should_pause;
+            }
+        }
+        else
+        {
+            tab_held = false;
+        }
+
+        for (int i = 0; i < obj.entities.size(); i++)
+        {
+            SDL_Rect bounding_box = {
+                obj.entities[i].xp + obj.entities[i].cx,
+                obj.entities[i].yp + obj.entities[i].cy,
+                obj.entities[i].w,
+                obj.entities[i].h
+            };
+
+            if (key.leftbutton)
+            {
+                if (mouse_within(&bounding_box))
+                {
+                    if (!mouse_held)
+                    {
+                        mouse_held = true;
+                        held_entity = i;
+                        grabber_offset_x = key.mx - obj.entities[i].xp;
+                        grabber_offset_y = key.my - obj.entities[i].yp;
+
+                        if (!key.keymap[SDLK_LSHIFT] && !key.keymap[SDLK_RSHIFT])
+                        {
+                            for (int j = 0; j < obj.blocks.size(); j++)
+                            {
+                                if (obj.entities[i].xp == obj.blocks[j].rect.x && obj.entities[i].yp == obj.blocks[j].rect.y)
+                                {
+                                    held_block = j;
+                                }
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+            else
+            {
+                mouse_held = false;
+                held_entity = -1;
+                held_block = -1;
+            }
+        }
+
+        if (held_entity == -1)
+        {
+            for (int i = 0; i < obj.blocks.size(); i++)
+            {
+                SDL_Rect bounding_box = {
+                    obj.blocks[i].rect.x,
+                    obj.blocks[i].rect.y,
+                    obj.blocks[i].rect.w,
+                    obj.blocks[i].rect.h
+                };
+
+                if (key.leftbutton)
+                {
+                    if (mouse_within(&bounding_box))
+                    {
+                        if (!mouse_held)
+                        {
+                            mouse_held = true;
+                            held_block = i;
+                            grabber_offset_x = key.mx - obj.blocks[i].rect.x;
+                            grabber_offset_y = key.my - obj.blocks[i].rect.y;
+                        }
+                        break;
+                    }
+                }
+                else
+                {
+                    held_entity = -1;
+                    mouse_held = false;
+                    held_block = -1;
+                }
+            }
+        }
+
+        if (INBOUNDS_VEC(held_entity, obj.entities))
+        {
+            obj.entities[held_entity].xp = key.mx - grabber_offset_x;
+            obj.entities[held_entity].yp = key.my - grabber_offset_y;
+
+            if (key.isDown(SDLK_LSHIFT) || key.isDown(SDLK_RSHIFT))
+            {
+                obj.entities[held_entity].xp -= obj.entities[held_entity].xp % 8;
+                obj.entities[held_entity].yp -= obj.entities[held_entity].yp % 8;
+            }
+        }
+
+        if (INBOUNDS_VEC(held_block, obj.blocks))
+        {
+            int new_xp = key.mx - grabber_offset_x;
+            int new_yp = key.my - grabber_offset_y;
+
+            if (key.isDown(SDLK_LSHIFT) || key.isDown(SDLK_RSHIFT))
+            {
+                new_xp -= new_xp % 8;
+                new_yp -= new_yp % 8;
+            }
+
+            obj.blocks[held_block].xp = new_xp;
+            obj.blocks[held_block].yp = new_yp;
+            obj.blocks[held_block].rect.x = new_xp;
+            obj.blocks[held_block].rect.y = new_yp;
+        }
+    }
+
+    void render_info(int y, const char* text, const char* value)
+    {
+        char buffer[SCREEN_WIDTH_CHARS + 1];
+        vformat_buf(buffer, sizeof(buffer), text, "value:str", value);
+        font::print(PR_BOR | PR_FONT_8X8, 5, 32 + (10 * y), buffer, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
+    }
+
+    void render(void)
+    {
+        if (!active)
+        {
+            return;
+        }
+
+        int hovered = -1;
+        bool hovered_entity = true;
+        SDL_Rect hover_box;
+
+        for (int i = 0; i < obj.entities.size(); i++)
+        {
+            SDL_Rect bounding_box = {
+                obj.entities[i].xp + obj.entities[i].cx,
+                obj.entities[i].yp + obj.entities[i].cy,
+                obj.entities[i].w,
+                obj.entities[i].h
+            };
+
+            bool hovering = false;
+
+            if (hovered == -1 && mouse_within(&bounding_box))
+            {
+                hovering = true;
+                hovered = i;
+                hovered_entity = true;
+                hover_box = bounding_box;
+            }
+
+            graphics.draw_rect(bounding_box.x, bounding_box.y, bounding_box.w, bounding_box.h, graphics.getRGB(15, 90, 90));
+        }
+
+        for (int i = 0; i < obj.blocks.size(); i++)
+        {
+            SDL_Rect bounding_box = {
+                obj.blocks[i].rect.x,
+                obj.blocks[i].rect.y,
+                obj.blocks[i].rect.w,
+                obj.blocks[i].rect.h
+            };
+
+            bool hovering = false;
+
+            if (hovered == -1 && mouse_within(&bounding_box))
+            {
+                hovering = true;
+                hovered = i;
+                hovered_entity = false;
+                hover_box = bounding_box;
+            }
+
+            graphics.draw_rect(bounding_box.x, bounding_box.y, bounding_box.w, bounding_box.h, graphics.getRGB(90, 15, 15));
+        }
+
+        font::print(PR_BOR | PR_FONT_8X8, 5, 14, loc::gettext("[Press TAB to toggle movement]"), 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
+
+        if (hovered != -1)
+        {
+            int line = 0;
+            if (hovered_entity)
+            {
+                entclass* entity = &obj.entities[hovered];
+                render_info(line++, "Index: {value}", help.String(hovered).c_str());
+                render_info(line++, "X: {value}", help.String(entity->xp).c_str());
+                render_info(line++, "Y: {value}", help.String(entity->yp).c_str());
+                render_info(line++, "Width: {value}", help.String(entity->w).c_str());
+                render_info(line++, "Height: {value}", help.String(entity->h).c_str());
+                line++;
+                render_info(line++, "Rule: {value}", help.String(entity->rule).c_str());
+                render_info(line++, "Type: {value}", help.String(entity->type).c_str());
+                render_info(line++, "Behave: {value}", help.String(entity->behave).c_str());
+                render_info(line++, "Para: {value}", help.String(entity->para).c_str());
+                line++;
+                render_info(line++, "Tile: {value}", help.String(entity->tile).c_str());
+                render_info(line++, "Draw Frame: {value}", help.String(entity->drawframe).c_str());
+                render_info(line++, "Size: {value}", help.String(entity->size).c_str());
+                render_info(line++, "Direction: {value}", help.String(entity->dir).c_str());
+
+                graphics.draw_rect(hover_box.x, hover_box.y, hover_box.w, hover_box.h, graphics.getRGB(32, 255 - help.glow, 255 - help.glow));
+            }
+            else
+            {
+                blockclass* block = &obj.blocks[hovered];
+                render_info(line++, "Index: {value}", help.String(hovered).c_str());
+                render_info(line++, "X: {value}", help.String(block->rect.x).c_str());
+                render_info(line++, "Y: {value}", help.String(block->rect.y).c_str());
+                render_info(line++, "Width: {value}", help.String(block->rect.w).c_str());
+                render_info(line++, "Height: {value}", help.String(block->rect.h).c_str());
+
+                line++;
+
+                if (block->type == TRIGGER || block->type == ACTIVITY)
+                {
+                    render_info(line++, "Script: {value}", block->script.c_str());
+                    render_info(line++, "State: {value}", help.String(block->trigger).c_str());
+                }
+                else if (block->type == DIRECTIONAL)
+                {
+                    render_info(line++, "Direction: {value}", help.String(block->trigger).c_str());
+                }
+
+                graphics.draw_rect(hover_box.x, hover_box.y, hover_box.w, hover_box.h, graphics.getRGB(255 - help.glow, 32, 32));
+            }
+        }
+    }
+};

--- a/desktop_version/src/LevelDebugger.cpp
+++ b/desktop_version/src/LevelDebugger.cpp
@@ -93,7 +93,7 @@ namespace level_debugger
             tab_held = false;
         }
 
-        for (int i = 0; i < obj.entities.size(); i++)
+        for (int i = 0; i < (int) obj.entities.size(); i++)
         {
             SDL_Rect bounding_box = {
                 obj.entities[i].xp + obj.entities[i].cx,
@@ -115,7 +115,7 @@ namespace level_debugger
 
                         if (!key.keymap[SDLK_LSHIFT] && !key.keymap[SDLK_RSHIFT])
                         {
-                            for (int j = 0; j < obj.blocks.size(); j++)
+                            for (int j = 0; j < (int) obj.blocks.size(); j++)
                             {
                                 if (obj.entities[i].xp == obj.blocks[j].rect.x && obj.entities[i].yp == obj.blocks[j].rect.y)
                                 {
@@ -155,7 +155,7 @@ namespace level_debugger
 
         if (held_entity == -1)
         {
-            for (int i = 0; i < obj.blocks.size(); i++)
+            for (int i = 0; i < (int) obj.blocks.size(); i++)
             {
                 SDL_Rect bounding_box = {
                     obj.blocks[i].rect.x,
@@ -247,7 +247,7 @@ namespace level_debugger
         bool hovered_entity = true;
         SDL_Rect hover_box;
 
-        for (int i = 0; i < obj.entities.size(); i++)
+        for (int i = 0; i < (int) obj.entities.size(); i++)
         {
             SDL_Rect bounding_box = {
                 obj.entities[i].xp + obj.entities[i].cx,
@@ -256,11 +256,8 @@ namespace level_debugger
                 obj.entities[i].h
             };
 
-            bool hovering = false;
-
             if (hovered == -1 && mouse_within(&bounding_box))
             {
-                hovering = true;
                 hovered = i;
                 hovered_entity = true;
                 hover_box = bounding_box;
@@ -269,7 +266,7 @@ namespace level_debugger
             graphics.draw_rect(bounding_box.x, bounding_box.y, bounding_box.w, bounding_box.h, graphics.getRGB(15, 90, 90));
         }
 
-        for (int i = 0; i < obj.blocks.size(); i++)
+        for (int i = 0; i < (int) obj.blocks.size(); i++)
         {
             SDL_Rect bounding_box = {
                 obj.blocks[i].rect.x,
@@ -278,11 +275,8 @@ namespace level_debugger
                 obj.blocks[i].rect.h
             };
 
-            bool hovering = false;
-
             if (hovered == -1 && mouse_within(&bounding_box))
             {
-                hovering = true;
                 hovered = i;
                 hovered_entity = false;
                 hover_box = bounding_box;
@@ -305,7 +299,7 @@ namespace level_debugger
             int x = 0;
             int y = 0;
 
-            for (int i = 0; i < SDL_arraysize(obj.flags); i++)
+            for (int i = 0; i < (int) SDL_arraysize(obj.flags); i++)
             {
                 SDL_Color color = obj.flags[i] ? on : off;
                 font::print(PR_BOR | PR_FONT_8X8, 48 + x * 24, 48 + y * 16, help.String(i), color.r, color.g, color.b);
@@ -423,6 +417,6 @@ namespace level_debugger
             }
         }
 
-        font::print(PR_BOR | PR_FONT_8X8, 5, 14, loc::gettext("[Press TAB to toggle movement]"), 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
+        font::print(PR_BOR, 5, 14, loc::gettext("[Press TAB to toggle movement]"), 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
     }
-};
+}

--- a/desktop_version/src/LevelDebugger.cpp
+++ b/desktop_version/src/LevelDebugger.cpp
@@ -17,6 +17,7 @@ namespace level_debugger
     bool should_pause = true;
     bool tab_held = false;
     bool debug_held = false;
+    bool forced = false;
 
     // Moving entities/blocks
     bool mouse_held = false;
@@ -48,9 +49,14 @@ namespace level_debugger
             key.my >= rect->y && key.my < rect->y + rect->h;
     }
 
+    void set_forced(void)
+    {
+        forced = true;
+    }
+
     void input(void)
     {
-        if (!map.custommode || map.custommodeforreal)
+        if (!forced && (!map.custommode || map.custommodeforreal))
         {
             active = false;
             return;
@@ -285,14 +291,12 @@ namespace level_debugger
             graphics.draw_rect(bounding_box.x, bounding_box.y, bounding_box.w, bounding_box.h, graphics.getRGB(90, 15, 15));
         }
 
-        font::print(PR_BOR | PR_FONT_8X8, 5, 14, loc::gettext("[Press TAB to toggle movement]"), 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
-
         int line = 0;
 
         if (key.isDown(SDLK_u))
         {
             SDL_Color on = graphics.getRGB(220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
-            SDL_Color off = graphics.getRGB(220 / 2 - (help.glow), 220 / 2 - (help.glow), 255 / 2 - (help.glow / 2));
+            SDL_Color off = graphics.getRGB(220 / 1.5 - (help.glow), 220 / 1.5 - (help.glow), 255 / 1.5 - (help.glow / 2));
 
             graphics.set_blendmode(SDL_BLENDMODE_BLEND);
             graphics.fill_rect(NULL, 0, 0, 0, 127);
@@ -304,13 +308,13 @@ namespace level_debugger
             for (int i = 0; i < SDL_arraysize(obj.flags); i++)
             {
                 SDL_Color color = obj.flags[i] ? on : off;
-                font::print(PR_BOR | PR_FONT_8X8, 5 + x, 32 + y, help.String(i), color.r, color.g, color.b);
+                font::print(PR_BOR | PR_FONT_8X8, 48 + x * 24, 48 + y * 16, help.String(i), color.r, color.g, color.b);
 
-                x += 16 + 8;
-                if (x >= 300)
+                x++;
+                if (x >= 10)
                 {
                     x = 0;
-                    y += 16;
+                    y++;
                 }
             }
         }
@@ -418,5 +422,7 @@ namespace level_debugger
                 graphics.draw_rect(hover_box.x, hover_box.y, hover_box.w, hover_box.h, graphics.getRGB(255 - help.glow, 32, 32));
             }
         }
+
+        font::print(PR_BOR | PR_FONT_8X8, 5, 14, loc::gettext("[Press TAB to toggle movement]"), 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
     }
 };

--- a/desktop_version/src/LevelDebugger.h
+++ b/desktop_version/src/LevelDebugger.h
@@ -9,6 +9,7 @@ namespace level_debugger
     bool is_active(void);
     void input(void);
     void render(void);
+    void set_forced(void);
 }
 
 #endif /* LEVELDEBUGGER_H */

--- a/desktop_version/src/LevelDebugger.h
+++ b/desktop_version/src/LevelDebugger.h
@@ -8,6 +8,7 @@ namespace level_debugger
     bool is_pausing(void);
     bool is_active(void);
     void input(void);
+    void logic(void);
     void render(void);
     void set_forced(void);
 }

--- a/desktop_version/src/LevelDebugger.h
+++ b/desktop_version/src/LevelDebugger.h
@@ -1,0 +1,14 @@
+#ifndef LEVELDEBUGGER_H
+#define LEVELDEBUGGER_H
+
+#include <SDL.h>
+
+namespace level_debugger
+{
+    bool is_pausing(void);
+    bool is_active(void);
+    void input(void);
+    void render(void);
+}
+
+#endif /* LEVELDEBUGGER_H */

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -5,6 +5,7 @@
 #include "Game.h"
 #include "GlitchrunnerMode.h"
 #include "Graphics.h"
+#include "LevelDebugger.h"
 #include "Map.h"
 #include "Music.h"
 #include "Network.h"
@@ -131,6 +132,7 @@ void gamelogic(void)
 {
     if (game.physics_frozen())
     {
+        level_debugger::logic();
         return;
     }
 
@@ -1475,4 +1477,6 @@ void gamelogic(void)
 
 #undef gotoroom
 #undef GOTOROOM
+
+    level_debugger::logic();
 }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -14,6 +14,7 @@
 #include "GraphicsUtil.h"
 #include "InterimVersion.h"
 #include "KeyPoll.h"
+#include "LevelDebugger.h"
 #include "Localization.h"
 #include "LocalizationStorage.h"
 #include "MakeAndPlay.h"
@@ -2407,6 +2408,7 @@ void gamerender(void)
         graphics.drawtrophytext();
     }
 
+    level_debugger::render();
 
     graphics.renderwithscreeneffects();
 }

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -19,6 +19,7 @@
 #include "Input.h"
 #include "InterimVersion.h"
 #include "KeyPoll.h"
+#include "LevelDebugger.h"
 #include "Localization.h"
 #include "LocalizationStorage.h"
 #include "Logic.h"
@@ -510,6 +511,10 @@ int main(int argc, char *argv[])
                 // Even if this is a directory, FILESYSTEM_mountAssets() expects '.vvvvvv' on the end
                 playassets = "levels/" + std::string(argv[i]) + ".vvvvvv";
             })
+        }
+        else if (ARG("-leveldebugger"))
+        {
+            level_debugger::set_forced();
         }
         else if (ARG("-nooutput"))
         {


### PR DESCRIPTION
## Changes:

This PR adds a level debugger. By pressing `Y` in playtesting mode (or in play mode if you pass in the flag `-leveldebugger`), the debug overlay appears which tells you information about the current game's state, and hovering over entities shows their information as well.

Holding `U` while in this state will show the flags and their current values.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
