### PR TITLE
Fix loading of PNG resources on big-endian machines

### DIFF
--- a/desktop_version/src/GraphicsResources.cpp
+++ b/desktop_version/src/GraphicsResources.cpp
@@ -65,7 +65,11 @@ static SDL_Surface* LoadImageRaw(const char* filename, unsigned char** data)
         height,
         32,
         width * 4,
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+        SDL_PIXELFORMAT_RGBA8888
+#else
         SDL_PIXELFORMAT_ABGR8888
+#endif
     );
 
     return loadedImage;


### PR DESCRIPTION
## Changes:

LodePNG always loads PNG in big-endian RGBA format. For this reason, when loading PNG files VVVVVV was specifying the format as ABGR and the conversion would then be performed by SDL. However, then running on big-endian machines, this conversion should not be performed at all, and the surface format should then be set to RGBA.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes
