### PR TITLE
Apply changes to two terminal textboxes in Japanese

### DIFF
--- a/desktop_version/lang/ja/cutscenes.xml
+++ b/desktop_version/lang/ja/cutscenes.xml
@@ -1195,11 +1195,9 @@ Pipe Dream" tt="1" pad="1"/>
     </cutscene>
     <cutscene id="terminal_station_1" explanation="">
         <dialogue speaker="gray" english="-= PERSONAL LOG =-" translation="-= 個人ログ =-" padtowidth="132"/>
-        <dialogue speaker="gray" english="Almost everyone has been evacuated from the space station now. The rest of us are leaving in a couple of days, once our research has been completed." translation="宇宙ステーションからの避難は
-ほぼ全員完了したようだ。
-残った我々も、あと数日で
-離れる事になろう。
-研究が終わればの話だが。" pad="1"/>
+        <dialogue speaker="gray" english="Almost everyone has been evacuated from the space station now. The rest of us are leaving in a couple of days, once our research has been completed." translation="宇宙ステーションからの避難は、ほぼ全員
+完了したようだ。残った我々も、あと数日で
+離れる事になろう。研究が終わればの話だが。" pad="1"/>
     </cutscene>
     <cutscene id="terminal_station_2" explanation="">
         <dialogue speaker="gray" english="-= Research Notes =-" translation="-= 研究資料 =-" padtowidth="132"/>
@@ -1260,9 +1258,8 @@ Pipe Dream" tt="1" pad="1"/>
     </cutscene>
     <cutscene id="terminal_outside_5" explanation="">
         <dialogue speaker="gray" english="-= Personal Log =-" translation="-= 個人ログ =-" padtowidth="132"/>
-        <dialogue speaker="gray" english="... I&apos;ve had to seal off access to most of our research. Who knows what could happen if it fell into the wrong hands? ..." translation="面倒だが我々の研究結果への
-アクセスを遮断する必要があった。
-もしもこの情報が悪しき者に渡れば
+        <dialogue speaker="gray" english="... I&apos;ve had to seal off access to most of our research. Who knows what could happen if it fell into the wrong hands? ..." translation="面倒だが我々の研究結果へのアクセスを遮断する
+必要があった。もしもこの情報が悪しき者に渡れば
 どんな恐ろしい事になるか…。
 それだけは避けねばならなかったのだ。" pad="1"/>
     </cutscene>


### PR DESCRIPTION
## Changes:

These are to make the textboxes not overlap with the header, by making them wrap to less lines.

Screenshots:
![image](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/dca71b00-257c-43f1-80e3-cd93c62bc6ee)
![image](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/6fadb610-b097-4ab1-8920-66f34cf7da56)



## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
