### PR TITLE
Remove slowdown during death animation

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7838,8 +7838,13 @@ void Game::invalidate_ndm_trophy(void)
     nodeatheligible = false;
 }
 
-static inline int get_framerate(const int slowdown)
+static inline int get_framerate(const int slowdown, const int deathseq)
 {
+    if (deathseq != -1)
+    {
+        return 34;
+    }
+
     switch (slowdown)
     {
     case 30:
@@ -7868,7 +7873,7 @@ int Game::get_timestep(void)
     switch (gamestate)
     {
     case GAMEMODE:
-        return get_framerate(slowdown);
+        return get_framerate(slowdown, deathseq);
     default:
         return 34;
     }


### PR DESCRIPTION
Some discussion on the Discord server resulted in this change. It's a quality-of-life improvement where, if the game is in slowdown mode, it will return to 100% speed for the duration of the death animation.

The reasoning is obvious. There is nothing to do during the death animation, so making it take longer during slowdown is just an annoyance to the player, almost a penalty for them using an accessibility option. This is the same reason why slowdown no longer applies in menus, etc.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
