### PR TITLE
Fix position of crewmate in "You have rescued a crew member!" box

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -702,7 +702,7 @@ void Game::crewmate_textbox(const int color)
     float spaces_per_8 = font::len(PR_FONT_INTERFACE, " ")/8.0f;
     graphics.textboxpad(SDL_ceilf(5/spaces_per_8), SDL_ceilf(2/spaces_per_8));
     graphics.textboxcenterx();
-    graphics.addsprite(14, 12, 0, color);
+    graphics.addsprite(14, 12 + extra_cjk_height/2, 0, color);
 }
 
 void Game::remaining_textbox(void)


### PR DESCRIPTION
## Changes:

At first my CJK changes also misaligned this sprite, and my solution that time was to position the textbox higher depending on the height of the textbox, so it would be centered around the crewmate sprite (which stayed at a hardcoded place onscreen). Recently, #987 changed these sprites to be relative to the position of the textbox instead of relative to the screen, which is much more logical, but it stopped centering these sprites again. But it's an easy fix: simply account for the extra-added height when adding the sprite in.


Before:
!["You have rescued a crew member!" but in Chinese, misaligned](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/50397a4e-b273-4d97-b489-065f7629793d)

After:
![The same but aligned correctly](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/b586d2d9-5324-4697-a4f9-1535ae10e29c)

And in flip mode:
![The same but in flip mode](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/0a49b611-1d9c-4ecb-910f-ec605fae77bf)




## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
