### PR TITLE
Translate summary at display time instead of at time of saving, and improve summary system

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -225,8 +225,6 @@ void Game::init(void)
 
     SDL_memset(crewstats, false, sizeof(crewstats));
     SDL_memset(ndmresultcrewstats, false, sizeof(ndmresultcrewstats));
-    SDL_memset(tele_crewstats, false, sizeof(tele_crewstats));
-    SDL_memset(quick_crewstats, false, sizeof(quick_crewstats));
     SDL_memset(besttimes, -1, sizeof(besttimes));
     SDL_memset(bestframes, -1, sizeof(bestframes));
     SDL_memset(besttrinkets, -1, sizeof(besttrinkets));
@@ -235,13 +233,6 @@ void Game::init(void)
 
     crewstats[0] = true;
     lastsaved = 0;
-
-    tele_gametime = "00:00";
-    tele_trinkets = 0;
-    tele_currentarea = "Error! Error!";
-    quick_gametime = "00:00";
-    quick_trinkets = 0;
-    quick_currentarea = "Error! Error!";
 
     //Menu stuff initiliased here:
     SDL_memset(unlock, false, sizeof(unlock));
@@ -5623,29 +5614,11 @@ void Game::loadsummary(void)
     if (FILESYSTEM_loadTiXml2Document("saves/tsave.vvv", doc))
     {
         loadthissummary("tsave.vvv", &last_telesave, doc);
-
-        tele_gametime = giventimestring(
-            last_telesave.hours,
-            last_telesave.minutes,
-            last_telesave.seconds
-        );
-        tele_currentarea = map.currentarea(last_telesave.saverx, last_telesave.savery);
-        SDL_memcpy(tele_crewstats, last_telesave.crewstats, sizeof(tele_crewstats));
-        tele_trinkets = last_telesave.trinkets;
     }
 
     if (FILESYSTEM_loadTiXml2Document("saves/qsave.vvv", doc))
     {
         loadthissummary("qsave.vvv", &last_quicksave, doc);
-
-        quick_gametime = giventimestring(
-            last_quicksave.hours,
-            last_quicksave.minutes,
-            last_quicksave.seconds
-        );
-        quick_currentarea = map.currentarea(last_quicksave.saverx, last_quicksave.savery);
-        SDL_memcpy(quick_crewstats, last_quicksave.crewstats, sizeof(quick_crewstats));
-        quick_trinkets = last_quicksave.trinkets;
     }
 }
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5683,9 +5683,7 @@ void Game::loadsummary(void)
             summary.seconds
         );
         map.finalmode = summary.finalmode;
-        tele_currentarea = map.currentarea(
-            map.area(summary.savex, summary.savey)
-        );
+        tele_currentarea = map.currentarea(summary.savex, summary.savey);
         SDL_memcpy(tele_crewstats, summary.crewstats, sizeof(tele_crewstats));
         tele_trinkets = summary.trinkets;
     }
@@ -5708,9 +5706,7 @@ void Game::loadsummary(void)
             summary.seconds
         );
         map.finalmode = summary.finalmode;
-        quick_currentarea = map.currentarea(
-            map.area(summary.savex, summary.savey)
-        );
+        quick_currentarea = map.currentarea(summary.savex, summary.savey);
         SDL_memcpy(quick_crewstats, summary.crewstats, sizeof(quick_crewstats));
         quick_trinkets = summary.trinkets;
     }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6058,8 +6058,6 @@ bool Game::customsavequick(const std::string& savfile)
     std::string summary = savearea + ", " + timestring();
     xml::update_tag(msgs, "summary", summary.c_str());
 
