### PR TITLE
Add glitchless mode

### DIFF
--- a/desktop_version/lang/ar/strings.xml
+++ b/desktop_version/lang/ar/strings.xml
@@ -249,6 +249,14 @@
     <string english="none" translation="بدون" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2" max_local="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20" max_local="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3" max_local="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2" max_local="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2" max_local="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2" max_local="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39" max_local="39"/>
     <string english="input delay" translation="تأجيل الضغطة" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="تأجيل الضغطة" explanation="title, enable 1 frame of delay after pressing input" max="20" max_local="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="إرجاع تأجيل الضغطة بإطار واحد كما كان الحال في تحديثات اللعبة السابقة" explanation="input delay" max="38*3" max_local="38*3"/>

--- a/desktop_version/lang/ca/strings.xml
+++ b/desktop_version/lang/ca/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="cap" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="retard en l’entrada" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Retard en l’entrada" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Reactiva el retard en l’entrada|d’un fotograma que hi havia|en versions anteriors del joc." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/cy/strings.xml
+++ b/desktop_version/lang/cy/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="dim" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="oedi mewnbwn" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Oedi Mewnbwn" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Ail-alluogi&apos;r oedi mewnbwn 1-ffrâm o fersiynau blaenorol y gêm." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/de/strings.xml
+++ b/desktop_version/lang/de/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="keine" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="eingabeverzögerung" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Eingabeverzögerung" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Reaktiviere die 1-Frame-Eingabeverzögerung aus früheren Versionen des Spiels." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="" explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/eo/strings.xml
+++ b/desktop_version/lang/eo/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="neniu" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="enig-prokrasto" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Prokrasto de enigoj" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Reebligi la 1-kadran enigprokraston de pli-fruaj versioj de la ludo." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/es/strings.xml
+++ b/desktop_version/lang/es/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="ninguna" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="retraso la entrada" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Retraso la entrada" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Reactiva el retraso de 1 fotograma de respuesta de versiones anteriores del juego." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/es_419/strings.xml
+++ b/desktop_version/lang/es_419/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="ninguna" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="demorar respuesta" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Demorar respuesta" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Reactiva la demora de un fotograma de respuesta de versiones anteriores del juego." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/es_AR/strings.xml
+++ b/desktop_version/lang/es_AR/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="ninguna" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="demorar respuesta" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Demorar respuesta" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Reactiva la demora de un fotograma de respuesta de versiones anteriores del juego." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/fr/strings.xml
+++ b/desktop_version/lang/fr/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="aucune" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="délai d&apos;entrée" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Délai d&apos;entrée" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Réactive le délai d&apos;entrée|de 1 image présent dans les précédentes versions du jeu." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/ga/strings.xml
+++ b/desktop_version/lang/ga/strings.xml
@@ -245,6 +245,14 @@ Déan cóip chúltaca, ar eagla na heagla." explanation="translation maintenance
     <string english="none" translation="gan ceann ar bith" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="moill ionchuir" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Moill Ionchuir" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Cuir an mhoill ionchuir fráma amháin a bhí i seanleaganacha den chluiche i bhfeidhm." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/it/strings.xml
+++ b/desktop_version/lang/it/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="nessuna" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="ritardo comandi" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Ritardo comandi" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Ripristina il ritardo comandi di un frame delle versioni precedenti del gioco." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/ja/strings.xml
+++ b/desktop_version/lang/ja/strings.xml
@@ -258,6 +258,14 @@ Escキーを押すと表示を終了する。" explanation="" max="38*6" max_loc
     <string english="none" translation="OFF" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2" max_local="38*1"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20" max_local="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3" max_local="38*2"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2" max_local="38*1"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2" max_local="38*1"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2" max_local="38*1"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39" max_local="39"/>
     <string english="input delay" translation="入力遅延" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="入力遅延" explanation="title, enable 1 frame of delay after pressing input" max="20" max_local="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="古いバージョンに存在した、1フレームの入力遅延の有無を切り替える。" explanation="input delay" max="38*3" max_local="38*2"/>

