### PR TITLE
Add screenshot functions

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -316,7 +316,6 @@ add_library(lodepng-static STATIC ${PNG_SRC})
 target_compile_definitions(lodepng-static PRIVATE
     -DLODEPNG_NO_COMPILE_ALLOCATORS
     -DLODEPNG_NO_COMPILE_DISK
-    -DLODEPNG_NO_COMPILE_ENCODER
 )
 
 add_library(c-hashmap-static STATIC ${CHM_SRC})

--- a/desktop_version/src/CWrappers.cpp
+++ b/desktop_version/src/CWrappers.cpp
@@ -2,6 +2,8 @@
 
 #include <SDL.h>
 
+#include "Graphics.h"
+#include "GraphicsUtil.h"
 #include "Localization.h"
 #include "UtilityClass.h"
 
@@ -25,6 +27,16 @@ char* HELP_number_words(int _t, const char* number_class)
 uint32_t LOC_toupper_ch(uint32_t ch)
 {
     return loc::toupper_ch(ch);
+}
+
+SDL_Surface* GRAPHICS_tempScreenshot(void)
+{
+    return graphics.tempScreenshot;
+}
+
+uint8_t UTIL_TakeScreenshot(SDL_Surface** surface)
+{
+    return TakeScreenshot(surface);
 }
 
 } /* extern "C" */

--- a/desktop_version/src/CWrappers.cpp
+++ b/desktop_version/src/CWrappers.cpp
@@ -34,9 +34,19 @@ SDL_Surface* GRAPHICS_tempScreenshot(void)
     return graphics.tempScreenshot;
 }
 
+SDL_Surface* GRAPHICS_tempScreenshot2x(void)
+{
+    return graphics.tempScreenshot2x;
+}
+
 uint8_t UTIL_TakeScreenshot(SDL_Surface** surface)
 {
     return TakeScreenshot(surface);
+}
+
+uint8_t UTIL_UpscaleScreenshot2x(SDL_Surface* src, SDL_Surface** dest)
+{
+    return UpscaleScreenshot2x(src, dest);
 }
 
 } /* extern "C" */

--- a/desktop_version/src/CWrappers.h
+++ b/desktop_version/src/CWrappers.h
@@ -11,7 +11,9 @@ extern "C" {
 char* HELP_number_words(int _t, const char* number_class);
 uint32_t LOC_toupper_ch(uint32_t ch);
 SDL_Surface* GRAPHICS_tempScreenshot(void);
+SDL_Surface* GRAPHICS_tempScreenshot2x(void);
 uint8_t UTIL_TakeScreenshot(SDL_Surface** surface);
+uint8_t UTIL_UpscaleScreenshot2x(SDL_Surface* src, SDL_Surface** dest);
 
 #ifdef __cplusplus
 }

--- a/desktop_version/src/CWrappers.h
+++ b/desktop_version/src/CWrappers.h
@@ -1,6 +1,7 @@
 #ifndef CWRAPPERS_H
 #define CWRAPPERS_H
 
+#include <SDL_surface.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -9,6 +10,8 @@ extern "C" {
 
 char* HELP_number_words(int _t, const char* number_class);
 uint32_t LOC_toupper_ch(uint32_t ch);
+SDL_Surface* GRAPHICS_tempScreenshot(void);
+uint8_t UTIL_TakeScreenshot(SDL_Surface** surface);
 
 #ifdef __cplusplus
 }

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -270,6 +270,19 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath, char* langD
     mkdir(screenshotDir, 0777);
     vlog_info("Screenshot directory: %s", screenshotDir);
 
+    /* We also need to make the subdirectories */
+    {
+        char temp[MAX_PATH];
+        SDL_snprintf(temp, sizeof(temp), "%s%s%s",
+            screenshotDir, "1x", pathSep
+        );
+        mkdir(temp, 0777);
+        SDL_snprintf(temp, sizeof(temp), "%s%s%s",
+            screenshotDir, "2x", pathSep
+        );
+        mkdir(temp, 0777);
+    }
+
     basePath = SDL_GetBasePath();
 
     if (basePath == NULL)

--- a/desktop_version/src/FileSystemUtils.h
+++ b/desktop_version/src/FileSystemUtils.h
@@ -32,6 +32,7 @@ void FILESYSTEM_unmountAssets(void);
 bool FILESYSTEM_isAssetMounted(const char* filename);
 bool FILESYSTEM_areAssetsInSameRealDir(const char* filenameA, const char* filenameB);
 
