### PR TITLE
Remove NO_EDITOR/NO_CUSTOM_LEVELS, disable editor on Steam Deck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,20 +46,6 @@ jobs:
     - name: Build (M&P)
       run: ninja -C ${SRC_DIR_PATH}/build
 
-    - name: CMake configure (no custom levels)
-      run: |
-        cd ${SRC_DIR_PATH}/build
-        cmake -DMAKEANDPLAY=OFF -DCUSTOM_LEVEL_SUPPORT=DISABLED ..
-    - name: Build (no custom levels)
-      run: ninja -C ${SRC_DIR_PATH}/build
-
-    - name: CMake configure (no editor)
-      run: |
-        cd ${SRC_DIR_PATH}/build
-        cmake -DCUSTOM_LEVEL_SUPPORT=NO_EDITOR ..
-    - name: Build (no editor)
-      run: ninja -C ${SRC_DIR_PATH}/build
-
   build-lin:
     name: Build (CentOS 7)
 
@@ -95,20 +81,6 @@ jobs:
         cd ${SRC_DIR_PATH}/build
         cmake -DOFFICIAL_BUILD=OFF -DMAKEANDPLAY=ON ..
     - name: Build (M&P)
-      run: make -j $(nproc) -C ${SRC_DIR_PATH}/build
-
-    - name: CMake configure (no custom levels)
-      run: |
-        cd ${SRC_DIR_PATH}/build
-        cmake -DMAKEANDPLAY=OFF -DCUSTOM_LEVEL_SUPPORT=DISABLED ..
-    - name: Build (no custom levels)
-      run: make -j $(nproc) -C ${SRC_DIR_PATH}/build
-
-    - name: CMake configure (no editor)
-      run: |
-        cd ${SRC_DIR_PATH}/build
-        cmake -DCUSTOM_LEVEL_SUPPORT=NO_EDITOR ..
-    - name: Build (no editor)
       run: make -j $(nproc) -C ${SRC_DIR_PATH}/build
 
   build-win:
@@ -183,24 +155,6 @@ jobs:
         cd $env:SRC_DIR_PATH/build
         cmake -DOFFICIAL_BUILD=OFF -DMAKEANDPLAY=ON ..
     - name: Build (M&P)
-      run: |
-        cd $env:SRC_DIR_PATH/build
-        cmake --build .
-
-    - name: CMake configure (no custom levels)
-      run: |
-        cd $env:SRC_DIR_PATH/build
-        cmake -DMAKEANDPLAY=OFF -DCUSTOM_LEVEL_SUPPORT=DISABLED ..
-    - name: Build (no custom levels)
-      run: |
-        cd $env:SRC_DIR_PATH/build
-        cmake --build .
-
-    - name: CMake configure (no editor)
-      run: |
-        cd $env:SRC_DIR_PATH/build
-        cmake -DCUSTOM_LEVEL_SUPPORT=NO_EDITOR ..
-    - name: Build (no editor)
       run: |
         cd $env:SRC_DIR_PATH/build
         cmake --build .

--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -9,9 +9,6 @@ option(ENABLE_WERROR "Treat compilation warnings as errors" OFF)
 
 option(BUNDLE_DEPENDENCIES "Use bundled TinyXML-2, PhysicsFS, and FAudio (if disabled, TinyXML-2, PhysicsFS, and FAudio will be dynamically linked; LodePNG and C-HashMap will still be statically linked)" ON)
 
-set(CUSTOM_LEVEL_SUPPORT ENABLED CACHE STRING "Optionally disable playing and/or editing of custom levels")
-set_property(CACHE CUSTOM_LEVEL_SUPPORT PROPERTY STRINGS ENABLED NO_EDITOR DISABLED)
-
 option(STEAM "Use the Steam API" OFF)
 option(GOG "Use the GOG API" OFF)
 
@@ -72,7 +69,9 @@ set(VVV_SRC
     src/BinaryBlob.cpp
     src/BlockV.cpp
     src/ButtonGlyphs.cpp
+    src/CustomLevels.cpp
     src/CWrappers.cpp
+    src/Editor.cpp
     src/Ent.cpp
     src/Entity.cpp
     src/FileSystemUtils.cpp
@@ -118,12 +117,6 @@ set(VVV_SRC
     src/Xoshiro.c
     ../third_party/physfs/extras/physfsrwops.c
 )
-if(NOT CUSTOM_LEVEL_SUPPORT STREQUAL "DISABLED")
-    list(APPEND VVV_SRC src/CustomLevels.cpp)
-    if(NOT CUSTOM_LEVEL_SUPPORT STREQUAL "NO_EDITOR")
-        LIST(APPEND VVV_SRC src/Editor.cpp)
-    endif()
-endif()
 if(STEAM)
     list(APPEND VVV_SRC src/SteamNetwork.c)
 endif()
@@ -247,12 +240,6 @@ if(ENABLE_WARNINGS)
             -Wall -Wpedantic $<$<BOOL:${ENABLE_WERROR}>:-Werror>>
         $<$<CXX_COMPILER_ID:MSVC>:
             /W4 $<$<BOOL:${ENABLE_WERROR}>:/WX>>)
