### PR TITLE
Add `position(force)` and `textoutline(on/off/default)`

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3214,15 +3214,15 @@ SDL_Color Graphics::bigchunkygetcol(int t)
     return color;
 }
 
-void Graphics::textboxforcepos(int x, int y)
+void Graphics::textboxabsolutepos(int x, int y)
 {
     if (!INBOUNDS_VEC(m, textboxes))
     {
-        vlog_error("textboxforcepos() out-of-bounds!");
+        vlog_error("textboxabsolutepos() out-of-bounds!");
         return;
     }
 
-    textboxes[m].position_forced = true;
+    textboxes[m].position_absolute = true;
     textboxes[m].xp = x;
     textboxes[m].yp = y;
 }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -929,13 +929,20 @@ void Graphics::drawgui(void)
             size_t j;
             for (j = 0; j < textboxes[i].lines.size(); j++)
             {
-                font::print(
-                    print_flags | PR_BOR,
-                    text_xp,
-                    yp + text_yoff + text_sign * (j * (font_height + textboxes[i].linegap)),
-                    textbox_line(buffer, sizeof(buffer), i, j),
-                    0, 0, 0
-                );
+                const int x = text_xp;
+                const int y = yp + text_yoff + text_sign * (j * (font_height + textboxes[i].linegap));
+                if (!textboxes[i].force_outline)
+                {
+                    font::print(print_flags | PR_BOR, x, y, textbox_line(buffer, sizeof(buffer), i, j), 0, 0, 0);
+                }
+                else if (textboxes[i].outline)
+                {
+                    // We're forcing an outline, so we'll have to draw it ourselves instead of relying on PR_BOR.
+                    font::print(print_flags, x - 1, y, textbox_line(buffer, sizeof(buffer), i, j), 0, 0, 0);
+                    font::print(print_flags, x + 1, y, textbox_line(buffer, sizeof(buffer), i, j), 0, 0, 0);
+                    font::print(print_flags, x, y - 1, textbox_line(buffer, sizeof(buffer), i, j), 0, 0, 0);
+                    font::print(print_flags, x, y + 1, textbox_line(buffer, sizeof(buffer), i, j), 0, 0, 0);
+                }
             }
             for (j = 0; j < textboxes[i].lines.size(); j++)
             {
@@ -1472,6 +1479,18 @@ void Graphics::setimage(TextboxImage image)
     }
 
     textboxes[m].setimage(image);
+}
+
+void Graphics::textboxoutline(bool enabled)
+{
+    if (!INBOUNDS_VEC(m, textboxes))
+    {
+        vlog_error("textboxoutline() out-of-bounds!");
+        return;
+    }
+
+    textboxes[m].force_outline = true;
+    textboxes[m].outline = enabled;
 }
 
 void Graphics::addline( const std::string& t )

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3195,6 +3195,19 @@ SDL_Color Graphics::bigchunkygetcol(int t)
     return color;
 }
 
+void Graphics::textboxforcepos(int x, int y)
+{
+    if (!INBOUNDS_VEC(m, textboxes))
+    {
+        vlog_error("textboxforcepos() out-of-bounds!");
+        return;
+    }
+
+    textboxes[m].position_forced = true;
+    textboxes[m].xp = x;
+    textboxes[m].yp = y;
+}
+
 void Graphics::textboxcenterx(void)
 {
     if (!INBOUNDS_VEC(m, textboxes))

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -94,7 +94,7 @@ public:
         int r, int g, int b
     );
 
-    void textboxforcepos(int x, int y);
+    void textboxabsolutepos(int x, int y);
 
     void textboxcenterx(void);
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -137,6 +137,8 @@ public:
 
     void setimage(TextboxImage image);
 
+    void textboxoutline(bool enabled);
+
     void textboxindex(int index);
 
     void textboxremove(void);

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -94,6 +94,8 @@ public:
         int r, int g, int b
     );
 
+    void textboxforcepos(int x, int y);
+
     void textboxcenterx(void);
 
     int textboxwidth(void);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -551,6 +551,8 @@ void scriptclass::run(void)
                 textbox_sprites.clear();
                 textbox_image = TEXTIMAGE_NONE;
                 textbox_forcepos = false;
