### PR TITLE
Only trigger CI workflows for code or CI changes

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,7 +1,45 @@
 name: CI (Android)
 
-# Trigger this workflow on push or pull request
-on: [push, pull_request]
+# Only trigger workflow when Android-specific code could have changed.
+# This includes C/C++ files that have __ANDROID__ ifdefs.
+# If adding new ifdefs, make sure to update these lists.
+on:
+  push:
+    paths:
+      - "desktop_version/CMakeLists.txt"
+      - "desktop_version/src/ButtonGlyphs.cpp"
+      - "desktop_version/src/FileSystemUtils.cpp"
+      - "desktop_version/src/Screen.cpp"
+      - "desktop_version/src/Vlogging.c"
+      - "desktop_version/VVVVVV-android/gradlew"
+      - "desktop_version/VVVVVV-android/gradlew.bat"
+      - "desktop_version/VVVVVV-android/**/CMakeLists.txt"
+      - "desktop_version/VVVVVV-android/**.java"
+      - "desktop_version/VVVVVV-android/**.xml"
+      - "desktop_version/VVVVVV-android/**.pro"
+      - "desktop_version/VVVVVV-android/**.mk"
+      - "desktop_version/VVVVVV-android/**.gradle"
+      - "desktop_version/VVVVVV-android/**.jar"
+      - "desktop_version/VVVVVV-android/**.properties"
+      - ".github/workflows/android.yml"
+  pull_request:
+    paths:
+      - "desktop_version/CMakeLists.txt"
+      - "desktop_version/src/ButtonGlyphs.cpp"
+      - "desktop_version/src/FileSystemUtils.cpp"
+      - "desktop_version/src/Screen.cpp"
+      - "desktop_version/src/Vlogging.c"
+      - "desktop_version/VVVVVV-android/gradlew"
+      - "desktop_version/VVVVVV-android/gradlew.bat"
+      - "desktop_version/VVVVVV-android/**/CMakeLists.txt"
+      - "desktop_version/VVVVVV-android/**.java"
+      - "desktop_version/VVVVVV-android/**.xml"
+      - "desktop_version/VVVVVV-android/**.pro"
+      - "desktop_version/VVVVVV-android/**.mk"
+      - "desktop_version/VVVVVV-android/**.gradle"
+      - "desktop_version/VVVVVV-android/**.jar"
+      - "desktop_version/VVVVVV-android/**.properties"
+      - ".github/workflows/android.yml"
 
 env:
   SRC_DIR_PATH: VVVVVV/desktop_version/VVVVVV-android

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,22 @@
 name: CI
 
-# Trigger this workflow on push or pull request
-on: [push, pull_request]
+# Only trigger workflow when code changes, or this file is changed.
+# Android has a different workflow and different rules.
+on:
+  push:
+    paths:
+      - "desktop_version/CMakeLists.txt"
+      - "desktop_version/src/**.cpp"
+      - "desktop_version/src/**.c"
+      - "desktop_version/src/**.h"
+      - ".github/workflows/ci.yml"
+  pull_request:
+    paths:
+      - "desktop_version/CMakeLists.txt"
+      - "desktop_version/src/**.cpp"
+      - "desktop_version/src/**.c"
+      - "desktop_version/src/**.h"
+      - ".github/workflows/ci.yml"
 
 env:
   SRC_DIR_PATH: desktop_version


### PR DESCRIPTION
This makes it so that the main CI workflow will only trigger if a change is made to a code file in `desktop_version/` (as the CI is only for `desktop_version/`), or if the CI file itself is changed.

The CI workflow for Android will only trigger if Android-specific code _could have_ changed. This includes all code that is definitely Android-specific (e.g. Java files), but also C/C++ files that have `__ANDROID__` ifdefs.

Unfortunately, it's [not possible to reuse the same list of paths across two different event trigger types](https://github.com/orgs/community/discussions/37645). So we have to copy-paste here.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
