### PR TITLE
Fix text images not fading

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -959,6 +959,7 @@ void Graphics::drawgui(void)
             opacity = tl_lerp;
         }
 
+        const int alpha = opacity * 255;
         if (textboxes[i].image == TEXTIMAGE_LEVELCOMPLETE)
         {
             // Level complete
@@ -982,7 +983,6 @@ void Graphics::drawgui(void)
                     y = 240 - y - 8 * sc;
                 }
                 SDL_Color color = TEXT_COLOUR("cyan");
-                const int alpha = opacity * 255;
                 font::print(
                     (sc == 2 ? PR_2X : PR_1X) | PR_CEN | PR_BRIGHTNESS(alpha),
                     -1, y, translation, color.r, color.g, color.b
@@ -990,7 +990,7 @@ void Graphics::drawgui(void)
             }
             else
             {
-                const SDL_Color color = {255, 255, 255, (Uint8) (opacity * 255)};
+                const SDL_Color color = {alpha, alpha, alpha};
                 if (flipmode)
                 {
                     drawimagecol(IMAGE_FLIPLEVELCOMPLETE, 0, 180, color, true);


### PR DESCRIPTION
## Changes:

While a7b22919ae379c96001c8dcdb9f73c36d298f967 makes text sprites modulate their RGB values, text images continued using alpha, despite alpha blending not even being enabled, so the initial commit didn't work right either.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
