### PR TITLE
Fix several bugs relating to switching languages, active input devices, or Flip Mode while having a text box or menu open, and add debug keybind for cycling languages

### DIFF
--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -87,26 +87,14 @@ static bool compare_nocase (std::string first, std::string second)
  * as being translated, while they're actually stored in English in the level file.
  * This way we translate "Untitled Level" and "Unknown" without
  * spreading around translations in level files posted online! */
-std::string translate_title(const std::string& title, bool* is_gettext)
+bool translate_title(const std::string& title)
 {
-    if (title == "Untitled Level")
-    {
-        *is_gettext = true;
-        return loc::gettext("Untitled Level");
-    }
-    *is_gettext = false;
-    return title;
+    return title == "Untitled Level";
 }
 
-std::string translate_creator(const std::string& creator, bool* is_gettext)
+bool translate_creator(const std::string& creator)
 {
-    if (creator == "Unknown")
-    {
-        *is_gettext = true;
-        return loc::gettext("Unknown");
-    }
-    *is_gettext = false;
-    return creator;
+    return creator == "Unknown";
 }
 
 static void levelZipCallback(const char* filename)
@@ -306,8 +294,10 @@ bool customlevelclass::getLevelMetaDataAndPlaytestArgs(const std::string& _path,
         return false;
     }
 
-    _data.creator = translate_creator(find_creator(buf), &_data.creator_is_gettext);
-    _data.title = translate_title(find_title(buf), &_data.title_is_gettext);
+    _data.creator = find_creator(buf);
+    _data.creator_is_gettext = translate_creator(_data.creator);
+    _data.title = find_title(buf);
+    _data.title_is_gettext = translate_title(_data.title);
     _data.Desc1 = find_desc1(buf);
     _data.Desc2 = find_desc2(buf);
     _data.Desc3 = find_desc3(buf);

--- a/desktop_version/src/CustomLevels.h
+++ b/desktop_version/src/CustomLevels.h
@@ -171,9 +171,9 @@ public:
     bool onewaycol_override;
 };
 
-std::string translate_title(const std::string& title, bool* is_gettext);
+bool translate_title(const std::string& title);
 
-std::string translate_creator(const std::string& creator, bool* is_gettext);
+bool translate_creator(const std::string& creator);
 
 #ifndef CL_DEFINITION
 extern customlevelclass cl;

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -544,13 +544,31 @@ static void editormenurender(int tr, int tg, int tb)
         }
         else
         {
-            bool title_is_gettext;
-            std::string title = translate_title(cl.title, &title_is_gettext);
+            const char* title = cl.title.c_str();
+            const bool title_is_gettext = translate_title(cl.title);
+            if (title_is_gettext)
+            {
+                title = loc::gettext(title);
+            }
             font::print(PR_2X | PR_CEN | (title_is_gettext ? PR_FONT_INTERFACE : PR_FONT_LEVEL), -1, 35, title, tr, tg, tb);
         }
 
-        bool creator_is_gettext = false;
-        std::string creator = (ed.current_text_mode == TEXT_CREATOR) ? input_text : translate_creator(cl.creator, &creator_is_gettext);
+        bool creator_is_gettext;
+        const char* creator;
+        if (ed.current_text_mode == TEXT_CREATOR)
+        {
+            creator_is_gettext = false;
+            creator = input_text.c_str();
+        }
+        else
+        {
+            creator_is_gettext = translate_creator(cl.creator);
+            creator = cl.creator.c_str();
+        }
+        if (creator_is_gettext)
+        {
+            creator = loc::gettext(creator);
+        }
 
         int sp = SDL_max(10, font::height(PR_FONT_LEVEL));
         graphics.print_level_creator((creator_is_gettext ? PR_FONT_INTERFACE : PR_FONT_LEVEL), 60, creator, tr, tg, tb);