-endif()
-
-if(CUSTOM_LEVEL_SUPPORT STREQUAL "NO_EDITOR")
-    target_compile_definitions(VVVVVV PRIVATE -DNO_EDITOR)
-elseif(CUSTOM_LEVEL_SUPPORT STREQUAL "DISABLED")
-    target_compile_definitions(VVVVVV PRIVATE -DNO_CUSTOM_LEVELS -DNO_EDITOR)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -417,7 +417,8 @@
     <string english="start from beginning" translation="" explanation="menu option"/>
     <string english="delete save" translation="" explanation="menu option"/>
     <string english="back to levels" translation="" explanation="menu option"/>
-    <string english="This version of the game does not support the level editor, but it might be supported in the future." translation="" max="38*3"/>
+    <string english="The level editor is not currently supported on Steam Deck, as it requires a keyboard and mouse to use." translation="" explanation="" max="38*3"/>
+    <string english="The level editor is not currently supported on this device, as it requires a keyboard and mouse to use." translation="" explanation="" max="38*3"/>
     <string english="To install new player levels, copy the .vvvvvv files to the levels folder." translation="" explanation="" max="38*3"/>
     <string english="Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming." translation="" explanation="" max="38*4"/>
     <string english="The levels path is:" translation="" explanation="" max="40"/>

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -417,6 +417,7 @@
     <string english="start from beginning" translation="" explanation="menu option"/>
     <string english="delete save" translation="" explanation="menu option"/>
     <string english="back to levels" translation="" explanation="menu option"/>
+    <string english="This version of the game does not support the level editor, but it might be supported in the future." translation="" max="38*3"/>
     <string english="To install new player levels, copy the .vvvvvv files to the levels folder." translation="" explanation="" max="38*3"/>
     <string english="Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming." translation="" explanation="" max="38*4"/>
     <string english="The levels path is:" translation="" explanation="" max="40"/>

--- a/desktop_version/src/ButtonGlyphs.cpp
+++ b/desktop_version/src/ButtonGlyphs.cpp
@@ -152,6 +152,13 @@ bool BUTTONGLYPHS_keyboard_is_available(void)
 {
     /* Returns true if it makes sense to show button hints that are only available
      * on keyboards (like press M to mute), false if we're on a console. */
+
+    if (BUTTONGLYPHS_keyboard_is_active())
+    {
+        /* The keyboard is active, so there HAS to be a keyboard available */
+        return true;
+    }
+
     return !SDL_GetHintBoolean("SteamDeck", SDL_FALSE);
 }
 

--- a/desktop_version/src/ButtonGlyphs.cpp
+++ b/desktop_version/src/ButtonGlyphs.cpp
@@ -152,7 +152,7 @@ bool BUTTONGLYPHS_keyboard_is_available(void)
 {
     /* Returns true if it makes sense to show button hints that are only available
      * on keyboards (like press M to mute), false if we're on a console. */
-    return true;
+    return !SDL_GetHintBoolean("SteamDeck", SDL_FALSE);
 }
 
 bool BUTTONGLYPHS_keyboard_is_active(void)

--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -1,5 +1,3 @@
-#if !defined(NO_CUSTOM_LEVELS)
-
 #define CL_DEFINITION
 #include "CustomLevels.h"
 
@@ -996,9 +994,7 @@ bool customlevelclass::load(std::string _path)
     tinyxml2::XMLElement* pElem;
 
     reset();
-#ifndef NO_EDITOR
     ed.reset();
-#endif
 
     static const char *levelDir = "levels/";
     if (_path.compare(0, SDL_strlen(levelDir), levelDir) != 0)
@@ -1037,9 +1033,7 @@ bool customlevelclass::load(std::string _path)
         goto fail;
     }
 
-#ifndef NO_EDITOR
     ed.loaded_filepath = _path;
-#endif
 
     version = 0;
     level_font_name = "font";
@@ -1452,7 +1446,6 @@ fail:
     return false;
 }
 
-#ifndef NO_EDITOR
 bool customlevelclass::save(const std::string& _path)
 {
     tinyxml2::XMLDocument doc;
@@ -1651,8 +1644,6 @@ bool customlevelclass::save(const std::string& _path)
 
     return FILESYSTEM_saveTiXml2Document(newpath.c_str(), doc);
 }
-#endif /* NO_EDITOR */
-
 
 void customlevelclass::generatecustomminimap(void)
 {
@@ -1923,14 +1914,11 @@ SDL_Color customlevelclass::getonewaycol(const int rx, const int ry)
 // This version detects the room automatically
 SDL_Color customlevelclass::getonewaycol(void)
 {
-#ifndef NO_EDITOR
     if (game.gamestate == EDITORMODE)
     {
         return getonewaycol(ed.levx, ed.levy);
     }
-    else
-#endif
-    if (map.custommode)
+    else if (map.custommode)
     {
         return getonewaycol(game.roomx - 100, game.roomy - 100);
     }
@@ -1973,5 +1961,3 @@ int customlevelclass::numcrewmates(void)
     }
     return temp;
 }
-
-#endif /* NO_CUSTOM_LEVELS */

--- a/desktop_version/src/CustomLevels.h
+++ b/desktop_version/src/CustomLevels.h
@@ -1,5 +1,3 @@
-#if !defined(NO_CUSTOM_LEVELS)
-
 #ifndef CUSTOMLEVELS_H
 #define CUSTOMLEVELS_H
 
@@ -138,9 +136,8 @@ public:
     int absfree(int x, int y);
 
     bool load(std::string _path);
