### PR TITLE
Minor language file maintenance: sync Spanish LATAM&ARG, translate proxy strings into Dutch, add missing spaces in Welsh

### DIFF
--- a/desktop_version/lang/cy/strings.xml
+++ b/desktop_version/lang/cy/strings.xml
@@ -569,7 +569,7 @@
     <string english="PLATFORM BOUNDS: Click on the last corner" translation="FFINIAU LLWYFAN: Cliciwch ar y gornel olaf" explanation="editor, invisible box which moving platforms always stay inside of" max="39*3"/>
     <string english="Click on the first corner" translation="Cliciwch ar y gornel gyntaf" explanation="" max="39*3"/>
     <string english="Click on the last corner" translation="Cliciwch ar y gornel olaf" explanation="" max="39*3"/>
-    <string english="**** VVVVVV SCRIPT EDITOR ****" translation="****VVVVVV GOLYGYDD SGRIPT****" explanation="supposed to look like a Commodore 64 screen" max="36"/>
+    <string english="**** VVVVVV SCRIPT EDITOR ****" translation="**** VVVVVV GOLYGYDD SGRIPT ****" explanation="supposed to look like a Commodore 64 screen" max="36"/>
     <string english="PRESS ESC TO RETURN TO MENU" translation="ESC I DDYCHWELYD I&apos;R DDEWISLEN" explanation="Commodore 64-style script editor, TO MENU is redundant" max="36"/>
     <string english="NO SCRIPT IDS FOUND" translation="DIM SGRIPT IDS WEDI&apos;I FFEINDIO" explanation="Commodore 64-style script editor, basically NO SCRIPTS FOUND" max="36"/>
     <string english="CREATE A SCRIPT WITH EITHER THE TERMINAL OR SCRIPT BOX TOOLS" translation="CREU SGRIPT GYDA NAILL AI&apos;R TERFYNOL NEU&apos;R OFFER BLWCH SGRIPT" explanation="Commodore 64-style script editor" max="36*5"/>

--- a/desktop_version/lang/es_419/cutscenes.xml
+++ b/desktop_version/lang/es_419/cutscenes.xml
@@ -76,10 +76,9 @@
     <cutscene id="bigopenworldskip" explanation="">
         <dialogue speaker="purple" english="I&apos;ll be right here if you need any help!" translation="Si necesitas ayuda, ¡aquí me tienes!"/>
     </cutscene>
-    <cutscene id="talkpurple_intro" explanation="***ENTER is OUTDATED***">
+    <cutscene id="talkpurple_intro" explanation="">
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Siento que me gana el agobio, doctora."/>
         <dialogue speaker="player" english="Where do I begin?" translation="¿Por dónde empiezo?"/>
-        <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="¡Recuerda que puedes pulsar la tecla ENTRAR para comprobar tu posición en el mapa!"/>
         <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="¡Recuerda que puedes oprimir {b_map} para comprobar tu posición en el mapa!" buttons="1"/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Busca lugares donde pueda estar el resto de la tripulación..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Si te pierdes, puedes volver a la nave desde cualquier teletransportador."/>

--- a/desktop_version/lang/es_419/meta.xml
+++ b/desktop_version/lang/es_419/meta.xml
@@ -26,6 +26,9 @@
     <!-- When automatically uppercasing, allow ~ to be used to stop the next letter from being uppercased (for Irish) -->
     <toupper_lower_escape_char>0</toupper_lower_escape_char>
 
+    <!-- Enable for RTL languages like Arabic or Hebrew -->
+    <rtl>0</rtl>
+
     <!-- The indication that a certain menu option or button is selected -->
     <menu_select>[ {label} ]</menu_select>
     <menu_select_tight>[{label}]</menu_select_tight>

--- a/desktop_version/lang/es_419/strings.xml
+++ b/desktop_version/lang/es_419/strings.xml
@@ -317,6 +317,9 @@
     <string english="Currently ENABLED!" translation="¡Está ACTIVADO!" explanation="flip mode" max="38*3"/>
     <string english="Currently Disabled." translation="Está DESACTIVADO." explanation="flip mode" max="38*3"/>
     <string english="TO UNLOCK: Complete the game." translation="Para desbloquear: Completa el juego." explanation="" max="38*3"/>
+    <string english="Invincibility mode enabled" translation="" explanation="in-game message" max="39"/>
+    <string english="Glitchrunner mode enabled ({version})" translation="" explanation="in-game message" max="39"/>
+    <string english="Flip Mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="Are you sure you want to quit?" translation="¿Confirmas que quieres salir?" explanation="quit the program" max="38*4"/>
     <string english="GAME OVER" translation="FIN PARTIDA" explanation="bigger title" max="13"/>
     <string english="You managed to reach:" translation="Llegaste hasta:" explanation="you managed to reach the following room" max="40"/>
