### PR TITLE
Add missing Viridian squeaks to cutscene test menu

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1338,6 +1338,7 @@ static void menuactionpress(void)
         else if (game.currentmenuoption == (int)game.menuoptions.size()-2)
         {
             // play the cutscene, from clipboard
+            music.playef(Sound_VIRIDIAN);
             game.cutscenetest_menu_play_id = std::string(SDL_GetClipboardText());
             startmode(Start_CUTSCENETEST);
         }
@@ -1351,6 +1352,7 @@ static void menuactionpress(void)
         else
         {
             // play the cutscene!
+            music.playef(Sound_VIRIDIAN);
             game.cutscenetest_menu_play_id = loc::testable_script_ids[(game.cutscenetest_menu_page*14)+game.currentmenuoption];
             startmode(Start_CUTSCENETEST);
         }


### PR DESCRIPTION
These mildly annoyed me. It should be consistent that whenever you press ACTION on a menu option, you get a Viridian squeak (at least if something happens).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