--- a/desktop_version/lang/ko/strings.xml
+++ b/desktop_version/lang/ko/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="없음" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2" max_local="30*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20" max_local="16"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3" max_local="30*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2" max_local="30*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2" max_local="30*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2" max_local="30*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39" max_local="31"/>
     <string english="input delay" translation="입력 지연" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="입력 지연" explanation="title, enable 1 frame of delay after pressing input" max="20" max_local="16"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="이전 게임 버전에 있던 1프레임 입력 지연을 재활성화 합니다." explanation="input delay" max="38*3" max_local="30*3"/>

--- a/desktop_version/lang/nl/strings.xml
+++ b/desktop_version/lang/nl/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="geen" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="invoervertraging" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Invoervertraging" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Herstel de invoervertraging van 1 frame uit vorige versies van het spel." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/pl/strings.xml
+++ b/desktop_version/lang/pl/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="brak" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="opóźnienie inputu" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Opóźnienie Inputu" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Przywróć 1-klatkowe opóźnienie inputu z poprzednich wersji gry." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/pt_BR/strings.xml
+++ b/desktop_version/lang/pt_BR/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="nenhuma" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="atraso de comando" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Atraso de comando" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Reativa o atraso de 1 quadro na execução de comandos, como em versões anteriores do jogo." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/pt_PT/strings.xml
+++ b/desktop_version/lang/pt_PT/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="nenhuma" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="atraso de reação" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Atraso de Reação" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Reintroduz 1 fotograma no atraso de reação, presente em versões anteriores do jogo." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/ru/strings.xml
+++ b/desktop_version/lang/ru/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="отключить" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="задержка ввода" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Задержка ввода" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Восстановите 1-кадровую задержку ввода из предыдущих версий игры." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/szl/strings.xml
+++ b/desktop_version/lang/szl/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="niy ma" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="niyskoroś wchodu" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Niyskoroś Wchodu" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Załōncz drugi rŏz 1-klatkowo niyskoroś wchodu z piyrwyjszych wersyji szpila." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/tr/strings.xml
+++ b/desktop_version/lang/tr/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="hiçbiri" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="giriş gecikmesi" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Giriş Gecikmesi" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Oyunun önceki sürümlerinden 1 karelik|giriş gecikmesini etkinleştir." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/uk/strings.xml
+++ b/desktop_version/lang/uk/strings.xml
@@ -244,6 +244,14 @@
     <string english="none" translation="жодної" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39"/>
     <string english="input delay" translation="затримка введення" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="Затримка введення" explanation="title, enable 1 frame of delay after pressing input" max="20"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="Повернути затримку введення на 1 кадр з попередніх версій гри." explanation="input delay" max="38*3"/>

--- a/desktop_version/lang/zh/strings.xml
+++ b/desktop_version/lang/zh/strings.xml
@@ -250,6 +250,14 @@
     <string english="none" translation="不使用" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2" max_local="25*1"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20" max_local="13"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3" max_local="25*2"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2" max_local="25*1"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2" max_local="25*1"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2" max_local="25*1"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39" max_local="26"/>
     <string english="input delay" translation="输入延迟" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="输入延迟" explanation="title, enable 1 frame of delay after pressing input" max="20" max_local="13"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="重新启用在过去游戏版本中存在的1帧输入延迟。" explanation="input delay" max="38*3" max_local="25*2"/>

--- a/desktop_version/lang/zh_TW/strings.xml
+++ b/desktop_version/lang/zh_TW/strings.xml
@@ -250,6 +250,14 @@
     <string english="none" translation="不使用" explanation="menu option, do not emulate any older version"/>
     <string english="2.0" translation="2.0" explanation="VVVVVV version number for glitchrunner mode"/>
     <string english="2.2" translation="2.2" explanation="VVVVVV version number for glitchrunner mode"/>
