### PR TITLE
Add Github action to upload complete tarball

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,51 @@
+name: Create Release
+
+on:
+  push:
+    tags: ['v*']
+    branches: [master]
+  release:
+    types: [published]
+  pull_request:
+    paths: [.github/workflows/create_release.yml]
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Fake name for PRs
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "GITHUB_REF=refs/tags/pr-tag" >> "$GITHUB_ENV"
+      - name: Real name for non-PRs
+        if: ${{ github.event_name != 'pull_request' }}
+        run: echo "GITHUB_REF=$GITHUB_REF" >> "$GITHUB_ENV"
+      - name: Set filenames
+        run: |
+          tag_or_branch="${GITHUB_REF#refs/tags/}"
+          tag_or_branch="${tag_or_branch#refs/heads/}"
+          echo "RELEASE_NAME=VVVVVV-$tag_or_branch" >> "$GITHUB_ENV"
+          echo "RELEASE_FILE=VVVVVV-$tag_or_branch.tar.gz" >> "$GITHUB_ENV"
+      - name: Create source distribution
+        run: |
+            # Create new folder with specified name so extracting the archive yields that
+            rm -rf "/tmp/$RELEASE_NAME"
+            cp -r "$PWD" "/tmp/$RELEASE_NAME"
+            mv "/tmp/$RELEASE_NAME" .
+            # Cleanup
+            find "$RELEASE_NAME" -name '.git*' -exec rm -rv {} \; || true
+            # Create archive
+            tar -czf "$RELEASE_FILE" "$RELEASE_NAME"
+            echo "Created source archive $RELEASE_FILE with content: $(ls -a "$RELEASE_NAME")"
+      - name: Upload source distribution
+        if: ${{ github.event_name == 'release' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{env.RELEASE_FILE}}
+
+concurrency:
+  group: create-release-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true


### PR DESCRIPTION
## Changes:
Nothing changed in the game itself. This new workflow creates a complete tarball upon every release.
*shameless (almost) copy from pytorch repo workflow*
Closes: https://github.com/TerryCavanagh/VVVVVV/issues/1111

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
