### PR TITLE
Checkpoint autosaving

### DIFF
--- a/desktop_version/lang/ar/strings.xml
+++ b/desktop_version/lang/ar/strings.xml
@@ -236,6 +236,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="وضوح رؤية ما وراء اسم الغرفة أسفل الشاشة." explanation="" max="38*3" max_local="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="خلفية اسم الغرفة شفافة" explanation="" max="38*2" max_local="38*2"/>
     <string english="Room name background is OPAQUE" translation="خلفية اسم الغرفة ليست شفافة" explanation="" max="38*2" max_local="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20" max_local="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3" max_local="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2" max_local="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2" max_local="38*2"/>
     <string english="speedrun options" translation="إعدادات التختيم السريع" explanation="menu option"/>
     <string english="Speedrunner Options" translation="إعدادات التختيم السريع" explanation="title" max="20" max_local="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="دخول إعدادات متقدمة قد تحظى باهتمام

--- a/desktop_version/lang/ca/strings.xml
+++ b/desktop_version/lang/ca/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Permet veure què hi ha darrere del nom a la part inferior de la pantalla." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="El fons del nom de sala és TRANSLÚCID" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="El fons del nom de sala és OPAC" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="opcions per a speedruns" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Speedruns" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Accedeix a opcions avançades que poden ser d’interès per als speedrunners." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/cy/strings.xml
+++ b/desktop_version/lang/cy/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Yn gadael i chi weld trwy&apos;r hyn sydd y tu ôl i&apos;r enw ar waelod y sgrin." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="Mae cefndir enw ystafell yn TRYLOYW" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="Mae cefndir enw ystafell yn DI-DRAIDD" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="opsiynau rhediad-gwib" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Opsiynau Rhedwr-Gwib" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Cyrchwch rai gosodiadau uwch a allai fod o ddiddordeb i redwyr cyflym ." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/de/strings.xml
+++ b/desktop_version/lang/de/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Lässt dich sehen, was sich hinter dem Namen am unteren Rand des Bildschirms verbirgt." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="Raumnamen-Hintergrund ist DURCHSICHTIG" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="Raumnamen-Hintergrund ist UNDURCHSICHTIG" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="speedrunner-optionen" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Speedrunner-Optionen" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Greife auf erweiterte Einstellungen zu, die für Speedrunner interessant sind." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="" explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="" explanation="menu option"/>
     <string english="Speedrunner Options" translation="" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="" explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/eo/strings.xml