@@ -2653,8 +2671,7 @@ static void editormenuactionpress(void)
         {
         case 0:
         {
-            bool title_is_gettext;
-            translate_title(cl.title, &title_is_gettext);
+            const bool title_is_gettext = translate_title(cl.title);
 
             ed.current_text_mode = TEXT_TITLE;
             ed.substate = EditorSubState_MENU_INPUT;
@@ -2673,8 +2690,7 @@ static void editormenuactionpress(void)
         }
         case 1:
         {
-            bool creator_is_gettext;
-            translate_creator(cl.creator, &creator_is_gettext);
+            const bool creator_is_gettext = translate_creator(cl.creator);
 
             ed.current_text_mode = TEXT_CREATOR;
             ed.substate = EditorSubState_MENU_INPUT;

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -1816,7 +1816,7 @@ void editorrender(void)
         case EditorSubState_DRAW_INPUT:
         {
             short lines;
-            std::string wrapped = font::string_wordwrap(0, ed.current_text_desc, 312, &lines);
+            std::string wrapped = font::string_wordwrap(0, loc::gettext(ed.current_text_desc.c_str()), 312, &lines);
             short textheight = font::height(0) * lines + font::height(PR_FONT_LEVEL);
 
             graphics.fill_rect(0, 238 - textheight, 320, 240, graphics.getRGB(32, 32, 32));
@@ -2481,7 +2481,7 @@ void editorclass::entity_clicked(const int index)
         break;
     case 17:
         // Roomtext
-        get_input_line(TEXT_ROOMTEXT, loc::gettext("Enter roomtext:"), &entity->scriptname);
+        get_input_line(TEXT_ROOMTEXT, "Enter roomtext:", &entity->scriptname);
         text_entity = index;
         break;
     case 18:
@@ -2494,7 +2494,7 @@ void editorclass::entity_clicked(const int index)
         SDL_FALLTHROUGH;
     case 19:
         // Script Boxes (and terminals)
-        get_input_line(TEXT_SCRIPT, loc::gettext("Enter script name:"), &entity->scriptname);
+        get_input_line(TEXT_SCRIPT, "Enter script name:", &entity->scriptname);
         text_entity = index;
         break;
     }
@@ -2574,13 +2574,13 @@ void editorclass::tool_place()
         lclickdelay = 1;
         text_entity = customentities.size();
         add_entity(levx, levy, tilex, tiley, 17, cl.rtl ? 1 : 0);
-        get_input_line(TEXT_ROOMTEXT, loc::gettext("Enter roomtext:"), &(customentities[text_entity].scriptname));
+        get_input_line(TEXT_ROOMTEXT, "Enter roomtext:", &(customentities[text_entity].scriptname));
         break;
     case EditorTool_TERMINALS:
         lclickdelay = 1;
         text_entity = customentities.size();
         add_entity(levx, levy, tilex, tiley, 18, 0);
-        get_input_line(TEXT_SCRIPT, loc::gettext("Enter script name:"), &(customentities[text_entity].scriptname));
+        get_input_line(TEXT_SCRIPT, "Enter script name:", &(customentities[text_entity].scriptname));
         break;
     case EditorTool_SCRIPTS:
         substate = EditorSubState_DRAW_BOX;
@@ -2772,7 +2772,7 @@ static void editormenuactionpress(void)
             map.nexttowercolour();
 
             ed.keydelay = 6;
-            ed.get_input_line(TEXT_LOAD, loc::gettext("Enter map filename to load:"), &(ed.filename));
+            ed.get_input_line(TEXT_LOAD, "Enter map filename to load:", &(ed.filename));
             game.mapheld = true;
             graphics.backgrounddrawn = false;
             break;
@@ -2781,7 +2781,7 @@ static void editormenuactionpress(void)
             map.nexttowercolour();
 
             ed.keydelay = 6;
-            ed.get_input_line(TEXT_SAVE, loc::gettext("Enter map filename to save as:"), &(ed.filename));
+            ed.get_input_line(TEXT_SAVE, "Enter map filename to save as:", &(ed.filename));
             game.mapheld = true;
             graphics.backgrounddrawn = false;
             break;
@@ -2848,7 +2848,7 @@ static void editormenuactionpress(void)
             map.nexttowercolour();
 
             ed.keydelay = 6;
-            ed.get_input_line(TEXT_SAVE, loc::gettext("Enter map filename to save as:"), &(ed.filename));
+            ed.get_input_line(TEXT_SAVE, "Enter map filename to save as:", &(ed.filename));
             game.mapheld = true;
             graphics.backgrounddrawn = false;
             break;
@@ -3060,13 +3060,13 @@ static void handle_draw_input()
         if (key.keymap[SDLK_e])
         {
             ed.keydelay = 6;
-            ed.get_input_line(TEXT_ROOMNAME, loc::gettext("Enter new room name:"), const_cast<std::string*>(&(cl.getroomprop(ed.levx, ed.levy)->roomname)));
+            ed.get_input_line(TEXT_ROOMNAME, "Enter new room name:", const_cast<std::string*>(&(cl.getroomprop(ed.levx, ed.levy)->roomname)));
             game.mapheld = true;
         }
         if (key.keymap[SDLK_g])
         {
             ed.keydelay = 6;
-            ed.get_input_line(TEXT_GOTOROOM, loc::gettext("Enter room coordinates x,y:"), NULL);
+            ed.get_input_line(TEXT_GOTOROOM, "Enter room coordinates x,y:", NULL);
             game.mapheld = true;
         }
 
@@ -3074,14 +3074,14 @@ static void handle_draw_input()
         if (key.keymap[SDLK_s])
         {
             ed.keydelay = 6;
-            ed.get_input_line(TEXT_SAVE, loc::gettext("Enter map filename to save as:"), &(ed.filename));
+            ed.get_input_line(TEXT_SAVE, "Enter map filename to save as:", &(ed.filename));
             game.mapheld = true;
         }
 
         if (key.keymap[SDLK_l])
         {
             ed.keydelay = 6;
-            ed.get_input_line(TEXT_LOAD, loc::gettext("Enter map filename to load:"), &(ed.filename));
+            ed.get_input_line(TEXT_LOAD, "Enter map filename to load:", &(ed.filename));
             game.mapheld = true;
         }
 
@@ -3401,7 +3401,7 @@ void editorinput(void)
 
                         ed.add_entity(ed.levx, ed.levy, left / 8, top / 8, 19, (right - left) / 8, (bottom - top) / 8);
 
-                        ed.get_input_line(TEXT_SCRIPT, loc::gettext("Enter script name:"), &(customentities[ed.text_entity].scriptname));
+                        ed.get_input_line(TEXT_SCRIPT, "Enter script name:", &(customentities[ed.text_entity].scriptname));
                         break;
                     case BoxType_ENEMY:
                         cl.setroomenemyx1(ed.levx, ed.levy, left);

--- a/desktop_version/src/Editor.h
+++ b/desktop_version/src/Editor.h
@@ -220,7 +220,11 @@ public:
 
     int note_timer;
     int old_note_timer;
-    std::string note;
+    const char* note;
+    const char* note_format_string;
+    int note_platv;
+    const char* note_tileset_name;
+
     std::string keybuffer;
     std::string filename;
     std::string loaded_filepath;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1081,6 +1081,7 @@ void Game::updatestate(void)
             setstate(3);
             graphics.createtextbox("To do: write quick", 50, 80, TEXT_COLOUR("cyan"));
             graphics.addline("intro to story!");
+            graphics.textboxoriginalcontextauto();
             graphics.textboxprintflags(PR_FONT_8X8);
             //Oh no! what happen to rest of crew etc crash into dimension
             break;
@@ -1920,6 +1921,7 @@ void Game::updatestate(void)
             hascontrol = false;
 
             graphics.createtextbox("Captain! I've been so worried!", 60, 90, 164, 255, 164);
+            graphics.textboxoriginalcontextauto();
             graphics.textboxprintflags(PR_FONT_8X8);
             incstate();
             music.playef(Sound_VERDIGRIS);
@@ -1927,6 +1929,7 @@ void Game::updatestate(void)
         break;
         case 104:
             graphics.createtextbox("I'm glad you're ok!", 135, 152, TEXT_COLOUR("cyan"));
+            graphics.textboxoriginalcontextauto();
             graphics.textboxprintflags(PR_FONT_8X8);
             incstate();
             music.playef(Sound_VIRIDIAN);
@@ -1937,6 +1940,7 @@ void Game::updatestate(void)
             graphics.createtextbox("I've been trying to find a", 74, 70, 164, 255, 164);
             graphics.addline("way out, but I keep going");
             graphics.addline("around in circles...");
+            graphics.textboxoriginalcontextauto();
             graphics.textboxprintflags(PR_FONT_8X8);
             incstate();
             music.playef(Sound_CRY);
@@ -1952,6 +1956,7 @@ void Game::updatestate(void)
         case 108:
             graphics.createtextbox("Don't worry! I have a", 125, 152, TEXT_COLOUR("cyan"));
             graphics.addline("teleporter key!");
+            graphics.textboxoriginalcontextauto();
             graphics.textboxprintflags(PR_FONT_8X8);
             incstate();
             music.playef(Sound_VIRIDIAN);
@@ -1967,6 +1972,7 @@ void Game::updatestate(void)
                 obj.entities[i].state = 1;
             }
             graphics.createtextbox("Follow me!", 185, 154, TEXT_COLOUR("cyan"));
+            graphics.textboxoriginalcontextauto();
             graphics.textboxprintflags(PR_FONT_8X8);
             incstate();
             music.playef(Sound_VIRIDIAN);
@@ -1995,6 +2001,7 @@ void Game::updatestate(void)
 
             graphics.createtextbox("Sorry Eurogamers! Teleporting around", 60 - 20, 200, 255, 64, 64);
             graphics.addline("the map doesn't work in this version!");
+            graphics.textboxoriginalcontextauto();
             graphics.textboxprintflags(PR_FONT_8X8);
             graphics.textboxcenterx();
             incstate();
@@ -2049,6 +2056,7 @@ void Game::updatestate(void)
             hascontrol = false;
 
             graphics.createtextbox("Captain! You're ok!", 60-10, 90-40, TEXT_COLOUR("yellow"));
+            graphics.textboxoriginalcontextauto();
             graphics.textboxprintflags(PR_FONT_8X8);
             incstate();
             music.playef(Sound_VITELLARY);
@@ -2058,6 +2066,7 @@ void Game::updatestate(void)
         {
             graphics.createtextbox("I've found a teleporter, but", 60-20, 90 - 40, TEXT_COLOUR("yellow"));
             graphics.addline("I can't get it to go anywhere...");
+            graphics.textboxoriginalcontextauto();
             graphics.textboxprintflags(PR_FONT_8X8);
             incstate();
             music.playef(Sound_CRY);
@@ -2066,6 +2075,7 @@ void Game::updatestate(void)
         }
         case 126:
             graphics.createtextbox("I can help with that!", 125, 152-40, TEXT_COLOUR("cyan"));
+            graphics.textboxoriginalcontextauto();
             graphics.textboxprintflags(PR_FONT_8X8);
             incstate();
             music.playef(Sound_VIRIDIAN);
@@ -2074,6 +2084,7 @@ void Game::updatestate(void)
         case 128:
             graphics.createtextbox("I have the teleporter", 130, 152-35, TEXT_COLOUR("cyan"));
             graphics.addline("codex for our ship!");
+            graphics.textboxoriginalcontextauto();
             graphics.textboxprintflags(PR_FONT_8X8);
             incstate();
             music.playef(Sound_VIRIDIAN);
@@ -2083,6 +2094,7 @@ void Game::updatestate(void)
         case 130:
         {
             graphics.createtextbox("Yey! Let's go home!", 60-30, 90-35, TEXT_COLOUR("yellow"));
+            graphics.textboxoriginalcontextauto();
             graphics.textboxprintflags(PR_FONT_8X8);
             incstate();
             music.playef(Sound_VITELLARY);
@@ -2472,6 +2484,7 @@ void Game::updatestate(void)
             advancetext = true;
             hascontrol = false;
             graphics.createtextbox("Hello?", 125+24, 152-20, TEXT_COLOUR("cyan"));
+            graphics.textboxoriginalcontextauto();
             graphics.textboxprintflags(PR_FONT_8X8);
             incstate();
             music.playef(Sound_VIRIDIAN);
@@ -2481,6 +2494,7 @@ void Game::updatestate(void)
             advancetext = true;
             hascontrol = false;
             graphics.createtextbox("Is anyone there?", 125+8, 152-24, TEXT_COLOUR("cyan"));
+            graphics.textboxoriginalcontextauto();
             graphics.textboxprintflags(PR_FONT_8X8);
             incstate();
             music.playef(Sound_VIRIDIAN);

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1632,56 +1632,56 @@ void Game::updatestate(void)
 
         case 50:
             music.playef(Sound_VIOLET);
-            graphics.createtextbox(loc::gettext("Help! Can anyone hear this message?"), 5, 8, TEXT_COLOUR("purple"));
-            graphics.textboxcommsrelay();
+            graphics.createtextbox("", 5, 8, TEXT_COLOUR("purple"));
+            graphics.textboxcommsrelay("Help! Can anyone hear this message?");
             graphics.textboxtimer(60);
             incstate();
             setstatedelay(100);
             break;
         case 51:
             music.playef(Sound_VIOLET);
-            graphics.createtextbox(loc::gettext("Verdigris? Are you out there? Are you ok?"), 5, 8, TEXT_COLOUR("purple"));
-            graphics.textboxcommsrelay();
+            graphics.createtextbox("", 5, 8, TEXT_COLOUR("purple"));
+            graphics.textboxcommsrelay("Verdigris? Are you out there? Are you ok?");
             graphics.textboxtimer(60);
             incstate();
             setstatedelay(100);
             break;
         case 52:
             music.playef(Sound_VIOLET);
-            graphics.createtextbox(loc::gettext("Please help us! We've crashed and need assistance!"), 5, 8, TEXT_COLOUR("purple"));
-            graphics.textboxcommsrelay();
+            graphics.createtextbox("", 5, 8, TEXT_COLOUR("purple"));
+            graphics.textboxcommsrelay("Please help us! We've crashed and need assistance!");
             graphics.textboxtimer(60);
             incstate();
             setstatedelay(100);
             break;
         case 53:
             music.playef(Sound_VIOLET);
-            graphics.createtextbox(loc::gettext("Hello? Anyone out there?"), 5, 8, TEXT_COLOUR("purple"));
-            graphics.textboxcommsrelay();
+            graphics.createtextbox("", 5, 8, TEXT_COLOUR("purple"));
+            graphics.textboxcommsrelay("Hello? Anyone out there?");
             graphics.textboxtimer(60);
             incstate();
             setstatedelay(100);
             break;
         case 54:
             music.playef(Sound_VIOLET);
-            graphics.createtextbox(loc::gettext("This is Doctor Violet from the D.S.S. Souleye! Please respond!"), 5, 8, TEXT_COLOUR("purple"));
-            graphics.textboxcommsrelay();
+            graphics.createtextbox("", 5, 8, TEXT_COLOUR("purple"));
+            graphics.textboxcommsrelay("This is Doctor Violet from the D.S.S. Souleye! Please respond!");
             graphics.textboxtimer(60);
             incstate();
             setstatedelay(100);
             break;
         case 55:
             music.playef(Sound_VIOLET);
-            graphics.createtextbox(loc::gettext("Please... Anyone..."), 5, 8, TEXT_COLOUR("purple"));
-            graphics.textboxcommsrelay();
+            graphics.createtextbox("", 5, 8, TEXT_COLOUR("purple"));
+            graphics.textboxcommsrelay("Please... Anyone...");
             graphics.textboxtimer(60);
             incstate();
             setstatedelay(100);
             break;
         case 56:
             music.playef(Sound_VIOLET);
-            graphics.createtextbox(loc::gettext("Please be alright, everyone..."), 5, 8, TEXT_COLOUR("purple"));
-            graphics.textboxcommsrelay();
+            graphics.createtextbox("", 5, 8, TEXT_COLOUR("purple"));
+            graphics.textboxcommsrelay("Please be alright, everyone...");
             graphics.textboxtimer(60);
             setstate(50);
             setstatedelay(100);

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -806,6 +806,21 @@ void Game::actionprompt_textbox(void)
     graphics.textboxapplyposition();
 }
 
+static void savetele_textbox_success(textboxclass* THIS)
+{
+    THIS->lines.clear();
+    THIS->lines.push_back(loc::gettext("Game Saved"));
+    THIS->pad(3, 3);
+}
+
+static void savetele_textbox_fail(textboxclass* THIS)
+{
+    THIS->lines.clear();
+    THIS->lines.push_back(loc::gettext("ERROR: Could not save game!"));
+    THIS->wrap(2);
+    THIS->pad(1, 1);
+}
+
 void Game::savetele_textbox(void)
 {
     if (inspecial() || map.custommode)
@@ -815,21 +830,174 @@ void Game::savetele_textbox(void)
 
     if (savetele())
     {
-        graphics.createtextboxflipme(loc::gettext("Game Saved"), -1, 12, TEXT_COLOUR("gray"));
+        graphics.createtextboxflipme("", -1, 12, TEXT_COLOUR("gray"));
         graphics.textboxprintflags(PR_FONT_INTERFACE);
-        graphics.textboxpad(3, 3);
         graphics.textboxcenterx();
         graphics.textboxtimer(25);
+        graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, savetele_textbox_success);
     }
     else
     {
-        graphics.createtextboxflipme(loc::gettext("ERROR: Could not save game!"), -1, 12, TEXT_COLOUR("red"));
+        graphics.createtextboxflipme("", -1, 12, TEXT_COLOUR("red"));
         graphics.textboxprintflags(PR_FONT_INTERFACE);
-        graphics.textboxwrap(2);
-        graphics.textboxpad(1, 1);
         graphics.textboxcenterx();
         graphics.textboxtimer(50);
+        graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, savetele_textbox_fail);
     }
+    graphics.textboxapplyposition();
+}
+
+static void wasd_textbox(textboxclass* THIS)
+{
+    THIS->lines.clear();
+    THIS->lines.push_back(BUTTONGLYPHS_get_wasd_text());
+    THIS->wrap(4);
+    THIS->centertext();
+    THIS->pad(2, 2);
+}
+
+static void flip_textbox(textboxclass* THIS)
+{
+    THIS->lines.clear();
+
+    char buffer[SCREEN_WIDTH_CHARS*3 + 1];
+    vformat_buf(
+        buffer, sizeof(buffer),
+        loc::gettext("Press {button} to flip"),
+        "button:but",
+        vformat_button(ActionSet_InGame, Action_InGame_ACTION)
+    );
+    THIS->lines.push_back(buffer);
+    THIS->wrap(4);
+    THIS->centertext();
+    THIS->pad(2, 2);
+}
+
+static void arrowkey_textbox(textboxclass* THIS)
+{
+    THIS->lines.clear();
+    THIS->lines.push_back(loc::gettext("If you prefer, you can press UP or DOWN instead of ACTION to flip."));
+    THIS->wrap(2);
+    THIS->centertext();
+    THIS->pad(1, 1);
+}
+
+static void map_textbox(textboxclass* THIS)
+{
+    THIS->lines.clear();
+
+    char buffer[SCREEN_WIDTH_CHARS*3 + 1];
+    vformat_buf(
+        buffer, sizeof(buffer),
+        loc::gettext("Press {button} to view map and quicksave"),
+        "button:but",
+        vformat_button(ActionSet_InGame, Action_InGame_Map)
+    );
+
+    THIS->lines.push_back(buffer);
+    THIS->wrap(4);
+    THIS->centertext();
+    THIS->pad(2, 2);
+}
+
+static void im1_instructions_textbox1(textboxclass* THIS)
+{
+    extern Game game;
+    THIS->lines.clear();
+
+    // Intermission 1 instructional textbox, depends on last saved
+    const char* floorceiling = graphics.flipmode ? "ceiling" : "floor";
+    const char* crewmate;
+    switch (game.lastsaved)
+    {
+    case 2:
+        crewmate = "Vitellary";
+        break;
+    case 3:
+        crewmate = "Vermilion";
+        break;
+    case 4:
+        crewmate = "Verdigris";
+        break;
+    case 5:
+        crewmate = "Victoria";
+        break;
+    default:
+        crewmate = "your companion";
+    }
+    char english[SCREEN_WIDTH_TILES*3 + 1]; /* ASCII only */
+    vformat_buf(english, sizeof(english),
+        "When you're standing on the {floorceiling}, {crewmate} will try to walk to you.",
+        "floorceiling:str, crewmate:str",
+        floorceiling, crewmate
+    );
+
+    THIS->lines.push_back(loc::gettext(english));
+    THIS->wrap(2);
+    THIS->padtowidth(36*8);
+}
+
+static void im1_instructions_textbox2(textboxclass* THIS)
+{
+    extern Game game;
+    THIS->lines.clear();
+
+    // Intermission 1 instructional textbox, depends on last saved
+    const char* floorceiling = graphics.flipmode ? "ceiling" : "floor";
+    const char* crewmate;
+    switch (game.lastsaved)
+    {
+    case 2:
+        crewmate = "Vitellary";
+        break;
+    case 3:
+        crewmate = "Vermilion";
+        break;
+    case 4:
+        crewmate = "Verdigris";
+        break;
+    case 5:
+        crewmate = "Victoria";
+        break;
+    default:
+        crewmate = "your companion";
+    }
+    char english[SCREEN_WIDTH_TILES*3 + 1]; /* ASCII only */
+    vformat_buf(english, sizeof(english),
+        "When you're NOT standing on the {floorceiling}, {crewmate} will stop and wait for you.",
+        "floorceiling:str, crewmate:str",
+        floorceiling, crewmate
+    );
+
+    THIS->lines.push_back(loc::gettext(english));
+    THIS->wrap(2);
+    THIS->padtowidth(36*8);
+}
+
+static void im1_instructions_textbox3(textboxclass* THIS)
+{
+    extern Game game;
+    THIS->lines.clear();
+
+    // Intermission 1 instructional textbox, depends on last saved
+    const char* english;
+    switch (game.lastsaved)
+    {
+    case 2:
+    case 3:
+    case 4:
+        english = "You can't continue to the next room until he is safely across.";
+        break;
+    case 5:
+        english = "You can't continue to the next room until she is safely across.";
+        break;
+    default:
+        english = "You can't continue to the next room until they are safely across.";
+    }
+
+    THIS->lines.push_back(loc::gettext(english));
+    THIS->wrap(2);
+    THIS->padtowidth(36*8);
 }
 
 void Game::setstate(const int gamestate)
