### PR TITLE
Fix squeak and save spam in gamepad menu

### DIFF
--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2377,16 +2377,25 @@ void titleinput(void)
             game.jumpheld = true;
         }
 
+        static bool controller_held = false;
+
         if (    game.currentmenuname == Menu::controller &&
                 game.currentmenuoption > 0 &&
                 game.currentmenuoption < 6 &&
                 (game.separate_interact || game.currentmenuoption < 5) &&
                 key.controllerButtonDown()      )
         {
-            updatebuttonmappings(game.currentmenuoption);
-            music.playef(Sound_VIRIDIAN);
-            game.savestatsandsettings_menu();
+            if (!controller_held)
+            {
+                controller_held = true;
+                updatebuttonmappings(game.currentmenuoption);
+                game.savestatsandsettings_menu();
+            }
             return;
+        }
+        else
+        {
+            controller_held = false;
         }
 
         if (game.menustart


### PR DESCRIPTION
## Changes:

If you push a button to set a controller binding, you may either hear one Viridian squeak, two Viridian squeaks (a louder one), or Viridian doesn't stop squeaking until you let go of the button. While you hear the continuous squeaking, your save file is also repeatedly saved.

(Don't forget to unmute the video:)

https://github.com/user-attachments/assets/1fdf2063-fbba-4823-a2e9-0761280d01bd

There are two small bugs at play here:
- the squeak is actually played in two different places at the same time (both in `titleinput()` whenever a button is pressed, and in `updatebuttonmappings()` when a mapping is succesfully changed)
- `titleinput()` doesn't register that a button is held down and applies the button (and saves to file) every frame for as long as the button is held

This PR fixes both these issues. Now a single button press always causes one squeak, and only if the bindings actually changed. Your save file is also no longer saved repeatedly from holding down the button.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