+++ b/desktop_version/lang/eo/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Ebligi vidi tion, kio estas malantaŭ la nomo ĉe la ekranmalsupro" explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="Ĉambronoma fono estas TRAVIDEBLA" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="Ĉambronoma fono estas NETRAVIDEBLA" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="opcioj de kurludado" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Kurludaj opcioj" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Iuj altnivelaj agordoj, utilaj por kurludistoj." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/es/strings.xml
+++ b/desktop_version/lang/es/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Permite ver qué hay detrás del nombre que aparece en la parte baja de la pantalla." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="El fondo de los nombres de sala es TRASLÚCIDO" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="El fondo de los nombres de sala es OPACO" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="opciones de speedrun" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Opciones de speedrun" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Accede a opciones avanzadas que podrían interesar a quienes hacen speedrun." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/es_419/strings.xml
+++ b/desktop_version/lang/es_419/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Permite ver qué hay detrás del nombre que aparece en la parte inferior de la pantalla." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="El fondo de los nombres de sala es TRASLÚCIDO" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="El fondo de los nombres de sala es OPACO" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="opciones de speedrun" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Opciones de speedrun" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Accede a opciones avanzadas que podrían interesarte si haces speedrun." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/es_AR/strings.xml
+++ b/desktop_version/lang/es_AR/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Te permite ver qué hay atrás del nombre que aparece en la parte inferior de la pantalla." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="El fondo de los nombres de sala es TRASLÚCIDO" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="El fondo de los nombres de sala es OPACO" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="opciones de speedrun" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Opciones de speedrun" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Entrá a opciones avanzadas que podrían interesarte si hacés speedrun." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/fr/strings.xml
+++ b/desktop_version/lang/fr/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Vous permet de voir ce qui se|trouve derrière le nom affiché|en bas de l&apos;écran." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="Fond de nom des salles TRANSPARENT" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="Fond de nom des salles OPAQUE" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="options de speedrun" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Options de speedrun" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Accédez à des paramètres|avancés susceptibles d&apos;intéresser|les speedrunners." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/ga/strings.xml
+++ b/desktop_version/lang/ga/strings.xml
@@ -233,6 +233,11 @@ Déan cóip chúltaca, ar eagla na heagla." explanation="translation maintenance
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Beidh tú in ann a fheiceáil céard atá taobh thiar den ainm ag bun an scáileáin." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="Cúlra Ainmneacha na Seomraí: TRÉSHOILSEACH" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="Cúlra Ainmneacha na Seomraí: TEIMHNEACH" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="socruithe sciuirde" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Socruithe Sciuirde" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Socruithe breise a bhaineann le sciuirdeanna." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/it/strings.xml
+++ b/desktop_version/lang/it/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Consente di vedere dietro il nome nella parte bassa dello schermo." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="Lo sfondo del nome della stanza è TRASPARENTE" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="Lo sfondo del nome della stanza è OPACO" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="opzioni speedrun" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Opzioni speedrunner" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Accedi ad alcune impostazioni avanzate di interesse per gli speedrunner." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/ja/strings.xml
+++ b/desktop_version/lang/ja/strings.xml
@@ -246,6 +246,11 @@ Escキーを押すと表示を終了する。" explanation="" max="38*6" max_loc
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="画面下部に表示されるルームタイトルの背景を半透明にする。" explanation="" max="38*3" max_local="38*2"/>
     <string english="Room name background is TRANSLUCENT" translation="現在の設定: 半透明" explanation="" max="38*2" max_local="38*1"/>
     <string english="Room name background is OPAQUE" translation="現在の設定: 不透明" explanation="" max="38*2" max_local="38*1"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20" max_local="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3" max_local="38*2"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2" max_local="38*1"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2" max_local="38*1"/>
     <string english="speedrun options" translation="RTA用設定" explanation="menu option"/>
     <string english="Speedrunner Options" translation="RTA用設定" explanation="title" max="20" max_local="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="RTA/スピードランで役に立つ設定を変更する。" explanation="description for speedrunner options" max="38*5" max_local="38*4"/>

--- a/desktop_version/lang/ko/strings.xml
+++ b/desktop_version/lang/ko/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="화면 아래에 있는 이름 뒤쪽에 있는 것을 볼 수 있게 합니다." explanation="" max="38*3" max_local="30*3"/>
     <string english="Room name background is TRANSLUCENT" translation="방 이름 배경 투명" explanation="" max="38*2" max_local="30*2"/>
     <string english="Room name background is OPAQUE" translation="방 이름 배경 불투명" explanation="" max="38*2" max_local="30*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20" max_local="16"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3" max_local="30*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2" max_local="30*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2" max_local="30*2"/>
     <string english="speedrun options" translation="스피드런 설정" explanation="menu option"/>
     <string english="Speedrunner Options" translation="스피드런 설정" explanation="title" max="20" max_local="16"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="스피드런을 하는 유저들에게 흥미가 갈만한 고급 설정에 진입합니다." explanation="description for speedrunner options" max="38*5" max_local="30*5"/>

