### PR TITLE
Fix bug with `destroy(moving)`/`destroy(disappear)`

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -290,11 +290,13 @@ void scriptclass::run(void)
                 }
                 else if (words[1] == "platforms" || words[1] == "moving")
                 {
+                    const bool fixed = words[1] == "moving";
+
                     for (size_t edi = 0; edi < obj.entities.size(); edi++)
                     {
                         if (obj.entities[edi].rule == 2 && obj.entities[edi].animate == 100)
                         {
-                            if (words[1] == "moving")
+                            if (fixed)
                             {
                                 obj.disableblockat(obj.entities[edi].xp, obj.entities[edi].yp);
                             }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -280,7 +280,8 @@ void scriptclass::run(void)
                 }
                 else if (words[1] == "warptokens")
                 {
-                    for (size_t edi = 0; edi < obj.entities.size(); edi++) {
+                    for (size_t edi = 0; edi < obj.entities.size(); edi++)
+                    {
                         if (obj.entities[edi].type == 11)
                         {
                             obj.disableentity(edi);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -268,25 +268,48 @@ void scriptclass::run(void)
             }
             if (words[0] == "destroy")
             {
-                if(words[1]=="gravitylines"){
-                    for(size_t edi=0; edi<obj.entities.size(); edi++){
-                        if(obj.entities[edi].type==9) obj.disableentity(edi);
-                        if(obj.entities[edi].type==10) obj.disableentity(edi);
+                if (words[1] == "gravitylines")
+                {
+                    for (size_t edi = 0; edi < obj.entities.size(); edi++)
+                    {
+                        if (obj.entities[edi].type == 9 || obj.entities[edi].type == 10)
+                        {
+                            obj.disableentity(edi);
+                        }
                     }
-                }else if(words[1]=="warptokens"){
-                    for(size_t edi=0; edi<obj.entities.size(); edi++){
-                        if(obj.entities[edi].type==11) obj.disableentity(edi);
+                }
+                else if (words[1] == "warptokens")
+                {
+                    for (size_t edi = 0; edi < obj.entities.size(); edi++) {
+                        if (obj.entities[edi].type == 11)
+                        {
+                            obj.disableentity(edi);
+                        }
                     }
-                }else if(words[1]=="platforms"||words[1]=="moving"){
-                    bool fixed=words[1]=="moving";
-                    for(size_t edi=0; edi<obj.entities.size(); edi++){
-                        if(fixed) obj.disableblockat(obj.entities[edi].xp, obj.entities[edi].yp);
-                        if(obj.entities[edi].rule==2 && obj.entities[edi].animate==100) obj.disableentity(edi);
+                }
+                else if (words[1] == "platforms" || words[1] == "moving")
+                {
+                    for (size_t edi = 0; edi < obj.entities.size(); edi++)
+                    {
+                        if (obj.entities[edi].rule == 2 && obj.entities[edi].animate == 100)
+                        {
+                            if (words[1] == "moving")
+                            {
+                                obj.disableblockat(obj.entities[edi].xp, obj.entities[edi].yp);
+                            }
+                            obj.disableentity(edi);
+                        }
                     }
-                }else if(words[1]=="disappear"){
-                    for(size_t edi=0; edi<obj.entities.size(); edi++){
+                }
+                else if (words[1] == "disappear")
+                {
+                    for (size_t edi = 0; edi < obj.entities.size(); edi++)
+                    {
                         obj.disableblockat(obj.entities[edi].xp, obj.entities[edi].yp);
-                        if(obj.entities[edi].type==2 && obj.entities[edi].rule==3) obj.disableentity(edi);
+                        if (obj.entities[edi].type == 2 && obj.entities[edi].rule == 3)
+                        {
+                            obj.disableentity(edi);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Changes:

This commit fixes an obscure bug with `destroy(moving)` and `destroy(disappear)` where, when looping through entities, the code doesn't actually check what the entity is before trying to destroy the block underneath it.

To fix this, we just put the block-destroying code *inside* of the check, instead of being outside of it.

I also fixed the code style because it was horrible.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
