### PR TITLE
Fix some bugs related to switching languages

### DIFF
--- a/desktop_version/lang/ca/strings.xml
+++ b/desktop_version/lang/ca/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="Canvia les opcions del controlador." explanation="" max="38*2"/>
     <string english="language" translation="llengua" explanation="menu option"/>
     <string english="Language" translation="Llengua" explanation="title" max="20"/>
-    <string english="Change the language." translation="Canvia la llengua." explanation="" max="38*5"/>
+    <string english="Change the language." translation="Canvia la llengua." explanation="" max="38*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3"/>
     <string english="clear main game data" translation="esborra dades de partides" explanation="menu option"/>
     <string english="clear custom level data" translation="esborra dades de niv. person." explanation="menu option"/>
     <string english="Clear Data" translation="Esborra dades" explanation="title" max="20"/>

--- a/desktop_version/lang/cy/strings.xml
+++ b/desktop_version/lang/cy/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="Newid opsiynau rheolydd." explanation="" max="38*2"/>
     <string english="language" translation="iaith" explanation="menu option"/>
     <string english="Language" translation="Iaith" explanation="title" max="20"/>
-    <string english="Change the language." translation="Newid yr iaith." explanation="" max="38*5"/>
+    <string english="Change the language." translation="Newid yr iaith." explanation="" max="38*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3"/>
     <string english="clear main game data" translation="clirio data prif gêm" explanation="menu option"/>
     <string english="clear custom level data" translation="clirio data lefel cwstwm" explanation="menu option"/>
     <string english="Clear Data" translation="Clirio Data" explanation="title" max="20"/>

--- a/desktop_version/lang/de/strings.xml
+++ b/desktop_version/lang/de/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="Ändere Controller-Optionen." explanation="" max="38*2"/>
     <string english="language" translation="sprache" explanation="menu option"/>
     <string english="Language" translation="Sprache" explanation="title" max="20"/>
-    <string english="Change the language." translation="Ändere die Spielsprache." explanation="" max="38*5"/>
+    <string english="Change the language." translation="Ändere die Spielsprache." explanation="" max="38*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3"/>
     <string english="clear main game data" translation="hauptspieldaten löschen" explanation="menu option"/>
     <string english="clear custom level data" translation="eigene-level-daten löschen" explanation="menu option"/>
     <string english="Clear Data" translation="Daten löschen" explanation="title" max="20"/>

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="" explanation="" max="38*2"/>
     <string english="language" translation="" explanation="menu option"/>
     <string english="Language" translation="" explanation="title" max="20"/>
-    <string english="Change the language." translation="" explanation="" max="38*5"/>
+    <string english="Change the language." translation="" explanation="" max="38*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3"/>
     <string english="clear main game data" translation="" explanation="menu option"/>
     <string english="clear custom level data" translation="" explanation="menu option"/>
     <string english="Clear Data" translation="" explanation="title" max="20"/>

--- a/desktop_version/lang/eo/strings.xml
+++ b/desktop_version/lang/eo/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="Ŝanĝi regilajn agordojn." explanation="" max="38*2"/>
     <string english="language" translation="lingvo" explanation="menu option"/>
     <string english="Language" translation="Lingvo" explanation="title" max="20"/>
-    <string english="Change the language." translation="Ŝanĝi la lingvon." explanation="" max="38*5"/>
+    <string english="Change the language." translation="Ŝanĝi la lingvon." explanation="" max="38*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3"/>
     <string english="clear main game data" translation="viŝi datumojn ĉefludajn" explanation="menu option"/>
     <string english="clear custom level data" translation="viŝi datumojn ludantnivelajn" explanation="menu option"/>
     <string english="Clear Data" translation="Viŝi datumojn" explanation="title" max="20"/>

--- a/desktop_version/lang/es/strings.xml
+++ b/desktop_version/lang/es/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="Cambia las opciones del mando." explanation="" max="38*2"/>
     <string english="language" translation="idioma" explanation="menu option"/>
     <string english="Language" translation="Idioma" explanation="title" max="20"/>
