### PR TITLE
Give Master of the Universe trophy in normal mode, meeting certain conditions

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -225,6 +225,7 @@ void Game::init(void)
     ndmresulthardestroom_x = hardestroom_x;
     ndmresulthardestroom_y = hardestroom_y;
     ndmresulthardestroom_specialname = false;
+    nodeatheligible = false;
 
     customcol=0;
 
@@ -3312,11 +3313,14 @@ void Game::updatestate(void)
             }
         }
 
-
-            if (nodeathmode)
+            if (nodeathmode || nodeatheligible)
             {
                 unlockAchievement("vvvvvvmaster"); //bloody hell
                 unlocknum(UnlockTrophy_NODEATHMODE_COMPLETE);
+            }
+
+            if (nodeathmode)
+            {
                 setstate(3520);
                 setstatedelay(0);
             }
@@ -7768,6 +7772,11 @@ void Game::returntoingame(void)
         }
     }
     DEFER_CALLBACK(nextbgcolor);
+
+    if (nocompetitive())
+    {
+        invalidate_ndm_trophy();
+    }
 }
 
 void Game::unlockAchievement(const char* name)
@@ -7818,6 +7827,15 @@ void Game::copyndmresults(void)
     ndmresulthardestroom_y = hardestroom_y;
     ndmresulthardestroom_specialname = hardestroom_specialname;
     SDL_memcpy(ndmresultcrewstats, crewstats, sizeof(ndmresultcrewstats));
+}
+
+void Game::invalidate_ndm_trophy(void)
+{
+    if (nodeatheligible)
+    {
+        vlog_debug("NDM trophy is invalidated!");
+    }
+    nodeatheligible = false;
 }
 
 static inline int get_framerate(const int slowdown)

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -432,6 +432,8 @@ public:
     int ndmresulthardestroom_y;
     bool ndmresulthardestroom_specialname;
     void copyndmresults(void);
+    bool nodeatheligible;
+    void invalidate_ndm_trophy(void);
 
     //Time Trials
     bool intimetrial, timetrialparlost;

--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -461,6 +461,8 @@ void gamelogic(void)
         game.deathseq--;
         if (game.deathseq <= 0)
         {
+            game.invalidate_ndm_trophy();
+
             if (game.nodeathmode)
             {
                 game.deathseq = 1;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -2651,6 +2651,16 @@ void scriptclass::startgamemode(const enum StartMode mode)
             graphics.showcutscenebars = true;
             graphics.setbars(320);
             load("intro");
+
+            if (!game.nocompetitive())
+            {
+                game.nodeatheligible = true;
+                vlog_debug("NDM trophy is eligible.");
+            }
+            else
+            {
+                game.invalidate_ndm_trophy();
+            }
         }
         break;
 
@@ -3088,6 +3098,7 @@ void scriptclass::hardreset(void)
 
     game.nodeathmode = false;
     game.nocutscenes = false;
+    game.nodeatheligible = false;
 
     for (i = 0; i < (int) SDL_arraysize(game.crewstats); i++)
     {


### PR DESCRIPTION
This makes it so that it is possible to obtain the Master of the Universe trophy/achievement, usually unlocked by beating No Death Mode, outside of NDM.

There are several conditions that need to be met:

1. The game needs to be started from a new game and cannot be from loading a save.
2. Accessibility modes (invincibility and slowdown) must never be enabled.

If either condition is violated, then the boolean that keeps track of NDM eligibility will be set to false.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
