### PR TITLE
Fix resizing the map not changing the current room

### DIFF
--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -3261,6 +3261,14 @@ void editorinput(void)
                     cl.mapwidth = SDL_clamp(cl.mapwidth, 1, cl.maxwidth);
                     cl.mapheight = SDL_clamp(cl.mapheight, 1, cl.maxheight);
 
+                    ed.updatetiles = true;
+                    ed.changeroom = true;
+                    graphics.backgrounddrawn = false;
+                    graphics.foregrounddrawn = false;
+
+                    ed.levx = POS_MOD(ed.levx, cl.mapwidth);
+                    ed.levy = POS_MOD(ed.levy, cl.mapheight);
+
                     char buffer[3 * SCREEN_WIDTH_CHARS + 1];
                     vformat_buf(
                         buffer, sizeof(buffer),


### PR DESCRIPTION
## Changes:

If you're in (5, 5) (1-indexed) and you resize the map to (4,5), the editor stays in (5, 5). This has no real consequences, other than possibly confusing the user, but it should probably be fixed anyway.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
