### PR TITLE
Sprite textboxes

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -695,12 +695,13 @@ void Game::savecustomlevelstats(void)
 
 void Game::levelcomplete_textbox(void)
 {
-    graphics.createtextboxflipme("", -1, 12, 165, 165, 255);
+    graphics.createtextboxflipme("", -1, 12, TEXT_COLOUR("cyan"));
     graphics.addline("                                    ");
     graphics.addline("");
     graphics.addline("");
     graphics.textboxprintflags(PR_FONT_8X8);
     graphics.textboxcenterx();
+    graphics.setimage(TEXTIMAGE_LEVELCOMPLETE);
 }
 
 void Game::crewmate_textbox(const int color)
@@ -2901,12 +2902,13 @@ void Game::updatestate(void)
             setstatedelay(75);
             music.play(Music_PLENARY);
 
-            graphics.createtextboxflipme("", -1, 12, 164, 165, 255);
+            graphics.createtextboxflipme("", -1, 12, TEXT_COLOUR("cyan"));
             graphics.addline("                                    ");
             graphics.addline("");
             graphics.addline("");
             graphics.textboxprintflags(PR_FONT_8X8);
             graphics.textboxcenterx();
+            graphics.setimage(TEXTIMAGE_GAMECOMPLETE);
             break;
         case 3502:
         {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -703,10 +703,10 @@ void Game::levelcomplete_textbox(void)
     graphics.textboxcenterx();
 }
 
-void Game::crewmate_textbox(const int r, const int g, const int b)
+void Game::crewmate_textbox(const int color)
 {
     const int extra_cjk_height = (font::height(PR_FONT_INTERFACE) * 4) - 32;
-    graphics.createtextboxflipme("", -1, 64 + 8 + 16 - extra_cjk_height/2, r, g, b);
+    graphics.createtextboxflipme("", -1, 64 + 8 + 16 - extra_cjk_height/2, TEXT_COLOUR("gray"));
 
     /* This is a special case for wrapping, we MUST have two lines.
      * So just make sure it can't fit in one line. */
@@ -729,6 +729,7 @@ void Game::crewmate_textbox(const int r, const int g, const int b)
     float spaces_per_8 = font::len(PR_FONT_INTERFACE, " ")/8.0f;
     graphics.textboxpad(SDL_ceilf(5/spaces_per_8), SDL_ceilf(2/spaces_per_8));
     graphics.textboxcenterx();
+    graphics.addsprite(14, 12, 0, color);
 }
 
 void Game::remaining_textbox(void)
@@ -2493,7 +2494,7 @@ void Game::updatestate(void)
             incstate();
             setstatedelay(45);
 
-            crewmate_textbox(175, 174, 174);
+            crewmate_textbox(13);
             break;
         case 3008:
             incstate();
@@ -2535,7 +2536,7 @@ void Game::updatestate(void)
             incstate();
             setstatedelay(45);
 
-            crewmate_textbox(174, 175, 174);
+            crewmate_textbox(14);
             break;
         case 3022:
             incstate();
@@ -2576,7 +2577,7 @@ void Game::updatestate(void)
             incstate();
             setstatedelay(45);
 
-            crewmate_textbox(174, 174, 175);
+            crewmate_textbox(16);
             break;
         case 3042:
             incstate();
@@ -2618,7 +2619,7 @@ void Game::updatestate(void)
             incstate();
             setstatedelay(45);
 
-            crewmate_textbox(175, 175, 174);
+            crewmate_textbox(20);
             break;
         case 3052:
             incstate();
@@ -2684,7 +2685,7 @@ void Game::updatestate(void)
             incstate();
             setstatedelay(45);
 
-            crewmate_textbox(175, 174, 175);
+            crewmate_textbox(15);
             break;
         case 3062:
             incstate();

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -222,7 +222,7 @@ public:
     void gethardestroom(void);
 
     void levelcomplete_textbox(void);
-    void crewmate_textbox(const int r, const int g, const int b);
+    void crewmate_textbox(const int color);
     void remaining_textbox(void);
     void actionprompt_textbox(void);
     void savetele_textbox(void);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -883,7 +883,7 @@ void Graphics::drawgui(void)
             continue;
         }
 
