### PR TITLE
Fix "Thanks for playing!" reversed in Flip Mode

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -2135,9 +2135,21 @@ void gamecompleterender(void)
     creditOffset += 140;
     if (graphics.onscreen(creditOffset + position))
     {
-        font::print(PR_2X | PR_CEN | PR_CJK_HIGH, -1, creditOffset + position, loc::gettext("Thanks for"), tr, tg, tb);
+        const char* line1;
+        const char* line2;
+        if (graphics.flipmode)
+        {
+            line1 = loc::gettext("playing!");
+            line2 = loc::gettext("Thanks for");
+        }
+        else
+        {
+            line1 = loc::gettext("Thanks for");
+            line2 = loc::gettext("playing!");
+        }
+        font::print(PR_2X | PR_CEN | PR_CJK_HIGH, -1, creditOffset + position, line1, tr, tg, tb);
         creditOffset += 20;
-        font::print(PR_2X | PR_CEN | PR_CJK_LOW, -1, creditOffset + position, loc::gettext("playing!"), tr, tg, tb);
+        font::print(PR_2X | PR_CEN | PR_CJK_LOW, -1, creditOffset + position, line2, tr, tg, tb);
     }
 
     draw_skip_message();


### PR DESCRIPTION
For localization, the "Thanks for playing!" text was split into two lines, when it was originally one line. Unfortunately, it was not updated to account for Flip Mode, so in Flip Mode, it looked like "playing! Thanks for".

This has been fixed.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
