### PR TITLE
Language updates - Sync new string from #1002 into languages added by #989, raise some false-alarm-causing string limits

### DIFF
--- a/desktop_version/lang/ca/strings.xml
+++ b/desktop_version/lang/ca/strings.xml
@@ -387,7 +387,7 @@
     <string english="DEATH:" translation="MORTS:" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="LLUE.:" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="PAR:" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="MILLOR RANG" explanation="ranks are B A S V" max="14"/>
+    <string english="BEST RANK" translation="MILLOR RANG" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="JA!" explanation="3, 2, 1, GO!" max="13"/>
     <string english="Go!" translation="Ja!" explanation="3, 2, 1, Go!" max="10"/>
     <string english="Congratulations!" translation="Enhorabona!" explanation="title" max="20"/>

--- a/desktop_version/lang/ca/strings_plural.xml
+++ b/desktop_version/lang/ca/strings_plural.xml
@@ -13,11 +13,11 @@
         <translation form="0" translation="I has trobat {n_trinkets|wordy} lluentons."/>
         <translation form="1" translation="I has trobat {n_trinkets|wordy} lluentó."/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
         <translation form="0" translation="{n_crew|wordy|upper} tripulants restants"/>
         <translation form="1" translation="{n_crew|wordy|upper} tripulant restant"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation="En resten {n_crew|wordy}"/>
         <translation form="1" translation="En resta {n_crew|wordy}"/>
     </string>

--- a/desktop_version/lang/cy/strings.xml
+++ b/desktop_version/lang/cy/strings.xml
@@ -387,7 +387,7 @@
     <string english="DEATH:" translation="MARWOLAETH:" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="TLYSAU:" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="AMSER PAR:" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="SAFLE GORAU" explanation="ranks are B A S V" max="14"/>
+    <string english="BEST RANK" translation="SAFLE GORAU" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="EWCH!" explanation="3, 2, 1, GO!" max="13"/>
     <string english="Go!" translation="Ewch!" explanation="3, 2, 1, Go!" max="10"/>
     <string english="Congratulations!" translation="Llongyfarchiadau!" explanation="title" max="20"/>

--- a/desktop_version/lang/cy/strings_plural.xml
+++ b/desktop_version/lang/cy/strings_plural.xml
@@ -13,11 +13,11 @@
         <translation form="0" translation="A daethoch o hyd i {n_trinkets|wordy} tlysau."/>
         <translation form="1" translation="A daethoch o hyd i {n_trinkets|wordy} tlws."/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
         <translation form="0" translation="{n_crew|wordy} o&apos;r criw sy&apos;n weddill."/>
         <translation form="1" translation="{n_crew|wordy} o&apos;r criw sy&apos;n weddill."/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation="{n_crew|wordy} sy&apos;n weddill"/>
         <translation form="1" translation="{n_crew|wordy} sy&apos;n weddill"/>
     </string>

--- a/desktop_version/lang/de/strings.xml
+++ b/desktop_version/lang/de/strings.xml
@@ -387,7 +387,7 @@
     <string english="DEATH:" translation="TODE:" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="DINGSDAS:" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="ZIELZEIT:" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="BESTER RANG" explanation="ranks are B A S V" max="14"/>
+    <string english="BEST RANK" translation="BESTER RANG" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="LOS!" explanation="3, 2, 1, GO!" max="13"/>
     <string english="Go!" translation="Los!" explanation="3, 2, 1, Go!" max="10"/>
     <string english="Congratulations!" translation="Gratulation!" explanation="title" max="20"/>

--- a/desktop_version/lang/de/strings_plural.xml
+++ b/desktop_version/lang/de/strings_plural.xml
@@ -13,11 +13,11 @@
         <translation form="0" translation="Und du hast {n_trinkets|wordy} Dingsdas gefunden."/>
         <translation form="1" translation="Und du hast {n_trinkets|wordy} Dingsda gefunden."/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
         <translation form="0" translation="{n_crew|wordy} Crewmitglieder übrig"/>
         <translation form="1" translation="{n_crew|wordy} Crewmitglied übrig"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation="{n_crew|wordy} übrig"/>
         <translation form="1" translation="{n_crew|wordy} übrig"/>
     </string>

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -387,7 +387,7 @@
     <string english="DEATH:" translation="" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="" explanation="ranks are B A S V" max="14"/>
