### PR TITLE
Fix regression: Escape from conveyor spikes

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -835,7 +835,7 @@ void gamelogic(void)
                 }
             }
 
-            if(obj.horplatforms)
+            if (obj.horplatforms)
             {
                 for (int ie = obj.entities.size() - 1; ie >= 0;  ie--)
                 {
@@ -859,7 +859,10 @@ void gamelogic(void)
                 //is the player standing on a moving platform?
                 int i = obj.getplayer();
                 float j = obj.entitycollideplatformfloor(i);
-                if (INBOUNDS_VEC(i, obj.entities) && j > -1000)
+                // To match 2.2, we need to give a bit of leeway in the lifeseq
+                // before we start pushing the player.
+                const bool horz_active = game.lifeseq < 8;
+                if (horz_active && INBOUNDS_VEC(i, obj.entities) && j > -1000)
                 {
                     obj.entities[i].newxp = obj.entities[i].xp + j;
                     obj.entitymapcollision(i);
@@ -867,7 +870,7 @@ void gamelogic(void)
                 else
                 {
                     j = obj.entitycollideplatformroof(i);
-                    if (INBOUNDS_VEC(i, obj.entities) && j > -1000)
+                    if (horz_active && INBOUNDS_VEC(i, obj.entities) && j > -1000)
                     {
                         obj.entities[i].newxp = obj.entities[i].xp + j;
                         obj.entitymapcollision(i);


### PR DESCRIPTION
This fixes a regression from 2.3. Consider the following diagram:

       CC
    X  CC
      <<<<

"C" indicates one tile of a checkpoint entity, "X" indicates a spike tile, and "<" indicates one tile of a conveyor entity that has the default speed (4 pixels per frame) going leftwards.

Now consider if the player were to touch the checkpoint and die. In 2.2, they would be able to escape from the spike by holding right. But in 2.3, they would not be able to, and would die from the spike continuously with no escape.

This happens because in 2.2, the player would spawn a couple pixels off the surface, and this gained them an extra frame of movement to move away from the conveyor. 2.3 places the player directly on the ground, moving them one frame earlier and thus forcing them to their doom.

Now consider the following diagram:

      CC
    X CC
     <<<<

The difference with the previous diagram is that this time, the spike is one tile closer. This time, there is no escape in 2.2 and you will always die no matter what.

By the way, both diagrams have the same behavior if the conveyor is rightwards and if everything is flipped upside-down. Thankfully, it doesn't seem to be direction-dependent.

The reason 2.3 lowered the player onto the surface was for consistency (see PR #502), and I don't want to undo that. So I think the best solution here is to re-add the extra frame of control by conveyors only moving the player after lifeseq has advanced enough.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
