### PR TITLE
Use wordy2 in Dutch to capitalize één as Eén

### DIFF
--- a/desktop_version/lang/nl/numbers.xml
+++ b/desktop_version/lang/nl/numbers.xml
@@ -1,107 +1,107 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Please read README.txt for information about the language files -->
 <numbers>
-    <number value="0" form="0" english="Zero" translation="nul"/>
-    <number value="1" form="1" english="One" translation="één"/>
-    <number value="2" form="0" english="Two" translation="twee"/>
-    <number value="3" form="0" english="Three" translation="drie"/>
-    <number value="4" form="0" english="Four" translation="vier"/>
-    <number value="5" form="0" english="Five" translation="vijf"/>
-    <number value="6" form="0" english="Six" translation="zes"/>
-    <number value="7" form="0" english="Seven" translation="zeven"/>
-    <number value="8" form="0" english="Eight" translation="acht"/>
-    <number value="9" form="0" english="Nine" translation="negen"/>
-    <number value="10" form="0" english="Ten" translation="tien"/>
-    <number value="11" form="0" english="Eleven" translation="elf"/>
-    <number value="12" form="0" english="Twelve" translation="twaalf"/>
-    <number value="13" form="0" english="Thirteen" translation="dertien"/>
-    <number value="14" form="0" english="Fourteen" translation="veertien"/>
-    <number value="15" form="0" english="Fifteen" translation="vijftien"/>
-    <number value="16" form="0" english="Sixteen" translation="zestien"/>
-    <number value="17" form="0" english="Seventeen" translation="zeventien"/>
-    <number value="18" form="0" english="Eighteen" translation="achttien"/>
-    <number value="19" form="0" english="Nineteen" translation="negentien"/>
-    <number value="20" form="0" english="Twenty" translation="twintig"/>
-    <number value="21" form="0" english="Twenty One" translation="eenentwintig"/>
-    <number value="22" form="0" english="Twenty Two" translation="tweeëntwintig"/>
-    <number value="23" form="0" english="Twenty Three" translation="drieëntwintig"/>
-    <number value="24" form="0" english="Twenty Four" translation="vierentwintig"/>
-    <number value="25" form="0" english="Twenty Five" translation="vijfentwintig"/>
-    <number value="26" form="0" english="Twenty Six" translation="zesentwintig"/>
-    <number value="27" form="0" english="Twenty Seven" translation="zevenentwintig"/>
-    <number value="28" form="0" english="Twenty Eight" translation="achtentwintig"/>
-    <number value="29" form="0" english="Twenty Nine" translation="negenentwintig"/>
-    <number value="30" form="0" english="Thirty" translation="dertig"/>
-    <number value="31" form="0" english="Thirty One" translation="eenendertig"/>
-    <number value="32" form="0" english="Thirty Two" translation="tweeëndertig"/>
-    <number value="33" form="0" english="Thirty Three" translation="drieëndertig"/>
-    <number value="34" form="0" english="Thirty Four" translation="vierendertig"/>
-    <number value="35" form="0" english="Thirty Five" translation="vijfendertig"/>
-    <number value="36" form="0" english="Thirty Six" translation="zesendertig"/>
-    <number value="37" form="0" english="Thirty Seven" translation="zevenendertig"/>
-    <number value="38" form="0" english="Thirty Eight" translation="achtendertig"/>
-    <number value="39" form="0" english="Thirty Nine" translation="negenendertig"/>
-    <number value="40" form="0" english="Forty" translation="veertig"/>
-    <number value="41" form="0" english="Forty One" translation="eenenveertig"/>
-    <number value="42" form="0" english="Forty Two" translation="tweeënveertig"/>
-    <number value="43" form="0" english="Forty Three" translation="drieënveertig"/>
-    <number value="44" form="0" english="Forty Four" translation="vierenveertig"/>
-    <number value="45" form="0" english="Forty Five" translation="vijfenveertig"/>
-    <number value="46" form="0" english="Forty Six" translation="zesenveertig"/>
-    <number value="47" form="0" english="Forty Seven" translation="zevenenveertig"/>
-    <number value="48" form="0" english="Forty Eight" translation="achtenveertig"/>
-    <number value="49" form="0" english="Forty Nine" translation="negenenveertig"/>
-    <number value="50" form="0" english="Fifty" translation="vijftig"/>
-    <number value="51" form="0" english="Fifty One" translation="eenenvijftig"/>
-    <number value="52" form="0" english="Fifty Two" translation="tweeënvijftig"/>
-    <number value="53" form="0" english="Fifty Three" translation="drieënvijftig"/>
-    <number value="54" form="0" english="Fifty Four" translation="vierenvijftig"/>
-    <number value="55" form="0" english="Fifty Five" translation="vijfenvijftig"/>
-    <number value="56" form="0" english="Fifty Six" translation="zesenvijftig"/>
-    <number value="57" form="0" english="Fifty Seven" translation="zevenenvijftig"/>
-    <number value="58" form="0" english="Fifty Eight" translation="achtenvijftig"/>
-    <number value="59" form="0" english="Fifty Nine" translation="negenenvijftig"/>
-    <number value="60" form="0" english="Sixty" translation="zestig"/>
-    <number value="61" form="0" english="Sixty One" translation="eenenzestig"/>
-    <number value="62" form="0" english="Sixty Two" translation="tweeënzestig"/>
-    <number value="63" form="0" english="Sixty Three" translation="drieënzestig"/>
-    <number value="64" form="0" english="Sixty Four" translation="vierenzestig"/>
-    <number value="65" form="0" english="Sixty Five" translation="vijfenzestig"/>
-    <number value="66" form="0" english="Sixty Six" translation="zesenzestig"/>
-    <number value="67" form="0" english="Sixty Seven" translation="zevenenzestig"/>
-    <number value="68" form="0" english="Sixty Eight" translation="achtenzestig"/>
-    <number value="69" form="0" english="Sixty Nine" translation="negenenzestig"/>
-    <number value="70" form="0" english="Seventy" translation="zeventig"/>
-    <number value="71" form="0" english="Seventy One" translation="eenenzeventig"/>
-    <number value="72" form="0" english="Seventy Two" translation="tweeënzeventig"/>
-    <number value="73" form="0" english="Seventy Three" translation="drieënzeventig"/>
-    <number value="74" form="0" english="Seventy Four" translation="vierenzeventig"/>
-    <number value="75" form="0" english="Seventy Five" translation="vijfenzeventig"/>
-    <number value="76" form="0" english="Seventy Six" translation="zesenzeventig"/>
-    <number value="77" form="0" english="Seventy Seven" translation="zevenenzeventig"/>
-    <number value="78" form="0" english="Seventy Eight" translation="achtenzeventig"/>
-    <number value="79" form="0" english="Seventy Nine" translation="negenenzeventig"/>
-    <number value="80" form="0" english="Eighty" translation="tachtig"/>
-    <number value="81" form="0" english="Eighty One" translation="eenentachtig"/>
-    <number value="82" form="0" english="Eighty Two" translation="tweeëntachtig"/>
-    <number value="83" form="0" english="Eighty Three" translation="drieëntachtig"/>
-    <number value="84" form="0" english="Eighty Four" translation="vierentachtig"/>
-    <number value="85" form="0" english="Eighty Five" translation="vijfentachtig"/>
-    <number value="86" form="0" english="Eighty Six" translation="zesentachtig"/>
-    <number value="87" form="0" english="Eighty Seven" translation="zevenentachtig"/>
-    <number value="88" form="0" english="Eighty Eight" translation="achtentachtig"/>
-    <number value="89" form="0" english="Eighty Nine" translation="negenentachtig"/>
-    <number value="90" form="0" english="Ninety" translation="negentig"/>
-    <number value="91" form="0" english="Ninety One" translation="eenennegentig"/>
-    <number value="92" form="0" english="Ninety Two" translation="tweeënnegentig"/>
-    <number value="93" form="0" english="Ninety Three" translation="drieënnegentig"/>
-    <number value="94" form="0" english="Ninety Four" translation="vierennegentig"/>
-    <number value="95" form="0" english="Ninety Five" translation="vijfennegentig"/>
-    <number value="96" form="0" english="Ninety Six" translation="zesennegentig"/>
-    <number value="97" form="0" english="Ninety Seven" translation="zevenennegentig"/>
-    <number value="98" form="0" english="Ninety Eight" translation="achtennegentig"/>
-    <number value="99" form="0" english="Ninety Nine" translation="negenennegentig"/>
-    <number value="100" form="0" english="One Hundred" translation="honderd"/>
+    <number value="0" form="0" english="Zero" translation="nul" translation2="Nul"/>
+    <number value="1" form="1" english="One" translation="één" translation2="Eén"/>
+    <number value="2" form="0" english="Two" translation="twee" translation2="Twee"/>
+    <number value="3" form="0" english="Three" translation="drie" translation2="Drie"/>
+    <number value="4" form="0" english="Four" translation="vier" translation2="Vier"/>
+    <number value="5" form="0" english="Five" translation="vijf" translation2="Vijf"/>
+    <number value="6" form="0" english="Six" translation="zes" translation2="Zes"/>
+    <number value="7" form="0" english="Seven" translation="zeven" translation2="Zeven"/>
+    <number value="8" form="0" english="Eight" translation="acht" translation2="Acht"/>
+    <number value="9" form="0" english="Nine" translation="negen" translation2="Negen"/>
+    <number value="10" form="0" english="Ten" translation="tien" translation2="Tien"/>
+    <number value="11" form="0" english="Eleven" translation="elf" translation2="Elf"/>
+    <number value="12" form="0" english="Twelve" translation="twaalf" translation2="Twaalf"/>
+    <number value="13" form="0" english="Thirteen" translation="dertien" translation2="Dertien"/>
+    <number value="14" form="0" english="Fourteen" translation="veertien" translation2="Veertien"/>
+    <number value="15" form="0" english="Fifteen" translation="vijftien" translation2="Vijftien"/>
+    <number value="16" form="0" english="Sixteen" translation="zestien" translation2="Zestien"/>
+    <number value="17" form="0" english="Seventeen" translation="zeventien" translation2="Zeventien"/>
+    <number value="18" form="0" english="Eighteen" translation="achttien" translation2="Achttien"/>
+    <number value="19" form="0" english="Nineteen" translation="negentien" translation2="Negentien"/>
+    <number value="20" form="0" english="Twenty" translation="twintig" translation2="Twintig"/>
+    <number value="21" form="0" english="Twenty One" translation="eenentwintig" translation2="Eenentwintig"/>
+    <number value="22" form="0" english="Twenty Two" translation="tweeëntwintig" translation2="Tweeëntwintig"/>
+    <number value="23" form="0" english="Twenty Three" translation="drieëntwintig" translation2="Drieëntwintig"/>
+    <number value="24" form="0" english="Twenty Four" translation="vierentwintig" translation2="Vierentwintig"/>
+    <number value="25" form="0" english="Twenty Five" translation="vijfentwintig" translation2="Vijfentwintig"/>
+    <number value="26" form="0" english="Twenty Six" translation="zesentwintig" translation2="Zesentwintig"/>
+    <number value="27" form="0" english="Twenty Seven" translation="zevenentwintig" translation2="Zevenentwintig"/>
+    <number value="28" form="0" english="Twenty Eight" translation="achtentwintig" translation2="Achtentwintig"/>
+    <number value="29" form="0" english="Twenty Nine" translation="negenentwintig" translation2="Negenentwintig"/>
+    <number value="30" form="0" english="Thirty" translation="dertig" translation2="Dertig"/>
+    <number value="31" form="0" english="Thirty One" translation="eenendertig" translation2="Eenendertig"/>
+    <number value="32" form="0" english="Thirty Two" translation="tweeëndertig" translation2="Tweeëndertig"/>
+    <number value="33" form="0" english="Thirty Three" translation="drieëndertig" translation2="Drieëndertig"/>
+    <number value="34" form="0" english="Thirty Four" translation="vierendertig" translation2="Vierendertig"/>
+    <number value="35" form="0" english="Thirty Five" translation="vijfendertig" translation2="Vijfendertig"/>
+    <number value="36" form="0" english="Thirty Six" translation="zesendertig" translation2="Zesendertig"/>
+    <number value="37" form="0" english="Thirty Seven" translation="zevenendertig" translation2="Zevenendertig"/>
+    <number value="38" form="0" english="Thirty Eight" translation="achtendertig" translation2="Achtendertig"/>
+    <number value="39" form="0" english="Thirty Nine" translation="negenendertig" translation2="Negenendertig"/>
+    <number value="40" form="0" english="Forty" translation="veertig" translation2="Veertig"/>
+    <number value="41" form="0" english="Forty One" translation="eenenveertig" translation2="Eenenveertig"/>
+    <number value="42" form="0" english="Forty Two" translation="tweeënveertig" translation2="Tweeënveertig"/>
+    <number value="43" form="0" english="Forty Three" translation="drieënveertig" translation2="Drieënveertig"/>
+    <number value="44" form="0" english="Forty Four" translation="vierenveertig" translation2="Vierenveertig"/>
+    <number value="45" form="0" english="Forty Five" translation="vijfenveertig" translation2="Vijfenveertig"/>
+    <number value="46" form="0" english="Forty Six" translation="zesenveertig" translation2="Zesenveertig"/>
+    <number value="47" form="0" english="Forty Seven" translation="zevenenveertig" translation2="Zevenenveertig"/>
+    <number value="48" form="0" english="Forty Eight" translation="achtenveertig" translation2="Achtenveertig"/>
+    <number value="49" form="0" english="Forty Nine" translation="negenenveertig" translation2="Negenenveertig"/>
+    <number value="50" form="0" english="Fifty" translation="vijftig" translation2="Vijftig"/>
+    <number value="51" form="0" english="Fifty One" translation="eenenvijftig" translation2="Eenenvijftig"/>
+    <number value="52" form="0" english="Fifty Two" translation="tweeënvijftig" translation2="Tweeënvijftig"/>
+    <number value="53" form="0" english="Fifty Three" translation="drieënvijftig" translation2="Drieënvijftig"/>
+    <number value="54" form="0" english="Fifty Four" translation="vierenvijftig" translation2="Vierenvijftig"/>
+    <number value="55" form="0" english="Fifty Five" translation="vijfenvijftig" translation2="Vijfenvijftig"/>
+    <number value="56" form="0" english="Fifty Six" translation="zesenvijftig" translation2="Zesenvijftig"/>
+    <number value="57" form="0" english="Fifty Seven" translation="zevenenvijftig" translation2="Zevenenvijftig"/>
+    <number value="58" form="0" english="Fifty Eight" translation="achtenvijftig" translation2="Achtenvijftig"/>
+    <number value="59" form="0" english="Fifty Nine" translation="negenenvijftig" translation2="Negenenvijftig"/>
+    <number value="60" form="0" english="Sixty" translation="zestig" translation2="Zestig"/>
+    <number value="61" form="0" english="Sixty One" translation="eenenzestig" translation2="Eenenzestig"/>
+    <number value="62" form="0" english="Sixty Two" translation="tweeënzestig" translation2="Tweeënzestig"/>
+    <number value="63" form="0" english="Sixty Three" translation="drieënzestig" translation2="Drieënzestig"/>
+    <number value="64" form="0" english="Sixty Four" translation="vierenzestig" translation2="Vierenzestig"/>
+    <number value="65" form="0" english="Sixty Five" translation="vijfenzestig" translation2="Vijfenzestig"/>
+    <number value="66" form="0" english="Sixty Six" translation="zesenzestig" translation2="Zesenzestig"/>
+    <number value="67" form="0" english="Sixty Seven" translation="zevenenzestig" translation2="Zevenenzestig"/>
+    <number value="68" form="0" english="Sixty Eight" translation="achtenzestig" translation2="Achtenzestig"/>
+    <number value="69" form="0" english="Sixty Nine" translation="negenenzestig" translation2="Negenenzestig"/>
+    <number value="70" form="0" english="Seventy" translation="zeventig" translation2="Zeventig"/>
+    <number value="71" form="0" english="Seventy One" translation="eenenzeventig" translation2="Eenenzeventig"/>
+    <number value="72" form="0" english="Seventy Two" translation="tweeënzeventig" translation2="Tweeënzeventig"/>
+    <number value="73" form="0" english="Seventy Three" translation="drieënzeventig" translation2="Drieënzeventig"/>
+    <number value="74" form="0" english="Seventy Four" translation="vierenzeventig" translation2="Vierenzeventig"/>
+    <number value="75" form="0" english="Seventy Five" translation="vijfenzeventig" translation2="Vijfenzeventig"/>
+    <number value="76" form="0" english="Seventy Six" translation="zesenzeventig" translation2="Zesenzeventig"/>
+    <number value="77" form="0" english="Seventy Seven" translation="zevenenzeventig" translation2="Zevenenzeventig"/>
+    <number value="78" form="0" english="Seventy Eight" translation="achtenzeventig" translation2="Achtenzeventig"/>
+    <number value="79" form="0" english="Seventy Nine" translation="negenenzeventig" translation2="Negenenzeventig"/>
+    <number value="80" form="0" english="Eighty" translation="tachtig" translation2="Tachtig"/>
+    <number value="81" form="0" english="Eighty One" translation="eenentachtig" translation2="Eenentachtig"/>
+    <number value="82" form="0" english="Eighty Two" translation="tweeëntachtig" translation2="Tweeëntachtig"/>
+    <number value="83" form="0" english="Eighty Three" translation="drieëntachtig" translation2="Drieëntachtig"/>
+    <number value="84" form="0" english="Eighty Four" translation="vierentachtig" translation2="Vierentachtig"/>
+    <number value="85" form="0" english="Eighty Five" translation="vijfentachtig" translation2="Vijfentachtig"/>
+    <number value="86" form="0" english="Eighty Six" translation="zesentachtig" translation2="Zesentachtig"/>
+    <number value="87" form="0" english="Eighty Seven" translation="zevenentachtig" translation2="Zevenentachtig"/>
+    <number value="88" form="0" english="Eighty Eight" translation="achtentachtig" translation2="Achtentachtig"/>
+    <number value="89" form="0" english="Eighty Nine" translation="negenentachtig" translation2="Negenentachtig"/>
+    <number value="90" form="0" english="Ninety" translation="negentig" translation2="Negentig"/>
+    <number value="91" form="0" english="Ninety One" translation="eenennegentig" translation2="Eenennegentig"/>
+    <number value="92" form="0" english="Ninety Two" translation="tweeënnegentig" translation2="Tweeënnegentig"/>
+    <number value="93" form="0" english="Ninety Three" translation="drieënnegentig" translation2="Drieënnegentig"/>
+    <number value="94" form="0" english="Ninety Four" translation="vierennegentig" translation2="Vierennegentig"/>
+    <number value="95" form="0" english="Ninety Five" translation="vijfennegentig" translation2="Vijfennegentig"/>
+    <number value="96" form="0" english="Ninety Six" translation="zesennegentig" translation2="Zesennegentig"/>
+    <number value="97" form="0" english="Ninety Seven" translation="zevenennegentig" translation2="Zevenennegentig"/>
+    <number value="98" form="0" english="Ninety Eight" translation="achtennegentig" translation2="Achtennegentig"/>
+    <number value="99" form="0" english="Ninety Nine" translation="negenennegentig" translation2="Negenennegentig"/>
+    <number value="100" form="0" english="One Hundred" translation="honderd" translation2="Honderd"/>
     <number value="101" form="0"/>
     <number value="102" form="0"/>
     <number value="103" form="0"/>