-    customquicksummary = summary;
-
     if(!FILESYSTEM_saveTiXml2Document(("saves/"+levelfile+".vvv").c_str(), doc))
     {
         vlog_error("Could Not Save game!");

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5629,11 +5629,11 @@ static void loadthissummary(
         }
         else if (SDL_strcmp(pKey, "saverx") == 0)
         {
-            summary->savex = help.Int(pText);
+            summary->saverx = help.Int(pText);
         }
         else if (SDL_strcmp(pKey, "savery") == 0)
         {
-            summary->savey = help.Int(pText);
+            summary->savery = help.Int(pText);
         }
         else if (SDL_strcmp(pKey, "trinkets") == 0)
         {
@@ -5670,7 +5670,7 @@ void Game::loadsummary(void)
             summary.seconds
         );
         map.finalmode = summary.finalmode;
-        tele_currentarea = map.currentarea(summary.savex, summary.savey);
+        tele_currentarea = map.currentarea(summary.saverx, summary.savery);
         SDL_memcpy(tele_crewstats, summary.crewstats, sizeof(tele_crewstats));
         tele_trinkets = summary.trinkets;
     }
@@ -5693,7 +5693,7 @@ void Game::loadsummary(void)
             summary.seconds
         );
         map.finalmode = summary.finalmode;
-        quick_currentarea = map.currentarea(summary.savex, summary.savey);
+        quick_currentarea = map.currentarea(summary.saverx, summary.savery);
         SDL_memcpy(quick_crewstats, summary.crewstats, sizeof(quick_crewstats));
         quick_trinkets = summary.trinkets;
     }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5605,16 +5605,10 @@ static void loadthissummary(
             pText = "";
         }
 
-        if (pText == NULL)
-        {
-            pText = "";
-        }
-
         if (SDL_strcmp(pKey, "summary") == 0)
         {
             summary->summary = pText;
         }
-
         else if (SDL_strcmp(pKey, "seconds") == 0)
         {
             summary->seconds = help.Int(pText);

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5575,22 +5575,9 @@ void Game::customloadquick(const std::string& savfile)
     }
 }
 
-struct Summary
-{
-    const char* summary;
-    int seconds;
-    int minutes;
-    int hours;
-    int savex;
-    int savey;
-    int trinkets;
-    bool finalmode;
-    bool crewstats[Game::numcrew];
-};
-
 static void loadthissummary(
     const char* filename,
-    struct Summary* summary,
+    struct Game::Summary* summary,
     tinyxml2::XMLDocument& doc
 ) {
     tinyxml2::XMLHandle hDoc(&doc);

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5639,10 +5639,6 @@ static void loadthissummary(
         {
             summary->trinkets = help.Int(pText);
         }
-        else if (SDL_strcmp(pKey, "finalmode") == 0)
-        {
-            map.finalmode = help.Int(pText);
-        }
 
         LOAD_ARRAY_RENAME(crewstats, summary->crewstats)
     }
@@ -5669,7 +5665,6 @@ void Game::loadsummary(void)
             summary.minutes,
             summary.seconds
         );
-        map.finalmode = summary.finalmode;
         tele_currentarea = map.currentarea(summary.saverx, summary.savery);
         SDL_memcpy(tele_crewstats, summary.crewstats, sizeof(tele_crewstats));
         tele_trinkets = summary.trinkets;
@@ -5692,7 +5687,6 @@ void Game::loadsummary(void)
             summary.minutes,
             summary.seconds
         );
-        map.finalmode = summary.finalmode;
         quick_currentarea = map.currentarea(summary.saverx, summary.savery);
         SDL_memcpy(quick_crewstats, summary.crewstats, sizeof(quick_crewstats));
         quick_trinkets = summary.trinkets;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -267,7 +267,6 @@ void Game::init(void)
     gamesaved = false;
     gamesavefailed = false;
     savetime = "00:00";
-    savearea = "nowhere";
     savetrinkets = 0;
 
     intimetrial = false;
@@ -5840,7 +5839,7 @@ struct Game::Summary Game::writemaingamesave(tinyxml2::XMLDocument& doc)
     xml::update_tag(msgs, "finalstretch", (int) map.finalstretch);
 
 
-    std::string legacy_summary = savearea + ", " + timestring();
+    std::string legacy_summary = std::string(map.currentarea(saverx, savery)) + ", " + timestring();
     xml::update_tag(msgs, "summary", legacy_summary.c_str());
 
 
