### PR TITLE
Change editor unsupported message to only appear when editor is selected

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1664,13 +1664,16 @@ static void menurender(void)
     case Menu::playerworlds:
         if (game.editor_disabled)
         {
-            if (SDL_GetHintBoolean("SteamDeck", SDL_FALSE))
+            if (game.currentmenuoption == 1)
             {
-                font::print_wrap(PR_CEN, -1, 180, loc::gettext("The level editor is not currently supported on Steam Deck, as it requires a keyboard and mouse to use."), tr, tg, tb);
-            }
-            else
-            {
-                font::print_wrap(PR_CEN, -1, 180, loc::gettext("The level editor is not currently supported on this device, as it requires a keyboard and mouse to use."), tr, tg, tb);
+                if (SDL_GetHintBoolean("SteamDeck", SDL_FALSE))
+                {
+                    font::print_wrap(PR_CEN, -1, 180, loc::gettext("The level editor is not currently supported on Steam Deck, as it requires a keyboard and mouse to use."), tr, tg, tb);
+                }
+                else
+                {
+                    font::print_wrap(PR_CEN, -1, 180, loc::gettext("The level editor is not currently supported on this device, as it requires a keyboard and mouse to use."), tr, tg, tb);
+                }
             }
         }
         else


### PR DESCRIPTION
## Changes:

Showing the option on the "play a level" option feels to me as though inexperienced players would think they're not supposed to open the player levels, because the message says editor levels are unsupported, right? But the message is only referring to the level editor, so in my opinion, it's clearer to only show it there.

Existing view:
![Existing screen with the message showing even when "play a level" is selected](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/b99a41c8-f1b7-4785-ae21-ae1a67afb5c7)

New view:

https://github.com/TerryCavanagh/VVVVVV/assets/44736680/bf976cb9-1391-4fc0-a3f9-be417fee5e83


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
