### PR TITLE
Always have interim version indicators

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -213,10 +213,9 @@ if(NOT OFFICIAL_BUILD)
     set(VERSION_INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/InterimVersion.in.c)
     set(VERSION_OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/InterimVersion.out.c)
 
-    add_custom_target(
-        GenerateVersion ALL
-        # This BYPRODUCTS line is required for this to be ran every time
-        BYPRODUCTS ${VERSION_OUTPUT_FILE}
+    add_custom_command(
+        # This OUTPUT line is required for this to be ran every time
+        OUTPUT ${VERSION_OUTPUT_FILE} ${CMAKE_CURRENT_SOURCE_DIR}/src/_dummy.c
         COMMAND ${CMAKE_COMMAND}
         # These args have to be passed through, otherwise the script can't see them
         # Also, these args have to come BEFORE `-P`! (Otherwise it fails with an unclear error)
@@ -224,8 +223,6 @@ if(NOT OFFICIAL_BUILD)
         -DOUTPUT_FILE=${VERSION_OUTPUT_FILE}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/version.cmake
     )
-
-    add_dependencies(VVVVVV GenerateVersion)
 
     target_compile_definitions(VVVVVV PRIVATE -DINTERIM_VERSION_EXISTS)
 

--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -208,35 +208,29 @@ set(SBIDI_SRC ../third_party/SheenBidi/Source/SheenBidi.c)
 if(NOT OFFICIAL_BUILD)
     # Add interim commit hash and its date to the build
 
-    # find_package sets GIT_FOUND and GIT_EXECUTABLE
-    find_package(Git)
+    # These filenames have to be qualified, because when we run
+    # the CMake script, its work dir gets set to the build folder
+    set(VERSION_INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/InterimVersion.in.c)
+    set(VERSION_OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/InterimVersion.out.c)
 
-    if(GIT_FOUND)
-        # These filenames have to be qualified, because when we run
-        # the CMake script, its work dir gets set to the build folder
-        set(VERSION_INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/InterimVersion.in.c)
-        set(VERSION_OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/InterimVersion.out.c)
+    add_custom_target(
+        GenerateVersion ALL
+        # This BYPRODUCTS line is required for this to be ran every time
+        BYPRODUCTS ${VERSION_OUTPUT_FILE}
+        COMMAND ${CMAKE_COMMAND}
+        # These args have to be passed through, otherwise the script can't see them
+        # Also, these args have to come BEFORE `-P`! (Otherwise it fails with an unclear error)
+        -DINPUT_FILE=${VERSION_INPUT_FILE}
+        -DOUTPUT_FILE=${VERSION_OUTPUT_FILE}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/version.cmake
+    )
 
-        add_custom_target(
-            GenerateVersion ALL
-            # This BYPRODUCTS line is required for this to be ran every time
-            BYPRODUCTS ${VERSION_OUTPUT_FILE}
-            COMMAND ${CMAKE_COMMAND}
-            # These args have to be passed through, otherwise the script can't see them
-            # Also, these args have to come BEFORE `-P`! (Otherwise it fails with an unclear error)
-            -DGIT_EXECUTABLE=${GIT_EXECUTABLE}
-            -DINPUT_FILE=${VERSION_INPUT_FILE}
-            -DOUTPUT_FILE=${VERSION_OUTPUT_FILE}
-            -P ${CMAKE_CURRENT_SOURCE_DIR}/version.cmake
-        )
+    add_dependencies(VVVVVV GenerateVersion)
 
-        add_dependencies(VVVVVV GenerateVersion)
+    target_compile_definitions(VVVVVV PRIVATE -DINTERIM_VERSION_EXISTS)
 
-        target_compile_definitions(VVVVVV PRIVATE -DINTERIM_VERSION_EXISTS)
-
-        add_library(InterimVersion STATIC src/InterimVersion.out.c)
-        list(APPEND STATIC_LIBRARIES InterimVersion)
-    endif()
+    add_library(InterimVersion STATIC src/InterimVersion.out.c)
+    list(APPEND STATIC_LIBRARIES InterimVersion)
 endif()
 
 # Build options

--- a/desktop_version/version.cmake
+++ b/desktop_version/version.cmake
@@ -5,19 +5,19 @@ find_package(Git)
 
 if(GIT_FOUND)
     # Get interim commit and date of commit
-    EXECUTE_PROCESS(
+    execute_process(
         COMMAND "${GIT_EXECUTABLE}" log -1 --format=%h
         OUTPUT_VARIABLE INTERIM_COMMIT
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
-    EXECUTE_PROCESS(
+    execute_process(
         COMMAND "${GIT_EXECUTABLE}" log -1 --format=%cd --date=short
         OUTPUT_VARIABLE COMMIT_DATE
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
-    EXECUTE_PROCESS(
+    execute_process(
         COMMAND "${GIT_EXECUTABLE}" branch --show-current
         OUTPUT_VARIABLE BRANCH_NAME
         OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -36,7 +36,7 @@ if("${BRANCH_NAME}" STREQUAL "")
     set(BRANCH_NAME "(branch?)")
 endif()
 
-MESSAGE(STATUS "This is interim commit ${INTERIM_COMMIT} (committed ${COMMIT_DATE}) on branch ${BRANCH_NAME}")
+message(STATUS "This is interim commit ${INTERIM_COMMIT} (committed ${COMMIT_DATE}) on branch ${BRANCH_NAME}")
 
 # Take the template file and replace the macros with what we have
-CONFIGURE_FILE(${INPUT_FILE} ${OUTPUT_FILE})
+configure_file(${INPUT_FILE} ${OUTPUT_FILE})

--- a/desktop_version/version.cmake
+++ b/desktop_version/version.cmake
@@ -1,23 +1,40 @@
 # Expects INPUT_FILE and OUTPUT_FILE to be defined
 
-# Get interim commit and date of commit
-EXECUTE_PROCESS(
-    COMMAND "${GIT_EXECUTABLE}" log -1 --format=%h
-    OUTPUT_VARIABLE INTERIM_COMMIT
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+# find_package sets GIT_FOUND and GIT_EXECUTABLE
+find_package(Git)
 
-EXECUTE_PROCESS(
-    COMMAND "${GIT_EXECUTABLE}" log -1 --format=%cd --date=short
-    OUTPUT_VARIABLE COMMIT_DATE
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+if(GIT_FOUND)
+    # Get interim commit and date of commit
+    EXECUTE_PROCESS(
+        COMMAND "${GIT_EXECUTABLE}" log -1 --format=%h
+        OUTPUT_VARIABLE INTERIM_COMMIT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
 
-EXECUTE_PROCESS(
-    COMMAND "${GIT_EXECUTABLE}" branch --show-current
-    OUTPUT_VARIABLE BRANCH_NAME
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+    EXECUTE_PROCESS(
+        COMMAND "${GIT_EXECUTABLE}" log -1 --format=%cd --date=short
+        OUTPUT_VARIABLE COMMIT_DATE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    EXECUTE_PROCESS(
+        COMMAND "${GIT_EXECUTABLE}" branch --show-current
+        OUTPUT_VARIABLE BRANCH_NAME
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+endif()
+
+# Defaults if we don't have git or its commands fail for any reason or give blanks
+# For annoying CMake reasons, must use "${VAR}" syntax rather than VAR
+if("${INTERIM_COMMIT}" STREQUAL "")
+    set(INTERIM_COMMIT "(commit?)")
+endif()
+if("${COMMIT_DATE}" STREQUAL "")
+    set(COMMIT_DATE "(date?)")
+endif()
+if("${BRANCH_NAME}" STREQUAL "")
+    set(BRANCH_NAME "(branch?)")
+endif()
 
 MESSAGE(STATUS "This is interim commit ${INTERIM_COMMIT} (committed ${COMMIT_DATE}) on branch ${BRANCH_NAME}")
 


### PR DESCRIPTION
Previously, the interim version indicators (commit, date, and branch) would go away on development builds if git didn't exist. And if it did exist but provided blank output for whatever reason, that was almost exactly the same as not having them at all (save for the window title saying "VVVVVV []" which can be easy to overlook). This was bad because it complicates troubleshooting when you potentially have an unofficial or in-development build since those get distributed around or compiled by some people frequently.

Now, there will always be an interim version indicators unless the game is compiled with `-DOFFICIAL_BUILD=ON`. And if the indicators are blank for any reason, they will just be replaced with placeholder defaults so they will still show up.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
