### PR TITLE
Tweak IME selection background left bound

### DIFF
--- a/desktop_version/src/IMERender.cpp
+++ b/desktop_version/src/IMERender.cpp
@@ -67,8 +67,12 @@ void ime_render(void)
             SDL_memcpy(in_sel, sel_start_ptr, in_sel_nbytes);
             in_sel[in_sel_nbytes] = '\0';
 
-            int before_sel_pixels = font::len(PR_FONT_LEVEL, before_sel);
+            int before_sel_pixels = font::len(PR_FONT_LEVEL, before_sel) - 1;
             int in_sel_pixels = font::len(PR_FONT_LEVEL, in_sel);
+            if (in_sel_pixels > 0)
+            {
+                in_sel_pixels += 1;
+            }
 
             SDL_Rect selrect = imebox;
             selrect.x += before_sel_pixels + 1;


### PR DESCRIPTION
## Changes:

Just extending the selection background left by one pixel so there's not one pixel of black background to the left of a selection that starts at the beginning of the text, and so some characters being selected show up better (particularly where there's a long vertical bar at the first pixel). We shouldn't be overlapping any part of the previous character, since every character normally has a pixel of spacing on the right.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
