### PR TITLE
Enable SDL_HINT_IME_SHOW_UI to make typing CJK not guesswork

### DIFF
--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -551,6 +551,8 @@ int main(int argc, char *argv[])
     }
 #endif
 
+    SDL_SetHintWithPriority(SDL_HINT_IME_SHOW_UI, "1", SDL_HINT_OVERRIDE);
+
     if(!FILESYSTEM_init(argv[0], baseDir, assetsPath, langDir, fontsDir))
     {
         vlog_error("Unable to initialize filesystem!");


### PR DESCRIPTION
## Changes:

For some reason, the default behavior of SDL and/or Windows(?) (I only tested this on Windows) seems to result in the fact that if any SDL app doesn't account for it, there is no way for Japanese and Chinese speakers to know what they're typing in.

How IMEs are supposed to work is that you can type words as sort of WIP versions, and then select out of a list of candidates what the final result should be. The app may display the WIP text and tell the IME where the text field is so that the IME's menu can be displayed around it. But if the app doesn't say where the text field is, then the candidate list can also be displayed at the corner of the screen, which is done in Minecraft.

By default, however, SDL apps don't get a candidate list at all, which means you're basically flying blind as to what you're typing in, and you would have to basically open notepad and copy-paste everything from there - unless I'm missing something.

This commit sets the SDL_HINT_IME_SHOW_UI hint (added in SDL 2.0.18 apparently), so that the candidate list is at least shown in the corner. We can probably deal with positioning and uncommitted text later.

Demo video with this hint enabled:

https://github.com/TerryCavanagh/VVVVVV/assets/44736680/2b13b5d9-1254-4972-8ae3-33dbccce4813

With this hint _disabled_, functionality is the same (you can arrow key through the candidates) but the entire interface in the bottom right is not there.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
