### PR TITLE
Fixed duplicated/shifted characters in font

### DIFF
--- a/desktop_version/fonts/font.fontmeta
+++ b/desktop_version/fonts/font.fontmeta
@@ -56,7 +56,6 @@
         <range start="0x260E" end="0x260F"/>
         <range start="0x261C" end="0x2620"/>
         <range start="0x2622" end="0x2623"/>
-        <range start="0x263A" end="0x263B"/>
         <range start="0x262E" end="0x262E"/>
         <range start="0x263A" end="0x2640"/>
         <range start="0x2642" end="0x2653"/>


### PR DESCRIPTION
## Changes:

Some characters were duplicated in fontmeta, causing e.g. the wrong icons to be displayed on the minimap. This fixes it by regenerating the font from git.txt.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
