### PR TITLE
Some fixes to the translator credits

### DIFF
--- a/desktop_version/lang/ca/strings.xml
+++ b/desktop_version/lang/ca/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="i també hi han donat suport" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="i" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="Aportacions a GitHub" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="Amb aportacions a GitHub de" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="Amb aportacions a GitHub de" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="i també gràcies a:" explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="Tu!" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="El teu suport fa possible que pugui continuar creant els jocs que vull crear, ara i en un futur!" explanation="credits" max="38*5"/>
@@ -777,11 +777,11 @@ Has trobat el laboratori secret!" explanation="" max="34*4"/>
     <string english="Error parsing {path}: {error}" translation="S’ha produït un error en analitzar {path}: {error}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="Les dimensions de «{filename}» no són múltiples exactes de {width}x{height}!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="ERROR: No s’ha pogut escriure|a la carpeta de llengua! Assegura’t|que no hi hagi cap carpeta «lang»|al costat de les partides desades normals." explanation="" max="38*5"/>
-    <string english="Localisation" translation="Localització" explanation=""/>
-    <string english="Localisation Project Led by" translation="Projecte de localització liderat per" explanation=""/>
+    <string english="Localisation" translation="Localització" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="Projecte de localització liderat per" explanation="" max="40"/>
     <string english="Translations by" translation="Traduccions de" explanation=""/>
-    <string english="Translators" translation="Traductors" explanation=""/>
-    <string english="Pan-European Font Design by" translation="Disseny de la font paneuropea de" explanation=""/>
+    <string english="Translators" translation="Traductors" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="Disseny de la font paneuropea de" explanation="" max="40"/>
     <string english="Fonts by" translation="Fonts de" explanation=""/>
     <string english="Other Fonts by" translation="Altres fonts de" explanation=""/>
     <string english="Catalan" translation="Català" explanation=""/>

--- a/desktop_version/lang/cy/strings.xml
+++ b/desktop_version/lang/cy/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="a hefyd gan" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="a" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="Cyfranwyr GitHub" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="Gyda chyfraniadau ar GitHub gan" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="Gyda chyfraniadau ar GitHub gan" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="a diolch hefyd i:" explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="Ti!" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="Mae eich cefnogaeth yn ei gwneud hi&apos;n bosibl i mi barhau i wneud y gemau rydw i eisiau eu gwneud, nawr ac yn y dyfodol." explanation="credits" max="38*5"/>
@@ -771,11 +771,11 @@ You have found the secret lab!" translation="Llongyfarchiadau! Rwyt ti wedi dod 
     <string english="Error parsing {path}: {error}" translation="Gwall yn dosrannu {path}: {error}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="{filename} nid yw dimensiynau yn union luosrifau {width} gan {height}!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="GWALL: Methu ysgrifennu i&apos;r ffolder iaith! Gwnewch yn siŵr nad oes ffolder &quot;lang&quot; wrth ymyl y storfa arferol." explanation="" max="38*5"/>
-    <string english="Localisation" translation="Lleoleiddiad" explanation=""/>
-    <string english="Localisation Project Led by" translation="Arweinir Prosiect Lleoleiddio gan" explanation=""/>
+    <string english="Localisation" translation="Lleoleiddiad" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="Arweinir Prosiect Lleoleiddio gan" explanation="" max="40"/>
     <string english="Translations by" translation="Cyfieithiadau gan" explanation=""/>
-    <string english="Translators" translation="Cyfieithwyr" explanation=""/>
-    <string english="Pan-European Font Design by" translation="Dyluniad Ffont Pan-Ewropeaidd gan" explanation=""/>
+    <string english="Translators" translation="Cyfieithwyr" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="Dyluniad Ffont Pan-Ewropeaidd gan" explanation="" max="40"/>
     <string english="Fonts by" translation="Ffontiau gan" explanation=""/>
     <string english="Other Fonts by" translation="Ffontiau Eraill gan" explanation=""/>
     <string english="Catalan" translation="Catalaneg" explanation=""/>

--- a/desktop_version/lang/de/strings.xml
+++ b/desktop_version/lang/de/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="und auch von" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="und" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="GitHub-Beitragende" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="Mit GitHub-Beiträgen von" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="Mit GitHub-Beiträgen von" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="vielen Dank auch an:" explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="Dich!" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="Dank deiner Unterstützung kann ich weiterhin die Spiele entwickeln, die ich machen will! Jetzt und in Zukunft!" explanation="credits" max="38*5"/>
@@ -777,11 +777,11 @@ Du hast das Geheimlabor gefunden!" explanation="" max="34*4"/>
     <string english="Error parsing {path}: {error}" translation="Fehler beim Parsen von {path}: {error}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="{filename} Dimensionen nicht genaues Vielfaches von {width} mal {height}!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="FEHLER: Konnte nicht in den Sprachordner schreiben! Stelle sicher, dass es keinen &quot;lang&quot;-Ordner neben den regulären Spielständen gibt." explanation="" max="38*5"/>
-    <string english="Localisation" translation="Übersetzung" explanation=""/>
-    <string english="Localisation Project Led by" translation="Lokalisierungsprojekt geleitet von" explanation=""/>
+    <string english="Localisation" translation="Übersetzung" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="Lokalisierungsprojekt geleitet von" explanation="" max="40"/>
     <string english="Translations by" translation="Übersetzungen von" explanation=""/>
-    <string english="Translators" translation="Übersetzer" explanation=""/>
-    <string english="Pan-European Font Design by" translation="Pan-European Font Design von" explanation=""/>
+    <string english="Translators" translation="Übersetzer" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="Pan-European Font Design von" explanation="" max="40"/>
     <string english="Fonts by" translation="Schriftarten von" explanation=""/>
     <string english="Other Fonts by" translation="Andere Schriftarten von" explanation=""/>
     <string english="Catalan" translation="Katalanisch" explanation=""/>

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="" explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="" explanation="credits" max="38*5"/>
@@ -772,11 +772,11 @@ You have found the secret lab!" translation="" explanation="" max="34*4"/>
     <string english="Error parsing {path}: {error}" translation="" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="" explanation="" max="38*5"/>