--- a/desktop_version/lang/nl/strings.xml
+++ b/desktop_version/lang/nl/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Laat zien wat er achter de naam van een kamer zit onder in beeld." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="Kamernaamachtergrond is DOORZICHTIG" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="Kamernaamachtergrond is ONDOORZICHTIG" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="speedrunopties" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Speedrunopties" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Een aantal geavanceerde instellingen die interessant kunnen zijn voor speedrunners." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/pl/strings.xml
+++ b/desktop_version/lang/pl/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Pozwala widzieć przestrzeń za nazwami pokoi." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="Tło za nazwami jest PRZEZROCZYSTE" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="Tło za nazwami jest NIEPRZEZROCZYSTE" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="opcje dla speedrunnerów" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Opcje Speedrunnerów" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Zaawansowane ustawienia|do speedrunnerów." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/pt_BR/strings.xml
+++ b/desktop_version/lang/pt_BR/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Permite ver o que está por trás do nome na parte inferior da tela." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="O plano de fundo do nome da sala está TRANSLÚCIDO" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="O plano de fundo do nome da sala está OPACO" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="opções de speedrun" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Opções de speedrun" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Acessa algumas configurações avançadas que podem interessar aos speedrunners." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/pt_PT/strings.xml
+++ b/desktop_version/lang/pt_PT/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Define se é possível ver o que está por detrás do nome das salas na parte inferior do ecrã." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="Fundo do nome da sala: TRANSPARENTE" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="Fundo do nome da sala: OPACO" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="opções de corrida" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Corrida" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Acede a definições avançadas que poderão ser úteis a quem quiser fazer corridas." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/ru/strings.xml
+++ b/desktop_version/lang/ru/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Позволяет вам увидеть, что находится позади названий комнат внизу экрана." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="Фон названий комнат ПРОЗРАЧНЫЙ" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="Фон названий комнат НЕПРОЗРАЧНЫЙ" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="настройки спидрана" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Для спидранеров" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Просмотрите расширенные настройки, которые могут быть полезны спидранерам." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/szl/strings.xml
+++ b/desktop_version/lang/szl/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Dozwŏlo widzieć, co je za mianami izbōw." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="Tło za mianami je PRZEZDZIYRNE" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="Tło za mianami je NIYPRZEZDZIYRNE" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="ôpcyje do speedrunnerōw" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Ôpcyje Speedrunnerōw" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Zaawansowane sztalowania|do speedrunnerōw." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/tr/strings.xml
+++ b/desktop_version/lang/tr/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Ekranın altında oda adı yazılı olan|panelin arkasını görmeni sağlar." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="Oda adı arka planı SAYDAM" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="Oda adı arka planı OPAK" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="speedrun seçenekleri" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Speedrun Seçenekleri" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Speedrun seven oyunculara yönelik bazı gelişmiş seçeneklere eriş." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/uk/strings.xml
+++ b/desktop_version/lang/uk/strings.xml
@@ -232,6 +232,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="Дозволяє побачити те, що розташовано за назвою внизу екрана." explanation="" max="38*3"/>
     <string english="Room name background is TRANSLUCENT" translation="Тло назв кімнат ПРОЗОРЕ" explanation="" max="38*2"/>
     <string english="Room name background is OPAQUE" translation="Тло назв кімнат НЕПРОЗОРЕ" explanation="" max="38*2"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2"/>
     <string english="speedrun options" translation="швидкісна гра" explanation="menu option"/>
     <string english="Speedrunner Options" translation="Швидкісна гра" explanation="title" max="20"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="Додаткові налаштування, що можуть бути корисні для швидкісного проходження." explanation="description for speedrunner options" max="38*5"/>

--- a/desktop_version/lang/zh/strings.xml
+++ b/desktop_version/lang/zh/strings.xml
@@ -238,6 +238,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="让你可以看见屏幕底端房间名后面的背景。" explanation="" max="38*3" max_local="25*2"/>
     <string english="Room name background is TRANSLUCENT" translation="房间名背景 透明" explanation="" max="38*2" max_local="25*1"/>
     <string english="Room name background is OPAQUE" translation="房间名背景 不透明" explanation="" max="38*2" max_local="25*1"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20" max_local="13"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3" max_local="25*2"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2" max_local="25*1"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2" max_local="25*1"/>
     <string english="speedrun options" translation="竞速选项" explanation="menu option"/>
     <string english="Speedrunner Options" translation="竞速玩家选项" explanation="title" max="20" max_local="13"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="竞速玩家可能会感兴趣的一些高级设定。" explanation="description for speedrunner options" max="38*5" max_local="25*4"/>

