### PR TITLE
Minor language fixes for Japanese and Italian

### DIFF
--- a/desktop_version/lang/it/strings.xml
+++ b/desktop_version/lang/it/strings.xml
@@ -207,8 +207,8 @@
     <string english="toggle in-game timer" translation="timer nel gioco" explanation="menu option"/>
     <string english="In-Game Timer" translation="Timer nel gioco" explanation="title" max="20"/>
     <string english="Toggle the in-game timer outside of time trials." translation="Attiva o disattiva il timer nel gioco al di fuori delle prove a tempo." explanation="" max="38*3"/>
-    <string english="In-Game Timer is ON" translation="Timer nel gioco: NO" explanation="" max="38*2"/>
-    <string english="In-Game Timer is OFF" translation="Timer nel gioco: SÌ" explanation="" max="38*2"/>
+    <string english="In-Game Timer is ON" translation="Timer nel gioco: SÌ" explanation="" max="38*2"/>
+    <string english="In-Game Timer is OFF" translation="Timer nel gioco: NO" explanation="" max="38*2"/>
     <string english="english sprites" translation="sprite inglesi" explanation="menu option"/>
     <string english="English Sprites" translation="Sprite inglesi" explanation="title" max="20"/>
     <string english="Show the original English word enemies regardless of your language setting." translation="Mostra le parole nemiche in inglese indipendentemente dalla lingua impostata." explanation="" max="38*3"/>

--- a/desktop_version/lang/ja/strings.xml
+++ b/desktop_version/lang/ja/strings.xml
@@ -347,7 +347,7 @@ Sランク以上を獲得" explanation="ranks are B A S V, see below" max="38*3"
     <string english="Keep trying! You&apos;ll get there!" translation="頑張れ! やればできるっ!!" explanation="player died before managing to save anybody" max="38*2" max_local="38*1"/>
     <string english="Nice one!" translation="ナイス!" explanation="player died after saving one crewmate" max="38*2" max_local="38*1"/>
     <string english="Wow! Congratulations!" translation="WOW! おめでとう!!" explanation="player died after saving two crewmates" max="38*2" max_local="38*1"/>
-    <string english="Incredible!" translation="凄い!" explanation="player died after saving three crewmates" max="38*2" max_local="38*1"/>
+    <string english="Incredible!" translation="すごい!" explanation="player died after saving three crewmates" max="38*2" max_local="38*1"/>
     <string english="Unbelievable! Well done!" translation="信じられない! 良くやった!!" explanation="player died after saving four crewmates" max="38*2" max_local="38*1"/>
     <string english="Er, how did you do that?" translation="えっ? 今のどうやったの…?" explanation="player died even though they were finished, lol" max="38*2" max_local="38*1"/>
     <string english="WOW" translation="WOW!" explanation="even bigger title" max="10" max_local="10"/>


### PR DESCRIPTION
## Changes:

Japanese: Apply change from 凄い to すごい
Italian: Fix in-game timer ON/OFF being reversed (see https://github.com/TerryCavanagh/VVVVVV/issues/1060#issuecomment-1830923642)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
