### PR TITLE
Properly fix using `setfont()`/`setrtl()` script commands in between text boxes

### DIFF
--- a/desktop_version/src/Font.h
+++ b/desktop_version/src/Font.h
@@ -56,6 +56,7 @@
 #define PR_CJK_HIGH (2 << 20) /* larger fonts should stick out fully on the top */
 #define PR_RTL_FORCE (1 << 22) /* force the RTL flag, not needed if the font is set to INTERFACE or LEVEL */
 #define PR_RTL_XFLIP (1 << 23) /* in RTL languages, mirror the X axis, so left is 320 and right is 0, and invert the meaning of PR_LEFT and PR_RIGHT */
+#define PR_FONT_IDX_IS_CUSTOM (1 << 24) /* with PR_FONT_IDX, mark that the font index is of a custom font */
 
 
 namespace font
@@ -63,6 +64,9 @@ namespace font
 // Options in font selection menu
 extern uint8_t font_idx_options_n;
 extern uint8_t font_idx_options[20];
+
+extern uint8_t font_idx_level;
+extern bool font_idx_level_is_custom;
 
 bool find_main_font_by_name(const char* name, uint8_t* idx);
 const char* get_main_font_name(uint8_t idx);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -798,6 +798,16 @@ void scriptclass::run(void)
                     graphics.textboxcentery();
                 }
 
+                if (map.custommode)
+                {
+                    uint32_t flags = PR_FONT_IDX(font::font_idx_level, cl.rtl);
+                    if (font::font_idx_level_is_custom)
+                    {
+                        flags |= PR_FONT_IDX_IS_CUSTOM;
+                    }
+                    graphics.textboxprintflags(flags);
+                }
+
                 graphics.textboxadjust();
                 if (words[0] == "speak_active")
                 {
@@ -2481,39 +2491,38 @@ void scriptclass::run(void)
             }
             else if (words[0] == "setfont" || words[0] == "setrtl")
             {
-                // If any textbox is currently fading out, wait for that first
-                bool blocked = false;
-                for (size_t i = 0; i < graphics.textboxes.size(); i++)
+                if (words[0] == "setrtl")
                 {
-                    if (graphics.textboxes[i].tm == 2)
+                    if (words[1] == "on")
                     {
-                        scriptdelay = 1;
-                        position--;
-                        blocked = true;
-                        break;
+                        cl.rtl = true;
+                    }
+                    else if (words[1] == "off")
+                    {
+                        cl.rtl = false;
                     }
                 }
-
-                if (!blocked)
+                else if (words[1] == "")
                 {
-                    if (words[0] == "setrtl")
+                    font::set_level_font(cl.level_font_name.c_str());
+                }
+                else
+                {
+                    font::set_level_font(raw_words[1].c_str());
+                }
+                if (argexists[2] && words[2] == "all")
+                {
+                    /* Immediately update all text boxes. */
+                    uint32_t flags = PR_FONT_IDX(font::font_idx_level, cl.rtl);
+                    if (font::font_idx_level_is_custom)
                     {
-                        if (words[1] == "on")
-                        {
-                            cl.rtl = true;
-                        }
-                        else if (words[1] == "off")
-                        {
-                            cl.rtl = false;
-                        }
+                        flags |= PR_FONT_IDX_IS_CUSTOM;
                     }
-                    else if (words[1] == "")
+
+                    for (size_t i = 0; i < graphics.textboxes.size(); i++)
                     {
-                        font::set_level_font(cl.level_font_name.c_str());
-                    }
-                    else
-                    {
-                        font::set_level_font(raw_words[1].c_str());
+                        graphics.textboxes[i].print_flags = flags;
+                        graphics.textboxes[i].resize();
                     }
                 }
             }


### PR DESCRIPTION
There used to be a problem with the `setfont()` and `setrtl()` script commands. Namely, if you used them in between text boxes naïvely, without any careful thought, then the fading out text box would suddenly gain the font of the new one. A kludge solution to this was implemented by simply blocking the script until the existing text box faded out before switching the font or RTL, and shipped for 2.4.0.

However, a better solution is to simply bake the font flags in to the text box, so that way, if the level font switches, then the text box keeps its font.

This is only for custom levels, because in the main game, the font in a text box needs to be able to change depending on language. But it seems like custom level translations weren't much on the roadmap, and so even the existing hack didn't support changing the font based on translation (even though translation of custom level cutscenes is supported). So baking the font flags into the text box here doesn't make things any worse.

It also makes things better, arguably, by allowing multiple text boxes to exist on screen at once with different fonts.

Maybe in the future we'll need a flag that specifies that the font should change depending on language if a translation in said language exists for the text box, or something like that.

For people that want to override the fonts of every existing text box on screen, you can specify `all` as the second parameter of `setfont` or `setrtl` to do so.

Here is an example of what you can do now.

![2024-01-22_12-15-34_1x](https://github.com/TerryCavanagh/VVVVVV/assets/59748578/2480ac51-d60c-46c6-981e-01753b9ffd9c)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