-    <string english="Change the language." translation="Cambia el idioma." explanation="" max="38*5"/>
+    <string english="Change the language." translation="Cambia el idioma." explanation="" max="38*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3"/>
     <string english="clear main game data" translation="borrar datos de juego" explanation="menu option"/>
     <string english="clear custom level data" translation="borrar datos de niveles" explanation="menu option"/>
     <string english="Clear Data" translation="Borrar datos" explanation="title" max="20"/>

--- a/desktop_version/lang/fr/strings.xml
+++ b/desktop_version/lang/fr/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="Modifiez les options de votre manette." explanation="" max="38*2"/>
     <string english="language" translation="langue" explanation="menu option"/>
     <string english="Language" translation="Langue" explanation="title" max="20"/>
-    <string english="Change the language." translation="Changez de langue." explanation="" max="38*5"/>
+    <string english="Change the language." translation="Changez de langue." explanation="" max="38*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3"/>
     <string english="clear main game data" translation="effacer les données principales" explanation="menu option"/>
     <string english="clear custom level data" translation="effacer les données personnalisées" explanation="menu option"/>
     <string english="Clear Data" translation="Effacer les données" explanation="title" max="20"/>

--- a/desktop_version/lang/ga/strings.xml
+++ b/desktop_version/lang/ga/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="Socruithe rialaitheora." explanation="" max="38*2"/>
     <string english="language" translation="teanga" explanation="menu option"/>
     <string english="Language" translation="Teanga" explanation="title" max="20"/>
-    <string english="Change the language." translation="Athraigh an teanga." explanation="" max="38*5"/>
+    <string english="Change the language." translation="Athraigh an teanga." explanation="" max="38*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3"/>
     <string english="clear main game data" translation="sonraí phríomhchuid an chluiche" explanation="menu option"/>
     <string english="clear custom level data" translation="sonraí na leibhéal saincheaptha" explanation="menu option"/>
     <string english="Clear Data" translation="Scrios Sonraí" explanation="title" max="20"/>

--- a/desktop_version/lang/it/strings.xml
+++ b/desktop_version/lang/it/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="Modifica le opzioni del controller." explanation="" max="38*2"/>
     <string english="language" translation="lingua" explanation="menu option"/>
     <string english="Language" translation="Lingua" explanation="title" max="20"/>
-    <string english="Change the language." translation="Cambia la lingua." explanation="" max="38*5"/>
+    <string english="Change the language." translation="Cambia la lingua." explanation="" max="38*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3"/>
     <string english="clear main game data" translation="cancella dati gioco principale" explanation="menu option"/>
     <string english="clear custom level data" translation="cancella dati livelli personalizzati" explanation="menu option"/>
     <string english="Clear Data" translation="Cancella dati" explanation="title" max="20"/>

--- a/desktop_version/lang/nl/strings.xml
+++ b/desktop_version/lang/nl/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="Wijzig controlleropties." explanation="" max="38*2"/>
     <string english="language" translation="taal" explanation="menu option"/>
     <string english="Language" translation="Taal" explanation="title" max="20"/>
-    <string english="Change the language." translation="Wijzig de taal." explanation="" max="38*5"/>
+    <string english="Change the language." translation="Wijzig de taal." explanation="" max="38*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3"/>
     <string english="clear main game data" translation="data hoofdspel wissen" explanation="menu option"/>
     <string english="clear custom level data" translation="data spelerlevels wissen" explanation="menu option"/>
     <string english="Clear Data" translation="Data wissen" explanation="title" max="20"/>

--- a/desktop_version/lang/pt_BR/strings.xml
+++ b/desktop_version/lang/pt_BR/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="Altere as opções do controle." explanation="" max="38*2"/>
     <string english="language" translation="idioma" explanation="menu option"/>
     <string english="Language" translation="Idioma" explanation="title" max="20"/>
