### PR TITLE
French: Add spaces at the end of "TEMPS :" string (and MORTS and BLINGS)

### DIFF
--- a/desktop_version/lang/fr/strings.xml
+++ b/desktop_version/lang/fr/strings.xml
@@ -388,9 +388,9 @@
     <string english="SHINY" translation="BLINGS" explanation="record number of trinkets" max="8"/>
     <string english="LIVES" translation="VIES" explanation="record lowest number of deaths" max="8"/>
     <string english="PAR TIME" translation="RÉFÉRENCE" explanation="followed by the goal time for this time trial" max="14"/>
-    <string english="TIME:" translation="TEMPS :" explanation="in time trial. Stopwatch time, not too long"/>
-    <string english="DEATH:" translation="MORTS :" explanation="in time trial. Number of times player died, not too long"/>
-    <string english="SHINY:" translation="BLINGS :" explanation="in time trial. Number of shiny trinkets collected, not too long"/>
+    <string english="TIME:" translation="TEMPS : " explanation="in time trial. Stopwatch time, not too long"/>
+    <string english="DEATH:" translation="MORTS : " explanation="in time trial. Number of times player died, not too long"/>
+    <string english="SHINY:" translation="BLINGS : " explanation="in time trial. Number of shiny trinkets collected, not too long"/>
     <string english="PAR TIME:" translation="RÉFÉRENCE :" explanation="in time trial. Goal time for time trial"/>
     <string english="BEST RANK" translation="MEILLEUR RANG" explanation="ranks are B A S V" max="17"/>
     <string english="GO!" translation="GO !" explanation="3, 2, 1, GO!" max="13"/>


### PR DESCRIPTION
## Changes:

This string is used both in time trials (alongside "MORTS :" and "BLINGS :") as well as outside time trials if you enable the in-game timer. In English, this looks like "TIME:1:23.45". Since French adds a space before the colon, it will look like "TEMPS :1:23.45" instead. Therefore, I've added a space after the colon as well.

![Time trial](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/1be6c3d0-5f34-4c56-8f74-16aa91012c41)
![In-game timer](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/d7a1170e-4962-4ae2-acfc-180511b6ad7e)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