-    <string english="Localisation" translation="" explanation=""/>
-    <string english="Localisation Project Led by" translation="" explanation=""/>
+    <string english="Localisation" translation="" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="" explanation="" max="40"/>
     <string english="Translations by" translation="" explanation=""/>
-    <string english="Translators" translation="" explanation=""/>
-    <string english="Pan-European Font Design by" translation="" explanation=""/>
+    <string english="Translators" translation="" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="" explanation="" max="40"/>
     <string english="Fonts by" translation="" explanation=""/>
     <string english="Other Fonts by" translation="" explanation=""/>
     <string english="Catalan" translation="" explanation=""/>

--- a/desktop_version/lang/eo/strings.xml
+++ b/desktop_version/lang/eo/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="kaj ankaŭ de" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="kaj" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="Kod-kontribuantoj" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="Kun kontribuoj ĉe GitHub de" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="Kun kontribuoj ĉe GitHub de" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="kaj dankon ankaŭ al:" explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="Vi!" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="Via subteno ebligas por mi daŭre fari la ludojn, kiujn mi volas fari, nun kaj estontecen." explanation="credits" max="38*5"/>
@@ -777,11 +777,11 @@ Vi trovis la sekretan labon!" explanation="" max="34*4"/>
     <string english="Error parsing {path}: {error}" translation="Eraro dum analizado de {path}: {error}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="Dimensioj de {filename} ne estas ekzaktaj obloj de {width} oble {height}!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="ERARO: Ne eblis skribi en lingvo-dosierujo! Certigu, ke ne estas dosierujo &quot;lang&quot; apud la normalaj konservaĵoj." explanation="" max="38*5"/>
-    <string english="Localisation" translation="Tradukado" explanation=""/>
-    <string english="Localisation Project Led by" translation="Ĉefo de traduka projekto" explanation=""/>
+    <string english="Localisation" translation="Tradukado" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="Ĉefo de traduka projekto" explanation="" max="40"/>
     <string english="Translations by" translation="Tradukis" explanation=""/>
-    <string english="Translators" translation="Tradukistoj" explanation=""/>
-    <string english="Pan-European Font Design by" translation="Tuteŭropan tiparon desegnis" explanation=""/>
+    <string english="Translators" translation="Tradukistoj" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="Tuteŭropan tiparon desegnis" explanation="" max="40"/>
     <string english="Fonts by" translation="Tiparoj de" explanation=""/>
     <string english="Other Fonts by" translation="Aliaj tiparoj de" explanation=""/>
     <string english="Catalan" translation="Katalunen" explanation=""/>

--- a/desktop_version/lang/es/strings.xml
+++ b/desktop_version/lang/es/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="y también" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="y" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="Colaboradores GitHub" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="Con colaboraciones en GitHub de" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="Con colaboraciones en GitHub de" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="y también gracias a:" explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="¡ti!" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="Tu apoyo hace posible que yo pueda seguir creando los juegos que quiero hacer, ahora y en el futuro." explanation="credits" max="38*5"/>
@@ -777,11 +777,11 @@ You have found the secret lab!" translation="¡Enhorabuena!
     <string english="Error parsing {path}: {error}" translation="Error de análisis en {path}: {error}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="¡Las dimensiones de {filename} no son múltiplos exactos de {width} por {height}!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="ERROR: No se ha podido escribir en la carpeta de idioma. Comprueba que no haya una carpeta &quot;lang&quot; junto a los guardados normales." explanation="" max="38*5"/>
-    <string english="Localisation" translation="Localización" explanation=""/>
-    <string english="Localisation Project Led by" translation="Proyecto de localización dirigido por" explanation=""/>
+    <string english="Localisation" translation="Localización" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="Proyecto de localización dirigido por" explanation="" max="40"/>
     <string english="Translations by" translation="Traducciones de" explanation=""/>
-    <string english="Translators" translation="Traductores" explanation=""/>
-    <string english="Pan-European Font Design by" translation="Diseño de fuente paneuropea" explanation=""/>
+    <string english="Translators" translation="Traductores" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="Diseño de fuente paneuropea" explanation="" max="40"/>
     <string english="Fonts by" translation="Fuentes de" explanation=""/>
     <string english="Other Fonts by" translation="Otras fuentes de" explanation=""/>
     <string english="Catalan" translation="Catalán" explanation=""/>

--- a/desktop_version/lang/fr/strings.xml
+++ b/desktop_version/lang/fr/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="et également par" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="et" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="Contributeurs GitHub" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="Avec des contributions sur GitHub de" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="Avec des contributions sur GitHub de" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="Merci également à" explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="Vous !" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="Votre soutien me permet de développer les concepts de jeux qui me passent par la tête, et me permettra de continuer à le faire." explanation="credits" max="38*5"/>
@@ -777,11 +777,11 @@ Vous avez trouvé le labo secret !" explanation="" max="34*4"/>
     <string english="Error parsing {path}: {error}" translation="Erreur de traitement de {path} : {error}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="Les dimensions de {filename} ne sont pas des multiples exacts de {width} par {height} !" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="ERREUR : impossible d&apos;écrire dans le dossier de langue ! Assurez-vous qu&apos;il n&apos;y ait pas de dossier « lang » à côté des sauvegardes standard." explanation="" max="38*5"/>
-    <string english="Localisation" translation="Localisation" explanation=""/>
-    <string english="Localisation Project Led by" translation="Projet de localisation dirigé par" explanation=""/>
+    <string english="Localisation" translation="Localisation" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="Projet de localisation dirigé par" explanation="" max="40"/>
     <string english="Translations by" translation="Traductions par" explanation=""/>
