### PR TITLE
Fix binding menu allowing you to lock yourself out of the game

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -386,6 +386,22 @@ void Game::setdefaultcontrollerbuttons(void)
     {
         controllerButton_interact.push_back(SDL_CONTROLLER_BUTTON_X);
     }
+
+    /* If one of the arrays was empty, and others weren't, we might now have conflicts...
+     * A crucial one is if the ACTION button is also "ESC", because then you can't
+     * fix it with just a controller anymore, which might make the game unplayable.
+     * This is similar to updatebuttonmappings() in Input.cpp, except less... complete? */
+    for (size_t f = 0; f < controllerButton_flip.size(); f++)
+    {
+        for (size_t e = 0; e < controllerButton_esc.size(); e++)
+        {
+            if (controllerButton_flip[f] == controllerButton_esc[e])
+            {
+                controllerButton_esc.erase(controllerButton_esc.begin() + e);
+                break;
+            }
+        }
+    }
 }
 
 void Game::lifesequence(void)


### PR DESCRIPTION
## Changes:

Or well, lock yourself out if you don't have (easy) access to a keyboard, like on Steam Deck.

In 2.3, this problem used to be much worse, since you could bind any button to "menu" - which is actually also "return" in menus - and that button could then no longer be bound to any other action, because exiting the bindings menu had priority over assigning a different binding. The result would be that people could have all their buttons bound to "escape" with no way of undoing it or using their controllers at all other than manually going into their config file to change it.

In 2.4, the most important bugs in the bindings menu are fixed, but it's still possible to remove all your bindings from the "flip" (confirm) action, meaning you can't navigate the menus anymore with a controller to fix your bindings or even do anything.

![Flip is bound to nothing, Menu is bound to B/A](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/900bcdff-9b54-430e-b75b-499a5de362c1)

(Besides, if people already got hit by 2.3's bug, their broken config will keep having effect in 2.4, it's just now possible to fix it manually, _in_ the gamepad menu)

There is one interesting part to all this: if an action has no buttons bound to it at all when the game is started, then that action is populated with the default button for that action. This is done for each action separately, without accounting for the case where the default button was already bound to another action which was not empty. (This is something that the binding menu does try to prevent). Therefore, having no buttons bound to "flip" while having A and B bound to "menu", would result in A being bound to "flip" and A and B bound to "menu".

![Flip is bound to A, Menu is bound to B/A](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/f37905c6-a4da-4652-ac61-539ac68b6da1)


That would still make you unable to enter the gamepad menu, since both "confirm" and "return" are pressed in a row.

This commit fixes the specific situation where flip/confirm buttons are also bound to menu/return, by removing all buttons that are in the flip button list from the menu list. This means that, on Steam Deck, you can still go to your bindings menu.



## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