+    <string english="Glitchrunner mode is incompatible with glitchless mode." translation="" explanation="" max="38*2" max_local="25*1"/>
+    <string english="glitchless mode" translation="" explanation="menu option, disables all glitches in the game that would be useful for speedruns"/>
+    <string english="Glitchless Mode" translation="" explanation="title, disables all glitches in the game that would be useful for speedruns" max="20" max_local="13"/>
+    <string english="Disable glitches that might otherwise be useful for speedruns." translation="" explanation="glitchless mode" max="38*3" max_local="25*2"/>
+    <string english="Glitchless mode is OFF" translation="" explanation="" max="38*2" max_local="25*1"/>
+    <string english="Glitchless mode is ON" translation="" explanation="" max="38*2" max_local="25*1"/>
+    <string english="Glitchless mode is incompatible with glitchrunner mode." translation="" explanation="" max="38*2" max_local="25*1"/>
+    <string english="Glitchless mode enabled" translation="" explanation="in-game message" max="39" max_local="26"/>
     <string english="input delay" translation="輸入延遲" explanation="menu option, enable 1 frame of delay after pressing input"/>
     <string english="Input Delay" translation="輸入延遲" explanation="title, enable 1 frame of delay after pressing input" max="20" max_local="13"/>
     <string english="Re-enable the 1-frame input delay from previous versions of the game." translation="重新啟用在過去遊戲版本中存在的1幀輸入延遲。" explanation="input delay" max="38*3" max_local="25*2"/>

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -3953,6 +3953,10 @@ int entityclass::getscm(void)
         }
     }
 
+    if (game.glitchlessmode)
+    {
+        return -1;
+    }
     return 0;
 }
 
@@ -3970,6 +3974,10 @@ int entityclass::getlineat( int t )
         }
     }
 
+    if (game.glitchlessmode)
+    {
+        return -1;
+    }
     return 0;
 }
 
@@ -3989,6 +3997,10 @@ int entityclass::getcrewman( int t, int fallback /*= 0*/ )
         }
     }
 
+    if (game.glitchlessmode)
+    {
+        return -1;
+    }
     return fallback;
 }
 
@@ -4013,6 +4025,10 @@ int entityclass::getcustomcrewman( int t )
         }
     }
 
+    if (game.glitchlessmode)
+    {
+        return -1;
+    }
     return 0;
 }
 

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -2783,6 +2783,14 @@ bool entityclass::updateentities( int i )
                 {
                     if (INBOUNDS_VEC(temp, entities) && entities[temp].vy > -3) entities[temp].vy = -3;
                 }
+
+                if (game.glitchlessmode && INBOUNDS_VEC(temp, entities))
+                {
+                    /* Fix line clipping: Invalidate flipping eligibility so
+                     * a second flip is impossible. */
+                    entities[temp].onground = 0;
+                    entities[temp].onroof = 0;
+                }
             }
             else if (entities[i].state == 2)
             {
@@ -4876,6 +4884,14 @@ void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
 
         entities[j].state = entities[j].onentity;
         entities[j].life = 6;
+
+        if (game.glitchlessmode)
+        {
+            /* Fix line clipping: Invalidate flipping eligibility so
+             * a second flip is impossible. */
+            entities[i].onground = 0;
+            entities[i].onroof = 0;
+        }
         break;
     }
     case 5:   //Person vs vertical gravity/warp line!

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4852,30 +4852,32 @@ void entityclass::collisioncheck(int i, int j, bool scm /*= false*/)
         }
         break;
     case 4:   //Person vs horizontal line!
-        if(game.deathseq==-1)
+    {
+        const bool collision =
+            game.deathseq == -1
+            && entities[j].onentity > 0
+            && entityhlinecollide(i, j);
+        if (!collision)
         {
-            if (entities[j].onentity > 0)
-            {
-                if (entityhlinecollide(i, j))
-                {
-                    music.playef(Sound_GRAVITYLINE);
-                    game.gravitycontrol = (game.gravitycontrol + 1) % 2;
-                    game.totalflips++;
-                    if (game.gravitycontrol == 0)
-                    {
-                        if (entities[i].vy < 1) entities[i].vy = 1;
-                    }
-                    else
-                    {
-                        if (entities[i].vy > -1) entities[i].vy = -1;
-                    }
-
-                    entities[j].state = entities[j].onentity;
-                    entities[j].life = 6;
-                }
-            }
+            break;
         }
+
+        music.playef(Sound_GRAVITYLINE);
+        game.gravitycontrol = (game.gravitycontrol + 1) % 2;
+        game.totalflips++;
+        if (game.gravitycontrol == 0)
+        {
+            if (entities[i].vy < 1) entities[i].vy = 1;
+        }
+        else
+        {
+            if (entities[i].vy > -1) entities[i].vy = -1;
+        }
+
+        entities[j].state = entities[j].onentity;
+        entities[j].life = 6;
         break;
+    }
     case 5:   //Person vs vertical gravity/warp line!
         if(game.deathseq==-1)
         {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -154,6 +154,7 @@ void Game::init(void)
     musicmutebutton = 0;
 
     glitchrunkludge = false;
+    glitchlessmode = false;
     gamestate = TITLEMODE;
     prevgamestate = TITLEMODE;
     hascontrol = true;
@@ -4826,6 +4827,11 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, struct ScreenSett
             GlitchrunnerMode_set(GlitchrunnerMode_string_to_enum(pText));
         }
 
