### PR TITLE
Revert "Disable typing pipes in script names"

### DIFF
--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -3472,20 +3472,6 @@ void editorinput(void)
 
         case EditorSubState_DRAW_INPUT:
             // We're taking input!
-            if (customentities[ed.text_entity].t == 18 || customentities[ed.text_entity].t == 19)
-            {
-                // This is a terminal or script box, so this is a script name.
-                // Remove all pipes, they are the line separator in the XML.
-                // When this loop reaches the end, it wraps to SIZE_MAX; SIZE_MAX + 1 is 0
-                for (size_t i = key.keybuffer.length() - 1; i + 1 > 0; i--)
-                {
-                    if (key.keybuffer[i] == '|')
-                    {
-                        key.keybuffer.erase(key.keybuffer.begin() + i);
-                    }
-                }
-            }
-
             if (escape_pressed)
             {
                 // Cancel it, and remove the enemy it's tied to if necessary


### PR DESCRIPTION
## Changes:

This reverts commit a806b072bd8635e40c0a30bd0ceab4f75218a06f.

It causes an instant segfault if there's no entities or if you're not editing terminals/script boxes or something, whatever it's not crucial as a last-minute fix.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