--- a/desktop_version/lang/zh_TW/strings.xml
+++ b/desktop_version/lang/zh_TW/strings.xml
@@ -238,6 +238,11 @@
     <string english="Lets you see through what is behind the name at the bottom of the screen." translation="讓你可以看見屏幕底端房間名後面的背景。" explanation="" max="38*3" max_local="25*2"/>
     <string english="Room name background is TRANSLUCENT" translation="房間名背景 透明" explanation="" max="38*2" max_local="25*1"/>
     <string english="Room name background is OPAQUE" translation="房間名背景 不透明" explanation="" max="38*2" max_local="25*1"/>
+    <string english="checkpoint saving" translation="" explanation="menu option"/>
+    <string english="Checkpoint Saving" translation="" explanation="title, makes checkpoints save the game" max="20" max_local="13"/>
+    <string english="Toggle if checkpoints should save the game." translation="" explanation="" max="38*3" max_local="25*2"/>
+    <string english="Checkpoint saving is OFF" translation="" explanation="makes checkpoints save the game" max="38*2" max_local="25*1"/>
+    <string english="Checkpoint saving is ON" translation="" explanation="makes checkpoints save the game" max="38*2" max_local="25*1"/>
     <string english="speedrun options" translation="競速選項" explanation="menu option"/>
     <string english="Speedrunner Options" translation="競速玩家選項" explanation="title" max="20" max_local="13"/>
     <string english="Access some advanced settings that might be of interest to speedrunners." translation="競速玩家可能會感興趣的一些高級設定。" explanation="description for speedrunner options" max="38*5" max_local="25*4"/>

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2733,17 +2733,7 @@ bool entityclass::updateentities( int i )
                 }
                 entities[i].state = 0;
 
-                if (game.checkpoint_saving)
-                {
-                    bool success = game.savequick();
-                    game.gamesaved = success;
-                    game.gamesavefailed = !success;
-
-                    if (game.gamesavefailed) {
-                        game.show_save_fail();
-                        graphics.textboxapplyposition();
-                    }
-                }
+                game.checkpoint_save();
             }
             break;
         case 9: //Gravity Lines

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2732,6 +2732,13 @@ bool entityclass::updateentities( int i )
                     game.savedir = entities[player].dir;
                 }
                 entities[i].state = 0;
+
+                if (game.checkpoint_saving)
+                {
+                    bool success = game.savequick();
+                    game.gamesaved = success;
+                    game.gamesavefailed = !success;
+                }
             }
             break;
         case 9: //Gravity Lines

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2738,6 +2738,11 @@ bool entityclass::updateentities( int i )
                     bool success = game.savequick();
                     game.gamesaved = success;
                     game.gamesavefailed = !success;
+
+                    if (game.gamesavefailed) {
+                        game.show_save_fail();
+                        graphics.textboxapplyposition();
+                    }
                 }
             }
             break;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -6864,6 +6864,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option(loc::gettext("unfocus pause"));
         option(loc::gettext("unfocus audio pause"));
         option(loc::gettext("room name background"));
+        option(loc::gettext("checkpoint saving"));
         option(loc::gettext("return"));
         menuyoff = 0;
         maxspacing = 15;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -827,12 +827,21 @@ static void savetele_textbox_success(textboxclass* THIS)
     THIS->pad(3, 3);
 }
 