+        if (SDL_strcmp(pKey, "glitchlessmode") == 0)
+        {
+            glitchlessmode = help.Int(pText);
+        }
+
         if (SDL_strcmp(pKey, "showingametimer") == 0)
         {
             showingametimer = help.Int(pText);
@@ -4939,6 +4945,14 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, struct ScreenSett
     }
 
     setdefaultcontrollerbuttons();
+
+    if (GlitchrunnerMode_get() != GlitchrunnerNone && glitchlessmode)
+    {
+        /* Glitchrunner and glitchless mode are incompatible.
+         * If the file was manually edited to enable both, disable both. */
+        GlitchrunnerMode_set(GlitchrunnerNone);
+        glitchlessmode = false;
+    }
 }
 
 bool Game::savestats(bool sync /*= true*/)
@@ -5114,6 +5128,8 @@ void Game::serializesettings(tinyxml2::XMLElement* dataNode, const struct Screen
         "glitchrunnermode",
         GlitchrunnerMode_enum_to_string(GlitchrunnerMode_get())
     );
+
+    xml::update_tag(dataNode, "glitchlessmode", (int) glitchlessmode);
 
     xml::update_tag(dataNode, "showingametimer", (int) showingametimer);
 
@@ -6826,7 +6842,8 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         maxspacing = 15;
         break;
     case Menu::speedrunneroptions:
-        option(loc::gettext("glitchrunner mode"));
+        option(loc::gettext("glitchrunner mode"), !glitchlessmode);
+        option(loc::gettext("glitchless mode"), GlitchrunnerMode_get() == GlitchrunnerNone);
         option(loc::gettext("input delay"));
         option(loc::gettext("interact button"));
         option(loc::gettext("fake load screen"));

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -330,6 +330,7 @@ public:
     int state, statedelay;
 
     bool glitchrunkludge;
+    bool glitchlessmode;
 
     enum GameGamestate gamestate;
     enum GameGamestate prevgamestate; //only used sometimes

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -787,36 +787,56 @@ static void menuactionpress(void)
         {
         case 0:
             // Glitchrunner mode
+            if (game.glitchlessmode)
+            {
+                music.playef(Sound_CRY);
+                break;
+            }
+
             music.playef(Sound_VIRIDIAN);
             game.createmenu(Menu::setglitchrunner);
             game.currentmenuoption = GlitchrunnerMode_get();
             map.nexttowercolour();
             break;
         case 1:
+            /* Glitchless mode */
+            if (GlitchrunnerMode_get() != GlitchrunnerNone)
+            {
+                music.playef(2);
+                break;
+            }
+
+            music.playef(11);
+            game.glitchlessmode = !game.glitchlessmode;
+
+            /* Recreate menu to update glitchrunner mode */
+            game.createmenu(game.currentmenuname, true);
+            break;
+        case 2:
             /* Input delay */
             music.playef(Sound_VIRIDIAN);
             game.inputdelay = !game.inputdelay;
             game.savestatsandsettings_menu();
             break;
-        case 2:
+        case 3:
             /* Interact button toggle */
             music.playef(Sound_VIRIDIAN);
             game.separate_interact = !game.separate_interact;
             game.savestatsandsettings_menu();
             break;
-        case 3:
+        case 4:
             // toggle fake load screen
             game.skipfakeload = !game.skipfakeload;
             game.savestatsandsettings_menu();
             music.playef(Sound_VIRIDIAN);
             break;
-        case 4:
+        case 5:
             // toggle in game timer
             game.showingametimer = !game.showingametimer;
             game.savestatsandsettings_menu();
             music.playef(Sound_VIRIDIAN);
             break;
-        case 5:
+        case 6:
             // english sprites
             loc::english_sprites = !loc::english_sprites;
             if (!loc::english_sprites)

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -3009,7 +3009,10 @@ void gameinput(void)
         game.menupage = 30; // Pause screen
     }
 
