### PR TITLE
Fix UB where image loading fails in certain cases

### DIFF
--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -21,7 +21,9 @@ extern "C"
 
 static SDL_Surface* LoadImageRaw(const char* filename, unsigned char** data)
 {
-    //Temporary storage for the image that's loaded
+    *data = NULL;
+
+    // Temporary storage for the image that's loaded
     SDL_Surface* loadedImage = NULL;
 
     unsigned int width, height;
@@ -84,7 +86,6 @@ SDL_Surface* LoadImageSurface(const char* filename)
 
     if (optimizedImage == NULL)
     {
-        VVV_free(data);
         vlog_error("Image not found: %s", filename);
         SDL_assert(0 && "Image not found! See stderr.");
     }


### PR DESCRIPTION
## Changes:

Looks like I forgot to set `data` to `NULL`, and uh, there's a double free somewhere. Not anymore.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