-    <string english="Translators" translation="Traducteurs" explanation=""/>
-    <string english="Pan-European Font Design by" translation="Police paneuropéenne par" explanation=""/>
+    <string english="Translators" translation="Traducteurs" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="Police paneuropéenne par" explanation="" max="40"/>
     <string english="Fonts by" translation="Polices par" explanation=""/>
     <string english="Other Fonts by" translation="Autres polices par" explanation=""/>
     <string english="Catalan" translation="Catalan" explanation=""/>

--- a/desktop_version/lang/ga/strings.xml
+++ b/desktop_version/lang/ga/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="agus le" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="agus le" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="Cuiditheoirí GitHub" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="Le cuidiú ar GitHub ó" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="Le cuidiú ar GitHub ó" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="agus buíochas..." explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="leatsa!" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="Is de bharr do chuid tacaíochta is féidir liomsa leanúint ar aghaidh ag déanamh na gcluichí atá uaim." explanation="credits" max="38*5"/>
@@ -773,11 +773,11 @@ You have found the secret lab!" translation="Comhghairdeas! Fuair tú an tsaotha
     <string english="Error parsing {path}: {error}" translation="Tharla earráid le parsáil {path}: {error}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="Níl toisí {filename} ina n-iolraithe cruinne de {width} agus {height}!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="EARRÁID: Theip ar shonraí a chur san fhillteán teanga! Déan cinnte nach bhfuil fillteán darb ainm &quot;lang&quot; in aice leis na gnáthshábhálacha." explanation="" max="38*5"/>
-    <string english="Localisation" translation="Logánú" explanation=""/>
-    <string english="Localisation Project Led by" translation="Bainisteoir an Tionscadail Logánaithe" explanation=""/>
+    <string english="Localisation" translation="Logánú" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="Bainisteoir an Tionscadail Logánaithe" explanation="" max="40"/>
     <string english="Translations by" translation="Aistriúcháin le" explanation=""/>
-    <string english="Translators" translation="Aistritheoirí" explanation=""/>
-    <string english="Pan-European Font Design by" translation="Cló Pan-Eorpach le" explanation=""/>
+    <string english="Translators" translation="Aistritheoirí" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="Cló Pan-Eorpach le" explanation="" max="40"/>
     <string english="Fonts by" translation="Clónna le" explanation=""/>
     <string english="Other Fonts by" translation="Clónna eile le" explanation=""/>
     <string english="Catalan" translation="Catalóinis" explanation=""/>

--- a/desktop_version/lang/it/strings.xml
+++ b/desktop_version/lang/it/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="e anche da" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="e" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="Collaboratori GitHub" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="Con contributi su GitHub di" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="Con contributi su GitHub di" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="e grazie anche a:" explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="Te!" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="Grazie al tuo sostegno posso continuare a creare i giochi che amo, ora e in futuro." explanation="credits" max="38*5"/>
@@ -777,11 +777,11 @@ Hai trovato il laboratorio segreto!" explanation="" max="34*4"/>
     <string english="Error parsing {path}: {error}" translation="Errore di lettura {path}: {error}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="Le dimensioni di {filename} non sono un multiplo esatto di {width} x {height}!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="ERRORE: impossibile scrivere sulla cartella lingua! Assicurati che non ci sia una cartella &quot;lang&quot; insieme ai normali salvataggi." explanation="" max="38*5"/>
-    <string english="Localisation" translation="Localizzazione" explanation=""/>
-    <string english="Localisation Project Led by" translation="Direzione del progetto di localizzazione" explanation=""/>
+    <string english="Localisation" translation="Localizzazione" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="Direzione del progetto di localizzazione" explanation="" max="40"/>
     <string english="Translations by" translation="Traduzioni" explanation=""/>
-    <string english="Translators" translation="Traduttori" explanation=""/>
-    <string english="Pan-European Font Design by" translation="Progettazione del font pan-europeo" explanation=""/>
+    <string english="Translators" translation="Traduttori" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="Progettazione del font pan-europeo" explanation="" max="40"/>
     <string english="Fonts by" translation="Font" explanation=""/>
     <string english="Other Fonts by" translation="Altri font" explanation=""/>
     <string english="Catalan" translation="Catalano" explanation=""/>

--- a/desktop_version/lang/ja/strings.xml
+++ b/desktop_version/lang/ja/strings.xml
@@ -129,7 +129,7 @@
     <string english="and also by" translation="その他、支援してくださった方々" explanation="credits, VVVVVV is also supported by the following people" max="38*2" max_local="38*1"/>
     <string english="and" translation="その他の支援" explanation="credits. This list of names, AND furthermore, this other list of names" max="38" max_local="38"/>
     <string english="GitHub Contributors" translation="GitHubによる開発貢献" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20" max_local="20"/>
-    <string english="With contributions on GitHub from" translation="GitHubによる開発貢献" explanation="credits" max="38*3" max_local="38*2"/>
+    <string english="With contributions on GitHub from" translation="GitHubによる開発貢献" explanation="credits" max="40" max_local="40"/>
     <string english="and thanks also to:" translation="スペシャルサンクス" explanation="credits, and thanks also to ... you!" max="38*3" max_local="38*2"/>
     <string english="You!" translation="プレイしてくださったあなた" explanation="credits, and thanks also to ... you!" max="20" max_local="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="あなたのサポートがあるからこそ、今まで、そしてこれからも
@@ -843,11 +843,11 @@ You have found the secret lab!" translation="よくやった!
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="エラー: 言語フォルダーに書き込めません!
 セーブファイルと同じ場所に「lang」ディレクトリーが
 ないことを確認してください。" explanation="" max="38*5" max_local="38*4"/>
-    <string english="Localisation" translation="ローカライズ" explanation=""/>
-    <string english="Localisation Project Led by" translation="ローカライズ プロジェクト主任" explanation=""/>
+    <string english="Localisation" translation="ローカライズ" explanation="" max="20" max_local="20"/>
+    <string english="Localisation Project Led by" translation="ローカライズ プロジェクト主任" explanation="" max="40" max_local="40"/>
     <string english="Translations by" translation="翻訳" explanation=""/>