+    <string english="BEST RANK" translation="" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="" explanation="3, 2, 1, GO!" max="13"/>
     <string english="Go!" translation="" explanation="3, 2, 1, Go!" max="10"/>
     <string english="Congratulations!" translation="" explanation="title" max="20"/>

--- a/desktop_version/lang/en/strings_plural.xml
+++ b/desktop_version/lang/en/strings_plural.xml
@@ -13,11 +13,11 @@
         <translation form="0" translation=""/>
         <translation form="1" translation=""/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
         <translation form="0" translation=""/>
         <translation form="1" translation=""/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation=""/>
         <translation form="1" translation=""/>
     </string>

--- a/desktop_version/lang/eo/strings.xml
+++ b/desktop_version/lang/eo/strings.xml
@@ -387,7 +387,7 @@
     <string english="DEATH:" translation="MORTO: " explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="BRILO: " explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="CELTEMPO:" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="PLEJA RANGO" explanation="ranks are B A S V" max="14"/>
+    <string english="BEST RANK" translation="PLEJA RANGO" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="EK!" explanation="3, 2, 1, GO!" max="13"/>
     <string english="Go!" translation="Ek!" explanation="3, 2, 1, Go!" max="10"/>
     <string english="Congratulations!" translation="Gratulon!" explanation="title" max="20"/>

--- a/desktop_version/lang/eo/strings_plural.xml
+++ b/desktop_version/lang/eo/strings_plural.xml
@@ -13,11 +13,11 @@
         <translation form="0" translation="Kaj vi trovis {n_trinkets|wordy} kolektaĵojn."/>
         <translation form="1" translation="Kaj vi trovis {n_trinkets|wordy} kolektaĵon."/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
         <translation form="0" translation="{n_crew|wordy|upper} skipanoj restas"/>
         <translation form="1" translation="{n_crew|wordy|upper} skipano restas"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation="{n_crew|wordy|upper} restas"/>
         <translation form="1" translation="{n_crew|wordy|upper} restas"/>
     </string>

--- a/desktop_version/lang/es/strings.xml
+++ b/desktop_version/lang/es/strings.xml
@@ -387,7 +387,7 @@
     <string english="DEATH:" translation="MUERTES:" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="BRILL.:" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="TIEMPO IDEAL:" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="MEJOR RANGO" explanation="ranks are B A S V" max="14"/>
+    <string english="BEST RANK" translation="MEJOR RANGO" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="¡YA!" explanation="3, 2, 1, GO!" max="13"/>
     <string english="Go!" translation="¡Ya!" explanation="3, 2, 1, Go!" max="10"/>
     <string english="Congratulations!" translation="¡Enhorabuena!" explanation="title" max="20"/>

--- a/desktop_version/lang/es/strings_plural.xml
+++ b/desktop_version/lang/es/strings_plural.xml
@@ -13,11 +13,11 @@
         <translation form="0" translation="Y has encontrado {n_trinkets|wordy} baratijas."/>
         <translation form="1" translation="Y has encontrado una baratija."/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
         <translation form="0" translation="Quedan {n_crew|wordy} tripulantes"/>
         <translation form="1" translation="Queda un tripulante"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation="Quedan {n_crew|wordy}"/>
         <translation form="1" translation="Queda uno"/>
     </string>

--- a/desktop_version/lang/fr/strings.xml
+++ b/desktop_version/lang/fr/strings.xml
@@ -387,7 +387,7 @@
     <string english="DEATH:" translation="MORTS :" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="BLINGS :" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="RÉFÉRENCE :" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="MEILLEUR RANG" explanation="ranks are B A S V" max="14"/>
+    <string english="BEST RANK" translation="MEILLEUR RANG" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="GO !" explanation="3, 2, 1, GO!" max="13"/>
     <string english="Go!" translation="Go !" explanation="3, 2, 1, Go!" max="10"/>
     <string english="Congratulations!" translation="Félicitations !" explanation="title" max="20"/>

