### PR TITLE
Translate hardest room at display time instead of at time of death

### DIFF
--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -505,8 +505,11 @@ public:
 
     //Some stats:
     int totalflips;
-    std::string hardestroom; // don't change to C string unless you wanna handle language switches (or make it store coords)
+    std::string hardestroom; // don't change to C string unless you wanna handle when this string is loaded from the XML
     int hardestroomdeaths, currentroomdeaths;
+    int hardestroom_x, hardestroom_y;
+    bool hardestroom_specialname;
+    bool hardestroom_finalstretch;
 
 
     bool quickrestartkludge;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3153,8 +3153,12 @@ void scriptclass::hardreset(void)
     game.translator_cutscene_test = false;
 
     game.totalflips = 0;
-    game.hardestroom = loc::gettext_roomname(false, 13, 5, "Welcome Aboard", false);
+    game.hardestroom = "Welcome Aboard";
     game.hardestroomdeaths = 0;
+    game.hardestroom_x = 13;
+    game.hardestroom_y = 5;
+    game.hardestroom_specialname = false;
+    game.hardestroom_finalstretch = false;
     game.currentroomdeaths=0;
 
     game.swnmode = false;


### PR DESCRIPTION
## Changes:

The hardest room used to be stored as a room name in whatever language it was in when you last died enough times to break the record (before localization, that was always English). Even after localization became a thing we could get away with this since we only had a single font, but now we might have actual question marks appearing when the new font doesn't support characters from the old language.

Therefore, this commit adds more info about the hardest room to save files - everything that is needed to know in order to do the translation at display time. These are hardestroom_x and hardestroom_y for the room coordinates, as well as hardestroom_specialname to mark special names, in addition to changing the stored room name back to English. I've also added hardestroom_finalstretch in case we later decide to drop the English name as a key and rely on just the coordinates (even though I think that change itself would be more complicated than any simplification it would accomplish, and I don't think it's necessary, but better to have it if we do need it later)



## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