-        if (textboxes[i].yp == 12 && textboxes[i].r == 165)
+        if (textboxes[i].image == TEXTIMAGE_LEVELCOMPLETE)
         {
             // Level complete
             const char* english = "Level Complete!";
@@ -920,7 +920,7 @@ void Graphics::drawgui(void)
                 }
             }
         }
-        else if (textboxes[i].yp == 12 && textboxes[i].g == 165)
+        else if (textboxes[i].image == TEXTIMAGE_GAMECOMPLETE)
         {
             // Game complete
             const char* english = "Game Complete!";
@@ -1367,6 +1367,17 @@ void Graphics::addsprite(int x, int y, int tile, int col)
     }
 
     textboxes[m].addsprite(x, y, tile, col);
+}
+
+void Graphics::setimage(TextboxImage image)
+{
+    if (!INBOUNDS_VEC(m, textboxes))
+    {
+        vlog_error("setimage() out-of-bounds!");
+        return;
+    }
+
+    textboxes[m].setimage(image);
 }
 
 void Graphics::addline( const std::string& t )

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -988,6 +988,17 @@ void Graphics::drawgui(void)
             //blue guy
             draw_sprite(crew_xp, crew_yp, crew_sprite, 75, 75, 255 - help.glow / 4 - textboxes[i].rand);
         }
+
+        for (int index = 0; index < (int) textboxes[i].sprites.size(); index++)
+        {
+            TextboxSprite* sprite = &textboxes[i].sprites[index];
+            draw_sprite(
+                sprite->x + textboxes[i].xp,
+                sprite->y + textboxes[i].yp,
+                sprite->tile,
+                getcol(sprite->col)
+            );
+        }
     }
 }
 
@@ -1365,6 +1376,17 @@ void Graphics::textboxtimer(int t)
     }
 
     textboxes[m].timer = t;
+}
+
+void Graphics::addsprite(int x, int y, int tile, int col)
+{
+    if (!INBOUNDS_VEC(m, textboxes))
+    {
+        vlog_error("addsprite() out-of-bounds!");
+        return;
+    }
+
+    textboxes[m].addsprite(x, y, tile, col);
 }
 
 void Graphics::addline( const std::string& t )

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -777,20 +777,14 @@ const char* Graphics::textbox_line(
 void Graphics::drawgui(void)
 {
     int text_sign;
-    int crew_yp;
-    int crew_sprite;
 
     if (flipmode)
     {
         text_sign = -1;
-        crew_yp = 64 + 48 + 4;
-        crew_sprite = 6;
     }
     else
     {
         text_sign = 1;
-        crew_yp = 64 + 32 + 4;
-        crew_sprite = 0;
     }
 
     //Draw all the textboxes to the screen
@@ -962,41 +956,27 @@ void Graphics::drawgui(void)
                 }
             }
         }
-        int crew_xp = textboxes[i].xp+20 - 6;
-        if (textboxes[i].r == 175 && textboxes[i].g == 175)
-        {
-            //purple guy
-            draw_sprite(crew_xp, crew_yp, crew_sprite, 220 - help.glow / 4 - textboxes[i].rand, 120 - help.glow / 4, 210 - help.glow / 4);
-        }
-        else if (textboxes[i].r == 175 && textboxes[i].b == 175)
-        {
-            //red guy
-            draw_sprite(crew_xp, crew_yp, crew_sprite, 255 - help.glow / 8, 70 - help.glow / 4, 70 - help.glow / 4);
-        }
-        else if (textboxes[i].r == 175)
-        {
-            //green guy
-            draw_sprite(crew_xp, crew_yp, crew_sprite, 120 - help.glow / 4 - textboxes[i].rand, 220 - help.glow / 4, 120 - help.glow / 4);
-        }
-        else if (textboxes[i].g == 175)
-        {
-            //yellow guy
-            draw_sprite(crew_xp, crew_yp, crew_sprite, 220 - help.glow / 4 - textboxes[i].rand, 210 - help.glow / 4, 120 - help.glow / 4);
-        }
-        else if (textboxes[i].b == 175)
-        {
-            //blue guy
-            draw_sprite(crew_xp, crew_yp, crew_sprite, 75, 75, 255 - help.glow / 4 - textboxes[i].rand);
-        }
 
