### PR TITLE
Change timing of textsprites in transparent textboxes

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -853,7 +853,6 @@ void Graphics::drawgui(void)
     {
         int text_yoff;
         int yp;
-        bool opaque;
         int font_height = font::height(textboxes[i].print_flags);
         if (flipmode)
         {
@@ -872,7 +871,9 @@ void Graphics::drawgui(void)
 
         char buffer[SCREEN_WIDTH_CHARS + 1];
 
-        if (textboxes[i].r == 0 && textboxes[i].g == 0 && textboxes[i].b == 0)
+        const bool transparent = (textboxes[i].r | textboxes[i].g | textboxes[i].b) == 0;
+
+        if (transparent)
         {
             /* To avoid the outlines for different lines overlapping the text itself,
              * first draw all the outlines and then draw the text. */
@@ -937,9 +938,10 @@ void Graphics::drawgui(void)
             }
         }
 
-        opaque = textboxes[i].tl >= 1.0;
+        const bool opaque = textboxes[i].tl >= 1.0;
+        const bool draw_overlays = opaque || transparent;
 
-        if (!opaque && textboxes[i].r != 0 && textboxes[i].g != 0 && textboxes[i].b != 0)
+        if (!draw_overlays)
         {
             continue;
         }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -939,7 +939,7 @@ void Graphics::drawgui(void)
 
         opaque = textboxes[i].tl >= 1.0;
 
-        if (!opaque)
+        if (!opaque && textboxes[i].r != 0 && textboxes[i].g != 0 && textboxes[i].b != 0)
         {
             continue;
         }


### PR DESCRIPTION
## Changes:

Textsprites and textimages no longer wait for the opacity value in order to display within transparent textboxes, so they now display at the same time as the text itself. Text sprites in normal opaque textboxes are not affected by this change.

This video shows the change in action (before the cut is current behaviour, after is with the change):

https://github.com/TerryCavanagh/VVVVVV/assets/44736084/a6e3f953-766c-4506-ae67-6fd2344c6e09

With this change, opportunities to use textsprites for e.g. animation and on-screen graphics display are made more convenient and easier to persue.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