+bool FILESYSTEM_saveFile(const char* name, const unsigned char* data, size_t len);
 void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem,
                                  size_t *len);
 void FILESYSTEM_loadAssetToMemory(

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -364,6 +364,10 @@ void Game::init(void)
     old_mode_indicator_timer = 0;
     mode_indicator_timer = 0;
 
+    old_screenshot_border_timer = 0;
+    screenshot_border_timer = 0;
+    screenshot_saved_success = false;
+
     setdefaultcontrollerbuttons();
 }
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -592,6 +592,10 @@ public:
 
     int old_mode_indicator_timer;
     int mode_indicator_timer;
+
+    int old_screenshot_border_timer;
+    int screenshot_border_timer;
+    bool screenshot_saved_success;
 };
 
 #ifndef GAME_DEFINITION

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -112,6 +112,7 @@ void Graphics::init(void)
     backgroundTexture = NULL;
     foregroundTexture = NULL;
     tempScreenshot = NULL;
+    tempScreenshot2x = NULL;
     towerbg = TowerBG();
     titlebg = TowerBG();
     trinketr = 0;
@@ -222,6 +223,7 @@ void Graphics::destroy_buffers(void)
     VVV_freefunc(SDL_FreeSurface, tempFilterSrc);
     VVV_freefunc(SDL_FreeSurface, tempFilterDest);
     VVV_freefunc(SDL_FreeSurface, tempScreenshot);
+    VVV_freefunc(SDL_FreeSurface, tempScreenshot2x);
 }
 
 void Graphics::drawspritesetcol(int x, int y, int t, int c)

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -111,6 +111,7 @@ void Graphics::init(void)
     tempShakeTexture = NULL;
     backgroundTexture = NULL;
     foregroundTexture = NULL;
+    tempScreenshot = NULL;
     towerbg = TowerBG();
     titlebg = TowerBG();
     trinketr = 0;
@@ -220,6 +221,7 @@ void Graphics::destroy_buffers(void)
     VVV_freefunc(SDL_DestroyTexture, titlebg.texture);
     VVV_freefunc(SDL_FreeSurface, tempFilterSrc);
     VVV_freefunc(SDL_FreeSurface, tempFilterDest);
+    VVV_freefunc(SDL_FreeSurface, tempScreenshot);
 }
 
 void Graphics::drawspritesetcol(int x, int y, int t, int c)

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3345,6 +3345,8 @@ void Graphics::screenshake(void)
 
     copy_texture(gameTexture, NULL, &shake);
 
+    draw_screenshot_border();
+
     set_render_target(gameTexture);
     clear();
 
@@ -3370,6 +3372,8 @@ void Graphics::updatescreenshake(void)
 
 void Graphics::render(void)
 {
+    draw_screenshot_border();
+
     if (gameScreen.badSignalEffect)
     {
         ApplyFilter(&tempFilterSrc, &tempFilterDest);
@@ -3423,6 +3427,46 @@ void Graphics::renderfixedpost(void)
     {
         --game.screenshake;
     }
+
+    game.old_screenshot_border_timer = game.screenshot_border_timer;
+    if (game.screenshot_border_timer > 0)
+    {
+        game.screenshot_border_timer -= 15;
+    }
+}
+
+void Graphics::draw_screenshot_border(void)
+{
+    const int border_alpha = lerp(game.old_screenshot_border_timer, game.screenshot_border_timer);
+
+    if (border_alpha <= 100)
+    {
+        return;
+    }
+
+    int width = 0;
+    int height = 0;
+    int result = query_texture(gameTexture, NULL, NULL, &width, &height);
+    if (result != 0)
+    {
+        return;
+    }
+
+    const SDL_Rect rect_inner = {1, 1, width - 2, height - 2};
+
+    if (game.screenshot_saved_success)
+    {
+        set_color(196, 196, 20, border_alpha);
+    }
+    else
+    {
+        set_color(196, 20, 20, border_alpha);
+    }
+
+    set_blendmode(SDL_BLENDMODE_BLEND);
+    draw_rect(NULL);
+    draw_rect(&rect_inner);
+    set_blendmode(SDL_BLENDMODE_NONE);
 }
 
 void Graphics::drawtele(int x, int y, int t, const SDL_Color color)

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -333,6 +333,7 @@ public:
     SDL_Texture* foregroundTexture;
     SDL_Texture* tempScrollingTexture;
     SDL_Surface* tempScreenshot;
+    SDL_Surface* tempScreenshot2x;
 
     TowerBG towerbg;
     TowerBG titlebg;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -332,6 +332,7 @@ public:
     SDL_Texture* backgroundTexture;
     SDL_Texture* foregroundTexture;
     SDL_Texture* tempScrollingTexture;
+    SDL_Surface* tempScreenshot;
 
     TowerBG towerbg;
     TowerBG titlebg;

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -252,6 +252,8 @@ public:
     void renderfixedpre(void);
     void renderfixedpost(void);
 
+    void draw_screenshot_border(void);
+
     bool Hitest(SDL_Surface* surface1, SDL_Point p1, SDL_Surface* surface2, SDL_Point p2);
 
     void drawentities(void);

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -1,5 +1,6 @@
 #include "GraphicsResources.h"
 
+#include <time.h>
 #include <tinyxml2.h>
 
 #include "Alloc.h"
@@ -516,8 +517,17 @@ bool SaveScreenshot(void)
         vlog_error("Could not take screenshot");
         return false;
     }
