### PR TITLE
Add enemy speed as a room property

### DIFF
--- a/desktop_version/lang/ar/strings.xml
+++ b/desktop_version/lang/ar/strings.xml
@@ -630,6 +630,7 @@
     <string english="Tileset Colour Changed" translation="تغير لون مجموعة الخلايا" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3" max_local="38*3"/>
     <string english="Enemy Type Changed" translation="تغير نوع الأعداء" explanation="level editor, user changed enemy appearance for the room" max="38*3" max_local="38*3"/>
     <string english="Platform speed is now {speed}" translation="تغيرت سرعة المنصات إلى {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3" max_local="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3" max_local="38*3"/>
     <string english="Reloaded resources" translation="أعيد فتح ملفات الموارد" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3" max_local="38*3"/>
     <string english="ERROR: Invalid format" translation="خطأ: صيغة المكتوب غير مناسبة" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3" max_local="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="فتحت الغرفة: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3" max_local="38*3"/>

--- a/desktop_version/lang/ca/strings.xml
+++ b/desktop_version/lang/ca/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="S’ha canviat el color|del conjunt de peces" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="S’ha canviat el tipus d’enemic" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="La velocitat de les plataformes és ara {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="S’han recarregat els recursos" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERROR: Format invàlid" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="S’ha obert el mapa: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/cy/strings.xml
+++ b/desktop_version/lang/cy/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="Lliw Set Teil wedi&apos;i Newid" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="Newidiodd Math y Gelyn" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Cyflymder llwyfan yw {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Adnoddau wedi&apos;u hail-lwytho" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="GWALL: Fformat annilys" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Map wedi&apos;i lwytho: {filename}.vvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/de/strings.xml
+++ b/desktop_version/lang/de/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="Tileset-Farbe geändert" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="Feindtyp geändert" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Plattformgeschwindigkeit ist jetzt {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Ressourcen neu geladen" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="FEHLER: ungültiges Format" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Karte geladen: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/eo/strings.xml
+++ b/desktop_version/lang/eo/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="Kahelara koloro ŝanĝiĝis" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="Malamika tipo ŝanĝiĝis" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Platforma rapido nun estas {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Resursoj reŝargiĝis" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERARO: malĝusta formo" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Ŝargiĝis mapo: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/es/strings.xml
+++ b/desktop_version/lang/es/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="Color de casillas cambiado" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="Tipo de enemigo cambiado" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="La velocidad plataforma es {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Recursos recargados" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERROR: Formato no válido" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Mapa cargado: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/es_419/strings.xml
+++ b/desktop_version/lang/es_419/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="Color de casillas cambiado" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="Tipo de enemigo cambiado" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Velocidad de las plataformas: {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Recursos recargados" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERROR: Formato no válido" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Mapa cargado: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/es_AR/strings.xml
+++ b/desktop_version/lang/es_AR/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="Color de casillas cambiado" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="Tipo de enemigo cambiado" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Velocidad de las plataformas: {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Recursos recargados" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERROR: Formato no válido" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Mapa cargado: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/fr/strings.xml
+++ b/desktop_version/lang/fr/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="Couleur des tuiles modifiée" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="Type d&apos;ennemis modifié" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Vitesse des plateformes réglée sur {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Recharger les ressources" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERREUR : format invalide" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Carte chargée : {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/ga/strings.xml
+++ b/desktop_version/lang/ga/strings.xml
@@ -624,6 +624,7 @@ Déan cóip chúltaca, ar eagla na heagla." explanation="translation maintenance
     <string english="Tileset Colour Changed" translation="Athraíodh Dath na dTíleanna" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="Athraíodh Cineál Naimhde" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Luas na n-ardán {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Athlódáladh acmhainní" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="EARRÁID: Formáid Neamhbhailí" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Mapa lódáilte: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/it/strings.xml
+++ b/desktop_version/lang/it/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="Colore set di caselle cambiato" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="Tipo di nemico cambiato" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="La velocità piattaforma ora è {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Risorse ricaricate" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERRORE: Formato non valido" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Mappa caricata: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/ja/strings.xml
+++ b/desktop_version/lang/ja/strings.xml
@@ -658,6 +658,7 @@ Steam Deckには対応していません。" explanation="" max="38*5" max_local
     <string english="Tileset Colour Changed" translation="タイルセットのカラーを変更しました" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3" max_local="38*2"/>
     <string english="Enemy Type Changed" translation="敵の種類を変更しました" explanation="level editor, user changed enemy appearance for the room" max="38*3" max_local="38*2"/>
     <string english="Platform speed is now {speed}" translation="プラットフォームの速度を {speed} に変更しました" explanation="level editor, user changed speed of platforms for the room" max="38*3" max_local="38*2"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3" max_local="38*2"/>
     <string english="Reloaded resources" translation="リソースを再読み込みしました" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3" max_local="38*2"/>
     <string english="ERROR: Invalid format" translation="エラー: 無効な記述形式" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3" max_local="38*2"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="{filename}.vvvvvv をロードしました" explanation="successfully loaded level file" max="38*3" max_local="38*2"/>

--- a/desktop_version/lang/ko/strings.xml
+++ b/desktop_version/lang/ko/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="타일셋 색 변경됨" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3" max_local="30*3"/>
     <string english="Enemy Type Changed" translation="적 종류 변경됨" explanation="level editor, user changed enemy appearance for the room" max="38*3" max_local="30*3"/>
     <string english="Platform speed is now {speed}" translation="플랫폼 속도 현재 {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3" max_local="30*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3" max_local="30*3"/>
     <string english="Reloaded resources" translation="자원 다시 불러오기" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3" max_local="30*3"/>
     <string english="ERROR: Invalid format" translation="오류: 이용 불가능한 포맷" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3" max_local="30*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="불러온 지도: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3" max_local="30*3"/>

--- a/desktop_version/lang/nl/strings.xml
+++ b/desktop_version/lang/nl/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="Tilesetkleur aangepast" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="Vijandtype aangepast" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Platformsnelheid is nu {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Bronnen opnieuw geladen" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="FOUT: Ongeldig formaat" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Level geladen: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/pl/strings.xml
+++ b/desktop_version/lang/pl/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="Zmieniono Kolor Klocków" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="Zmieniono Typ Wroga" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Prędkość platformy: {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Załadowano zasoby ponownie" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="BŁĄD: Niewłaściwy format" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Wczytano poziom: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/pt_BR/strings.xml
+++ b/desktop_version/lang/pt_BR/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="A cor do conjunto de blocos foi alterada" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="O tipo de inimigo foi alterado" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="A velocidade da plataforma agora é {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Recursos recarregados" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERRO: formato inválido" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Mapa carregado: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/pt_PT/strings.xml
+++ b/desktop_version/lang/pt_PT/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="Cor de padrão alterada" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="Tipo de inimigo alterado" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Velocidade atual da plataforma: {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Recursos recarregados" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ERRO: Formato inválido" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Mapa carregado: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/ru/strings.xml
+++ b/desktop_version/lang/ru/strings.xml
@@ -647,6 +647,7 @@
     <string english="Tileset Colour Changed" translation="Цвет плиток изменён" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="Тип врагов изменён" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Установлена скорость платформ {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Ресурсы перезагружены" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ОШИБКА: Недопустимый формат" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Карта загружена: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/szl/strings.xml
+++ b/desktop_version/lang/szl/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="Zmiyniōno Farba Klockōw" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="Zmiyniōno Zorta Niyprzŏciela" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Gibkoś platformy: {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Nafolowano zasoby drugi rŏz" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="FELER: Felerny format" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Nafolowano poziōm: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/tr/strings.xml
+++ b/desktop_version/lang/tr/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="Kare Renkleri Değişti" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="Düşman Türü Değişti" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Platform hızı: {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Kaynaklar tekrar yüklendi" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="HATA: Geçersiz format" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Yüklenen harita: {dosyaadi}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/uk/strings.xml
+++ b/desktop_version/lang/uk/strings.xml
@@ -622,6 +622,7 @@
     <string english="Tileset Colour Changed" translation="Колір набору плиток змінено" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3"/>
     <string english="Enemy Type Changed" translation="Тип ворога змінено" explanation="level editor, user changed enemy appearance for the room" max="38*3"/>
     <string english="Platform speed is now {speed}" translation="Тепер швидкість платформи {speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3"/>
     <string english="Reloaded resources" translation="Ресурси перезавантажено" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3"/>
     <string english="ERROR: Invalid format" translation="ПОМИЛКА: Неприпустимий формат" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="Завантажено мапу: {filename}.vvvvvv" explanation="successfully loaded level file" max="38*3"/>

--- a/desktop_version/lang/zh/strings.xml
+++ b/desktop_version/lang/zh/strings.xml
@@ -632,6 +632,7 @@
     <string english="Tileset Colour Changed" translation="Tileset颜色已改变" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3" max_local="25*2"/>
     <string english="Enemy Type Changed" translation="敌人类型已改变" explanation="level editor, user changed enemy appearance for the room" max="38*3" max_local="25*2"/>
     <string english="Platform speed is now {speed}" translation="平台速度现在为{speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3" max_local="25*2"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3" max_local="25*2"/>
     <string english="Reloaded resources" translation="资源已重新载入" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3" max_local="25*2"/>
     <string english="ERROR: Invalid format" translation="错误：格式不符合" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3" max_local="25*2"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="已载入地图：{filename}.vvvvvv" explanation="successfully loaded level file" max="38*3" max_local="25*2"/>

--- a/desktop_version/lang/zh_TW/strings.xml
+++ b/desktop_version/lang/zh_TW/strings.xml
@@ -632,6 +632,7 @@
     <string english="Tileset Colour Changed" translation="Tileset 顏色已改變" explanation="level editor, user changed the tileset colour/variant of the room" max="38*3" max_local="25*2"/>
     <string english="Enemy Type Changed" translation="敵人類型已改變" explanation="level editor, user changed enemy appearance for the room" max="38*3" max_local="25*2"/>
     <string english="Platform speed is now {speed}" translation="平臺速度現在為{speed}" explanation="level editor, user changed speed of platforms for the room" max="38*3" max_local="25*2"/>
+    <string english="Enemy speed is now {speed}" translation="" explanation="level editor, user changed speed of enemies for the room" max="38*3" max_local="25*2"/>
     <string english="Reloaded resources" translation="資源已重新載入" explanation="level editor, reloaded graphics assets/resources, music and sound effects" max="38*3" max_local="25*2"/>
     <string english="ERROR: Invalid format" translation="錯誤：格式不符合" explanation="user was supposed to enter something like `12,12`, but entered `as@df`" max="38*3" max_local="25*2"/>
     <string english="Loaded map: {filename}.vvvvvv" translation="已載入地圖：{filename}.vvvvvv" explanation="successfully loaded level file" max="38*3" max_local="25*2"/>

--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -57,6 +57,7 @@ RoomProperty::RoomProperty(void)
     enemyx2=320;
     enemyy2=240;
     enemytype=0;
+    enemyv=0;
     directmode=0;
 }
 
@@ -389,6 +390,7 @@ void customlevelclass::reset(void)
             roomproperties[i+(j*maxwidth)].enemyx2=320;
             roomproperties[i+(j*maxwidth)].enemyy2=240;
             roomproperties[i+(j*maxwidth)].enemytype=0;
+            roomproperties[i+(j*maxwidth)].enemyv=0;
             roomproperties[i+(j*maxwidth)].directmode=0;
         }
     }
@@ -1264,6 +1266,7 @@ bool customlevelclass::load(std::string _path)
                 edLevelClassElement->QueryIntAttribute("enemyx2", &roomproperties[i].enemyx2);
                 edLevelClassElement->QueryIntAttribute("enemyy2", &roomproperties[i].enemyy2);
                 edLevelClassElement->QueryIntAttribute("enemytype", &roomproperties[i].enemytype);
+                edLevelClassElement->QueryIntAttribute("enemyv", &roomproperties[i].enemyv);
                 edLevelClassElement->QueryIntAttribute("directmode", &roomproperties[i].directmode);
 
                 edLevelClassElement->QueryIntAttribute("warpdir", &roomproperties[i].warpdir);
@@ -1645,6 +1648,7 @@ bool customlevelclass::save(const std::string& _path)
         roompropertyElement->SetAttribute(  "enemyx2", roomproperties[i].enemyx2);
         roompropertyElement->SetAttribute(  "enemyy2", roomproperties[i].enemyy2);
         roompropertyElement->SetAttribute(  "enemytype", roomproperties[i].enemytype);
+        roompropertyElement->SetAttribute( "enemyv", roomproperties[i].enemyv);
         roompropertyElement->SetAttribute(  "directmode", roomproperties[i].directmode);
         roompropertyElement->SetAttribute(  "warpdir", roomproperties[i].warpdir);
 

--- a/desktop_version/src/CustomLevels.h
+++ b/desktop_version/src/CustomLevels.h
@@ -31,6 +31,7 @@ public:
     FOREACH_PROP(enemyx2, int) \
     FOREACH_PROP(enemyy2, int) \
     FOREACH_PROP(enemytype, int) \
+    FOREACH_PROP(enemyv, int) \
     FOREACH_PROP(directmode, int)
 
 class RoomProperty

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -3096,12 +3096,22 @@ static void handle_draw_input()
 
         const int room = ed.levx + ed.levy * cl.maxwidth;
         const int plat_speed = cl.roomproperties[room].platv;
+        const int enemy_speed = cl.roomproperties[room].enemyv;
 
+        const bool ctrl = key.keymap[SDLK_LCTRL] || key.keymap[SDLK_RCTRL];
+        const bool shift = key.keymap[SDLK_LSHIFT] || key.keymap[SDLK_RSHIFT];
         if (key.keymap[SDLK_COMMA])
         {
-            if (key.keymap[SDLK_LCTRL] || key.keymap[SDLK_RCTRL])
+            if (ctrl)
             {
-                cl.roomproperties[room].platv = plat_speed - 1;
+                if (shift)
+                {
+                    cl.roomproperties[room].enemyv = enemy_speed - 1;
+                }
+                else
+                {
+                    cl.roomproperties[room].platv = plat_speed - 1;
+                }
             }
             else
             {
@@ -3111,9 +3121,16 @@ static void handle_draw_input()
         }
         else if (key.keymap[SDLK_PERIOD])
         {
-            if (key.keymap[SDLK_LCTRL] || key.keymap[SDLK_RCTRL])
+            if (ctrl)
             {
-                cl.roomproperties[room].platv = plat_speed + 1;
+                if (shift)
+                {
+                    cl.roomproperties[room].enemyv = enemy_speed + 1;
+                }
+                else
+                {
+                    cl.roomproperties[room].platv = plat_speed + 1;
+                }
             }
             else
             {
@@ -3130,6 +3147,18 @@ static void handle_draw_input()
                 loc::gettext("Platform speed is now {speed}"),
                 "speed:int",
                 cl.roomproperties[room].platv
+            );
+            ed.show_note(buffer);
+        }
+
+        if (enemy_speed != cl.roomproperties[room].enemyv)
+        {
+            char buffer[3 * SCREEN_WIDTH_CHARS + 1];
+            vformat_buf(
+                buffer, sizeof(buffer),
+                loc::gettext("Enemy speed is now {speed}"),
+                "speed:int",
+                cl.roomproperties[room].enemyv + 4
             );
             ed.show_note(buffer);
         }

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -1850,7 +1850,7 @@ void mapclass::loadlevel(int rx, int ry)
             {
             case 1: // Enemies
                 obj.customenemy = room->enemytype;
-                obj.createentity(ex, ey, 56, ent.p1, 4, bx1, by1, bx2, by2);
+                obj.createentity(ex, ey, 56, ent.p1, 4 + room->enemyv, bx1, by1, bx2, by2);
                 break;
             case 2: // Platforms and conveyors
                 if (ent.p1 <= 4)


### PR DESCRIPTION
## Changes:

Currently, you can change platform speed, but not enemy speed, which is always hardcoded to be 4. This commit fixes that, by adding the `enemyv` property, which is an offset to the speed of 4. Since it defaults to 0, older levels are not broken by this change.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
