### PR TITLE
Fix texture cache missing in certain situations after resizing the window

### DIFF
--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -3511,6 +3511,7 @@ void editorinput(void)
                 if (game.currentmenuname == Menu::ed_settings)
                 {
                     ed.state = EditorState_DRAW;
+                    gameScreen.recacheTextures();
                 }
                 else
                 {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7477,6 +7477,7 @@ void Game::mapmenuchange(const enum GameGamestate newgamestate, const bool user_
     gamestate = newgamestate;
     graphics.resumegamemode = false;
     mapheld = true;
+    gameScreen.recacheTextures();
 
     if (prevgamestate == GAMEMODE)
     {

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -170,9 +170,9 @@ void Screen::ResizeScreen(int x, int y)
     else
     {
         int result = SDL_SetWindowFullscreen(m_window, 0);
-        recacheTextures();
         if (result != 0)
         {
+            recacheTextures();
             vlog_error("Error: could not set the game to windowed mode: %s", SDL_GetError());
             return;
         }
@@ -185,6 +185,7 @@ void Screen::ResizeScreen(int x, int y)
                 SDL_WINDOWPOS_CENTERED_DISPLAY(windowDisplay)
             );
         }
+        recacheTextures();
     }
 }
 

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -172,11 +172,9 @@ void Screen::ResizeScreen(int x, int y)
         int result = SDL_SetWindowFullscreen(m_window, 0);
         if (result != 0)
         {
-            recacheTextures();
             vlog_error("Error: could not set the game to windowed mode: %s", SDL_GetError());
-            return;
         }
-        if (x != -1 && y != -1)
+        else if (x != -1 && y != -1)
         {
             SDL_SetWindowSize(m_window, windowWidth, windowHeight);
             SDL_SetWindowPosition(


### PR DESCRIPTION
## Changes:

This PR fixes an issue where resizing the window can cause textures to not properly recache, rendering invisible.

Fixes #988, fixes #977.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
