### PR TITLE
Make language screen show up once more

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -1142,7 +1142,7 @@ static void menuactionpress(void)
             loc::languagelist_curlang = game.currentmenuoption;
             loc::lang = loc::languagelist[game.currentmenuoption].code;
             loc::loadtext(false);
-            loc::lang_set = true;
+            loc::lang_set = loc::lang_set_current;
             graphics.grphx.init_translations();
         }
 

--- a/desktop_version/src/Localization.cpp
+++ b/desktop_version/src/Localization.cpp
@@ -11,7 +11,7 @@
 namespace loc
 {
 
-bool lang_set = false;
+int lang_set = 0;
 bool pre_title_lang_menu = false;
 
 std::string lang = "en";

--- a/desktop_version/src/Localization.h
+++ b/desktop_version/src/Localization.h
@@ -45,7 +45,8 @@ struct TextboxFormat
     unsigned short padtowidth; // pad to X pixels (0 to disable)
 };
 
-extern bool lang_set;
+extern int lang_set;
+static const int lang_set_current = 2;
 extern bool pre_title_lang_menu;
 
 extern std::string lang;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -674,7 +674,15 @@ int main(int argc, char *argv[])
         game.gamestate = TITLEMODE;
     if (game.slowdown == 0) game.slowdown = 30;
 
-    if (loc::lang_set < loc::lang_set_current && !loc::languagelist.empty())
+    int min_lang_set = loc::lang_set_current;
+    if (baseDir != NULL)
+    {
+        /* For people who manage tons of basedirs, never re-ask
+         * the language, except in the default basedir. */
+        min_lang_set = 1;
+    }
+
+    if (loc::lang_set < min_lang_set && !loc::languagelist.empty())
     {
         loc::pre_title_lang_menu = true;
         game.gamestate = TITLEMODE;

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -674,7 +674,7 @@ int main(int argc, char *argv[])
         game.gamestate = TITLEMODE;
     if (game.slowdown == 0) game.slowdown = 30;
 
-    if (!loc::lang_set && !loc::languagelist.empty())
+    if (loc::lang_set < loc::lang_set_current && !loc::languagelist.empty())
     {
         loc::pre_title_lang_menu = true;
         game.gamestate = TITLEMODE;


### PR DESCRIPTION
## Changes:

Now that two new variants of Spanish have been added, it would be a shame that many players from Latin-America/Argentina may stay on Castilian or English because they don't realize the new versions were added for them. So now, if you've set your language in 2.4.0, the language screen will show up once more in 2.4.1. This is done by simply incrementing the lang_set flag to 2 - so that if it's 0 or 1, your language setting is considered to be possibly outdated.

This shouldn't inconvenience players who don't need to select a new language - their existing language will still be pre-selected, so they can just hit ACTION once.

Terry confirms he did the same thing with Dicey Dungeons and says it's a good idea (and that nobody minds).


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
