### PR TITLE
Unload zips before loading zips

### DIFF
--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -251,12 +251,31 @@ static void levelMetaDataCallback(const char* filename)
     }
 }
 
+static void unloadZips(void)
+{
+    char** list = PHYSFS_getSearchPath();
+    if (list == NULL)
+    {
+        return;
+    }
+    for (char** path = list; *path != NULL; path++)
+    {
+        if (SDL_strncmp(*path, "levels/", 7) == 0 && endsWith(*path, ".zip"))
+        {
+            PHYSFS_unmount(*path);
+        }
+    }
+    PHYSFS_freeList(list);
+}
+
 void customlevelclass::getDirectoryData(void)
 {
 
     ListOfMetaData.clear();
 
     FILESYSTEM_clearLevelDirError();
+
+    unloadZips();
 
     loadZips();
 


### PR DESCRIPTION
This fixes a minor issue where if you had a zip in the levels list, but then removed it, it would still show up in the levels list after reloading it (if you also had a `.vvvvvv` file named the same as in the zip) even though it shouldn't.

Thankfully, this didn't lead to a memory leak or duplicate zip mounts or anything like that, because PhysFS ignores mounting a zip if it's already mounted.

This also didn't result in a level entry from a zip persisting after removal after reloading the levels list, because the entry would be gone due to the `.vvvvvv` file not being found.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