-#ifndef NO_EDITOR
     bool save(const std::string& _path);
-#endif
+
     void generatecustomminimap(void);
 
     int findtrinket(int t);
@@ -182,4 +179,3 @@ extern customlevelclass cl;
 
 #endif /* CUSTOMLEVELS_H */
 
-#endif /* NO_CUSTOM_LEVELS */

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -1,5 +1,3 @@
-#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
-
 #define ED_DEFINITION
 #include "Editor.h"
 
@@ -4160,5 +4158,3 @@ void editorclass::switch_warpdir(const bool reversed)
 
     graphics.backgrounddrawn = false;
 }
-
-#endif /* NO_CUSTOM_LEVELS and NO_EDITOR */

--- a/desktop_version/src/Editor.h
+++ b/desktop_version/src/Editor.h
@@ -1,5 +1,3 @@
-#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
-
 #ifndef EDITOR_H
 #define EDITOR_H
 
@@ -295,5 +293,3 @@ extern editorclass ed;
 #endif
 
 #endif /* EDITOR_H */
-
-#endif /* NO_CUSTOM_LEVELS and NO_EDITOR */

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1287,7 +1287,6 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
     //Rule 6 is a crew member
 
     bool custom_gray;
-#if !defined(NO_CUSTOM_LEVELS)
     // Special case for gray Warp Zone tileset!
     if (map.custommode)
     {
@@ -1295,7 +1294,6 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         custom_gray = room->tileset == 3 && room->tilecol == 6;
     }
     else
-#endif
     {
         custom_gray = false;
     }

--- a/desktop_version/src/Font.cpp
+++ b/desktop_version/src/Font.cpp
@@ -548,9 +548,7 @@ void set_level_font_new(void)
         }
     }
 
-#ifndef NO_CUSTOM_LEVELS
     cl.level_font_name = get_main_font_name(font_idx_level);
-#endif
 }
 
 static void fill_map_name_idx(FontContainer* container)

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7284,6 +7284,7 @@ void Game::quittomenu(void)
         else
         {
             //Returning from editor
+            editor_disabled = !BUTTONGLYPHS_keyboard_is_available();
             returntomenu(Menu::playerworlds);
         }
     }

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -337,6 +337,7 @@ public:
 
     int framecounter;
     bool seed_use_sdl_getticks;
+    bool editor_disabled;
     int frames, seconds, minutes, hours;
     bool gamesaved;
     bool gamesavefailed;
@@ -552,9 +553,7 @@ public:
     bool fadetolab;
     int fadetolabdelay;
 
-#if !defined(NO_CUSTOM_LEVELS)
     void returntoeditor(void);
