### PR TITLE
Change Warp Zone roomname in Esperanto translation

### DIFF
--- a/desktop_version/lang/eo/roomnames.xml
+++ b/desktop_version/lang/eo/roomnames.xml
@@ -68,7 +68,7 @@
     <roomname x="12" y="12" english="The High Road is Low" translation="La alta vojo malaltas" explanation="This room has two paths - a high path and a low path. The &apos;low&apos; path leads to a trinket, so the roomname is a sort of clue about which way to go."/>
     <roomname x="12" y="13" english="Give Me A V" translation="Vertikala V-jaĝo" explanation="Room is in the shape of a big letter V. The roomname suggests the common american cheerleading chant - e.g. Give me an L! Give me an O! Give me a C! Give me an A! Give me an L! Give me an I! Give me an S! Give me an A! Give me a T! Give me an I! Give me an O! Give me an N! What does it spell? LOCALISATION!"/>
     <roomname x="12" y="14" english="Outer Hull" translation="Ekstera hulo" explanation="The entrance to the Space Station 2 level - the outer hull of a space station."/>
-    <roomname x="13" y="0" english="It&apos;s Not Easy Being Green" translation="La verdita generacio" explanation="References a song by Kermit from the Muppets. This room is where you find the green crewmate."/>
+    <roomname x="13" y="0" english="It&apos;s Not Easy Being Green" translation="Verda reaperis!" explanation="References a song by Kermit from the Muppets. This room is where you find the green crewmate."/>
     <roomname x="13" y="3" english="Linear Collider" translation="Lineara koliziaĵo" explanation="An early room, name is just meant to suggest something sciency. Room contains long, wave like enemies."/>
     <roomname x="13" y="4" english="Comms Relay" translation="Komunikada plusendejo" explanation="This room contains some communication equipment, like a radio."/>
     <roomname x="13" y="5" english="Welcome Aboard" translation="Bonvenon stacien" explanation="The first room in the game"/>


### PR DESCRIPTION
## Changes:

This replaces the translated roomname for "It's Not Easy Being Green" (previously "La verdita generacio") with "Verda reaperis!", a different [cultural reference](https://en.wikipedia.org/wiki/Gerda_malaperis!) with a much better pun.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
