### PR TITLE
Remove extra unnecessary palettes

### DIFF
--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -613,17 +613,24 @@ void entclass::updatecolour(void)
     switch (size)
     {
     case 0: // Sprites
+    case 3: // Big chunky pixels!
+    case 4: // Small pickups
     case 7: // Teleporter
     case 9: // Really Big Sprite! (2x2)
     case 10: // 2x1 Sprite
     case 13: // Special for epilogue: huge hero!
         realcol = graphics.getcol(colour);
         break;
-    case 3: // Big chunky pixels!
-        realcol = graphics.bigchunkygetcol(colour);
-        break;
-    case 4: // Small pickups
-        realcol = graphics.huetilegetcol();
+    case 5: // Horizontal gravity line
+    case 6: // Vertical gravity line
+        if (life == 0)
+        {
+            realcol = graphics.getcol(colour);
+        }
+        else
+        {
+            realcol = graphics.getcol(24);
+        }
         break;
     case 11: // The fucking elephant
         if (game.noflashingmode)

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -1292,7 +1292,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
     //Size 1 is a tile
     //Beyond that are special cases (to do)
     //Size 2 is a moving platform of width 4 (32)
-    //Size 3 is apparently a "bug chunky pixel"
+    //Size 3 is apparently a "big chunky pixel"
     //Size 4 is a coin/small pickup
     //Size 5 is a horizontal line, 6 is vertical
 
@@ -1515,7 +1515,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
     case 6: //Decorative particles
         entity.rule = 2;
         entity.type = EntityType_PARTICLE;  //Particles
-        entity.colour = 1;
+        entity.colour = 27;
         entity.size = 3;
         entity.vx = meta1;
         entity.vy = meta2;
@@ -1525,7 +1525,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
     case 7: //Decorative particles
         entity.rule = 2;
         entity.type = EntityType_PARTICLE;  //Particles
-        entity.colour = 2;
+        entity.colour = 0;
         entity.size = 3;
         entity.vx = meta1;
         entity.vy = meta2;
@@ -1536,6 +1536,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.rule = 3;
         entity.type = EntityType_COIN;
         entity.size = 4;
+        entity.colour = 26;
         entity.tile = 48;
         entity.w = 8;
         entity.h = 8;
@@ -1589,6 +1590,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.type = EntityType_HORIZONTAL_GRAVITY_LINE;
         entity.size = 5;
         entity.life = 0;
+        entity.colour = 25;
         entity.w = meta1;
         entity.h = 1;
         entity.onentity = 1;
@@ -1598,6 +1600,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.type = EntityType_VERTICAL_GRAVITY_LINE;
         entity.size = 6;
         entity.life = 0;
+        entity.colour = 25;
         entity.w = 1;
         entity.h = meta1;
         //entity.colour = 0;

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -1869,53 +1869,7 @@ void Graphics::drawgravityline(const int t, const int x, const int y, const int 
         return;
     }
 
-    if (obj.entities[t].life == 0)
-    {
-        if (game.noflashingmode)
-        {
-            set_color(200 - 20, 200 - 20, 200 - 20);
-            draw_line(x, y, x + w, y + h);
-            return;
-        }
-
-        switch(linestate)
-        {
-        case 0:
-            set_color(200 - 20, 200 - 20, 200 - 20);
-            break;
-        case 1:
-            set_color(245 - 30, 245 - 30, 225 - 30);
-            break;
-        case 2:
-            set_color(225 - 30, 245 - 30, 245 - 30);
-            break;
-        case 3:
-            set_color(200 - 20, 200 - 20, 164 - 10);
-            break;
-        case 4:
-            set_color(196 - 20, 255 - 30, 224 - 20);
-            break;
-        case 5:
-            set_color(196 - 20, 235 - 30, 205 - 20);
-            break;
-        case 6:
-            set_color(164 - 10, 164 - 10, 164 - 10);
-            break;
-        case 7:
-            set_color(205 - 20, 245 - 30, 225 - 30);
-            break;
-        case 8:
-            set_color(225 - 30, 255 - 30, 205 - 20);
-            break;
-        case 9:
-            set_color(245 - 30, 245 - 30, 245 - 30);
-            break;
-        }
-    }
-    else
-    {
-        set_color(96, 96, 96);
-    }
+    set_color(obj.entities[t].realcol);
 
     draw_line(x, y, x + w, y + h);
 }
