### PR TITLE
Make 0-length gravity lines invisible again

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1864,6 +1864,11 @@ void Graphics::drawgravityline(const int t, const int x, const int y, const int 
         return;
     }
 
+    if (w <= 0 && h <= 0)
+    {
+        return;
+    }
+
     if (obj.entities[t].life == 0)
     {
         if (game.noflashingmode)


### PR DESCRIPTION
## Changes:

0-length gravity lines used to be invisible, but it "broke" some time in 2.4. This PR makes them invisible again.

## Legal Stuff:

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
