### PR TITLE
Fix regression: Entities not moving

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1235,6 +1235,12 @@ static void entityclonefix(entclass* entity)
     const bool is_lies_emitter = entity->behave == 10;
     const bool is_factory_emitter = entity->behave == 12;
 
+    const bool is_emitter = is_lies_emitter || is_factory_emitter;
+    if (!is_emitter)
+    {
+        return;
+    }
+
     const bool in_lies_emitter_room =
         game.roomx >= 113 && game.roomx <= 117 && game.roomy == 111;
     const bool in_factory_emitter_room =


### PR DESCRIPTION
Commit 53d725f78a3550b750d652a62ffe9d8b51dd0e18, intended to fix an overzealous commit, was itself overzealous. This is because it applied to all entities when it should only apply to entity-emitting entities. To fix this, `entityclonefix` needs to no-op if the entity is not an entity emitter.

Fixes #1176.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