@@ -6003,7 +6002,7 @@ bool Game::customsavequick(const std::string& savfile)
         }
     }
 
-    std::string legacy_summary = savearea + ", " + timestring();
+    std::string legacy_summary = customleveltitle + ", " + timestring();
     xml::update_tag(msgs, "summary", legacy_summary.c_str());
 
     if(!FILESYSTEM_saveTiXml2Document(("saves/"+levelfile+".vvv").c_str(), doc))

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -294,7 +294,7 @@ public:
 
     struct Summary
     {
-        const char* summary;
+        bool exists;
         int seconds;
         int minutes;
         int hours;
@@ -304,8 +304,11 @@ public:
         bool crewstats[numcrew];
     };
 
+    struct Summary last_telesave, last_quicksave;
+    bool save_exists(void);
+
     void readmaingamesave(const char* savename, tinyxml2::XMLDocument& doc);
-    std::string writemaingamesave(tinyxml2::XMLDocument& doc);
+    struct Summary writemaingamesave(tinyxml2::XMLDocument& doc);
 
     void initteleportermode(void);
 
@@ -503,9 +506,6 @@ public:
     int activity_r, activity_g, activity_b, activity_y;
     std::string activity_lastprompt;
     bool activity_gettext;
-
-    std::string telesummary, quicksummary;
-    bool save_exists(void);
 
     bool backgroundtext;
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -290,6 +290,21 @@ public:
 
     void loadsummary(void);
 
+    static const int numcrew = 6;
+
+    struct Summary
+    {
+        const char* summary;
+        int seconds;
+        int minutes;
+        int hours;
+        int savex;
+        int savey;
+        int trinkets;
+        bool finalmode;
+        bool crewstats[numcrew];
+    };
+
     void readmaingamesave(const char* savename, tinyxml2::XMLDocument& doc);
     std::string writemaingamesave(tinyxml2::XMLDocument& doc);
 
@@ -434,7 +449,6 @@ public:
 
     bool inintermission;
 
-    static const int numcrew = 6;
     bool crewstats[numcrew];
     bool ndmresultcrewstats[numcrew];
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -491,7 +491,7 @@ public:
     std::string activity_lastprompt;
     bool activity_gettext;
 
-    std::string telesummary, quicksummary, customquicksummary;
+    std::string telesummary, quicksummary;
     bool save_exists(void);
 
     bool backgroundtext;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -298,8 +298,8 @@ public:
         int seconds;
         int minutes;
         int hours;
-        int savex;
-        int savey;
+        int saverx;
+        int savery;
         int trinkets;
         bool finalmode;
         bool crewstats[numcrew];

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -457,10 +457,6 @@ public:
     int alarmdelay;
     bool blackout;
 
-    bool tele_crewstats[numcrew];
-
-    bool quick_crewstats[numcrew];
-
     static const int numunlock = 25;
     bool unlock[numunlock];
     bool unlocknotify[numunlock];
@@ -475,13 +471,6 @@ public:
     int besttrinkets[numtrials];
     int bestlives[numtrials];
     int bestrank[numtrials];
-
-    std::string tele_gametime;
-    int tele_trinkets;
-    std::string tele_currentarea;
-    std::string quick_gametime;
-    int quick_trinkets;
-    std::string quick_currentarea;
 
     int screenshake, flashlight;
     bool advancetext, pausescript;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -359,7 +359,6 @@ public:
     bool gamesaved;
     bool gamesavefailed;
     std::string savetime;
-    std::string savearea;
     int savetrinkets;
     bool startscript;
     std::string newscript;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -301,7 +301,6 @@ public:
         int saverx;
         int savery;
         int trinkets;
-        bool finalmode;
         bool crewstats[numcrew];
     };
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1762,13 +1762,13 @@ static void menuactionpress(void)
                 music.playef(Sound_VIRIDIAN);
                 startmode(Start_MAINGAME);
             }
-            else if (game.telesummary == "")
+            else if (!game.last_telesave.exists)
             {
                 //You at least have a quicksave, or you couldn't have gotten here
                 music.playef(Sound_VIRIDIAN);
                 startmode(Start_MAINGAME_QUICKSAVE);
             }