-static void savetele_textbox_fail(textboxclass* THIS)
+static void save_textbox_fail(textboxclass* THIS)
 {
     THIS->lines.clear();
     THIS->lines.push_back(loc::gettext("ERROR: Could not save game!"));
     THIS->wrap(2);
     THIS->pad(1, 1);
+}
+
+void Game::show_save_fail(void)
+{
+    graphics.createtextboxflipme("", -1, 12, TEXT_COLOUR("red"));
+    graphics.textboxprintflags(PR_FONT_INTERFACE);
+    graphics.textboxcenterx();
+    graphics.textboxtimer(50);
+    graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, save_textbox_fail);
 }
 
 void Game::savetele_textbox(void)
@@ -852,11 +861,7 @@ void Game::savetele_textbox(void)
     }
     else
     {
-        graphics.createtextboxflipme("", -1, 12, TEXT_COLOUR("red"));
-        graphics.textboxprintflags(PR_FONT_INTERFACE);
-        graphics.textboxcenterx();
-        graphics.textboxtimer(50);
-        graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, savetele_textbox_fail);
+        show_save_fail();
     }
     graphics.textboxapplyposition();
 }

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -376,6 +376,12 @@ void Game::init(void)
     screenshot_border_timer = 0;
     screenshot_saved_success = false;
 
+#ifdef __ANDROID__
+    checkpoint_saving = true;
+#else
+    checkpoint_saving = false;
+#endif
+
     setdefaultcontrollerbuttons();
 }
 
@@ -4936,6 +4942,10 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, struct ScreenSett
             roomname_translator::set_enabled(help.Int(pText));
         }
 
+        if (SDL_strcmp(pKey, "checkpoint_saving") == 0)
+        {
+            checkpoint_saving = help.Int(pText);
+        }
     }
 
     setdefaultcontrollerbuttons();
@@ -5194,6 +5204,8 @@ void Game::serializesettings(tinyxml2::XMLElement* dataNode, const struct Screen
     xml::update_tag(dataNode, "english_sprites", (int) loc::english_sprites);
     xml::update_tag(dataNode, "new_level_font", loc::new_level_font.c_str());
     xml::update_tag(dataNode, "roomname_translator", (int) roomname_translator::enabled);
+
+    xml::update_tag(dataNode, "checkpoint_saving", (int) checkpoint_saving);
 }
 
 static bool settings_loaded = false;

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -844,6 +844,22 @@ void Game::show_save_fail(void)
     graphics.textboxtranslate(TEXTTRANSLATE_FUNCTION, save_textbox_fail);
 }
 