@@ -918,13 +1086,12 @@ void Game::updatestate(void)
             break;
         case 4:
             //End of opening cutscene for now
-            graphics.createtextbox(BUTTONGLYPHS_get_wasd_text(), -1, 195, TEXT_COLOUR("gray"));
+            graphics.createtextbox("", -1, 195, TEXT_COLOUR("gray"));
             graphics.textboxprintflags(PR_FONT_INTERFACE);
-            graphics.textboxwrap(4);
-            graphics.textboxcentertext();
-            graphics.textboxpad(2, 2);
             graphics.textboxcenterx();
             graphics.textboxtimer(60);
+            graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, wasd_textbox);
+            graphics.textboxapplyposition();
             setstate(0);
             break;
         case 5:
@@ -951,21 +1118,12 @@ void Game::updatestate(void)
             {
                 obj.flags[13] = true;
 
-                char buffer[SCREEN_WIDTH_CHARS*3 + 1];
-                vformat_buf(
-                    buffer, sizeof(buffer),
-                    loc::gettext("Press {button} to view map and quicksave"),
-                    "button:but",
-                    vformat_button(ActionSet_InGame, Action_InGame_Map)
-                );
-
-                graphics.createtextbox(buffer, -1, 155, TEXT_COLOUR("gray"));
+                graphics.createtextbox("", -1, 155, TEXT_COLOUR("gray"));
                 graphics.textboxprintflags(PR_FONT_INTERFACE);
-                graphics.textboxwrap(4);
-                graphics.textboxcentertext();
-                graphics.textboxpad(2, 2);
                 graphics.textboxcenterx();
                 graphics.textboxtimer(60);
+                graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, map_textbox);
+                graphics.textboxapplyposition();
             }
             setstate(0);
             break;
@@ -1024,70 +1182,27 @@ void Game::updatestate(void)
             break;
 
         case 11:
-        {
-            //Intermission 1 instructional textbox, depends on last saved
             graphics.textboxremovefast();
-            const char* floorceiling = graphics.flipmode ? "ceiling" : "floor";
-            const char* crewmate;
-            switch (lastsaved)
-            {
-            case 2:
-                crewmate = "Vitellary";
-                break;
-            case 3:
-                crewmate = "Vermilion";
-                break;
-            case 4:
-                crewmate = "Verdigris";
-                break;
-            case 5:
-                crewmate = "Victoria";
-                break;
-            default:
-                crewmate = "your companion";
-            }
-            char english[SCREEN_WIDTH_TILES*3 + 1]; /* ASCII only */
-            vformat_buf(english, sizeof(english),
-                "When you're NOT standing on the {floorceiling}, {crewmate} will stop and wait for you.",
-                "floorceiling:str, crewmate:str",
-                floorceiling, crewmate
-            );
-            graphics.createtextbox(loc::gettext(english), -1, 3, TEXT_COLOUR("gray"));
+            graphics.createtextbox("", -1, 3, TEXT_COLOUR("gray"));
             graphics.textboxprintflags(PR_FONT_INTERFACE);
-            graphics.textboxwrap(2);
-            graphics.textboxpadtowidth(36*8);
             graphics.textboxcenterx();
             graphics.textboxtimer(180);
+            graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, im1_instructions_textbox2);
+            graphics.textboxapplyposition();
             setstate(0);
             break;
-        }
         case 12:
-            //Intermission 1 instructional textbox, depends on last saved
             obj.removetrigger(12);
             if (!obj.flags[61])
             {
                 obj.flags[61] = true;
                 graphics.textboxremovefast();
-                const char* english;
-                switch (lastsaved)
-                {
-                case 2:
-                case 3:
-                case 4:
-                    english = "You can't continue to the next room until he is safely across.";
-                    break;
-                case 5:
-                    english = "You can't continue to the next room until she is safely across.";
-                    break;
-                default:
-                    english = "You can't continue to the next room until they are safely across.";
-                }
-                graphics.createtextbox(loc::gettext(english), -1, 3, TEXT_COLOUR("gray"));
+                graphics.createtextbox("", -1, 3, TEXT_COLOUR("gray"));
                 graphics.textboxprintflags(PR_FONT_INTERFACE);
-                graphics.textboxwrap(2);
-                graphics.textboxpadtowidth(36*8);
                 graphics.textboxcenterx();
                 graphics.textboxtimer(120);
+                graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, im1_instructions_textbox3);
+                graphics.textboxapplyposition();
             }
             setstate(0);
             break;
@@ -1098,43 +1213,15 @@ void Game::updatestate(void)
             setstate(0);
             break;
         case 14:
-        {
-            //Intermission 1 instructional textbox, depends on last saved
-            const char* floorceiling = graphics.flipmode ? "ceiling" : "floor";
-            const char* crewmate;
-            switch (lastsaved)
-            {
-            case 2:
-                crewmate = "Vitellary";
-                break;
-            case 3:
-                crewmate = "Vermilion";
-                break;
-            case 4:
-                crewmate = "Verdigris";
-                break;
-            case 5:
-                crewmate = "Victoria";
-                break;
-            default:
-                crewmate = "your companion";
-            }
-            char english[SCREEN_WIDTH_TILES*3 + 1]; /* ASCII only */
-            vformat_buf(english, sizeof(english),
-                "When you're standing on the {floorceiling}, {crewmate} will try to walk to you.",
-                "floorceiling:str, crewmate:str",
-                floorceiling, crewmate
-            );
-            graphics.createtextbox(loc::gettext(english), -1, 3, TEXT_COLOUR("gray"));
+            graphics.createtextbox("", -1, 3, TEXT_COLOUR("gray"));
             graphics.textboxprintflags(PR_FONT_INTERFACE);
-            graphics.textboxwrap(2);
-            graphics.textboxpadtowidth(36*8);
             graphics.textboxcenterx();
             graphics.textboxtimer(280);
+            graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, im1_instructions_textbox1);
+            graphics.textboxapplyposition();
 
             setstate(0);
             break;
-        }
         case 15:
         {
             //leaving the naughty corner
@@ -1164,13 +1251,12 @@ void Game::updatestate(void)
             obj.removetrigger(17);
             if (BUTTONGLYPHS_keyboard_is_active())
             {
-                graphics.createtextbox(loc::gettext("If you prefer, you can press UP or DOWN instead of ACTION to flip."), -1, 187, TEXT_COLOUR("gray"));
+                graphics.createtextbox("", -1, 187, TEXT_COLOUR("gray"));
                 graphics.textboxprintflags(PR_FONT_INTERFACE);
-                graphics.textboxwrap(2);
-                graphics.textboxcentertext();
-                graphics.textboxpad(1, 1);
                 graphics.textboxcenterx();
                 graphics.textboxtimer(100);
+                graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, arrowkey_textbox);
+                graphics.textboxapplyposition();
             }
             setstate(0);
             break;
@@ -1200,20 +1286,12 @@ void Game::updatestate(void)
                 obj.flags[3] = true;
                 setstate(0);
 
-                char buffer[SCREEN_WIDTH_CHARS*3 + 1];
-                vformat_buf(
-                    buffer, sizeof(buffer),
-                    loc::gettext("Press {button} to flip"),
-                    "button:but",
-                    vformat_button(ActionSet_InGame, Action_InGame_ACTION)
-                );
-                graphics.createtextbox(buffer, -1, 25, TEXT_COLOUR("gray"));
+                graphics.createtextbox("", -1, 25, TEXT_COLOUR("gray"));
                 graphics.textboxprintflags(PR_FONT_INTERFACE);
-                graphics.textboxwrap(4);
-                graphics.textboxcentertext();
-                graphics.textboxpad(2, 2);
                 graphics.textboxcenterx();
                 graphics.textboxtimer(60);
+                graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, flip_textbox);
+                graphics.textboxapplyposition();
             }
             obj.removetrigger(22);
             break;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -1000,6 +1000,86 @@ static void im1_instructions_textbox3(textboxclass* THIS)
     THIS->padtowidth(36*8);
 }
 