--- a/desktop_version/lang/fr/strings_plural.xml
+++ b/desktop_version/lang/fr/strings_plural.xml
@@ -13,11 +13,11 @@
         <translation form="0" translation="Et vous avez trouvé {n_trinkets|wordy} bidules."/>
         <translation form="1" translation="Et vous avez trouvé {n_trinkets|wordy} bidule."/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
         <translation form="0" translation="{n_crew|wordy|upper} compagnons restants"/>
         <translation form="1" translation="{n_crew|wordy|upper} compagnon restant"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation="Il en reste {n_crew|wordy}"/>
         <translation form="1" translation="Il en reste {n_crew|wordy}"/>
     </string>

--- a/desktop_version/lang/ga/strings.xml
+++ b/desktop_version/lang/ga/strings.xml
@@ -389,7 +389,7 @@ Déan cóip chúltaca, ar eagla na heagla." explanation="translation maintenance
     <string english="DEATH:" translation="BÁSANNA:" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="ORNÁIDÍ" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="FAD SPRICE:" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="CÉIM IS FEARR" explanation="ranks are B A S V" max="14"/>
+    <string english="BEST RANK" translation="CÉIM IS FEARR" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="AR AGHAIDH!" explanation="3, 2, 1, GO!" max="13"/>
     <string english="Go!" translation="Ar aghaidh" explanation="3, 2, 1, Go!" max="10"/>
     <string english="Congratulations!" translation="Comhghairdeas!" explanation="title" max="20"/>

--- a/desktop_version/lang/ga/strings_plural.xml
+++ b/desktop_version/lang/ga/strings_plural.xml
@@ -25,7 +25,7 @@
         <translation form="4" translation="Agus fuair tú {n_trinkets|wordy} ornáid."/>
         <translation form="5" translation="Agus fuair tú {n_trinkets|wordy} ornáid."/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
         <translation form="0" translation="Níl aon duine fós le tarrtháil"/>
         <translation form="1" translation="Tá duine amháin fós le tarrtháil"/>
         <translation form="2" translation="Tá {n_crew|wordy} dhuine fós le tarrtháil"/>
@@ -33,7 +33,7 @@
         <translation form="4" translation="Tá {n_crew|wordy} dhuine fós le tarrtháil"/>
         <translation form="5" translation="Tá {n_crew|wordy} duine fós le tarrtháil"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation="Níl aon duine fós le tarrtháil."/>
         <translation form="1" translation="Tá duine fós le tarrtháil."/>
         <translation form="2" translation="Tá {n_crew|wordy} dhuine fós le tarrtháil."/>

--- a/desktop_version/lang/it/strings.xml
+++ b/desktop_version/lang/it/strings.xml
@@ -387,7 +387,7 @@
     <string english="DEATH:" translation="MORTI:" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="GINGILLI:" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="TEMPO PAR:" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="RANGO MIGLIORE" explanation="ranks are B A S V" max="14"/>
+    <string english="BEST RANK" translation="RANGO MIGLIORE" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="VIA!" explanation="3, 2, 1, GO!" max="13"/>
     <string english="Go!" translation="Via!" explanation="3, 2, 1, Go!" max="10"/>
     <string english="Congratulations!" translation="Congratulazioni!" explanation="title" max="20"/>

--- a/desktop_version/lang/it/strings_plural.xml
+++ b/desktop_version/lang/it/strings_plural.xml
@@ -13,11 +13,11 @@
         <translation form="0" translation="E hai trovato {n_trinkets|wordy} gingilli."/>
         <translation form="1" translation="E hai trovato {n_trinkets|wordy} gingillo."/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
         <translation form="0" translation="Restano {n_crew|wordy} compagni"/>
         <translation form="1" translation="Resta {n_crew|wordy} compagno"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation="Ne restano {n_crew|wordy}"/>
         <translation form="1" translation="Ne resta {n_crew|wordy}"/>
     </string>

--- a/desktop_version/lang/ja/strings.xml
+++ b/desktop_version/lang/ja/strings.xml
@@ -53,7 +53,8 @@
     <string english="Change controller options." translation="コントローラーの設定を変更する。" explanation="" max="38*2" max_local="38*1"/>
     <string english="language" translation="言語" explanation="menu option"/>
     <string english="Language" translation="言語" explanation="title" max="20" max_local="20"/>
-    <string english="Change the language." translation="ゲーム内で表示される言語を変更する。" explanation="" max="38*5" max_local="38*4"/>
+    <string english="Change the language." translation="ゲーム内で表示される言語を変更する。" explanation="" max="38*2" max_local="38*1"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3" max_local="38*2"/>
     <string english="clear main game data" translation="ストーリーの進捗を削除" explanation="menu option"/>
     <string english="clear custom level data" translation="カスタムステージの進捗を削除" explanation="menu option"/>
     <string english="Clear Data" translation="データ削除" explanation="title" max="20" max_local="20"/>

