### PR TITLE
Language patches - Final string updates for Dutch, partially for Esperanto, AVOID for Irish

### DIFF
--- a/desktop_version/lang/eo/strings.xml
+++ b/desktop_version/lang/eo/strings.xml
@@ -209,11 +209,11 @@
     <string english="Toggle the in-game timer outside of time trials." translation="Baskuligi la enludan tempomontron ekster tempoprovoj." explanation="" max="38*3"/>
     <string english="In-Game Timer is ON" translation="Enluda tempomontro estas ŜALTA" explanation="" max="38*2"/>
     <string english="In-Game Timer is OFF" translation="Enluda tempomontro estas MALŜALTA" explanation="" max="38*2"/>
-    <string english="english sprites" translation="" explanation="menu option"/>
-    <string english="English Sprites" translation="" explanation="title" max="20"/>
-    <string english="Show the original English word enemies regardless of your language setting." translation="" explanation="" max="38*3"/>
-    <string english="Sprites are currently translated" translation="" explanation="" max="38*2"/>
-    <string english="Sprites are currently ALWAYS ENGLISH" translation="" explanation="" max="38*2"/>
+    <string english="english sprites" translation="anglalingvaj grafikoj" explanation="menu option"/>
+    <string english="English Sprites" translation="Anglaj grafikoj" explanation="title" max="20"/>
+    <string english="Show the original English word enemies regardless of your language setting." translation="Montri la originalajn anglalingvajn vorto-malamikojn sendistinge de la lingva agordo." explanation="" max="38*3"/>
+    <string english="Sprites are currently translated" translation="Grafikoj estas nune tradukitaj" explanation="" max="38*2"/>
+    <string english="Sprites are currently ALWAYS ENGLISH" translation="Grafikoj estas nune ĈIAM ANGLALINGVAJ" explanation="" max="38*2"/>
     <string english="interact button" translation="interaga butono" explanation="menu option"/>
     <string english="Interact Button" translation="Interaga butono" explanation="title, lets the user change the key for interacting with objects or crewmates" max="20"/>
     <string english="Toggle whether you interact with prompts using ENTER or E." translation="Baskuligi ĉu interagi al invitoj per aŭ ENTER aŭ E." explanation="prompts: see the `Press {button} to talk to .../activate terminal/teleport` below" max="38*3"/>
@@ -667,7 +667,7 @@
     <string english="{min}:{sec|digits=2}.{cen|digits=2}" translation="{min}:{sec|digits=2},{cen|digits=2}" explanation="time format M:SS.CC"/>
     <string english="{sec}.{cen|digits=2}" translation="{sec},{cen|digits=2}" explanation="time format S.CC"/>
     <string english=".99" translation=",99" explanation="appended to time format for 99/100 seconds (example: 1:15.99). Time trial results"/>
-    <string english="{area}, {time}" translation="" explanation="saved game summary, e.g. `Space Station, 12:30:59`"/>
+    <string english="{area}, {time}" translation="{area}, {time}" explanation="saved game summary, e.g. `Space Station, 12:30:59`"/>
     <string english="Level Complete!" translation="Fino de nivelo!" explanation="Might be tight, the exclamation mark may be removed" max="18"/>
     <string english="Game Complete!" translation="Fino de ludo!" explanation="Might be tight, the exclamation mark may be removed" max="18"/>
     <string english="You have rescued a crew member!" translation="Vi savis skipanon!" explanation="If you need to manually wordwrap: please ensure this has exactly two lines. Ignore the (font-adapted) maximum if it says 1 line." max="30*2"/>

--- a/desktop_version/lang/ga/cutscenes.xml
+++ b/desktop_version/lang/ga/cutscenes.xml
@@ -869,7 +869,7 @@ Pipe Dream" tt="1" pad="1"/>
         <dialogue speaker="gray" english="Hah! Nobody will ever get this one." translation="Há! Ní bhfaighidh aon duine an ceann seo go deo!" pad="1"/>
     </cutscene>
     <cutscene id="terminal_warp_1" explanation="">
-        <dialogue speaker="gray" english="...The other day I was chased down a hallway by a giant cube with the word AVOID on it." translation="...An lá faoi dheireadh cuireadh an ruaig orm síos an halla ag ciúb ollmhór ar a raibh an focal &quot;AVOID&quot;."/>
+        <dialogue speaker="gray" english="...The other day I was chased down a hallway by a giant cube with the word AVOID on it." translation="...An lá faoi dheireadh cuireadh an ruaig orm síos an halla ag ciúb ollmhór ar a raibh an focal &quot;FAINIC&quot;."/>
         <dialogue speaker="gray" english="These security measures go too far!" translation="Téann na bearta slándála seo thar fóir!"/>
     </cutscene>
     <cutscene id="terminal_warp_2" explanation="">