@@ -428,15 +431,13 @@
     <string english="To install new player levels, copy the .vvvvvv files to the levels folder." translation="Para instalar niveles personalizados, copia los archivos .vvvvvv en la carpeta &quot;levels&quot;." explanation="" max="38*5"/>
     <string english="Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming." translation="¿Confirmas que quieres mostrar la ruta de los niveles? Esta opción podría revelar información delicada si estás transmitiendo en directo." explanation="" max="38*4"/>
     <string english="The levels path is:" translation="La ruta de los niveles es:" explanation="" max="40"/>
-    <string english="[ Press ACTION to Start ]" translation="[ Oprime ACCIÓN para empezar ]" explanation="***OUTDATED***" max="38*2"/>
     <string english="[ Press {button} to Start ]" translation="[ Oprime {button} para empezar ]" explanation="title screen. Expect `ACTION`" max="38*2"/>
     <string english="ACTION = Space, Z, or V" translation="ACCIÓN = Espacio, Z o V" explanation="title screen" max="38*3"/>
-    <string english="[Press ENTER to return to editor]" translation="[Oprime ENTRAR para volver al editor]" explanation="***OUTDATED***" max="40"/>
     <string english="[Press {button} to return to editor]" translation="[Oprime {button} para volver al editor]" explanation="`to editor` is sorta redundant" max="40"/>
-    <string english="- Press ACTION to advance text -" translation="- Oprime ACCIÓN para avanzar el texto -" explanation="***OUTDATED***" max="40"/>
     <string english="- Press {button} to advance text -" translation="- Oprime {button} para avanzar el texto -" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
-    <string english="Press ACTION to continue" translation="Oprime ACCIÓN para continuar" explanation="***OUTDATED***" max="34"/>
     <string english="Press {button} to continue" translation="Oprime {button} para continuar" explanation="Expect `ACTION`" max="34"/>
+    <string english="[Press {button} to unfreeze gameplay]" translation="" explanation="in level debugger: {button} makes everything start moving as normal. Limit is treacherous, expect TAB for {button}. Frozen is the initial state, so this is the first string of the two that users will see!" max="39"/>
+    <string english="[Press {button} to freeze gameplay]" translation="" explanation="in level debugger: {button} makes everything stop moving. Limit is treacherous, expect TAB for {button}." max="39"/>
     <string english="Current Time" translation="Tiempo actual" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="Mejor tiempo" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="Siguiente trofeo en 5 segundos" explanation="" max="38*2"/>
@@ -448,7 +449,6 @@
     <string english="All Trophies collected!" translation="¡Conseguiste todos los trofeos!" explanation="" max="38*2"/>
     <string english="New Record!" translation="¡Nuevo récord!" explanation="" max="20"/>
     <string english="New Trophy!" translation="¡Nuevo trofeo!" explanation="" max="20"/>
-    <string english="[Press ENTER to stop]" translation="[Oprime ENTRAR para parar]" explanation="***OUTDATED***" max="40"/>
     <string english="[Press {button} to stop]" translation="[Oprime {button} para parar]" explanation="stop super gravitron" max="40"/>
     <string english="SUPER GRAVITRON" translation="SUPERGRAVITRÓN" explanation="" max="20"/>
     <string english="SUPER GRAVITRON HIGHSCORE" translation="PUNTUACIÓN MÁXIMA EN SUPERGRAVITRÓN" explanation="" max="38*4"/>
@@ -462,7 +462,6 @@
     <string english="[ QUIT ]" translation="[ SALIR ]" explanation="in-game menu" max="40"/>
     <string english="[ GRAVITRON ]" translation="[ GRAVITRÓN ]" explanation="in-game menu" max="40"/>
     <string english="NO SIGNAL" translation="SIN SEÑAL" explanation="map screen. So like a TV/computer monitor" max="29"/>
-    <string english="Press ACTION to warp to the ship." translation="Oprime ACCIÓN para teletransportarte a la nave." explanation="***OUTDATED***" max="38*7"/>
     <string english="Press {button} to warp to the ship." translation="{button}: teletransportarte a la nave" explanation="spaceship. Warp = teleport. Expect `ACTION`" max="38*7"/>
     <string english="Missing..." translation="No está..." case="1" explanation="this male crew member is missing" max="15"/>
     <string english="Missing..." translation="No está..." case="2" explanation="this female crew member is missing" max="15"/>
@@ -477,7 +476,6 @@
     <string english="ERROR: Could not save game!" translation="ERROR: ¡No se puedo guardar la partida!" explanation="in-game menu" max="34*2"/>
     <string english="ERROR: Could not save settings file!" translation="ERROR: ¡No se pudo guardar el archivo de ajustes!" explanation="" max="38*2"/>
     <string english="Game saved ok!" translation="¡Se guardó la partida guardada!" explanation="in-game menu" max="38*2"/>