--- a/desktop_version/lang/ja/strings.xml
+++ b/desktop_version/lang/ja/strings.xml
@@ -411,7 +411,7 @@ Sランク以上を獲得" explanation="ranks are B A S V, see below" max="38*3"
     <string english="DEATH:" translation="ミス:" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="トリンケット:" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="目標タイム:" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="ランク" explanation="ranks are B A S V" max="14" max_local="14"/>
+    <string english="BEST RANK" translation="ランク" explanation="ranks are B A S V" max="17" max_local="17"/>
     <string english="GO!" translation="GO!" explanation="3, 2, 1, GO!" max="13" max_local="13"/>
     <string english="Go!" translation="GO!" explanation="3, 2, 1, Go!" max="10" max_local="10"/>
     <string english="Congratulations!" translation="おめでとう!" explanation="title" max="20" max_local="20"/>

--- a/desktop_version/lang/ja/strings_plural.xml
+++ b/desktop_version/lang/ja/strings_plural.xml
@@ -10,10 +10,10 @@
     <string english_plural="And you found {n_trinkets|wordy} trinkets." english_singular="And you found {n_trinkets|wordy} trinket." explanation="You rescued all the crewmates! And you found XX trinket(s)." max="38*3" var="n_trinkets" expect="20" max_local="38*2">
         <translation form="0" translation="トリンケットを{n_trinkets|wordy}個集めた!"/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100" max_local="40">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100" max_local="38*1">
         <translation form="0" translation="クルー 残り{n_crew|wordy}名"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100" max_local="32">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100" max_local="32*1">
         <translation form="0" translation="残り{n_crew|wordy}名"/>
     </string>
     <string english_plural="Hardest Room (with {n_deaths} deaths)" english_singular="Hardest Room (with {n_deaths} death)" explanation="game complete screen" max="40" var="n_deaths" expect="1000" max_local="40">

--- a/desktop_version/lang/ko/strings.xml
+++ b/desktop_version/lang/ko/strings.xml
@@ -387,7 +387,7 @@
     <string english="DEATH:" translation="사망:" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="장신구:" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="완료 시간:" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="최고 랭크" explanation="ranks are B A S V" max="14" max_local="11"/>
+    <string english="BEST RANK" translation="최고 랭크" explanation="ranks are B A S V" max="17" max_local="13"/>
     <string english="GO!" translation="GO!" explanation="3, 2, 1, GO!" max="13" max_local="10"/>
     <string english="Go!" translation="GO!" explanation="3, 2, 1, Go!" max="10" max_local="8"/>
     <string english="Congratulations!" translation="축하합니다!" explanation="title" max="20" max_local="16"/>

--- a/desktop_version/lang/ko/strings.xml
+++ b/desktop_version/lang/ko/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="컨트롤러 설정을 변경합니다." explanation="" max="38*2" max_local="30*2"/>
     <string english="language" translation="언어" explanation="menu option"/>
     <string english="Language" translation="언어" explanation="title" max="20" max_local="16"/>
-    <string english="Change the language." translation="언어를 변경합니다." explanation="" max="38*5" max_local="30*5"/>
+    <string english="Change the language." translation="언어를 변경합니다." explanation="" max="38*2" max_local="30*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3" max_local="30*3"/>
     <string english="clear main game data" translation="주 게임 데이터 제거" explanation="menu option"/>
     <string english="clear custom level data" translation="커스텀 레벨 데이터 제거" explanation="menu option"/>
     <string english="Clear Data" translation="데이터 제거" explanation="title" max="20" max_local="16"/>

