### PR TITLE
Correct one letter's capitalization in German

### DIFF
--- a/desktop_version/lang/de/strings.xml
+++ b/desktop_version/lang/de/strings.xml
@@ -69,7 +69,7 @@
     <string english="Toggle between MMMMMM and PPPPPP." translation="Wechsle zwischen MMMMMM und PPPPPP." explanation="" max="38*2"/>
     <string english="Current soundtrack: PPPPPP" translation="Aktueller Soundtrack: PPPPPP" explanation="" max="38*3"/>
     <string english="Current soundtrack: MMMMMM" translation="Aktueller Soundtrack: MMMMMM" explanation="" max="38*3"/>
-    <string english="toggle fullscreen" translation="Vollbild umschalten" explanation="menu option"/>
+    <string english="toggle fullscreen" translation="vollbild umschalten" explanation="menu option"/>
     <string english="Toggle Fullscreen" translation="Vollbild umschalten" explanation="title" max="20"/>
     <string english="Change to fullscreen/windowed mode." translation="Wechselt zwischen Vollbild-/Fenstermodus." explanation="" max="38*3"/>
     <string english="Current mode: FULLSCREEN" translation="Aktueller Modus: VOLLBILD" explanation="" max="38*2"/>


### PR DESCRIPTION
## Changes:

It's a menu option, so it should be uncapitalized, like all other menu options.

![Vollbild umschalten](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/5aa09ee2-7023-441c-9574-2f33e75e8607)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