-    <string english="[Press ACTION to save your game]" translation="[Oprime ACCIÓN para guardar la partida]" explanation="***OUTDATED***" max="40"/>
     <string english="[Press {button} to save your game]" translation="[Oprime {button} para guardar la partida]" explanation="in-game menu. Expect `ACTION`" max="40"/>
     <string english="(Note: The game is autosaved at every teleporter.)" translation="(Nota: La partida se guarda automáticamente en cada teletransportador)." explanation="in-game menu" max="38*3"/>
     <string english="Last Save:" translation="Último guardado:" explanation="in-game menu" max="40"/>
@@ -563,21 +561,13 @@
     <string english="Untitled Level" translation="Nivel sin nombre" explanation="" max="20"/>
     <string english="Unknown" translation="Desconocido" explanation="by Unknown [author]"/>
     <string english="Tile:" translation="Casilla:" explanation="editor, selected " max="34"/>
-    <string english="SCRIPT BOX: Click on top left" translation="CAJA DE SCRIPT: clic en parte superior izquierda" explanation="***OUTDATED***"/>
     <string english="SCRIPT BOX: Click on the first corner" translation="CAJA SCRIPT: clic en primera esquina" explanation="editor, a script box is an invisible box that runs a script when touched" max="39*3"/>
-    <string english="SCRIPT BOX: Click on bottom right" translation="CAJA DE SCRIPT: clic en parte inferior derecha" explanation="***OUTDATED***"/>
     <string english="SCRIPT BOX: Click on the last corner" translation="CAJA SCRIPT: clic en última esquina" explanation="editor, a script box is an invisible box that runs a script when touched" max="39*3"/>
-    <string english="ENEMY BOUNDS: Click on top left" translation="LÍMITES DE ENEMIGO: clic en parte superior izquierda" explanation="***OUTDATED***"/>
     <string english="ENEMY BOUNDS: Click on the first corner" translation="LÍMITES DE ENEMIGO: clic en primera esquina" explanation="editor, invisible box which enemies always stay inside of" max="39*3"/>
-    <string english="ENEMY BOUNDS: Click on bottom right" translation="LÍMITES DE ENEMIGO: clic en parte inferior derecha" explanation="***OUTDATED***"/>
     <string english="ENEMY BOUNDS: Click on the last corner" translation="LÍMITES DE ENEMIGO: clic en última esquina" explanation="editor, invisible box which enemies always stay inside of" max="39*3"/>
-    <string english="PLATFORM BOUNDS: Click on top left" translation="LÍMITES DE PLATAFORMA: clic en parte superior izquierda" explanation="***OUTDATED***"/>
     <string english="PLATFORM BOUNDS: Click on the first corner" translation="LÍMITES DE PLATAFORMA: clic en primera esquina" explanation="editor, invisible box which moving platforms always stay inside of" max="39*3"/>
-    <string english="PLATFORM BOUNDS: Click on bottom right" translation="LÍMITES DE PLATAFORMA: clic en parte inferior derecha" explanation="***OUTDATED***"/>
     <string english="PLATFORM BOUNDS: Click on the last corner" translation="LÍMITES DE PLATAFORMA: clic en última esquina" explanation="editor, invisible box which moving platforms always stay inside of" max="39*3"/>
-    <string english="Click on top left" translation="Clic en parte superior izquierda" explanation="***OUTDATED***"/>
     <string english="Click on the first corner" translation="Clic en primera esquina" explanation="" max="39*3"/>
-    <string english="Click on bottom right" translation="Clic en parte inferior derecha" explanation="***OUTDATED***"/>
     <string english="Click on the last corner" translation="Clic en última esquina" explanation="" max="39*3"/>
     <string english="**** VVVVVV SCRIPT EDITOR ****" translation="*** EDITOR DE SCRIPTS DE VVVVVV ***" explanation="supposed to look like a Commodore 64 screen" max="36"/>
     <string english="PRESS ESC TO RETURN TO MENU" translation="PULSA ESC PARA VOLVER AL MENÚ" explanation="Commodore 64-style script editor, TO MENU is redundant" max="36"/>
@@ -591,25 +581,17 @@
     <string english="2: Backing" translation="2: Fondos" explanation="editor tool. Non-solid background tiles" max="32"/>
     <string english="3: Spikes" translation="3: Pinchos" explanation="editor tool" max="32"/>
     <string english="4: Trinkets" translation="4: Baratijas" explanation="editor tool. Shiny trinkets/collectibles" max="32"/>
-    <string english="5: Checkpoint" translation="5: Punto de control" explanation="***OUTDATED***"/>
     <string english="5: Checkpoints" translation="5: Puntos de control" explanation="editor tool. You restart at the last checkpoint after death" max="32"/>