-            else if (game.quicksummary == "")
+            else if (!game.last_quicksave.exists)
             {
                 //You at least have a telesave, or you couldn't have gotten here
                 music.playef(Sound_VIRIDIAN);

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -3057,10 +3057,8 @@ static void mapmenuactionpress(const bool version2_2)
         music.playef(Sound_GAMESAVED);
 
         game.savetime = game.timestring();
-        game.savearea = map.currentarea(map.area(game.roomx, game.roomy));
+        game.savearea = map.currentarea(game.roomx, game.roomy);
         game.savetrinkets = game.trinkets();
-
-        if (game.roomx >= 102 && game.roomx <= 104 && game.roomy >= 110 && game.roomy <= 111) game.savearea = loc::gettext_roomname_special("The Ship");
 
         bool success;
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -3057,7 +3057,6 @@ static void mapmenuactionpress(const bool version2_2)
         music.playef(Sound_GAMESAVED);
 
         game.savetime = game.timestring();
-        game.savearea = map.currentarea(game.roomx, game.roomy);
         game.savetrinkets = game.trinkets();
 
         bool success;

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1242,51 +1242,54 @@ void mapclass::spawncompanion(void)
 
 const char* mapclass::currentarea(const int roomx, const int roomy)
 {
+    /* For translation, the returned value is passed to loc::gettext_roomname_special().
+     * Returned strings must therefore be found in roomnames_special.xml! */
+
     if (roomx >= 102 && roomx <= 104 && roomy >= 110 && roomy <= 111)
     {
-        return loc::gettext_roomname_special("The Ship");
+        return "The Ship";
     }
 
     switch (area(roomx, roomy))
     {
     case 0:
-        return loc::gettext_roomname_special("Dimension VVVVVV");
+        return "Dimension VVVVVV";
         break;
     case 1:
-        return loc::gettext_roomname_special("Dimension VVVVVV");
+        return "Dimension VVVVVV";
         break;
     case 2:
-        return loc::gettext_roomname_special("Laboratory");
+        return "Laboratory";
         break;
     case 3:
-        return loc::gettext_roomname_special("The Tower");
+        return "The Tower";
         break;
     case 4:
-        return loc::gettext_roomname_special("Warp Zone");
+        return "Warp Zone";
         break;
     case 5:
-        return loc::gettext_roomname_special("Space Station");
+        return "Space Station";
         break;
     case 6:
-        return loc::gettext_roomname_special("Outside Dimension VVVVVV");
+        return "Outside Dimension VVVVVV";
         break;
     case 7:
-        return loc::gettext_roomname_special("Outside Dimension VVVVVV");
+        return "Outside Dimension VVVVVV";
         break;
     case 8:
-        return loc::gettext_roomname_special("Outside Dimension VVVVVV");
+        return "Outside Dimension VVVVVV";
         break;
     case 9:
-        return loc::gettext_roomname_special("Outside Dimension VVVVVV");
+        return "Outside Dimension VVVVVV";
         break;
     case 10:
-        return loc::gettext_roomname_special("Outside Dimension VVVVVV");
+        return "Outside Dimension VVVVVV";
         break;
     case 11:
-        return loc::gettext_roomname_special("The Tower");
+        return "The Tower";
         break;
     }
-    return loc::gettext_roomname_special("???");
+    return "???";
 }
 
 static void copy_short_to_int(int* dest, const short* src, const size_t size)

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1240,9 +1240,14 @@ void mapclass::spawncompanion(void)
     }
 }
 
