### PR TITLE
Fix blurry images when starting the game filtered

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3422,6 +3422,9 @@ bool Graphics::reloadresources(void)
     grphx.destroy();
     grphx.init();
 
+    gameScreen.isFiltered = !gameScreen.isFiltered;
+    gameScreen.toggleLinearFilter();
+
     MAYBE_FAIL(checktexturesize("tiles.png", grphx.im_tiles, 8, 8));
     MAYBE_FAIL(checktexturesize("tiles2.png", grphx.im_tiles2, 8, 8));
     MAYBE_FAIL(checktexturesize("tiles3.png", grphx.im_tiles3, 8, 8));

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -262,6 +262,8 @@ static void LoadSprites(const char* filename, SDL_Texture** texture, SDL_Surface
 
 void GraphicsResources::init(void)
 {
+    SDL_SetHintWithPriority(SDL_HINT_RENDER_SCALE_QUALITY, "nearest", SDL_HINT_OVERRIDE);
+
     LoadVariants("graphics/tiles.png", &im_tiles, &im_tiles_white, &im_tiles_tint);
     LoadVariants("graphics/tiles2.png", &im_tiles2, NULL, &im_tiles2_tint);
     LoadVariants("graphics/entcolours.png", &im_entcolours, NULL, &im_entcolours_tint);

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -39,11 +39,8 @@ void Screen::init(const struct ScreenSettings* settings)
     badSignalEffect = settings->badSignal;
     vsync = settings->useVsync;
 
-    SDL_SetHintWithPriority(
-        SDL_HINT_RENDER_SCALE_QUALITY,
-        isFiltered ? "linear" : "nearest",
-        SDL_HINT_OVERRIDE
-    );
+    SDL_SetHintWithPriority(SDL_HINT_RENDER_SCALE_QUALITY, "nearest", SDL_HINT_OVERRIDE);
+
     SDL_SetHintWithPriority(
         SDL_HINT_RENDER_VSYNC,
         vsync ? "1" : "0",


### PR DESCRIPTION
## Changes:

If the game started in linear mode, the graphics would be created with linear filtering on. This means, when you switch off of linear filtering, all of the assets are still blurry.

This commit makes sure that the assets are loaded as nearest, then it toggles linear on only after.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
