### PR TITLE
Use variable timestep for `SDL_Delay`

### DIFF
--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -866,9 +866,10 @@ int main(int argc, char *argv[])
         f_time = SDL_GetTicks64();
 
         const Uint64 f_timetaken = f_time - f_timePrev;
-        if (!game.over30mode && f_timetaken < 34)
+        const int timestep = game.get_timestep();
+        if (!game.over30mode && f_timetaken < (Uint64) timestep)
         {
-            const volatile Uint64 f_delay = 34 - f_timetaken;
+            const volatile Uint64 f_delay = timestep - f_timetaken;
             SDL_Delay((Uint32) f_delay);
             f_time = SDL_GetTicks64();
         }


### PR DESCRIPTION
This fixes a bug where fast-forward wouldn't work in 30-FPS-only mode.

This is because the 30-FPS-only code has a hardcoded check for the number 34, as in 34 milliseconds must pass before the next frame can advance. This is why slowdown still worked, because slowdown means you're waiting longer than 34 ms anyways, but fast-forward tries to wait for only 1 ms, which wouldn't work if the 34 limit was still enforced.

So instead, swap out the 34 with `game.get_timestep()` and this will be fixed.

Fixes #1185.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
