### PR TITLE
Minor language fixes to Esperanto, Welsh, Irish and Dutch

### DIFF
--- a/desktop_version/lang/cy/cutscenes.xml
+++ b/desktop_version/lang/cy/cutscenes.xml
@@ -774,7 +774,11 @@ SEFYDLOGWR DIMENSIWN ALLANOL" centertext="1" pad="1"/>
 
 Songs will continue to play until you leave the ship.
 
-Collect trinkets to unlock new songs!" translation="-= JIWCBOCS =-  Bydd caneuon yn parhau i chwarae nes i chi adael y llong. Casglwch dlysau i ddatgloi caneuon newydd!" centertext="1" padtowidth="264"/>
+Collect trinkets to unlock new songs!" translation="-= JIWCBOCS =-
+
+Bydd caneuon yn parhau i chwarae nes i chi adael y llong.
+
+Casglwch dlysau i ddatgloi caneuon newydd!" centertext="1" padtowidth="272"/>
     </cutscene>
     <cutscene id="terminal_jukeunlock1" explanation="">
         <dialogue speaker="gray" english="NEXT UNLOCK:

--- a/desktop_version/lang/cy/strings.xml
+++ b/desktop_version/lang/cy/strings.xml
@@ -670,13 +670,19 @@
     <string english="Please be alright, everyone..." translation="Byddwch yn iawn, pawb..." explanation="Violet speaking via Comms Relay" max="25*4"/>
     <string english="Congratulations!
 
-You have found a shiny trinket!" translation="Llongyfarchiadau! Rwyt ti wedi dod o hyd i dlws sgleiniog!" explanation="" max="34*4"/>
+You have found a shiny trinket!" translation="Llongyfarchiadau!
+
+Rwyt ti wedi dod o hyd i dlws sgleiniog!" explanation="" max="34*4"/>
     <string english="Congratulations!
 
-You have found a lost crewmate!" translation="Llongyfarchiadau! Rwyt ti wedi dod o hyd i aelod o&apos;r criw oedd ar goll!" explanation="" max="34*4"/>
+You have found a lost crewmate!" translation="Llongyfarchiadau!
+
+Rwyt ti wedi dod o hyd i aelod o&apos;r criw oedd ar goll!" explanation="" max="34*4"/>
     <string english="Congratulations!
 
-You have found the secret lab!" translation="Llongyfarchiadau! Rwyt ti wedi dod o hyd i&apos;r labordy cyfrinachol!" explanation="" max="34*4"/>
+You have found the secret lab!" translation="Llongyfarchiadau!
+
+Rwyt ti wedi dod o hyd i&apos;r labordy cyfrinachol!" explanation="" max="34*4"/>
     <string english="The secret lab is separate from the rest of the game. You can now come back here at any time by selecting the new SECRET LAB option in the play menu." translation="Mae&apos;r labordy cyfrinachol ar wahân i weddill y gêm. Gallwch nawr ddod yn ôl yma ar unrhyw adeg trwy ddewis yr opsiwn LAB CYFRINACHOL newydd yn y ddewislen chwarae." explanation="" max="36*10"/>
     <string english="Viridian" translation="Viridian" explanation="crewmate name (player)" max="15"/>
     <string english="Violet" translation="Violet" explanation="crewmate name" max="15"/>

--- a/desktop_version/lang/eo/cutscenes.xml
+++ b/desktop_version/lang/eo/cutscenes.xml
@@ -79,7 +79,7 @@
     <cutscene id="talkpurple_intro" explanation="">
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Mi sentas min iom superŝarĝita, Doktoro."/>
         <dialogue speaker="player" english="Where do I begin?" translation="Kie mi komencu?"/>
-        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="Memoru, ke vi povas premi {button} por kontroli, kie vi estas sur la mapo!" buttons="1"/>
+        <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="Memoru, ke vi povas premi {b_map} por kontroli, kie vi estas sur la mapo!" buttons="1"/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Serĉu areojn, kie eble estas la skipanoj..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Se vi perdiĝas, vi povas reveni al la ŝipo per iu ajn teleportilo."/>
         <dialogue speaker="purple" english="And don&apos;t worry! We&apos;ll find everyone!" translation="Kaj ne ĉagreniĝu! Ni ĉiujn trovos!"/>