-    <string english="Translators" translation="翻訳" explanation=""/>
-    <string english="Pan-European Font Design by" translation="欧米フォントデザイン" explanation=""/>
+    <string english="Translators" translation="翻訳" explanation="" max="20" max_local="20"/>
+    <string english="Pan-European Font Design by" translation="欧米フォントデザイン" explanation="" max="40" max_local="40"/>
     <string english="Fonts by" translation="フォントデザイン" explanation=""/>
     <string english="Other Fonts by" translation="他言語フォントデザイン" explanation=""/>
     <string english="Catalan" translation="カタロニア語" explanation=""/>

--- a/desktop_version/lang/ko/strings.xml
+++ b/desktop_version/lang/ko/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="그리고 이분들도 도와주셨습니다" explanation="credits, VVVVVV is also supported by the following people" max="38*2" max_local="30*2"/>
     <string english="and" translation="그리고 이분들도" explanation="credits. This list of names, AND furthermore, this other list of names" max="38" max_local="30"/>
     <string english="GitHub Contributors" translation="GitHub 기여자" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20" max_local="16"/>
-    <string english="With contributions on GitHub from" translation="다음 GitHub 사용자들로부터 기여를 받았습니다" explanation="credits" max="38*3" max_local="30*3"/>
+    <string english="With contributions on GitHub from" translation="다음 GitHub 사용자들로부터 기여를 받았습니다" explanation="credits" max="40" max_local="32"/>
     <string english="and thanks also to:" translation="그리고" explanation="credits, and thanks also to ... you!" max="38*3" max_local="30*3"/>
     <string english="You!" translation="여러분께도 감사드립니다!" explanation="credits, and thanks also to ... you!" max="20" max_local="16"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="귀하의 지원이 제가 만들고자 하는 게임을 지금, 그리고 미래에도 만들 수 있게 합니다." explanation="credits" max="38*5" max_local="30*5"/>
@@ -777,11 +777,11 @@ You have found the secret lab!" translation="축하합니다!
     <string english="Error parsing {path}: {error}" translation="{path}의 경로를 분석할 수 없음: {error}" explanation="we tried to parse the level file, but failed" max="38*6" max_local="30*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="{filename} 차원의 크기가 {width}, {height}의 정확한 배수가 아님!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6" max_local="30*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="오류: 언어 폴더에 쓰기 실패! 일반 저장 파일과 함께 &quot;lang&quot; 폴더가 없는지 확인해 주세요." explanation="" max="38*5" max_local="30*5"/>
-    <string english="Localisation" translation="현지화" explanation=""/>
-    <string english="Localisation Project Led by" translation="현지화 프로젝트 주도" explanation=""/>
+    <string english="Localisation" translation="현지화" explanation="" max="20" max_local="16"/>
+    <string english="Localisation Project Led by" translation="현지화 프로젝트 주도" explanation="" max="40" max_local="32"/>
     <string english="Translations by" translation="번역" explanation=""/>
-    <string english="Translators" translation="번역가" explanation=""/>
-    <string english="Pan-European Font Design by" translation="범유럽 폰트 디자인" explanation=""/>
+    <string english="Translators" translation="번역가" explanation="" max="20" max_local="16"/>
+    <string english="Pan-European Font Design by" translation="범유럽 폰트 디자인" explanation="" max="40" max_local="32"/>
     <string english="Fonts by" translation="폰트" explanation=""/>
     <string english="Other Fonts by" translation="기타 폰트" explanation=""/>
     <string english="Catalan" translation="카탈루냐어" explanation=""/>

--- a/desktop_version/lang/nl/strings.xml
+++ b/desktop_version/lang/nl/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="en ook door" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="en" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="GitHub-bijdragers" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="Met bijdragen op GitHub van" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="Met bijdragen op GitHub van" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="en ook met dank aan:" explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="Jou!" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="Jouw ondersteuning maakt het mogelijk voor mij om de spellen te blijven maken die ik wil maken, nu en in de toekomst." explanation="credits" max="38*5"/>
@@ -778,11 +778,11 @@ Je hebt het geheime lab gevonden!" explanation="" max="34*4"/>
     <string english="Error parsing {path}: {error}" translation="Fout bij parseren van {path}: {error}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="Dimensies van {filename} zijn geen exact veelvoud van {width} bij {height}!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="FOUT: Kan niet schrijven naar talenmap! Zorg dat er geen &quot;lang&quot;-map naast de normale opgeslagen bestanden staat." explanation="" max="38*5"/>
-    <string english="Localisation" translation="Lokalisering" explanation=""/>
-    <string english="Localisation Project Led by" translation="Lokaliseringsproject geleid door" explanation=""/>
+    <string english="Localisation" translation="Lokalisering" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="Lokaliseringsproject geleid door" explanation="" max="40"/>
     <string english="Translations by" translation="Vertalingen door" explanation=""/>
-    <string english="Translators" translation="Vertalers" explanation=""/>
-    <string english="Pan-European Font Design by" translation="Ontwerp pan-Europees lettertype door" explanation=""/>
+    <string english="Translators" translation="Vertalers" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="Ontwerp pan-Europees lettertype door" explanation="" max="40"/>
     <string english="Fonts by" translation="Lettertypen door" explanation=""/>
     <string english="Other Fonts by" translation="Overige lettertypen door" explanation=""/>
     <string english="Catalan" translation="Catalaans" explanation=""/>

--- a/desktop_version/lang/pl/strings.xml
+++ b/desktop_version/lang/pl/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="a także" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="oraz" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="Współprogramiści:" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="Przy użyciu zmian na GitHubie autorstwa" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="Przy użyciu zmian na GitHubie autorstwa" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="a także z podziękowaniem dla:" explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="Ciebie!" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="Twoje wsparcie pomaga mi ciągle tworzyć takie gry, jakie chcę,|teraz i w przyszłości." explanation="credits" max="38*5"/>
@@ -777,11 +777,11 @@ Znaleziono tajne laboratorium!" explanation="" max="34*4"/>
     <string english="Error parsing {path}: {error}" translation="Błąd czytania {path}: {błąd}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="Wymiary {filename} nie są wielokrotnościami {width} na {height}!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="BŁĄD: Nie zapisano do folderu językowego! Upewnij się, że nie ma folderu &quot;lang&quot; obok regularnych zapisów." explanation="" max="38*5"/>