-    <string english="6: Disappear" translation="6: Plataforma fugaz" explanation="***OUTDATED***"/>
     <string english="6: Disappearing Platforms" translation="6: Plataformas fugaces" explanation="editor tool. Platform that disappears when you step on it (disappearing platform, crumbling platform)" max="32"/>
     <string english="7: Conveyors" translation="7: Cinta transportadora" explanation="editor tool. Conveyor belt" max="32"/>
-    <string english="8: Moving" translation="8: Plataforma móvil" explanation="***OUTDATED***"/>
     <string english="8: Moving Platforms" translation="8: Plataformas móviles" explanation="editor tool. Moving platform" max="32"/>
     <string english="9: Enemies" translation="9: Enemigos" explanation="editor tool" max="32"/>
-    <string english="0: Grav Line" translation="0: Línea de gravedad" explanation="***OUTDATED***"/>
     <string english="0: Gravity Lines" translation="0: Líneas de gravedad" explanation="editor tool. Gravity line, which flips your gravity when touching it" max="32"/>
     <string english="R: Roomtext" translation="R: Textos en la sala" explanation="editor tool. Freely typed text, consider just Text" max="32"/>
-    <string english="T: Terminal" translation="T: Terminal" explanation="***OUTDATED***"/>
     <string english="T: Terminals" translation="T: Terminales" explanation="editor tool. Computer which can be activated by the player to run a script" max="32"/>
-    <string english="Y: Script Box" translation="Y: Caja de script" explanation="***OUTDATED***"/>
     <string english="Y: Script Boxes" translation="Y: Cajas script" explanation="editor tool. Invisible box that runs a script when touched" max="32"/>
-    <string english="U: Warp Token" translation="U: Portal" explanation="***OUTDATED***"/>
     <string english="U: Warp Tokens" translation="U: Portales" explanation="editor tool. Small teleporter with entrance and destination" max="32"/>
     <string english="I: Warp Lines" translation="I: Líneas cíclicas" explanation="editor tool. Makes a room edge be connected to its opposite edge" max="32"/>
-    <string english="O: Crewmate" translation="O: Tripulante" explanation="***OUTDATED***"/>
     <string english="O: Crewmates" translation="O: Tripulantes" explanation="editor tool. Crewmate that can be rescued" max="32"/>
     <string english="P: Start Point" translation="P: Punto de inicio" explanation="editor tool" max="32"/>
     <string english="START" translation="INICIAR" explanation="start point in level editor" max="10"/>
@@ -676,9 +658,7 @@
     <string english="Game Saved" translation="Partida guardada" explanation="" max="30"/>
     <string english="Press arrow keys or WASD to move" translation="Oprime las teclas de dirección o WASD para moverte" explanation="" max="32*2"/>
     <string english="Press left/right to move" translation="Oprime izq./der. para moverte" explanation="" max="32*2"/>
-    <string english="Press ACTION to flip" translation="Oprime ACCIÓN para voltear a tu personaje" explanation="***OUTDATED***" max="32*3"/>
     <string english="Press {button} to flip" translation="Oprime {button} para voltear a tu personaje" explanation="expect `ACTION`" max="32*3"/>
-    <string english="Press ENTER to view map and quicksave" translation="Oprime ENTRAR para ver el mapa y hacer un guardado rápido" explanation="***OUTDATED***" max="32*3"/>
     <string english="Press {button} to view map and quicksave" translation="Oprime {button} para ver el mapa y hacer guardado rápido" explanation="" max="32*3"/>
     <string english="If you prefer, you can press UP or DOWN instead of ACTION to flip." translation="Si lo prefieres, puedes oprimir ARRIBA o ABAJO en lugar de ACCIÓN para voltear a tu personaje." explanation="" max="34*3"/>
     <string english="Help! Can anyone hear this message?" translation="¡Ayuda! ¿Alguien oye este mensaje?" explanation="Violet speaking via Comms Relay" max="25*4"/>
@@ -785,6 +765,7 @@ You have found the secret lab!" translation="¡Felicitaciones!
     <string english="Fonts by" translation="Fuentes de" explanation=""/>
     <string english="Other Fonts by" translation="Otras fuentes de" explanation=""/>
     <string english="Editing and LQA" translation="y también gracias a:" explanation=""/>
+    <string english="Arabic" translation="" explanation=""/>
     <string english="Catalan" translation="Catalán" explanation=""/>
     <string english="Welsh" translation="Galés" explanation=""/>
     <string english="German" translation="Alemán" explanation=""/>

--- a/desktop_version/lang/es_AR/cutscenes.xml
+++ b/desktop_version/lang/es_AR/cutscenes.xml
@@ -76,10 +76,9 @@
     <cutscene id="bigopenworldskip" explanation="">
         <dialogue speaker="purple" english="I&apos;ll be right here if you need any help!" translation="Si necesitás una mano, ¡acá estoy!"/>
     </cutscene>
