### PR TITLE
Fix played jingles (Path Complete and Plenary) briefly not respecting user volume

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -962,7 +962,7 @@ void musicclass::play(int t)
             m_doFadeInVol = false;
             m_doFadeOutVol = false;
             musicVolume = VVV_MAX_VOLUME;
-            MusicTrack::SetVolume(musicVolume);
+            MusicTrack::SetVolume(VVV_MAX_VOLUME * user_music_volume / USER_VOLUME_MAX);
         }
     }
     else


### PR DESCRIPTION
## Changes:

There seems to be a lot of confusion between user volume and game's master volume. As a result, a bug was introduced when the user volume setting was added in which for a single frame the music of these jingles was set to the VVV_MAX_VOLUME which may be much louder than the user's volume setting. This was especially noticeable for Path Complete, but could be heard in Plenary too (even with its baked-in fade). It might be a good idea to generally clean up the audio code because the different volume variables between user and master are peppered throughout the audio functions instead of being localized and processed in one place. Either way, this PR fixes the bug with the jingles (tracks 0 and 7). 


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
