### PR TITLE
Make language sync support creating blank language files; clarify lang/README-programmers.txt

### DIFF
--- a/desktop_version/lang/README-programmers.txt
+++ b/desktop_version/lang/README-programmers.txt
@@ -1,6 +1,8 @@
 === I N T R O D U C T I O N ===
 
-This file will explain what you need to know when maintaining translations of VVVVVV (like adding new strings and syncing them across languages).
+This file will explain what you need to know when maintaining translations of VVVVVV (like adding new strings to the game and syncing them across languages).
+
+For making new translations of the game, read README-translators.txt instead.
 
 
 

--- a/desktop_version/lang/README-translators.txt
+++ b/desktop_version/lang/README-translators.txt
@@ -16,6 +16,8 @@ The English language files are basically templates for other languages (all the 
 
 To create a new language, simply copy the `en` folder, and start by filling out meta.xml (further explained below).
 
+Alternatively, you can create an empty language folder, and then use the in-game sync tool (translator > maintenance > sync language files) to populate it.
+
 
 
 === E X C E L ===

--- a/desktop_version/src/LocalizationMaint.cpp
+++ b/desktop_version/src/LocalizationMaint.cpp
@@ -177,6 +177,17 @@ static void sync_lang_file(const std::string& langcode)
         FILESYSTEM_saveTiXml2Document((langcode + "/strings.xml").c_str(), doc);
     }
 
+    if (!load_lang_doc("numbers", doc, langcode))
+    {
+        /* If numbers.xml doesn't exist _at all_, then simply copy it from English,
+         * so that you can make a new translation simply by making a folder and syncing. */
+
+        if (load_lang_doc("numbers", doc, "en"))
+        {
+            FILESYSTEM_saveTiXml2Document((langcode + "/numbers.xml").c_str(), doc);
+        }
+    }
+
     if (load_lang_doc("strings_plural", doc, "en"))
     {
         /* Form 255 is technically invalid, but we have to account for it */

--- a/desktop_version/src/LocalizationStorage.cpp
+++ b/desktop_version/src/LocalizationStorage.cpp
@@ -59,6 +59,10 @@ static void loadmeta(LangMeta& meta, const std::string& langcode = lang)
 {
     meta.active = true;
     meta.code = langcode;
+    meta.nativename = langcode;
+    meta.credit = "";
+    meta.action_hint = "Press Space, Z, or V to select";
+    meta.gamepad_hint = "Press {button} to select";
     meta.autowordwrap = true;
     meta.toupper = true;
     meta.toupper_i_dot = false;
@@ -238,6 +242,7 @@ void resettext(bool final_shutdown)
             number[i] = "";
         }
         SDL_zeroa(number_plural_form);
+        number_plural_form[1] = 1;
 
         SDL_zeroa(translation_roomnames);
         SDL_zeroa(explanation_roomnames);


### PR DESCRIPTION
## Changes:

Two translators thus far have tried to populate initial language files by creating a blank folder and then using the in-game sync option. For example, see #1078.

That is not how the sync option was intended to be used, but it's really close to getting everything, so I decided to just complete the support by making sure `numbers.xml` is copied from English, and making sure `meta.xml` is filled in with English text and not text from an arbitrary language. Also, minor detail on plural form 1 being set to 1 by default if reset, so `strings_plural.xml` is fully consistent too.

The top of lang/README-programmers.txt now also says that you need the translators readme to translate the game into a new language.



## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