-#endif
 
     bool inline inspecial(void)
     {
@@ -572,9 +571,7 @@ public:
     bool showingametimer;
 
     bool ingame_titlemode;
-#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
     bool ingame_editormode;
-#endif
 
     void returntoingame(void);
     void unlockAchievement(const char *name);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -139,11 +139,9 @@ void Graphics::init(void)
 
     kludgeswnlinewidth = false;
 
-#ifndef NO_CUSTOM_LEVELS
     tiles1_mounted = false;
     tiles2_mounted = false;
     minimap_mounted = false;
-#endif
 
     gamecomplete_mounted = false;
     levelcomplete_mounted = false;
@@ -686,24 +684,20 @@ void Graphics::scroll_texture(SDL_Texture* texture, SDL_Texture* temp, const int
     copy_texture(temp, &src, &src);
 }
 
-#ifndef NO_CUSTOM_LEVELS
 bool Graphics::shouldrecoloroneway(const int tilenum, const bool mounted)
 {
     return (tilenum >= 14 && tilenum <= 17
     && (!mounted
     || cl.onewaycol_override));
 }
-#endif
 
 void Graphics::drawtile(int x, int y, int t)
 {
-#if !defined(NO_CUSTOM_LEVELS)
     if (shouldrecoloroneway(t, tiles1_mounted))
     {
         draw_grid_tile(grphx.im_tiles_tint, t, x, y, tiles_rect.w, tiles_rect.h, cl.getonewaycol());
     }
     else
-#endif
     {
         draw_grid_tile(grphx.im_tiles, t, x, y, tiles_rect.w, tiles_rect.h);
     }
@@ -712,13 +706,11 @@ void Graphics::drawtile(int x, int y, int t)
 
 void Graphics::drawtile2(int x, int y, int t)
 {
-#if !defined(NO_CUSTOM_LEVELS)
     if (shouldrecoloroneway(t, tiles2_mounted))
     {
         draw_grid_tile(grphx.im_tiles2_tint, t, x, y, tiles_rect.w, tiles_rect.h, cl.getonewaycol());
     }
     else
-#endif
     {
         draw_grid_tile(grphx.im_tiles2, t, x, y, tiles_rect.w, tiles_rect.h);
     }
@@ -1575,7 +1567,6 @@ void Graphics::drawmenu(int cr, int cg, int cb, enum Menu::MenuName menu)
             y = 140 + i * 12 + game.menuyoff;
         }
 
-#ifndef NO_CUSTOM_LEVELS
         if (menu == Menu::levellist)
         {
             size_t separator;
@@ -1598,7 +1589,7 @@ void Graphics::drawmenu(int cr, int cg, int cb, enum Menu::MenuName menu)
                 y += 4;
             }
         }
-#endif
+
         if (menu == Menu::translator_options_cutscenetest)
         {
             size_t separator = 4;
@@ -1904,7 +1895,7 @@ void Graphics::drawentity(const int i, const int yoff)
     SDL_Rect drawRect;
 
     bool custom_gray;
-#if !defined(NO_CUSTOM_LEVELS)
+
     // Special case for gray Warp Zone tileset!
     if (map.custommode)
     {
@@ -1912,7 +1903,6 @@ void Graphics::drawentity(const int i, const int yoff)
         custom_gray = room->tileset == 3 && room->tilecol == 6;
     }
     else
-#endif
     {
         custom_gray = false;
     }
@@ -2681,14 +2671,12 @@ void Graphics::drawmap(void)
             {
                 int tile;
                 int tileset;
-#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
                 if (game.gamestate == EDITORMODE)
                 {
                     tile = cl.gettile(ed.levx, ed.levy, x, y);
                     tileset = (cl.getroomprop(ed.levx, ed.levy)->tileset == 0) ? 0 : 1;
                 }
                 else
-#endif
                 {
                     tile = map.contents[TILE_IDX(x, y)];
                     tileset = map.tileset;
@@ -3467,11 +3455,9 @@ bool Graphics::reloadresources(void)
     music.destroy();
     music.init();
 
-#ifndef NO_CUSTOM_LEVELS
     tiles1_mounted = FILESYSTEM_isAssetMounted("graphics/tiles.png");
     tiles2_mounted = FILESYSTEM_isAssetMounted("graphics/tiles2.png");
     minimap_mounted = FILESYSTEM_isAssetMounted("graphics/minimap.png");
-#endif
 
     gamecomplete_mounted = FILESYSTEM_isAssetMounted("graphics/gamecomplete.png");
     levelcomplete_mounted = FILESYSTEM_isAssetMounted("graphics/levelcomplete.png");

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -263,9 +263,9 @@ public:
 
     void drawbackground(int t);
     void updatebackground(int t);
-#ifndef NO_CUSTOM_LEVELS
+
     bool shouldrecoloroneway(const int tilenum, const bool mounted);
-#endif
+
     void drawtile3(int x, int y, int t, int off, int height_subtract = 0);
     void drawtile2(int x, int y, int t);
     void drawtile(int x, int y, int t);
@@ -283,11 +283,10 @@ public:
         const char* filename, SDL_Texture* texture,
         int tilewidth, int tileheight
     );
-#ifndef NO_CUSTOM_LEVELS
+
     bool tiles1_mounted;
     bool tiles2_mounted;
     bool minimap_mounted;
-#endif
 
     bool gamecomplete_mounted;
     bool levelcomplete_mounted;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -391,9 +391,7 @@ static void menuactionpress(void)
 #if !defined(MAKEANDPLAY)
         OPTION_ID(0) /* play */
 #endif
-#if !defined(NO_CUSTOM_LEVELS)
         OPTION_ID(1) /* levels */
-#endif
         OPTION_ID(2) /* options */
         if (loc::show_translator_menu)
         {
@@ -427,14 +425,12 @@ static void menuactionpress(void)
             }
             break;
 #endif
-#if !defined(NO_CUSTOM_LEVELS)
         case 1:
             //Bring you to the normal playmenu
             music.playef(Sound_VIRIDIAN);
             game.createmenu(Menu::playerworlds);
             map.nexttowercolour();
             break;
-#endif
         case 2:
             //Options
             music.playef(Sound_VIRIDIAN);
@@ -463,7 +459,6 @@ static void menuactionpress(void)
         }
         break;
     }
-#if !defined(NO_CUSTOM_LEVELS)
     case Menu::levellist:
     {
         const bool nextlastoptions = cl.ListOfMetaData.size() > 8;
@@ -513,7 +508,6 @@ static void menuactionpress(void)
         }
         break;
     }
-#endif
     case Menu::quickloadlevel:
         switch (game.currentmenuoption)
         {
@@ -537,7 +531,6 @@ static void menuactionpress(void)
             break;
         }
         break;
