### PR TITLE
Allow UTF-8 console output on Windows (for -console)

### DIFF
--- a/desktop_version/src/Vlogging.c
+++ b/desktop_version/src/Vlogging.c
@@ -181,6 +181,11 @@ void vlog_open_console(void)
     }
 
     check_color_support();
+
+    if (!SetConsoleOutputCP(CP_UTF8))
+    {
+        vlog_warn("Could not set code page for console output to UTF-8.");
+    }
 }
 #endif /* _WIN32 */
 


### PR DESCRIPTION
## Changes:

Right now, Windows assumes all our console output is code page ????. That means our UTF-8 output appears mangled. (I ran into this while testing IME text input by outputting strings to the console)

For a moment I was scared we'd need to do UTF-16 conversions and call Windows-specific print functions like WriteConsoleW() in our vlog functions, but fortunately SetConsoleOutputCP(CP_UTF8) works just fine.

Example of `vlog_warn(loc::gettext("return"))` in German (just to make sure the encoding of the source file is not a factor) before this change:

![zurCOUGHck](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/8e0161d0-f893-4973-b4b3-45686968c787)

After:

![zurück](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/e4ea71f2-437d-461b-b197-3dc2d2845672)



## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
