### PR TITLE
Change levelstats data type from vector to map (to fix inflated files)

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -536,10 +536,6 @@ void Game::loadcustomlevelstats(void)
 
     customlevelstats.clear();
 
-    // Old system
-    std::vector<std::string> customlevelnames;
-    std::vector<int> customlevelscores;
-
     tinyxml2::XMLElement* pElem;
     tinyxml2::XMLElement* firstElement;
 
@@ -585,6 +581,9 @@ void Game::loadcustomlevelstats(void)
 
 
     // Since we're still here, we must be on the old system
+    std::vector<std::string> customlevelnames;
+    std::vector<int> customlevelscores;
+
     for (pElem = firstElement; pElem; pElem=pElem->NextSiblingElement())
     {
         const char* pKey = pElem->Value();

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -455,29 +455,9 @@ void Game::updatecustomlevelstats(std::string clevel, int cscore)
     {
         clevel = clevel.substr(7);
     }
-    int tvar=-1;
-    for(size_t j=0; j<customlevelstats.size(); j++)
+    if (customlevelstats.count(clevel) == 0 || cscore > customlevelstats[clevel])
     {
-        if(clevel==customlevelstats[j].name)
-        {
-            tvar=j;
-            break;
-        }
-    }
-    if(tvar>=0)
-    {
-        // We have an existing entry
-        // Don't update it unless it's a higher score
-        if (cscore > customlevelstats[tvar].score)
-        {
-            customlevelstats[tvar].score=cscore;
-        }
-    }
-    else
-    {
-        //add a new entry
-        CustomLevelStat levelstat = {clevel, cscore};
-        customlevelstats.push_back(levelstat);
+        customlevelstats[clevel] = cscore;
     }
     savecustomlevelstats();
 }
@@ -558,21 +538,40 @@ void Game::loadcustomlevelstats(void)
 
         if (SDL_strcmp(pKey, "stats") == 0)
         {
+            bool file_has_duplicates = false;
+
             for (tinyxml2::XMLElement* stat_el = pElem->FirstChildElement(); stat_el; stat_el = stat_el->NextSiblingElement())
             {
-                CustomLevelStat stat = {};
+                int score = 0;
+                std::string name;
 
                 if (stat_el->GetText() != NULL)
                 {
-                    stat.score = help.Int(stat_el->GetText());
+                    score = help.Int(stat_el->GetText());
                 }
 
                 if (stat_el->Attribute("name"))
                 {
-                    stat.name = stat_el->Attribute("name");
+                    name = stat_el->Attribute("name");
                 }
 
-                customlevelstats.push_back(stat);
+                int existing = customlevelstats.count(name);
+                if (existing > 0)
+                {
+                    file_has_duplicates = true;
+                }
+
+                if (existing == 0 || score > customlevelstats[name])
+                {
+                    customlevelstats[name] = score;
+                }
+            }
+
+            if (file_has_duplicates)
+            {
+                /* This might be really inflated, so simply save the map we have now,
+                 * so we don't have to keep loading a 90 MB file. */
+                savecustomlevelstats();
             }
 
             return;
@@ -622,8 +621,13 @@ void Game::loadcustomlevelstats(void)
     // If the two arrays happen to differ in length, just go with the smallest one
     for (size_t i = 0; i < SDL_min(customlevelnames.size(), customlevelscores.size()); i++)
     {
-        CustomLevelStat stat = {customlevelnames[i], customlevelscores[i]};
-        customlevelstats.push_back(stat);
+        const std::string& name = customlevelnames[i];
+        const int score = customlevelscores[i];
+
+        if (customlevelstats.count(name) == 0 || score > customlevelstats[name])
+        {
+            customlevelstats[name] = score;
+        }
     }
 }
 
@@ -654,29 +658,25 @@ void Game::savecustomlevelstats(void)
     xml::update_tag(msgs, "numcustomlevelstats", numcustomlevelstats);
 
     std::string customlevelscorestr;
-    for(int i = 0; i < numcustomlevelstats; i++ )
+    std::string customlevelstatsstr;
+    std::map<std::string, int>::iterator iter;
+    for (iter = customlevelstats.begin(); iter != customlevelstats.end(); iter++)
     {
-        customlevelscorestr += help.String(customlevelstats[i].score) + ",";
+        customlevelscorestr += help.String(iter->second) + ",";
+        customlevelstatsstr += iter->first + "|";
     }
     xml::update_tag(msgs, "customlevelscore", customlevelscorestr.c_str());
