### PR TITLE
Render uncommitted IME text in bottom left corner

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -82,6 +82,7 @@ set(VVV_CXX_SRC
     src/Graphics.cpp
     src/GraphicsResources.cpp
     src/GraphicsUtil.cpp
+    src/IMERender.cpp
     src/Input.cpp
     src/KeyPoll.cpp
     src/Labclass.cpp

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -12,6 +12,7 @@
 #include "FileSystemUtils.h"
 #include "Font.h"
 #include "GraphicsUtil.h"
+#include "IMERender.h"
 #include "Localization.h"
 #include "Map.h"
 #include "Maths.h"
@@ -3529,6 +3530,7 @@ void Graphics::get_stretch_info(SDL_Rect* rect)
 
 void Graphics::render(void)
 {
+    ime_render();
     draw_screenshot_border();
 
     if (gameScreen.badSignalEffect)
@@ -3541,10 +3543,12 @@ void Graphics::render(void)
 
     draw_window_background();
 
-    SDL_Rect rect;
-    get_stretch_info(&rect);
+    SDL_Rect stretch_info;
+    get_stretch_info(&stretch_info);
 
-    copy_texture(gameTexture, NULL, &rect, 0, NULL, flipmode ? SDL_FLIP_VERTICAL : SDL_FLIP_NONE);
+    ime_set_rect(&stretch_info);
+
+    copy_texture(gameTexture, NULL, &stretch_info, 0, NULL, flipmode ? SDL_FLIP_VERTICAL : SDL_FLIP_NONE);
 }
 
 void Graphics::renderwithscreeneffects(void)

--- a/desktop_version/src/IMERender.cpp
+++ b/desktop_version/src/IMERender.cpp
@@ -1,0 +1,57 @@
+#include <SDL.h>
+
+#include "Constants.h"
+#include "Font.h"
+#include "Graphics.h"
+#include "KeyPoll.h"
+
+static bool render_done = false;
+static SDL_Rect imebox;
+
+void ime_render(void)
+{
+    render_done = false;
+
+    if (!SDL_IsTextInputActive() || key.imebuffer == "")
+    {
+        return;
+    }
+
+    int fontheight = font::height(PR_FONT_LEVEL);
+    imebox.x = 8;
+    imebox.y = SCREEN_HEIGHT_PIXELS - 32 - fontheight;
+    imebox.w = font::len(PR_FONT_LEVEL, key.imebuffer.c_str()) + 1;
+    imebox.h = fontheight + 1;
+
+    SDL_Rect imebox_border = imebox;
+    imebox_border.x -= 1;
+    imebox_border.y -= 1;
+    imebox_border.w += 2;
+    imebox_border.h += 2;
+
+    graphics.fill_rect(&imebox_border, 128, 128, 128);
+    graphics.fill_rect(&imebox, 0, 0, 0);
+    font::print(PR_FONT_LEVEL | PR_CJK_LOW, imebox.x + 1, imebox.y + 1, key.imebuffer, 255, 255, 255);
+
+    render_done = true;
+}
+
+void ime_set_rect(SDL_Rect* stretch_info)
+{
+    if (!render_done)
+    {
+        return;
+    }
+
+    SDL_Rect imebox_scaled = imebox;
+    float x_scale = (float) stretch_info->w / SCREEN_WIDTH_PIXELS;
+    float y_scale = (float) stretch_info->h / SCREEN_HEIGHT_PIXELS;
+    imebox_scaled.x *= x_scale;
+    imebox_scaled.y *= y_scale;
+    imebox_scaled.w *= x_scale;
+    imebox_scaled.h *= y_scale;
+    imebox_scaled.x += stretch_info->x;
+    imebox_scaled.y += stretch_info->y;
+
+    SDL_SetTextInputRect(&imebox_scaled);
+}

--- a/desktop_version/src/IMERender.cpp
+++ b/desktop_version/src/IMERender.cpp
@@ -4,6 +4,7 @@
 #include "Font.h"
 #include "Graphics.h"
 #include "KeyPoll.h"
+#include "UTF8.h"
 
 static bool render_done = false;
 static SDL_Rect imebox;
@@ -31,6 +32,53 @@ void ime_render(void)
 
     graphics.fill_rect(&imebox_border, 128, 128, 128);
     graphics.fill_rect(&imebox, 0, 0, 0);
+
+    if (key.imebuffer_length > 0)
+    {
+        /* Also show a selection, so we need to know where and how long it is...
+         * Because SDL gives us the number of "characters" (so, codepoints)... */
+        const char* imebuffer_ptr = key.imebuffer.c_str();
+        const char* sel_start_ptr = imebuffer_ptr;
+        for (int i = 0; i < key.imebuffer_start; i++)
+        {
+            if (UTF8_next(&sel_start_ptr) == 0)
+            {
+                // Already past the '\0'...
+                sel_start_ptr--;
+                break;
+            }
+        }
+        const char* sel_end_ptr = sel_start_ptr;
+        for (int i = 0; i < key.imebuffer_length; i++)
+        {
+            if (UTF8_next(&sel_end_ptr) == 0)
+            {
+                break;
+            }
+        }
+        size_t before_sel_nbytes = sel_start_ptr - imebuffer_ptr;
+        size_t in_sel_nbytes = sel_end_ptr - sel_start_ptr;
+        char* before_sel = (char*) SDL_malloc(before_sel_nbytes + 1);
+        char* in_sel = (char*) SDL_malloc(in_sel_nbytes + 1);
+        if (before_sel != NULL && in_sel != NULL)
+        {
+            SDL_memcpy(before_sel, imebuffer_ptr, before_sel_nbytes);
+            before_sel[before_sel_nbytes] = '\0';
+            SDL_memcpy(in_sel, sel_start_ptr, in_sel_nbytes);
+            in_sel[in_sel_nbytes] = '\0';
+
+            int before_sel_pixels = font::len(PR_FONT_LEVEL, before_sel);
+            int in_sel_pixels = font::len(PR_FONT_LEVEL, in_sel);
+
+            SDL_Rect selrect = imebox;
+            selrect.x += before_sel_pixels + 1;
+            selrect.w = in_sel_pixels;
+            graphics.fill_rect(&selrect, 128, 64, 0);
+        }
+        SDL_free(before_sel);
+        SDL_free(in_sel);
+    }
+
     font::print(PR_FONT_LEVEL | PR_CJK_LOW, imebox.x + 1, imebox.y + 1, key.imebuffer, 255, 255, 255);
 
     render_done = true;

--- a/desktop_version/src/IMERender.h
+++ b/desktop_version/src/IMERender.h
@@ -1,0 +1,7 @@
+#ifndef IMERENDER_H
+#define IMERENDER_H
+
+void ime_render(void);
+void ime_set_rect(SDL_Rect* stretch_info);
+
+#endif /* IMERENDER_H */

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -52,6 +52,8 @@ KeyPoll::KeyPoll(void)
 
     keybuffer = "";
     imebuffer = "";
+    imebuffer_start = 0;
+    imebuffer_length = 0;
     leftbutton=0; rightbutton=0; middlebutton=0;
     mousex = 0;
     mousey = 0;
@@ -67,6 +69,8 @@ void KeyPoll::enabletextentry(void)
 {
     keybuffer = "";
     imebuffer = "";
+    imebuffer_start = 0;
+    imebuffer_length = 0;
     SDL_StartTextInput();
 }
 
@@ -74,6 +78,8 @@ void KeyPoll::disabletextentry(void)
 {
     SDL_StopTextInput();
     imebuffer = "";
+    imebuffer_start = 0;
+    imebuffer_length = 0;
 }
 
 bool KeyPoll::textentry(void)
@@ -326,9 +332,13 @@ void KeyPoll::Poll(void)
             break;
         case SDL_TEXTEDITING:
             imebuffer = evt.edit.text;
+            imebuffer_start = evt.edit.start;
+            imebuffer_length = evt.edit.length;
             break;
         case SDL_TEXTEDITING_EXT:
             imebuffer = evt.editExt.text;
+            imebuffer_start = evt.editExt.start;
+            imebuffer_length = evt.editExt.length;
             SDL_free(evt.editExt.text);
             break;
 

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -50,7 +50,8 @@ KeyPoll::KeyPoll(void)
     // 0..5
     sensitivity = 2;
 
-    keybuffer="";
+    keybuffer = "";
+    imebuffer = "";
     leftbutton=0; rightbutton=0; middlebutton=0;
     mousex = 0;
     mousey = 0;
@@ -64,13 +65,15 @@ KeyPoll::KeyPoll(void)
 
 void KeyPoll::enabletextentry(void)
 {
-    keybuffer="";
+    keybuffer = "";
+    imebuffer = "";
     SDL_StartTextInput();
 }
 
 void KeyPoll::disabletextentry(void)
 {
     SDL_StopTextInput();
+    imebuffer = "";
 }
 
 bool KeyPoll::textentry(void)
@@ -320,6 +323,13 @@ void KeyPoll::Poll(void)
             {
                 keybuffer += evt.text.text;
             }
+            break;
+        case SDL_TEXTEDITING:
+            imebuffer = evt.edit.text;
+            break;
+        case SDL_TEXTEDITING_EXT:
+            imebuffer = evt.editExt.text;
+            SDL_free(evt.editExt.text);
             break;
 
         /* Mouse Input */

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -69,6 +69,7 @@ public:
     bool textentry(void);
     bool pressedbackspace;
     std::string keybuffer;
+    std::string imebuffer;
 
     bool linealreadyemptykludge;
 

--- a/desktop_version/src/KeyPoll.h
+++ b/desktop_version/src/KeyPoll.h
@@ -70,6 +70,8 @@ public:
     bool pressedbackspace;
     std::string keybuffer;
     std::string imebuffer;
+    int imebuffer_start;
+    int imebuffer_length;
 
     bool linealreadyemptykludge;
 

--- a/desktop_version/src/main.cpp
+++ b/desktop_version/src/main.cpp
@@ -599,6 +599,7 @@ int main(int argc, char *argv[])
     }
 
     SDL_SetHintWithPriority(SDL_HINT_IME_SHOW_UI, "1", SDL_HINT_OVERRIDE);
+    SDL_SetHintWithPriority(SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, "1", SDL_HINT_OVERRIDE);
 
     /* We already do the button swapping in ButtonGlyphs, disable SDL's swapping */
     SDL_SetHintWithPriority(SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS, "0", SDL_HINT_OVERRIDE);


### PR DESCRIPTION
## Changes:

As a followup to #1041 and the discussion inside it, this PR now shows the current candidate text (the uncommitted text being edited in the IME) in a box in the bottom left corner. This visualizes the data from `SDL_TEXTEDITING[_EXT]` events and makes it easier to input CJK text.

So at first (before #1041) you couldn't see what you were doing at all, after #1041 you could at least see the candidate list making it much clearer what was going on but you couldn't see the uncommitted text, and now you can also see the uncommitted text.

Not much more to explain about it except for a demo video:

https://github.com/user-attachments/assets/596c3519-c588-4a00-b9a3-04d818e46d0c


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
