### PR TITLE
Fix ACCIÓN having changed to ACTION in Spanish

### DIFF
--- a/desktop_version/lang/es/strings.xml
+++ b/desktop_version/lang/es/strings.xml
@@ -220,7 +220,7 @@
     <string english="E" translation="E" explanation="keyboard key E. Speedrunner options menu"/>
     <string english="ENTER" translation="ENTRAR" explanation="keyboard key ENTER. Speedrunner options menu"/>
     <string english="ESC" translation="ESC" explanation="keyboard key ESC"/>
-    <string english="ACTION" translation="ACTION" explanation="the ACTION key is either the SPACE key, Z or V (this is explained on the title screen). It&apos;s used in strings like `Press ACTION to advance text`"/>
+    <string english="ACTION" translation="ACCIÓN" explanation="the ACTION key is either the SPACE key, Z or V (this is explained on the title screen). It&apos;s used in strings like `Press ACTION to advance text`"/>
     <string english="Interact button: {button}" translation="Botón de interacción: {button}" explanation="keyboard key (E or ENTER) is filled in for {button}. Speedrunner options menu" max="38*2"/>
     <string english="fake load screen" translation="pantalla de carga" explanation="menu option"/>
     <string english="Fake Load Screen" translation="Pantalla de carga" explanation="title, allows the loading screen which counts to 100% to be turned off" max="20"/>


### PR DESCRIPTION
## Changes:

Fixes this (found by toni57 on Discord):

![Pulsa ACTION para empezar](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/b7b85e9d-080d-49e8-8773-67dd43ed7d4c)



## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