--- a/desktop_version/lang/ko/strings_plural.xml
+++ b/desktop_version/lang/ko/strings_plural.xml
@@ -10,10 +10,10 @@
     <string english_plural="And you found {n_trinkets|wordy} trinkets." english_singular="And you found {n_trinkets|wordy} trinket." explanation="You rescued all the crewmates! And you found XX trinket(s)." max="38*3" var="n_trinkets" expect="20" max_local="30*3">
         <translation form="0" translation="그리고 {n_trinkets|wordy}개의 장신구를 찾았습니다."/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100" max_local="32">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100" max_local="30*2">
         <translation form="0" translation="선원 {n_crew|wordy}명 남음"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100" max_local="25">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100" max_local="25*2">
         <translation form="0" translation="{n_crew|wordy}명 남음"/>
     </string>
     <string english_plural="Hardest Room (with {n_deaths} deaths)" english_singular="Hardest Room (with {n_deaths} death)" explanation="game complete screen" max="40" var="n_deaths" expect="1000" max_local="32">

--- a/desktop_version/lang/nl/strings.xml
+++ b/desktop_version/lang/nl/strings.xml
@@ -387,7 +387,7 @@
     <string english="DEATH:" translation="DOOD:" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="ARTE:" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="PAR-TIJD:" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="BESTE SCORE" explanation="ranks are B A S V" max="14"/>
+    <string english="BEST RANK" translation="BESTE SCORE" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="GO!" explanation="3, 2, 1, GO!" max="13"/>
     <string english="Go!" translation="Go!" explanation="3, 2, 1, Go!" max="10"/>
     <string english="Congratulations!" translation="Gefeliciteerd!" explanation="title" max="20"/>

--- a/desktop_version/lang/nl/strings_plural.xml
+++ b/desktop_version/lang/nl/strings_plural.xml
@@ -13,11 +13,11 @@
         <translation form="0" translation="En je hebt {n_trinkets|wordy} artefacten gevonden."/>
         <translation form="1" translation="En je hebt {n_trinkets|wordy} artefact gevonden."/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
         <translation form="0" translation="{n_crew|wordy|upper} bemanningsleden te gaan"/>
         <translation form="1" translation="{n_crew|wordy|upper} bemanningslid te gaan"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation="Nog {n_crew|wordy} te gaan"/>
         <translation form="1" translation="Nog {n_crew|wordy} te gaan"/>
     </string>

--- a/desktop_version/lang/pl/strings.xml
+++ b/desktop_version/lang/pl/strings.xml
@@ -387,7 +387,7 @@
     <string english="DEATH:" translation="WYPADKI:" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="DROBIAZG:" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="CZAS DOCELOWY:" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="NAJLEPSZY STOPIEŃ" explanation="ranks are B A S V" max="14"/>
+    <string english="BEST RANK" translation="NAJLEPSZY STOPIEŃ" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="START!" explanation="3, 2, 1, GO!" max="13"/>
     <string english="Go!" translation="Start!" explanation="3, 2, 1, Go!" max="10"/>
     <string english="Congratulations!" translation="Gratulacje!" explanation="title" max="20"/>

--- a/desktop_version/lang/pl/strings.xml
+++ b/desktop_version/lang/pl/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="Zmień opcje kontrolera." explanation="" max="38*2"/>
     <string english="language" translation="język" explanation="menu option"/>
     <string english="Language" translation="Język" explanation="title" max="20"/>
-    <string english="Change the language." translation="Zmień język gry." explanation="" max="38*5"/>
+    <string english="Change the language." translation="Zmień język gry." explanation="" max="38*2"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3"/>
     <string english="clear main game data" translation="wyczyść dane główne" explanation="menu option"/>
     <string english="clear custom level data" translation="wyczyść dane dodatkowe" explanation="menu option"/>
     <string english="Clear Data" translation="Wyczyść Dane" explanation="title" max="20"/>

--- a/desktop_version/lang/pl/strings_plural.xml
+++ b/desktop_version/lang/pl/strings_plural.xml
@@ -25,7 +25,7 @@
         <translation form="4" translation="Odnaleziono {n_trinkets|wordy} drobiazgi."/>
         <translation form="5" translation="Odnaleziono {n_trinkets|wordy} drobiazgi."/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
         <translation form="0" translation="Pozostało {n_crew}"/>
         <translation form="1" translation="Pozostał jeden"/>
         <translation form="2" translation="Pozostało dwóch"/>
@@ -33,7 +33,7 @@
         <translation form="4" translation="Pozostało czterech"/>
         <translation form="5" translation="Pozostało {n_crew}"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation="Pozostało {n_crew}"/>
         <translation form="1" translation="Pozostał jeden"/>
         <translation form="2" translation="Pozostało dwóch"/>

