### PR TITLE
Fix typing pipes in save/load prompts in editor

### DIFF
--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -3472,10 +3472,9 @@ void editorinput(void)
 
         case EditorSubState_DRAW_INPUT:
             // We're taking input!
-            if (INBOUNDS_VEC(ed.text_entity, customentities)
-            && (customentities[ed.text_entity].t == 18 || customentities[ed.text_entity].t == 19))
+            if (ed.current_text_mode == TEXT_SCRIPT)
             {
-                // This is a terminal or script box, so this is a script name.
+                // This is editing an entity's text field, currently only used as a script name.
                 // Remove all pipes, they are the line separator in the XML.
                 // When this loop reaches the end, it wraps to SIZE_MAX; SIZE_MAX + 1 is 0
                 for (size_t i = key.keybuffer.length() - 1; i + 1 > 0; i--)


### PR DESCRIPTION
## Changes:

13d6b2d64c1d3a78c8bf049161f1446820765e99 adds a check where you can't type a pipe in script/terminal input fields anymore. It does this completely incorrectly, checking if certain variables are set instead of checking what's actually trying to be done.

This PR fixes that, simplifying the check a lot in the process.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
