### PR TITLE
Revert text image fading

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -920,7 +920,6 @@ void Graphics::drawgui(void)
         }
 
         const bool transparent = (textboxes[i].r | textboxes[i].g | textboxes[i].b) == 0;
-        float opacity;
 
         if (transparent)
         {
@@ -947,8 +946,6 @@ void Graphics::drawgui(void)
                     196, 196, 255 - help.glow
                 );
             }
-
-            opacity = 1.0f;
         }
         else
         {
@@ -969,11 +966,16 @@ void Graphics::drawgui(void)
                     textboxes[i].r, textboxes[i].g, textboxes[i].b
                 );
             }
-
-            opacity = tl_lerp;
         }
 
-        const int alpha = opacity * 255;
+        const bool opaque = textboxes[i].tl >= 1.0;
+        const bool draw_overlays = opaque || transparent;
+
+        if (!draw_overlays)
+        {
+            continue;
+        }
+
         if (textboxes[i].image == TEXTIMAGE_LEVELCOMPLETE)
         {
             // Level complete
@@ -997,21 +999,17 @@ void Graphics::drawgui(void)
                     y = 240 - y - 8 * sc;
                 }
                 SDL_Color color = TEXT_COLOUR("cyan");
-                font::print(
-                    (sc == 2 ? PR_2X : PR_1X) | PR_CEN | PR_BRIGHTNESS(alpha),
-                    -1, y, translation, color.r, color.g, color.b
-                );
+                font::print((sc == 2 ? PR_2X : PR_1X) | PR_CEN, -1, y, translation, color.r, color.g, color.b);
             }
             else
             {
-                const SDL_Color color = {(Uint8) alpha, (Uint8) alpha, (Uint8) alpha, 255};
                 if (flipmode)
                 {
-                    drawimagecol(IMAGE_FLIPLEVELCOMPLETE, 0, 180, color, true);
+                    drawimage(IMAGE_FLIPLEVELCOMPLETE, 0, 180, true);
                 }
                 else
                 {
-                    drawimagecol(IMAGE_LEVELCOMPLETE, 0, 12, color, true);
+                    drawimage(IMAGE_LEVELCOMPLETE, 0, 12, true);
                 }
             }
         }
@@ -1037,22 +1035,17 @@ void Graphics::drawgui(void)
                 {
                     y = 240 - y - 8 * sc;
                 }
-                const int alpha = opacity * 255;
-                font::print(
-                    (sc == 2 ? PR_2X : PR_1X) | PR_CEN | PR_BRIGHTNESS(alpha),
-                    -1, y, translation, 196, 196, 243
-                );
+                font::print((sc == 2 ? PR_2X : PR_1X) | PR_CEN, -1, y, translation, 196, 196, 243);
             }
             else
             {
-                const SDL_Color color = {255, 255, 255, (Uint8) (opacity * 255)};
                 if (flipmode)
                 {
-                    drawimagecol(IMAGE_FLIPGAMECOMPLETE, 0, 180, color, true);
+                    drawimage(IMAGE_FLIPGAMECOMPLETE, 0, 180, true);
                 }
                 else
                 {
-                    drawimagecol(IMAGE_GAMECOMPLETE, 0, 12, color, true);
+                    drawimage(IMAGE_GAMECOMPLETE, 0, 12, true);
                 }
             }
         }
@@ -1061,10 +1054,6 @@ void Graphics::drawgui(void)
         {
             TextboxSprite* sprite = &textboxes[i].sprites[index];
             int y = sprite->y + yp;
-            SDL_Color color = getcol(sprite->col);
-            color.r *= opacity;
-            color.g *= opacity;
-            color.b *= opacity;
 
             if (flipmode)
             {
@@ -1078,7 +1067,7 @@ void Graphics::drawgui(void)
                 y,
                 sprites_rect.w,
                 sprites_rect.h,
-                color,
+                getcol(sprite->col),
                 1,
                 (flipmode ? -1 : 1)
             );


### PR DESCRIPTION
## Changes:

This reverts the following commits:

- 29f05c41b1add3aeea3b6b870349020f6cd13b94
- f1bf1f683c459ac4de4de05f938587d196084dea
- a7b22919ae379c96001c8dcdb9f73c36d298f967
- 2ed1aac67d050f19f0a2170ac71f6fe19bb3f747

Recently, text images were changed to fade in with textboxes, where before they previously appeared after the fade. This created a charming effect where the images would appear to "load in" once the textbox finishes fading in. This behavior really complements the retro aesthetic the game is going for. Changing it to a fade is a needless change in direction, as it was not a bug in the first place and looked good already.

Additionally, custom levels have used text images (levelcomplete and gamecomplete) in creative ways by replacing them with something else to show as 'foreground' or as a cutscene image. Changing text images to fade has unintended consequences for levels that have utilized them in this fashion.

Current behavior, with fades (in English and Arabic):

https://github.com/TerryCavanagh/VVVVVV/assets/19874772/79d59cca-f2fe-4cca-9f0f-465ea3c1093b

https://github.com/TerryCavanagh/VVVVVV/assets/19874772/b6f55f57-73ed-4a12-896d-da575908db77


Without fades (behavior before today):

https://github.com/TerryCavanagh/VVVVVV/assets/19874772/0474803c-2a8a-49c1-98fb-a2b35aa5f7b1

https://github.com/TerryCavanagh/VVVVVV/assets/19874772/88344e25-9e43-4b87-89ea-47c881176c30



## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