+/* Also used in foundtrinket() script command. */
+void foundtrinket_textbox1(textboxclass* THIS)
+{
+    THIS->lines.clear();
+
+    THIS->lines.push_back(loc::gettext("Congratulations!\n\nYou have found a shiny trinket!"));
+    THIS->wrap(2);
+    THIS->centertext();
+    THIS->pad(1, 1);
+}
+
+/* Also used in foundtrinket() script command. */
+void foundtrinket_textbox2(textboxclass* THIS)
+{
+    extern Game game;
+    THIS->lines.clear();
+
+    const int max_trinkets = map.custommode ? cl.numtrinkets() : 20;
+
+    char buffer[SCREEN_WIDTH_CHARS + 1];
+    vformat_buf(
+        buffer, sizeof(buffer),
+        loc::gettext("{n_trinkets|wordy} out of {max_trinkets|wordy}"),
+        "n_trinkets:int, max_trinkets:int",
+        game.trinkets(), max_trinkets
+    );
+    THIS->lines.push_back(buffer);
+
+    if (INBOUNDS_VEC(THIS->other_textbox_index, graphics.textboxes)
+    && &graphics.textboxes[THIS->other_textbox_index] != THIS)
+    {
+        THIS->yp = 95 + graphics.textboxes[THIS->other_textbox_index].h;
+    }
+    THIS->wrap(2);
+    THIS->centertext();
+    THIS->pad(1, 1);
+}
+
+static void foundcrewmate_textbox1(textboxclass* THIS)
+{
+    THIS->lines.clear();
+
+    THIS->lines.push_back(loc::gettext("Congratulations!\n\nYou have found a lost crewmate!"));
+    THIS->wrap(2);
+    THIS->centertext();
+    THIS->pad(1, 1);
+}
+
+static void foundcrewmate_textbox2(textboxclass* THIS)
+{
+    extern Game game;
+    THIS->lines.clear();
+
+    const int num_remaining = cl.numcrewmates() - game.crewmates();
+    if (num_remaining == 0)
+    {
+        THIS->lines.push_back(loc::gettext("All crewmates rescued!"));
+    }
+    else
+    {
+        char buffer[SCREEN_WIDTH_CHARS + 1];
+        loc::gettext_plural_fill(
+            buffer, sizeof(buffer),
+            "{n_crew|wordy} remain", "{n_crew|wordy} remains",
+            "n_crew:int",
+            num_remaining
+        );
+        THIS->lines.push_back(buffer);
+    }
+
+    if (INBOUNDS_VEC(THIS->other_textbox_index, graphics.textboxes)
+    && &graphics.textboxes[THIS->other_textbox_index] != THIS)
+    {
+        THIS->yp = 95 + graphics.textboxes[THIS->other_textbox_index].h;
+    }
+    THIS->wrap(4);
+    THIS->centertext();
+    THIS->pad(2, 2);
+}
+
 void Game::setstate(const int gamestate)
 {
     if (!statelocked || GlitchrunnerMode_less_than_or_equal(Glitchrunner2_2))
@@ -2189,43 +2269,22 @@ void Game::updatestate(void)
             setstatedelay(15);
             break;
         case 1001:
-        {
             //Found a trinket!
             advancetext = true;
             incstate();
-            graphics.createtextboxflipme(loc::gettext("Congratulations!\n\nYou have found a shiny trinket!"), 50, 85, TEXT_COLOUR("gray"));
+            graphics.createtextboxflipme("", 50, 85, TEXT_COLOUR("gray"));
             graphics.textboxprintflags(PR_FONT_INTERFACE);
-            int h = graphics.textboxwrap(2);
-            graphics.textboxcentertext();
-            graphics.textboxpad(1, 1);
             graphics.textboxcenterx();
+            graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, foundtrinket_textbox1);
+            graphics.textboxapplyposition();
 
-            int max_trinkets;
-
-            if(map.custommode)
-            {
-                max_trinkets = cl.numtrinkets();
-            }
-            else
-            {
-                max_trinkets = 20;
-            }
-
-            char buffer[SCREEN_WIDTH_CHARS + 1];
-            vformat_buf(
-                buffer, sizeof(buffer),
-                loc::gettext("{n_trinkets|wordy} out of {max_trinkets|wordy}"),
-                "n_trinkets:int, max_trinkets:int",
-                trinkets(), max_trinkets
-            );
-            graphics.createtextboxflipme(buffer, 50, 95+h, TEXT_COLOUR("gray"));
+            graphics.createtextboxflipme("", 50, 95, TEXT_COLOUR("gray"));
             graphics.textboxprintflags(PR_FONT_INTERFACE);
-            graphics.textboxwrap(2);
-            graphics.textboxcentertext();
-            graphics.textboxpad(1, 1);
             graphics.textboxcenterx();
+            graphics.textboxindex(graphics.textboxes.size() - 2);
+            graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, foundtrinket_textbox2);
+            graphics.textboxapplyposition();
             break;
-        }
         case 1002:
             if (!advancetext)
             {
@@ -2254,39 +2313,22 @@ void Game::updatestate(void)
             setstatedelay(15);
             break;
         case 1011:
-        {
             //Found a crewmate!
             advancetext = true;
             incstate();
-            graphics.createtextboxflipme(loc::gettext("Congratulations!\n\nYou have found a lost crewmate!"), 50, 85, TEXT_COLOUR("gray"));
+            graphics.createtextboxflipme("", 50, 85, TEXT_COLOUR("gray"));
             graphics.textboxprintflags(PR_FONT_INTERFACE);
-            int h = graphics.textboxwrap(2);
-            graphics.textboxcentertext();
-            graphics.textboxpad(1, 1);
             graphics.textboxcenterx();
+            graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, foundcrewmate_textbox1);
+            graphics.textboxapplyposition();
 
-            if(cl.numcrewmates()-crewmates()==0)
-            {
-                graphics.createtextboxflipme(loc::gettext("All crewmates rescued!"), 50, 95+h, TEXT_COLOUR("gray"));
-            }
-            else
-            {
-                char buffer[SCREEN_WIDTH_CHARS + 1];
-                loc::gettext_plural_fill(
-                    buffer, sizeof(buffer),
-                    "{n_crew|wordy} remain", "{n_crew|wordy} remains",
-                    "n_crew:int",
-                    cl.numcrewmates()-crewmates()
-                );
-                graphics.createtextboxflipme(buffer, 50, 95+h, TEXT_COLOUR("gray"));
-            }
+            graphics.createtextboxflipme("", 50, 95, TEXT_COLOUR("gray"));
             graphics.textboxprintflags(PR_FONT_INTERFACE);
-            graphics.textboxwrap(4);
-            graphics.textboxcentertext();
-            graphics.textboxpad(2, 2);
             graphics.textboxcenterx();
+            graphics.textboxindex(graphics.textboxes.size() - 2);
+            graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, foundcrewmate_textbox2);
+            graphics.textboxapplyposition();
             break;
-        }
         case 1012:
             if (!advancetext)
             {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -262,6 +262,10 @@ void Game::init(void)
     savetime = "00:00";
     savetrinkets = 0;
 
+    /* These are only used some of the time. */
+    saveframes = 0;
+    saveseconds = 0;
+
     intimetrial = false;
     timetrialcountdown = 0;
     timetrialshinytarget = 0;
@@ -1078,6 +1082,102 @@ static void foundcrewmate_textbox2(textboxclass* THIS)
     THIS->wrap(4);
     THIS->centertext();
     THIS->pad(2, 2);
+}
+
+static void gamecomplete_textbox2(textboxclass* THIS)
+{
+    THIS->lines.clear();
+    THIS->lines.push_back(loc::gettext("All Crew Members Rescued!"));
+}
+
+static void gamecomplete_textbox3(textboxclass* THIS)
+{
+    THIS->lines.clear();
+
+    const char* label = loc::gettext("Trinkets Found:");
+    THIS->lines.push_back(label);
+    THIS->xp = 170 - font::len(PR_FONT_INTERFACE, label);
+}
+
+static void gamecomplete_textbox4(textboxclass* THIS)
+{
+    extern Game game;
+    THIS->lines.clear();
+
+    char buffer[SCREEN_WIDTH_CHARS + 1];
+    vformat_buf(buffer, sizeof(buffer),
+        loc::gettext("{gamecomplete_n_trinkets|wordy}"),
+        "gamecomplete_n_trinkets:int",
+        game.trinkets()
+    );
+    THIS->lines.push_back(buffer);
+}
+
+static void gamecomplete_textbox5(textboxclass* THIS)
+{
+    THIS->lines.clear();
+
+    const char* label = loc::gettext("Game Time:");
+    THIS->lines.push_back(label);
+    THIS->xp = 170 - font::len(PR_FONT_INTERFACE, label);
+}
+
+static void gamecomplete_textbox6(textboxclass* THIS)
+{
+    extern Game game;
+    THIS->lines.clear();
+
+    char buffer[SCREEN_WIDTH_CHARS + 1];
+    help.format_time(buffer, sizeof(buffer), game.saveseconds, game.saveframes, true);
+    THIS->lines.push_back(buffer);
+}
+
+static void gamecomplete_textbox7(textboxclass* THIS)
+{
+    THIS->lines.clear();
+
+    const char* label = loc::gettext("Total Flips:");
+    THIS->lines.push_back(label);
+    THIS->xp = 170 - font::len(PR_FONT_INTERFACE, label);
+}
+
+static void gamecomplete_textbox9(textboxclass* THIS)
+{
+    THIS->lines.clear();
+
+    const char* label = loc::gettext("Total Deaths:");
+    THIS->lines.push_back(label);
+    THIS->xp = 170 - font::len(PR_FONT_INTERFACE, label);
+}
+
+static void gamecomplete_textbox11(textboxclass* THIS)
+{
+    extern Game game;
+    THIS->lines.clear();
+
+    char buffer[SCREEN_WIDTH_CHARS + 1];
+    loc::gettext_plural_fill(
+        buffer, sizeof(buffer),
+        "Hardest Room (with {n_deaths} deaths)",
+        "Hardest Room (with {n_deaths} death)",
+        "n_deaths:int",
+        game.hardestroomdeaths
+    );
+    THIS->lines.push_back(buffer);
+}
+
+static void gamecomplete_textbox12(textboxclass* THIS)
+{
+    extern Game game;
+    THIS->lines.clear();
+
+    THIS->lines.push_back(
+        loc::gettext_roomname(
+            map.custommode,
+            game.hardestroom_x, game.hardestroom_y,
+            game.hardestroom.c_str(), game.hardestroom_specialname
+        )
+    );
 }
 
 void Game::setstate(const int gamestate)
@@ -3077,97 +3177,82 @@ void Game::updatestate(void)
             graphics.textboxapplyposition();
             break;
         case 3502:
-        {
             incstate();
             setstatedelay(45+15);
 
-            graphics.createtextboxflipme(loc::gettext("All Crew Members Rescued!"), -1, 64, TEXT_COLOUR("transparent"));
+            graphics.createtextboxflipme("", -1, 64, TEXT_COLOUR("transparent"));
             graphics.textboxprintflags(PR_FONT_INTERFACE);
             graphics.textboxcenterx();
-            char buffer[SCREEN_WIDTH_CHARS + 1];
-            timestringcenti(buffer, sizeof(buffer));
-            savetime = buffer;
+            graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, gamecomplete_textbox2);
+            graphics.textboxapplyposition();
+            saveframes = frames;
+            saveseconds = help.hms_to_seconds(hours, minutes, seconds);
             break;
-        }
         case 3503:
-        {
             incstate();
             setstatedelay(45);
 
-            const char* label = loc::gettext("Trinkets Found:");
-            char buffer[SCREEN_WIDTH_CHARS + 1];
-            vformat_buf(buffer, sizeof(buffer),
-                loc::gettext("{gamecomplete_n_trinkets|wordy}"),
-                "gamecomplete_n_trinkets:int",
-                trinkets()
-            );
-            graphics.createtextboxflipme(label, 170-font::len(PR_FONT_INTERFACE, label), 84, TEXT_COLOUR("transparent"));
+            graphics.createtextboxflipme("", 170, 84, TEXT_COLOUR("transparent"));
             graphics.textboxprintflags(PR_FONT_INTERFACE | PR_RTL_XFLIP);
-            graphics.createtextboxflipme(buffer, 180, 84, TEXT_COLOUR("transparent"));
+            graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, gamecomplete_textbox3);
+            graphics.textboxapplyposition();
+            graphics.createtextboxflipme("", 180, 84, TEXT_COLOUR("transparent"));
             graphics.textboxprintflags(PR_FONT_INTERFACE | PR_RTL_XFLIP);
+            graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, gamecomplete_textbox4);
+            graphics.textboxapplyposition();
             break;
-        }
         case 3504:
-        {
             incstate();
             setstatedelay(45+15);
 
-            const char* label = loc::gettext("Game Time:");
-            std::string tempstring = savetime;
-            graphics.createtextboxflipme(label, 170-font::len(PR_FONT_INTERFACE, label), 96, TEXT_COLOUR("transparent"));
+            graphics.createtextboxflipme("", 170, 96, TEXT_COLOUR("transparent"));
             graphics.textboxprintflags(PR_FONT_INTERFACE | PR_RTL_XFLIP);
-            graphics.createtextboxflipme(tempstring, 180, 96, TEXT_COLOUR("transparent"));
+            graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, gamecomplete_textbox5);
+            graphics.textboxapplyposition();
+            graphics.createtextboxflipme("", 180, 96, TEXT_COLOUR("transparent"));
             graphics.textboxprintflags(PR_FONT_INTERFACE | PR_RTL_XFLIP);
+            graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, gamecomplete_textbox6);
+            graphics.textboxapplyposition();
             break;
-        }
         case 3505:
-        {
             incstate();
             setstatedelay(45);
 
-            const char* label = loc::gettext("Total Flips:");
-            graphics.createtextboxflipme(label, 170-font::len(PR_FONT_INTERFACE, label), 123, TEXT_COLOUR("transparent"));
+            graphics.createtextboxflipme("", 170, 123, TEXT_COLOUR("transparent"));
             graphics.textboxprintflags(PR_FONT_INTERFACE | PR_RTL_XFLIP);
+            graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, gamecomplete_textbox7);
+            graphics.textboxapplyposition();
             graphics.createtextboxflipme(help.String(totalflips), 180, 123, TEXT_COLOUR("transparent"));