+                textbox_force_outline = false;
+                textbox_outline = false;
             }
             else if (words[0] == "position")
             {
@@ -729,6 +731,23 @@ void scriptclass::run(void)
                     textbox_image = TEXTIMAGE_NONE;
                 }
             }
+            else if (words[0] == "textoutline")
+            {
+                if (words[1] == "default")
+                {
+                    textbox_force_outline = false;
+                }
+                else if (words[1] == "on")
+                {
+                    textbox_force_outline = true;
+                    textbox_outline = true;
+                }
+                else if (words[1] == "off")
+                {
+                    textbox_force_outline = true;
+                    textbox_outline = false;
+                }
+            }
             else if (words[0] == "flipme")
             {
                 textflipme = !textflipme;
@@ -784,6 +803,11 @@ void scriptclass::run(void)
                         graphics.textboxcentery();
                         textcrewmateposition.override_y = false;
                     }
+                }
+
+                if (textbox_force_outline)
+                {
+                    graphics.textboxoutline(textbox_outline);
                 }
 
                 TextboxOriginalContext context = TextboxOriginalContext();

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -53,6 +53,7 @@ scriptclass::scriptclass(void)
     textlarge = false;
     textbox_sprites.clear();
     textbox_image = TEXTIMAGE_NONE;
+    textbox_forcepos = false;
 }
 
 void scriptclass::add_default_colours(void)
@@ -549,11 +550,13 @@ void scriptclass::run(void)
                 textcrewmateposition = TextboxCrewmatePosition();
                 textbox_sprites.clear();
                 textbox_image = TEXTIMAGE_NONE;
+                textbox_forcepos = false;
             }
             else if (words[0] == "position")
             {
                 //are we facing left or right? for some objects we don't care, default at 0.
                 j = 0;
+                textbox_forcepos = false;
 
                 //the first word is the object to position relative to
                 if (words[1] == "centerx")
@@ -574,6 +577,13 @@ void scriptclass::run(void)
                     j = -1;
                     textx = -500;
                     texty = -500;
+                }
+                else if (words[1] == "force")
+                {
+                    words[2] = "donothing";
+                    j = -1;
+                    textbox_forcepos = true;
+
                 }
                 else // Well, are they asking for a crewmate...?
                 {
@@ -757,16 +767,23 @@ void scriptclass::run(void)
 
                 graphics.setimage(textbox_image);
 
-                if (textx == -500 || textx == -1)
+                if (textbox_forcepos)
                 {
-                    graphics.textboxcenterx();
-                    textcrewmateposition.override_x = false;
+                    graphics.textboxforcepos(textx, texty);
                 }
-
-                if (texty == -500)
+                else
                 {
-                    graphics.textboxcentery();
-                    textcrewmateposition.override_y = false;
+                    if (textx == -500 || textx == -1)
+                    {
+                        graphics.textboxcenterx();
+                        textcrewmateposition.override_x = false;
+                    }
+
+                    if (texty == -500)
+                    {
+                        graphics.textboxcentery();
+                        textcrewmateposition.override_y = false;
+                    }
                 }
 
                 TextboxOriginalContext context = TextboxOriginalContext();

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -53,7 +53,7 @@ scriptclass::scriptclass(void)
     textlarge = false;
     textbox_sprites.clear();
     textbox_image = TEXTIMAGE_NONE;
-    textbox_forcepos = false;
+    textbox_absolutepos = false;
 }
 
 void scriptclass::add_default_colours(void)
@@ -550,7 +550,7 @@ void scriptclass::run(void)
                 textcrewmateposition = TextboxCrewmatePosition();
                 textbox_sprites.clear();
                 textbox_image = TEXTIMAGE_NONE;
-                textbox_forcepos = false;
+                textbox_absolutepos = false;
                 textbox_force_outline = false;
                 textbox_outline = false;
             }
@@ -558,7 +558,7 @@ void scriptclass::run(void)
             {
                 //are we facing left or right? for some objects we don't care, default at 0.
                 j = 0;
-                textbox_forcepos = false;
+                textbox_absolutepos = false;
 
                 //the first word is the object to position relative to
                 if (words[1] == "centerx")
@@ -580,11 +580,11 @@ void scriptclass::run(void)
                     textx = -500;
                     texty = -500;
                 }
