### PR TITLE
Fix double return when pressing Esc in editor font menu

### DIFF
--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -3509,11 +3509,11 @@ void editorinput(void)
                 }
                 else
                 {
-                    game.returnmenu();
-                    map.nexttowercolour();
-
                     // Avoid double return
                     esc_from_font = game.currentmenuname == Menu::ed_font;
+
+                    game.returnmenu();
+                    map.nexttowercolour();
                 }
 
                 if (ed.state == EditorState_MENU && !esc_from_font)


### PR DESCRIPTION
## Changes:

The line that checked if the current menu is the font menu ended up below the code that returned a menu, so this was an easy fix.

Closes #1017.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