--- a/desktop_version/lang/pt_BR/strings.xml
+++ b/desktop_version/lang/pt_BR/strings.xml
@@ -387,7 +387,7 @@
     <string english="DEATH:" translation="MORTE:" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="TRECOS:" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="TEMPO PARCIAL:" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="MELHOR RANK" explanation="ranks are B A S V" max="14"/>
+    <string english="BEST RANK" translation="MELHOR RANK" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="VÁ!" explanation="3, 2, 1, GO!" max="13"/>
     <string english="Go!" translation="VÁ!" explanation="3, 2, 1, Go!" max="10"/>
     <string english="Congratulations!" translation="Parabéns!" explanation="title" max="20"/>

--- a/desktop_version/lang/pt_BR/strings_plural.xml
+++ b/desktop_version/lang/pt_BR/strings_plural.xml
@@ -13,11 +13,11 @@
         <translation form="0" translation="E você encontrou {n_trinkets|wordy} trecos."/>
         <translation form="1" translation="E você encontrou {n_trinkets|wordy} treco."/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
         <translation form="0" translation="Faltam {n_crew|wordy} membros"/>
         <translation form="1" translation="Falta {n_crew|wordy} membro"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation="Faltam {n_crew|wordy}"/>
         <translation form="1" translation="Falta {n_crew|wordy}"/>
     </string>

--- a/desktop_version/lang/pt_PT/strings.xml
+++ b/desktop_version/lang/pt_PT/strings.xml
@@ -387,7 +387,7 @@
     <string english="DEATH:" translation="MORTES:" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="FICHAS:" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="TEMPO LIMITE:" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="MELHOR NOTA" explanation="ranks are B A S V" max="14"/>
+    <string english="BEST RANK" translation="MELHOR NOTA" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="COMEÇA!" explanation="3, 2, 1, GO!" max="13"/>
     <string english="Go!" translation="Começa!" explanation="3, 2, 1, Go!" max="10"/>
     <string english="Congratulations!" translation="Parabéns!" explanation="title" max="20"/>

--- a/desktop_version/lang/pt_PT/strings_plural.xml
+++ b/desktop_version/lang/pt_PT/strings_plural.xml
@@ -13,11 +13,11 @@
         <translation form="0" translation="E encontraste {n_trinkets|wordy} fichas."/>
         <translation form="1" translation="E encontraste {n_trinkets|wordy} ficha."/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
         <translation form="0" translation="Faltam {n_crew|wordy} tripulantes"/>
         <translation form="1" translation="Falta {n_crew|wordy} tripulante"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation="Faltam {n_crew|wordy}"/>
         <translation form="1" translation="Falta {n_crew|wordy}"/>
     </string>

--- a/desktop_version/lang/ru/strings.xml
+++ b/desktop_version/lang/ru/strings.xml
@@ -387,7 +387,7 @@
     <string english="DEATH:" translation="СМЕРТИ:" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="ШТУЧКИ:" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="МАКС:" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="ЛУЧШИЙ РАНГ" explanation="ranks are B A S V" max="14"/>
+    <string english="BEST RANK" translation="ЛУЧШИЙ РАНГ" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="ВПЕРЁД!" explanation="3, 2, 1, GO!" max="13"/>
     <string english="Go!" translation="Вперёд!" explanation="3, 2, 1, Go!" max="10"/>
     <string english="Congratulations!" translation="Поздравляем!" explanation="title" max="20"/>

--- a/desktop_version/lang/ru/strings_plural.xml
+++ b/desktop_version/lang/ru/strings_plural.xml
@@ -16,12 +16,12 @@
         <translation form="1" translation="А ещё вы нашли {n_trinkets} штучку."/>
         <translation form="2" translation="А ещё вы нашли {n_trinkets} штучки."/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
         <translation form="0" translation="Осталось {n_crew} членов экипажа"/>
         <translation form="1" translation="Остался {n_crew} член экипажа"/>
         <translation form="2" translation="Осталось {n_crew} члена экипажа"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation="Осталось {n_crew}"/>
         <translation form="1" translation="Остался {n_crew}"/>
         <translation form="2" translation="Осталось {n_crew}"/>

