### PR TITLE
Change name of Silesian option by request of translator

### DIFF
--- a/desktop_version/lang/szl/meta.xml
+++ b/desktop_version/lang/szl/meta.xml
@@ -3,7 +3,7 @@
     <active>1</active>
 
     <!-- should be lowercase because menu style, and should be in the language itself -->
-    <nativename>ślonsko godka</nativename>
+    <nativename>ślōnsko</nativename>
 
     <!-- English translation by X -->
     <credit>Ślōnski przekłŏd: Kuba Kallus</credit>


### PR DESCRIPTION
## Changes:

Our Silesian translator asked for "Ślonsko godka" to be changed to "Ślōnsko". (This would probably also be nice as a backport to 2.4-updates since it's a really minor change)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
