### PR TITLE
Translated missing strings into Esperanto

### DIFF
--- a/desktop_version/lang/eo/strings.xml
+++ b/desktop_version/lang/eo/strings.xml
@@ -317,9 +317,9 @@
     <string english="Currently ENABLED!" translation="Nune EBLIGITA!" explanation="flip mode" max="38*3"/>
     <string english="Currently Disabled." translation="Nune neebligita." explanation="flip mode" max="38*3"/>
     <string english="TO UNLOCK: Complete the game." translation="POR MALŜLOSI: Finu la ludon." explanation="" max="38*3"/>
-    <string english="Invincibility mode enabled" translation="" explanation="in-game message" max="39"/>
-    <string english="Glitchrunner mode enabled ({version})" translation="" explanation="in-game message" max="39"/>
-    <string english="Flip Mode enabled" translation="" explanation="in-game message" max="39"/>
+    <string english="Invincibility mode enabled" translation="Nevundebleco estas ebligita" explanation="in-game message" max="39"/>
+    <string english="Glitchrunner mode enabled ({version})" translation="Cimkurluda reĝimo estas ebligita ({version})" explanation="in-game message" max="39"/>
+    <string english="Flip Mode enabled" translation="Renversa reĝimo estas ebligita" explanation="in-game message" max="39"/>
     <string english="Are you sure you want to quit?" translation="Ĉu vi vere volas eliri?" explanation="quit the program" max="38*4"/>
     <string english="GAME OVER" translation="LUDO FINIĜIS" explanation="bigger title" max="13"/>
     <string english="You managed to reach:" translation="Vi sukcesis atingi:" explanation="you managed to reach the following room" max="40"/>
@@ -436,8 +436,8 @@
     <string english="[Press {button} to return to editor]" translation="[Premu {button} por reveni al redaktilo]" explanation="`to editor` is sorta redundant" max="40"/>
     <string english="- Press {button} to advance text -" translation="- Premu {button} por daŭrigi -" explanation="to dismiss a textbox. Expect `ACTION`" max="40"/>
     <string english="Press {button} to continue" translation="Premu {button} por daŭrigi" explanation="Expect `ACTION`" max="34"/>
-    <string english="[Press {button} to unfreeze gameplay]" translation="" explanation="in level debugger: {button} makes everything start moving as normal. Limit is treacherous, expect TAB for {button}. Frozen is the initial state, so this is the first string of the two that users will see!" max="39"/>
-    <string english="[Press {button} to freeze gameplay]" translation="" explanation="in level debugger: {button} makes everything stop moving. Limit is treacherous, expect TAB for {button}." max="39"/>
+    <string english="[Press {button} to unfreeze gameplay]" translation="[Premu {button} por malfrostigi ludon]" explanation="in level debugger: {button} makes everything start moving as normal. Limit is treacherous, expect TAB for {button}. Frozen is the initial state, so this is the first string of the two that users will see!" max="39"/>
+    <string english="[Press {button} to freeze gameplay]" translation="[Premu {button} por frostigi ludon]" explanation="in level debugger: {button} makes everything stop moving. Limit is treacherous, expect TAB for {button}." max="39"/>
     <string english="Current Time" translation="Nuna tempo" explanation="super gravitron, stopwatch time" max="20"/>
     <string english="Best Time" translation="Plej bona tempo" explanation="super gravitron, best stopwatch time" max="20"/>
     <string english="Next Trophy at 5 seconds" translation="Sekva trofeo je 5 sekundoj" explanation="" max="38*2"/>
@@ -764,7 +764,7 @@ Vi trovis la sekretan labon!" explanation="" max="34*4"/>
     <string english="Pan-European Font Design by" translation="Tuteŭropan tiparon desegnis" explanation="" max="40"/>
     <string english="Fonts by" translation="Tiparoj de" explanation=""/>
     <string english="Other Fonts by" translation="Aliaj tiparoj de" explanation=""/>
-    <string english="Editing and LQA" translation="kaj ankaŭ de" explanation=""/>
+    <string english="Editing and LQA" translation="Redaktado kaj kontrolado" explanation=""/>
     <string english="Arabic" translation="Araben" explanation=""/>
     <string english="Catalan" translation="Katalunen" explanation=""/>
     <string english="Welsh" translation="Kimren" explanation=""/>
@@ -786,9 +786,9 @@ Vi trovis la sekretan labon!" explanation="" max="34*4"/>
     <string english="Ukrainian" translation="Ukrainen" explanation=""/>
     <string english="Chinese (Simplified)" translation="Ĉinen (simpligite)" explanation=""/>
     <string english="Chinese (Traditional)" translation="Ĉinen (tradicie)" explanation=""/>
-    <string english="Spanish (ES)" translation="Hispanen" explanation=""/>
-    <string english="Spanish (LATAM)" translation="Hispanen" explanation=""/>
-    <string english="Spanish (ARG.)" translation="Hispanen" explanation=""/>
+    <string english="Spanish (ES)" translation="Hispanen (Hispanio)" explanation=""/>
+    <string english="Spanish (LATAM)" translation="Hispanen (Latinameriko)" explanation=""/>
+    <string english="Spanish (ARG.)" translation="Hispanen (Argentino)" explanation=""/>
     <string english="" translation="" explanation=""/>
     <string english="" translation="" explanation=""/>
 </strings>


### PR DESCRIPTION
## Changes:

New strings have been added into the Esperanto translation. This includes the Spanish variant names, "Editing and LQA", the "mode enabled" bug text, and the debug mode freeze prompts.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
