### PR TITLE
Indicate modes when loading in to gameplay

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -361,6 +361,9 @@ void Game::init(void)
     old_skip_message_timer = 0;
     skip_message_timer = 0;
 
+    old_mode_indicator_timer = 0;
+    mode_indicator_timer = 0;
+
     setdefaultcontrollerbuttons();
 }
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -589,6 +589,9 @@ public:
 
     int old_skip_message_timer;
     int skip_message_timer;
+
+    int old_mode_indicator_timer;
+    int mode_indicator_timer;
 };
 
 #ifndef GAME_DEFINITION

--- a/desktop_version/src/RenderFixed.cpp
+++ b/desktop_version/src/RenderFixed.cpp
@@ -137,6 +137,12 @@ void gamerenderfixed(void)
         ed.return_message_timer -= 15;
     }
 
+    game.old_mode_indicator_timer = game.mode_indicator_timer;
+    if (game.mode_indicator_timer > 0)
+    {
+        game.mode_indicator_timer -= 15;
+    }
+
     // Editor ghosts!
     if (game.ghostsenabled)
     {

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2694,6 +2694,21 @@ void scriptclass::startgamemode(const enum StartMode mode)
         font::set_level_font_interface();
     }
 
+    /* Indicate invincibility, glitchrunner, etc. for all modes except these */
+    switch (mode)
+    {
+    case Start_EDITOR:
+    case Start_CUTSCENETEST:
+        break;
+    case Start_QUIT:
+        VVV_unreachable();
+
+    default:
+        /* If there's editor return text, make this show up after it */
+        game.mode_indicator_timer = ed.return_message_timer + 2000;
+        game.old_mode_indicator_timer = game.mode_indicator_timer;
+    }
+
     game.jumpheld = true;
 
     switch (mode)


### PR DESCRIPTION
If you load in to gameplay with invincibility mode, glitchrunner mode, Flip Mode, or slowdown enabled, then there will be text displayed on screen for a few seconds that says so.

This is to serve as a useful reminder. A common pitfall with using  invincibility is forgetting to turn it off when you don't want it anymore. What usually happens is that players forget that they have it on until they encounter a hazard. Now, they can realize it as soon as they load in.

~~The only reason this is a draft pull request is because there is an issue with the Japanese translation where some menu option strings I would like to reuse, e.g. "Glitchrunner mode is {version}", can't be reused on account of them being genericized in Japanese (i.e. they say "Mode: OFF" and that gets reused across multiple strings). Waiting on this to be resolved before merging.~~ Actually instead I'll use the header strings which definitely can't be generic.

Fixes #1091.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