-const char* mapclass::currentarea(int t)
+const char* mapclass::currentarea(const int roomx, const int roomy)
 {
-    switch(t)
+    if (roomx >= 102 && roomx <= 104 && roomy >= 110 && roomy <= 111)
+    {
+        return loc::gettext_roomname_special("The Ship");
+    }
+
+    switch (area(roomx, roomy))
     {
     case 0:
         return loc::gettext_roomname_special("Dimension VVVVVV");

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -108,7 +108,7 @@ public:
 
     void spawncompanion(void);
 
-    const char* currentarea(int t);
+    const char* currentarea(int roomx, int roomy);
 
     void loadlevel(int rx, int ry);
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1266,7 +1266,7 @@ static void menurender(void)
             font::print(PR_2X | PR_CEN, -1, 20, title, tr, tg, tb);
             font::print(
                 PR_CEN, -1, 80-20,
-                map.currentarea(summary->saverx, summary->savery),
+                loc::gettext_roomname_special(map.currentarea(summary->saverx, summary->savery)),
                 25, 255 - (help.glow / 2), 255 - (help.glow / 2)
             );
             for (int i = 0; i < 6; i++)
@@ -2974,7 +2974,7 @@ void maprender(void)
                 buffer, sizeof(buffer),
                 loc::gettext("{area}, {time}"),
                 "area:str, time:str",
-                map.currentarea(last->saverx, last->savery),
+                loc::gettext_roomname_special(map.currentarea(last->saverx, last->savery)),
                 game.giventimestring(last->hours, last->minutes, last->seconds).c_str()
             );
 
@@ -2997,7 +2997,7 @@ void maprender(void)
             size_t i;
             font::print(
                 PR_CEN, -1, FLIP(80, 8),
-                map.currentarea(game.last_quicksave.saverx, game.last_quicksave.savery),
+                loc::gettext_roomname_special(map.currentarea(game.last_quicksave.saverx, game.last_quicksave.savery)),
                 25, 255 - help.glow/2, 255 - help.glow/2
             );
             for (i = 0; i < SDL_arraysize(game.crewstats); ++i)

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1243,58 +1243,58 @@ static void menurender(void)
         font::print_wrap(PR_CEN, -1, 75, loc::gettext("Are you sure you want to quit?"), tr, tg, tb);
         break;
     case Menu::continuemenu:
+    {
+        const char* title = NULL;
+        struct Game::Summary* summary = NULL;
+
         switch (game.currentmenuoption)
         {
         case 0:
-        {
-            //Show teleporter save info
-            graphics.drawpixeltextbox(17, 65-20, 286, 90, 65, 185, 207);
-
-            font::print(PR_2X | PR_CEN, -1, 20, loc::gettext("Tele Save"), tr, tg, tb);
-            font::print(PR_CEN, -1, 80-20, game.tele_currentarea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2));
-            for (int i = 0; i < 6; i++)
-            {
-                graphics.drawcrewman(169-(3*42)+(i*42), 95-20, i, game.tele_crewstats[i], true);
-            }
-            font::print(0, 59, 132-20, game.tele_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-            char buffer[SCREEN_WIDTH_CHARS + 1];
-            vformat_buf(buffer, sizeof(buffer),
-                loc::gettext("{savebox_n_trinkets|wordy}"),
-                "savebox_n_trinkets:int",
-                game.tele_trinkets
-            );
-            font::print(PR_RIGHT, 262, 132-20, buffer, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
-
-            graphics.draw_sprite(34, 126-20, 50, graphics.col_clock);
-            graphics.draw_sprite(270, 126-20, 22, graphics.col_trinket);
+            title = loc::gettext("Tele Save");
+            summary = &game.last_telesave;
             break;
-        }
         case 1:
+            title = loc::gettext("Quick Save");
+            summary = &game.last_quicksave;
+            break;
+        }
+
+        if (summary != NULL)
         {
-            //Show quick save info
             graphics.drawpixeltextbox(17, 65-20, 286, 90, 65, 185, 207);
 
-            font::print(PR_2X | PR_CEN, -1, 20, loc::gettext("Quick Save"), tr, tg, tb);
-            font::print(PR_CEN, -1, 80-20, game.quick_currentarea, 25, 255 - (help.glow / 2), 255 - (help.glow / 2));
+            font::print(PR_2X | PR_CEN, -1, 20, title, tr, tg, tb);
+            font::print(
+                PR_CEN, -1, 80-20,
+                map.currentarea(summary->saverx, summary->savery),
+                25, 255 - (help.glow / 2), 255 - (help.glow / 2)
+            );
             for (int i = 0; i < 6; i++)
             {
-                graphics.drawcrewman(169-(3*42)+(i*42), 95-20, i, game.quick_crewstats[i], true);
+                graphics.drawcrewman(169-(3*42)+(i*42), 95-20, i, summary->crewstats[i], true);
             }
-            font::print(0, 59, 132-20, game.quick_gametime, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
+            font::print(
+                0, 59, 132-20,
+                game.giventimestring(
+                    summary->hours,
+                    summary->minutes,
+                    summary->seconds
+                ),
+                255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2)
+            );
             char buffer[SCREEN_WIDTH_CHARS + 1];
             vformat_buf(buffer, sizeof(buffer),
                 loc::gettext("{savebox_n_trinkets|wordy}"),
                 "savebox_n_trinkets:int",
-                game.quick_trinkets
+                summary->trinkets
             );
             font::print(PR_RIGHT, 262, 132-20, buffer, 255 - (help.glow / 2), 255 - (help.glow / 2), 255 - (help.glow / 2));
 
             graphics.draw_sprite(34, 126-20, 50, graphics.col_clock);
             graphics.draw_sprite(270, 126-20, 22, graphics.col_trinket);
-            break;
-        }
         }
         break;
+    }
     case Menu::gameover:
     case Menu::gameover2:
     {

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2995,7 +2995,11 @@ void maprender(void)
         else
         {
             size_t i;
-            font::print(PR_CEN, -1, FLIP(80, 8), game.savearea, 25, 255 - help.glow/2, 255 - help.glow/2);
+            font::print(
+                PR_CEN, -1, FLIP(80, 8),
+                map.currentarea(game.last_quicksave.saverx, game.last_quicksave.savery),
+                25, 255 - help.glow/2, 255 - help.glow/2
+            );
             for (i = 0; i < SDL_arraysize(game.crewstats); ++i)
             {
                 /* Crewmates are annoying. Their height is 21 pixels, but to flip them,

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2962,13 +2962,23 @@ void maprender(void)
 
             font::print(PR_CEN, -1, 80, buffer, 255 - help.glow*2, 255 - help.glow*2, 255 - help.glow);
 
-            if (map.custommode || game.quicksummary == "")
+            if (map.custommode || !game.last_quicksave.exists)
             {
                 break;
             }
 
             font::print(PR_CEN, -1, FLIP(100, 8), loc::gettext("Last Save:"), 164 - help.glow/4, 164 - help.glow/4, 164);
-            font::print(PR_CEN, -1, FLIP(112, 8), game.quicksummary, 164 - help.glow/4, 164 - help.glow/4, 164);
+
+            struct Game::Summary* last = &game.last_quicksave;
+            vformat_buf(
+                buffer, sizeof(buffer),
+                loc::gettext("{area}, {time}"),
+                "area:str, time:str",
+                map.currentarea(last->saverx, last->savery),
+                game.giventimestring(last->hours, last->minutes, last->seconds).c_str()
+            );
+
+            font::print(PR_CEN, -1, FLIP(112, 8), buffer, 164 - help.glow/4, 164 - help.glow/4, 164);
             break;
         }
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3127,7 +3127,6 @@ void scriptclass::hardreset(void)
     game.gamesaved = false;
     game.gamesavefailed = false;
     game.savetime = "00:00";
-    game.savearea = "nowhere";
     game.savetrinkets = 0;
     if (!version2_2)
     {


### PR DESCRIPTION
## Changes:

`<summary>` in the save files is a string like "Space Station, 10:30:59" which is displayed in the SAVE tab in the map menu. This poses a problem if a save is made in one language and then that save is viewed in another language, since the new font may not display the old language properly.

This PR overhauls the entire save summary system in order to fix that bug, and fixes some quirks and improves the system in the process. The `<summary>` tag is now no longer read from, only still written to for older versions of the game.

That is only a summary of the changes (seriously), the commit messages go into much more detail.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