--- a/desktop_version/lang/nl/strings.xml
+++ b/desktop_version/lang/nl/strings.xml
@@ -343,9 +343,9 @@
     <string english=" / " translation=" / " explanation="inserted between two times, ex: 0:46.90 / 1:15.99. Time trial results"/>
     <string english="{n_trinkets}/{max_trinkets}" translation="{n_trinkets}/{max_trinkets}" explanation="ex: 2/5"/>
     <string english="{n_trinkets} of {max_trinkets}" translation="{n_trinkets} van {max_trinkets}" explanation="ex: 2 of 5"/>
-    <string english="{n_trinkets|wordy} out of {max_trinkets|wordy}" translation="{n_trinkets|wordy|upper} van de {max_trinkets|wordy}" explanation="ex: One out of Twenty, see numbers.xml. You can add |upper for an uppercase letter." max="34"/>
-    <string english="{savebox_n_trinkets|wordy}" translation="{savebox_n_trinkets|wordy|upper}" explanation="trinket count in telesave/quicksave information box. You can add |upper for an uppercase letter."/>
-    <string english="{gamecomplete_n_trinkets|wordy}" translation="{gamecomplete_n_trinkets|wordy|upper}" explanation="trinket count on Game Complete screen (after Trinkets Found:) You can add |upper for an uppercase letter."/>
+    <string english="{n_trinkets|wordy} out of {max_trinkets|wordy}" translation="{n_trinkets|wordy2} van de {max_trinkets|wordy}" explanation="ex: One out of Twenty, see numbers.xml. You can add |upper for an uppercase letter." max="34"/>
+    <string english="{savebox_n_trinkets|wordy}" translation="{savebox_n_trinkets|wordy2}" explanation="trinket count in telesave/quicksave information box. You can add |upper for an uppercase letter."/>
+    <string english="{gamecomplete_n_trinkets|wordy}" translation="{gamecomplete_n_trinkets|wordy2}" explanation="trinket count on Game Complete screen (after Trinkets Found:) You can add |upper for an uppercase letter."/>
     <string english="+1 Rank!" translation="+1 score!" explanation="time trial rank was upgraded (B → A → S → V). B is minimum, which is purposefully high (see it as 7/10) - S is a popular rank above A in a lot of games, so VVVVVV added a rank above that." max="12"/>
     <string english="Rank:" translation="Score:" explanation="time trial rank" max="9"/>
     <string english="B" translation="B" explanation="time trial rank" max="5"/>

--- a/desktop_version/lang/nl/strings_plural.xml
+++ b/desktop_version/lang/nl/strings_plural.xml
@@ -14,8 +14,8 @@
         <translation form="1" translation="En je hebt {n_trinkets|wordy} artefact gevonden."/>
     </string>
     <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100">
-        <translation form="0" translation="{n_crew|wordy|upper} bemanningsleden te gaan"/>
-        <translation form="1" translation="{n_crew|wordy|upper} bemanningslid te gaan"/>
+        <translation form="0" translation="{n_crew|wordy2} bemanningsleden te gaan"/>
+        <translation form="1" translation="{n_crew|wordy2} bemanningslid te gaan"/>
     </string>
     <string english_plural="{n_crew|wordy} remain" english_singular="{n_crew|wordy} remains" explanation="You have rescued a crew member! XX remain" max="32*2" var="n_crew" expect="100">
         <translation form="0" translation="Nog {n_crew|wordy} te gaan"/>


### PR DESCRIPTION
## Changes:

The number "one" in Dutch is "één" (silly, I know :P). Capital letters can have accents, but there's an exception where for this specific word, the first accent is much more often left off than not. So I'm now using wordy2 as the uppercase variants of all the numbers, and using that instead of the |upper flag.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