--- a/desktop_version/lang/ga/strings.xml
+++ b/desktop_version/lang/ga/strings.xml
@@ -672,13 +672,19 @@ Déan cóip chúltaca, ar eagla na heagla." explanation="translation maintenance
     <string english="Please be alright, everyone..." translation="Go raibh sibh slán, a chairde..." explanation="Violet speaking via Comms Relay" max="25*4"/>
     <string english="Congratulations!
 
-You have found a shiny trinket!" translation="Comhghairdeas! Fuair tú ornáid lonrach!" explanation="" max="34*4"/>
+You have found a shiny trinket!" translation="Comhghairdeas!
+
+Fuair tú ornáid lonrach!" explanation="" max="34*4"/>
     <string english="Congratulations!
 
-You have found a lost crewmate!" translation="Comhghairdeas! Fuair tú leathbhádóir a bhí ar strae!" explanation="" max="34*4"/>
+You have found a lost crewmate!" translation="Comhghairdeas!
+
+Fuair tú leathbhádóir a bhí ar strae!" explanation="" max="34*4"/>
     <string english="Congratulations!
 
-You have found the secret lab!" translation="Comhghairdeas! Fuair tú an tsaotharlann rúnda!" explanation="" max="34*4"/>
+You have found the secret lab!" translation="Comhghairdeas!
+
+Fuair tú an tsaotharlann rúnda!" explanation="" max="34*4"/>
     <string english="The secret lab is separate from the rest of the game. You can now come back here at any time by selecting the new SECRET LAB option in the play menu." translation="Tá an tsaotharlann rúnda scartha ón gcuid eile den chluiche. Is féidir filleadh uirthi trí SAOTHARLANN RÚNDA a roghnú ar an roghchlár imeartha." explanation="" max="36*10"/>
     <string english="Viridian" translation="Virideach" explanation="crewmate name (player)" max="15"/>
     <string english="Violet" translation="Vialait" explanation="crewmate name" max="15"/>

--- a/desktop_version/lang/nl/strings.xml
+++ b/desktop_version/lang/nl/strings.xml
@@ -304,9 +304,9 @@
     <string english="unlock intermissions" translation="intermissies ontgrendelen" explanation="menu option"/>
     <string english="TO UNLOCK: Complete the intermission levels in-game." translation="OM TE ONTGRENDELEN: Voltooi de intermissielevels in het spel." explanation="" max="38*4"/>
     <string english="no death mode" translation="éénlevenmodus" explanation="menu option"/>
-    <string english="No Death Mode" translation="Éénlevenmodus" explanation="title" max="20"/>
+    <string english="No Death Mode" translation="Eénlevenmodus" explanation="title" max="20"/>
     <string english="Play the entire game without dying once." translation="Speel het gehele spel zonder ook maar één keer dood te gaan." explanation="" max="38*4"/>
-    <string english="No Death Mode is not available with slowdown or invincibility." translation="Éénlevenmodus is niet beschikbaar met vertraging of onkwetsbaarheid." explanation="" max="38*3"/>
+    <string english="No Death Mode is not available with slowdown or invincibility." translation="Eénlevenmodus is niet beschikbaar met vertraging of onkwetsbaarheid." explanation="" max="38*3"/>
     <string english="unlock no death mode" translation="éénlevenmodus ontgrendelen" explanation="menu option"/>
     <string english="TO UNLOCK: Achieve an S-rank or above in at least 4 time trials." translation="OM TE ONTGRENDELEN: Behaal een S-score of hoger in ten minste 4 races tegen de klok." explanation="ranks are B A S V, see below" max="38*3"/>
     <string english="flip mode" translation="spiegelmodus" explanation="menu option, mirrors the entire game vertically"/>


### PR DESCRIPTION
## Changes:

- Esperanto: Fixed Violet cutscene saying `[button?]` instead of the map button
- Welsh: Added newlines to "Congratulations!" and jukebox dialog boxes
- Irish: Added newlines to "Congratulations!" dialog boxes
- Dutch: Changed capitalization of no death mode to be consistent with the capitalization of the number "one"


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