-    <string english="Localisation" translation="Lokalizacja" explanation=""/>
-    <string english="Localisation Project Led by" translation="Projektem lokalizacji przewodził" explanation=""/>
+    <string english="Localisation" translation="Lokalizacja" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="Projektem lokalizacji przewodził" explanation="" max="40"/>
     <string english="Translations by" translation="Tłumaczyli" explanation=""/>
-    <string english="Translators" translation="Tłumacze" explanation=""/>
-    <string english="Pan-European Font Design by" translation="Design Pan-Europejskiej Czcionki" explanation=""/>
+    <string english="Translators" translation="Tłumacze" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="Design Pan-Europejskiej Czcionki" explanation="" max="40"/>
     <string english="Fonts by" translation="Czcionki" explanation=""/>
     <string english="Other Fonts by" translation="Inne czcionki" explanation=""/>
     <string english="Catalan" translation="katalonski" explanation=""/>

--- a/desktop_version/lang/pt_BR/strings.xml
+++ b/desktop_version/lang/pt_BR/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="e também por" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="e" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="Apoiadores do GitHub" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="Com apoio no GitHub de" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="Com apoio no GitHub de" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="e agradecimentos também a:" explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="Você!" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="Seu apoio torna possível para mim continuar criando os jogos que desejo, agora e no futuro." explanation="credits" max="38*5"/>
@@ -777,11 +777,11 @@ Você encontrou o laboratório secreto!" explanation="" max="34*4"/>
     <string english="Error parsing {path}: {error}" translation="Erro ao analisar {path}: {error}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="As dimensões de {filename} não são múltiplos de {width} por {height}!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="ERRO: não foi possível gravar na pasta do idioma! Não pode ter &quot;lang&quot; ao lado dos salvamentos comuns." explanation="" max="38*5"/>
-    <string english="Localisation" translation="Localização" explanation=""/>
-    <string english="Localisation Project Led by" translation="Projeto de localização liderado por" explanation=""/>
+    <string english="Localisation" translation="Localização" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="Projeto de localização liderado por" explanation="" max="40"/>
     <string english="Translations by" translation="Traduções por" explanation=""/>
-    <string english="Translators" translation="Tradutores" explanation=""/>
-    <string english="Pan-European Font Design by" translation="Design de fonte pan-europeia por" explanation=""/>
+    <string english="Translators" translation="Tradutores" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="Design de fonte pan-europeia por" explanation="" max="40"/>
     <string english="Fonts by" translation="Fontes por" explanation=""/>
     <string english="Other Fonts by" translation="Outras fontes por" explanation=""/>
     <string english="Catalan" translation="Catalão" explanation=""/>

--- a/desktop_version/lang/pt_PT/strings.xml
+++ b/desktop_version/lang/pt_PT/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="e também de" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="e" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="Contribuintes GitHub" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="Contribuições no GitHub por" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="Contribuições no GitHub por" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="agradecemos também a:" explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="ti!" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="O teu apoio permite-me continuar a fazer os jogos que pretendo, não só agora, como futuramente." explanation="credits" max="38*5"/>
@@ -777,11 +777,11 @@ Encontraste o laboratório secreto!" explanation="" max="34*4"/>
     <string english="Error parsing {path}: {error}" translation="Ocorreu um erro ao analisar {path}: {error}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="As dimensões de {filename} não correspondem a múltiplos inteiros de {width} por {height}!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="ERRO: Não foi possível escrever na pasta de idioma! Certifica-te de que não há uma pasta &apos;&apos;lang&apos;&apos; junto dos dados guardados." explanation="" max="38*5"/>
-    <string english="Localisation" translation="Tradução" explanation=""/>
-    <string english="Localisation Project Led by" translation="Tradução liderada por" explanation=""/>
+    <string english="Localisation" translation="Tradução" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="Tradução liderada por" explanation="" max="40"/>
     <string english="Translations by" translation="Traduções por" explanation=""/>
-    <string english="Translators" translation="Tradução" explanation=""/>
-    <string english="Pan-European Font Design by" translation="Tipo de letra Pan-European criado por" explanation=""/>
+    <string english="Translators" translation="Tradução" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="Tipo de letra Pan-European criado por" explanation="" max="40"/>
     <string english="Fonts by" translation="Tipos de letra por" explanation=""/>
     <string english="Other Fonts by" translation="Tipos de letra adicionais por" explanation=""/>
     <string english="Catalan" translation="Catalão" explanation=""/>

--- a/desktop_version/lang/ru/strings.xml
+++ b/desktop_version/lang/ru/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="а также" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="и" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="Вклад в GitHub" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="Вклад в GitHub совершили" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="Вклад в GitHub совершили" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="а также отдельное спасибо:" explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="Вам!" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="Благодаря Вашей поддержке я могу продолжать делать игры, которые хочу делать, сейчас и в будущем." explanation="credits" max="38*5"/>
@@ -802,11 +802,11 @@ You have found the secret lab!" translation="Поздравляем!
     <string english="Error parsing {path}: {error}" translation="Ошибка обработки {path}: {error}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="Размеры изображения {filename} не кратны {width} на {height}!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="ОШИБКА: Не удалось записать данные в папку локализации! Убедитесь, что рядом с обычными сохранениями нет папки &quot;lang&quot;." explanation="" max="38*5"/>
-    <string english="Localisation" translation="Локализация" explanation=""/>
-    <string english="Localisation Project Led by" translation="Ведущий проекта локализации" explanation=""/>
+    <string english="Localisation" translation="Локализация" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="Ведущий проекта локализации" explanation="" max="40"/>
     <string english="Translations by" translation="Переводы от" explanation=""/>