+            graphics.textboxoriginalcontextauto();
             graphics.textboxprintflags(PR_FONT_INTERFACE | PR_RTL_XFLIP);
             break;
-        }
         case 3506:
-        {
             incstate();
             setstatedelay(45+15);
 
-            const char* label = loc::gettext("Total Deaths:");
-            graphics.createtextboxflipme(label, 170-font::len(PR_FONT_INTERFACE, label), 135, TEXT_COLOUR("transparent"));
+            graphics.createtextboxflipme("", 170, 135, TEXT_COLOUR("transparent"));
             graphics.textboxprintflags(PR_FONT_INTERFACE | PR_RTL_XFLIP);
+            graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, gamecomplete_textbox9);
+            graphics.textboxapplyposition();
             graphics.createtextboxflipme(help.String(deathcounts), 180, 135, TEXT_COLOUR("transparent"));
+            graphics.textboxoriginalcontextauto();
             graphics.textboxprintflags(PR_FONT_INTERFACE | PR_RTL_XFLIP);
             break;
-        }
         case 3507:
-        {
             incstate();
             setstatedelay(45+15);
 
-            char buffer[SCREEN_WIDTH_CHARS + 1];
-            loc::gettext_plural_fill(
-                buffer, sizeof(buffer),
-                "Hardest Room (with {n_deaths} deaths)",
-                "Hardest Room (with {n_deaths} death)",
-                "n_deaths:int",
-                hardestroomdeaths
-            );
-            graphics.createtextboxflipme(buffer, -1, 158, TEXT_COLOUR("transparent"));
+            graphics.createtextboxflipme("", -1, 158, TEXT_COLOUR("transparent"));
             graphics.textboxprintflags(PR_FONT_INTERFACE);
             graphics.textboxcenterx();
-            graphics.createtextboxflipme(
-                loc::gettext_roomname(map.custommode, hardestroom_x, hardestroom_y, hardestroom.c_str(), hardestroom_specialname),
-                -1, 170, TEXT_COLOUR("transparent")
-            );
+            graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, gamecomplete_textbox11);
+            graphics.textboxapplyposition();
+            graphics.createtextboxflipme("", -1, 170, TEXT_COLOUR("transparent"));
             graphics.textboxprintflags(PR_FONT_INTERFACE);
             graphics.textboxcenterx();
+            graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, gamecomplete_textbox12);
+            graphics.textboxapplyposition();
             break;
-        }
         case 3508:
             incstate();
             setstatedelay(0);

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6545,7 +6545,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option(loc::gettext("audio"));
         option(loc::gettext("game pad"));
         option(loc::gettext("accessibility"));
-        option(loc::gettext("language"), graphics.textboxes.empty());
+        option(loc::gettext("language"));
         option(loc::gettext("return"));
         menuyoff = 0;
         maxspacing = 15;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6809,7 +6809,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option(loc::gettext("audio"));
         option(loc::gettext("game pad"));
         option(loc::gettext("accessibility"));
-        option(loc::gettext("language"));
+        option(loc::gettext("language"), !translator_cutscene_test);
         option(loc::gettext("return"));
         menuyoff = 0;
         maxspacing = 15;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6638,6 +6638,11 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
                         prefix = "";
                         break;
                     }
+                    const char* title = cl.ListOfMetaData[i].title.c_str();
+                    if (cl.ListOfMetaData[i].title_is_gettext)
+                    {
+                        title = loc::gettext(title);
+                    }
                     /* We have to make sure the stars and spaces are consistently on the
                      * correct side of the title, no matter what bidi characters are in there.
                      * So just always let the bidi engine handle it, with a few control chars. */
@@ -6650,7 +6655,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
                         prefix,
                         // FIRST STRONG ISOLATE, to start an isolated block oriented however bidi sees fit
                         UTF8_encode(0x2068).bytes,
-                        cl.ListOfMetaData[i].title.c_str(),
+                        title,
                         // POP DIRECTIONAL ISOLATE, exit isolated level title
                         UTF8_encode(0x2069).bytes
                     );

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -221,6 +221,10 @@ void Game::init(void)
     nocutscenes = false;
     ndmresultcrewrescued = 0;
     ndmresulttrinkets = 0;
+    ndmresulthardestroom.clear();
+    ndmresulthardestroom_x = hardestroom_x;
+    ndmresulthardestroom_y = hardestroom_y;
+    ndmresulthardestroom_specialname = false;
 
     customcol=0;
 
@@ -7798,7 +7802,10 @@ void Game::copyndmresults(void)
 {
     ndmresultcrewrescued = crewrescued();
     ndmresulttrinkets = trinkets();
-    ndmresulthardestroom = loc::gettext_roomname(false, hardestroom_x, hardestroom_y, hardestroom.c_str(), hardestroom_specialname);
+    ndmresulthardestroom = hardestroom;
+    ndmresulthardestroom_x = hardestroom_x;
+    ndmresulthardestroom_y = hardestroom_y;
+    ndmresulthardestroom_specialname = hardestroom_specialname;
     SDL_memcpy(ndmresultcrewstats, crewstats, sizeof(ndmresultcrewstats));
 }
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -359,6 +359,7 @@ public:
     bool gamesaved;
     bool gamesavefailed;
     std::string savetime;
+    int saveframes, saveseconds;
     int savetrinkets;
     bool startscript;
     std::string newscript;

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -428,6 +428,9 @@ public:
     int ndmresultcrewrescued;
     int ndmresulttrinkets;
     std::string ndmresulthardestroom;
+    int ndmresulthardestroom_x;
+    int ndmresulthardestroom_y;
+    bool ndmresulthardestroom_specialname;
     void copyndmresults(void);
 
     //Time Trials

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3361,6 +3361,11 @@ void Graphics::textboxtranslate(const TextboxTranslate translate, const TextboxF
         SDL_assert(0 && "function is NULL!");
         return;
     }
+    if (translate != TEXTTRANSLATE_FUNCTION && function != NULL)
+    {
+        SDL_assert(0 && "function provided when it won't be used!");
+        return;
+    }
 
     textboxes[m].translate = translate;
     textboxes[m].function = function;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3240,39 +3240,14 @@ void Graphics::textboxcentery(void)
 
 int Graphics::textboxwrap(int pad)
 {
-    /* This function just takes a single-line textbox and wraps it...
-     * pad = the total number of characters we are going to pad this textbox.
-     * (or how many characters we should stay clear of 288 pixels width in general)
-     * Only to be used after a manual graphics.createtextbox[flipme] call.
-     * Returns the new, total height of the textbox. */
+    // TODO: delete this function?
     if (!INBOUNDS_VEC(m, textboxes))
     {
         vlog_error("textboxwrap() out-of-bounds!");
         return 16;
     }
-    if (textboxes[m].lines.empty())
-    {
-        vlog_error("textboxwrap() has no first line!");
-        return 16;
-    }
-    std::string wrapped = font::string_wordwrap_balanced(
-        textboxes[m].print_flags,
-        textboxes[m].lines[0],
-        36 * 8 - pad * 8
-    );
-    textboxes[m].lines.clear();
 
-    size_t startline = 0;
-    size_t newline;
-    do {
-        size_t pos_n = wrapped.find('\n', startline);
-        size_t pos_p = wrapped.find('|', startline);
-        newline = SDL_min(pos_n, pos_p);
-        addline(wrapped.substr(startline, newline-startline));
-        startline = newline + 1;
-    } while (newline != std::string::npos);
-
-    return textboxes[m].h;
+    return textboxes[m].wrap(pad);
 }
 
 void Graphics::textboxpad(size_t left_pad, size_t right_pad)

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3320,6 +3320,50 @@ void Graphics::textboxbuttons(void)
     textboxes[m].fill_buttons = true;
 }
 
+void Graphics::textboxcrewmateposition(const TextboxCrewmatePosition* crewmate_position)
+{
+    if (!INBOUNDS_VEC(m, textboxes))
+    {
+        vlog_error("textboxcrewmateposition() out-of-bounds!");
+        return;
+    }
+
+    textboxes[m].crewmate_position = *crewmate_position;
+}
+
+void Graphics::textboxoriginalcontext(const TextboxOriginalContext* original_context)
+{
+    if (!INBOUNDS_VEC(m, textboxes))
+    {
+        vlog_error("textboxoriginalcontext() out-of-bounds!");
+        return;
+    }
+
+    textboxes[m].original = *original_context;
+}
+
+void Graphics::textboxcase(char text_case)
+{
+    if (!INBOUNDS_VEC(m, textboxes))
+    {
+        vlog_error("textboxcase() out-of-bounds!");
+        return;
+    }
+
+    textboxes[m].original.text_case = text_case;
+}
+
+void Graphics::textboxtranslate(void)
+{
+    if (!INBOUNDS_VEC(m, textboxes))
+    {
+        vlog_error("textboxtranslate() out-of-bounds!");
+        return;
+    }
+
+    textboxes[m].translate();
+}
+
 void Graphics::textboxcommsrelay(void)
 {
     // Special treatment for the gamestate textboxes in Comms Relay

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1495,6 +1495,17 @@ void Graphics::setlarge(bool large)
     textboxes[m].large = large;
 }
 
+void Graphics::textboxapplyposition(void)
+{
+    if (!INBOUNDS_VEC(m, textboxes))
+    {
+        vlog_error("textboxapplyposition() out-of-bounds!");
+        return;
+    }
+
+    textboxes[m].applyposition();
+}
+
 void Graphics::textboxadjust(void)
 {
     if (!INBOUNDS_VEC(m, textboxes))
@@ -3272,7 +3283,8 @@ void Graphics::textboxpad(size_t left_pad, size_t right_pad)
         return;
     }
 
-    textboxes[m].pad(left_pad, right_pad);
+    textboxes[m].spacing.pad_left = left_pad;
+    textboxes[m].spacing.pad_right = right_pad;
 }
 
 void Graphics::textboxpadtowidth(size_t new_w)
@@ -3283,7 +3295,7 @@ void Graphics::textboxpadtowidth(size_t new_w)
         return;
     }
 
-    textboxes[m].padtowidth(new_w);
+    textboxes[m].spacing.padtowidth = new_w;
 }
 
 void Graphics::textboxcentertext(void)
@@ -3294,7 +3306,7 @@ void Graphics::textboxcentertext(void)
         return;
     }
 
-    textboxes[m].centertext();
+    textboxes[m].spacing.centertext = true;
 }
 
 void Graphics::textboxprintflags(const uint32_t flags)
@@ -3342,6 +3354,25 @@ void Graphics::textboxoriginalcontext(const TextboxOriginalContext* original_con
     textboxes[m].original = *original_context;
 }
 
+void Graphics::textboxoriginalcontextauto(void)
+{
+    if (!INBOUNDS_VEC(m, textboxes))
+    {
+        vlog_error("textboxoriginalcontextauto() out-of-bounds!");
+        return;
+    }
+
+    TextboxOriginalContext context = TextboxOriginalContext();
+    context.text_case = 1;
+    context.lines = textboxes[m].lines;
+    if (script.running)
+    {
+        context.script_name = script.scriptname;
+    }
+
+    textboxes[m].original = context;
+}
+
 void Graphics::textboxcase(char text_case)
 {
     if (!INBOUNDS_VEC(m, textboxes))
@@ -3353,7 +3384,7 @@ void Graphics::textboxcase(char text_case)
     textboxes[m].original.text_case = text_case;
 }
 
-void Graphics::textboxtranslate(void)
+void Graphics::textboxtranslate(const TextboxTranslate translate, const TextboxFunction function)
 {
     if (!INBOUNDS_VEC(m, textboxes))
     {
@@ -3361,7 +3392,15 @@ void Graphics::textboxtranslate(void)
         return;
     }
 
-    textboxes[m].translate();
+    if (translate == TEXTTRANSLATE_FUNCTION && function == NULL)
+    {
+        SDL_assert(0 && "function is NULL!");
+        return;
+    }
+
+    textboxes[m].translate = translate;
+    textboxes[m].function = function;
+    textboxes[m].updatetext();
 }
 
 void Graphics::textboxcommsrelay(void)

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3344,6 +3344,8 @@ void Graphics::textboxoriginalcontextauto(void)
     {
         context.script_name = script.scriptname;
     }
