### PR TITLE
Disable state locking if incrementing state with ACTION

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2617,6 +2617,7 @@ void gameinput(void)
                 || !game.glitchrunkludge)
                 {
                     game.state++;
+                    game.unlockstate();
                 }
                     game.jumpheld = true;
                     game.glitchrunkludge=true;


### PR DESCRIPTION
This fixes a bug report from Elomavi that you could still softlock from warping to ship and incrementing the gamestate by pressing ACTION, which is diverging behavior from how it was in 2.3. Warping to ship and incrementing by pressing ACTION is useful behavior for a couple niche speedrun categories.

I had already fixed this earlier by ignoring state locking if glitchrunner 2.2 or 2.0 was enabled, but softlocks could still happen because having glitchrunner mode off still enabled you to increment the gamestate when otherwise unintended. Softlocks shouldn't happen.

But without removing state locking entirely, I've chosen a middle ground where it will only be disabled if you press ACTION. That signifies intent that you still want to perform state incrementing glitches even with glitchrunner mode off (but in the future it could be considered a 2.3/2.4 glitch that could be patched and made re-enable-able). That way, casual players can't interrupt the warp to ship by accident (unless they accidentally press ACTION) while softlocks will be removed.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