-    <string english="Translators" translation="Переводчики" explanation=""/>
-    <string english="Pan-European Font Design by" translation="Общеевропейский шрифт от" explanation=""/>
+    <string english="Translators" translation="Переводчики" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="Общеевропейский шрифт от" explanation="" max="40"/>
     <string english="Fonts by" translation="Шрифты от" explanation=""/>
     <string english="Other Fonts by" translation="Другие шрифты от" explanation=""/>
     <string english="Catalan" translation="Каталанский" explanation=""/>

--- a/desktop_version/lang/szl/strings.xml
+++ b/desktop_version/lang/szl/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="a tyż" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="tyż" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="Spōłprogramiści:" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="Przi użyciu zmian na GitHubie autorstwa" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="Przi użyciu zmian na GitHubie autorstwa" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="a tyż z podziynkowaniym dlo:" explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="Cie!" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="Twoje wsparcie spōmŏgo mi durś wyrobiać take szpile, kere chca, terŏzki i na prziszłoś." explanation="credits" max="38*5"/>
@@ -773,11 +773,11 @@ You have found the secret lab!" translation="Winszujymy!" explanation="" max="34
     <string english="Error parsing {path}: {error}" translation="Feler czytanio {path}: {feler}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="Miary {filename} niy som wielakrotnōściami {width} na {height}!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="Feler: Niy zachowano do folderu ôd gŏdki! Bydź zicher, co niy ma folderu &quot;lang&quot; kole regularnych zapisōw." explanation="" max="38*5"/>
-    <string english="Localisation" translation="Lokalizacyjo" explanation=""/>
-    <string english="Localisation Project Led by" translation="Projektym lokalizacyji regiyrowoł" explanation=""/>
+    <string english="Localisation" translation="Lokalizacyjo" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="Projektym lokalizacyji regiyrowoł" explanation="" max="40"/>
     <string english="Translations by" translation="Przekłŏdali" explanation=""/>
-    <string english="Translators" translation="Przekłŏdocze" explanation=""/>
-    <string english="Pan-European Font Design by" translation="Design Pan-Europyjskij Czciōnki" explanation=""/>
+    <string english="Translators" translation="Przekłŏdocze" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="Design Pan-Europyjskij Czciōnki" explanation="" max="40"/>
     <string english="Fonts by" translation="Czciōnki" explanation=""/>
     <string english="Other Fonts by" translation="Inksze czciōnki" explanation=""/>
     <string english="Catalan" translation="gŏdka katalońsko" explanation=""/>

--- a/desktop_version/lang/tr/strings.xml
+++ b/desktop_version/lang/tr/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="Ayrıca:" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="ve" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="GitHub Destekçileri:" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="GitHub Destekçileri:" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="GitHub Destekçileri:" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="Son olarak da:" explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="Sana teşekkürler!" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="Desteğin sayesinde hem şimdi hem de gelecekte yapmak istediğim oyunları geliştirebiliyorum." explanation="credits" max="38*5"/>
@@ -777,11 +777,11 @@ Gizli laboratuvarı buldun!" explanation="" max="34*4"/>
     <string english="Error parsing {path}: {error}" translation="{path} işlenemedi: {error}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="{filename} dosyasının boyutları {width} x {height} değerlerinin tam katı değil!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="HATA: Dil klasörüne yazılamadı! Normal kayıt dosyalarının yanında &quot;lang&quot; adlı bir klasör olmadığından emin ol." explanation="" max="38*5"/>
-    <string english="Localisation" translation="Yerelleştirme" explanation=""/>
-    <string english="Localisation Project Led by" translation="Yerelleştirme Proje Lideri" explanation=""/>
+    <string english="Localisation" translation="Yerelleştirme" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="Yerelleştirme Proje Lideri" explanation="" max="40"/>
     <string english="Translations by" translation="Çevirmenler" explanation=""/>
-    <string english="Translators" translation="Çevirmenler" explanation=""/>
-    <string english="Pan-European Font Design by" translation="Pan-European Yazı Tipi Tasarımı" explanation=""/>
+    <string english="Translators" translation="Çevirmenler" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="Pan-European Yazı Tipi Tasarımı" explanation="" max="40"/>
     <string english="Fonts by" translation="Yazı Tipleri" explanation=""/>
     <string english="Other Fonts by" translation="Diğer Yazı Tipleri" explanation=""/>
     <string english="Catalan" translation="Katalanca" explanation=""/>

--- a/desktop_version/lang/uk/strings.xml
+++ b/desktop_version/lang/uk/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="а також" explanation="credits, VVVVVV is also supported by the following people" max="38*2"/>
     <string english="and" translation="і" explanation="credits. This list of names, AND furthermore, this other list of names" max="38"/>
     <string english="GitHub Contributors" translation="Учасники з GitHub" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20"/>
-    <string english="With contributions on GitHub from" translation="За участі доброчинців з GitHub" explanation="credits" max="38*3"/>
+    <string english="With contributions on GitHub from" translation="За участі доброчинців з GitHub" explanation="credits" max="40"/>
     <string english="and thanks also to:" translation="а також:" explanation="credits, and thanks also to ... you!" max="38*3"/>
     <string english="You!" translation="Вас!" explanation="credits, and thanks also to ... you!" max="20"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="Ваша підтримка дає мені змогу|й надалі створювати ігри,|які я хочу." explanation="credits" max="38*5"/>
@@ -777,11 +777,11 @@ You have found the secret lab!" translation="Поздоровляємо!
     <string english="Error parsing {path}: {error}" translation="Помилка під час аналізу {path}: {error}" explanation="we tried to parse the level file, but failed" max="38*6"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="Розміри {filename} не відповідають співвідношенню {width} до {height}!" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="ПОМИЛКА: Не вдалося здійснити збереження в мовну папку! Перевірте, чи нема папки «lang» поряд зі звичайними збереженнями." explanation="" max="38*5"/>
