### PR TITLE
Implement scaling modes manually

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3492,8 +3492,8 @@ void Graphics::get_stretch_info(SDL_Rect* rect)
         rect->y = (height - SCREEN_HEIGHT_PIXELS * scale) / 2;
         rect->w = SCREEN_WIDTH_PIXELS * scale;
         rect->h = SCREEN_HEIGHT_PIXELS * scale;
+        break;
     }
-    break;
     case SCALING_LETTERBOX:
         if (width * SCREEN_HEIGHT_PIXELS > height * SCREEN_WIDTH_PIXELS)
         {

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -258,6 +258,10 @@ public:
     int screenshake_x;
     int screenshake_y;
 
+    void draw_window_background(void);
+
+    void get_stretch_info(SDL_Rect* rect);
+
     void render(void);
     void renderwithscreeneffects(void);
     void renderfixedpre(void);

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -548,21 +548,11 @@ void KeyPoll::Poll(void)
         toggleFullscreen();
     }
 
-    if (gameScreen.scalingMode == SCALING_STRETCH)
-    {
-        /* In this mode specifically, we have to fix the mouse coordinates */
-        int actualscreenwidth;
-        int actualscreenheight;
-        gameScreen.GetScreenSize(&actualscreenwidth, &actualscreenheight);
+    SDL_Rect rect;
+    graphics.get_stretch_info(&rect);
 
-        mousex = raw_mousex * SCREEN_WIDTH_PIXELS / actualscreenwidth;
-        mousey = raw_mousey * SCREEN_HEIGHT_PIXELS / actualscreenheight;
-    }
-    else
-    {
-        mousex = raw_mousex;
-        mousey = raw_mousey;
-    }
+    mousex = (raw_mousex - rect.x) * SCREEN_WIDTH_PIXELS / rect.w;
+    mousey = (raw_mousey - rect.y) * SCREEN_HEIGHT_PIXELS / rect.h;
 
     active_input_device_changed = keyboard_was_active != BUTTONGLYPHS_keyboard_is_active();
     should_recompute_textboxes |= active_input_device_changed;

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -247,39 +247,8 @@ void Screen::GetScreenSize(int* x, int* y)
     }
 }
 
-void Screen::UpdateScaling(void)
-{
-    int width;
-    int height;
-    if (scalingMode == SCALING_STRETCH)
-    {
-        GetScreenSize(&width, &height);
-    }
-    else
-    {
-        width = SCREEN_WIDTH_PIXELS;
-        height = SCREEN_HEIGHT_PIXELS;
-    }
-    int result = SDL_RenderSetLogicalSize(m_renderer, width, height);
-    if (result != 0)
-    {
-        vlog_error("Error: could not set logical size: %s", SDL_GetError());
-        return;
-    }
-
-    result = SDL_RenderSetIntegerScale(m_renderer, (SDL_bool) (scalingMode == SCALING_INTEGER));
-    if (result != 0)
-    {
-        vlog_error("Error: could not set scale: %s", SDL_GetError());
-    }
-}
-
 void Screen::RenderPresent(void)
 {
-    /* In certain cases, the window size might mismatch with the logical size.
-     * So it's better to just always call this. */
-    UpdateScaling();
-
     SDL_RenderPresent(m_renderer);
     graphics.clear();
 }
@@ -299,7 +268,6 @@ void Screen::toggleFullScreen(void)
 void Screen::toggleScalingMode(void)
 {
     scalingMode = (scalingMode + 1) % NUM_SCALING_MODES;
-    UpdateScaling();
 }
 
 void Screen::toggleLinearFilter(void)

--- a/desktop_version/src/Screen.h
+++ b/desktop_version/src/Screen.h
@@ -19,7 +19,6 @@ public:
     void ResizeToNearestMultiple(void);
     void GetScreenSize(int* x, int* y);
 
-    void UpdateScaling(void);
     void RenderPresent(void);
 
     void toggleFullScreen(void);


### PR DESCRIPTION
## Changes:

For future PRs, it'll be very nice to have full control over how VVVVVV gets drawn to the window. This means we can use the entire window size for things like touch input, drawing borders, or anything we want.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