-    <cutscene id="talkpurple_intro" explanation="***ENTER is OUTDATED***">
+    <cutscene id="talkpurple_intro" explanation="">
         <dialogue speaker="player" english="I&apos;m feeling a bit overwhelmed, Doctor." translation="Siento que me gana el agobio, doctora."/>
         <dialogue speaker="player" english="Where do I begin?" translation="¿Por dónde empiezo?"/>
-        <dialogue speaker="purple" english="Remember that you can press ENTER to check where you are on the map!" translation="¡Acordate que podés apretar la tecla ENTRAR para ver tu posición en el mapa!"/>
         <dialogue speaker="purple" english="Remember that you can press {b_map} to check where you are on the map!" translation="¡Acordate que podés apretar {b_map} para ver tu posición en el mapa!" buttons="1"/>
         <dialogue speaker="purple" english="Look for areas where the rest of the crew might be..." translation="Buscá lugares donde pueda estar el resto de la tripulación..."/>
         <dialogue speaker="purple" english="If you get lost, you can get back to the ship from any teleporter." translation="Si te perdés, podés volver a la nave desde cualquier teletransportador."/>

--- a/desktop_version/lang/es_AR/meta.xml
+++ b/desktop_version/lang/es_AR/meta.xml
@@ -26,6 +26,9 @@
     <!-- When automatically uppercasing, allow ~ to be used to stop the next letter from being uppercased (for Irish) -->
     <toupper_lower_escape_char>0</toupper_lower_escape_char>
 
+    <!-- Enable for RTL languages like Arabic or Hebrew -->
+    <rtl>0</rtl>
+
     <!-- The indication that a certain menu option or button is selected -->
     <menu_select>[ {label} ]</menu_select>
     <menu_select_tight>[{label}]</menu_select_tight>

--- a/desktop_version/lang/es_AR/strings.xml
+++ b/desktop_version/lang/es_AR/strings.xml
@@ -317,6 +317,9 @@
     <string english="Currently ENABLED!" translation="¡Está ACTIVADO!" explanation="flip mode" max="38*3"/>
     <string english="Currently Disabled." translation="Está DESACTIVADO." explanation="flip mode" max="38*3"/>
     <string english="TO UNLOCK: Complete the game." translation="Para desbloquear: Completá el juego." explanation="" max="38*3"/>
+    <string english="Invincibility mode enabled" translation="" explanation="in-game message" max="39"/>
+    <string english="Glitchrunner mode enabled ({version})" translation="" explanation="in-game message" max="39"/>
+    <string english="Flip Mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="Are you sure you want to quit?" translation="¿Confirmás que querés salir?" explanation="quit the program" max="38*4"/>
     <string english="GAME OVER" translation="FIN PARTIDA" explanation="bigger title" max="13"/>
     <string english="You managed to reach:" translation="Llegaste hasta:" explanation="you managed to reach the following room" max="40"/>
@@ -428,15 +431,13 @@
     <string english="To install new player levels, copy the .vvvvvv files to the levels folder." translation="Para instalar niveles personalizados, copiá los archivos .vvvvvv en la carpeta &quot;levels&quot;." explanation="" max="38*5"/>
     <string english="Are you sure you want to show the levels path? This may reveal sensitive information if you are streaming." translation="¿Confirmás que querés mostrar la ruta de los niveles? Esta opción podría revelar información delicada si estás transmitiendo en directo." explanation="" max="38*4"/>
     <string english="The levels path is:" translation="La ruta de los niveles es:" explanation="" max="40"/>
-    <string english="[ Press ACTION to Start ]" translation="[ Apretá ACCIÓN para empezar ]" explanation="***OUTDATED***" max="38*2"/>
     <string english="[ Press {button} to Start ]" translation="[ Apretá {button} para empezar ]" explanation="title screen. Expect `ACTION`" max="38*2"/>
     <string english="ACTION = Space, Z, or V" translation="ACCIÓN = Espacio, Z o V" explanation="title screen" max="38*3"/>
-    <string english="[Press ENTER to return to editor]" translation="[Apretá ENTRAR para volver al editor]" explanation="***OUTDATED***" max="40"/>
     <string english="[Press {button} to return to editor]" translation="[Apretá {button} para volver al editor]" explanation="`to editor` is sorta redundant" max="40"/>
-    <string english="- Press ACTION to advance text -" translation="- Apretá ACCIÓN para avanzar el texto -" explanation="***OUTDATED***" max="40"/>
     <string english="- Press {button} to advance text -" translation="- Apretá {button} para avanzar el texto -" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
-    <string english="Press ACTION to continue" translation="Apretá ACCIÓN para continuar" explanation="***OUTDATED***" max="34"/>
     <string english="Press {button} to continue" translation="Apretá {button} para continuar" explanation="Expect `ACTION`" max="34"/>