-    <string english="Localisation" translation="Локалізація" explanation=""/>
-    <string english="Localisation Project Led by" translation="Керівник проєкту з локалізації" explanation=""/>
+    <string english="Localisation" translation="Локалізація" explanation="" max="20"/>
+    <string english="Localisation Project Led by" translation="Керівник проєкту з локалізації" explanation="" max="40"/>
     <string english="Translations by" translation="Переклад виконали" explanation=""/>
-    <string english="Translators" translation="Перекладачі" explanation=""/>
-    <string english="Pan-European Font Design by" translation="Розробка загальноєвропейського шрифту" explanation=""/>
+    <string english="Translators" translation="Перекладачі" explanation="" max="20"/>
+    <string english="Pan-European Font Design by" translation="Розробка загальноєвропейського шрифту" explanation="" max="40"/>
     <string english="Fonts by" translation="Автори шрифтів" explanation=""/>
     <string english="Other Fonts by" translation="Автори інших шрифтів" explanation=""/>
     <string english="Catalan" translation="каталанська" explanation=""/>

--- a/desktop_version/lang/zh/strings.xml
+++ b/desktop_version/lang/zh/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="此外还有" explanation="credits, VVVVVV is also supported by the following people" max="38*2" max_local="25*1"/>
     <string english="and" translation="以及" explanation="credits. This list of names, AND furthermore, this other list of names" max="38" max_local="25"/>
     <string english="GitHub Contributors" translation="GitHub贡献者" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20" max_local="13"/>
-    <string english="With contributions on GitHub from" translation="以下人士在GitHub上做出了贡献" explanation="credits" max="38*3" max_local="25*2"/>
+    <string english="With contributions on GitHub from" translation="以下人士在GitHub上做出了贡献" explanation="credits" max="40" max_local="26"/>
     <string english="and thanks also to:" translation="此外还要感谢：" explanation="credits, and thanks also to ... you!" max="38*3" max_local="25*2"/>
     <string english="You!" translation="您！" explanation="credits, and thanks also to ... you!" max="20" max_local="13"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="你的支持让我能够在现在和将来、
@@ -787,11 +787,11 @@ You have found the secret lab!" translation="恭喜你！
     <string english="Error parsing {path}: {error}" translation="解析{path}时出错：{error}" explanation="we tried to parse the level file, but failed" max="38*6" max_local="25*5"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="{filename}的尺寸不是{width}x{height}的整数倍！" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6" max_local="25*5"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="错误：无法写入语言文件夹！请确保存档文件夹的同路径没有“lang”文件夹。" explanation="" max="38*5" max_local="25*4"/>
-    <string english="Localisation" translation="本地化" explanation=""/>
-    <string english="Localisation Project Led by" translation="本地化项目领导者" explanation=""/>
+    <string english="Localisation" translation="本地化" explanation="" max="20" max_local="13"/>
+    <string english="Localisation Project Led by" translation="本地化项目领导者" explanation="" max="40" max_local="26"/>
     <string english="Translations by" translation="翻译者" explanation=""/>
-    <string english="Translators" translation="译者" explanation=""/>
-    <string english="Pan-European Font Design by" translation="泛欧洲字体设计" explanation=""/>
+    <string english="Translators" translation="译者" explanation="" max="20" max_local="13"/>
+    <string english="Pan-European Font Design by" translation="泛欧洲字体设计" explanation="" max="40" max_local="26"/>
     <string english="Fonts by" translation="字体" explanation=""/>
     <string english="Other Fonts by" translation="其他字体" explanation=""/>
     <string english="Catalan" translation="加泰罗尼亚语" explanation=""/>

--- a/desktop_version/lang/zh_TW/strings.xml
+++ b/desktop_version/lang/zh_TW/strings.xml
@@ -124,7 +124,7 @@
     <string english="and also by" translation="此外還有" explanation="credits, VVVVVV is also supported by the following people" max="38*2" max_local="25*1"/>
     <string english="and" translation="以及" explanation="credits. This list of names, AND furthermore, this other list of names" max="38" max_local="25"/>
     <string english="GitHub Contributors" translation="GitHub貢獻者" explanation="credits. This doesn&apos;t _really_ need `GitHub` specifically, it could be replaced with `Code`" max="20" max_local="13"/>
-    <string english="With contributions on GitHub from" translation="以下人士在GitHub上做出了貢獻" explanation="credits" max="38*3" max_local="25*2"/>
+    <string english="With contributions on GitHub from" translation="以下人士在GitHub上做出了貢獻" explanation="credits" max="40" max_local="26"/>
     <string english="and thanks also to:" translation="此外還要感謝：" explanation="credits, and thanks also to ... you!" max="38*3" max_local="25*2"/>
     <string english="You!" translation="您！" explanation="credits, and thanks also to ... you!" max="20" max_local="13"/>
     <string english="Your support makes it possible for me to continue making the games I want to make, now and into the future." translation="你的支持讓我能夠在現在和將來、
@@ -787,11 +787,11 @@ You have found the secret lab!" translation="恭喜你！
     <string english="Error parsing {path}: {error}" translation="解析{path}時出錯：{error}" explanation="we tried to parse the level file, but failed" max="38*6" max_local="25*5"/>
     <string english="{filename} dimensions not exact multiples of {width} by {height}!" translation="{filename}的尺寸不是{width}x{height}的整數倍！" explanation="filename is something like tiles.png, tiles2.png, etc. and width/height are something like 8, 32, etc.; this is used if the dimensions of a graphics file aren&apos;t an exact multiple of the given size (e.g. 8x8, 32x32, etc.)" max="38*6" max_local="25*5"/>
     <string english="ERROR: Could not write to language folder! Make sure there is no &quot;lang&quot; folder next to the regular saves." translation="錯誤：無法寫入語言資料夾！請確保存檔資料夾的同路徑沒有“lang”資料夾。" explanation="" max="38*5" max_local="25*4"/>
-    <string english="Localisation" translation="本地化" explanation=""/>
-    <string english="Localisation Project Led by" translation="本地化項目領導者" explanation=""/>
+    <string english="Localisation" translation="本地化" explanation="" max="20" max_local="13"/>
+    <string english="Localisation Project Led by" translation="本地化項目領導者" explanation="" max="40" max_local="26"/>
     <string english="Translations by" translation="翻譯者" explanation=""/>