-    if (game.deathseq == -1 && (key.isDown(SDLK_r) || key.isDown(game.controllerButton_restart)) && !game.nodeathmode)// && map.custommode) //Have fun glitchrunners!
+    if (game.deathseq == -1 &&
+        (key.isDown(SDLK_r) || key.isDown(game.controllerButton_restart))
+        && !game.nodeathmode
+        && (map.custommode || !game.glitchlessmode)) /* Have fun glitchrunners! */
     {
         game.deathseq = 30;
     }

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -854,6 +854,20 @@ void mapclass::resetplayer(const bool player_died)
             game.scmprogress = game.roomx - 40;
         }
     }
+
+    if (game.glitchlessmode)
+    {
+        /* Fix warp token death warps:
+         * Reset the state of all warp tokens to 0. */
+        for (size_t i = 0; i < obj.entities.size(); i++)
+        {
+            entclass* entity = &obj.entities[i];
+            if (entity->type == 11)
+            {
+                entity->state = 0;
+            }
+        }
+    }
 }
 
 void mapclass::warpto(int rx, int ry , int t, int tx, int ty)

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -1022,10 +1022,38 @@ static void menurender(void)
         {
             font::print(PR_2X | PR_CEN, -1, 30, loc::gettext("Glitchrunner Mode"), tr, tg, tb);
             int next_y = font::print_wrap(PR_CEN, -1, 65, loc::gettext("Re-enable glitches that existed in previous versions of the game."), tr, tg, tb);
+
+            if (game.glitchlessmode)
+            {
+                font::print_wrap(PR_CEN, -1, next_y, loc::gettext("Glitchrunner mode is incompatible with glitchless mode."), tr, tg, tb);
+                break;
+            }
+
             drawglitchrunnertext(next_y);
             break;
         }
         case 1:
+        {
+            font::print(PR_2X | PR_CEN, -1, 30, loc::gettext("Glitchless Mode"), tr, tg, tb);
+            const int next_y = font::print_wrap(PR_CEN, -1, 65, loc::gettext("Disable glitches that might otherwise be useful for speedruns."), tr, tg, tb);
+
+            if (GlitchrunnerMode_get() != GlitchrunnerNone)
+            {
+                font::print_wrap(PR_CEN, -1, next_y, loc::gettext("Glitchless mode is incompatible with glitchrunner mode."), tr, tg, tb);
+                break;
+            }
+
+            if (game.glitchlessmode)
+            {
+                font::print_wrap(PR_CEN, -1, next_y, loc::gettext("Glitchless mode is ON"), tr, tg, tb);
+            }
+            else
+            {
+                font::print_wrap(PR_CEN, -1, next_y, loc::gettext("Glitchless mode is OFF"), tr / 2, tg / 2, tb / 2);
+            }
+            break;
+        }
+        case 2:
         {
             font::print(PR_2X | PR_CEN, -1, 30, loc::gettext("Input Delay"), tr, tg, tb);
             int next_y = font::print_wrap(PR_CEN, -1, 65, loc::gettext("Re-enable the 1-frame input delay from previous versions of the game."), tr, tg, tb);
@@ -1039,7 +1067,7 @@ static void menurender(void)
             }
             break;
         }
-        case 2:
+        case 3:
         {
             char buffer[SCREEN_WIDTH_CHARS + 1];
             const char* button;
@@ -1060,7 +1088,7 @@ static void menurender(void)
             font::print_wrap(PR_CEN, -1, next_y, buffer, tr, tg, tb);
             break;
         }