+    <string english="[Press {button} to unfreeze gameplay]" translation="" explanation="in level debugger: {button} makes everything start moving as normal. Limit is treacherous, expect TAB for {button}. Frozen is the initial state, so this is the first string of the two that users will see!" max="39"/>
+    <string english="[Press {button} to freeze gameplay]" translation="" explanation="in level debugger: {button} makes everything stop moving. Limit is treacherous, expect TAB for {button}." max="39"/>
     <string english="Current Time" translation="Tiempo actual" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="Mejor tiempo" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="Siguiente trofeo en 5 segundos" explanation="" max="38*2"/>
@@ -448,7 +449,6 @@
     <string english="All Trophies collected!" translation="¡Conseguiste todos los trofeos!" explanation="" max="38*2"/>
     <string english="New Record!" translation="¡Nuevo récord!" explanation="" max="20"/>
     <string english="New Trophy!" translation="¡Nuevo trofeo!" explanation="" max="20"/>
-    <string english="[Press ENTER to stop]" translation="[Apretá ENTRAR para parar]" explanation="***OUTDATED***" max="40"/>
     <string english="[Press {button} to stop]" translation="[Apretá {button} para parar]" explanation="stop super gravitron" max="40"/>
     <string english="SUPER GRAVITRON" translation="SUPERGRAVITRÓN" explanation="" max="20"/>
     <string english="SUPER GRAVITRON HIGHSCORE" translation="PUNTUACIÓN MÁXIMA EN SUPERGRAVITRÓN" explanation="" max="38*4"/>
@@ -462,7 +462,6 @@
     <string english="[ QUIT ]" translation="[ SALIR ]" explanation="in-game menu" max="40"/>
     <string english="[ GRAVITRON ]" translation="[ GRAVITRÓN ]" explanation="in-game menu" max="40"/>
     <string english="NO SIGNAL" translation="SIN SEÑAL" explanation="map screen. So like a TV/computer monitor" max="29"/>
-    <string english="Press ACTION to warp to the ship." translation="Apretá ACCIÓN para teletransportarte a la nave." explanation="***OUTDATED***" max="38*7"/>
     <string english="Press {button} to warp to the ship." translation="{button}: teletransportarte a la nave" explanation="spaceship. Warp = teleport. Expect `ACTION`" max="38*7"/>
     <string english="Missing..." translation="No está..." case="1" explanation="this male crew member is missing" max="15"/>
     <string english="Missing..." translation="No está..." case="2" explanation="this female crew member is missing" max="15"/>
@@ -477,7 +476,6 @@
     <string english="ERROR: Could not save game!" translation="ERROR: ¡No se puedo guardar la partida!" explanation="in-game menu" max="34*2"/>
     <string english="ERROR: Could not save settings file!" translation="ERROR: ¡No se pudo guardar el archivo de ajustes!" explanation="" max="38*2"/>
     <string english="Game saved ok!" translation="¡Se guardó la partida guardada!" explanation="in-game menu" max="38*2"/>
-    <string english="[Press ACTION to save your game]" translation="[Apretá ACCIÓN para guardar la partida]" explanation="***OUTDATED***" max="40"/>
     <string english="[Press {button} to save your game]" translation="[Apretá {button} para guardar la partida]" explanation="in-game menu. Expect `ACTION`" max="40"/>
     <string english="(Note: The game is autosaved at every teleporter.)" translation="(Nota: La partida se guarda automáticamente en cada teletransportador)." explanation="in-game menu" max="38*3"/>
     <string english="Last Save:" translation="Último guardado:" explanation="in-game menu" max="40"/>
@@ -563,21 +561,13 @@
     <string english="Untitled Level" translation="Nivel sin nombre" explanation="" max="20"/>
     <string english="Unknown" translation="Desconocido" explanation="by Unknown [author]"/>
     <string english="Tile:" translation="Casilla:" explanation="editor, selected " max="34"/>
-    <string english="SCRIPT BOX: Click on top left" translation="CAJA DE SCRIPT: clic en parte superior izquierda" explanation="***OUTDATED***"/>
     <string english="SCRIPT BOX: Click on the first corner" translation="CAJA SCRIPT: clic en primera esquina" explanation="editor, a script box is an invisible box that runs a script when touched" max="39*3"/>
-    <string english="SCRIPT BOX: Click on bottom right" translation="CAJA DE SCRIPT: clic en parte inferior derecha" explanation="***OUTDATED***"/>
     <string english="SCRIPT BOX: Click on the last corner" translation="CAJA SCRIPT: clic en última esquina" explanation="editor, a script box is an invisible box that runs a script when touched" max="39*3"/>
-    <string english="ENEMY BOUNDS: Click on top left" translation="LÍMITES DE ENEMIGO: clic en parte superior izquierda" explanation="***OUTDATED***"/>
     <string english="ENEMY BOUNDS: Click on the first corner" translation="LÍMITES DE ENEMIGO: clic en primera esquina" explanation="editor, invisible box which enemies always stay inside of" max="39*3"/>
