### PR TITLE
Minor Russian translation fixes

### DIFF
--- a/desktop_version/lang/ru/cutscenes.xml
+++ b/desktop_version/lang/ru/cutscenes.xml
@@ -788,7 +788,8 @@ Collect trinkets to unlock new songs!" translation="-= МУЗЫКАЛЬНЫЙ А
 Pushing Onwards" translation="СЛЕДУЮЩАЯ ЦЕЛЬ:
 5 штучек
 
-Pushing Onwards" tt="1" pad="1"/>
+Pushing Onwards
+(Преодолевая трудности)" tt="1" pad="1"/>
     </cutscene>
     <cutscene id="terminal_jukeunlock2" explanation="">
         <dialogue speaker="gray" english="NEXT UNLOCK:
@@ -797,7 +798,8 @@ Pushing Onwards" tt="1" pad="1"/>
 Positive Force" translation="СЛЕДУЮЩАЯ ЦЕЛЬ:
 8 штучек
 
-Positive Force" tt="1" pad="1"/>
+Positive Force
+(Положительная сила)" tt="1" pad="1"/>
     </cutscene>
     <cutscene id="terminal_jukeunlock3" explanation="">
         <dialogue speaker="gray" english="NEXT UNLOCK:
@@ -806,7 +808,8 @@ Positive Force" tt="1" pad="1"/>
 Presenting VVVVVV" translation="СЛЕДУЮЩАЯ ЦЕЛЬ:
 10 штучек
 
-Presenting VVVVVV" tt="1" pad="1"/>
+Presenting VVVVVV
+(Представляем VVVVVV)" tt="1" pad="1"/>
     </cutscene>
     <cutscene id="terminal_jukeunlock4" explanation="">
         <dialogue speaker="gray" english="NEXT UNLOCK:
@@ -815,7 +818,8 @@ Presenting VVVVVV" tt="1" pad="1"/>
 Potential for Anything" translation="СЛЕДУЮЩАЯ ЦЕЛЬ:
 12 штучек
 
-Potential for Anything" tt="1" pad="1"/>
+Potential for Anything
+(Потенциал для всего)" tt="1" pad="1"/>
     </cutscene>
     <cutscene id="terminal_jukeunlock41" explanation="">
         <dialogue speaker="gray" english="NEXT UNLOCK:
@@ -824,7 +828,8 @@ Potential for Anything" tt="1" pad="1"/>
 Pressure Cooker" translation="СЛЕДУЮЩАЯ ЦЕЛЬ:
 14 штучек
 
-Pressure Cooker" tt="1" pad="1"/>
+Pressure Cooker
+(Полная скороварка)" tt="1" pad="1"/>
     </cutscene>
     <cutscene id="terminal_jukeunlock5" explanation="">
         <dialogue speaker="gray" english="NEXT UNLOCK:
@@ -833,7 +838,8 @@ Pressure Cooker" tt="1" pad="1"/>
 Predestined Fate" translation="СЛЕДУЮЩАЯ ЦЕЛЬ:
 16 штучек
 
-Predestined Fate" tt="1" pad="1"/>
+Predestined Fate
+(Предначертанная судьба)" tt="1" pad="1"/>
     </cutscene>
     <cutscene id="terminal_jukeunlock6" explanation="">
         <dialogue speaker="gray" english="NEXT UNLOCK:
@@ -842,7 +848,8 @@ Predestined Fate" tt="1" pad="1"/>
 Popular Potpourri" translation="СЛЕДУЮЩАЯ ЦЕЛЬ:
 18 штучек
 
-Popular Potpourri" tt="1" pad="1"/>
+Popular Potpourri
+(Популярное попурри)" tt="1" pad="1"/>
     </cutscene>
     <cutscene id="terminal_jukeunlock7" explanation="">
         <dialogue speaker="gray" english="NEXT UNLOCK:
@@ -851,7 +858,8 @@ Popular Potpourri" tt="1" pad="1"/>
 Pipe Dream" translation="СЛЕДУЮЩАЯ ЦЕЛЬ:
 20 штучек
 
-Pipe Dream" tt="1" pad="1"/>
+Pipe Dream
+(Пустая мечта)" tt="1" pad="1"/>
     </cutscene>
     <cutscene id="terminal_station_1" explanation="">
         <dialogue speaker="gray" english="-= PERSONAL LOG =-" translation="-= ЛИЧНЫЙ ЖУРНАЛ =-" padtowidth="280"/>

--- a/desktop_version/lang/ru/strings.xml
+++ b/desktop_version/lang/ru/strings.xml
@@ -548,7 +548,7 @@
     <string english="Current map music:" translation="Текущая музыка карты:" explanation="editor, followed by the number and name of a song, or `No background music`. Can be changed with scripting later, so this is really just initial music" max="38*2"/>
     <string english="No background music" translation="Без фоновой музыки" explanation="editor, level starts with no song playing" max="38*2"/>
     <string english="1: Pushing Onwards" translation="1: Pushing Onwards
-(Потенциал для всего)" explanation="editor, song name should probably not be translated" max="38*2"/>
+(Преодолевая трудности)" explanation="editor, song name should probably not be translated" max="38*2"/>
     <string english="2: Positive Force" translation="2: Positive Force
 (Положительная сила)" explanation="editor, song name should probably not be translated" max="38*2"/>
     <string english="3: Potential for Anything" translation="3: Potential for Anything


### PR DESCRIPTION
## Changes:
This PR fixes an issue with the Russian translation, where the "Map Music" menu in the Level Editor showed the string for Pushing Onwards as "1: Pushing Onwards (Потенциал для всего)" ("1: Pushing Onwards (Potential for Anything)"), and also adds Russian translations for song names when previewing their names in the "NEXT UNLOCK" dialogue with the Jukebox.
![image](https://github.com/TerryCavanagh/VVVVVV/assets/26709843/16f5a11d-d349-4f33-9ed9-408cd275ed68)
![image](https://github.com/TerryCavanagh/VVVVVV/assets/26709843/73c0c7e6-639d-42c4-9af0-f5a4ea6e9825)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
