### PR TITLE
Add a system for selecting between wordy/wordy2

### DIFF
--- a/desktop_version/src/CWrappers.cpp
+++ b/desktop_version/src/CWrappers.cpp
@@ -5,12 +5,12 @@
 #include "Localization.h"
 #include "UtilityClass.h"
 
-char* HELP_number_words(int _t)
+char* HELP_number_words(int _t, const char* number_class)
 {
     /* C wrapper for UtilityClass::number_words.
      * Caller must VVV_free. */
 
-    std::string str = help.number_words(_t);
+    std::string str = help.number_words(_t, number_class);
 
     char* buffer = (char*) SDL_malloc(str.size() + 1);
     str.copy(buffer, str.size());

--- a/desktop_version/src/CWrappers.h
+++ b/desktop_version/src/CWrappers.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-char* HELP_number_words(int _t);
+char* HELP_number_words(int _t, const char* number_class);
 uint32_t LOC_toupper_ch(uint32_t ch);
 
 #ifdef __cplusplus

--- a/desktop_version/src/Localization.cpp
+++ b/desktop_version/src/Localization.cpp
@@ -125,18 +125,28 @@ void gettext_plural_fill(char* buf, size_t buf_len, const char* eng_plural, cons
     va_end(args);
 }
 
-std::string getnumber(int n)
+std::string getnumber(int n, const char* number_class)
 {
     if (n < 0 || n > 100)
     {
         return help.String(n);
     }
 
-    if (number[n].empty())
+    // FIXME: implement a more flexible system later, where translators define the classes
+    std::string (*number_ptr)[101];
+    if (SDL_strcmp(number_class, "wordy2") == 0)
+    {
+        number_ptr = &number2;
+    }
+    else
+    {
+        number_ptr = &number;
+    }
+    if ((*number_ptr)[n].empty())
     {
         return help.String(n);
     }
-    return number[n];
+    return (*number_ptr)[n];
 }
 
 static bool is_script_custom(const char* script_id)

--- a/desktop_version/src/Localization.h
+++ b/desktop_version/src/Localization.h
@@ -82,7 +82,7 @@ const char* gettext(const char* eng);
 const char* gettext_case(const char* eng, char textcase);
 const char* gettext_plural(const char* eng_plural, const char* eng_singular, int count);
 void gettext_plural_fill(char* buf, size_t buf_len, const char* eng_plural, const char* eng_singular, const char* args_index, ...);
-std::string getnumber(int n);
+std::string getnumber(int n, const char* number_class);
 const TextboxFormat* gettext_cutscene(const std::string& script_id, const std::string& eng, char textcase);
 const char* get_roomname_explanation(bool custom_level, int roomx, int roomy);
 const char* get_roomname_translation(bool custom_level, int roomx, int roomy);

--- a/desktop_version/src/LocalizationStorage.cpp
+++ b/desktop_version/src/LocalizationStorage.cpp
@@ -240,6 +240,7 @@ void resettext(bool final_shutdown)
         for (size_t i = 0; i <= 100; i++)
         {
             number[i] = "";
+            number2[i] = "";
         }
         SDL_zeroa(number_plural_form);
         number_plural_form[1] = 1;
@@ -743,6 +744,14 @@ static void loadtext_numbers(void)
             number[value] = std::string(tra);
 
             tally_untranslated(tra, &n_untranslated[UNTRANSLATED_NUMBERS]);
+
+            // FIXME: implement a more flexible system later, where translators define the classes
+            tra = pElem->Attribute("translation2");
+            if (tra == NULL)
+            {
+                tra = "";
+            }
+            number2[value] = std::string(tra);
         }
         if (value >= 0 && value <= 199)
         {

--- a/desktop_version/src/LocalizationStorage.h
+++ b/desktop_version/src/LocalizationStorage.h
@@ -27,6 +27,7 @@ namespace loc
     LS_INTERN hashmap* map_translation;
     LS_INTERN hashmap* map_translation_plural;
     LS_INTERN std::string number[101]; /* 0..100 */
+    LS_INTERN std::string number2[101]; /* 0..100 */
     LS_INTERN unsigned char number_plural_form[200]; /* [0..99] for 0..99, [100..199] for *00..*99 */
     LS_INTERN hashmap* map_translation_cutscene;
     LS_INTERN hashmap* map_translation_cutscene_custom;

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -173,11 +173,11 @@ std::string UtilityClass::timestring( int t )
     return output;
 }
 
