### PR TITLE
Fix warnings when calculating image color

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1004,7 +1004,7 @@ void Graphics::drawgui(void)
             }
             else
             {
-                const SDL_Color color = {alpha, alpha, alpha};
+                const SDL_Color color = {(Uint8) alpha, (Uint8) alpha, (Uint8) alpha, 255};
                 if (flipmode)
                 {
                     drawimagecol(IMAGE_FLIPLEVELCOMPLETE, 0, 180, color, true);


### PR DESCRIPTION
This fixes warnings about narrowing and missing a component of the struct.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