-    <string english="Translators" translation="譯者" explanation=""/>
-    <string english="Pan-European Font Design by" translation="泛歐洲字體設計" explanation=""/>
+    <string english="Translators" translation="譯者" explanation="" max="20" max_local="13"/>
+    <string english="Pan-European Font Design by" translation="泛歐洲字體設計" explanation="" max="40" max_local="26"/>
     <string english="Fonts by" translation="字體" explanation=""/>
     <string english="Other Fonts by" translation="其他字體" explanation=""/>
     <string english="Catalan" translation="加泰羅尼亞語" explanation=""/>

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1591,6 +1591,7 @@ static void menuactionpress(void)
             //next page
             music.playef(Sound_VIRIDIAN);
             game.translator_credits_pagenum = 0;
+            game.current_credits_list_index = 0;
             game.createmenu(Menu::credits_localisations_translations, true);
             map.nexttowercolour();
             break;

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1987,25 +1987,34 @@ void gamecompleterender(void)
 
     if (graphics.onscreen(creditOffset + position))
     {
-        font::print(PR_2X | PR_CEN, -1, creditOffset + position, loc::gettext("Localisation"), tr, tg, tb);
+        font::print(PR_2X | PR_CJK_HIGH | PR_CEN, -1, creditOffset + position, loc::gettext("Localisation"), tr, tg, tb);
     }
     creditOffset += 30;
 
     if (graphics.onscreen(creditOffset + position))
     {
-        font::print(PR_CJK_HIGH, 40, creditOffset + position, loc::gettext("Localisation Project Led by"), tr, tg, tb);
+        const char* text = loc::gettext("Localisation Project Led by");
+        int x = SCREEN_WIDTH_PIXELS - font::len(0, text);
+        x = SDL_min(x, 40);
+        font::print(PR_CJK_HIGH, x, creditOffset + position, text, tr, tg, tb);
         font::print(PR_2X | PR_FONT_8X8, 60, creditOffset + position + 10, "Dav999", tr, tg, tb);
     }
     creditOffset += 40;
     if (graphics.onscreen(creditOffset + position))
     {
-        font::print(PR_CJK_HIGH, 40, creditOffset + position, loc::gettext("Pan-European Font Design by"), tr, tg, tb);
+        const char* text = loc::gettext("Pan-European Font Design by");
+        int x = SCREEN_WIDTH_PIXELS - font::len(0, text);
+        x = SDL_min(x, 40);
+        font::print(PR_CJK_HIGH, x, creditOffset + position, text, tr, tg, tb);
         font::print(PR_2X | PR_FONT_8X8, 60, creditOffset + position + 10, "Reese Rivers", tr, tg, tb);
     }
     creditOffset += 40;
     if (graphics.onscreen(creditOffset + position))
     {
-        font::print(PR_CJK_HIGH, 40, creditOffset + position, loc::gettext("With contributions on GitHub from"), tr, tg, tb);
+        const char* text = loc::gettext("With contributions on GitHub from");
+        int x = SCREEN_WIDTH_PIXELS - font::len(0, text);
+        x = SDL_min(x, 40);
+        font::print(PR_CJK_HIGH, x, creditOffset + position, text, tr, tg, tb);
         font::print(PR_2X | PR_FONT_8X8, 60, creditOffset + position + 10, "Alexandra Fox", tr, tg, tb);
         font::print(PR_2X | PR_FONT_8X8, 60, creditOffset + position + 30, "mothbeanie", tr, tg, tb);
     }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -577,10 +577,12 @@ static void menurender(void)
         {
             if (Credits::translators[i][0] != ' ')
             {
-              yofs += 5;
-              font::print(PR_CJK_HIGH, 80, yofs, loc::gettext(Credits::translators[i]), tr, tg, tb);
-            }else{
-              font::print(PR_FONT_8X8, 80, yofs, Credits::translators[i], tr, tg, tb);
+                yofs += 5;
+                font::print(PR_CJK_HIGH, 80, yofs, loc::gettext(Credits::translators[i]), tr, tg, tb);
+            }
+            else
+            {
+                font::print(PR_FONT_8X8, 80, yofs, Credits::translators[i], tr, tg, tb);
             }
             yofs += 10;
         }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -559,7 +559,7 @@ static void menurender(void)
         break;
     case Menu::credits_localisations_translations:
     {
-        font::print_wrap(PR_2X | PR_CEN | PR_FONT_8X8, -1, 15, loc::gettext("Translators"), tr, tg, tb);
+        font::print_wrap(PR_2X | PR_CEN, -1, 15, loc::gettext("Translators"), tr, tg, tb);
 
         int startidx = game.current_credits_list_index;
         int endidx = game.current_credits_list_index;
@@ -578,7 +578,7 @@ static void menurender(void)
             if (Credits::translators[i][0] != ' ')
             {
               yofs += 5;
-              font::print(PR_FONT_8X8, 80, yofs, loc::gettext(Credits::translators[i]), tr, tg, tb);
+              font::print(PR_CJK_HIGH, 80, yofs, loc::gettext(Credits::translators[i]), tr, tg, tb);
             }else{
               font::print(PR_FONT_8X8, 80, yofs, Credits::translators[i], tr, tg, tb);
             }


### PR DESCRIPTION
## Changes:

- Fixed translator credits headers being forced to 8x8 font:
  ![Question marks because the 8x8 font doesn't support Chinese](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/e8c5021c-6b61-4f83-b982-1fd160d181a2)
- Fixed current_credits_list_index not always being reset - explained further in the commit message
- Try to prevent some lines in rolling credits going offscreen - fixed version for Italian for example:
  ![It just goes further left instead of offscreen](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/a7cc095f-34c3-4c71-b864-9ecead3be177)
- Added limits (like `max="40"`) to the translator credits strings
- Minor indentation style fix in Render.cpp



## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
