### PR TITLE
Restore gravity/warp lines sticking out a tile offscreen

### DIFF
--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -4014,6 +4014,11 @@ bool editorclass::lines_can_pass(int x, int y)
     {
         return tile == 0 || tile >= 680;
     }
+    if (x == -1 || y == -1 || x == SCREEN_WIDTH_TILES || y == SCREEN_HEIGHT_TILES)
+    {
+        // If lines go offscreen, they stick out one tile
+        return true;
+    }
     return false;
 }
 


### PR DESCRIPTION
## Changes:

I just discovered this: whereas 2.3 and older versions make gravity and warp lines - when placed in the editor - stick out one tile offscreen, the latest version stops the lines at the room border.

In this situation, all the gravity lines should be 4 tiles long:

![Four 3-tile gravity lines sticking offscreen](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/51983f72-1fb3-454b-b77c-a5bc32edecc1)

This change restores the old behavior, and it's a simple fix: the refactored code was written to let tiles outside the room block gravity/warp lines. Instead of all offscreen tiles blocking lines, now there's a 1-tile padding around the room that will let them through.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
