### PR TITLE
Add support for right-aligned roomtext

### DIFF
--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -1052,8 +1052,14 @@ static void draw_entities(void)
                     height = font::height(PR_FONT_LEVEL);
                 }
 
-                graphics.draw_rect(x, y, width, height, graphics.getRGB(96, 96, 96));
-                font::print(PR_FONT_LEVEL | PR_CJK_LOW, x, y, entity->scriptname, 196, 196, 255 - help.glow);
+                int rect_x = x;
+                if (entity->p1)
+                {
+                    // RTL. The 8 is the size of a tile, not font width!
+                    rect_x -= width - 8;
+                }
+                graphics.draw_rect(rect_x, y, width, height, graphics.getRGB(96, 96, 96));
+                graphics.print_roomtext(x, y, entity->scriptname.c_str(), entity->p1);
                 break;
             }
             case 18: // Terminals
@@ -2549,7 +2555,7 @@ void editorclass::tool_place()
     case EditorTool_ROOMTEXT:
         lclickdelay = 1;
         text_entity = customentities.size();
-        add_entity(levx, levy, tilex, tiley, 17);
+        add_entity(levx, levy, tilex, tiley, 17, cl.rtl ? 1 : 0);
         get_input_line(TEXT_ROOMTEXT, loc::gettext("Enter roomtext:"), &(customentities[text_entity].scriptname));
         break;
     case EditorTool_TERMINALS:

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3602,3 +3602,15 @@ void Graphics::render_roomname(uint32_t font_flag, const char* roomname, int r, 
     font::print(font_flag | PR_CEN | PR_BOR | PR_CJK_LOW, -1, footerrect.y+1, roomname, r, g, b);
     set_blendmode(SDL_BLENDMODE_NONE);
 }
+
+void Graphics::print_roomtext(int x, const int y, const char* text, const bool rtl)
+{
+    uint32_t flags = PR_FONT_LEVEL | PR_CJK_LOW;
+
+    if (rtl)
+    {
+        flags |= PR_RIGHT;
+        x += 8; // the size of a tile, not font width!
+    }
+    font::print(flags, x, y, text, 196, 196, 255 - help.glow);
+}

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -414,6 +414,8 @@ public:
     SDL_Color crewcolourreal(int t);
 
     void render_roomname(uint32_t font_flag, const char* roomname, int r, int g, int b);
+
+    void print_roomtext(int x, int y, const char* text, bool rtl);
 };
 
 #ifndef GRAPHICS_DEFINITION

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1895,6 +1895,7 @@ void mapclass::loadlevel(int rx, int ry)
                 text.x = ex / 8;
                 text.y = ey / 8;
                 text.text = ent.scriptname.c_str();
+                text.rtl = ent.p1;
                 roomtext.push_back(text);
                 break;
             }

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -16,6 +16,7 @@ struct Roomtext
 {
     int x, y;
     const char* text;
+    bool rtl;
 };
 
 enum RoomnameType

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2364,7 +2364,7 @@ void gamerender(void)
         //Draw room text!
         for (size_t i = 0; i < map.roomtext.size(); i++)
         {
-            font::print(PR_FONT_LEVEL | PR_CJK_LOW, map.roomtext[i].x*8, (map.roomtext[i].y*8), map.roomtext[i].text, 196, 196, 255 - help.glow);
+            graphics.print_roomtext(map.roomtext[i].x*8, map.roomtext[i].y*8, map.roomtext[i].text, map.roomtext[i].rtl);
         }
     }
 


### PR DESCRIPTION
## Changes:

This is mostly so people making levels in an RTL language have a more pleasant and logical experience. If roomtext is placed in a level set to RTL, it will get p1=1, which makes that roomtext right-aligned. Because, imagine for English you click to place roomtext, and the text runs left of where you clicked, which wouldn't be logical.

Since it's an entity-bound property, switching RTL on and off either in the editor or via a script does not affect existing entities.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
