### PR TITLE
Change name of Silesian option (part 2)

### DIFF
--- a/desktop_version/lang/szl/meta.xml
+++ b/desktop_version/lang/szl/meta.xml
@@ -3,7 +3,7 @@
     <active>1</active>
 
     <!-- should be lowercase because menu style, and should be in the language itself -->
-    <nativename>ślōnsko</nativename>
+    <nativename>ślōnsko gŏdka</nativename>
 
     <!-- English translation by X -->
     <credit>Ślōnski przekłŏd: Kuba Kallus</credit>


### PR DESCRIPTION
## Changes:

Turns out there was a little miscommunication with the translator - they said the option needed to say "Ślōnsko" but were only talking about correcting the first word, where I thought the whole thing needed to be replaced.

So for confirmation:

![this menu should ideally say "Ślōnsko gŏdka"](https://github.com/user-attachments/assets/f62b0bdf-acda-4d93-b436-fc2107930307)

(Previous PR: #1220)



## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
