### PR TITLE
Fix `setfont()` changing font of fading out text boxes

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2416,13 +2416,29 @@ void scriptclass::run(void)
             }
             else if (words[0] == "setfont")
             {
-                if (words[1] == "")
+                // If any textbox is currently fading out, wait for that first
+                bool blocked = false;
+                for (size_t i = 0; i < graphics.textboxes.size(); i++)
                 {
-                    font::set_level_font(cl.level_font_name.c_str());
+                    if (graphics.textboxes[i].tm == 2)
+                    {
+                        scriptdelay = 1;
+                        position--;
+                        blocked = true;
+                        break;
+                    }
                 }
-                else
+
+                if (!blocked)
                 {
-                    font::set_level_font(raw_words[1].c_str());
+                    if (words[1] == "")
+                    {
+                        font::set_level_font(cl.level_font_name.c_str());
+                    }
+                    else
+                    {
+                        font::set_level_font(raw_words[1].c_str());
+                    }
                 }
             }
 


### PR DESCRIPTION
## Changes:

Closes #925.

My fix here is to delay the font change until all fading-out textboxes have disappeared. See it as adding a sort of `untilbars` or `untilfade` for text box fadeout, into setfont.

Before:

https://github.com/TerryCavanagh/VVVVVV/assets/44736680/30ed2d7c-4292-41b5-af86-382ae2df0ec1

After:

https://github.com/TerryCavanagh/VVVVVV/assets/44736680/ca5ca402-899a-49cb-9292-4a2225d4ad9b


This doesn't prevent every possible way to change the font of an existing textbox, but you would need to use internal scripting to still do it (and basically be doing it on purpose) - the problem in simplified scripting when you simply do textbox-setfont-textbox is gone.


Also, #1000!


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