+    context.x = textboxes[m].xp;
+    context.y = textboxes[m].yp;
 
     textboxes[m].original = context;
 }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3238,18 +3238,6 @@ void Graphics::textboxcentery(void)
     textboxes[m].should_centery = true;
 }
 
-int Graphics::textboxwrap(int pad)
-{
-    // TODO: delete this function?
-    if (!INBOUNDS_VEC(m, textboxes))
-    {
-        vlog_error("textboxwrap() out-of-bounds!");
-        return 16;
-    }
-
-    return textboxes[m].wrap(pad);
-}
-
 void Graphics::textboxpad(size_t left_pad, size_t right_pad)
 {
     if (!INBOUNDS_VEC(m, textboxes))

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1525,6 +1525,17 @@ int Graphics::getlinegap(void)
     return 1;
 }
 
+void Graphics::textboxindex(const int index)
+{
+    if (!INBOUNDS_VEC(m, textboxes))
+    {
+        vlog_error("textboxindex() out-of-bounds!");
+        return;
+    }
+
+    textboxes[m].other_textbox_index = index;
+}
+
 void Graphics::createtextboxreal(
     const std::string& t,
     int xp, int yp,

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3191,7 +3191,7 @@ void Graphics::textboxcenterx(void)
         return;
     }
 
-    textboxes[m].centerx();
+    textboxes[m].should_centerx = true;
 }
 
 int Graphics::textboxwidth(void)
@@ -3224,7 +3224,7 @@ void Graphics::textboxcentery(void)
         return;
     }
 
-    textboxes[m].centery();
+    textboxes[m].should_centery = true;
 }
 
 int Graphics::textboxwrap(int pad)

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1506,17 +1506,6 @@ void Graphics::textboxapplyposition(void)
     textboxes[m].applyposition();
 }
 
-void Graphics::textboxadjust(void)
-{
-    if (!INBOUNDS_VEC(m, textboxes))
-    {
-        vlog_error("textboxadjust() out-of-bounds!");
-        return;
-    }
-
-    textboxes[m].adjust();
-}
-
 void Graphics::setlinegap(int customvalue)
 {
     if (!INBOUNDS_VEC(m, textboxes))

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3367,7 +3367,21 @@ void Graphics::textboxtranslate(const TextboxTranslate translate, const TextboxF
     textboxes[m].updatetext();
 }
 
-void Graphics::textboxcommsrelay(void)
+static void commsrelay_textbox(textboxclass* THIS)
+{
+    THIS->lines.clear();
+
+    if (THIS->original.lines.empty())
+    {
+        return;
+    }
+    THIS->lines.push_back(loc::gettext(THIS->original.lines[0].c_str()));
+    THIS->wrap(11);
+    THIS->resize();
+    THIS->xp = 224 - THIS->w;
+}
+
+void Graphics::textboxcommsrelay(const char* text)
 {
     // Special treatment for the gamestate textboxes in Comms Relay
     if (!INBOUNDS_VEC(m, textboxes))
@@ -3376,8 +3390,8 @@ void Graphics::textboxcommsrelay(void)
         return;
     }
     textboxprintflags(PR_FONT_INTERFACE);
-    textboxwrap(11);
-    textboxes[m].xp = 224 - textboxes[m].w;
+    textboxes[m].original.lines.push_back(text);
+    textboxtranslate(TEXTTRANSLATE_FUNCTION, commsrelay_textbox);
 }
 
 int Graphics::crewcolour(const int t)

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -102,8 +102,6 @@ public:
 
     void textboxcentery(void);
 
-    int textboxwrap(int pad);
-
     void textboxpad(size_t left_pad, size_t right_pad);
 
     void textboxpadtowidth(size_t new_w);

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -123,7 +123,7 @@ public:
 
     void textboxtranslate(TextboxTranslate translate, TextboxFunction function);
 
-    void textboxcommsrelay(void);
+    void textboxcommsrelay(const char* text);
 
     void textboxapplyposition(void);
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -127,8 +127,6 @@ public:
 
     void textboxapplyposition(void);
 
-    void textboxadjust(void);
-
     void addline(const std::string& t);
 
     void setlarge(bool large);

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -137,6 +137,8 @@ public:
 
     void setimage(TextboxImage image);
 
+    void textboxindex(int index);
+
     void textboxremove(void);
 
     void textboxremovefast(void);

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -117,12 +117,15 @@ public:
     void textboxcrewmateposition(const TextboxCrewmatePosition* crewmate_position);
 
     void textboxoriginalcontext(const TextboxOriginalContext* original_context);
+    void textboxoriginalcontextauto(void);
 
     void textboxcase(char text_case);
 
-    void textboxtranslate(void);
+    void textboxtranslate(TextboxTranslate translate, TextboxFunction function);
 
     void textboxcommsrelay(void);
+
+    void textboxapplyposition(void);
 
     void textboxadjust(void);
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -114,6 +114,14 @@ public:
 
     void textboxbuttons(void);
 
+    void textboxcrewmateposition(const TextboxCrewmatePosition* crewmate_position);
+
+    void textboxoriginalcontext(const TextboxOriginalContext* original_context);
+
+    void textboxcase(char text_case);
+
+    void textboxtranslate(void);
+
     void textboxcommsrelay(void);
 
     void textboxadjust(void);

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -269,6 +269,16 @@ static void updatebuttonmappings(int bind)
     }
 }
 
+static void recomputetextboxes(void)
+{
+    /* Retranslate and reposition all text boxes. */
+    for (size_t i = 0; i < graphics.textboxes.size(); i++)
+    {
+        graphics.textboxes[i].updatetext();
+        graphics.textboxes[i].applyposition();
+    }
+}
+
 static void toggleflipmode(void)
 {
     graphics.setflipmode = !graphics.setflipmode;
@@ -283,6 +293,12 @@ static void toggleflipmode(void)
     {
         music.playef(Sound_VIRIDIAN);
     }
+
+    /* Some text boxes change depending on Flip Mode, so update text boxes. */
+    const bool temp = graphics.flipmode;
+    graphics.flipmode = graphics.setflipmode;
+    recomputetextboxes();
+    graphics.flipmode = temp;
 }
 
 static bool fadetomode = false;
@@ -1131,12 +1147,7 @@ static void menuactionpress(void)
 
         if (prev_lang != loc::lang)
         {
-            /* Retranslate and reposition all text boxes. */
-            for (size_t i = 0; i < graphics.textboxes.size(); i++)
-            {
-                graphics.textboxes[i].updatetext();
-                graphics.textboxes[i].applyposition();
-            }
+            recomputetextboxes();
         }
 
         game.returnmenu();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -271,7 +271,8 @@ static void updatebuttonmappings(int bind)
 
 static void recomputetextboxes(void)
 {
-    /* Retranslate and reposition all text boxes. */
+    /* Retranslate and reposition all text boxes.
+     * WARNING: Needs to update in linear order, starting from 0. */
     for (size_t i = 0; i < graphics.textboxes.size(); i++)
     {
         graphics.textboxes[i].updatetext();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1044,19 +1044,12 @@ static void menuactionpress(void)
             break;
         case 5:
             //language options
-            if (graphics.textboxes.empty())
-            {
-                music.playef(Sound_VIRIDIAN);
-                loc::loadlanguagelist();
-                loc::pre_title_lang_menu = false;
-                game.createmenu(Menu::language);
-                game.currentmenuoption = loc::languagelist_curlang;
-                map.nexttowercolour();
-            }
-            else
-            {
-                music.playef(Sound_CRY);
-            }
+            music.playef(Sound_VIRIDIAN);
+            loc::loadlanguagelist();
+            loc::pre_title_lang_menu = false;
+            game.createmenu(Menu::language);
+            game.currentmenuoption = loc::languagelist_curlang;
+            map.nexttowercolour();
             break;
         default:
             /* Return */
@@ -1115,6 +1108,8 @@ static void menuactionpress(void)
         break;
     case Menu::language:
     {
+        std::string prev_lang = std::string(loc::lang);
+
         music.playef(Sound_VIRIDIAN);
 
         if (loc::languagelist.size() != 0 && (unsigned)game.currentmenuoption < loc::languagelist.size())
@@ -1133,6 +1128,17 @@ static void menuactionpress(void)
             game.menustart = false;
             loc::pre_title_lang_menu = false;
         }
+
+        if (prev_lang != loc::lang)
+        {
+            /* Retranslate and reposition all text boxes. */
+            for (size_t i = 0; i < graphics.textboxes.size(); i++)
+            {
+                graphics.textboxes[i].translate();
+                graphics.textboxes[i].adjust(); // FIXME: not all textboxes obey the 10-pixel inner border!
+            }
+        }
+
         game.returnmenu();
         map.nexttowercolour();
         game.savestatsandsettings_menu();

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1134,8 +1134,8 @@ static void menuactionpress(void)
             /* Retranslate and reposition all text boxes. */
             for (size_t i = 0; i < graphics.textboxes.size(); i++)
             {
-                graphics.textboxes[i].translate();
-                graphics.textboxes[i].adjust(); // FIXME: not all textboxes obey the 10-pixel inner border!
+                graphics.textboxes[i].updatetext();
+                graphics.textboxes[i].applyposition();
             }
         }
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -269,7 +269,8 @@ static void updatebuttonmappings(int bind)
     }
 }
 