-    // TODO: Timestamp in filename
-    success = SaveImage(graphics.tempScreenshot, "screenshots/test.png");
+
+    const time_t now = time(NULL);
+    const tm* date = localtime(&now);
+
+    char timestamp[32];
+    strftime(timestamp, sizeof(timestamp), "%Y-%m-%d_%H-%M-%S", date);
+
+    char filename[64];
+    SDL_snprintf(filename, sizeof(filename), "screenshots/1x/%s_1x.png", timestamp);
+
+    success = SaveImage(graphics.tempScreenshot, filename);
     if (!success)
     {
         return false;
@@ -530,12 +540,14 @@ bool SaveScreenshot(void)
         return false;
     }
 
-    success = SaveImage(graphics.tempScreenshot2x, "screenshots/test2x.png");
+    SDL_snprintf(filename, sizeof(filename), "screenshots/2x/%s_2x.png", timestamp);
+
+    success = SaveImage(graphics.tempScreenshot2x, filename);
     if (!success)
     {
         return false;
     }
 
-    vlog_info("Saved screenshot");
+    vlog_info("Saved screenshot %s", timestamp);
     return true;
 }

--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -523,6 +523,19 @@ bool SaveScreenshot(void)
         return false;
     }
 
+    success = UpscaleScreenshot2x(graphics.tempScreenshot, &graphics.tempScreenshot2x);
+    if (!success)
+    {
+        vlog_error("Could not upscale screenshot to 2x");
+        return false;
+    }
+
+    success = SaveImage(graphics.tempScreenshot2x, "screenshots/test2x.png");
+    if (!success)
+    {
+        return false;
+    }
+
     vlog_info("Saved screenshot");
     return true;
 }

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -257,3 +257,60 @@ void ApplyFilter(SDL_Surface** src, SDL_Surface** dest)
 
     SDL_UpdateTexture(graphics.gameTexture, NULL, (*dest)->pixels, (*dest)->pitch);
 }
+
+bool TakeScreenshot(SDL_Surface** surface)
+{
+    if (surface == NULL)
+    {
+        SDL_assert(0 && "surface is NULL!");
+        return false;
+    }
+
+    int width = 0;
+    int height = 0;
+    int result = graphics.query_texture(
+        graphics.gameTexture, NULL, NULL, &width, &height
+    );
+    if (result != 0)
+    {
+        return false;
+    }
+
+    if (*surface == NULL)
+    {
+        *surface = SDL_CreateRGBSurface(0, width, height, 24, 0, 0, 0, 0);
+        if (*surface == NULL)
+        {
+            WHINE_ONCE_ARGS(
+                ("Could not create temporary surface: %s", SDL_GetError())
+            );
+            return false;
+        }
+    }
+
+    if ((*surface)->w != width || (*surface)->h != height)
+    {
+        SDL_assert(0 && "Width and height of surface and texture mismatch!");
+        return false;
+    }
+
+    result = graphics.set_render_target(graphics.gameTexture);
+    if (result != 0)
+    {
+        return false;
+    }
+
+    result = SDL_RenderReadPixels(
+        gameScreen.m_renderer, NULL, SDL_PIXELFORMAT_RGB24,
+        (*surface)->pixels, (*surface)->pitch
+    );
+    if (result != 0)
+    {
+        WHINE_ONCE_ARGS(
+            ("Could not read pixels from renderer: %s", SDL_GetError())
+        );
+        return false;
+    }
+
+    return true;
+}

--- a/desktop_version/src/GraphicsUtil.cpp
+++ b/desktop_version/src/GraphicsUtil.cpp
@@ -346,3 +346,40 @@ bool TakeScreenshot(SDL_Surface** surface)
 
     return true;
 }
