### PR TITLE
Controller layout detection

### DIFF
--- a/desktop_version/src/ButtonGlyphs.cpp
+++ b/desktop_version/src/ButtonGlyphs.cpp
@@ -167,6 +167,44 @@ void BUTTONGLYPHS_keyboard_set_active(bool active)
     keyboard_is_active = active;
 }
 
+void BUTTONGLYPHS_update_layout(Uint16 vendor, Uint16 product)
+{
+    if (vendor == 0x054c)
+    {
+        layout = LAYOUT_PLAYSTATION;
+    }
+    else if (vendor == 0x28de)
+    {
+        layout = LAYOUT_DECK;
+    }
+    else if (vendor == 0x057e)
+    {
+        if (product == 0x2006)
+        {
+            layout = LAYOUT_NINTENDO_SWITCH_JOYCON_L;
+        }
+        else if (product == 0x2007)
+        {
+            layout = LAYOUT_NINTENDO_SWITCH_JOYCON_R;
+        }
+        else
+        {
+            layout = LAYOUT_NINTENDO_SWITCH_PRO;
+        }
+    }
+    else if (vendor == 0x2dc8) /* 8BitDo */
+    {
+        layout = LAYOUT_NINTENDO_SWITCH_PRO;
+    }
+    else
+    {
+        /* For now we assume Xbox (0x045e), Generic will be used when
+         * migrating to SDL_ActionSet
+         */
+        layout = LAYOUT_XBOX;
+    }
+}
+
 const char* BUTTONGLYPHS_get_wasd_text(void)
 {
     /* Returns the string to use in Welcome Aboard */

--- a/desktop_version/src/ButtonGlyphs.h
+++ b/desktop_version/src/ButtonGlyphs.h
@@ -17,6 +17,8 @@ bool BUTTONGLYPHS_keyboard_is_available(void);
 bool BUTTONGLYPHS_keyboard_is_active(void);
 void BUTTONGLYPHS_keyboard_set_active(bool active);
 
+void BUTTONGLYPHS_update_layout(Uint16 vendor, Uint16 product);
+
 const char* BUTTONGLYPHS_get_wasd_text(void);
 const char* BUTTONGLYPHS_get_button(ActionSet actionset, Action action, int binding);
 


### PR DESCRIPTION
The only weird-ish thing here is that we're using the Valve vendor ID to assign the Deck layout, but that technically applies to _all_ virtual gamepads. This will eventually fix itself when we migrate to a system that uses Steam Input directly and we can get the hardware information again.

Fixes #945