### PR TITLE
Allow overriding state lock in glitchrunner mode 2.2 or 2.0

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -793,7 +793,7 @@ void Game::savetele_textbox(void)
 
 void Game::setstate(const int gamestate)
 {
-    if (!statelocked)
+    if (!statelocked || GlitchrunnerMode_less_than_or_equal(Glitchrunner2_2))
     {
         state = gamestate;
     }
@@ -801,7 +801,7 @@ void Game::setstate(const int gamestate)
 
 void Game::incstate(void)
 {
-    if (!statelocked)
+    if (!statelocked || GlitchrunnerMode_less_than_or_equal(Glitchrunner2_2))
     {
         state++;
     }
@@ -809,7 +809,7 @@ void Game::incstate(void)
 
 void Game::setstatedelay(const int delay)
 {
-    if (!statelocked)
+    if (!statelocked || GlitchrunnerMode_less_than_or_equal(Glitchrunner2_2))
     {
         statedelay = delay;
     }


### PR DESCRIPTION
This fixes a regression where attempting to warp to ship with a trinket text box open in glitchrunner 2.0, and then incrementing the gamestate afterwards, would result in a softlock. This is a speedrunning strat that speedrunners use.

The state lock wasn't ever intended to remove any strats or anything, just fix warping to ship under normal circumstances. So it's okay to re-enable interrupting the state by having glitchrunner enabled.

This bug was reported by mohoc in the VVVVVV Speedrunning Discord server.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
