### PR TITLE
Fix remaining audio speedup/slowdown bug

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -435,27 +435,12 @@ end:
         sample_pos = 0;
         stb_vorbis_seek_start(vorbis);
 
-        if (!IsHalted())
-        {
-            if (SDL_memcmp(&musicVoiceFormat, &format, sizeof(format)) != 0)
-            {
-                Halt();
-                musicVoiceFormat = format;
-            }
-        }
+        Halt();
 
-        if (IsHalted())
-        {
-            SDL_zero(callbacks);
-            callbacks.OnBufferStart = &MusicTrack::refillReserve;
-            callbacks.OnBufferEnd = &MusicTrack::swapBuffers;
-            FAudio_CreateSourceVoice(faudioctx, &musicVoice, &format, 0, 2.0f, &callbacks, NULL, NULL);
-        }
-        else
-        {
-            Pause();
-            FAudioSourceVoice_FlushSourceBuffers(musicVoice);
-        }
+        SDL_zero(callbacks);
+        callbacks.OnBufferStart = &MusicTrack::refillReserve;
+        callbacks.OnBufferEnd = &MusicTrack::swapBuffers;
+        FAudio_CreateSourceVoice(faudioctx, &musicVoice, &format, 0, 2.0f, &callbacks, NULL, NULL);
 
         FAudioBuffer faudio_buffer;
         SDL_zero(faudio_buffer);
@@ -546,7 +531,6 @@ end:
 
     static bool paused;
     static FAudioSourceVoice* musicVoice;
-    static FAudioWaveFormatEx musicVoiceFormat;
 
     static void refillReserve(FAudioVoiceCallback* callback, void* ctx)
     {
@@ -725,7 +709,6 @@ end:
 };
 bool MusicTrack::paused = false;
 FAudioSourceVoice* MusicTrack::musicVoice = NULL;
-FAudioWaveFormatEx MusicTrack::musicVoiceFormat;
 
 musicclass::musicclass(void)
 {


### PR DESCRIPTION
## Changes:

Fixes #1057.

Based on Ethan's hunch, I simply removed the format comparison that decides whether to halt and restart, or reuse the voice. Voices are now always restarted when playing a new track.

This also simplifies the code somewhat: `MusicTrack::musicVoiceFormat` was now no longer used, and an `if (!IsHalted())` was no longer necessary because `Halt()` already does that. So those are now removed as well.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