-        for (int index = 0; index < (int) textboxes[i].sprites.size(); index++)
+        for (size_t index = 0; index < textboxes[i].sprites.size(); index++)
         {
             TextboxSprite* sprite = &textboxes[i].sprites[index];
-            draw_sprite(
-                sprite->x + textboxes[i].xp,
-                sprite->y + textboxes[i].yp,
+            int y = sprite->y + yp;
+
+            if (flipmode)
+            {
+                y = yp + textboxes[i].h - sprite->y - sprites_rect.h;
+            }
+
+            draw_grid_tile(
+                grphx.im_sprites,
                 sprite->tile,
-                getcol(sprite->col)
+                sprite->x + textboxes[i].xp,
+                y,
+                sprites_rect.w,
+                sprites_rect.h,
+                getcol(sprite->col),
+                1,
+                (flipmode ? -1 : 1)
             );
         }
     }

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -122,6 +122,8 @@ public:
 
     void textboxtimer(int t);
 
+    void addsprite(int x, int y, int tile, int col);
+
     void textboxremove(void);
 
     void textboxremovefast(void);

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -124,6 +124,8 @@ public:
 
     void addsprite(int x, int y, int tile, int col);
 
+    void setimage(TextboxImage image);
+
     void textboxremove(void);
 
     void textboxremovefast(void);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -54,6 +54,7 @@ scriptclass::scriptclass(void)
     textcase = 1;
     textbuttons = false;
     textlarge = false;
+    textbox_sprites.clear();
 }
 
 void scriptclass::add_default_colours(void)
@@ -505,6 +506,7 @@ void scriptclass::run(void)
                 textpad_right = 0;
                 textpadtowidth = 0;
                 textboxtimer = 0;
+                textbox_sprites.clear();
 
                 translate_dialogue();
             }
@@ -675,6 +677,15 @@ void scriptclass::run(void)
             {
                 textboxtimer = ss_toi(words[1]);
             }
+            else if (words[0] == "textsprite")
+            {
+                TextboxSprite sprite;
+                sprite.x = ss_toi(words[1]);
+                sprite.y = ss_toi(words[2]);
+                sprite.tile = ss_toi(words[3]);
+                sprite.col = ss_toi(words[4]);
+                textbox_sprites.push_back(sprite);
+            }
             else if (words[0] == "flipme")
             {
                 textflipme = !textflipme;
@@ -704,6 +715,11 @@ void scriptclass::run(void)
                 if (textboxtimer > 0)
                 {
                     graphics.textboxtimer(textboxtimer);
+                }
+
+                for (size_t i = 0; i < textbox_sprites.size(); i++)
+                {
+                    graphics.addsprite(textbox_sprites[i].x, textbox_sprites[i].y, textbox_sprites[i].tile, textbox_sprites[i].col);
                 }
 
                 // Some textbox formatting that can be set by translations...

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -55,6 +55,7 @@ scriptclass::scriptclass(void)
     textbuttons = false;
     textlarge = false;
     textbox_sprites.clear();
+    textbox_image = TEXTIMAGE_NONE;
 }
 
 void scriptclass::add_default_colours(void)
@@ -507,6 +508,7 @@ void scriptclass::run(void)
                 textpadtowidth = 0;
                 textboxtimer = 0;
                 textbox_sprites.clear();
+                textbox_image = TEXTIMAGE_NONE;
 
                 translate_dialogue();
             }
@@ -686,6 +688,21 @@ void scriptclass::run(void)
                 sprite.col = ss_toi(words[4]);
                 textbox_sprites.push_back(sprite);
             }