-                else if (words[1] == "force")
+                else if (words[1] == "absolute")
                 {
                     words[2] = "donothing";
                     j = -1;
-                    textbox_forcepos = true;
+                    textbox_absolutepos = true;
 
                 }
                 else // Well, are they asking for a crewmate...?
@@ -786,9 +786,9 @@ void scriptclass::run(void)
 
                 graphics.setimage(textbox_image);
 
-                if (textbox_forcepos)
+                if (textbox_absolutepos)
                 {
-                    graphics.textboxforcepos(textx, texty);
+                    graphics.textboxabsolutepos(textx, texty);
                 }
                 else
                 {

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -123,6 +123,8 @@ public:
     std::vector<TextboxSprite> textbox_sprites;
     TextboxImage textbox_image;
     bool textbox_forcepos;
+    bool textbox_force_outline;
+    bool textbox_outline;
 
     //Misc
     int i, j, k;

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -122,6 +122,7 @@ public:
     int textboxtimer;
     std::vector<TextboxSprite> textbox_sprites;
     TextboxImage textbox_image;
+    bool textbox_forcepos;
 
     //Misc
     int i, j, k;

--- a/desktop_version/src/Script.h
+++ b/desktop_version/src/Script.h
@@ -122,7 +122,7 @@ public:
     int textboxtimer;
     std::vector<TextboxSprite> textbox_sprites;
     TextboxImage textbox_image;
-    bool textbox_forcepos;
+    bool textbox_absolutepos;
     bool textbox_force_outline;
     bool textbox_outline;
 

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -29,7 +29,7 @@ textboxclass::textboxclass(int gap)
 
     large = false;
 
-    position_forced = false;
+    position_absolute = false;
 
     should_centerx = false;
     should_centery = false;
@@ -83,7 +83,7 @@ void textboxclass::centery(void)
 void textboxclass::applyposition(void)
 {
     resize();
-    if (!position_forced)
+    if (!position_absolute)
     {
         reposition();
         if (should_centerx)

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -43,6 +43,9 @@ textboxclass::textboxclass(int gap)
 
     image = TEXTIMAGE_NONE;
 
+    force_outline = false;
+    outline = false;
+
     crewmate_position = TextboxCrewmatePosition();
     original = TextboxOriginalContext();
     original.text_case = 1;

--- a/desktop_version/src/Textbox.cpp
+++ b/desktop_version/src/Textbox.cpp
@@ -29,6 +29,8 @@ textboxclass::textboxclass(int gap)
 
     large = false;
 
+    position_forced = false;
+
     should_centerx = false;
     should_centery = false;
 
@@ -78,18 +80,21 @@ void textboxclass::centery(void)
 void textboxclass::applyposition(void)
 {
     resize();
-    reposition();
-    if (should_centerx)
+    if (!position_forced)
     {
-        centerx();
-    }
-    if (should_centery)
-    {
-        centery();
-    }
-    if (translate == TEXTTRANSLATE_CUTSCENE)
-    {
-        adjust();
+        reposition();
+        if (should_centerx)
+        {
+            centerx();
+        }
+        if (should_centery)
+        {
+            centery();
+        }
+        if (translate == TEXTTRANSLATE_CUTSCENE)
+        {
+            adjust();
+        }
     }
 }
 

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -125,6 +125,8 @@ public:
 
     bool large;
 
+    bool position_forced;
+
     bool should_centerx;
     bool should_centery;
 

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -137,6 +137,9 @@ public:
     std::vector<TextboxSprite> sprites;
     TextboxImage image;
 
+    bool force_outline;
+    bool outline;
+
     TextboxCrewmatePosition crewmate_position;
     TextboxOriginalContext original;
     TextboxSpacing spacing;

--- a/desktop_version/src/Textbox.h
+++ b/desktop_version/src/Textbox.h
@@ -125,7 +125,7 @@ public:
 
     bool large;
 
-    bool position_forced;
+    bool position_absolute;
 
     bool should_centerx;
     bool should_centery;


### PR DESCRIPTION
## Changes:

The `force` argument in `position`  forces the textbox position, meaning it won't be moved to be inside of the bounds of the screen (nor have the 10 pixel padding on each side.)

`textoutline(on/off/default)` is a new scripting command for textbox visual control, where you're able to force the transparent textbox's outline on or off. This does NOT affect roomtext.

These changes are both solely visual.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
