### PR TITLE
Fix wrong comment on disabling MSVC exceptions

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -287,7 +287,8 @@ endif()
 if(MSVC)
     # MSVC doesn't have /std:c99 or /std:c++98 switches!
 
-    # Disable exceptions
+    # MSVC does not officially support disabling exceptions,
+    # so this is as far as we are willing to go to disable them.
     string(REGEX REPLACE "/EH[a-z]+" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
 


### PR DESCRIPTION
`/EHsc` does not actually disable exceptions on MSVC, it only makes the compiler assume that `extern "C"` functions never throw C++ exceptions.

We had a discussion on Discord about actually disabling exceptions, and from research, that requires defining `_HAS_EXCEPTIONS=0`, but it's unsupported and undocumented so we deemed the benefits not worth it. Thus, we will stay with `/EHsc`. But the comment still has to be updated.

[skip ci]

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