+            else if (words[0] == "textimage")
+            {
+                if (words[1] == "levelcomplete")
+                {
+                    textbox_image = TEXTIMAGE_LEVELCOMPLETE;
+                }
+                else if (words[1] == "gamecomplete")
+                {
+                    textbox_image = TEXTIMAGE_GAMECOMPLETE;
+                }
+                else
+                {
+                    textbox_image = TEXTIMAGE_NONE;
+                }
+            }
             else if (words[0] == "flipme")
             {
                 textflipme = !textflipme;
@@ -721,6 +738,8 @@ void scriptclass::run(void)
                 {
                     graphics.addsprite(textbox_sprites[i].x, textbox_sprites[i].y, textbox_sprites[i].tile, textbox_sprites[i].col);
                 }
+
+                graphics.setimage(textbox_image);
 
                 // Some textbox formatting that can be set by translations...
                 if (textcentertext)

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -125,6 +125,7 @@ public:
     bool textlarge;
     int textboxtimer;
     std::vector<TextboxSprite> textbox_sprites;
+    TextboxImage textbox_image;
 
     //Misc
     int i, j, k;

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -2,10 +2,11 @@
 #define SCRIPT_H
 
 #include <map>
+#include <SDL.h>
 #include <string>
 #include <vector>
 
-#include <SDL.h>
+#include "Textbox.h"
 
 #define filllines(lines) commands.insert(commands.end(), lines, lines + SDL_arraysize(lines))
 
@@ -123,6 +124,7 @@ public:
     bool textbuttons;
     bool textlarge;
     int textboxtimer;
+    std::vector<TextboxSprite> textbox_sprites;
 
     //Misc
     int i, j, k;

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -28,6 +28,18 @@ textboxclass::textboxclass(void)
 
     print_flags = PR_FONT_LEVEL;
     fill_buttons = false;
+
+    sprites.clear();
+}
+
+void textboxclass::addsprite(int x, int y, int tile, int col)
+{
+    TextboxSprite sprite;
+    sprite.x = x;
+    sprite.y = y;
+    sprite.tile = tile;
+    sprite.col = col;
+    sprites.push_back(sprite);
 }
 
 void textboxclass::centerx(void)

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -30,6 +30,8 @@ textboxclass::textboxclass(void)
     fill_buttons = false;
 
     sprites.clear();
+
+    image = TEXTIMAGE_NONE;
 }
 
 void textboxclass::addsprite(int x, int y, int tile, int col)
@@ -40,6 +42,11 @@ void textboxclass::addsprite(int x, int y, int tile, int col)
     sprite.tile = tile;
     sprite.col = col;
     sprites.push_back(sprite);
+}
+
+void textboxclass::setimage(TextboxImage new_image)
+{
+    image = new_image;
 }
 
 void textboxclass::centerx(void)

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -5,10 +5,20 @@
 #include <string>
 #include <vector>
 
+struct TextboxSprite
+{
+    int x;
+    int y;
+    int col;
+    int tile;
+};
+
 class textboxclass
 {
 public:
     textboxclass(void);
+
+    void addsprite(int x, int y, int tile, int col);
 
     void centerx(void);
 
@@ -53,6 +63,8 @@ public:
 
     uint32_t print_flags;
     bool fill_buttons;
+
+    std::vector<TextboxSprite> sprites;
 };
 
 #endif /* TEXTBOX_H */

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -13,12 +13,21 @@ struct TextboxSprite
     int tile;
 };
 
+enum TextboxImage
+{
+    TEXTIMAGE_NONE,
+    TEXTIMAGE_LEVELCOMPLETE,
+    TEXTIMAGE_GAMECOMPLETE
+};
+
 class textboxclass
 {
 public:
     textboxclass(void);
 
     void addsprite(int x, int y, int tile, int col);
+
+    void setimage(TextboxImage image);
 
     void centerx(void);
 
@@ -65,6 +74,7 @@ public:
     bool fill_buttons;
 
     std::vector<TextboxSprite> sprites;
+    TextboxImage image;
 };
 
 #endif /* TEXTBOX_H */


### PR DESCRIPTION
## Changes:

This commit adds a system for displaying sprites in textboxes, which replaces the hardcoded system in the main game.

This also adds a couple new commands to go along with it.
- `textsprite(x,y,sprite,color)` adds sprites to the textbox you're currently constructing. The coordinates are relative to the textbox.
- `textimage(levelcomplete/gamecomplete)` displays `levelcomplete.png` or `gamecomplete.png` and their flip mode variants (or text due to translation)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
