### PR TITLE
Add a one pixel gap between each line in textboxes

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -698,6 +698,7 @@ void Game::levelcomplete_textbox(void)
     graphics.textboxprintflags(PR_FONT_8X8);
     graphics.textboxcenterx();
     graphics.setimage(TEXTIMAGE_LEVELCOMPLETE);
+    graphics.setlinegap(0);
 }
 
 void Game::crewmate_textbox(const int color)
@@ -727,6 +728,7 @@ void Game::crewmate_textbox(const int color)
     graphics.textboxpad(SDL_ceilf(5/spaces_per_8), SDL_ceilf(2/spaces_per_8));
     graphics.textboxcenterx();
     graphics.addsprite(14, 12 + extra_cjk_height/2, 0, color);
+    graphics.setlinegap(0);
 }
 
 void Game::remaining_textbox(void)
@@ -2897,6 +2899,7 @@ void Game::updatestate(void)
             graphics.textboxprintflags(PR_FONT_8X8);
             graphics.textboxcenterx();
             graphics.setimage(TEXTIMAGE_GAMECOMPLETE);
+            graphics.setlinegap(0);
             break;
         case 3502:
         {

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -874,7 +874,7 @@ void Graphics::drawgui(void)
         int font_height = font::height(textboxes[i].print_flags);
         if (flipmode)
         {
-            text_yoff = 8 + (textboxes[i].lines.size() - 1) * font_height;
+            text_yoff = 8 + (textboxes[i].lines.size() - 1) * (font_height + textboxes[i].linegap);
         }
         else
         {
@@ -884,7 +884,7 @@ void Graphics::drawgui(void)
         yp = textboxes[i].yp;
         if (flipmode && textboxes[i].flipme)
         {
-            yp = SCREEN_HEIGHT_PIXELS - yp - 16 - textboxes[i].lines.size() * font_height;
+            yp = SCREEN_HEIGHT_PIXELS - yp - 16 - textboxes[i].lines.size() * (font_height + textboxes[i].linegap);
         }
 
         char buffer[SCREEN_WIDTH_CHARS + 1];
@@ -931,7 +931,7 @@ void Graphics::drawgui(void)
                 font::print(
                     print_flags | PR_BOR,
                     text_xp,
-                    yp + text_yoff + text_sign * (j * font_height),
+                    yp + text_yoff + text_sign * (j * (font_height + textboxes[i].linegap)),
                     textbox_line(buffer, sizeof(buffer), i, j),
                     0, 0, 0
                 );
@@ -941,7 +941,7 @@ void Graphics::drawgui(void)
                 font::print(
                     print_flags,
                     text_xp,
-                    yp + text_yoff + text_sign * (j * font_height),
+                    yp + text_yoff + text_sign * (j * (font_height + textboxes[i].linegap)),
                     textbox_line(buffer, sizeof(buffer), i, j),
                     196, 196, 255 - help.glow
                 );
@@ -961,7 +961,7 @@ void Graphics::drawgui(void)
                 font::print(
                     print_flags | PR_BRIGHTNESS(tl_lerp*255),
                     text_xp,
-                    yp + text_yoff + text_sign * (j * font_height),
+                    yp + text_yoff + text_sign * (j * (font_height + textboxes[i].linegap)),
                     textbox_line(buffer, sizeof(buffer), i, j),
                     textboxes[i].r, textboxes[i].g, textboxes[i].b
                 );
@@ -1506,6 +1506,12 @@ void Graphics::textboxadjust(void)
     textboxes[m].adjust();
 }
 
+int Graphics::getlinegap(void) 
+{
+    // Don't use linegaps in custom levels, for now anyway
+    if (map.custommode) return 0;
+    return 1;
+}
 
 void Graphics::createtextboxreal(
     const std::string& t,
@@ -1517,7 +1523,7 @@ void Graphics::createtextboxreal(
 
     if (m < 20)
     {
-        textboxclass text;
+        textboxclass text(getlinegap());
         text.lines.push_back(t);
         text.xp = xp;
         if (xp == -1) text.xp = 160 - ((font::len(PR_FONT_LEVEL, t.c_str()) / 2) + 8);

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1506,6 +1506,12 @@ void Graphics::textboxadjust(void)
     textboxes[m].adjust();
 }
 
+void Graphics::setlinegap(int customvalue)
+{
+    textboxes[m].linegap = customvalue;
+    textboxes[m].resize();
+}
+
 int Graphics::getlinegap(void) 
 {
     // Don't use linegaps in custom levels, for now anyway

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -65,6 +65,7 @@ public:
 
     void drawfade(void);
 
+    int getlinegap(void);
     void createtextboxreal(
         const std::string& t,
         int xp, int yp,

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -65,6 +65,7 @@ public:
 
     void drawfade(void);
 
+    void setlinegap(int);
     int getlinegap(void);
     void createtextboxreal(
         const std::string& t,

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -569,18 +569,21 @@ void scriptclass::run(void)
                     }
                 }
 
+                int linegap = graphics.getlinegap();
+
                 //next is whether to position above or below
                 if (INBOUNDS_VEC(i, obj.entities) && words[2] == "above")
                 {
                     if (j == 1)    //left
                     {
                         textx = obj.entities[i].xp -10000; //tells the box to be oriented correctly later
-                        texty = obj.entities[i].yp - 16 - (txt.size() * font::height(PR_FONT_LEVEL));
+                        texty = obj.entities[i].yp - 16 - (txt.size() * (font::height(PR_FONT_LEVEL) + linegap) - linegap);
+
                     }
                     else if (j == 0)     //Right
                     {
                         textx = obj.entities[i].xp - 16;
-                        texty = obj.entities[i].yp - 18 - (txt.size() * font::height(PR_FONT_LEVEL));
+                        texty = obj.entities[i].yp - 18 - (txt.size() * (font::height(PR_FONT_LEVEL) + linegap) - linegap);
                     }
                 }
                 else if (INBOUNDS_VEC(i, obj.entities))
@@ -666,18 +669,20 @@ void scriptclass::run(void)
                     texty = -500;
                 }
 
+                int linegap = graphics.getlinegap();
+                
                 //next is whether to position above or below
                 if (INBOUNDS_VEC(i, obj.entities) && words[2] == "above")
                 {
                     if (j == 1)    //left
                     {
                         textx = obj.entities[i].xp -10000; //tells the box to be oriented correctly later
-                        texty = obj.entities[i].yp - 16 - (txt.size() * font::height(PR_FONT_LEVEL));
+                        texty = obj.entities[i].yp - 16 - (txt.size() * (font::height(PR_FONT_LEVEL) + linegap) - linegap);
                     }
                     else if (j == 0)     //Right
                     {
                         textx = obj.entities[i].xp - 16;
-                        texty = obj.entities[i].yp - 18 - (txt.size() * font::height(PR_FONT_LEVEL));
+                        texty = obj.entities[i].yp - 18 - (txt.size() * (font::height(PR_FONT_LEVEL) + linegap) - linegap);
                     }
                 }
                 else if (INBOUNDS_VEC(i, obj.entities))

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -5,7 +5,7 @@
 #include "Font.h"
 #include "UTF8.h"
 
-textboxclass::textboxclass(void)
+textboxclass::textboxclass(int gap)
 {
     w = 0;
     h = 0;
@@ -19,6 +19,7 @@ textboxclass::textboxclass(void)
     r = 0;
     g = 0;
     b = 0;
+    linegap = gap;
 
     flipme = false;
 
@@ -132,7 +133,7 @@ void textboxclass::resize(void)
 
     // 16 for the borders
     w = max + 16;
-    h = lines.size()*font::height(print_flags) + 16;
+    h = lines.size()*(font::height(print_flags) + linegap) + 16 - linegap;
 }
 
 void textboxclass::addline(const std::string& t)

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -23,7 +23,7 @@ enum TextboxImage
 class textboxclass
 {
 public:
-    textboxclass(void);
+    textboxclass(int gap);
 
     void addsprite(int x, int y, int tile, int col);
 
@@ -57,6 +57,7 @@ public:
     std::vector<std::string> lines;
     int xp, yp, w, h;
     int r,g,b;
+    int linegap;
     int timer;
 
     float tl;


### PR DESCRIPTION
## Changes:

This change adds a one pixel gap between each line in textboxes, though only in the main game for now. It addresses this issue: https://github.com/TerryCavanagh/VVVVVV/issues/1051

A few screenshots of how it looks:

![screen1](https://github.com/TerryCavanagh/VVVVVV/assets/2874150/7dca057d-0b24-4ad3-9df8-fa0f7fb8f2d0)

![screen2](https://github.com/TerryCavanagh/VVVVVV/assets/2874150/a5a5231c-6b53-4364-9771-f273f559761b)

![screen3](https://github.com/TerryCavanagh/VVVVVV/assets/2874150/a343cda0-cf60-4e82-bc58-0551724ce64c)

So! There was a lot of discussion about whether or not this change was a good idea on the discord, which is very fair - it does change the look of the game pretty noticeably, and it breaks the C64 8x8 grid. I found myself going back and forth on it a little bit - so I figured the best thing to do was just to try it, and make it a bit less hypothetical. I'll distribute a compiled version on the discord for easy testing.

Now that I've done it, I really like it! I actually find it quite jarring to go back to the zero gap textboxes in custom levels:

![image](https://github.com/TerryCavanagh/VVVVVV/assets/2874150/e54eeb79-5c56-49e4-ba0c-d8c37353cb68)

What do you think?

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
