### PR TITLE
Fix minor [Press ACTION to save your game] overflow in Turkish and German

### DIFF
--- a/desktop_version/lang/de/strings.xml
+++ b/desktop_version/lang/de/strings.xml
@@ -478,7 +478,7 @@
     <string english="ERROR: Could not save settings file!" translation="FEHLER: Konnte die eingestellten Optionen nicht speichern!" explanation="" max="38*2"/>
     <string english="Game saved ok!" translation="Spiel gespeichert!" explanation="in-game menu" max="38*2"/>
     <string english="[Press ACTION to save your game]" translation="[Speichere mit HANDLUNG das Spiel]" explanation="***OUTDATED***" max="40"/>
-    <string english="[Press {button} to save your game]" translation="[Drücke {button}, um das Spiel zu speichern]" explanation="in-game menu. Expect `ACTION`" max="40"/>
+    <string english="[Press {button} to save your game]" translation="[Speichere mit {button} das Spiel]" explanation="in-game menu. Expect `ACTION`" max="40"/>
     <string english="(Note: The game is autosaved at every teleporter.)" translation="(Hinweis: Das Spiel wird bei jedem Teleporter automatisch gespeichert)." explanation="in-game menu" max="38*3"/>
     <string english="Last Save:" translation="Letzter Spielstand:" explanation="in-game menu" max="40"/>
     <string english="Return to main menu?" translation="Zurück zum Hauptmenü?" explanation="in-game menu" max="38*4"/>

--- a/desktop_version/lang/tr/strings.xml
+++ b/desktop_version/lang/tr/strings.xml
@@ -478,7 +478,7 @@
     <string english="ERROR: Could not save settings file!" translation="HATA: Ayarlar dosyası kaydedilemedi!" explanation="" max="38*2"/>
     <string english="Game saved ok!" translation="Oyun başarıyla kaydedildi!" explanation="in-game menu" max="38*2"/>
     <string english="[Press ACTION to save your game]" translation="[AKSİYON tuşuna basarak kaydet]" explanation="***OUTDATED***" max="40"/>
-    <string english="[Press {button} to save your game]" translation="[Oyunu kaydetmek için {button} tuşuna bas]" explanation="in-game menu. Expect `ACTION`" max="40"/>
+    <string english="[Press {button} to save your game]" translation="Oyunu kaydetmek için {button} tuşuna bas" explanation="in-game menu. Expect `ACTION`" max="40"/>
     <string english="(Note: The game is autosaved at every teleporter.)" translation="(Not: Işınlayıcılarda otomatik kaydedilir.)" explanation="in-game menu" max="38*3"/>
     <string english="Last Save:" translation="Son Kayıt:" explanation="in-game menu" max="40"/>
     <string english="Return to main menu?" translation="Ana menüye dönülsün mü?" explanation="in-game menu" max="38*4"/>


### PR DESCRIPTION
## Changes:

When ACTION is filled in, the closing ] will go offscreen in Turkish.

!["\[Oyunu kaydetmek için AKSİYON tuşuna bas"](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/dc6fac76-c953-4d1d-8f0b-e8ae973591a4)

To fix it, I simply removed the square brackets.

!["Oyunu kaydetmek için AKSİYON tuşuna bas"](https://github.com/TerryCavanagh/VVVVVV/assets/44736680/848cf1a3-1207-46c1-b516-595882242c5b)

Edit: see below for German



## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