-std::string UtilityClass::number_words( int _t )
+std::string UtilityClass::number_words(int _t, const char* number_class)
 {
     if (loc::lang != "en")
     {
-        return loc::getnumber(_t);
+        return loc::getnumber(_t, number_class);
     }
 
     static const std::string ones_place[] = {"One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine"};

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -107,7 +107,7 @@ public:
 
     std::string timestring(int t);
 
-    std::string number_words(int _t);
+    std::string number_words(int _t, const char* number_class);
 
 
     static bool intersects( SDL_Rect A, SDL_Rect B );

--- a/desktop_version/src/VFormat.c
+++ b/desktop_version/src/VFormat.c
@@ -151,6 +151,7 @@ void vformat_cb_valist(
             size_t name_len = 0;
 
             bool flag_wordy = false;
+            bool flag_wordy2 = false;
             int flag_digits = 0;
             bool flag_spaces = false;
             bool flag_upper = false;
@@ -184,6 +185,10 @@ void vformat_cb_valist(
                 else if (flag_len == 5 && SDL_memcmp(cursor, "wordy", 5) == 0)
                 {
                     flag_wordy = true;
+                }
+                else if (flag_len == 6 && SDL_memcmp(cursor, "wordy2", 6) == 0)
+                {
+                    flag_wordy2 = true;
                 }
                 else if (flag_len >= 8 && SDL_memcmp(cursor, "digits=", 7) == 0)
                 {
@@ -253,9 +258,9 @@ void vformat_cb_valist(
 
                     if (match)
                     {
-                        if (flag_wordy)
+                        if (flag_wordy || flag_wordy2)
                         {
-                            char* number = HELP_number_words(value);
+                            char* number = HELP_number_words(value, flag_wordy2 ? "wordy2" : "wordy");
                             if (flag_upper)
                             {
                                 call_with_upper(callback, userdata, number, SDL_strlen(number));


### PR DESCRIPTION
## Changes:

Some languages have different spellings of wordy numbers based on the gender of the things they're counting (uno crewmate versus una trinket) or what a number's role is in the sentence (e.g. twenta out of twentu). We've always had the idea we couldn't support such complex differences though, because the game can't be adapted to know what gender each object will have and what word classes might exist in other languages, so translators would in those cases just have to forgo the wordy numbers and just let the game use "20 out of 20".

A solution we came up semi-recently though (after all translations were finished except for Arabic), was to allow the translator to define however many classes of wordy numbers they need, and fill them all out. This would not need the game to be *adapted* for every language's specific grammar and word genders/classes. Instead, the translator would just choose their correct self-defined class at the time they use `wordy` in the VFormat placeholder. Something like {n|wordy|class=feminine}, or {n|wordy_feminine}.

So this would benefit several languages, but we came up with the solution a little late for all languages to benefit from it. The Arabic translators asked for two separate classes of wordy numbers though, so my plan is to first just have a second list of wordy numbers (translation2 in numbers.xml), which can be accessed by passing the `wordy2` flag to VFormat, instead of `wordy`.

Once 2.4 is released, we can take our time to do it properly. This would involve the ability for translators to define however many classes they need, to name them what they want, and this name would then be useable in VFormat placeholders. We can convert all existing translations to have one class defined by default, such as "wordy", or "translation" depending on implementation, but there's not so much concern for maintaining backwards compatibility here, so we can do a mass-switchover for all language files. That said, it wouldn't be too hard to add a special case for "translation" being "wordy" either. We can then ask translators if they would like to change anything with the new system in place.

For now, we can use this system for Arabic, maybe Spanish since there were complaints about uno/una, and *maybe* Dutch (it has a thing where the number "one" is often capitalized differently, but it's not mandatory per se)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
