### PR TITLE
Fix gravity line edgeguides

### DIFF
--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -762,17 +762,17 @@ static void draw_edgeguides(void)
         }
         if (entity->rx == POS_MOD(ed.levx - 1, cl.mapwidth)
             // It's to the left...
-            && x + w >= 312)
+            && x + w >= SCREEN_WIDTH_PIXELS - 8)
         {
             // And touching the right edge!
-            graphics.fill_rect(x, entity->y * 8, 2, 8, green);
+            graphics.fill_rect(0, entity->y * 8, 2, 8, green);
         }
         else if (entity->rx == POS_MOD(ed.levx + 1, cl.mapwidth)
             // It's to the right...
             && x <= 0)
         {
             // And touching the left edge!
-            graphics.fill_rect(x + w - 2, entity->y * 8, 2, 8, green);
+            graphics.fill_rect(SCREEN_WIDTH_PIXELS - 2, entity->y * 8, 2, 8, green);
         }
     }
 }


### PR DESCRIPTION
## Changes:

For some reason, their horizontal draw position depended on where the gravity line started (from the left).
Now they're always on the side of the screen.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