-#if !defined(NO_CUSTOM_LEVELS)
     case Menu::deletequicklevel:
         switch (game.currentmenuoption)
         {
@@ -556,17 +549,10 @@ static void menuactionpress(void)
         map.nexttowercolour();
         break;
     case Menu::playerworlds:
- #if defined(NO_EDITOR)
-  #define OFFSET -1
- #else
-  #define OFFSET 0
- #endif
-        switch (game.currentmenuoption)
+        if (game.currentmenuoption == 0)
         {
-        case 0:
-
             music.playef(Sound_VIRIDIAN);
-            game.levelpage=0;
+            game.levelpage = 0;
             cl.getDirectoryData();
             game.loadcustomlevelstats(); //Should only load a file if it's needed
             game.createmenu(Menu::levellist);
@@ -575,19 +561,26 @@ static void menuactionpress(void)
                 game.createmenu(Menu::warninglevellist);
             }
             map.nexttowercolour();
-            break;
- #if !defined(NO_EDITOR)
-        case 1:
-            //LEVEL EDITOR HOOK
-            music.playef(Sound_VIRIDIAN);
-            startmode(Start_EDITOR);
-            ed.filename="";
-            break;
- #endif
-        case OFFSET+2:
+        }
+        else if (game.currentmenuoption == 1)
+        {
+            // LEVEL EDITOR HOOK
+            if (game.editor_disabled)
+            {
+                music.playef(Sound_CRY);
+            }
+            else
+            {
+                music.playef(Sound_VIRIDIAN);
+                startmode(Start_EDITOR);
+                ed.filename = "";
+            }
+        }
+        else if (!game.editor_disabled && game.currentmenuoption == 2)
+        {
             //"OPENFOLDERHOOK"
             if (FILESYSTEM_openDirectoryEnabled()
-            && FILESYSTEM_openDirectory(FILESYSTEM_getUserLevelDirectory()))
+                && FILESYSTEM_openDirectory(FILESYSTEM_getUserLevelDirectory()))
             {
                 music.playef(Sound_VIRIDIAN);
                 SDL_MinimizeWindow(gameScreen.m_window);
@@ -596,22 +589,21 @@ static void menuactionpress(void)
             {
                 music.playef(Sound_CRY);
             }
-            break;
-        case OFFSET+3:
+        }
+        else if (!game.editor_disabled && game.currentmenuoption == 3)
+        {
             music.playef(Sound_VIRIDIAN);
             game.createmenu(Menu::confirmshowlevelspath);
             map.nexttowercolour();
-            break;
-        case OFFSET+4:
-            //back
+        }
+        else if (game.currentmenuoption == 4 || (game.editor_disabled && game.currentmenuoption == 2))
+        {
+            // back
             music.playef(Sound_VIRIDIAN);
             game.returnmenu();
             map.nexttowercolour();
-            break;
         }
-#undef OFFSET
         break;
-#endif
     case Menu::confirmshowlevelspath:
     {
         int prevmenuoption = game.currentmenuoption; /* returnmenu destroys this */
@@ -2495,7 +2487,6 @@ void gameinput(void)
     }
 
     //Returning to editor mode must always be possible
-#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
     if (map.custommode && !map.custommodeforreal)
     {
         if ((game.press_map || key.isDown(27)) && !game.mapheld)
@@ -2514,7 +2505,6 @@ void gameinput(void)
             }
         }
     }
-#endif
 
     //Entity type 0 is player controled
     bool has_control = false;
@@ -3070,13 +3060,12 @@ static void mapmenuactionpress(const bool version2_2)
         if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111) game.savearea = loc::gettext_roomname_special("The Ship");
 
         bool success;
-#if !defined(NO_CUSTOM_LEVELS)
+
         if(map.custommodeforreal)
         {
             success = game.customsavequick(cl.ListOfMetaData[game.playcustomlevel].filename);
         }
         else
-#endif
         {
             success = game.savequick();
         }

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1,6 +1,7 @@
 #include <tinyxml2.h>
 #include <vector>
 
+#include "ButtonGlyphs.h"
 #include "Credits.h"
 #include "CustomLevels.h"
 #include "Editor.h"
@@ -428,6 +429,7 @@ static void menuactionpress(void)
         case 1:
             //Bring you to the normal playmenu
             music.playef(Sound_VIRIDIAN);
+            game.editor_disabled = !BUTTONGLYPHS_keyboard_is_available();
             game.createmenu(Menu::playerworlds);
             map.nexttowercolour();
             break;
@@ -618,6 +620,7 @@ static void menuactionpress(void)
     }
     case Menu::showlevelspath:
         music.playef(Sound_VIRIDIAN);
+        game.editor_disabled = !BUTTONGLYPHS_keyboard_is_available();
         game.returntomenu(Menu::playerworlds);
         map.nexttowercolour();
         break;

--- a/desktop_version/src/LocalizationStorage.cpp
+++ b/desktop_version/src/LocalizationStorage.cpp
@@ -947,10 +947,9 @@ static void loadtext_roomnames(bool custom_level)
             {
                 continue;
             }
-#if !defined(NO_CUSTOM_LEVELS)
+
             const RoomProperty* const room = cl.getroomprop(x, y);
             if (SDL_strcmp(original_roomname, room->roomname.c_str()) != 0)
-#endif
             {
                 continue;
             }

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -124,24 +124,20 @@ const int mapclass::areamap[] = {
 
 int mapclass::getwidth(void)
 {
-#ifndef NO_CUSTOM_LEVELS
     if (custommode)
     {
         return cl.mapwidth;
     }
-#endif
 
     return 20;
 }
 
 int mapclass::getheight(void)
 {
-#ifndef NO_CUSTOM_LEVELS
     if (custommode)
     {
         return cl.mapheight;
     }
-#endif
 
     return 20;
 }
@@ -420,7 +416,6 @@ void mapclass::initcustommapdata(void)
 {
     shinytrinkets.clear();
 
-#if !defined(NO_CUSTOM_LEVELS)
     for (size_t i = 0; i < customentities.size(); i++)
     {
         const CustomEntity& ent = customentities[i];
@@ -431,7 +426,6 @@ void mapclass::initcustommapdata(void)
 
         settrinket(ent.rx, ent.ry);
     }
-#endif
 }
 
 int mapclass::finalat(int x, int y)
@@ -958,7 +952,6 @@ void mapclass::gotoroom(int rx, int ry)
             music.niceplay(Music_PREDESTINEDFATEREMIX);
         }
     }
-#if !defined(NO_CUSTOM_LEVELS)
     else if (custommode)
     {
         game.roomx = rx;
@@ -968,7 +961,6 @@ void mapclass::gotoroom(int rx, int ry)
         if (game.roomx > 100 + cl.mapwidth-1) game.roomx = 100;
         if (game.roomy > 100 + cl.mapheight-1) game.roomy = 100;
     }