-static void recomputetextboxes(void)
+/* Also used in KeyPoll.cpp. */
+void recomputetextboxes(void)
 {
     /* Retranslate and reposition all text boxes.
      * WARNING: Needs to update in linear order, starting from 0. */
@@ -1131,6 +1132,8 @@ static void menuactionpress(void)
 
         if (loc::languagelist.size() != 0 && (unsigned)game.currentmenuoption < loc::languagelist.size())
         {
+            /* Update code also used in KeyPoll.cpp. */
+            loc::languagelist_curlang = game.currentmenuoption;
             loc::lang = loc::languagelist[game.currentmenuoption].code;
             loc::loadtext(false);
             loc::lang_set = true;

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1062,6 +1062,12 @@ static void menuactionpress(void)
             break;
         case 5:
             //language options
+            if (game.translator_cutscene_test)
+            {
+                music.playef(Sound_CRY);
+                break;
+            }
+
             music.playef(Sound_VIRIDIAN);
             loc::loadlanguagelist();
             loc::pre_title_lang_menu = false;

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -12,6 +12,7 @@
 #include "Graphics.h"
 #include "GraphicsUtil.h"
 #include "Localization.h"
+#include "LocalizationMaint.h"
 #include "LocalizationStorage.h"
 #include "Music.h"
 #include "Screen.h"
@@ -189,6 +190,11 @@ bool cycle_language(bool should_recompute_textboxes)
 
     if (game.gamestate == TITLEMODE)
     {
+        if (game.currentmenuname == Menu::translator_options_limitscheck)
+        {
+            loc::local_limits_check();
+        }
+
         int temp = game.menucountdown;
         game.createmenu(game.currentmenuname, true);
         game.menucountdown = temp;

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -6,6 +6,7 @@
 #include "Alloc.h"
 #include "ButtonGlyphs.h"
 #include "Constants.h"
+#include "Editor.h"
 #include "Exit.h"
 #include "Game.h"
 #include "GlitchrunnerMode.h"
@@ -188,7 +189,8 @@ bool cycle_language(bool should_recompute_textboxes)
         should_recompute_textboxes = true;
     }
 
-    if (game.gamestate == TITLEMODE)
+    if (game.gamestate == TITLEMODE
+    || (game.gamestate == EDITORMODE && ed.state == EditorState_MENU))
     {
         if (game.currentmenuname == Menu::translator_options_limitscheck)
         {

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -187,8 +187,7 @@ void KeyPoll::Poll(void)
             {
                 if (keymap[SDLK_LCTRL])
                 {
-                    /* Debug keybind to cycle language.
-                     * Not really meant to be used inside menus. */
+                    /* Debug keybind to cycle language. */
                     int i = loc::languagelist_curlang;
                     if (keymap[SDLK_LSHIFT])
                     {
@@ -210,6 +209,18 @@ void KeyPoll::Poll(void)
                         graphics.grphx.init_translations();
 
                         should_recompute_textboxes = true;
+                    }
+
+                    if (game.gamestate == TITLEMODE)
+                    {
+                        int temp = game.menucountdown;
+                        game.createmenu(game.currentmenuname, true);
+                        game.menucountdown = temp;
+
+                        if (game.currentmenuname == Menu::language)
+                        {
+                            game.currentmenuoption = i;
+                        }
                     }
                 }
                 else

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -153,6 +153,9 @@ void KeyPoll::Poll(void)
     bool fullscreenkeybind = false;
     SDL_GameController *controller = NULL;
     SDL_Event evt;
+    bool should_recompute_textboxes = false;
+    bool active_input_device_changed = false;
+    bool keyboard_was_active = BUTTONGLYPHS_keyboard_is_active();
     while (SDL_PollEvent(&evt))
     {
         switch (evt.type)
@@ -206,7 +209,7 @@ void KeyPoll::Poll(void)
                         loc::loadtext(false);
                         graphics.grphx.init_translations();
 
-                        recomputetextboxes();
+                        should_recompute_textboxes = true;
                     }
                 }
                 else
@@ -513,6 +516,13 @@ void KeyPoll::Poll(void)
     {
         mousex = raw_mousex;
         mousey = raw_mousey;
+    }
+
+    active_input_device_changed = keyboard_was_active != BUTTONGLYPHS_keyboard_is_active();
+    should_recompute_textboxes |= active_input_device_changed;
+    if (should_recompute_textboxes)
+    {
+        recomputetextboxes();
     }
 }
 

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -272,10 +272,20 @@ static void menurender(void)
                 );
                 uint32_t title_flags = cl.ListOfMetaData[tmp].title_is_gettext ? PR_FONT_INTERFACE : level_flags;
                 uint32_t creator_flags = cl.ListOfMetaData[tmp].creator_is_gettext ? PR_FONT_INTERFACE : level_flags;
+                const char* title = cl.ListOfMetaData[tmp].title.c_str();
+                if (cl.ListOfMetaData[tmp].title_is_gettext)
+                {
+                    title = loc::gettext(title);
+                }
+                const char* creator = cl.ListOfMetaData[tmp].creator.c_str();
+                if (cl.ListOfMetaData[tmp].creator_is_gettext)
+                {
+                    creator = loc::gettext(creator);
+                }
 
-                font::print(title_flags | PR_2X | PR_CEN, -1, 15, cl.ListOfMetaData[tmp].title, tr, tg, tb);
+                font::print(title_flags | PR_2X | PR_CEN, -1, 15, title, tr, tg, tb);
                 int sp = SDL_max(10, font::height(level_flags));
-                graphics.print_level_creator(creator_flags, 40, cl.ListOfMetaData[tmp].creator, tr, tg, tb);
+                graphics.print_level_creator(creator_flags, 40, creator, tr, tg, tb);
                 font::print(level_flags | PR_CEN, -1, 40+sp, cl.ListOfMetaData[tmp].website, tr, tg, tb);
                 font::print(level_flags | PR_CEN, -1, 40+sp*3, cl.ListOfMetaData[tmp].Desc1, tr, tg, tb);
                 font::print(level_flags | PR_CEN, -1, 40+sp*4, cl.ListOfMetaData[tmp].Desc2, tr, tg, tb);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -385,15 +385,8 @@ static void menurender(void)
             font::print_wrap(PR_CEN, -1, 65, loc::gettext("Disable screen effects, enable slowdown modes or invincibility."), tr, tg, tb);
             break;
         case 5:
-        {
             font::print(PR_2X | PR_CEN,  -1, 30, loc::gettext("Language"), tr, tg, tb);
-            int next_y = font::print_wrap(PR_CEN, -1, 65, loc::gettext("Change the language."), tr, tg, tb);
-
-            if (!graphics.textboxes.empty())
-            {
-                font::print_wrap(PR_CEN, -1, next_y, loc::gettext("Can not change the language while a textbox is displayed in-game."), tr, tg, tb);
-            }
-        }
+            font::print_wrap(PR_CEN, -1, 65, loc::gettext("Change the language."), tr, tg, tb);
         }
         break;
     case Menu::graphicoptions:

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1382,7 +1382,15 @@ static void menurender(void)
         font::print_wrap(PR_CEN | PR_CJK_LOW, -1, 110, buffer, tr, tg, tb);
 
         font::print(PR_CEN, -1, 145, loc::gettext("You managed to reach:"), tr, tg, tb);
-        font::print(PR_CEN | PR_CJK_LOW, -1, 155, game.ndmresulthardestroom, tr, tg, tb);
+        font::print(
+            PR_CEN | PR_CJK_LOW, -1, 155,
+            loc::gettext_roomname(
+                false,
+                game.ndmresulthardestroom_x, game.ndmresulthardestroom_y,
+                game.ndmresulthardestroom.c_str(), game.ndmresulthardestroom_specialname
+            ),
+            tr, tg, tb
+        );
 
         const char* encouragement;
         switch (game.ndmresultcrewrescued)

--- a/desktop_version/src/RoomnameTranslator.cpp
+++ b/desktop_version/src/RoomnameTranslator.cpp
@@ -271,6 +271,8 @@ namespace roomname_translator
             graphics.textboxcenterx();
             graphics.textboxtimer(50);
         }
+        graphics.textboxoriginalcontextauto();
+        graphics.textboxapplyposition();
     }
 
     static void save_translation(const char* translation)
@@ -293,6 +295,8 @@ namespace roomname_translator
             graphics.textboxcenterx();
             graphics.textboxtimer(180);
         }
+        graphics.textboxoriginalcontextauto();
+        graphics.textboxapplyposition();
     }
 
     bool held_tab = false;
@@ -349,9 +353,11 @@ namespace roomname_translator
                     if (loc::lang == "en")
                     {
                         graphics.createtextboxflipme("ERROR: Can't add EN-EN translation", -1, 176, TEXT_COLOUR("red"));
+                        graphics.textboxoriginalcontextauto();
                         graphics.textboxprintflags(PR_FONT_8X8);
                         graphics.textboxcenterx();
                         graphics.textboxtimer(50);
+                        graphics.textboxapplyposition();
                     }
                     else
                     {

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -162,6 +162,24 @@ static int getcrewmanfromname(std::string name)
 void foundtrinket_textbox1(textboxclass* THIS);
 void foundtrinket_textbox2(textboxclass* THIS);
 
+static void foundlab_textbox1(textboxclass* THIS)
+{
+    THIS->lines.clear();
+
+    THIS->lines.push_back(loc::gettext("Congratulations!\n\nYou have found the secret lab!"));
+    THIS->wrap(2);
+    THIS->centertext();
+    THIS->pad(1, 1);
+}
+
+static void foundlab_textbox2(textboxclass* THIS)
+{
+    THIS->lines.clear();
+
+    THIS->lines.push_back(loc::gettext("The secret lab is separate from the rest of the game. You can now come back here at any time by selecting the new SECRET LAB option in the play menu."));
+    THIS->wrap(0);
+}
+
 void scriptclass::run(void)
 {
     if (!running)
@@ -1816,13 +1834,12 @@ void scriptclass::run(void)
 
                 graphics.textboxremovefast();
 
-                graphics.createtextbox(loc::gettext("Congratulations!\n\nYou have found the secret lab!"), 50, 85, TEXT_COLOUR("gray"));
+                graphics.createtextbox("", 50, 85, TEXT_COLOUR("gray"));
                 graphics.textboxprintflags(PR_FONT_INTERFACE);
-                graphics.textboxwrap(2);
-                graphics.textboxcentertext();
-                graphics.textboxpad(1, 1);
                 graphics.textboxcenterx();
                 graphics.textboxcentery();
+                graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, foundlab_textbox1);
+                graphics.textboxapplyposition();
 
                 if (!game.backgroundtext)
                 {
@@ -1838,11 +1855,12 @@ void scriptclass::run(void)
             {
                 graphics.textboxremovefast();
 
-                graphics.createtextbox(loc::gettext("The secret lab is separate from the rest of the game. You can now come back here at any time by selecting the new SECRET LAB option in the play menu."), 50, 85, TEXT_COLOUR("gray"));
+                graphics.createtextbox("", 50, 85, TEXT_COLOUR("gray"));
                 graphics.textboxprintflags(PR_FONT_INTERFACE);
-                graphics.textboxwrap(0);
                 graphics.textboxcenterx();
                 graphics.textboxcentery();
+                graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, foundlab_textbox2);
+                graphics.textboxapplyposition();
 
                 if (!game.backgroundtext)
                 {

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -158,6 +158,10 @@ static int getcrewmanfromname(std::string name)
 }
 
 
+/* Also used in gamestate 1001. */
+void foundtrinket_textbox1(textboxclass* THIS);
+void foundtrinket_textbox2(textboxclass* THIS);
+
 void scriptclass::run(void)
 {
     if (!running)
@@ -1783,37 +1787,18 @@ void scriptclass::run(void)
 
                 graphics.textboxremovefast();
 
-                graphics.createtextboxflipme(loc::gettext("Congratulations!\n\nYou have found a shiny trinket!"), 50, 85, TEXT_COLOUR("gray"));
+                graphics.createtextboxflipme("", 50, 85, TEXT_COLOUR("gray"));
                 graphics.textboxprintflags(PR_FONT_INTERFACE);
-                int h = graphics.textboxwrap(2);
-                graphics.textboxcentertext();
-                graphics.textboxpad(1, 1);
                 graphics.textboxcenterx();
+                graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, foundtrinket_textbox1);
+                graphics.textboxapplyposition();
 
-                int max_trinkets;
-
-                if (map.custommode)
-                {
-                    max_trinkets = cl.numtrinkets();
-                }
-                else
-                {
-                    max_trinkets = 20;
-                }
-
-                char buffer[SCREEN_WIDTH_CHARS + 1];
-                vformat_buf(
-                    buffer, sizeof(buffer),
-                    loc::gettext("{n_trinkets|wordy} out of {max_trinkets|wordy}"),
-                    "n_trinkets:int, max_trinkets:int",
-                    game.trinkets(), max_trinkets
-                );
-                graphics.createtextboxflipme(buffer, 50, 95+h, TEXT_COLOUR("gray"));
+                graphics.createtextboxflipme("", 50, 95, TEXT_COLOUR("gray"));
                 graphics.textboxprintflags(PR_FONT_INTERFACE);
-                graphics.textboxwrap(2);
-                graphics.textboxcentertext();
-                graphics.textboxpad(1, 1);
                 graphics.textboxcenterx();
+                graphics.textboxindex(graphics.textboxes.size() - 2);
+                graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, foundtrinket_textbox2);
+                graphics.textboxapplyposition();
 
                 if (!game.backgroundtext)
                 {

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -569,6 +569,8 @@ void scriptclass::run(void)
                         textcrewmateposition.text_above = true;
                     }
 
+                    textx = 0;
+                    texty = 0;
                     textcrewmateposition.x = obj.entities[i].xp;
                     textcrewmateposition.override_x = true;
                     textcrewmateposition.y = obj.entities[i].yp;
@@ -653,6 +655,8 @@ void scriptclass::run(void)
                         textcrewmateposition.text_above = true;
                     }
 
+                    textx = 0;
+                    texty = 0;
                     textcrewmateposition.x = obj.entities[i].xp;
                     textcrewmateposition.override_x = true;
                     textcrewmateposition.y = obj.entities[i].xp;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -764,7 +764,7 @@ void scriptclass::run(void)
                     }
                     graphics.textboxprintflags(flags);
                 }
-                graphics.textboxtranslate();
+                graphics.textboxtranslate(TEXTTRANSLATE_CUTSCENE, NULL);
 
                 graphics.textboxadjust();
                 if (words[0] == "speak_active")

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -773,6 +773,8 @@ void scriptclass::run(void)
                 context.text_case = textcase;
                 context.lines = std::vector<std::string>(txt);
                 context.script_name = scriptname;