--- a/desktop_version/lang/nl/cutscenes.xml
+++ b/desktop_version/lang/nl/cutscenes.xml
@@ -870,7 +870,7 @@ Pipe Dream" tt="1" pad="1"/>
         <dialogue speaker="gray" english="Hah! Nobody will ever get this one." translation="Ha! Niemand krijgt deze ooit te pakken." pad="1"/>
     </cutscene>
     <cutscene id="terminal_warp_1" explanation="">
-        <dialogue speaker="gray" english="...The other day I was chased down a hallway by a giant cube with the word AVOID on it." translation="...Laatst werd ik in de gang achtervolgd door een gigantische kubus met het woord ONTWIJKEN erop."/>
+        <dialogue speaker="gray" english="...The other day I was chased down a hallway by a giant cube with the word AVOID on it." translation="...Laatst werd ik in de gang achtervolgd door een gigantische kubus met het woord ONTWIJK erop."/>
         <dialogue speaker="gray" english="These security measures go too far!" translation="Die beveiligingsmaatregelen gaan te ver!"/>
     </cutscene>
     <cutscene id="terminal_warp_2" explanation="">

--- a/desktop_version/lang/nl/strings.xml
+++ b/desktop_version/lang/nl/strings.xml
@@ -209,11 +209,11 @@
     <string english="Toggle the in-game timer outside of time trials." translation="Toon een timer in het spel, ook buiten races tegen de klok." explanation="" max="38*3"/>
     <string english="In-Game Timer is ON" translation="Timer in spel staat AAN" explanation="" max="38*2"/>
     <string english="In-Game Timer is OFF" translation="Timer in spel staat UIT" explanation="" max="38*2"/>
-    <string english="english sprites" translation="" explanation="menu option"/>
-    <string english="English Sprites" translation="" explanation="title" max="20"/>
-    <string english="Show the original English word enemies regardless of your language setting." translation="" explanation="" max="38*3"/>
-    <string english="Sprites are currently translated" translation="" explanation="" max="38*2"/>
-    <string english="Sprites are currently ALWAYS ENGLISH" translation="" explanation="" max="38*2"/>
+    <string english="english sprites" translation="engelse sprites" explanation="menu option"/>
+    <string english="English Sprites" translation="Engelse sprites" explanation="title" max="20"/>
+    <string english="Show the original English word enemies regardless of your language setting." translation="Toon de originele Engelse woordvijanden, ongeacht je taalinstelling." explanation="" max="38*3"/>
+    <string english="Sprites are currently translated" translation="Sprites zijn momenteel vertaald" explanation="" max="38*2"/>
+    <string english="Sprites are currently ALWAYS ENGLISH" translation="Sprites zijn momenteel ALTIJD ENGELS" explanation="" max="38*2"/>
     <string english="interact button" translation="interactie-knop" explanation="menu option"/>
     <string english="Interact Button" translation="Interactie-knop" explanation="title, lets the user change the key for interacting with objects or crewmates" max="20"/>
     <string english="Toggle whether you interact with prompts using ENTER or E." translation="Wijzig of interacties met bemanningsleden en objecten|werken met ENTER of E." explanation="prompts: see the `Press {button} to talk to .../activate terminal/teleport` below" max="38*3"/>
@@ -667,7 +667,7 @@
     <string english="{min}:{sec|digits=2}.{cen|digits=2}" translation="{min}:{sec|digits=2},{cen|digits=2}" explanation="time format M:SS.CC"/>
     <string english="{sec}.{cen|digits=2}" translation="{sec},{cen|digits=2}" explanation="time format S.CC"/>
     <string english=".99" translation=",99" explanation="appended to time format for 99/100 seconds (example: 1:15.99). Time trial results"/>
-    <string english="{area}, {time}" translation="" explanation="saved game summary, e.g. `Space Station, 12:30:59`"/>
+    <string english="{area}, {time}" translation="{area}, {time}" explanation="saved game summary, e.g. `Space Station, 12:30:59`"/>
     <string english="Level Complete!" translation="Level voltooid!" explanation="Might be tight, the exclamation mark may be removed" max="18"/>
     <string english="Game Complete!" translation="Spel uitgespeeld!" explanation="Might be tight, the exclamation mark may be removed" max="18"/>
     <string english="You have rescued a crew member!" translation="Je hebt een bemanningslid gered!" explanation="If you need to manually wordwrap: please ensure this has exactly two lines. Ignore the (font-adapted) maximum if it says 1 line." max="30*2"/>
