### PR TITLE
Fix double error dialog if `data.zip` is missing

### DIFF
--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -342,6 +342,7 @@ int FILESYSTEM_init(char *argvZero, char* baseDir, char *assetsPath, char* langD
             "\nor get it from the free Make and Play Edition.",
             NULL
         );
+        VVV_exit(1);
         return 0;
     }
 


### PR DESCRIPTION
A minor gripe, but one thing I didn't notice with commit b4579d88d3631c36d3c6457e85ca0996c65941ca is that it now results in two dialogs if data.zip is missing: The first being the "`data.zip` is missing" dialog, and the second is the generic "Unable to initialize filesystem" dialog.

So just bail early if `data.zip` can't be found, it's going to take the error path in `main()` and also bail regardless.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