-    <string english="ENEMY BOUNDS: Click on bottom right" translation="LÍMITES DE ENEMIGO: clic en parte inferior derecha" explanation="***OUTDATED***"/>
     <string english="ENEMY BOUNDS: Click on the last corner" translation="LÍMITES DE ENEMIGO: clic en última esquina" explanation="editor, invisible box which enemies always stay inside of" max="39*3"/>
-    <string english="PLATFORM BOUNDS: Click on top left" translation="LÍMITES DE PLATAFORMA: clic en parte superior izquierda" explanation="***OUTDATED***"/>
     <string english="PLATFORM BOUNDS: Click on the first corner" translation="LÍMITES DE PLATAFORMA: clic en primera esquina" explanation="editor, invisible box which moving platforms always stay inside of" max="39*3"/>
-    <string english="PLATFORM BOUNDS: Click on bottom right" translation="LÍMITES DE PLATAFORMA: clic en parte inferior derecha" explanation="***OUTDATED***"/>
     <string english="PLATFORM BOUNDS: Click on the last corner" translation="LÍMITES DE PLATAFORMA: clic en última esquina" explanation="editor, invisible box which moving platforms always stay inside of" max="39*3"/>
-    <string english="Click on top left" translation="Clic en parte superior izquierda" explanation="***OUTDATED***"/>
     <string english="Click on the first corner" translation="Clic en primera esquina" explanation="" max="39*3"/>
-    <string english="Click on bottom right" translation="Clic en parte inferior derecha" explanation="***OUTDATED***"/>
     <string english="Click on the last corner" translation="Clic en última esquina" explanation="" max="39*3"/>
     <string english="**** VVVVVV SCRIPT EDITOR ****" translation="*** EDITOR DE SCRIPTS DE VVVVVV ***" explanation="supposed to look like a Commodore 64 screen" max="36"/>
     <string english="PRESS ESC TO RETURN TO MENU" translation="APRETÁ ESC PARA VOLVER AL MENÚ" explanation="Commodore 64-style script editor, TO MENU is redundant" max="36"/>
@@ -591,25 +581,17 @@
     <string english="2: Backing" translation="2: Fondos" explanation="editor tool. Non-solid background tiles" max="32"/>
     <string english="3: Spikes" translation="3: Pinches" explanation="editor tool" max="32"/>
     <string english="4: Trinkets" translation="4: Cositos" explanation="editor tool. Shiny trinkets/collectibles" max="32"/>
-    <string english="5: Checkpoint" translation="5: Punto de control" explanation="***OUTDATED***"/>
     <string english="5: Checkpoints" translation="5: Puntos de control" explanation="editor tool. You restart at the last checkpoint after death" max="32"/>
-    <string english="6: Disappear" translation="6: Plataforma fugaz" explanation="***OUTDATED***"/>
     <string english="6: Disappearing Platforms" translation="6: Plataformas fugaces" explanation="editor tool. Platform that disappears when you step on it (disappearing platform, crumbling platform)" max="32"/>
     <string english="7: Conveyors" translation="7: Cinta transportadora" explanation="editor tool. Conveyor belt" max="32"/>
-    <string english="8: Moving" translation="8: Plataforma móvil" explanation="***OUTDATED***"/>
     <string english="8: Moving Platforms" translation="8: Plataformas móviles" explanation="editor tool. Moving platform" max="32"/>
     <string english="9: Enemies" translation="9: Enemigos" explanation="editor tool" max="32"/>
-    <string english="0: Grav Line" translation="0: Línea de gravedad" explanation="***OUTDATED***"/>
     <string english="0: Gravity Lines" translation="0: Líneas de gravedad" explanation="editor tool. Gravity line, which flips your gravity when touching it" max="32"/>
     <string english="R: Roomtext" translation="R: Textos en la sala" explanation="editor tool. Freely typed text, consider just Text" max="32"/>
-    <string english="T: Terminal" translation="T: Terminal" explanation="***OUTDATED***"/>
     <string english="T: Terminals" translation="T: Terminales" explanation="editor tool. Computer which can be activated by the player to run a script" max="32"/>
-    <string english="Y: Script Box" translation="Y: Caja de script" explanation="***OUTDATED***"/>
     <string english="Y: Script Boxes" translation="Y: Cajas script" explanation="editor tool. Invisible box that runs a script when touched" max="32"/>
-    <string english="U: Warp Token" translation="U: Portal" explanation="***OUTDATED***"/>
     <string english="U: Warp Tokens" translation="U: Portales" explanation="editor tool. Small teleporter with entrance and destination" max="32"/>
     <string english="I: Warp Lines" translation="I: Líneas cíclicas" explanation="editor tool. Makes a room edge be connected to its opposite edge" max="32"/>