--- a/desktop_version/lang/tr/strings.xml
+++ b/desktop_version/lang/tr/strings.xml
@@ -387,7 +387,7 @@
     <string english="DEATH:" translation="ÖLÜM:" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="EŞYA:" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="ORTALAMA SÜRE:" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="EN İYİ KADEME" explanation="ranks are B A S V" max="14"/>
+    <string english="BEST RANK" translation="EN İYİ KADEME" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="BAŞLA!" explanation="3, 2, 1, GO!" max="13"/>
     <string english="Go!" translation="Başla!" explanation="3, 2, 1, Go!" max="10"/>
     <string english="Congratulations!" translation="Tebrikler!" explanation="title" max="20"/>

--- a/desktop_version/lang/tr/strings_plural.xml
+++ b/desktop_version/lang/tr/strings_plural.xml
@@ -13,11 +13,11 @@
         <translation form="0" translation="Ayrıca {n_trinkets|wordy} eşya buldun."/>
         <translation form="1" translation="Ayrıca {n_trinkets|wordy} eşya buldun."/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
         <translation form="0" translation="{n_crew|wordy} ekip üyesini bulamadın"/>
         <translation form="1" translation="{n_crew|wordy} ekip üyesini bulamadın"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation="{n_crew|wordy} kişi hâlâ kayıp"/>
         <translation form="1" translation="{n_crew|wordy} kişi hâlâ kayıp"/>
     </string>

--- a/desktop_version/lang/uk/strings.xml
+++ b/desktop_version/lang/uk/strings.xml
@@ -387,7 +387,7 @@
     <string english="DEATH:" translation="СМЕРТЬ:" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="БЛИЩИКИ:" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="МЕТА:" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="НАЙВИЩИЙ РАНГ" explanation="ranks are B A S V" max="14"/>
+    <string english="BEST RANK" translation="НАЙВИЩИЙ РАНГ" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="ПОЧИНАЙТЕ!" explanation="3, 2, 1, GO!" max="13"/>
     <string english="Go!" translation="Починайте!" explanation="3, 2, 1, Go!" max="10"/>
     <string english="Congratulations!" translation="Поздоровляємо!" explanation="title" max="20"/>

--- a/desktop_version/lang/uk/strings_plural.xml
+++ b/desktop_version/lang/uk/strings_plural.xml
@@ -16,12 +16,12 @@
         <translation form="1" translation="І знайшли {n_trinkets} блищик."/>
         <translation form="2" translation="І знайшли {n_trinkets} блищиків."/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
         <translation form="0" translation="Треба знайти ще {n_crew|wordy} членів команди"/>
         <translation form="1" translation="Треба знайти ще {n_crew|wordy} члена команди"/>
         <translation form="2" translation="Треба знайти ще {n_crew} членів команди"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation="Треба знайти ще {n_crew|wordy}"/>
         <translation form="1" translation="Треба знайти ще {n_crew|wordy}"/>
         <translation form="2" translation="Треба знайти ще {n_crew}"/>

--- a/desktop_version/lang/zh/strings.xml
+++ b/desktop_version/lang/zh/strings.xml
@@ -394,7 +394,7 @@
     <string english="DEATH:" translation="死亡：" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="饰品：" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="标准时间：" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="最高评级" explanation="ranks are B A S V" max="14" max_local="9"/>
+    <string english="BEST RANK" translation="最高评级" explanation="ranks are B A S V" max="17" max_local="11"/>
     <string english="GO!" translation="开始！" explanation="3, 2, 1, GO!" max="13" max_local="8"/>
     <string english="Go!" translation="开始！" explanation="3, 2, 1, Go!" max="10" max_local="6"/>
     <string english="Congratulations!" translation="恭喜！" explanation="title" max="20" max_local="13"/>

--- a/desktop_version/lang/zh/strings_plural.xml
+++ b/desktop_version/lang/zh/strings_plural.xml
@@ -10,10 +10,10 @@
     <string english_plural="And you found {n_trinkets|wordy} trinkets." english_singular="And you found {n_trinkets|wordy} trinket." explanation="You rescued all the crewmates! And you found XX trinket(s)." max="38*3" var="n_trinkets" expect="20" max_local="25*2">
         <translation form="0" translation="并找到了{n_trinkets|wordy}件饰品"/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100" max_local="26">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100" max_local="25*1">
         <translation form="0" translation="还剩下{n_crew|wordy}名船员"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100" max_local="21">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100" max_local="21*1">
         <translation form="0" translation="还剩下{n_crew|wordy}名"/>
     </string>
     <string english_plural="Hardest Room (with {n_deaths} deaths)" english_singular="Hardest Room (with {n_deaths} death)" explanation="game complete screen" max="40" var="n_deaths" expect="1000" max_local="26">

