### PR TITLE
Fix informational command-line arguments not working with `-console`

### DIFF
--- a/desktop_version/src/Vlogging.c
+++ b/desktop_version/src/Vlogging.c
@@ -220,6 +220,12 @@ void vlog_open_console(void)
         vlog_error("Could not redirect STDERR to console.");
     }
 
+    handle = freopen("CON", "r", stdin);
+    if (handle == NULL)
+    {
+        vlog_error("Could not redirect STDIN to console.");
+    }
+
     check_color_support();
 
     if (!SetConsoleOutputCP(CP_UTF8))


### PR DESCRIPTION
The intention of the `-console` argument was to enable seeing console output on Windows without having to use workarounds. However, this didn't actually work for arguments like `-addresses` and `-version`, because the program would exit first before it could get the chance to create the console.

The other issue is that the console closes too quickly before output can be read by the user. So to fix that, we must hold it open and let the user close it when they want to.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