@@ -3084,8 +3038,49 @@ SDL_Color Graphics::getcol( int t )
     case 23: // Enemy : Indicator Gray
         return getRGB(255 - help.glow / 2 - (int) (GETCOL_RANDOM * 40), 255 - help.glow/2 - (int) (GETCOL_RANDOM * 40), 255 - help.glow/2 - (int) (GETCOL_RANDOM * 40));
 
-        // Trophies
-        // cyan
+    case 24: // Gravity line (Inactive)
+        return getRGB(96, 96, 96);
+    case 25: // Gravity line (Active)
+        if (game.noflashingmode)
+        {
+            return getRGB(200 - 20, 200 - 20, 200 - 20);
+        }
+
+        switch (linestate)
+        {
+        default:
+        case 0:
+            return getRGB(200 - 20, 200 - 20, 200 - 20);
+        case 1:
+            return getRGB(245 - 30, 245 - 30, 225 - 30);
+        case 2:
+            return getRGB(225 - 30, 245 - 30, 245 - 30);
+        case 3:
+            return getRGB(200 - 20, 200 - 20, 164 - 10);
+        case 4:
+            return getRGB(196 - 20, 255 - 30, 224 - 20);
+        case 5:
+            return getRGB(196 - 20, 235 - 30, 205 - 20);
+        case 6:
+            return getRGB(164 - 10, 164 - 10, 164 - 10);
+        case 7:
+            return getRGB(205 - 20, 245 - 30, 225 - 30);
+        case 8:
+            return getRGB(225 - 30, 255 - 30, 205 - 20);
+        case 9:
+            return getRGB(245 - 30, 245 - 30, 245 - 30);
+        }
+    case 26: // Coin
+        if (game.noflashingmode)
+        {
+            return getRGB(234, 234, 10);
+        }
+        return getRGB(250 - (int) (GETCOL_RANDOM * 32), 250 - (int) (GETCOL_RANDOM * 32), 10);
+    case 27: // Particle flashy red
+        return getRGB((GETCOL_RANDOM * 64), 10, 10);
+
+    // Trophies
+    // cyan
     case 30:
         return RGBf(160, 200, 220);
         // Purple
@@ -3200,32 +3195,6 @@ void Graphics::menuoffrender(void)
     {
         return;
     }
-}
-
-SDL_Color Graphics::huetilegetcol()
-{
-    if (game.noflashingmode)
-    {
-        return getRGB(234, 234, 10);
-    }
-
-    return getRGB(250 - (int) (fRandom() * 32), 250 - (int) (fRandom() * 32), 10);
-}
-
-SDL_Color Graphics::bigchunkygetcol(int t)
-{
-    // A seperate index of colours, for simplicity
-    float random = game.noflashingmode ? 0.5 : fRandom();
-
-    switch (t)
-    {
-    case 1:
-        return getRGB(random * 64, 10, 10);
-    case 2:
-        return getRGB(160 - help.glow / 2 - (int) (random * 20), 200 - help.glow / 2, 220 - help.glow);
-    }
-    const SDL_Color color = {0, 0, 0, 0};
-    return color;
 }
 
 void Graphics::textboxabsolutepos(int x, int y)

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -51,9 +51,6 @@ public:
 
     GraphicsResources grphx;
 
-    SDL_Color huetilegetcol();
-    SDL_Color bigchunkygetcol(int t);
-
     void drawgravityline(int t, int x, int y, int w, int h);
 
     void drawcoloredtile(int x, int y, int t, int r, int g, int b);


### PR DESCRIPTION
## Changes:

This merges the colors from other palettes into the general entity palette function. Meaning, particles and "hue tiles" (aka coins) now use the main palette instead of having two extra palette functions.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