-    <string english="O: Crewmate" translation="O: Tripulante" explanation="***OUTDATED***"/>
     <string english="O: Crewmates" translation="O: Tripulantes" explanation="editor tool. Crewmate that can be rescued" max="32"/>
     <string english="P: Start Point" translation="P: Punto de inicio" explanation="editor tool" max="32"/>
     <string english="START" translation="INICIAR" explanation="start point in level editor" max="10"/>
@@ -676,9 +658,7 @@
     <string english="Game Saved" translation="Partida guardada" explanation="" max="30"/>
     <string english="Press arrow keys or WASD to move" translation="Apretá las teclas de dirección o WASD para moverte" explanation="" max="32*2"/>
     <string english="Press left/right to move" translation="Apretá izq./der. para moverte" explanation="" max="32*2"/>
-    <string english="Press ACTION to flip" translation="Apretá ACCIÓN para invertir tu posición" explanation="***OUTDATED***" max="32*3"/>
     <string english="Press {button} to flip" translation="Apretá {button} para invertir tu posición" explanation="expect `ACTION`" max="32*3"/>
-    <string english="Press ENTER to view map and quicksave" translation="Apretá ENTRAR para ver el mapa y hacer un guardado rápido" explanation="***OUTDATED***" max="32*3"/>
     <string english="Press {button} to view map and quicksave" translation="Apretá {button} para ver el mapa y hacer guardado rápido" explanation="" max="32*3"/>
     <string english="If you prefer, you can press UP or DOWN instead of ACTION to flip." translation="Si preferís, podés apretar ARRIBA o ABAJO en vez de ACCIÓN para invertir tu posición." explanation="" max="34*3"/>
     <string english="Help! Can anyone hear this message?" translation="¡Ayuda! ¿Alguien escucha este mensaje?" explanation="Violet speaking via Comms Relay" max="25*4"/>
@@ -785,6 +765,7 @@ You have found the secret lab!" translation="¡Felicitaciones!
     <string english="Fonts by" translation="Fuentes de" explanation=""/>
     <string english="Other Fonts by" translation="Otras fuentes de" explanation=""/>
     <string english="Editing and LQA" translation="y también gracias a:" explanation=""/>
+    <string english="Arabic" translation="" explanation=""/>
     <string english="Catalan" translation="Catalán" explanation=""/>
     <string english="Welsh" translation="Galés" explanation=""/>
     <string english="German" translation="Alemán" explanation=""/>

--- a/desktop_version/lang/nl/strings.xml
+++ b/desktop_version/lang/nl/strings.xml
@@ -765,7 +765,7 @@ Je hebt het geheime lab gevonden!" explanation="" max="34*4"/>
     <string english="Pan-European Font Design by" translation="Ontwerp pan-Europees lettertype door" explanation="" max="40"/>
     <string english="Fonts by" translation="Lettertypen door" explanation=""/>
     <string english="Other Fonts by" translation="Overige lettertypen door" explanation=""/>
-    <string english="Editing and LQA" translation="en ook met dank aan:" explanation=""/>
+    <string english="Editing and LQA" translation="Bewerking en LQA" explanation=""/>
     <string english="Arabic" translation="Arabisch" explanation=""/>
     <string english="Catalan" translation="Catalaans" explanation=""/>
     <string english="Welsh" translation="Welsh" explanation=""/>
@@ -787,9 +787,9 @@ Je hebt het geheime lab gevonden!" explanation="" max="34*4"/>
     <string english="Ukrainian" translation="Oekraïens" explanation=""/>
     <string english="Chinese (Simplified)" translation="Chinees (vereenvoudigd)" explanation=""/>
     <string english="Chinese (Traditional)" translation="Chinees (traditioneel)" explanation=""/>
-    <string english="Spanish (ES)" translation="Spaans" explanation=""/>
-    <string english="Spanish (LATAM)" translation="Spaans" explanation=""/>
-    <string english="Spanish (ARG.)" translation="Spaans" explanation=""/>
+    <string english="Spanish (ES)" translation="Spaans (Spanje)" explanation=""/>
+    <string english="Spanish (LATAM)" translation="Spaans (Latijns-Amerika)" explanation=""/>
+    <string english="Spanish (ARG.)" translation="Spaans (Argentinië)" explanation=""/>
     <string english="" translation="" explanation=""/>
     <string english="" translation="" explanation=""/>
 </strings>


### PR DESCRIPTION
## Changes:

- Sync Spanish LATAM and Spanish ARG language files
  They were missing the latest strings and also still had strings that had been deleted.
  (Whoever commits the upcoming delivery should also sync that version)

- Translate the current 4 proxy strings into Dutch
  These are the 3 variants of Spanish and "Editing and LQA".

- Add missing spaces to script editor title in Welsh



## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
