### PR TITLE
Fix centering of game complete texts if level font != interface font

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -2881,6 +2881,7 @@ void Game::updatestate(void)
 
             graphics.createtextboxflipme(loc::gettext("All Crew Members Rescued!"), -1, 64, TEXT_COLOUR("transparent"));
             graphics.textboxprintflags(PR_FONT_INTERFACE);
+            graphics.textboxcenterx();
             char buffer[SCREEN_WIDTH_CHARS + 1];
             timestringcenti(buffer, sizeof(buffer));
             savetime = buffer;
@@ -2956,11 +2957,13 @@ void Game::updatestate(void)
             );
             graphics.createtextboxflipme(buffer, -1, 158, TEXT_COLOUR("transparent"));
             graphics.textboxprintflags(PR_FONT_INTERFACE);
+            graphics.textboxcenterx();
             graphics.createtextboxflipme(
                 loc::gettext_roomname(map.custommode, hardestroom_x, hardestroom_y, hardestroom.c_str(), hardestroom_specialname),
                 -1, 170, TEXT_COLOUR("transparent")
             );
             graphics.textboxprintflags(PR_FONT_INTERFACE);
+            graphics.textboxcenterx();
             break;
         }
         case 3508:


### PR DESCRIPTION
## Changes:

Textboxes created with `graphics.createtextboxflipme()` use `PR_FONT_LEVEL` by default, but can be overridden with `graphics.textboxprintflags()` to, for example, set `PR_FONT_INTERFACE`. This happens for the textboxes on the Game Complete screen, which use interface text. The textboxes are centered by setting the X position to -1 though, which means they're solely centered based on the width of the first line, in the level font (because the font hasn't been changed to the interface font yet).

Normally, this isn't a problem, because in the main game (where the Game Complete screen usually appears), the level font is always equal to the interface font. However, in custom levels you can still get it (by calling gamestate 3500) and in that case some of the text may be misaligned. This change fixes that by adding `graphics.textboxcenterx()` to these textboxes.

As far as I can tell, these are the only textboxes that are centered by just x=-1 despite changing the font afterwards.

Before (showing a level using a Chinese level font in an English VVVVVV):
![misaligned](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/057f939e-0d13-4a5d-9a45-bfa9bc07e149)

After:
![aligned properly](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/93f4a379-ea6c-4bf6-8be5-b1da471e2b04)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