+void Game::checkpoint_save(void)
+{
+    if (checkpoint_saving && !inspecial())
+    {
+        bool success = map.custommode ? customsavequick(cl.ListOfMetaData[playcustomlevel].filename) : savequick();
+        gamesaved = success;
+        gamesavefailed = !success;
+
+        if (gamesavefailed)
+        {
+            show_save_fail();
+            graphics.textboxapplyposition();
+        }
+    }
+}
+
 void Game::savetele_textbox(void)
 {
     if (inspecial() || map.custommode)

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -225,6 +225,7 @@ public:
     void crewmate_textbox(const int color);
     void remaining_textbox(void);
     void actionprompt_textbox(void);
+    void show_save_fail(void);
     void savetele_textbox(void);
 
     void setstate(int gamestate);

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -226,6 +226,7 @@ public:
     void remaining_textbox(void);
     void actionprompt_textbox(void);
     void show_save_fail(void);
+    void checkpoint_save(void);
     void savetele_textbox(void);
 
     void setstate(int gamestate);

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -363,6 +363,7 @@ public:
     int savetrinkets;
     bool startscript;
     std::string newscript;
+    bool checkpoint_saving;
 
     bool menustart;
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -862,6 +862,12 @@ static void menuactionpress(void)
             game.savestatsandsettings_menu();
             music.playef(Sound_VIRIDIAN);
             break;
+        case 3:
+            // toggle checkpoint saving
+            game.checkpoint_saving = !game.checkpoint_saving;
+            game.savestatsandsettings_menu();
+            music.playef(Sound_VIRIDIAN);
+            break;
         default:
             //back
             music.playef(Sound_VIRIDIAN);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1152,7 +1152,7 @@ static void menurender(void)
         {
             font::print(PR_2X | PR_CEN, -1, 30, loc::gettext("Checkpoint Saving"), tr, tg, tb);
             int next_y = font::print_wrap(PR_CEN, -1, 65, loc::gettext("Toggle if checkpoints should save the game."), tr, tg, tb);
-            if (game.checkpoint_saving)
+            if (!game.checkpoint_saving)
             {
                 font::print_wrap(PR_CEN, -1, next_y, loc::gettext("Checkpoint saving is OFF"), tr / 2, tg / 2, tb / 2);
             }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1139,6 +1139,7 @@ static void menurender(void)
             break;
         }
         case 2:
+        {
             font::print(PR_2X | PR_CEN, -1, 30, loc::gettext("Room Name BG"), tr, tg, tb);
             int next_y = font::print_wrap(PR_CEN, -1, 65, loc::gettext("Lets you see through what is behind the name at the bottom of the screen."), tr, tg, tb);
             if (graphics.translucentroomname)
@@ -1146,6 +1147,21 @@ static void menurender(void)
             else
                 font::print_wrap(PR_CEN, -1, next_y, loc::gettext("Room name background is OPAQUE"), tr, tg, tb);
             break;
+        }
+        case 3:
+        {
+            font::print(PR_2X | PR_CEN, -1, 30, loc::gettext("Checkpoint Saving"), tr, tg, tb);
+            int next_y = font::print_wrap(PR_CEN, -1, 65, loc::gettext("Toggle if checkpoints should save the game."), tr, tg, tb);
+            if (game.checkpoint_saving)
+            {
+                font::print_wrap(PR_CEN, -1, next_y, loc::gettext("Checkpoint saving is OFF"), tr / 2, tg / 2, tb / 2);
+            }
+            else
+            {
+                font::print_wrap(PR_CEN, -1, next_y, loc::gettext("Checkpoint saving is ON"), tr, tg, tb);
+            }
+            break;
+        }
         }
         break;
     case Menu::accessibility:

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1206,6 +1206,13 @@ void scriptclass::run(void)
                 {
                     game.savedir = obj.entities[i].dir;
                 }
+
+                if (game.checkpoint_saving)
+                {
+                    bool success = game.savequick();
+                    game.gamesaved = success;
+                    game.gamesavefailed = !success;
+                }
             }
             else if (words[0] == "gamestate")
             {

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1207,17 +1207,7 @@ void scriptclass::run(void)
                     game.savedir = obj.entities[i].dir;
                 }
 
-                if (game.checkpoint_saving)
-                {
-                    bool success = game.savequick();
-                    game.gamesaved = success;
-                    game.gamesavefailed = !success;
-
-                    if (game.gamesavefailed) {
-                        game.show_save_fail();
-                        graphics.textboxapplyposition();
-                    }
-                }
+                game.checkpoint_save();
             }
             else if (words[0] == "gamestate")
             {

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1212,6 +1212,11 @@ void scriptclass::run(void)
                     bool success = game.savequick();
                     game.gamesaved = success;
                     game.gamesavefailed = !success;
+
+                    if (game.gamesavefailed) {
+                        game.show_save_fail();
+                        graphics.textboxapplyposition();
+                    }
                 }
             }
             else if (words[0] == "gamestate")


### PR DESCRIPTION
## Changes:

This is a small PR that adds mobile VVVVVV's behavior of saving on checkpoints. It quicksaves whenever your checkpoint gets set, either by touching a checkpoint or `setcheckpoint()`. On by default on Android, off otherwise. Can be manually overridden through `settings.vvv`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
