### PR TITLE
CI: Migrate to SLR Sniper SDK for Linux builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,41 +64,36 @@ jobs:
       run: ninja -C ${SRC_DIR_PATH}/build
 
   build-lin:
-    name: Build (CentOS 7)
+    name: Build (Steam Linux Runtime Sniper)
 
     runs-on: ubuntu-latest
-    container: ghcr.io/infoteddy/vvvvvv-build@sha256:50a2f769db3ca180286e9a76c1bf06b7016544a78e1fc7a9a0cc1144c675ced1
-
-    env:
-      CXXFLAGS: -I/usr/local/include/SDL2
-      LDFLAGS: -L/usr/local/lib
+    container: registry.gitlab.steamos.cloud/steamrt/sniper/sdk:beta
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
     - name: CMake configure (default version)
       run: |
         mkdir ${SRC_DIR_PATH}/build && cd ${SRC_DIR_PATH}/build
-        cmake ..
+        cmake -G Ninja ..
     - name: Build (default version)
-      run: make -j $(nproc) -C ${SRC_DIR_PATH}/build
+      run: ninja -C ${SRC_DIR_PATH}/build
 
     - name: CMake configure (official)
       run: |
         cd ${SRC_DIR_PATH}/build
-        cmake -DOFFICIAL_BUILD=ON ..
+        cmake -G Ninja -DOFFICIAL_BUILD=ON ..
     - name: Build (official)
-      run: |
-        make -j $(nproc) -C ${SRC_DIR_PATH}/build
+      run: ninja -C ${SRC_DIR_PATH}/build
 
     - name: CMake configure (M&P)
       run: |
         cd ${SRC_DIR_PATH}/build
-        cmake -DOFFICIAL_BUILD=OFF -DMAKEANDPLAY=ON ..
+        cmake -G Ninja -DOFFICIAL_BUILD=OFF -DMAKEANDPLAY=ON ..
     - name: Build (M&P)
-      run: make -j $(nproc) -C ${SRC_DIR_PATH}/build
+      run: ninja -C ${SRC_DIR_PATH}/build
 
   build-win:
     name: Build (windows-latest)


### PR DESCRIPTION
This isn't a _huge_ change, but it does bump the glibc requirement to 2.31, so this shouldn't be backported to 2.4-updates. The main benefit is that it gives us a container with access to new SDL APIs while also giving Misa one less thing to maintain locally.

Fixes #1205