### PR TITLE
Fix regression: Foreground redraw after G keybind

### DIFF
--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -2105,6 +2105,7 @@ static void input_submitted(void)
 
         ed.levx = SDL_clamp(help.Int(coord_x) - 1, 0, cl.mapwidth - 1);
         ed.levy = SDL_clamp(help.Int(coord_y) - 1, 0, cl.mapheight - 1);
+        graphics.foregrounddrawn = false;
         graphics.backgrounddrawn = false;
         break;
     }


### PR DESCRIPTION
This fixes a regression from 2.4 where the foreground wouldn't update after using the G keybind to go to a room, requiring the user to touch a tile to update the rendering.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