-    <string english="Change the language." translation="Altere o idioma." explanation="" max="38*5"/>
+    <string english="Change the language." translation="Altere o idioma." explanation="" max="38*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3"/>
     <string english="clear main game data" translation="limpar dados principais do jogo" explanation="menu option"/>
     <string english="clear custom level data" translation="limpar dados de níveis" explanation="menu option"/>
     <string english="Clear Data" translation="Apagar os dados" explanation="title" max="20"/>

--- a/desktop_version/lang/pt_PT/strings.xml
+++ b/desktop_version/lang/pt_PT/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="Altera as opções do comando." explanation="" max="38*2"/>
     <string english="language" translation="idioma" explanation="menu option"/>
     <string english="Language" translation="Idioma" explanation="title" max="20"/>
-    <string english="Change the language." translation="Altera o idioma." explanation="" max="38*5"/>
+    <string english="Change the language." translation="Altera o idioma." explanation="" max="38*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3"/>
     <string english="clear main game data" translation="eliminar dados de jogo" explanation="menu option"/>
     <string english="clear custom level data" translation="eliminar dados personalizados" explanation="menu option"/>
     <string english="Clear Data" translation="Eliminar Dados" explanation="title" max="20"/>

--- a/desktop_version/lang/ru/strings.xml
+++ b/desktop_version/lang/ru/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="Измените настройки контроллера." explanation="" max="38*2"/>
     <string english="language" translation="язык" explanation="menu option"/>
     <string english="Language" translation="Язык" explanation="title" max="20"/>
-    <string english="Change the language." translation="Смените язык." explanation="" max="38*5"/>
+    <string english="Change the language." translation="Смените язык." explanation="" max="38*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3"/>
     <string english="clear main game data" translation="стереть данные основной игры" explanation="menu option"/>
     <string english="clear custom level data" translation="стереть данные пользов. уровней" explanation="menu option"/>
     <string english="Clear Data" translation="Стереть данные" explanation="title" max="20"/>

--- a/desktop_version/lang/tr/strings.xml
+++ b/desktop_version/lang/tr/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="Oyun kumandası seçeneklerini değiştir." explanation="" max="38*2"/>
     <string english="language" translation="dil" explanation="menu option"/>
     <string english="Language" translation="Dil" explanation="title" max="20"/>
-    <string english="Change the language." translation="Dili değiştir." explanation="" max="38*5"/>
+    <string english="Change the language." translation="Dili değiştir." explanation="" max="38*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3"/>
     <string english="clear main game data" translation="ana oyun verilerini temizle" explanation="menu option"/>
     <string english="clear custom level data" translation="özel bölüm verilerini temizle" explanation="menu option"/>
     <string english="Clear Data" translation="Verileri Temizle" explanation="title" max="20"/>

--- a/desktop_version/lang/uk/strings.xml
+++ b/desktop_version/lang/uk/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="Змінити налаштування контролера." explanation="" max="38*2"/>
     <string english="language" translation="мова" explanation="menu option"/>
     <string english="Language" translation="Мова" explanation="title" max="20"/>
-    <string english="Change the language." translation="Змінити мову." explanation="" max="38*5"/>
+    <string english="Change the language." translation="Змінити мову." explanation="" max="38*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3"/>
     <string english="clear main game data" translation="очистити дані основної гри" explanation="menu option"/>
     <string english="clear custom level data" translation="очистити дані користувацьких рівнів" explanation="menu option"/>
     <string english="Clear Data" translation="Очистити дані" explanation="title" max="20"/>

--- a/desktop_version/lang/zh/strings.xml
+++ b/desktop_version/lang/zh/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="改变控制器选项。" explanation="" max="38*2" max_local="25*1"/>
     <string english="language" translation="语言" explanation="menu option"/>
     <string english="Language" translation="语言" explanation="title" max="20" max_local="13"/>