-#endif
     else
     {
         game.roomx = rx;
@@ -1725,7 +1717,6 @@ void mapclass::loadlevel(int rx, int ry)
         break;
     }
 #endif
-#if !defined(NO_CUSTOM_LEVELS)
     case 12: //Custom level
     {
         const RoomProperty* const room = cl.getroomprop(rx - 100, ry - 100);
@@ -1953,7 +1944,6 @@ void mapclass::loadlevel(int rx, int ry)
         //do the appear/remove roomname here
         break;
     }
-#endif
     }
     //The room's loaded: now we fill out damage blocks based on the tiles.
     if (towermode)

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1664,7 +1664,14 @@ static void menurender(void)
     case Menu::playerworlds:
         if (game.editor_disabled)
         {
-            font::print_wrap(PR_CEN, -1, 180, loc::gettext("This version of the game does not support the level editor, but it might be supported in the future."), tr, tg, tb);
+            if (SDL_GetHintBoolean("SteamDeck", SDL_FALSE))
+            {
+                font::print_wrap(PR_CEN, -1, 180, loc::gettext("The level editor is not currently supported on Steam Deck, as it requires a keyboard and mouse to use."), tr, tg, tb);
+            }
+            else
+            {
+                font::print_wrap(PR_CEN, -1, 180, loc::gettext("The level editor is not currently supported on this device, as it requires a keyboard and mouse to use."), tr, tg, tb);
+            }
         }
         else
         {

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -225,7 +225,6 @@ static void menurender(void)
         }
         break;
     }
-#if !defined(NO_CUSTOM_LEVELS)
     case Menu::levellist:
     {
         if (cl.ListOfMetaData.size()==0)
@@ -261,7 +260,6 @@ static void menurender(void)
         }
         break;
     }
-#endif
     case Menu::errornostart:
         font::print_wrap(PR_CEN, -1, 65, loc::gettext("ERROR: This level has no start point!"), tr, tg, tb);
         break;
@@ -1664,7 +1662,14 @@ static void menurender(void)
         font::print_wrap(PR_CEN, -1, 125, loc::gettext("You have unlocked the intermission levels."), tr, tg, tb);
         break;
     case Menu::playerworlds:
-        font::print_wrap(PR_CEN, -1, 180, loc::gettext("To install new player levels, copy the .vvvvvv files to the levels folder."), tr, tg, tb);
+        if (game.editor_disabled)
+        {
+            font::print_wrap(PR_CEN, -1, 180, loc::gettext("This version of the game does not support the level editor, but it might be supported in the future."), tr, tg, tb);
+        }
+        else
+        {
+            font::print_wrap(PR_CEN, -1, 180, loc::gettext("To install new player levels, copy the .vvvvvv files to the levels folder."), tr, tg, tb);
+        }
         break;
     case Menu::confirmshowlevelspath:
         font::print_wrap(PR_CEN, -1, 80, loc::gettext("Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming."), tr, tg, tb);
@@ -2079,7 +2084,6 @@ void gamerender(void)
         }
     }
 
-#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
     if(map.custommode && !map.custommodeforreal && !game.advancetext){
         //Return to level editor
         int alpha = graphics.lerp(ed.old_return_message_timer, ed.return_message_timer);
@@ -2096,8 +2100,6 @@ void gamerender(void)
             font::print(PR_BRIGHTNESS(alpha) | PR_BOR, 5, 5, buffer, 220 - (help.glow), 220 - (help.glow), 255 - (help.glow / 2));
         }
     }
-#endif
-
 
     graphics.cutscenebars();
     graphics.drawfade();
@@ -2465,14 +2467,12 @@ static MapRenderData getmaprenderdata(void)
 
 static void rendermap(void)
 {
-#ifndef NO_CUSTOM_LEVELS
     if (map.custommode && map.customshowmm)
     {
         graphics.drawpixeltextbox(35 + map.custommmxoff, 16 + map.custommmyoff, map.custommmxsize + 10, map.custommmysize + 10, 65, 185, 207);
         graphics.drawpartimage(graphics.minimap_mounted ? IMAGE_MINIMAP : IMAGE_CUSTOMMINIMAP, 40 + map.custommmxoff, 21 + map.custommmyoff, map.custommmxsize, map.custommmysize);
         return;
      }
-#endif /* NO_CUSTOM_LEVELS */
 
     graphics.drawpixeltextbox(35, 16, 250, 190, 65, 185, 207);
     graphics.drawimage(IMAGE_MINIMAP, 40, 21, false);
@@ -2750,7 +2750,6 @@ void maprender(void)
             );
             font::print_wrap(PR_CEN, -1, 105, buffer, 196, 196, 255 - help.glow);
         }
-#if !defined(NO_CUSTOM_LEVELS)
         else if(map.custommode){
             LevelMetaData& meta = cl.ListOfMetaData[game.playcustomlevel];
 
@@ -2780,7 +2779,6 @@ void maprender(void)
             );
             font::print(PR_CEN, -1, FLIP(165, 8), buffer, 196, 196, 255 - help.glow);
         }