+                context.x = textx;
+                context.y = texty;
 
                 graphics.textboxcrewmateposition(&textcrewmateposition);
                 graphics.textboxoriginalcontext(&context);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -766,7 +766,7 @@ void scriptclass::run(void)
                 }
                 graphics.textboxtranslate(TEXTTRANSLATE_CUTSCENE, NULL);
 
-                graphics.textboxadjust();
+                graphics.textboxapplyposition();
                 if (words[0] == "speak_active")
                 {
                     graphics.textboxactive();

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -811,6 +811,8 @@ void scriptclass::run(void)
                     graphics.textboxbuttons();
                 }
                 textbuttons = false;
+
+                textcase = 1;
             }
             else if (words[0] == "endtext")
             {

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -91,8 +91,6 @@ public:
 
     void run(void);
 
-    void translate_dialogue(void);
-
     void startgamemode(enum StartMode mode);
 
     void teleport(void);
@@ -114,12 +112,10 @@ public:
     std::map<std::string, SDL_Color> textbox_colours;
     int textx;
     int texty;
+    TextboxCrewmatePosition textcrewmateposition;
+    TextboxOriginalContext textoriginalcontext;
     int r,g,b;
     bool textflipme;
-    bool textcentertext;
-    size_t textpad_left;
-    size_t textpad_right;
-    size_t textpadtowidth;
     char textcase;
     bool textbuttons;
     bool textlarge;

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -28,6 +28,9 @@ textboxclass::textboxclass(int gap)
 
     large = false;
 
+    should_centerx = false;
+    should_centery = false;
+
     print_flags = PR_FONT_LEVEL;
     fill_buttons = false;
 
@@ -72,6 +75,14 @@ void textboxclass::adjust(void)
 {
     resize();
     repositionfromcrewmate();
+    if (should_centerx)
+    {
+        centerx();
+    }
+    if (should_centery)
+    {
+        centery();
+    }
     if (xp < 10) xp = 10;
     if (yp < 10) yp = 10;
     if (xp + w > 310) xp = 310 - w;

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -78,7 +78,7 @@ void textboxclass::centery(void)
 void textboxclass::applyposition(void)
 {
     resize();
-    repositionfromcrewmate();
+    reposition();
     if (should_centerx)
     {
         centerx();
@@ -165,11 +165,18 @@ void textboxclass::resize(void)
     h = lines.size()*(font::height(print_flags) + linegap) + 16 - linegap;
 }
 
-void textboxclass::repositionfromcrewmate(void)
+void textboxclass::reposition(void)
 {
+    // Function-based translation overrides position.
+    if (translate == TEXTTRANSLATE_FUNCTION)
+    {
+        return;
+    }
+
     const int font_height = font::height(print_flags);
 
     // Reposition based off crewmate position, if applicable
+    // Otherwise use original position, if applicable
     if (crewmate_position.override_x)
     {
         if (crewmate_position.dir == 1) // left
@@ -181,6 +188,11 @@ void textboxclass::repositionfromcrewmate(void)
             xp = crewmate_position.x - 16;
         }
     }
+    else
+    {
+        xp = original.x;
+    }
+
     if (crewmate_position.override_y)
     {
         if (crewmate_position.text_above)
@@ -198,6 +210,10 @@ void textboxclass::repositionfromcrewmate(void)
         {
             yp = crewmate_position.y + 26;
         }
+    }
+    else
+    {
+        yp = original.y;
     }
 }
 

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -45,6 +45,8 @@ textboxclass::textboxclass(int gap)
     original = TextboxOriginalContext();
     original.text_case = 1;
     spacing = TextboxSpacing();
+
+    other_textbox_index = -1;
 }
 
 void textboxclass::addsprite(int x, int y, int tile, int col)

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -274,7 +274,7 @@ void textboxclass::centertext(void)
     padtowidth(w-16);
 }
 
-int textboxclass::wrap(int pad)
+void textboxclass::wrap(int pad)
 {
     /* This function just takes a single-line textbox and wraps it...
      * pad = the total number of characters we are going to pad this textbox.
@@ -285,7 +285,7 @@ int textboxclass::wrap(int pad)
     if (lines.empty())
     {
         vlog_error("textboxclass::wrap() has no first line!");
-        return 16;
+        return;
     }
 
     std::string wrapped = font::string_wordwrap_balanced(
@@ -304,8 +304,6 @@ int textboxclass::wrap(int pad)
         addline(wrapped.substr(startline, newline-startline));
         startline = newline + 1;
     } while (newline != std::string::npos);
-
-    return h;
 }
 
 void textboxclass::copyoriginaltext(void)

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -239,8 +239,12 @@ void textboxclass::translate(void)
 {
     if (!loc::is_cutscene_translated(original.script_name))
     {
-        // Copy the original back
-        lines = std::vector<std::string>(original.lines);
+        // Copy the original back, but keep the limit of lines in mind
+        lines.clear();
+        for (size_t i = 0; i < original.lines.size(); i++)
+        {
+            addline(original.lines[i]);
+        }
         return;
     }
 

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -399,6 +399,8 @@ void textboxclass::translatecutscene(void)
     }
     while (newline != std::string::npos);
 
+    resize();
+
     if (format->centertext)
     {
         centertext();

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -87,12 +87,15 @@ void textboxclass::applyposition(void)
     {
         centery();
     }
+    if (translate == TEXTTRANSLATE_CUTSCENE)
+    {
+        adjust();
+    }
 }
 
 void textboxclass::adjust(void)
 {
     resize();
-    applyposition();
     if (xp < 10) xp = 10;
     if (yp < 10) yp = 10;
     if (xp + w > 310) xp = 310 - w;

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -66,13 +66,11 @@ void textboxclass::centerx(void)
 {
     resize();
     xp = 160 - (w / 2);
-    resize();
 }
 void textboxclass::centery(void)
 {
     resize();
     yp = 120 - (h / 2);
-    resize();
 }
 
 void textboxclass::applyposition(void)
@@ -100,7 +98,6 @@ void textboxclass::adjust(void)
     if (yp < 10) yp = 10;
     if (xp + w > 310) xp = 310 - w;
     if (yp + h > 230) yp = 230 - h;
-    resize();
 }
 
 void textboxclass::initcol(int rr, int gg, int bb)

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -94,6 +94,9 @@ public:
 
     bool large;
 
+    bool should_centerx;
+    bool should_centery;
+
     uint32_t print_flags;
     bool fill_buttons;
 

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -19,6 +19,8 @@ struct TextboxCrewmatePosition
 
 struct TextboxOriginalContext
 {
+    int x;
+    int y;
     std::vector<std::string> lines;
     std::string script_name;
     char text_case;
@@ -85,7 +87,7 @@ public:
 
     void resize(void);
 
-    void repositionfromcrewmate(void);
+    void reposition(void);
 
     void addline(const std::string& t);
 

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -95,6 +95,8 @@ public:
 
     void centertext(void);
 
+    int wrap(int pad);
+
     void copyoriginaltext(void);
 
     void applyoriginalspacing(void);

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -137,6 +137,8 @@ public:
     TextboxOriginalContext original;
     TextboxSpacing spacing;
     TextboxFunction function;
+
+    int other_textbox_index;
 };
 
 #endif /* TEXTBOX_H */

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -5,6 +5,25 @@
 #include <string>
 #include <vector>
 
+/* Position of the crewmate that the text box position is based off of.
+ * NOT a crewmate sprite inside the text box (that's a TextboxSprite). */
+struct TextboxCrewmatePosition
+{
+    bool override_x;
+    bool override_y;
+    int x;
+    int y;
+    int dir;
+    bool text_above;
+};
+
+struct TextboxOriginalContext
+{
+    std::vector<std::string> lines;
+    std::string script_name;
+    char text_case;
+};
+
 struct TextboxSprite
 {
     int x;
@@ -45,6 +64,8 @@ public:
 
     void resize(void);
 
+    void repositionfromcrewmate(void);
+
     void addline(const std::string& t);
 
     void pad(size_t left_pad, size_t right_pad);
@@ -52,6 +73,8 @@ public:
     void padtowidth(size_t new_w);
 
     void centertext(void);
+
+    void translate(void);
 public:
     //Fundamentals
     std::vector<std::string> lines;
@@ -76,6 +99,9 @@ public:
 
     std::vector<TextboxSprite> sprites;
     TextboxImage image;
+
+    TextboxCrewmatePosition crewmate_position;
+    TextboxOriginalContext original;
 };
 
 #endif /* TEXTBOX_H */

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -24,6 +24,15 @@ struct TextboxOriginalContext
     char text_case;
 };
 
+/* Similar to, but NOT the same as a loc::TextboxFormat. */
+struct TextboxSpacing
+{
+    bool centertext;
+    unsigned char pad_left;
+    unsigned char pad_right;
+    unsigned short padtowidth;
+};
+
 struct TextboxSprite
 {
     int x;
@@ -39,6 +48,16 @@ enum TextboxImage
     TEXTIMAGE_GAMECOMPLETE
 };
 
+enum TextboxTranslate
+{
+    TEXTTRANSLATE_NONE,
+    TEXTTRANSLATE_CUTSCENE,
+    TEXTTRANSLATE_FUNCTION
+};
+
+class textboxclass;
+typedef void (*TextboxFunction)(textboxclass* THIS);
+
 class textboxclass
 {
 public:
@@ -51,6 +70,8 @@ public:
     void centerx(void);
 
     void centery(void);
+
+    void applyposition(void);
 
     void adjust(void);
 
@@ -74,7 +95,13 @@ public:
 
     void centertext(void);
 
-    void translate(void);
+    void copyoriginaltext(void);
+
+    void applyoriginalspacing(void);
+
+    void updatetext(void);
+
+    void translatecutscene(void);
 public:
     //Fundamentals
     std::vector<std::string> lines;
@@ -98,6 +125,7 @@ public:
     bool should_centery;
 
     uint32_t print_flags;
+    TextboxTranslate translate;
     bool fill_buttons;
 
     std::vector<TextboxSprite> sprites;
@@ -105,6 +133,8 @@ public:
 
     TextboxCrewmatePosition crewmate_position;
     TextboxOriginalContext original;
+    TextboxSpacing spacing;
+    TextboxFunction function;
 };
 
 #endif /* TEXTBOX_H */

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -97,7 +97,7 @@ public:
 
     void centertext(void);
 
-    int wrap(int pad);
+    void wrap(int pad);
 
     void copyoriginaltext(void);
 


### PR DESCRIPTION
Previously, there used to be a bug where if you switched languages while a text box was open, the text box wouldn't update and would stay in the original language. This is because the text box translation was baked and couldn't be retranslated on-the-fly.

A kludge solution to this was implemented by disabling switching language with a text box open. However, a proper solution is to un-bake the translations and to retranslate them on-the-fly.

To do this, relevant state is saved for each text box, depending on the type of text box.

- Untranslated: Nothing.
- Cutscene: The original position and facing direction of the crewmate is saved, if the text box is positioned with respect to a crewmate. Additionally, the X and Y axes are independent of each other and can be overridden (or not) depending on the previous script commands issued.
- All other text boxes: Use a function to retranslate the text box on-the-fly. This function must handle the padding, wrapping, and text centering.

All text boxes will save the state of their original position (without considering centering or crewmate position) and if they are individually centered on the X and Y axis or not (which can be overridden by crewmate position).

Additionally, a debug keybind has been added, CTRL+F8, to immediately cycle the current language (except inside a cutscene test and the cutscene test list menu, which are inherently language XML-specific). CTRL+SHIFT+F8 cycles the language backwards. This keybind is only enabled if the translator menu is also enabled. I've also made sure that this works within the title screen menus (even though it wasn't possible to immediately switch the language in a menu before).

With being able to retranslate text boxes on-the-fly, this PR also fixes the following bugs:

- The Intermission 1 instructions don't update when toggling Flip Mode (they say "floor" or "ceiling" depending on Flip Mode).
- The "Press ACTION to continue" text box doesn't update when the active input device is switched from keyboard to controller, or vice versa.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