--- a/desktop_version/lang/zh_TW/strings.xml
+++ b/desktop_version/lang/zh_TW/strings.xml
@@ -51,7 +51,8 @@
     <string english="Change controller options." translation="改變控制器選項。" explanation="" max="38*2" max_local="25*1"/>
     <string english="language" translation="語言" explanation="menu option"/>
     <string english="Language" translation="語言" explanation="title" max="20" max_local="13"/>
-    <string english="Change the language." translation="變更語言。" explanation="" max="38*5" max_local="25*4"/>
+    <string english="Change the language." translation="變更語言。" explanation="" max="38*2" max_local="25*1"/>
+    <string english="Can not change the language while a textbox is displayed in-game." translation="" explanation="" max="38*3" max_local="25*2"/>
     <string english="clear main game data" translation="清除主遊戲數據" explanation="menu option"/>
     <string english="clear custom level data" translation="清除自制關卡數據" explanation="menu option"/>
     <string english="Clear Data" translation="清除數據" explanation="title" max="20" max_local="13"/>

--- a/desktop_version/lang/zh_TW/strings.xml
+++ b/desktop_version/lang/zh_TW/strings.xml
@@ -394,7 +394,7 @@
     <string english="DEATH:" translation="死亡：" explanation="in time trial. Number of times player died, not too long"/>
     <string english="SHINY:" translation="飾品：" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="標準時間：" explanation="in time trial. Goal time for time trial"/>
-    <string english="BEST RANK" translation="最高評級" explanation="ranks are B A S V" max="14" max_local="9"/>
+    <string english="BEST RANK" translation="最高評級" explanation="ranks are B A S V" max="17" max_local="11"/>
     <string english="GO!" translation="開始！" explanation="3, 2, 1, GO!" max="13" max_local="8"/>
     <string english="Go!" translation="開始！" explanation="3, 2, 1, Go!" max="10" max_local="6"/>
     <string english="Congratulations!" translation="恭喜！" explanation="title" max="20" max_local="13"/>

--- a/desktop_version/lang/zh_TW/strings_plural.xml
+++ b/desktop_version/lang/zh_TW/strings_plural.xml
@@ -10,10 +10,10 @@
     <string english_plural="And you found {n_trinkets|wordy} trinkets." english_singular="And you found {n_trinkets|wordy} trinket." explanation="You rescued all the crewmates! And you found XX trinket(s)." max="38*3" var="n_trinkets" expect="20" max_local="25*2">
         <translation form="0" translation="並找到了{n_trinkets|wordy}件飾品"/>
     </string>
-    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="40" var="n_crew" expect="100" max_local="26">
+    <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100" max_local="25*1">
         <translation form="0" translation="還剩下{n_crew|wordy}名船員"/>
     </string>
-    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32" var="n_crew" expect="100" max_local="21">
+    <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100" max_local="21*1">
         <translation form="0" translation="還剩下{n_crew|wordy}名"/>
     </string>
     <string english_plural="Hardest Room (with {n_deaths} deaths)" english_singular="Hardest Room (with {n_deaths} death)" explanation="game complete screen" max="40" var="n_deaths" expect="1000" max_local="26">

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2823,7 +2823,7 @@ void maprender(void)
                 "n_crew:int",
                 remaining
             );
-            font::print(PR_CEN, -1, FLIP(165, 8), buffer, 196, 196, 255 - help.glow);
+            font::print_wrap(PR_CEN, -1, FLIP(165, 8), buffer, 196, 196, 255 - help.glow);
         }
         else
         {


### PR DESCRIPTION
## Changes:

### Sync new string from #1002 into languages added by #989
These PRs were open in parallel so this simply syncs the language files back up.

### Make "{n_crew|wordy} crewmates remain" string wordwrap
It used to have a limit of 40 8x8 characters, but there's room for it to wrap.

### Raise limits on three strings in translation files
These were causing false alarms in translations for one reason or another (either to force translations to not wordwrap for style reasons, or to stay on the safe side if an adjacent string was also long), so they can be raised now.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