+
+bool UpscaleScreenshot2x(SDL_Surface* src, SDL_Surface** dest)
+{
+    if (src == NULL)
+    {
+        SDL_assert(0 && "src is NULL!");
+        return false;
+    }
+    if (dest == NULL)
+    {
+        SDL_assert(0 && "dest is NULL!");
+        return false;
+    }
+
+    if (*dest == NULL)
+    {
+        *dest = SDL_CreateRGBSurface(
+            0, src->w * 2, src->h * 2, src->format->BitsPerPixel, 0, 0, 0, 0
+        );
+        if (*dest == NULL)
+        {
+            WHINE_ONCE_ARGS(
+                ("Could not create temporary surface: %s", SDL_GetError())
+            );
+            return false;
+        }
+    }
+
+    int result = SDL_BlitScaled(src, NULL, *dest, NULL);
+    if (result != 0)
+    {
+        WHINE_ONCE_ARGS(("Could not blit surface: %s", SDL_GetError()));
+        return false;
+    }
+
+    return true;
+}

--- a/desktop_version/src/GraphicsUtil.h
+++ b/desktop_version/src/GraphicsUtil.h
@@ -14,4 +14,6 @@ SDL_Color ReadPixel(const SDL_Surface* surface, int x, int y);
 void UpdateFilter(void);
 void ApplyFilter(SDL_Surface** src, SDL_Surface** dest);
 
+bool TakeScreenshot(SDL_Surface** surface);
+
 #endif /* GRAPHICSUTIL_H */

--- a/desktop_version/src/GraphicsUtil.h
+++ b/desktop_version/src/GraphicsUtil.h
@@ -15,5 +15,6 @@ void UpdateFilter(void);
 void ApplyFilter(SDL_Surface** src, SDL_Surface** dest);
 
 bool TakeScreenshot(SDL_Surface** surface);
+bool UpscaleScreenshot2x(SDL_Surface* src, SDL_Surface** dest);
 
 #endif /* GRAPHICSUTIL_H */

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -10,12 +10,15 @@
 #include "Game.h"
 #include "GlitchrunnerMode.h"
 #include "Graphics.h"
+#include "GraphicsUtil.h"
 #include "Localization.h"
 #include "LocalizationStorage.h"
 #include "Music.h"
 #include "Screen.h"
 #include "UTF8.h"
 #include "Vlogging.h"
+
+bool SaveScreenshot(void);
 
 int inline KeyPoll::getThreshold(void)
 {
@@ -179,6 +182,11 @@ void KeyPoll::Poll(void)
                 loc::loadtext(false);
                 graphics.grphx.init_translations();
                 music.playef(Sound_COIN);
+            }
+
+            if (evt.key.keysym.sym == SDLK_F6 && !evt.key.repeat)
+            {
+                SaveScreenshot();
             }
 
             BUTTONGLYPHS_keyboard_set_active(true);

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -186,7 +186,10 @@ void KeyPoll::Poll(void)
 
             if (evt.key.keysym.sym == SDLK_F6 && !evt.key.repeat)
             {
-                SaveScreenshot();
+                const bool success = SaveScreenshot();
+                game.old_screenshot_border_timer = 255;
+                game.screenshot_border_timer = 255;
+                game.screenshot_saved_success = success;
             }
 
             BUTTONGLYPHS_keyboard_set_active(true);

--- a/desktop_version/src/SteamNetwork.c
+++ b/desktop_version/src/SteamNetwork.c
@@ -131,13 +131,19 @@ static void run_screenshot()
     {
         return;
     }
+    SDL_Surface* surface2x = GRAPHICS_tempScreenshot2x();
+    success = UTIL_UpscaleScreenshot2x(surface, &surface2x);
+    if (!success)
+    {
+        return;
+    }
 
     SteamAPI_ISteamScreenshots_WriteScreenshot(
         steamScreenshots,
-        surface->pixels,
-        surface->w * surface->h * surface->format->BytesPerPixel,
-        surface->w,
-        surface->h
+        surface2x->pixels,
+        surface2x->w * surface2x->h * surface2x->format->BytesPerPixel,
+        surface2x->w,
+        surface2x->h
     );
 }
 


### PR DESCRIPTION
This adds a screenshot keybind (F6) and hooks Steam's screenshot function to send our own screenshots. This is so that people can easily grab screenshots of pixel perfect internal resolution (320x240) without needing to downscale it themselves.

Issues:

* ~~We need to change the existing F12 keybind, which is currently bound to reloading language files in translator mode. This conflicts with Steam's default screenshot keybind. In this draft, I've just disabled it instead.~~
* ~~Still need to add timestamps to filenames for F6 screenshots.~~
* ~~Flip Mode needs to be manually corrected but it doesn't work as of now.~~

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
