### PR TITLE
README: Add step for compiling

### DIFF
--- a/desktop_version/README.md
+++ b/desktop_version/README.md
@@ -34,6 +34,8 @@ cd build
 cmake -A Win32 -G "Visual Studio 10 2010" .. -DSDL2_INCLUDE_DIRS="C:\SDL2-2.24.0\include" -DSDL2_LIBRARIES="C:\SDL2-2.24.0\lib\x86\SDL2;C:\SDL2-2.24.0\lib\x86\SDL2main"
 ```
 
+Then to compile the game, open the solution and click Build.
+
 For more detailed information and troubleshooting, see the [Compiling VVVVVV
 Guide](https://vsix.dev/wiki/Guide:Compiling_VVVVVV_on_Windows_with_Visual_Studio)
 on the Viki.
@@ -44,6 +46,8 @@ mkdir build
 cd build
 cmake ..
 ```
+
+Then to compile the game, type `make`.
 
 Including data.zip
 ------------


### PR DESCRIPTION
We recently had a user come in the VVVVVV Discord not knowing that, after running CMake, you then need to compile the game in a separate step. This clarifies the instructions.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