-    <string english="Change the language." translation="变更语言。" explanation="" max="38*5" max_local="25*4"/>
+    <string english="Change the language." translation="变更语言。" explanation="" max="38*2" max_local="25*1"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3" max_local="25*2"/>
     <string english="clear main game data" translation="清除主游戏数据" explanation="menu option"/>
     <string english="clear custom level data" translation="清除自制关卡数据" explanation="menu option"/>
     <string english="Clear Data" translation="清除数据" explanation="title" max="20" max_local="13"/>

--- a/desktop_version/src/BlockV.cpp
+++ b/desktop_version/src/BlockV.cpp
@@ -35,7 +35,7 @@ void blockclass::clear(void)
     script.clear();
     prompt.clear();
 
-    print_flags = PR_FONT_INTERFACE;
+    gettext = true;
 }
 
 void blockclass::rectset(const int xi, const int yi, const int wi, const int hi)

--- a/desktop_version/src/BlockV.h
+++ b/desktop_version/src/BlockV.h
@@ -23,7 +23,7 @@ public:
     std::string script, prompt;
     int r, g, b;
     int activity_y;
-    uint32_t print_flags;
+    bool gettext;
 };
 
 #endif /* BLOCKV_H */

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -858,211 +858,211 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
         switch(trig)
         {
         case 0: //testing zone
-            block.prompt = loc::gettext("Press {button} to explode");
+            block.prompt = "Press {button} to explode";
             block.script = "intro";
             block.setblockcolour("orange");
             trig=1;
             break;
         case 1:
-            block.prompt = loc::gettext("Press {button} to talk to Violet");
+            block.prompt = "Press {button} to talk to Violet";
             block.script = "talkpurple";
             block.setblockcolour("purple");
             trig=0;
             break;
         case 2:
-            block.prompt = loc::gettext("Press {button} to talk to Vitellary");
+            block.prompt = "Press {button} to talk to Vitellary";
             block.script = "talkyellow";
             block.setblockcolour("yellow");
             trig=0;
             break;
         case 3:
-            block.prompt = loc::gettext("Press {button} to talk to Vermilion");
+            block.prompt = "Press {button} to talk to Vermilion";
             block.script = "talkred";
             block.setblockcolour("red");
             trig=0;
             break;
         case 4:
-            block.prompt = loc::gettext("Press {button} to talk to Verdigris");
+            block.prompt = "Press {button} to talk to Verdigris";
             block.script = "talkgreen";
             block.setblockcolour("green");
             trig=0;
             break;
         case 5:
-            block.prompt = loc::gettext("Press {button} to talk to Victoria");
+            block.prompt = "Press {button} to talk to Victoria";
             block.script = "talkblue";
             block.setblockcolour("blue");
             trig=0;
             break;
         case 6:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_station_1";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 7:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_outside_1";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 8:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_outside_2";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 9:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_outside_3";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 10:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_outside_4";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 11:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_outside_5";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 12:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_outside_6";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 13:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_finallevel";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 14:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_station_2";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 15:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_station_3";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 16:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_station_4";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 17:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_warp_1";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 18:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_warp_2";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 19:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_lab_1";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 20:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_lab_2";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 21:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_secretlab";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 22:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_shipcomputer";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 23:
-            block.prompt = loc::gettext("Press {button} to activate terminals");
+            block.prompt = "Press {button} to activate terminals";
             block.script = "terminal_radio";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 24:
-            block.prompt = loc::gettext("Press {button} to activate terminal");
+            block.prompt = "Press {button} to activate terminal";
             block.script = "terminal_jukebox";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 25:
-            block.prompt = loc::gettext("Passion for Exploring");
+            block.prompt = "Passion for Exploring";
             block.script = "terminal_juke1";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 26:
-            block.prompt = loc::gettext("Pushing Onwards");
+            block.prompt = "Pushing Onwards";
             block.script = "terminal_juke2";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 27:
-            block.prompt = loc::gettext("Positive Force");
+            block.prompt = "Positive Force";
             block.script = "terminal_juke3";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 28:
-            block.prompt = loc::gettext("Presenting VVVVVV");
+            block.prompt = "Presenting VVVVVV";
             block.script = "terminal_juke4";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 29:
-            block.prompt = loc::gettext("Potential for Anything");
+            block.prompt = "Potential for Anything";
             block.script = "terminal_juke5";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 30:
-            block.prompt = loc::gettext("Predestined Fate");
+            block.prompt = "Predestined Fate";
             block.script = "terminal_juke6";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 31:
-            block.prompt = loc::gettext("Pipe Dream");
+            block.prompt = "Pipe Dream";
             block.script = "terminal_juke7";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 32:
-            block.prompt = loc::gettext("Popular Potpourri");
+            block.prompt = "Popular Potpourri";
             block.script = "terminal_juke8";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 33:
-            block.prompt = loc::gettext("Pressure Cooker");
+            block.prompt = "Pressure Cooker";
             block.script = "terminal_juke9";
             block.setblockcolour("orange");
             trig=0;
             break;
         case 34:
-            block.prompt = loc::gettext("ecroF evitisoP");
+            block.prompt = "ecroF evitisoP";
             block.script = "terminal_juke10";
             block.setblockcolour("orange");
             trig=0;
@@ -1070,11 +1070,11 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
         case 35:
             if (custom)
             {
-                block.prompt = loc::gettext("Press {button} to interact");
+                block.prompt = "Press {button} to interact";
             }
             else
             {
-                block.prompt = loc::gettext("Press {button} to activate terminal");
+                block.prompt = "Press {button} to activate terminal";
             }
             block.script = "custom_"+customscript;
             block.setblockcolour("orange");
@@ -1087,12 +1087,12 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
     if (customactivitytext != "")
     {
         block.prompt = customactivitytext;
-        block.print_flags = PR_FONT_LEVEL;
+        block.gettext = false;
         customactivitytext = "";
     }
     else
     {
-        block.print_flags = PR_FONT_INTERFACE;
+        block.gettext = true;
     }
 
     if (customactivitycolour != "")

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -17,6 +17,8 @@ char *FILESYSTEM_getUserSaveDirectory(void);
 char *FILESYSTEM_getUserLevelDirectory(void);
 char *FILESYSTEM_getUserMainLangDirectory(void);
 bool FILESYSTEM_isMainLangDirFromRepo(void);
+bool FILESYSTEM_doesLangDirExist(void);
+bool FILESYSTEM_doesFontsDirExist(void);
 
 bool FILESYSTEM_setLangWriteDir(void);
 bool FILESYSTEM_restoreWriteDir(void);

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6503,7 +6503,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option(loc::gettext("audio"));
         option(loc::gettext("game pad"));
         option(loc::gettext("accessibility"));
-        option(loc::gettext("language"));
+        option(loc::gettext("language"), graphics.textboxes.empty());
         option(loc::gettext("return"));
         menuyoff = 0;
         maxspacing = 15;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -489,7 +489,7 @@ public:
     int oldreadytotele;
     int activity_r, activity_g, activity_b, activity_y;
     std::string activity_lastprompt;
-    uint32_t activity_print_flags;
+    bool activity_gettext;
 
     std::string telesummary, quicksummary, customquicksummary;
     bool save_exists(void);

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1033,11 +1033,18 @@ static void menuactionpress(void)
             break;
         case 5:
             //language options
-            music.playef(Sound_VIRIDIAN);
-            loc::loadlanguagelist();
-            game.createmenu(Menu::language);
-            game.currentmenuoption = loc::languagelist_curlang;
-            map.nexttowercolour();
+            if (graphics.textboxes.empty())
+            {
+                music.playef(Sound_VIRIDIAN);
+                loc::loadlanguagelist();
+                game.createmenu(Menu::language);
+                game.currentmenuoption = loc::languagelist_curlang;
+                map.nexttowercolour();
+            }
+            else
+            {
+                music.playef(Sound_CRY);
+            }
             break;
         default:
             /* Return */

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1098,8 +1098,6 @@ static void menuactionpress(void)
     {
         music.playef(Sound_VIRIDIAN);
 
-        bool show_title = !loc::lang_set;
-
         if (loc::languagelist.size() != 0 && (unsigned)game.currentmenuoption < loc::languagelist.size())
         {
             loc::lang = loc::languagelist[game.currentmenuoption].code;
@@ -1107,12 +1105,13 @@ static void menuactionpress(void)
             loc::lang_set = true;
         }
 
-        if (show_title)
+        if (loc::pre_title_lang_menu)
         {
             /* Make the title screen appear, we haven't seen it yet */
             game.menustart = false;
             game.createmenu(Menu::mainmenu);
             game.currentmenuoption = 0;
+            loc::pre_title_lang_menu = false;
         }
         else
         {
@@ -2226,7 +2225,7 @@ void titleinput(void)
         && game.menucountdown <= 0
         && (key.isDown(27) || key.isDown(game.controllerButton_esc)))
         {
-            if (game.currentmenuname == Menu::language && !loc::lang_set)
+            if (game.currentmenuname == Menu::language && loc::pre_title_lang_menu)
             {
                 /* Don't exit from the initial language screen,
                  * you can't do this on the loading/title screen either. */

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1037,6 +1037,7 @@ static void menuactionpress(void)
             {
                 music.playef(Sound_VIRIDIAN);
                 loc::loadlanguagelist();
+                loc::pre_title_lang_menu = false;
                 game.createmenu(Menu::language);
                 game.currentmenuoption = loc::languagelist_curlang;
                 map.nexttowercolour();
@@ -1114,16 +1115,13 @@ static void menuactionpress(void)
 
         if (loc::pre_title_lang_menu)
         {
-            /* Make the title screen appear, we haven't seen it yet */
+            /* Make the title screen appear, we haven't seen it yet.
+             * game.returnmenu() works because Menu::mainmenu
+             * is created before the language menu. */
             game.menustart = false;
-            game.createmenu(Menu::mainmenu);
-            game.currentmenuoption = 0;
             loc::pre_title_lang_menu = false;
         }
-        else
-        {
-            game.returnmenu();
-        }
+        game.returnmenu();
         map.nexttowercolour();
         game.savestatsandsettings_menu();
 

--- a/desktop_version/src/Localization.cpp
+++ b/desktop_version/src/Localization.cpp
@@ -12,6 +12,8 @@ namespace loc
 {
 
 bool lang_set = false;
+bool pre_title_lang_menu = false;
+
 std::string lang = "en";
 std::string lang_custom = "";
 std::string new_level_font = "";

--- a/desktop_version/src/Localization.h
+++ b/desktop_version/src/Localization.h
@@ -45,6 +45,8 @@ struct TextboxFormat
 };
 
 extern bool lang_set;
+extern bool pre_title_lang_menu;
+
 extern std::string lang;
 extern std::string lang_custom;
 extern std::string new_level_font;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1431,7 +1431,7 @@ void gamelogic(void)
     && INBOUNDS_VEC(game.activeactivity, obj.blocks))
     {
         game.activity_lastprompt = obj.blocks[game.activeactivity].prompt;
-        game.activity_print_flags = obj.blocks[game.activeactivity].print_flags;
+        game.activity_gettext = obj.blocks[game.activeactivity].gettext;
         game.activity_r = obj.blocks[game.activeactivity].r;
         game.activity_g = obj.blocks[game.activeactivity].g;
         game.activity_b = obj.blocks[game.activeactivity].b;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2388,15 +2388,21 @@ void gamerender(void)
     float act_alpha = graphics.lerp(game.prev_act_fade, game.act_fade) / 10.0f;
     if(game.act_fade>5 || game.prev_act_fade>5)
     {
+        const char* prompt = game.activity_lastprompt.c_str();
+        if (game.activity_gettext)
+        {
+            prompt = loc::gettext(prompt);
+        }
         char buffer[SCREEN_WIDTH_CHARS + 1];
         const char* final_string = interact_prompt(
             buffer,
             sizeof(buffer),
-            game.activity_lastprompt.c_str()
+            prompt
         );
 
         uint8_t text_r, text_g, text_b;
-        uint32_t text_flags = game.activity_print_flags | PR_BRIGHTNESS(act_alpha*255) | PR_CJK_LOW | PR_CEN;
+        uint32_t text_flags = (game.activity_gettext ? PR_FONT_INTERFACE : PR_FONT_LEVEL)
+        | PR_BRIGHTNESS(act_alpha*255) | PR_CJK_LOW | PR_CEN;
 
         if (game.activity_r == 0 && game.activity_g == 0 && game.activity_b == 0)
         {

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -381,8 +381,15 @@ static void menurender(void)
             font::print_wrap(PR_CEN, -1, 65, loc::gettext("Disable screen effects, enable slowdown modes or invincibility."), tr, tg, tb);
             break;
         case 5:
+        {
             font::print(PR_2X | PR_CEN,  -1, 30, loc::gettext("Language"), tr, tg, tb);
-            font::print_wrap(PR_CEN, -1, 65, loc::gettext("Change the language."), tr, tg, tb);
+            int next_y = font::print_wrap(PR_CEN, -1, 65, loc::gettext("Change the language."), tr, tg, tb);
+
+            if (!graphics.textboxes.empty())
+            {
+                font::print_wrap(PR_CEN, -1, next_y, loc::gettext("Can not change the language while a textbox is displayed in-game."), tr, tg, tb);
+            }
+        }
         }
         break;
     case Menu::graphicoptions:

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -220,8 +220,31 @@ static void menurender(void)
 #endif
         font::print(PR_RIGHT, 310, 230, RELEASE_VERSION, tr/2, tg/2, tb/2);
 
-        if(music.mmmmmm){
-            font::print(0, 10, 230, loc::gettext("[MMMMMM Mod Installed]"), tr/2, tg/2, tb/2);
+        const char* left_msg = NULL;
+
+        const bool fonts_error = !FILESYSTEM_doesFontsDirExist();
+        const bool lang_error = !FILESYSTEM_doesLangDirExist();
+
+        if (fonts_error && lang_error)
+        {
+            left_msg = "[No fonts&lang folders]";
+        }
+        else if (fonts_error)
+        {
+            left_msg = "[No fonts folder]";
+        }
+        else if (lang_error)
+        {
+            left_msg = "[No lang folder]";
+        }
+        else if (music.mmmmmm)
+        {
+            left_msg = loc::gettext("[MMMMMM Mod Installed]");
+        }
+
+        if (left_msg != NULL)
+        {
+            font::print(0, 10, 230, left_msg, tr/2, tg/2, tb/2);
         }
         break;
     }

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -661,8 +661,9 @@ int main(int argc, char *argv[])
         game.gamestate = TITLEMODE;
     if (game.slowdown == 0) game.slowdown = 30;
 
-    if (!loc::lang_set)
+    if (!loc::lang_set && !loc::languagelist.empty())
     {
+        loc::pre_title_lang_menu = true;
         game.gamestate = TITLEMODE;
         game.menustart = true;
         game.createmenu(Menu::language);


### PR DESCRIPTION
## Changes:

This PR fixes several bugs and makes some improvements (described in more detail in the commit messages):

- Fixed getting sent to the title screen if you have no language files and have never had, and open the language screen while in-game
- Added warning messages for missing fonts/lang folders in the bottom left of the main menu
- Fixed activity zone prompt language not getting updated when switching languages while in-game
- Prevent changing language if a script is running (to prevent the hard-to-fix language and font mixups in dialogues)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