@@ -778,33 +778,33 @@ Je hebt het geheime lab gevonden!" explanation="" max="34*4"/>
     <string english="Error parsing {path}: {error}" translation="Fout bij parseren van {path}: {error}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="Dimensies van {filename} zijn geen exact veelvoud van {width} bij {height}!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="FOUT: Kan niet schrijven naar talenmap! Zorg dat er geen &quot;lang&quot;-map naast de normale opgeslagen bestanden staat." explanation="" max="38*5"/>
-    <string english="Localisation" translation="" explanation=""/>
-    <string english="Localisation Project Led by" translation="" explanation=""/>
-    <string english="Translations by" translation="" explanation=""/>
-    <string english="Translators" translation="" explanation=""/>
-    <string english="Pan-European Font Design by" translation="" explanation=""/>
-    <string english="Fonts by" translation="" explanation=""/>
-    <string english="Other Fonts by" translation="" explanation=""/>
-    <string english="Catalan" translation="" explanation=""/>
-    <string english="Welsh" translation="" explanation=""/>
-    <string english="German" translation="" explanation=""/>
-    <string english="Esperanto" translation="" explanation=""/>
-    <string english="Spanish" translation="" explanation=""/>
-    <string english="French" translation="" explanation=""/>
-    <string english="Irish" translation="" explanation=""/>
-    <string english="Italian" translation="" explanation=""/>
-    <string english="Japanese" translation="" explanation=""/>
-    <string english="Korean" translation="" explanation=""/>
-    <string english="Dutch" translation="" explanation=""/>
-    <string english="Polish" translation="" explanation=""/>
-    <string english="Brazilian Portuguese" translation="" explanation=""/>
-    <string english="European Portuguese" translation="" explanation=""/>
-    <string english="Russian" translation="" explanation=""/>
-    <string english="Silesian" translation="" explanation=""/>
-    <string english="Turkish" translation="" explanation=""/>
-    <string english="Ukrainian" translation="" explanation=""/>
-    <string english="Chinese (Simplified)" translation="" explanation=""/>
-    <string english="Chinese (Traditional)" translation="" explanation=""/>
+    <string english="Localisation" translation="Lokalisering" explanation=""/>
+    <string english="Localisation Project Led by" translation="Lokaliseringsproject geleid door" explanation=""/>
+    <string english="Translations by" translation="Vertalingen door" explanation=""/>
+    <string english="Translators" translation="Vertalers" explanation=""/>
+    <string english="Pan-European Font Design by" translation="Ontwerp pan-Europees lettertype door" explanation=""/>
+    <string english="Fonts by" translation="Lettertypen door" explanation=""/>
+    <string english="Other Fonts by" translation="Overige lettertypen door" explanation=""/>
+    <string english="Catalan" translation="Catalaans" explanation=""/>
+    <string english="Welsh" translation="Welsh" explanation=""/>
+    <string english="German" translation="Duits" explanation=""/>
+    <string english="Esperanto" translation="Esperanto" explanation=""/>
+    <string english="Spanish" translation="Spaans" explanation=""/>
+    <string english="French" translation="Frans" explanation=""/>
+    <string english="Irish" translation="Iers" explanation=""/>
+    <string english="Italian" translation="Italiaans" explanation=""/>
+    <string english="Japanese" translation="Japans" explanation=""/>
+    <string english="Korean" translation="Koreaans" explanation=""/>
+    <string english="Dutch" translation="Nederlands" explanation=""/>
+    <string english="Polish" translation="Pools" explanation=""/>
+    <string english="Brazilian Portuguese" translation="Braziliaans Portugees" explanation=""/>
+    <string english="European Portuguese" translation="Europees Portugees" explanation=""/>
+    <string english="Russian" translation="Russisch" explanation=""/>
+    <string english="Silesian" translation="Silezisch" explanation=""/>
+    <string english="Turkish" translation="Turks" explanation=""/>
+    <string english="Ukrainian" translation="Oekraïens" explanation=""/>
+    <string english="Chinese (Simplified)" translation="Chinees (vereenvoudigd)" explanation=""/>
+    <string english="Chinese (Traditional)" translation="Chinees (traditioneel)" explanation=""/>
     <string english="" translation="" explanation=""/>
     <string english="" translation="" explanation=""/>
 </strings>


### PR DESCRIPTION
## Changes:

- Final strings for Dutch are filled in
- Final strings for Esperanto are partially filled in, since I already had these ones (this does not yet include the credits strings)
- AVOID is changed to FAINIC for Irish

This PR is set to merge into `final_string_updates`, not `master`. I recommend using "Rebase and merge" so it doesn't create extra merge commits.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
