### PR TITLE
Change `reply` scripting command to `player` color

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3547,7 +3547,7 @@ bool scriptclass::loadcustom(const std::string& t)
         }else if(words[0] == "reply"){
             //For this version, terminal only
             if(squeakmode==0) add("squeak(player)");
-            add("text(cyan,0,0,"+words[1]+")");
+            add("text(player,0,0,"+words[1]+")");
 
             int ti=help.Int(words[1].c_str());
             int nti = ti>=0 ? ti : 1;


### PR DESCRIPTION
## Changes:

This is just a small visual fix to an inconsistency with textbox colors in simplified scripting. The `reply` command is meant to be used for the player, and always correctly positions it above the player, while the `say` command may be used to generate a cyan textbox that's positioned above a cyan non-player crewmate. However, the color for both textboxes is always `cyan`, so the `reply` command doesn't use the (normally identical) `player` color even though all its other behavior (squeak, position) does. Now that customized textbox colors were added in 2.4 (#910), it's a shame that this distinction isn't made between `cyan` and `player`, so this change addresses that (before we're stuck with levels that change `cyan` but not `player`).

As discussed with @InfoTeddy, this should be fine to include in a 2.4.2.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
