### PR TITLE
Show centiseconds for best time trial times (if available)

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1588,9 +1588,10 @@ static void menurender(void)
                 label_len = SDL_max(label_len, font::len(0, label));
                 font::print(0, 32, 65+sp*3, label, tr, tg, tb);
 
-                font::print(0, label_len+48, 65+sp, game.timetstring(game.besttimes[id_trial]), tr, tg, tb);
-
                 char buffer[SCREEN_WIDTH_CHARS + 1];
+                help.format_time(buffer, sizeof(buffer), game.besttimes[id_trial], game.bestframes[id_trial], true);
+                font::print(0, label_len+48, 65+sp, buffer, tr, tg, tb);
+
                 vformat_buf(
                     buffer, sizeof(buffer),
                     loc::gettext("{n_trinkets}/{max_trinkets}"),


### PR DESCRIPTION
## Changes:

Since VVVVVV 2.3, time trial best times are stored not just with the number of seconds, but also the number of frames. However, there was no room to display it with the old design of the time trials screen. Now there is, so it can easily be displayed now with a small change!

Unset frames are stored as -1, which fits perfectly into the frames argument of help.format_time(), because in that case the amount of centiseconds is not shown.

It should be noted that opening VVVVVV 2.2 will instantly wipe your frames records, as described by #1030. But many people will likely never open 2.2 anymore.

![1:57.66](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/4b996e26-0583-418e-8e34-5ddf53ebce52)



## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