-        case 3:
+        case 4:
         {
             font::print(PR_2X | PR_CEN, -1, 30, loc::gettext("Fake Load Screen"), tr, tg, tb);
             int next_y = font::print_wrap(PR_CEN, -1, 65, loc::gettext("Disable the fake loading screen which appears on game launch."), tr, tg, tb);
@@ -1070,7 +1098,7 @@ static void menurender(void)
                 font::print_wrap(PR_CEN, -1, next_y, loc::gettext("Fake loading screen is ON"), tr, tg, tb);
             break;
         }
-        case 4:
+        case 5:
         {
             font::print(PR_2X | PR_CEN, -1, 30, loc::gettext("In-Game Timer"), tr, tg, tb);
             int next_y = font::print_wrap(PR_CEN, -1, 65, loc::gettext("Toggle the in-game timer outside of time trials."), tr, tg, tb);
@@ -1084,7 +1112,7 @@ static void menurender(void)
             }
             break;
         }
-        case 5:
+        case 6:
         {
             font::print(PR_2X | PR_CEN, -1, 30, loc::gettext("English Sprites"), tr, tg, tb);
             int next_y = font::print_wrap(PR_CEN, -1, 65, loc::gettext("Show the original English word enemies regardless of your language setting."), tr, tg, tb);
@@ -2265,6 +2293,12 @@ static void mode_indicator_text(const int alpha)
         y += spacing;
     }
 
+    if (game.glitchlessmode)
+    {
+        font::print(flags, x, y, loc::gettext("Glitchless mode enabled"), r, g, b);
+        y += spacing;
+    }
+
     if (graphics.flipmode)
     {
         const char* english = "Flip Mode enabled";
@@ -2356,6 +2390,7 @@ void gamerender(void)
     );
     bool any_mode_active = map.invincibility
         || GlitchrunnerMode_get() != GlitchrunnerNone
+        || game.glitchlessmode
         || graphics.flipmode
         || game.slowdown < 30;
     bool draw_mode_indicator_text = mode_indicator_alpha > 100 && any_mode_active;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -157,6 +157,28 @@ static int getcrewmanfromname(const std::string& name)
     return obj.getcrewman(color);
 }
 
+static bool color_valid(const int index, const std::string& name)
+{
+    if (!INBOUNDS_VEC(index, obj.entities))
+    {
+        return false;
+    }
+
+    if (!game.glitchlessmode)
+    {
+        return true;
+    }
+
+    const int color = getcolorfromname(name);
+    const bool using_aem = color == -1;
+    if (using_aem)
+    {
+        return true;
+    }
+
+    return obj.entities[index].colour == color;
+}
+
 
 /* Also used in gamestate 1001. */
 void foundtrinket_textbox1(textboxclass* THIS);
@@ -1022,7 +1044,7 @@ void scriptclass::run(void)
                 int crewmate = getcrewmanfromname(words[1]);
                 if (crewmate != -1) i = crewmate; // Ensure AEM is kept
 
-                if (INBOUNDS_VEC(i, obj.entities))
+                if (color_valid(i, words[1]))
                 {
                     obj.entities[i].tile = ss_toi(words[2]);
                 }

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -131,7 +131,7 @@ void scriptclass::tokenize( const std::string& t )
     }
 }
 
-static int getcolorfromname(std::string name)
+static int getcolorfromname(const std::string& name)
 {
     if      (name == "player")     return CYAN;
     else if (name == "cyan")       return CYAN;
@@ -149,7 +149,7 @@ static int getcolorfromname(std::string name)
     return color; // Last effort to give a valid color, maybe they just input the color?
 }
 
-static int getcrewmanfromname(std::string name)
+static int getcrewmanfromname(const std::string& name)
 {
     if (name == "player") return obj.getplayer(); //  Return the player
     int color = getcolorfromname(name); // Maybe they passed in a crewmate name, or an id?


### PR DESCRIPTION
This adds a new mode (mutually incompatible with glitchrunner mode) that disables glitches that would otherwise be used in speedrunning. The intention is to facilitate speedrunning glitchless categories without accidentally triggering a glitch which would invalidate the run (e.g. line clipping).

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
