### PR TITLE
Add more checks for checkpoint saving

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -847,7 +847,7 @@ void Game::show_save_fail(void)
 
 void Game::checkpoint_save(void)
 {
-    if (checkpoint_saving && !inspecial())
+    if (checkpoint_saving && !inspecial() && (!map.custommode || (map.custommode && map.custommodeforreal)) && !cliplaytest)
     {
         bool success = map.custommode ? customsavequick(cl.ListOfMetaData[playcustomlevel].filename) : savequick();
         gamesaved = success;


### PR DESCRIPTION
## Changes:

Checkpoint saving no longer happens if:
- You're in `custommode`, but not `custommodeforreal` (editor playtesting)
- You're in `cliplaytest` (playtest mode, but it DOES work if you just pass the play flag without a save)

Fixes #1198.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