-#endif
         else
         {
             if (graphics.flipmode)
@@ -2842,13 +2840,11 @@ void maprender(void)
     case 2:
     {
         int max_trinkets;
-#ifndef NO_CUSTOM_LEVELS
         if (map.custommode)
         {
             max_trinkets = cl.numtrinkets();
         }
         else
-#endif
         {
             max_trinkets = 20;
         }

--- a/desktop_version/src/RenderFixed.cpp
+++ b/desktop_version/src/RenderFixed.cpp
@@ -131,7 +131,6 @@ void gamerenderfixed(void)
 
     map.updateroomnames();
 
-#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
     ed.old_return_message_timer = ed.return_message_timer;
     if (map.custommode && !map.custommodeforreal && ed.return_message_timer > 0)
     {
@@ -165,7 +164,6 @@ void gamerenderfixed(void)
             }
         }
     }
-#endif
 }
 
 void titlerenderfixed(void)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -195,7 +195,6 @@ void scriptclass::run(void)
                 }
                 scriptdelay = 1;
             }
-#if !defined(NO_CUSTOM_LEVELS)
             if (words[0] == "setroomname")
             {
                 ++position;
@@ -268,7 +267,6 @@ void scriptclass::run(void)
                     position--;
                 }
             }
-#endif
             if (words[0] == "destroy")
             {
                 if(words[1]=="gravitylines"){
@@ -1412,14 +1410,12 @@ void scriptclass::run(void)
             }
             else if (words[0] == "rollcredits")
             {
-#if !defined(NO_CUSTOM_LEVELS) && !defined(NO_EDITOR)
                 if (map.custommode && !map.custommodeforreal)
                 {
                     game.returntoeditor();
                     ed.show_note(loc::gettext("Rolled credits"));
                 }
                 else
-#endif
                 {
                     game.gamestate = GAMECOMPLETE;
                     graphics.fademode = FADE_START_FADEIN;
@@ -1768,13 +1764,11 @@ void scriptclass::run(void)
 
                 int max_trinkets;
 
-#if !defined(NO_CUSTOM_LEVELS)
                 if (map.custommode)
                 {
                     max_trinkets = cl.numtrinkets();
                 }
                 else
-#endif
                 {
                     max_trinkets = 20;
                 }
@@ -2423,7 +2417,6 @@ void scriptclass::run(void)
             }
             else if (words[0] == "setfont")
             {
-#ifndef NO_CUSTOM_LEVELS
                 if (words[1] == "")
                 {
                     font::set_level_font(cl.level_font_name.c_str());
@@ -2432,7 +2425,6 @@ void scriptclass::run(void)
                 {
                     font::set_level_font(raw_words[1].c_str());
                 }
-#endif
             }
 
             position++;
@@ -2783,10 +2775,6 @@ void scriptclass::startgamemode(const enum StartMode mode)
         }
         break;
 
-#ifdef NO_CUSTOM_LEVELS
-        UNUSED(gotoerrorloadinglevel);
-#else
-# ifndef NO_EDITOR
     case Start_EDITOR:
         cl.reset();
         ed.reset();
@@ -2824,7 +2812,6 @@ void scriptclass::startgamemode(const enum StartMode mode)
             music.currentsong = -1;
         }
         break;
-# endif /* NO_EDITOR */
 
     case Start_CUSTOM:
     case Start_CUSTOM_QUICKSAVE:
@@ -2867,8 +2854,6 @@ void scriptclass::startgamemode(const enum StartMode mode)
         graphics.fademode = FADE_START_FADEIN;
         break;
     }
-#endif /* NO_CUSTOM_LEVELS */
-
     case Start_CUTSCENETEST:
         music.fadeout();
         game.translator_exploring = true;
@@ -2881,12 +2866,7 @@ void scriptclass::startgamemode(const enum StartMode mode)
 
     case Start_QUIT:
         VVV_unreachable();
-
-#if defined(NO_CUSTOM_LEVELS) || defined(NO_EDITOR)
-    /* Silence warnings about unhandled cases. */
-    default:
         break;
-#endif
     }
 
     game.gravitycontrol = game.savegc;
@@ -2918,12 +2898,10 @@ void scriptclass::startgamemode(const enum StartMode mode)
     map.resetplayer();
     map.gotoroom(game.saverx, game.savery);
     map.initmapdata();
-#ifndef NO_CUSTOM_LEVELS
     if (map.custommode)
     {
         cl.generatecustomminimap();
     }
-#endif
 
     /* If we are spawning in a tower, ensure variables are set correctly */
     if (map.towermode)

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -21,7 +21,6 @@
 #include "Map.h"
 #include "Music.h"
 #include "Unreachable.h"
-#include "Unused.h"
 #include "UtilityClass.h"
 #include "VFormat.h"
 #include "Vlogging.h"

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -408,6 +408,8 @@ int main(int argc, char *argv[])
         }
         else if (ARG("-addresses"))
         {
+            printf("cl         : %p\n", (void*) &cl);
+            printf("ed         : %p\n", (void*) &ed);
             printf("game       : %p\n", (void*) &game);
             printf("gameScreen : %p\n", (void*) &gameScreen);
             printf("graphics   : %p\n", (void*) &graphics);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -37,13 +37,9 @@
 
 scriptclass script;
 
-#ifndef NO_CUSTOM_LEVELS
 std::vector<CustomEntity> customentities;
 customlevelclass cl;
-# ifndef NO_EDITOR
 editorclass ed;
-# endif
-#endif
 
 UtilityClass help;
 Graphics graphics;
@@ -107,9 +103,6 @@ static void teleportermodeinput(void)
     }
 }
 
