### PR TITLE
Clean up audio code

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -504,9 +504,9 @@ end:
         }
     }
 
-    static void SetVolume(int musicVolume)
+    static void SetVolume(int controlVolume)
     {
-        float adj_vol = (float) musicVolume / VVV_MAX_VOLUME;
+        float adj_vol = (float)controlVolume / VVV_MAX_VOLUME;
         if (!IsHalted())
         {
             FAudioVoice_SetVolume(musicVoice, adj_vol, FAUDIO_COMMIT_NOW);
@@ -715,7 +715,7 @@ musicclass::musicclass(void)
     safeToProcessMusic= false;
     m_doFadeInVol = false;
     m_doFadeOutVol = false;
-    musicVolume = 0;
+    controlVolume = 0;
 
     user_music_volume = USER_VOLUME_MAX;
     user_sound_volume = USER_VOLUME_MAX;
@@ -971,8 +971,8 @@ void musicclass::play(int t)
         {
             m_doFadeInVol = false;
             m_doFadeOutVol = false;
-            musicVolume = VVV_MAX_VOLUME;
-            set_music_volume(musicVolume);
+            controlVolume = VVV_MAX_VOLUME;
+            set_music_volume(controlVolume);
         }
     }
     else
@@ -1050,7 +1050,7 @@ void musicclass::haltdasmusik(const bool from_fade)
 
 void musicclass::silencedasmusik(void)
 {
-    musicVolume = 0;
+    controlVolume = 0;
     m_doFadeInVol = false;
     m_doFadeOutVol = false;
 }
@@ -1107,7 +1107,7 @@ void musicclass::fadeMusicVolumeIn(int ms)
     m_doFadeOutVol = false;
 
     /* Ensure it starts at 0 */
-    musicVolume = 0;
+    controlVolume = 0;
 
     /* Fix 1-frame glitch */
     set_music_volume(0);
@@ -1130,8 +1130,8 @@ void musicclass::fadeMusicVolumeOut(const int fadeout_ms)
 
     fade.step_ms = 0;
     /* Duration is proportional to current volume. */
-    fade.duration_ms = fadeout_ms * musicVolume / VVV_MAX_VOLUME;
-    fade.start_volume = musicVolume;
+    fade.duration_ms = fadeout_ms * controlVolume / VVV_MAX_VOLUME;
+    fade.start_volume = controlVolume;
     fade.end_volume = 0;
 }
 
@@ -1143,7 +1143,7 @@ void musicclass::fadeout(const bool quick_fade_ /*= true*/)
 
 void musicclass::processmusicfadein(void)
 {
-    enum FadeCode fade_code = processmusicfade(&fade, &musicVolume);
+    enum FadeCode fade_code = processmusicfade(&fade, &controlVolume);
     if (fade_code == Fade_finished)
     {
         m_doFadeInVol = false;
@@ -1152,10 +1152,10 @@ void musicclass::processmusicfadein(void)
 
 void musicclass::processmusicfadeout(void)
 {
-    enum FadeCode fade_code = processmusicfade(&fade, &musicVolume);
+    enum FadeCode fade_code = processmusicfade(&fade, &controlVolume);
     if (fade_code == Fade_finished)
     {
-        musicVolume = 0;
+        controlVolume = 0;
         m_doFadeOutVol = false;
         haltdasmusik(true);
     }
@@ -1322,7 +1322,7 @@ void musicclass::updatemutestate(void)
         }
         else
         {
-            set_music_volume(musicVolume);
+            set_music_volume(controlVolume);
         }
     }
 }

--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -909,6 +909,16 @@ void musicclass::destroy(void)
     VVV_freefunc(FAudio_Release, faudioctx);
 }
 
+void musicclass::set_music_volume(int volume)
+{
+    MusicTrack::SetVolume(volume * user_music_volume / USER_VOLUME_MAX);
+}
+
+void musicclass::set_sound_volume(int volume)
+{
+    SoundTrack::SetVolume(volume * user_sound_volume / USER_VOLUME_MAX);
+}
+
 void musicclass::play(int t)
 {
     if (mmmmmm && usingmmmmmm)
@@ -962,7 +972,7 @@ void musicclass::play(int t)
             m_doFadeInVol = false;
             m_doFadeOutVol = false;
             musicVolume = VVV_MAX_VOLUME;
-            MusicTrack::SetVolume(VVV_MAX_VOLUME * user_music_volume / USER_VOLUME_MAX);
+            set_music_volume(musicVolume);
         }
     }
     else
@@ -1100,7 +1110,7 @@ void musicclass::fadeMusicVolumeIn(int ms)
     musicVolume = 0;
 
     /* Fix 1-frame glitch */
-    MusicTrack::SetVolume(0);
+    set_music_volume(0);
 
     fade.step_ms = 0;
     fade.duration_ms = ms;
@@ -1299,20 +1309,20 @@ void musicclass::updatemutestate(void)
 {
     if (game.muted)
     {
-        MusicTrack::SetVolume(0);
-        SoundTrack::SetVolume(0);
+        set_music_volume(0);
+        set_sound_volume(0);
     }
     else
     {
-        SoundTrack::SetVolume(VVV_MAX_VOLUME * user_sound_volume / USER_VOLUME_MAX);
+        set_sound_volume(VVV_MAX_VOLUME);
 
         if (game.musicmuted)
         {
-            MusicTrack::SetVolume(0);
+            set_music_volume(0);
         }
         else
         {
-            MusicTrack::SetVolume(musicVolume * user_music_volume / USER_VOLUME_MAX);
+            set_music_volume(musicVolume);
         }
     }
 }

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -108,7 +108,7 @@ public:
 
     bool m_doFadeInVol;
     bool m_doFadeOutVol;
-    int musicVolume;
+    int controlVolume;
 
     /* 0..USER_VOLUME_MAX */
     int user_music_volume;

--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -70,6 +70,9 @@ public:
     void init(void);
     void destroy(void);
 
+    void set_music_volume(int volume);
+    void set_sound_volume(int volume);
+
     void play(int t);
     void resume(void);
     void resumefade(const int fadein_ms);

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -105,7 +105,7 @@ static void volumesliderrender(void)
     }
 
     char slider[40 + 1];
-    slider_get(slider, sizeof(slider), volume_max_position*volume/USER_VOLUME_MAX, volume_max_position+1, 240);
+    slider_get(slider, sizeof(slider), volume_max_position * volume / USER_VOLUME_MAX, volume_max_position + 1, 240);
 
     char buffer[SCREEN_WIDTH_CHARS + 1];
 


### PR DESCRIPTION
## Changes:

This cleans up the audio code as mentioned in #1183 to disambiguate `VVV_MAX_VOLUME` and `USER_VOLUME_MAX`. It introduces the `musicclass::set_music_volume()` and `musicclass::set_sound_volume()` methods - these handle adjusting the volume based on the user controlled volume setting and are called in place of `MusicTrack::SetVolume()` and `SoundTrack::SetVolume()` so modulating the user volume is not calculated in multiple disparate places.
It also changes `musicVolume` to `controlVolume`, as it's the variable used internally by the game to control the volume at any given time using a fade, which is then referenced by `musicclass::updatemutestate()` method.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
