### PR TITLE
Some small fixes to Arabic, Spanish LATAM and Spanish AR

### DIFF
--- a/desktop_version/lang/ar/strings_plural.xml
+++ b/desktop_version/lang/ar/strings_plural.xml
@@ -12,15 +12,15 @@
         <translation form="0" translation="ولم نجد أي تذكار."/>
         <translation form="1" translation="ووجدت تذكارا."/>
         <translation form="2" translation="ووجدت تذكارين."/>
-        <translation form="3" translation="ووجدت {n_crew|wordy} تذكارات."/>
-        <translation form="11" translation="ووجدت {n_crew|wordy} تذكارا."/>
+        <translation form="3" translation="ووجدت {n_trinkets|wordy} تذكارات."/>
+        <translation form="11" translation="ووجدت {n_trinkets|wordy} تذكارا."/>
     </string>
     <string english_plural="And you found {n_trinkets|wordy} trinkets." english_singular="And you found {n_trinkets|wordy} trinket." explanation="You rescued all the crewmates! And you found XX trinket(s)." max="38*3" var="n_trinkets" expect="20" max_local="38*3">
         <translation form="0" translation="ولم نجد أي تذكار."/>
         <translation form="1" translation="ووجدت تذكارا."/>
         <translation form="2" translation="ووجدت تذكارين."/>
-        <translation form="3" translation="ووجدت {n_crew|wordy} تذكارات."/>
-        <translation form="11" translation="ووجدت {n_crew|wordy} تذكارا."/>
+        <translation form="3" translation="ووجدت {n_trinkets|wordy} تذكارات."/>
+        <translation form="11" translation="ووجدت {n_trinkets|wordy} تذكارا."/>
     </string>
     <string english_plural="{n_crew|wordy} crewmates remain" english_singular="{n_crew|wordy} crewmate remains" explanation="Reminder: you can add |upper for an uppercase letter." max="38*2" var="n_crew" expect="100" max_local="38*2">
         <translation form="0" translation="لم يبق أي فرد من الطاقم"/>
@@ -40,14 +40,14 @@
         <translation form="0" translation="أصعب غرفة (بدون ميتات)"/>
         <translation form="1" translation="أصعب غرفة (ميتة واحدة)"/>
         <translation form="2" translation="أصعب غرفة (ميتتان)"/>
-        <translation form="3" translation="أصعب غرفة ({n_crew|wordy2} ميتات)"/>
-        <translation form="11" translation="أصعب غرفة ({n_crew|wordy2} ميتة)"/>
+        <translation form="3" translation="أصعب غرفة ({n_deaths|wordy2} ميتات)"/>
+        <translation form="11" translation="أصعب غرفة ({n_deaths|wordy2} ميتة)"/>
     </string>
     <string english_plural="{n} normal room names untranslated" english_singular="{n} normal room name untranslated" explanation="per-area counts for room name translator mode" max="38*4" var="n" expect="48" max_local="38*4">
         <translation form="0" translation="لم يبق أي اسم غرفة لم يترجم"/>
         <translation form="1" translation="اسم غرفة عادي لم يترجم"/>
         <translation form="2" translation="اسما غرفتين عادينين لم يترجما"/>
-        <translation form="3" translation="لم يترجم {n_crew|wordy} أسماء لغرف عادية"/>
-        <translation form="11" translation="لم يترجم {n_crew|wordy} اسم لغرف عادية"/>
+        <translation form="3" translation="لم يترجم {n|wordy} أسماء لغرف عادية"/>
+        <translation form="11" translation="لم يترجم {n|wordy} اسم لغرف عادية"/>
     </string>
 </strings_plural>

--- a/desktop_version/lang/es_419/cutscenes.xml
+++ b/desktop_version/lang/es_419/cutscenes.xml
@@ -662,7 +662,7 @@
 
 READY _" translation="GENERADOR DE ESTABILIDAD DIMENSIONAL
 
-    [ En funcionamiento ]
+       [ En funcionamiento ]
          Estabilidad máxima
 
              [ Estado ]

--- a/desktop_version/lang/es_419/meta.xml
+++ b/desktop_version/lang/es_419/meta.xml
@@ -12,7 +12,7 @@
     <action_hint>Pulsa Espacio, Z, o V para seleccionar</action_hint>
 
     <!-- Same as above, but for a gamepad button (hard limit 40 8x8 characters) -->
-    <gamepad_hint>Oprime {button} para seleccionar</gamepad_hint>
+    <gamepad_hint>Pulsa {button} para seleccionar</gamepad_hint>
 
     <!-- Enable automatic word wrapping instead of having to manually insert newlines -->
     <autowordwrap>1</autowordwrap>

--- a/desktop_version/lang/es_AR/cutscenes.xml
+++ b/desktop_version/lang/es_AR/cutscenes.xml
@@ -662,7 +662,7 @@
 
 READY _" translation="GENERADOR DE ESTABILIDAD DIMENSIONAL
 
-    [ En funcionamiento ]
+       [ En funcionamiento ]
          Estabilidad máxima
 
              [ Estado ]


### PR DESCRIPTION
## Changes:

- Fix placeholders in Arabic strings_plural
  For some reason all of us overlooked that all of them were {n_crew}, even those which required a different placeholder key... https://steamcommunity.com/sharedfiles/filedetails/?id=3154670529

- Change LATAM Spanish meta.xml Oprime to Pulsa
  All of them were changed except for the one in meta.xml. I think it's safe to assume this is correct, because everywhere else, the same "Oprime {button} para" pattern always became "Pulsa {button} para" too.

- Align dimensional stability generator in Spanish LATAM and Spanish AR

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