-/* Only gets used in EDITORMODE. I assume the compiler will optimize this away
- * if this is a NO_CUSTOM_LEVELS or NO_EDITOR build
- */
 static void flipmodeoff(void)
 {
     graphics.flipmode = false;
@@ -181,9 +174,6 @@ static const inline struct ImplFunc* get_gamestate_funcs(
         {Func_fixed, gamecompletelogic2},
     FUNC_LIST_END
 
-#if defined(NO_CUSTOM_LEVELS) || defined(NO_EDITOR)
-        UNUSED(flipmodeoff);
-#else
     FUNC_LIST_BEGIN(EDITORMODE)
         {Func_fixed, flipmodeoff},
         {Func_input, editorinput},
@@ -191,7 +181,6 @@ static const inline struct ImplFunc* get_gamestate_funcs(
         {Func_fixed, editorrenderfixed},
         {Func_delta, editorrender},
     FUNC_LIST_END
-#endif
 
     FUNC_LIST_BEGIN(PRELOADER)
         {Func_input, preloaderinput},
@@ -380,6 +369,7 @@ int main(int argc, char *argv[])
     char* langDir = NULL;
     char* fontsDir = NULL;
     bool seed_use_sdl_getticks = false;
+    bool editor_disabled = !BUTTONGLYPHS_keyboard_is_available();
 #ifdef _WIN32
     bool open_console = false;
 #endif
@@ -408,12 +398,6 @@ int main(int argc, char *argv[])
 #ifdef MAKEANDPLAY
                 " [M&P]"
 #endif
-#ifdef NO_CUSTOM_LEVELS
-                " [no custom levels]"
-#endif
-#ifdef NO_EDITOR
-                " [no editor]"
-#endif
             );
 #ifdef INTERIM_VERSION_EXISTS
             puts(COMMIT_DATE);
@@ -424,12 +408,6 @@ int main(int argc, char *argv[])
         }
         else if (ARG("-addresses"))
         {
-#ifndef NO_CUSTOM_LEVELS
-            printf("cl         : %p\n", (void*) &cl);
-# ifndef NO_EDITOR
-            printf("ed         : %p\n", (void*) &ed);
-# endif
-#endif
             printf("game       : %p\n", (void*) &game);
             printf("gameScreen : %p\n", (void*) &gameScreen);
             printf("graphics   : %p\n", (void*) &graphics);
@@ -553,6 +531,10 @@ int main(int argc, char *argv[])
         {
             seed_use_sdl_getticks = true;
         }
+        else if (ARG("-enable-editor"))
+        {
+            editor_disabled = false;
+        }
 #undef ARG_INNER
 #undef ARG
         else
@@ -626,6 +608,7 @@ int main(int argc, char *argv[])
 
     game.init();
     game.seed_use_sdl_getticks = seed_use_sdl_getticks;
+    game.editor_disabled = editor_disabled;
 
     game.gamestate = PRELOADER;
 
@@ -756,7 +739,6 @@ int main(int argc, char *argv[])
 
     obj.init();
 
-#if !defined(NO_CUSTOM_LEVELS)
     if (startinplaytest) {
         game.levelpage = 0;
         game.playcustomlevel = 0;
@@ -808,7 +790,6 @@ int main(int argc, char *argv[])
 
         graphics.fademode = FADE_NONE;
     }
-#endif
 
     /* Only create the window after we have loaded all the assets. */
     SDL_ShowWindow(gameScreen.m_window);

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -31,7 +31,6 @@
 #include "RenderFixed.h"
 #include "Screen.h"
 #include "Script.h"
-#include "Unused.h"
 #include "UtilityClass.h"
 #include "Vlogging.h"
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -368,7 +368,6 @@ int main(int argc, char *argv[])
     char* langDir = NULL;
     char* fontsDir = NULL;
     bool seed_use_sdl_getticks = false;
-    bool editor_disabled = !BUTTONGLYPHS_keyboard_is_available();
 #ifdef _WIN32
     bool open_console = false;
 #endif
@@ -532,10 +531,6 @@ int main(int argc, char *argv[])
         {
             seed_use_sdl_getticks = true;
         }
-        else if (ARG("-enable-editor"))
-        {
-            editor_disabled = false;
-        }
 #undef ARG_INNER
 #undef ARG
         else
@@ -609,7 +604,6 @@ int main(int argc, char *argv[])
 
     game.init();
     game.seed_use_sdl_getticks = seed_use_sdl_getticks;
-    game.editor_disabled = editor_disabled;
 
     game.gamestate = PRELOADER;
 


### PR DESCRIPTION
## Changes:

This PR removes the `NO_EDITOR` and `NO_CUSTOM_LEVELS` defines, which cleans up the code a lot, and they weren't really needed anyways.

This commit also disables the editor on the Steam Deck, ~~and adds a program argument to re-enable the editor, `-enable-editor`.~~ This has been removed in favor of detecting if a keyboard is available when you enter the menu.

When the editor is disabled, this is the screen which gets shown:

![Screenshot of the levels menu](https://github.com/TerryCavanagh/VVVVVV/assets/19293054/a43eb480-8704-4a7f-8669-ed1db2529dd5)

Closes #992.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