-
-    std::string customlevelstatsstr;
-    for(int i = 0; i < numcustomlevelstats; i++ )
-    {
-        customlevelstatsstr += customlevelstats[i].name + "|";
-    }
     xml::update_tag(msgs, "customlevelstats", customlevelstatsstr.c_str());
 
     // New system
     tinyxml2::XMLElement* msg = xml::update_element_delete_contents(msgs, "stats");
     tinyxml2::XMLElement* stat_el;
-    for (size_t i = 0; i < customlevelstats.size(); i++)
+    for (iter = customlevelstats.begin(); iter != customlevelstats.end(); iter++)
     {
         stat_el = doc.NewElement("stat");
-        CustomLevelStat& stat = customlevelstats[i];
 
-        stat_el->SetAttribute("name", stat.name.c_str());
-        stat_el->LinkEndChild(doc.NewText(help.String(stat.score).c_str()));
+        stat_el->SetAttribute("name", iter->first.c_str());
+        stat_el->LinkEndChild(doc.NewText(help.String(iter->second).c_str()));
 
         msg->LinkEndChild(stat_el);
     }
@@ -6301,49 +6301,37 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
             {
                 if(i>=levelpage*8 && i< (levelpage*8)+8)
                 {
-                    //This is, er, suboptimal. Whatever, life optimisation and all that
-                    int tvar=-1;
-                    for(size_t j=0; j<customlevelstats.size(); j++)
+                    const std::string filename = cl.ListOfMetaData[i].filename.substr(7);
+                    int score = 0;
+                    if (customlevelstats.count(filename) > 0)
                     {
-                        if(cl.ListOfMetaData[i].filename.substr(7) == customlevelstats[j].name)
-                        {
-                            tvar=j;
-                            break;
-                        }
+                        score = customlevelstats[filename];
                     }
                     const char* prefix;
-                    if(tvar>=0)
+                    switch (score)
                     {
-                        switch (customlevelstats[tvar].score)
-                        {
-                        case 0:
-                        {
-                            static const char tmp[] = "   ";
-                            prefix = tmp;
-                            break;
-                        }
-                        case 1:
-                        {
-                            static const char tmp[] = " * ";
-                            prefix = tmp;
-                            break;
-                        }
-                        case 3:
-                        {
-                            static const char tmp[] = "** ";
-                            prefix = tmp;
-                            break;
-                        }
-                        default:
-                            SDL_assert(0 && "Unhandled menu text prefix!");
-                            prefix = "";
-                            break;
-                        }
-                    }
-                    else
+                    case 0:
                     {
                         static const char tmp[] = "   ";
                         prefix = tmp;
+                        break;
+                    }
+                    case 1:
+                    {
+                        static const char tmp[] = " * ";
+                        prefix = tmp;
+                        break;
+                    }
+                    case 3:
+                    {
+                        static const char tmp[] = "** ";
+                        prefix = tmp;
+                        break;
+                    }
+                    default:
+                        SDL_assert(0 && "Unhandled menu text prefix!");
+                        prefix = "";
+                        break;
                     }
                     char text[MENU_TEXT_BYTES];
                     SDL_snprintf(text, sizeof(text), "%s%s", prefix, cl.ListOfMetaData[i].title.c_str());

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -2,6 +2,7 @@
 #define GAME_H
 
 #include <SDL.h>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -174,12 +175,6 @@ struct MenuStackFrame
 {
     int option;
     enum Menu::MenuName name;
-};
-
-struct CustomLevelStat
-{
-    std::string name;
-    int score; //0 - not played, 1 - finished, 2 - all trinkets, 3 - finished, all trinkets
 };
 
 
@@ -525,7 +520,8 @@ public:
     void updatecustomlevelstats(std::string clevel, int cscore);
     void deletecustomlevelstats(void);
 
-    std::vector<CustomLevelStat> customlevelstats;
+    // name -> score. 0 - not played, 1 - finished, 2 - all trinkets, 3 - finished, all trinkets
+    std::map<std::string, int> customlevelstats;
 
 
     std::vector<SDL_GameControllerButton> controllerButton_map;


### PR DESCRIPTION
## Changes:

As described in #1016, there used to be a bug that inflated `levelstats.vvv` in 2.3, which was fixed in 2.4, but there was no way for inflated files to get smaller yet.

This commit changes the storage of levelstats from a std::vector of structs to a std::map, so that uniqueness is guaranteed and thus the stats can be optimized automatically. And it also simplifies *and* optimizes the code that handles the levelstats - no more big loops that iterated over every element to find the matching level. (Farewell to the "life optimisation and all that" comment, too)

I tested this with both my own levelstats.vvv, as well as some inflated ones (including Balneor's 93 MB one) and saw this code correctly reduce the filesize and speed up the levels list.

Fixes #1016.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
