### PR TITLE
Add an undoing & redoing system to the editor

### DIFF
--- a/desktop_version/lang/ar/strings.xml
+++ b/desktop_version/lang/ar/strings.xml
@@ -646,6 +646,8 @@
     <string english="Enemy Type Changed" translation="تغير نوع الأعداء" explanation="level editor, user changed enemy appearance for the room" max="38*3" max_local="38*3"/>
     <string english="Platform speed is now {speed}" translation="تغيرت سرعة المنصات إلى {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3" max_local="38*3"/>
     <string english="Enemy speed is now {speed}" translation="تغيرت سرعة الأعداء إلى {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3" max_local="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3" max_local="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3" max_local="38*3"/>
     <string english="Reloaded resources" translation="أعيد فتح ملفات الموارد" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3" max_local="38*3"/>
     <string english="ERROR: Invalid format" translation="خطأ: صيغة المكتوب غير مناسبة" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3" max_local="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="فتحت الغرفة: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3" max_local="38*3"/>

--- a/desktop_version/lang/ca/strings.xml
+++ b/desktop_version/lang/ca/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="S’ha canviat el tipus d’enemic" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="La velocitat de les plataformes és ara {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="La velocitat dels enemics és ara {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="S’han recarregat els recursos" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERROR: Format invàlid" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="S’ha obert el mapa: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/cy/strings.xml
+++ b/desktop_version/lang/cy/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="Newidiodd Math y Gelyn" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Cyflymder llwyfan yw {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="Cyflymder y gelyn yw {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Adnoddau wedi&apos;u hail-lwytho" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="GWALL: Fformat annilys" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Map wedi&apos;i lwytho: {filename}.vvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/de/strings.xml
+++ b/desktop_version/lang/de/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="Feindtyp geändert" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Plattformgeschwindigkeit ist jetzt {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="Feindgeschwindigkeit ist jetzt {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Ressourcen neu geladen" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="FEHLER: ungültiges Format" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Karte geladen: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/eo/strings.xml
+++ b/desktop_version/lang/eo/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="Malamika tipo ŝanĝiĝis" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Platforma rapido nun estas {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="Malamika rapido nun estas {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Resursoj reŝargiĝis" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERARO: malĝusta formo" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Ŝargiĝis mapo: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/es/strings.xml
+++ b/desktop_version/lang/es/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="Tipo de enemigo cambiado" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="La velocidad plataforma es {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="Velocidad del enemigo en {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Recursos recargados" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERROR: Formato no válido" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Mapa cargado: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/es_419/strings.xml
+++ b/desktop_version/lang/es_419/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="Tipo de enemigo cambiado" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Velocidad de las plataformas: {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="Velocidad de los enemigos: {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Recursos recargados" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERROR: Formato no válido" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Mapa cargado: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/es_AR/strings.xml
+++ b/desktop_version/lang/es_AR/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="Tipo de enemigo cambiado" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Velocidad de las plataformas: {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="Velocidad de los enemigos: {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Recursos recargados" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERROR: Formato no válido" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Mapa cargado: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/fa/strings.xml
+++ b/desktop_version/lang/fa/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="نوع دشمن تغییر کرد" explanation="level editor, user changed enemy appearance for the room" max="38*3" max_local="38*3"/>
     <string english="Platform speed is now {speed}" translation="سرعت سکو اکنون برابر با {speed} است" explanation="level editor, user changed speed of platforms for the room" max="38*3" max_local="38*3"/>
     <string english="Enemy speed is now {speed}" translation="سرعت دشمن اکنون برابر با {speed} است" explanation="level editor, user changed speed of enemies for the room" max="38*3" max_local="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3" max_local="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3" max_local="38*3"/>
     <string english="Reloaded resources" translation="بارگذاری مجدد منابع" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3" max_local="38*3"/>
     <string english="ERROR: Invalid format" translation="خطا: فرمت اشتباه" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3" max_local="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="نقشه‌ی بارگذاری شده {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3" max_local="38*3"/>

--- a/desktop_version/lang/fr/strings.xml
+++ b/desktop_version/lang/fr/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="Type d&apos;ennemis modifié" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Vitesse des plateformes réglée sur {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="Vitesse des ennemis réglée sur {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Recharger les ressources" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERREUR : format invalide" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Carte chargée : {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/ga/strings.xml
+++ b/desktop_version/lang/ga/strings.xml
@@ -640,6 +640,8 @@ Déan cóip chúltaca, ar eagla na heagla." explanation="translation maintenance
     <string english="Enemy Type Changed" translation="Athraíodh Cineál Naimhde" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Luas na n-ardán {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="Luas na naimhde {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Athlódáladh acmhainní" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="EARRÁID: Formáid Neamhbhailí" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Mapa lódáilte: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/it/strings.xml
+++ b/desktop_version/lang/it/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="Tipo di nemico cambiato" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="La velocità piattaforma ora è {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="La velocità dei nemici è ora {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Risorse ricaricate" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERRORE: Formato non valido" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Mappa caricata: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/ja/strings.xml
+++ b/desktop_version/lang/ja/strings.xml
@@ -674,6 +674,8 @@ Steam Deckには対応していません。" explanation="" max="38*5" max_local
     <string english="Enemy Type Changed" translation="敵の種類を変更しました" explanation="level editor, user changed enemy appearance for the room" max="38*3" max_local="38*2"/>
     <string english="Platform speed is now {speed}" translation="プラットフォームの速度を {speed} に変更しました" explanation="level editor, user changed speed of platforms for the room" max="38*3" max_local="38*2"/>
     <string english="Enemy speed is now {speed}" translation="敵のスピードを {speed} に変更しました" explanation="level editor, user changed speed of enemies for the room" max="38*3" max_local="38*2"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3" max_local="38*2"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3" max_local="38*2"/>
     <string english="Reloaded resources" translation="リソースを再読み込みしました" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3" max_local="38*2"/>
     <string english="ERROR: Invalid format" translation="エラー: 無効な記述形式" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3" max_local="38*2"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="{filename}.vvvvvv をロードしました" explanation="successfully loaded level file" max="38*3" max_local="38*2"/>

--- a/desktop_version/lang/ko/strings.xml
+++ b/desktop_version/lang/ko/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="적 종류 변경됨" explanation="level editor, user changed enemy appearance for the room" max="38*3" max_local="30*3"/>
     <string english="Platform speed is now {speed}" translation="플랫폼 속도 현재 {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3" max_local="30*3"/>
     <string english="Enemy speed is now {speed}" translation="적의 속도 현재 {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3" max_local="30*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3" max_local="30*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3" max_local="30*3"/>
     <string english="Reloaded resources" translation="자원 다시 불러오기" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3" max_local="30*3"/>
     <string english="ERROR: Invalid format" translation="오류: 이용 불가능한 포맷" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3" max_local="30*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="불러온 지도: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3" max_local="30*3"/>

--- a/desktop_version/lang/nl/strings.xml
+++ b/desktop_version/lang/nl/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="Vijandtype aangepast" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Platformsnelheid is nu {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="Vijandsnelheid is nu {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Bronnen opnieuw geladen" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="FOUT: Ongeldig formaat" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Level geladen: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/pl/strings.xml
+++ b/desktop_version/lang/pl/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="Zmieniono Typ Wroga" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Prędkość platformy: {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="Prędkość przeciwników: {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Załadowano zasoby ponownie" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="BŁĄD: Niewłaściwy format" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Wczytano poziom: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/pt_BR/strings.xml
+++ b/desktop_version/lang/pt_BR/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="O tipo de inimigo foi alterado" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="A velocidade da plataforma agora é {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="A velocidade do inimigo agora é {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Recursos recarregados" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERRO: formato inválido" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Mapa carregado: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/pt_PT/strings.xml
+++ b/desktop_version/lang/pt_PT/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="Tipo de inimigo alterado" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Velocidade atual da plataforma: {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="Velocidade dos inimigos: {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Recursos recarregados" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERRO: Formato inválido" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Mapa carregado: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/ru/strings.xml
+++ b/desktop_version/lang/ru/strings.xml
@@ -663,6 +663,8 @@
     <string english="Enemy Type Changed" translation="Тип врагов изменён" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Установлена скорость платформ {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="Установлена скорость врагов {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Ресурсы перезагружены" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ОШИБКА: Недопустимый формат" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Карта загружена: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/szl/strings.xml
+++ b/desktop_version/lang/szl/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="Zmiyniōno Zorta Niyprzŏciela" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Gibkoś platformy: {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="Gibkoś ôpacznikōw: {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Nafolowano zasoby drugi rŏz" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="FELER: Felerny format" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Nafolowano poziōm: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/tr/strings.xml
+++ b/desktop_version/lang/tr/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="Düşman Türü Değişti" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Platform hızı: {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="Şu anki düşman hızı: {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Kaynaklar tekrar yüklendi" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="HATA: Geçersiz format" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Yüklenen harita: {dosyaadi}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/uk/strings.xml
+++ b/desktop_version/lang/uk/strings.xml
@@ -638,6 +638,8 @@
     <string english="Enemy Type Changed" translation="Тип ворога змінено" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Тепер швидкість платформи {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
     <string english="Enemy speed is now {speed}" translation="Тепер швидкість ворога {speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3"/>
     <string english="Reloaded resources" translation="Ресурси перезавантажено" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ПОМИЛКА: Неприпустимий формат" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Завантажено мапу: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/zh/strings.xml
+++ b/desktop_version/lang/zh/strings.xml
@@ -648,6 +648,8 @@
     <string english="Enemy Type Changed" translation="敌人类型已改变" explanation="level editor, user changed enemy appearance for the room" max="38*3" max_local="25*2"/>
     <string english="Platform speed is now {speed}" translation="平台速度现在为{speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3" max_local="25*2"/>
     <string english="Enemy speed is now {speed}" translation="敌人速度现在为{speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3" max_local="25*2"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3" max_local="25*2"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3" max_local="25*2"/>
     <string english="Reloaded resources" translation="资源已重新载入" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3" max_local="25*2"/>
     <string english="ERROR: Invalid format" translation="错误：格式不符合" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3" max_local="25*2"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="已载入地图：{filename}.vvvvvv" explanation="successfully loaded level file" max="38*3" max_local="25*2"/>

--- a/desktop_version/lang/zh_TW/strings.xml
+++ b/desktop_version/lang/zh_TW/strings.xml
@@ -648,6 +648,8 @@
     <string english="Enemy Type Changed" translation="敵人類型已改變" explanation="level editor, user changed enemy appearance for the room" max="38*3" max_local="25*2"/>
     <string english="Platform speed is now {speed}" translation="平臺速度現在為{speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3" max_local="25*2"/>
     <string english="Enemy speed is now {speed}" translation="敵人速度現在爲{speed}" explanation="level editor, user changed speed of enemies for the room" max="38*3" max_local="25*2"/>
+    <string english="ERROR: Nothing to undo" translation="" explanation="level editor, user tried to undo with nothing to undo" max="38*3" max_local="25*2"/>
+    <string english="ERROR: Nothing to redo" translation="" explanation="level editor, user tried to redo with nothing to redo" max="38*3" max_local="25*2"/>
     <string english="Reloaded resources" translation="資源已重新載入" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3" max_local="25*2"/>
     <string english="ERROR: Invalid format" translation="錯誤：格式不符合" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3" max_local="25*2"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="已載入地圖：{filename}.vvvvvv" explanation="successfully loaded level file" max="38*3" max_local="25*2"/>

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -414,6 +414,7 @@ void editorclass::reset(void)
     substate = EditorSubState_MAIN;
 
     undo_buffer.clear();
+    redo_buffer.clear();
 }
 
 void editorclass::show_note(const char* text)

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -2340,7 +2340,7 @@ static void commit_tiles()
     info.room_x = ed.levx;
     info.room_y = ed.levy;
     info.type = EditorUndoType_TILES;
-    SDL_memcpy(&info.tiles, &ed.old_tiles, sizeof(ed.old_tiles));
+    SDL_memcpy(info.tiles, ed.old_tiles, sizeof(ed.old_tiles));
 
     ed.undo_buffer.push_back(info);
     ed.redo_buffer.clear();
@@ -2371,7 +2371,7 @@ static void commit_roomdata_tiles_change()
     info.room_y = ed.levy;
     info.type = EditorUndoType_ROOMDATA_TILES;
     update_old_tiles();
-    SDL_memcpy(&info.tiles, &ed.old_tiles, sizeof(ed.old_tiles));
+    SDL_memcpy(info.tiles, ed.old_tiles, sizeof(ed.old_tiles));
     info.room_data = *cl.getroomprop(ed.levx, ed.levy);
 
     ed.undo_buffer.push_back(info);
@@ -3377,7 +3377,7 @@ void process_editor_buffer(const bool undo)
             cl.settile(ed.levx, ed.levy, x, y, info.tiles[i]);
         }
 
-        SDL_memcpy(&new_info.tiles, &ed.old_tiles, sizeof(ed.old_tiles));
+        SDL_memcpy(new_info.tiles, ed.old_tiles, sizeof(ed.old_tiles));
 
         graphics.foregrounddrawn = false;
         break;
@@ -3430,7 +3430,7 @@ void process_editor_buffer(const bool undo)
             cl.settile(ed.levx, ed.levy, x, y, info.tiles[i]);
         }
 
-        SDL_memcpy(&new_info.tiles, &ed.old_tiles, sizeof(ed.old_tiles));
+        SDL_memcpy(new_info.tiles, ed.old_tiles, sizeof(ed.old_tiles));
 
         new_info.room_data = cl.roomproperties[info.room_x + info.room_y * cl.maxwidth];
 

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -2278,7 +2278,6 @@ void editorclass::add_entity(int rx, int ry, int xp, int yp, int tp, int p1, int
 
 void editorclass::remove_entity(int t)
 {
-
     EditorUndoInfo info;
     info.room_x = levx;
     info.room_y = levy;
@@ -2310,10 +2309,7 @@ static void update_old_tiles()
     extern editorclass ed;
     for (int i = 0; i < SCREEN_WIDTH_TILES * SCREEN_HEIGHT_TILES; i++)
     {
-        const int x = i % SCREEN_WIDTH_TILES;
-        const int y = i / SCREEN_WIDTH_TILES;
-
-        ed.old_tiles[y * SCREEN_WIDTH_TILES + x] = ed.get_tile(x, y);
+        ed.old_tiles[i] = ed.get_tile(i % SCREEN_WIDTH_TILES, i / SCREEN_WIDTH_TILES);
     }
 }
 
@@ -2511,6 +2507,12 @@ void editorclass::handle_tile_placement(const int tile)
 
 void editorclass::tool_remove()
 {
+    if (!placing_tiles)
+    {
+        placing_tiles = true;
+        update_old_tiles();
+    }
+
     switch (current_tool)
     {
     case EditorTool_WALLS:
@@ -3661,23 +3663,25 @@ void editorinput(void)
             }
 
             // Mouse input
-            if (key.leftbutton && ed.lclickdelay == 0)
-            {
-                ed.tool_place();
-            }
-            else if (!key.leftbutton)
-            {
-                ed.lclickdelay = 0;
-                if (ed.placing_tiles)
-                {
-                    commit_tiles();
-                    ed.placing_tiles = false;
-                }
-            }
-
             if (key.rightbutton)
             {
                 ed.tool_remove();
+            }
+            else
+            {
+                if (key.leftbutton && ed.lclickdelay == 0)
+                {
+                    ed.tool_place();
+                }
+                else if (!key.leftbutton)
+                {
+                    ed.lclickdelay = 0;
+                    if (ed.placing_tiles)
+                    {
+                        commit_tiles();
+                        ed.placing_tiles = false;
+                    }
+                }
             }
 
             if (key.middlebutton)

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -2377,6 +2377,13 @@ static void commit_roomdata_tiles_change()
     ed.redo_buffer.clear();
 }
 
+static void uncommit()
+{
+    extern editorclass ed;
+
+    ed.undo_buffer.pop_back();
+}
+
 static void set_tile_interpolated(const int x1, const int x2, const int y1, const int y2, const int tile)
 {
     extern editorclass ed;
@@ -3848,6 +3855,9 @@ void editorinput(void)
                     if (ed.old_entity_text == "")
                     {
                         ed.remove_entity(ed.text_entity);
+                        // Uncommit the past two actions
+                        uncommit();
+                        uncommit();
                     }
                 }
 

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -415,6 +415,8 @@ void editorclass::reset(void)
 
     undo_buffer.clear();
     redo_buffer.clear();
+
+    placing_tiles = false;
 }
 
 void editorclass::show_note(const char* text)

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -3854,16 +3854,23 @@ void editorinput(void)
 
             if (escape_pressed)
             {
-                // Cancel it, and remove the enemy it's tied to if necessary
+                // Escape was pressed, cancel text entry
                 key.disabletextentry();
+
                 if (ed.current_text_mode >= FIRST_ENTTEXT && ed.current_text_mode <= LAST_ENTTEXT)
                 {
                     *ed.current_text_ptr = ed.old_entity_text;
+
+                    // Looks like we're giving an entity text for the first time, so cancelling should remove the entity
                     if (ed.old_entity_text == "")
                     {
+                        // Remove it.
                         ed.remove_entity(ed.text_entity);
-                        // Uncommit the past two actions
+
+                        // We have to uncommit twice here; once to prevent saving the "remove entity" action...
                         uncommit();
+
+                        // ...and once more to undo the "add entity" action we're cancelling
                         uncommit();
                     }
                 }

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -2651,6 +2651,12 @@ void editorclass::tool_place()
         break;
     }
     case EditorTool_SPIKES:
+        if (!placing_tiles)
+        {
+            placing_tiles = true;
+            update_old_tiles();
+        }
+
         set_tile_interpolated(old_tilex, tilex, old_tiley, tiley, 8);
         break;
     case EditorTool_TRINKETS:

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -2614,7 +2614,7 @@ void editorclass::entity_clicked(const int index)
             // Flip the terminal, but if it's not textured as a terminal leave it alone
             entity->p1 = (entity->p1 + 1) % 2;
         }
-        get_input_line(TEXT_SCRIPT, loc::gettext("Enter script name:"), &entity->scriptname);
+        get_input_line(TEXT_SCRIPT, "Enter script name:", &entity->scriptname);
         text_entity = index;
         break;
     case 19:
@@ -3344,7 +3344,7 @@ void editorclass::get_input_line(const enum TextMode mode, const std::string& pr
     old_entity_text = key.keybuffer;
 }
 
-void process_editor_buffer(const bool undo)
+static void handle_undo(const bool undo)
 {
     extern editorclass ed;
 
@@ -3563,11 +3563,11 @@ void editorinput(void)
 
             if (undo_pressed)
             {
-                process_editor_buffer(true);
+                handle_undo(true);
             }
             if (redo_pressed)
             {
-                process_editor_buffer(false);
+                handle_undo(false);
             }
 
             if (escape_pressed)

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -412,6 +412,8 @@ void editorclass::reset(void)
 
     state = EditorState_DRAW;
     substate = EditorSubState_MAIN;
+
+    undo_buffer.clear();
 }
 
 void editorclass::show_note(const char* text)
@@ -2262,11 +2264,30 @@ void editorclass::add_entity(int rx, int ry, int xp, int yp, int tp, int p1, int
     entity.p6 = p6;
     entity.scriptname = "";
 
+    EditorUndoInfo info;
+    info.room_x = rx;
+    info.room_y = ry;
+    info.type = EditorUndoType_ENTITY_ADDED;
+    info.entity = entity;
+    info.entity_id = customentities.size();
+    undo_buffer.push_back(info);
+    redo_buffer.clear();
+
     customentities.push_back(entity);
 }
 
 void editorclass::remove_entity(int t)
 {
+
+    EditorUndoInfo info;
+    info.room_x = levx;
+    info.room_y = levy;
+    info.type = EditorUndoType_ENTITY_REMOVED;
+    info.entity_id = t;
+    info.entity = customentities[t];
+    undo_buffer.push_back(info);
+    redo_buffer.clear();
+
     customentities.erase(customentities.begin() + t);
 }
 
@@ -2282,6 +2303,82 @@ int editorclass::get_entity_at(int rx, int ry, int xp, int yp)
         }
     }
     return -1;
+}
+
+static void update_old_tiles()
+{
+    extern editorclass ed;
+    for (int i = 0; i < SCREEN_WIDTH_TILES * SCREEN_HEIGHT_TILES; i++)
+    {
+        const int x = i % SCREEN_WIDTH_TILES;
+        const int y = i / SCREEN_WIDTH_TILES;
+
+        ed.old_tiles[y * SCREEN_WIDTH_TILES + x] = ed.get_tile(x, y);
+    }
+}
+
+static void commit_entity(int id)
+{
+    // We're gonna modify an entity, so save the old version
+    extern editorclass ed;
+
+    EditorUndoInfo info;
+
+    info.room_x = ed.levx;
+    info.room_y = ed.levy;
+    info.type = EditorUndoType_ENTITY_MODIFIED;
+    info.entity_id = id;
+    info.entity = customentities[id];
+    ed.undo_buffer.push_back(info);
+    ed.redo_buffer.clear();
+}
+
+static void commit_tiles()
+{
+    // We either let go of the mouse button, or we switched rooms, so we need to commit the tiles to the undo buffer
+    extern editorclass ed;
+
+    EditorUndoInfo info;
+
+    info.room_x = ed.levx;
+    info.room_y = ed.levy;
+    info.type = EditorUndoType_TILES;
+    SDL_memcpy(&info.tiles, &ed.old_tiles, sizeof(ed.old_tiles));
+
+    ed.undo_buffer.push_back(info);
+    ed.redo_buffer.clear();
+}
+
+static void commit_roomdata_change()
+{
+    extern editorclass ed;
+
+    EditorUndoInfo info;
+
+    info.room_x = ed.levx;
+    info.room_y = ed.levy;
+    info.type = EditorUndoType_ROOMDATA;
+    info.room_data = *cl.getroomprop(ed.levx, ed.levy);
+
+    ed.undo_buffer.push_back(info);
+    ed.redo_buffer.clear();
+}
+
+static void commit_roomdata_tiles_change()
+{
+    extern editorclass ed;
+
+    EditorUndoInfo info;
+
+    info.room_x = ed.levx;
+    info.room_y = ed.levy;
+    info.type = EditorUndoType_ROOMDATA_TILES;
+    update_old_tiles();
+    SDL_memcpy(&info.tiles, &ed.old_tiles, sizeof(ed.old_tiles));
+    info.room_data = *cl.getroomprop(ed.levx, ed.levy);
+
+    ed.undo_buffer.push_back(info);
+    ed.redo_buffer.clear();
 }
 
 static void set_tile_interpolated(const int x1, const int x2, const int y1, const int y2, const int tile)
@@ -2448,11 +2545,13 @@ void editorclass::entity_clicked(const int index)
     {
     case 1:
         // Enemies
+        commit_entity(index);
         entity->p1 = (entity->p1 + 1) % 4;
         break;
     case 2:
     {
         // Moving Platforms and Conveyors
+        commit_entity(index);
         const bool conveyor = entity->p1 >= 5;
         entity->p1++;
         if (conveyor)
@@ -2468,6 +2567,7 @@ void editorclass::entity_clicked(const int index)
     case 10:
         // Checkpoints
         // If it's not textured as a checkpoint, then just leave it be
+        commit_entity(index);
         if (entity->p1 == 0 || entity->p1 == 1)
         {
             entity->p1 = (entity->p1 + 1) % 2;
@@ -2476,27 +2576,34 @@ void editorclass::entity_clicked(const int index)
     case 11:
     case 16:
         // Gravity Lines, Start Point
+        commit_entity(index);
         entity->p1 = (entity->p1 + 1) % 2;
         break;
     case 15:
         // Crewmates
+        commit_entity(index);
         entity->p1 = (entity->p1 + 1) % 6;
         break;
     case 17:
         // Roomtext
+        commit_entity(index);
         get_input_line(TEXT_ROOMTEXT, "Enter roomtext:", &entity->scriptname);
         text_entity = index;
         break;
     case 18:
         // Terminals
+        commit_entity(index);
         if (entity->p1 == 0 || entity->p1 == 1)
         {
             // Flip the terminal, but if it's not textured as a terminal leave it alone
             entity->p1 = (entity->p1 + 1) % 2;
         }
-        SDL_FALLTHROUGH;
+        get_input_line(TEXT_SCRIPT, loc::gettext("Enter script name:"), &entity->scriptname);
+        text_entity = index;
+        break;
     case 19:
         // Script Boxes (and terminals)
+        commit_entity(index);
         get_input_line(TEXT_SCRIPT, "Enter script name:", &entity->scriptname);
         text_entity = index;
         break;
@@ -2518,6 +2625,12 @@ void editorclass::tool_place()
     case EditorTool_BACKING:
     {
         int tile = 0;
+
+        if (!placing_tiles)
+        {
+            placing_tiles = true;
+            update_old_tiles();
+        }
 
         if (cl.getroomprop(levx, levy)->directmode >= 1)
         {
@@ -2636,17 +2749,22 @@ void editorclass::tool_place()
         }
         break;
     case EditorTool_START_POINT:
-        //If there is another start point, destroy it
+        lclickdelay = 1;
+        //If there is another start point, move it instead
         for (size_t i = 0; i < customentities.size(); i++)
         {
             if (customentities[i].t == 16)
             {
-                remove_entity(i);
-                i--;
+                commit_entity(i);
+                customentities[i].rx = levx;
+                customentities[i].ry = levy;
+                customentities[i].x = tilex;
+                customentities[i].y = tiley;
+                customentities[i].p1 = 0;
+                return;
             }
         }
         add_entity(levx, levy, tilex, tiley, 16, 0);
-        lclickdelay = 1;
         break;
     default:
         break;
@@ -2999,21 +3117,25 @@ static void handle_draw_input()
     {
         if (key.keymap[SDLK_F1])
         {
+            commit_roomdata_tiles_change();
             ed.switch_tileset(shift_down);
             ed.keydelay = 6;
         }
         if (key.keymap[SDLK_F2])
         {
+            commit_roomdata_tiles_change();
             ed.switch_tilecol(shift_down);
             ed.keydelay = 6;
         }
         if (key.keymap[SDLK_F3])
         {
+            commit_roomdata_change();
             ed.switch_enemy(shift_down);
             ed.keydelay = 6;
         }
         if (key.keymap[SDLK_F4])
         {
+            commit_roomdata_change();
             ed.keydelay = 6;
             ed.substate = EditorSubState_DRAW_BOX;
             ed.box_corner = BoxCorner_FIRST;
@@ -3021,6 +3143,7 @@ static void handle_draw_input()
         }
         if (key.keymap[SDLK_F5])
         {
+            commit_roomdata_change();
             ed.keydelay = 6;
             ed.substate = EditorSubState_DRAW_BOX;
             ed.box_corner = BoxCorner_FIRST;
@@ -3028,6 +3151,7 @@ static void handle_draw_input()
         }
         if (key.keymap[SDLK_F10])
         {
+            commit_roomdata_tiles_change();
             if (cl.getroomprop(ed.levx, ed.levy)->directmode == 1)
             {
                 cl.setroomdirectmode(ed.levx, ed.levy, 0);
@@ -3057,11 +3181,13 @@ static void handle_draw_input()
 
         if (key.keymap[SDLK_w])
         {
+            commit_roomdata_change();
             ed.switch_warpdir(shift_down);
             ed.keydelay = 6;
         }
         if (key.keymap[SDLK_e])
         {
+            commit_roomdata_change();
             ed.keydelay = 6;
             ed.get_input_line(TEXT_ROOMNAME, "Enter new room name:", const_cast<std::string*>(&(cl.getroomprop(ed.levx, ed.levy)->roomname)));
             game.mapheld = true;
@@ -3104,6 +3230,7 @@ static void handle_draw_input()
         const bool shift = key.keymap[SDLK_LSHIFT] || key.keymap[SDLK_RSHIFT];
         if (key.keymap[SDLK_COMMA])
         {
+            commit_roomdata_change();
             if (ctrl)
             {
                 if (shift)
@@ -3123,6 +3250,7 @@ static void handle_draw_input()
         }
         else if (key.keymap[SDLK_PERIOD])
         {
+            commit_roomdata_change();
             if (ctrl)
             {
                 if (shift)
@@ -3194,6 +3322,115 @@ void editorclass::get_input_line(const enum TextMode mode, const std::string& pr
     old_entity_text = key.keybuffer;
 }
 
+void process_editor_buffer(const bool undo)
+{
+    extern editorclass ed;
+
+    std::vector<EditorUndoInfo>* buffer = undo ? &ed.undo_buffer : &ed.redo_buffer;
+
+    if (buffer->size() == 0)
+    {
+        ed.show_note(loc::gettext(undo ? "ERROR: Nothing to undo" : "ERROR: Nothing to redo"));
+        return;
+    }
+
+    EditorUndoInfo info = buffer->back();
+    buffer->pop_back();
+
+    ed.levx = info.room_x;
+    ed.levy = info.room_y;
+
+    EditorUndoInfo new_info;
+
+    new_info.room_x = info.room_x;
+    new_info.room_y = info.room_y;
+    new_info.type = info.type;
+
+    switch (info.type)
+    {
+    case EditorUndoType_TILES:
+        for (size_t i = 0; i < SCREEN_WIDTH_TILES * SCREEN_HEIGHT_TILES; i++)
+        {
+            const int x = i % SCREEN_WIDTH_TILES;
+            const int y = i / SCREEN_WIDTH_TILES;
+            ed.old_tiles[i] = ed.get_tile(x, y);
+            cl.settile(ed.levx, ed.levy, x, y, info.tiles[i]);
+        }
+
+        SDL_memcpy(&new_info.tiles, &ed.old_tiles, sizeof(ed.old_tiles));
+
+        graphics.foregrounddrawn = false;
+        break;
+    case EditorUndoType_ENTITY_ADDED:
+        // Remove the entity
+
+        if (!INBOUNDS_VEC(info.entity_id, customentities))
+        {
+            return;
+        }
+
+        new_info.type = EditorUndoType_ENTITY_REMOVED;
+        new_info.entity = customentities[info.entity_id];
+        new_info.entity_id = info.entity_id;
+        customentities.erase(customentities.begin() + info.entity_id);
+        break;
+    case EditorUndoType_ENTITY_REMOVED:
+        // Add the entity back
+
+        customentities.insert(customentities.begin() + info.entity_id, info.entity);
+        new_info.type = EditorUndoType_ENTITY_ADDED;
+        new_info.entity_id = info.entity_id;
+        new_info.entity = info.entity;
+        break;
+    case EditorUndoType_ENTITY_MODIFIED:
+        // Restore the entity
+
+        if (!INBOUNDS_VEC(info.entity_id, customentities))
+        {
+            return;
+        }
+
+        new_info.entity = customentities[info.entity_id];
+        new_info.entity_id = info.entity_id;
+        customentities[info.entity_id] = info.entity;
+        break;
+    case EditorUndoType_ROOMDATA:
+        new_info.room_data = cl.roomproperties[info.room_x + info.room_y * cl.maxwidth];
+        cl.roomproperties[info.room_x + info.room_y * cl.maxwidth] = info.room_data;
+        graphics.backgrounddrawn = false;
+        break;
+    case EditorUndoType_ROOMDATA_TILES:
+        // Restore the room data
+
+        for (size_t i = 0; i < SCREEN_WIDTH_TILES * SCREEN_HEIGHT_TILES; i++)
+        {
+            const int x = i % SCREEN_WIDTH_TILES;
+            const int y = i / SCREEN_WIDTH_TILES;
+            ed.old_tiles[i] = ed.get_tile(x, y);
+            cl.settile(ed.levx, ed.levy, x, y, info.tiles[i]);
+        }
+
+        SDL_memcpy(&new_info.tiles, &ed.old_tiles, sizeof(ed.old_tiles));
+
+        new_info.room_data = cl.roomproperties[info.room_x + info.room_y * cl.maxwidth];
+
+        cl.roomproperties[info.room_x + info.room_y * cl.maxwidth] = info.room_data;
+        graphics.backgrounddrawn = false;
+        graphics.foregrounddrawn = false;
+        ed.updatetiles = true;
+        break;
+    }
+
+    if (undo)
+    {
+        ed.redo_buffer.push_back(new_info);
+    }
+    else
+    {
+        ed.undo_buffer.push_back(new_info);
+    }
+}
+
 void editorinput(void)
 {
     extern editorclass ed;
@@ -3202,6 +3439,12 @@ void editorinput(void)
     {
         return;
     }
+
+    bool undo_pressed = false;
+    bool redo_pressed = false;
+
+    bool shift_down = key.keymap[SDLK_LSHIFT] || key.keymap[SDLK_RSHIFT];
+    bool ctrl_down = key.keymap[SDLK_LCTRL] || key.keymap[SDLK_RCTRL];
 
     ed.old_tilex = ed.tilex;
     ed.old_tiley = ed.tiley;
@@ -3228,10 +3471,22 @@ void editorinput(void)
     {
         game.press_right = true;
     }
-    if (key.isDown(KEYBOARD_z) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v) || key.isDown(game.controllerButton_flip))
+    if ((key.isDown(KEYBOARD_z) && !ctrl_down) || key.isDown(KEYBOARD_SPACE) || key.isDown(KEYBOARD_v) || key.isDown(game.controllerButton_flip))
     {
         game.press_action = true;
     };
+
+    if (key.isDown(KEYBOARD_z) && ctrl_down && (ed.keydelay == 0))
+    {
+        ed.keydelay = 6;
+        undo_pressed = true;
+    }
+
+    if (key.isDown(SDLK_y) && ctrl_down && (ed.keydelay == 0))
+    {
+        ed.keydelay = 6;
+        redo_pressed = true;
+    }
 
     if (key.keymap[SDLK_F9] && (ed.keydelay == 0)) {
         ed.keydelay = 30;
@@ -3263,9 +3518,6 @@ void editorinput(void)
         game.mapheld = false;
     }
 
-    bool shift_down = key.keymap[SDLK_LSHIFT] || key.keymap[SDLK_RSHIFT];
-    bool ctrl_down = key.keymap[SDLK_LCTRL] || key.keymap[SDLK_RCTRL];
-
     // Do different things depending on the current state (and substate)
     switch (ed.state)
     {
@@ -3274,6 +3526,16 @@ void editorinput(void)
         switch (ed.substate)
         {
         case EditorSubState_MAIN:
+
+            if (undo_pressed)
+            {
+                process_editor_buffer(true);
+            }
+            if (redo_pressed)
+            {
+                process_editor_buffer(false);
+            }
+
             if (escape_pressed)
             {
                 // We're just in draw mode, so go to the settings menu
@@ -3351,6 +3613,9 @@ void editorinput(void)
                 }
                 else
                 {
+                    commit_tiles();
+                    ed.placing_tiles = false;
+
                     ed.updatetiles = true;
                     ed.changeroom = true;
                     graphics.backgrounddrawn = false;
@@ -3379,6 +3644,11 @@ void editorinput(void)
             else if (!key.leftbutton)
             {
                 ed.lclickdelay = 0;
+                if (ed.placing_tiles)
+                {
+                    commit_tiles();
+                    ed.placing_tiles = false;
+                }
             }
 
             if (key.rightbutton)

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -3362,6 +3362,11 @@ void process_editor_buffer(const bool undo)
     ed.levx = info.room_x;
     ed.levy = info.room_y;
 
+    ed.updatetiles = true;
+    ed.changeroom = true;
+    graphics.backgrounddrawn = false;
+    graphics.foregrounddrawn = false;
+
     EditorUndoInfo new_info;
 
     new_info.room_x = info.room_x;
@@ -3380,14 +3385,13 @@ void process_editor_buffer(const bool undo)
         }
 
         SDL_memcpy(new_info.tiles, ed.old_tiles, sizeof(ed.old_tiles));
-
-        graphics.foregrounddrawn = false;
         break;
     case EditorUndoType_ENTITY_ADDED:
         // Remove the entity
 
         if (!INBOUNDS_VEC(info.entity_id, customentities))
         {
+            // Not sure how this would happen, but we should just consume it...
             return;
         }
 
@@ -3627,7 +3631,6 @@ void editorinput(void)
 
                     if (old_width != cl.mapwidth || old_height != cl.mapheight)
                     {
-
                         ed.updatetiles = true;
                         ed.changeroom = true;
                         graphics.backgrounddrawn = false;
@@ -3659,8 +3662,14 @@ void editorinput(void)
                 }
                 else
                 {
-                    commit_tiles();
-                    ed.placing_tiles = false;
+                    if (ed.placing_tiles)
+                    {
+                        // We were in the middle of placing tiles. Commit it, since we're done with the previous room.
+                        commit_tiles();
+
+                        // Must be done after every tile commit, as it's responsible for the "old tiles" cache
+                        ed.placing_tiles = false;
+                    }
 
                     ed.updatetiles = true;
                     ed.changeroom = true;

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -3330,7 +3330,7 @@ void process_editor_buffer(const bool undo)
 
     if (buffer->size() == 0)
     {
-        ed.show_note(loc::gettext(undo ? "ERROR: Nothing to undo" : "ERROR: Nothing to redo"));
+        ed.show_note(undo ? loc::gettext("ERROR: Nothing to undo") : loc::gettext("ERROR: Nothing to redo"));
         return;
     }
 

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -3419,6 +3419,14 @@ void process_editor_buffer(const bool undo)
         graphics.foregrounddrawn = false;
         ed.updatetiles = true;
         break;
+    case EditorUndoType_LEVEL_SIZE:
+        // Restore the level size
+        new_info.level_width = cl.mapwidth;
+        new_info.level_height = cl.mapheight;
+
+        cl.mapwidth = info.level_width;
+        cl.mapheight = info.level_height;
+        break;
     }
 
     if (undo)
@@ -3584,6 +3592,8 @@ void editorinput(void)
                 }
                 else if (shift_down)
                 {
+                    int old_width = cl.mapwidth;
+                    int old_height = cl.mapheight;
 
                     if (up_pressed) cl.mapheight--;
                     if (down_pressed) cl.mapheight++;
@@ -3593,23 +3603,37 @@ void editorinput(void)
                     cl.mapwidth = SDL_clamp(cl.mapwidth, 1, cl.maxwidth);
                     cl.mapheight = SDL_clamp(cl.mapheight, 1, cl.maxheight);
 
-                    ed.updatetiles = true;
-                    ed.changeroom = true;
-                    graphics.backgrounddrawn = false;
-                    graphics.foregrounddrawn = false;
+                    if (old_width != cl.mapwidth || old_height != cl.mapheight)
+                    {
 
-                    ed.levx = POS_MOD(ed.levx, cl.mapwidth);
-                    ed.levy = POS_MOD(ed.levy, cl.mapheight);
+                        ed.updatetiles = true;
+                        ed.changeroom = true;
+                        graphics.backgrounddrawn = false;
+                        graphics.foregrounddrawn = false;
 
-                    char buffer[3 * SCREEN_WIDTH_CHARS + 1];
-                    vformat_buf(
-                        buffer, sizeof(buffer),
-                        loc::gettext("Mapsize is now [{width},{height}]"),
-                        "width:int, height:int",
-                        cl.mapwidth, cl.mapheight
-                    );
+                        ed.levx = POS_MOD(ed.levx, cl.mapwidth);
+                        ed.levy = POS_MOD(ed.levy, cl.mapheight);
 
-                    ed.show_note(buffer);
+                        char buffer[3 * SCREEN_WIDTH_CHARS + 1];
+                        vformat_buf(
+                            buffer, sizeof(buffer),
+                            loc::gettext("Mapsize is now [{width},{height}]"),
+                            "width:int, height:int",
+                            cl.mapwidth, cl.mapheight
+                        );
+ 
+                        ed.show_note(buffer);
+
+                        EditorUndoInfo info;
+                        info.type = EditorUndoType_LEVEL_SIZE;
+                        info.level_width = old_width;
+                        info.level_height = old_height;
+                        info.room_x = ed.levx;
+                        info.room_y = ed.levy;
+
+                        ed.undo_buffer.push_back(info);
+                        ed.redo_buffer.clear();
+                    }
                 }
                 else
                 {

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -2514,19 +2514,23 @@ void editorclass::handle_tile_placement(const int tile)
 
 void editorclass::tool_remove()
 {
-    if (!placing_tiles)
-    {
-        placing_tiles = true;
-        update_old_tiles();
-    }
-
     switch (current_tool)
     {
     case EditorTool_WALLS:
     case EditorTool_BACKING:
+        if (!placing_tiles)
+        {
+            placing_tiles = true;
+            update_old_tiles();
+        }
         handle_tile_placement(0);
         break;
     case EditorTool_SPIKES:
+        if (!placing_tiles)
+        {
+            placing_tiles = true;
+            update_old_tiles();
+        }
         set_tile_interpolated(old_tilex, tilex, old_tiley, tiley, 0);
         break;
     default:

--- a/desktop_version/src/Editor.h
+++ b/desktop_version/src/Editor.h
@@ -142,6 +142,7 @@ enum EditorUndoTypes
     EditorUndoType_ENTITY_ADDED, // Entity added
     EditorUndoType_ENTITY_REMOVED, // Entity removed
     EditorUndoType_ENTITY_MODIFIED, // Entity properties modified
+    EditorUndoType_LEVEL_SIZE // Level size modified
 };
 
 struct EditorUndoInfo
@@ -155,7 +156,8 @@ struct EditorUndoInfo
     int entity_id;
     CustomEntity entity;
     RoomProperty room_data;
-
+    int level_width;
+    int level_height;
 };
 
 class editorclass

--- a/desktop_version/src/Editor.h
+++ b/desktop_version/src/Editor.h
@@ -133,6 +133,31 @@ struct GhostInfo
     int frame; // .drawframe
 };
 
+
+enum EditorUndoTypes
+{
+    EditorUndoType_TILES, // Tiles modified
+    EditorUndoType_ROOMDATA, // Room data modified
+    EditorUndoType_ROOMDATA_TILES, // Room data modified (and stores tiles)
+    EditorUndoType_ENTITY_ADDED, // Entity added
+    EditorUndoType_ENTITY_REMOVED, // Entity removed
+    EditorUndoType_ENTITY_MODIFIED, // Entity properties modified
+};
+
+struct EditorUndoInfo
+{
+    EditorUndoTypes type;
+    int tiles[SCREEN_WIDTH_TILES * SCREEN_HEIGHT_TILES];
+    int room_x;
+    int room_y;
+    EditorTilesets tileset;
+    int tilecol;
+    int entity_id;
+    CustomEntity entity;
+    RoomProperty room_data;
+
+};
+
 class editorclass
 {
 public:
@@ -282,6 +307,11 @@ public:
 
     std::vector<GhostInfo> ghosts;
     int current_ghosts;
+
+    std::vector<EditorUndoInfo> undo_buffer;
+    std::vector<EditorUndoInfo> redo_buffer;
+    bool placing_tiles = false;
+    int old_tiles[SCREEN_WIDTH_TILES * SCREEN_HEIGHT_TILES];
 };
 
 void editorrender(void);

--- a/desktop_version/src/Editor.h
+++ b/desktop_version/src/Editor.h
@@ -312,7 +312,7 @@ public:
 
     std::vector<EditorUndoInfo> undo_buffer;
     std::vector<EditorUndoInfo> redo_buffer;
-    bool placing_tiles = false;
+    bool placing_tiles;
     int old_tiles[SCREEN_WIDTH_TILES * SCREEN_HEIGHT_TILES];
 };
 


### PR DESCRIPTION
## Changes:

It's very easy to make mistakes in VVVVVV's built-in level editor, with no way to undo them. This PR adds an undo and redo system, bound to CTRL+Z for undo and CTRL+Y for redo. The undo and redo stacks don't have any limits, but could easily happen in the future. VVVVVV's data is small enough where this should never be an issue, however.

No notes show up for undoing and redoing, because keeping track of what specific action you're doing may bloat the system, and would get annoying for the end-user. Notes are a bit annoying in general, even, but that's not relevant for this PR.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
