### PR TITLE
Replace colour IDs with an enum

### DIFF
--- a/desktop_version/src/Ent.cpp
+++ b/desktop_version/src/Ent.cpp
@@ -18,7 +18,7 @@ void entclass::clear(void)
     state = 0;
     statedelay = 0;
     life = 0;
-    colour = 0;
+    colour = EntityColour_CREW_CYAN;
     para = 0;
     behave = 0;
     animate = 0;
@@ -108,7 +108,7 @@ void entclass::setenemy( int t )
         case 0:
             tile = 60;
             animate = 2;
-            colour = 6;
+            colour = EntityColour_ENEMY_RED;
             behave = 10;
             w = 32;
             h = 32;
@@ -119,7 +119,7 @@ void entclass::setenemy( int t )
             lerpoldyp += 10;
             tile = 63;
             animate = 100; //LIES
-            colour = 6;
+            colour = EntityColour_ENEMY_RED;
             behave = 11;
             para = 9; //destroyed when outside
             x1 = -200;
@@ -132,7 +132,7 @@ void entclass::setenemy( int t )
         case 2:
             tile = 62;
             animate = 100;
-            colour = 6;
+            colour = EntityColour_ENEMY_RED;
             behave = -1;
             w = 32;
             h = 32;
@@ -147,7 +147,7 @@ void entclass::setenemy( int t )
             tile = 72;
             animate = 3;
             size = 9;
-            colour = 6;
+            colour = EntityColour_ENEMY_RED;
             behave = 12;
             w = 64;
             h = 40;
@@ -161,7 +161,7 @@ void entclass::setenemy( int t )
             lerpoldyp -= 4;
             tile = 76;
             animate = 100; // Clouds
-            colour = 6;
+            colour = EntityColour_ENEMY_RED;
             behave = 13;
             para = -6; //destroyed when outside
             x2 = 400;
@@ -173,7 +173,7 @@ void entclass::setenemy( int t )
         case 2:
             tile = 77;
             animate = 100;
-            colour = 6;
+            colour = EntityColour_ENEMY_RED;
             behave = -1;
             w = 32;
             h = 16;
@@ -195,32 +195,32 @@ void entclass::setenemyroom( int rx, int ry )
         //Space Station 1
     case rn(12, 3):  //Security Drone
         tile = 36;
-        colour = 8;
+        colour = EntityColour_ENEMY_PINK;
         animate = 1;
         break;
     case rn(13, 3):  //Wavelengths
         tile = 32;
-        colour = 7;
+        colour = EntityColour_ENEMY_GREEN;
         animate = 1;
         w = 32;
         break;
     case rn(15, 3):  //Traffic
         tile = 28;
-        colour = 6;
+        colour = EntityColour_ENEMY_RED;
         animate = 1;
         w = 22;
         h = 32;
         break;
     case rn(12, 5):  //The Yes Men
         tile = 40;
-        colour = 9;
+        colour = EntityColour_ENEMY_YELLOW;
         animate = 1;
         w = 20;
         h = 20;
         break;
     case rn(13, 6):  //Hunchbacked Guards
         tile = 44;
-        colour = 8;
+        colour = EntityColour_ENEMY_PINK;
         animate = 1;
         w = 16;
         h = 20;
@@ -231,7 +231,7 @@ void entclass::setenemyroom( int rx, int ry )
         {
             //transmittor
             tile = 104;
-            colour = 4;
+            colour = EntityColour_INACTIVE_ENTITY;
             animate = 7;
             w = 16;
             h = 16;
@@ -244,7 +244,7 @@ void entclass::setenemyroom( int rx, int ry )
         {
             //radar dish
             tile =124;
-            colour = 4;
+            colour = EntityColour_INACTIVE_ENTITY;
             animate = 6;
             w = 32;
             h = 32;
@@ -260,37 +260,37 @@ void entclass::setenemyroom( int rx, int ry )
         //The Lab
     case rn(4, 0):
         tile = 78;
-        colour = 7;
+        colour = EntityColour_ENEMY_GREEN;
         animate = 1;
         w = 16;
         h = 16;
         break;
     case rn(2, 0):
         tile = 88;
-        colour = 11;
+        colour = EntityColour_ENEMY_CYAN;
         animate = 1;
         w = 16;
         h = 16;
         break;
         //Space Station 2
     case rn(14, 11):
-        colour = 17;
+        colour = EntityColour_ENEMY_ORANGE;
         break; //Lies
     case rn(16, 11):
-        colour = 8;
+        colour = EntityColour_ENEMY_PINK;
         break; //Lies
     case rn(13, 10):
-        colour = 11;
+        colour = EntityColour_ENEMY_CYAN;
         break; //Factory
     case rn(13, 9):
-        colour = 9;
+        colour = EntityColour_ENEMY_YELLOW;
         break; //Factory
     case rn(13, 8):
-        colour = 8;
+        colour = EntityColour_ENEMY_PINK;
         break; //Factory
     case rn(11, 13): //Truth
         tile = 64;
-        colour = 7;
+        colour = EntityColour_ENEMY_GREEN;
         animate = 100;
         w = 44;
         h = 10;
@@ -298,7 +298,7 @@ void entclass::setenemyroom( int rx, int ry )
         break;
     case rn(17, 7): //Brass sent us under the top
         tile =82;
-        colour = 8;
+        colour = EntityColour_ENEMY_PINK;
         animate = 5;
         w = 28;
         h = 32;
@@ -306,42 +306,42 @@ void entclass::setenemyroom( int rx, int ry )
         break;
     case rn(10, 7): // (deception)
         tile = 92;
-        colour = 6;
+        colour = EntityColour_ENEMY_RED;
         animate = 1;
         w = 16;
         h = 16;
         break;
     case rn(14, 13): // (chose poorly)
         tile = 56;
-        colour = 6;
+        colour = EntityColour_ENEMY_RED;
         animate = 1;
         w = 15;
         h = 24;
         break;
     case rn(13, 12): // (backsliders)
         tile = 164;
-        colour = 7;
+        colour = EntityColour_ENEMY_GREEN;
         animate = 1;
         w = 16;
         h = 16;
         break;
     case rn(14, 8): // (wheel of fortune room)
         tile = 116;
-        colour = 12;
+        colour = EntityColour_ENEMY_BLUE;
         animate = 1;
         w = 32;
         h = 32;
         break;
     case rn(16, 9): // (seeing dollar signs)
         tile = 68;
-        colour = 7;
+        colour = EntityColour_ENEMY_GREEN;
         animate = 1;
         w = 16;
         h = 16;
         break;
     case rn(16, 7): // (tomb of mad carew)
         tile = 106;
-        colour = 7;
+        colour = EntityColour_ENEMY_GREEN;
         animate = 2;
         w = 24;
         h = 25;
@@ -349,7 +349,7 @@ void entclass::setenemyroom( int rx, int ry )
         //Warp Zone
     case rn(15, 2): // (numbers)
         tile = 100;
-        colour = 6;
+        colour = EntityColour_ENEMY_RED;
         animate = 1;
         w = 32;
         h = 14;
@@ -358,7 +358,7 @@ void entclass::setenemyroom( int rx, int ry )
         break;
     case rn(16, 2): // (Manequins)
         tile = 52;
-        colour = 7;
+        colour = EntityColour_ENEMY_GREEN;
         animate = 5;
         w = 16;
         h = 25;
@@ -367,28 +367,28 @@ void entclass::setenemyroom( int rx, int ry )
         break;
     case rn(18, 0): // (Obey)
         tile = 51;
-        colour = 11;
+        colour = EntityColour_ENEMY_CYAN;
         animate = 100;
         w = 30;
         h = 14;
         break;
     case rn(19, 1): // Ascending and Descending
         tile = 48;
-        colour = 9;
+        colour = EntityColour_ENEMY_YELLOW;
         animate = 5;
         w = 16;
         h = 16;
         break;
     case rn(19, 2): // Shockwave Rider
         tile = 176;
-        colour = 6;
+        colour = EntityColour_ENEMY_RED;
         animate = 1;
         w = 16;
         h = 16;
         break;
     case rn(18, 3): // Mind the gap
         tile = 168;
-        colour = 7;
+        colour = EntityColour_ENEMY_GREEN;
         animate = 1;
         w = 16;
         h = 16;
@@ -397,7 +397,7 @@ void entclass::setenemyroom( int rx, int ry )
         if (yp ==96)
         {
             tile = 160;
-            colour = 8;
+            colour = EntityColour_ENEMY_PINK;
             animate = 1;
             w = 16;
             h = 16;
@@ -405,7 +405,7 @@ void entclass::setenemyroom( int rx, int ry )
         else
         {
             tile = 156;
-            colour = 8;
+            colour = EntityColour_ENEMY_PINK;
             animate = 1;
             w = 16;
             h = 16;
@@ -413,14 +413,14 @@ void entclass::setenemyroom( int rx, int ry )
         break;
     case rn(16, 0): // I love you
         tile = 112;
-        colour = 8;
+        colour = EntityColour_ENEMY_PINK;
         animate = 5;
         w = 16;
         h = 16;
         break;
     case rn(14, 2): // That's why I have to kill you
         tile = 114;
-        colour = 6;
+        colour = EntityColour_ENEMY_RED;
         animate = 5;
         w = 16;
         h = 16;
@@ -430,7 +430,7 @@ void entclass::setenemyroom( int rx, int ry )
         if (xp ==88)
         {
             tile = 54+12;
-            colour = 12;
+            colour = EntityColour_ENEMY_BLUE;
             animate = 100;
             w = 60;
             h = 16;
@@ -439,7 +439,7 @@ void entclass::setenemyroom( int rx, int ry )
         else
         {
             tile = 54;
-            colour = 12;
+            colour = EntityColour_ENEMY_BLUE;
             animate = 100;
             w = 60;
             h = 16;
@@ -449,62 +449,62 @@ void entclass::setenemyroom( int rx, int ry )
         //Final level
     case rn(50-100, 53-100):  //The Yes Men
         tile = 40;
-        colour = 9;
+        colour = EntityColour_ENEMY_YELLOW;
         animate = 1;
         w = 20;
         h = 20;
         break;
     case rn(48-100, 51-100):  //Wavelengths
         tile = 32;
-        colour = 7;
+        colour = EntityColour_ENEMY_GREEN;
         animate = 1;
         w = 32;
         break;
     case rn(43-100,52-100): // Ascending and Descending
         tile = 48;
-        colour = 9;
+        colour = EntityColour_ENEMY_YELLOW;
         animate = 5;
         w = 16;
         h = 16;
         break;
     case rn(46-100,51-100): //kids his age
         tile = 88;
-        colour = 11;
+        colour = EntityColour_ENEMY_CYAN;
         animate = 1;
         w = 16;
         h = 16;
         break;
     case rn(43-100,51-100): // Mind the gap
         tile = 168;
-        colour = 7;
+        colour = EntityColour_ENEMY_GREEN;
         animate = 1;
         w = 16;
         h = 16;
         break;
     case rn(44-100,51-100): // vertigo?
         tile = 172;
-        colour = 7;
+        colour = EntityColour_ENEMY_GREEN;
         animate = 100;
         w = 32;
         h = 32;
         break;
     case rn(44-100,52-100): // (backsliders)
         tile = 164;
-        colour = 7;
+        colour = EntityColour_ENEMY_GREEN;
         animate = 1;
         w = 16;
         h = 16;
         break;
     case rn(43-100, 56-100): //Intermission 1
         tile = 88;
-        colour = 21;
+        colour = EntityColour_ENEMY_GRAVITRON;
         animate = 1;
         w = 16;
         h = 16;
         break;
     case rn(45-100, 56-100): //Intermission 1
         tile = 88;
-        colour = 21;
+        colour = EntityColour_ENEMY_GRAVITRON;
         animate = 1;
         w = 16;
         h = 16;
@@ -515,7 +515,7 @@ void entclass::setenemyroom( int rx, int ry )
     case rn(11, 8):
     case rn(12, 8):
         tile = 0;
-        colour = 102;
+        colour = EntityColour_TELEPORTER_FLASHING;
         animate = 0;
         w = 464;
         h = 320;

--- a/desktop_version/src/Ent.h
+++ b/desktop_version/src/Ent.h
@@ -59,7 +59,8 @@ public:
     int state, statedelay;
     int behave, animate;
     float para;
-    int life, colour;
+    int life;
+    int colour; // As out-of-bounds colours are allowed, this should be an int instead of an EnemyColour.
 
     //Position and velocity
     int oldxp, oldyp;

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -109,13 +109,13 @@ void entityclass::resetallflags(void)
 int entityclass::swncolour( int t )
 {
     //given colour t, return colour in setcol
-    if (t == 0) return 11;
-    if (t == 1) return 6;
-    if (t == 2) return 8;
-    if (t == 3) return 12;
-    if (t == 4) return 9;
-    if (t == 5) return 7;
-    return 0;
+    if (t == 0) return EntityColour_ENEMY_CYAN;
+    if (t == 1) return EntityColour_ENEMY_RED;
+    if (t == 2) return EntityColour_ENEMY_PINK;
+    if (t == 3) return EntityColour_ENEMY_BLUE;
+    if (t == 4) return EntityColour_ENEMY_YELLOW;
+    if (t == 5) return EntityColour_ENEMY_GREEN;
+    return EntityColour_CREW_CYAN; // Fallback to color 0
 }
 
 void entityclass::swnenemiescol( int t )
@@ -1324,7 +1324,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
     case 0: //Player
         entity.rule = 0; //Playable character
         entity.tile = 0;
-        entity.colour = 0;
+        entity.colour = EntityColour_CREW_CYAN;
         entity.cx = 6;
         entity.cy = 2;
         entity.w = 12;
@@ -1357,7 +1357,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.harmful = true;
         entity.tile = 24;
         entity.animate = 0;
-        entity.colour = 8;
+        entity.colour = EntityColour_ENEMY_PINK;
 
         entity.type = EntityType_MOVING;
 
@@ -1375,7 +1375,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         {
             //MAVVERRRICK
             entity.tile = 96;
-            entity.colour = 6;
+            entity.colour = EntityColour_ENEMY_RED;
             entity.size = 9;
             entity.w = 64;
             entity.h = 44;
@@ -1515,7 +1515,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
     case 6: //Decorative particles
         entity.rule = 2;
         entity.type = EntityType_PARTICLE;  //Particles
-        entity.colour = 27;
+        entity.colour = EntityColour_PARTICLE_RED;
         entity.size = 3;
         entity.vx = meta1;
         entity.vy = meta2;
@@ -1525,7 +1525,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
     case 7: //Decorative particles
         entity.rule = 2;
         entity.type = EntityType_PARTICLE;  //Particles
-        entity.colour = 0;
+        entity.colour = EntityColour_CREW_CYAN;
         entity.size = 3;
         entity.vx = meta1;
         entity.vy = meta2;
@@ -1536,7 +1536,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.rule = 3;
         entity.type = EntityType_COIN;
         entity.size = 4;
-        entity.colour = 26;
+        entity.colour = EntityColour_COIN;
         entity.tile = 48;
         entity.w = 8;
         entity.h = 8;
@@ -1554,7 +1554,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.tile = 22;
         entity.w = 16;
         entity.h = 16;
-        entity.colour = 3;
+        entity.colour = EntityColour_TRINKET;
         entity.onentity = 1;
         entity.animate = 100;
 
@@ -1569,14 +1569,14 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.tile = 20 + meta1;
         entity.w = 16;
         entity.h = 16;
-        entity.colour = 4;
+        entity.colour = EntityColour_INACTIVE_ENTITY;
         entity.onentity = 1;
         entity.animate = 100;
         entity.para = meta2;
 
         if (game.savepoint == meta2)
         {
-            entity.colour = 5;
+            entity.colour = EntityColour_ACTIVE_ENTITY;
             entity.onentity = 0;
         }
 
@@ -1590,7 +1590,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.type = EntityType_HORIZONTAL_GRAVITY_LINE;
         entity.size = 5;
         entity.life = 0;
-        entity.colour = 25;
+        entity.colour = EntityColour_GRAVITY_LINE_ACTIVE;
         entity.w = meta1;
         entity.h = 1;
         entity.onentity = 1;
@@ -1600,10 +1600,10 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.type = EntityType_VERTICAL_GRAVITY_LINE;
         entity.size = 6;
         entity.life = 0;
-        entity.colour = 25;
+        entity.colour = EntityColour_GRAVITY_LINE_ACTIVE;
         entity.w = 1;
         entity.h = meta1;
-        //entity.colour = 0;
+        //entity.colour = EntityColour_CREW_CYAN;
         entity.onentity = 1;
         break;
     case 13: //Warp token
@@ -1613,7 +1613,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.tile = 18;
         entity.w = 16;
         entity.h = 16;
-        entity.colour = 10;
+        entity.colour = EntityColour_WARP_TOKEN;
         entity.onentity = 1;
         entity.animate = 2;
         //Added in port, hope it doesn't break anything
@@ -1627,7 +1627,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.tile = 1; //inactive
         entity.w = 96;
         entity.h = 96;
-        entity.colour = 100;
+        entity.colour = EntityColour_TELEPORTER_INACTIVE;
         entity.onentity = 1;
         entity.animate = 100;
         entity.para = meta2;
@@ -1636,7 +1636,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.rule = 6;
         entity.type = EntityType_CREWMATE; //A special case!
         entity.tile = 144;
-        entity.colour = 13; //144 for sad :(
+        entity.colour = EntityColour_CREW_GREEN; //144 for sad :(
         entity.cx = 6;
         entity.cy = 2;
         entity.w = 12;
@@ -1651,7 +1651,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.rule = 7;
         entity.type = EntityType_CREWMATE; //A special case!
         entity.tile = 144+6;
-        entity.colour = 14; //144 for sad (upside down+12):(
+        entity.colour = EntityColour_CREW_YELLOW; //144 for sad (upside down+12):(
         entity.cx = 6;
         entity.cy = 2;
         entity.w = 12;
@@ -1666,7 +1666,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.rule = 6;
         entity.type = EntityType_CREWMATE; //A special case!
         entity.tile = 144;
-        entity.colour = 16; //144 for sad :(
+        entity.colour = EntityColour_CREW_BLUE; //144 for sad :(
         entity.cx = 6;
         entity.cy = 2;
         entity.w = 12;
@@ -1710,7 +1710,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.rule = 6;
         entity.type = EntityType_CREWMATE; //A special case!
         entity.tile = 0;
-        entity.colour = 6; //54 for sad :(
+        entity.colour = EntityColour_ENEMY_RED; //54 for sad :(
         entity.cx = 6;
         entity.cy = 2;
         entity.w = 12;
@@ -1728,7 +1728,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.tile = 16 + meta1;
         entity.w = 16;
         entity.h = 16;
-        entity.colour = 4;
+        entity.colour = EntityColour_INACTIVE_ENTITY;
         entity.onentity = 1;
         entity.animate = 100;
         entity.para = meta2;
@@ -1740,7 +1740,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.tile = 16 + meta1;
         entity.w = 16;
         entity.h = 16;
-        entity.colour = 4;
+        entity.colour = EntityColour_INACTIVE_ENTITY;
         entity.onentity = 0;
         entity.animate = 100;
         entity.para = meta2;
@@ -1752,7 +1752,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.tile = 22;
         entity.w = 16;
         entity.h = 16;
-        entity.colour = 3;
+        entity.colour = EntityColour_TRINKET;
         entity.onentity = 0;
         entity.animate = 100;
 
@@ -1780,7 +1780,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
 
         //initilise tiles here based on behavior
         entity.size = 12; //don't wrap around
-        entity.colour = 21;
+        entity.colour = EntityColour_ENEMY_GRAVITRON;
         entity.tile = 78; //default case
         entity.animate = 1;
         if (game.swngame == SWN_SUPERGRAVITRON)
@@ -1838,7 +1838,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.size = 0;
         entity.w = 16;
         entity.h = 16;
-        entity.colour = 4;
+        entity.colour = EntityColour_INACTIVE_ENTITY;
         entity.onentity = 1;
         entity.animate = 100;
         entity.para = meta2;
@@ -1852,42 +1852,42 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
             if (game.bestrank[TimeTrial_SPACESTATION1] >= 3)
             {
                 entity.tile = 184 + meta1;
-                entity.colour = 31;
+                entity.colour = EntityColour_TROPHY_SPACE_STATION_1;
             }
             break;
         case 2:
             if (game.bestrank[TimeTrial_LABORATORY] >= 3)
             {
                 entity.tile = 186 + meta1;
-                entity.colour = 35;
+                entity.colour = EntityColour_TROPHY_LABORATORY;
             }
             break;
         case 3:
             if (game.bestrank[TimeTrial_TOWER] >= 3)
             {
                 entity.tile = 184 + meta1;
-                entity.colour = 33;
+                entity.colour = EntityColour_TROPHY_TOWER;
             }
             break;
         case 4:
             if (game.bestrank[TimeTrial_SPACESTATION2] >= 3)
             {
                 entity.tile = 184 + meta1;
-                entity.colour = 32;
+                entity.colour = EntityColour_TROPHY_SPACE_STATION_2;
             }
             break;
         case 5:
             if (game.bestrank[TimeTrial_WARPZONE] >= 3)
             {
                 entity.tile = 184 + meta1;
-                entity.colour = 34;
+                entity.colour = EntityColour_TROPHY_WARP_ZONE;
             }
             break;
         case 6:
             if (game.bestrank[TimeTrial_FINALLEVEL] >= 3)
             {
                 entity.tile = 184 + meta1;
-                entity.colour = 30;
+                entity.colour = EntityColour_TROPHY_FINAL_LEVEL;
             }
             break;
 
@@ -1895,7 +1895,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
             if (game.unlock[UnlockTrophy_GAME_COMPLETE])
             {
                 entity.tile = 188 + meta1;
-                entity.colour = 37;
+                entity.colour = EntityColour_TROPHY_GAME_COMPLETE;
                 entity.h += 3;
                 entity.yp -= 3;
             }
@@ -1904,7 +1904,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
             if (game.unlock[UnlockTrophy_FLIPMODE_COMPLETE])
             {
                 entity.tile = 188 + meta1;
-                entity.colour = 37;
+                entity.colour = EntityColour_TROPHY_GAME_COMPLETE;
                 entity.h += 3;
             }
             break;
@@ -1915,7 +1915,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
                 if (game.bestgamedeaths <= 50)
                 {
                     entity.tile = 182 + meta1;
-                    entity.colour = 40;
+                    entity.colour = EntityColour_TROPHY_FLASHY;
                 }
             }
             break;
@@ -1925,7 +1925,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
                 if (game.bestgamedeaths <= 100)
                 {
                     entity.tile = 182 + meta1;
-                    entity.colour = 36;
+                    entity.colour = EntityColour_TROPHY_GOLD;
                 }
             }
             break;
@@ -1935,7 +1935,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
                 if (game.bestgamedeaths <= 250)
                 {
                     entity.tile = 182 + meta1;
-                    entity.colour = 38;
+                    entity.colour = EntityColour_TROPHY_SILVER;
                 }
             }
             break;
@@ -1945,7 +1945,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
                 if (game.bestgamedeaths <= 500)
                 {
                     entity.tile = 182 + meta1;
-                    entity.colour = 39;
+                    entity.colour = EntityColour_TROPHY_BRONZE;
                 }
             }
             break;
@@ -1954,42 +1954,42 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
             if(game.swnbestrank>=1)
             {
                 entity.tile = 182 + meta1;
-                entity.colour = 39;
+                entity.colour = EntityColour_TROPHY_BRONZE;
             }
             break;
         case 14:
             if(game.swnbestrank>=2)
             {
                 entity.tile = 182 + meta1;
-                entity.colour = 39;
+                entity.colour = EntityColour_TROPHY_BRONZE;
             }
             break;
         case 15:
             if(game.swnbestrank>=3)
             {
                 entity.tile = 182 + meta1;
-                entity.colour = 39;
+                entity.colour = EntityColour_TROPHY_BRONZE;
             }
             break;
         case 16:
             if(game.swnbestrank>=4)
             {
                 entity.tile = 182 + meta1;
-                entity.colour = 38;
+                entity.colour = EntityColour_TROPHY_SILVER;
             }
             break;
         case 17:
             if(game.swnbestrank>=5)
             {
                 entity.tile = 182 + meta1;
-                entity.colour = 36;
+                entity.colour = EntityColour_TROPHY_GOLD;
             }
             break;
         case 18:
             if(game.swnbestrank>=6)
             {
                 entity.tile = 182 + meta1;
-                entity.colour = 40;
+                entity.colour = EntityColour_TROPHY_FLASHY;
             }
             break;
 
@@ -1997,7 +1997,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
             if (game.unlock[UnlockTrophy_NODEATHMODE_COMPLETE])
             {
                 entity.tile = 3;
-                entity.colour = 102;
+                entity.colour = EntityColour_TELEPORTER_FLASHING;
                 entity.size = 13;
                 entity.xp -= 64;
                 entity.yp -= 128;
@@ -2014,7 +2014,7 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
         entity.tile = 18;
         entity.w = 16;
         entity.h = 16;
-        entity.colour = 3;
+        entity.colour = EntityColour_TRINKET;
         entity.onentity = 0;
         entity.animate = 100;
         entity.para = meta2;
@@ -2137,41 +2137,41 @@ void entityclass::createentity(int xp, int yp, int t, int meta1, int meta2, int 
             //RED
             case 3: case 7: case 12: case 23: case 28:
             case 34: case 42: case 48: case 58:
-              entity.colour = 6; break;
+              entity.colour = EntityColour_ENEMY_RED; break;
             //GREEN
             case 5: case 9: case 22: case 25: case 29:
             case 31: case 38: case 46: case 52: case 53:
-              entity.colour = 7; break;
+              entity.colour = EntityColour_ENEMY_GREEN; break;
             //BLUE
             case 1: case 6: case 14: case 27: case 33:
             case 44: case 50: case 57:
-              entity.colour = 12; break;
+              entity.colour = EntityColour_ENEMY_BLUE; break;
             //YELLOW
             case 4: case 17: case 24: case 30: case 37:
             case 45: case 51: case 55:
-              entity.colour = 9; break;
+              entity.colour = EntityColour_ENEMY_YELLOW; break;
             //PURPLE
             case 2: case 11: case 15: case 19: case 32:
             case 36: case 49:
-              entity.colour = 20; break;
+              entity.colour = EntityColour_CREW_PURPLE; break;
             //CYAN
             case 8: case 10: case 13: case 18: case 26:
             case 35: case 41: case 47: case 54:
-              entity.colour = 11; break;
+              entity.colour = EntityColour_ENEMY_CYAN; break;
             //PINK
             case 16: case 20: case 39: case 43: case 56:
-              entity.colour = 8; break;
+              entity.colour = EntityColour_ENEMY_PINK; break;
             //ORANGE
             case 21: case 40:
-              entity.colour = 17; break;
+              entity.colour = EntityColour_ENEMY_ORANGE; break;
             default:
-              entity.colour = 6;
+              entity.colour = EntityColour_ENEMY_RED;
             break;
           }
         }
 
         if(custom_gray){
-          entity.colour = 18;
+          entity.colour = EntityColour_ENEMY_GRAY;
         }
 
         entityclonefix(&entity);
@@ -2744,11 +2744,11 @@ bool entityclass::updateentities( int i )
                 {
                     if (entities[j].type == EntityType_CHECKPOINT)
                     {
-                        entities[j].colour = 4;
+                        entities[j].colour = EntityColour_INACTIVE_ENTITY;
                         entities[j].onentity = 1;
                     }
                 }
-                entities[i].colour = 5;
+                entities[i].colour = EntityColour_ACTIVE_ENTITY;
                 entities[i].onentity = 0;
                 game.savepoint = entities[i].para;
                 music.playef(Sound_CHECKPOINT);
@@ -2936,7 +2936,7 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 11)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                int j=getcrewman(PURPLE);
+                int j=getcrewman(EntityColour_CREW_PURPLE);
                 if (INBOUNDS_VEC(j, entities))
                 {
                     if (entities[j].xp > entities[i].xp + 5)
@@ -2961,7 +2961,7 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 12)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                int j=getcrewman(YELLOW);
+                int j=getcrewman(EntityColour_CREW_YELLOW);
                 if (INBOUNDS_VEC(j, entities))
                 {
                     if (entities[j].xp > entities[i].xp + 5)
@@ -2986,7 +2986,7 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 13)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                int j=getcrewman(RED);
+                int j=getcrewman(EntityColour_CREW_RED);
                 if (INBOUNDS_VEC(j, entities))
                 {
                     if (entities[j].xp > entities[i].xp + 5)
@@ -3011,7 +3011,7 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 14)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                int j=getcrewman(GREEN);
+                int j=getcrewman(EntityColour_CREW_GREEN);
                 if (INBOUNDS_VEC(j, entities))
                 {
                     if (entities[j].xp > entities[i].xp + 5)
@@ -3036,7 +3036,7 @@ bool entityclass::updateentities( int i )
             else if (entities[i].state == 15)
             {
                 //11-15 means to follow a specific character, in crew order (cyan, purple, yellow, red, green, blue)
-                int j=getcrewman(BLUE);
+                int j=getcrewman(EntityColour_CREW_BLUE);
                 if (INBOUNDS_VEC(j, entities))
                 {
                     if (entities[j].xp > entities[i].xp + 5)
@@ -3190,7 +3190,7 @@ bool entityclass::updateentities( int i )
             //wait for collision
             if (entities[i].state == 1)
             {
-                entities[i].colour = 5;
+                entities[i].colour = EntityColour_ACTIVE_ENTITY;
                 entities[i].onentity = 0;
                 music.playef(Sound_TERMINALTOUCH);
 
@@ -3390,7 +3390,7 @@ bool entityclass::updateentities( int i )
                 {
                     music.playef(Sound_GAMESAVED);
                     entities[i].tile = 2;
-                    entities[i].colour = 101;
+                    entities[i].colour = EntityColour_TELEPORTER_ACTIVE;
                     if(!game.intimetrial && !game.nodeathmode)
                     {
                         game.setstate(2000);
@@ -3410,7 +3410,7 @@ bool entityclass::updateentities( int i )
                     {
                         if (entities[j].type == EntityType_CHECKPOINT)
                         {
-                            entities[j].colour = 4;
+                            entities[j].colour = EntityColour_INACTIVE_ENTITY;
                             entities[j].onentity = 1;
                         }
                     }
@@ -3436,7 +3436,7 @@ bool entityclass::updateentities( int i )
                 //Initilise the teleporter without changing the game state or playing sound
                 entities[i].onentity = 0;
                 entities[i].tile = 6;
-                entities[i].colour = 102;
+                entities[i].colour = EntityColour_TELEPORTER_FLASHING;
 
                 game.activetele = true;
                 game.teleblock.x = entities[i].xp - 32;
@@ -3994,34 +3994,29 @@ int entityclass::getlineat( int t )
     return 0;
 }
 
-int entityclass::getcrewman( int t, int fallback /*= 0*/ )
+int entityclass::getcrewman(int t)
 {
-    //Returns the index of the crewman with colour index given by t
+    // Returns the index of the crewman with colour index given by t.
+    // Note: this takes an int, not an EntityColour, as invalid colours are allowed in scripting
 
     for (size_t i = 0; i < entities.size(); i++)
     {
         if ((entities[i].type == EntityType_CREWMATE || entities[i].type == EntityType_SUPERCREWMATE)
-        && (entities[i].rule == 6 || entities[i].rule == 7))
+            && (entities[i].rule == 6 || entities[i].rule == 7))
         {
-            if(entities[i].colour==t)
+            if (entities[i].colour == t)
             {
                 return i;
             }
         }
     }
 
-    return fallback;
+    return -1;
 }
 
-int entityclass::getcustomcrewman( int t )
+int entityclass::getcustomcrewman(int t)
 {
-    //Returns the index of the crewman with colour index given by t
-    if (t == 0) t = 0;
-    if (t == 1) t = 20;
-    if (t == 2) t = 14;
-    if (t == 3) t = 15;
-    if (t == 4) t = 13;
-    if (t == 5) t = 16;
+    // like getcrewman, this returns the index of the CUSTOM crewman with colour index given by t
 
     for (size_t i = 0; i < entities.size(); i++)
     {

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -5,10 +5,10 @@
 #include <string>
 #include <vector>
 
-#include "Maths.h"
-#include "Ent.h"
 #include "BlockV.h"
+#include "Ent.h"
 #include "Game.h"
+#include "Maths.h"
 
 enum
 {
@@ -18,18 +18,6 @@ enum
     DIRECTIONAL = 3,
     SAFE = 4,
     ACTIVITY = 5
-};
-
-enum
-{
-    CYAN = 0,
-    PURPLE = 20,
-    YELLOW = 14,
-    RED = 15,
-    GREEN = 13,
-    BLUE = 16,
-    GRAY = 19,
-    TELEPORTER = 102
 };
 
 class entityclass
@@ -56,7 +44,7 @@ public:
         createblock(DAMAGE, 312, -8, 16, 260);
     }
 
-    int swncolour(int t );
+    int swncolour(int t);
 
     void swnenemiescol(int t);
 
@@ -106,7 +94,7 @@ public:
 
     int getlineat(int t);
 
-    int getcrewman(int t, int fallback = 0);
+    int getcrewman(int t);
     int getcustomcrewman(int t);
 
     int getteleporter(void);

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -146,7 +146,7 @@ void Game::init(void)
     prevroomy = 0;
     saverx = 0;
     savery = 0;
-    savecolour = 0;
+    savecolour = EntityColour_CREW_CYAN;
 
     mutebutton = 0;
     muted = false;
@@ -2563,7 +2563,7 @@ void Game::updatestate(void)
             int i = obj.getplayer();
             if (INBOUNDS_VEC(i, obj.entities))
             {
-                obj.entities[i].colour = 0;
+                obj.entities[i].colour = EntityColour_CREW_CYAN;
                 obj.entities[i].invis = false;
 
                 int j = obj.getteleporter();
@@ -2584,7 +2584,7 @@ void Game::updatestate(void)
             if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].tile = 1;
-                obj.entities[i].colour = 101;
+                obj.entities[i].colour = EntityColour_TELEPORTER_ACTIVE;
             }
             break;
         }
@@ -2757,7 +2757,7 @@ void Game::updatestate(void)
             int i = obj.getplayer();
             if (INBOUNDS_VEC(i, obj.entities))
             {
-                obj.entities[i].colour = 0;
+                obj.entities[i].colour = EntityColour_CREW_CYAN;
                 obj.entities[i].invis = true;
             }
 
@@ -2771,7 +2771,7 @@ void Game::updatestate(void)
             if (INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].tile = 1;
-                obj.entities[i].colour = 100;
+                obj.entities[i].colour = EntityColour_TELEPORTER_INACTIVE;
             }
             break;
         }
@@ -3365,7 +3365,7 @@ void Game::updatestate(void)
             int i = obj.getplayer();
             if (INBOUNDS_VEC(i, obj.entities))
             {
-                obj.entities[i].colour = 102;
+                obj.entities[i].colour = EntityColour_TELEPORTER_FLASHING;
             }
 
             incstate();
@@ -3407,7 +3407,7 @@ void Game::updatestate(void)
             int i = obj.getplayer();
             if (INBOUNDS_VEC(i, obj.entities))
             {
-                obj.entities[i].colour = 0;
+                obj.entities[i].colour = EntityColour_CREW_CYAN;
                 obj.entities[i].invis = true;
             }
 
@@ -3492,7 +3492,7 @@ void Game::updatestate(void)
             int i = obj.getplayer();
             if (INBOUNDS_VEC(i, obj.entities))
             {
-                obj.entities[i].colour = 0;
+                obj.entities[i].colour = EntityColour_CREW_CYAN;
                 obj.entities[i].invis = true;
             }
 
@@ -3500,7 +3500,7 @@ void Game::updatestate(void)
             if(INBOUNDS_VEC(i, obj.entities))
             {
                 obj.entities[i].tile = 1;
-                obj.entities[i].colour = 100;
+                obj.entities[i].colour = EntityColour_TELEPORTER_INACTIVE;
             }
             break;
         }
@@ -3544,9 +3544,9 @@ void Game::updatestate(void)
                     obj.entities[i].lerpoldxp = obj.entities[i].xp;
                     obj.entities[i].lerpoldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
-                    obj.entities[j].colour = 101;
+                    obj.entities[j].colour = EntityColour_TELEPORTER_ACTIVE;
                 }
-                obj.entities[i].colour = 0;
+                obj.entities[i].colour = EntityColour_CREW_CYAN;
                 obj.entities[i].invis = false;
                 obj.entities[i].dir = 1;
 
@@ -3675,9 +3675,9 @@ void Game::updatestate(void)
                     obj.entities[i].lerpoldxp = obj.entities[i].xp;
                     obj.entities[i].lerpoldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
-                    obj.entities[j].colour = 101;
+                    obj.entities[j].colour = EntityColour_TELEPORTER_ACTIVE;
                 }
-                obj.entities[i].colour = 0;
+                obj.entities[i].colour = EntityColour_CREW_CYAN;
                 obj.entities[i].invis = false;
                 obj.entities[i].dir = 1;
 
@@ -3788,9 +3788,9 @@ void Game::updatestate(void)
                     obj.entities[i].lerpoldxp = obj.entities[i].xp;
                     obj.entities[i].lerpoldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
-                    obj.entities[j].colour = 101;
+                    obj.entities[j].colour = EntityColour_TELEPORTER_ACTIVE;
                 }
-                obj.entities[i].colour = 0;
+                obj.entities[i].colour = EntityColour_CREW_CYAN;
                 obj.entities[i].invis = false;
                 obj.entities[i].dir = 0;
 
@@ -3901,9 +3901,9 @@ void Game::updatestate(void)
                     obj.entities[i].lerpoldxp = obj.entities[i].xp;
                     obj.entities[i].lerpoldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
-                    obj.entities[j].colour = 101;
+                    obj.entities[j].colour = EntityColour_TELEPORTER_ACTIVE;
                 }
-                obj.entities[i].colour = 0;
+                obj.entities[i].colour = EntityColour_CREW_CYAN;
                 obj.entities[i].invis = false;
                 obj.entities[i].dir = 1;
 
@@ -4019,9 +4019,9 @@ void Game::updatestate(void)
                     obj.entities[i].lerpoldxp = obj.entities[i].xp;
                     obj.entities[i].lerpoldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
-                    obj.entities[j].colour = 101;
+                    obj.entities[j].colour = EntityColour_TELEPORTER_ACTIVE;
                 }
-                obj.entities[i].colour = 0;
+                obj.entities[i].colour = EntityColour_CREW_CYAN;
                 obj.entities[i].invis = false;
                 obj.entities[i].dir = 1;
 
@@ -4137,9 +4137,9 @@ void Game::updatestate(void)
                     obj.entities[i].lerpoldxp = obj.entities[i].xp;
                     obj.entities[i].lerpoldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
-                    obj.entities[j].colour = 101;
+                    obj.entities[j].colour = EntityColour_TELEPORTER_ACTIVE;
                 }
-                obj.entities[i].colour = 0;
+                obj.entities[i].colour = EntityColour_CREW_CYAN;
                 obj.entities[i].invis = false;
                 obj.entities[i].dir = 0;
 
@@ -4253,7 +4253,7 @@ void Game::updatestate(void)
                     obj.entities[i].lerpoldxp = obj.entities[i].xp;
                     obj.entities[i].lerpoldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
-                    obj.entities[j].colour = 101;
+                    obj.entities[j].colour = EntityColour_TELEPORTER_ACTIVE;
                 }
                 obj.entities[i].invis = false;
                 obj.entities[i].dir = 1;
@@ -4366,9 +4366,9 @@ void Game::updatestate(void)
                     obj.entities[i].lerpoldxp = obj.entities[i].xp;
                     obj.entities[i].lerpoldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
-                    obj.entities[j].colour = 101;
+                    obj.entities[j].colour = EntityColour_TELEPORTER_ACTIVE;
                 }
-                obj.entities[i].colour = 0;
+                obj.entities[i].colour = EntityColour_CREW_CYAN;
                 obj.entities[i].invis = false;
                 obj.entities[i].dir = 1;
 
@@ -4479,9 +4479,9 @@ void Game::updatestate(void)
                     obj.entities[i].lerpoldxp = obj.entities[i].xp;
                     obj.entities[i].lerpoldyp = obj.entities[i].yp;
                     obj.entities[j].tile = 2;
-                    obj.entities[j].colour = 101;
+                    obj.entities[j].colour = EntityColour_TELEPORTER_ACTIVE;
                 }
-                obj.entities[i].colour = 0;
+                obj.entities[i].colour = EntityColour_CREW_CYAN;
                 obj.entities[i].invis = false;
                 obj.entities[i].dir = 1;
 
@@ -5363,7 +5363,7 @@ void Game::deathsequence(void)
     }
     if (INBOUNDS_VEC(i, obj.entities))
     {
-        obj.entities[i].colour = 1;
+        obj.entities[i].colour = EntityColour_DEAD;
 
         obj.entities[i].invis = false;
     }

--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3423,19 +3423,19 @@ int Graphics::crewcolour(const int t)
     switch (t)
     {
     case 0:
-        return CYAN;
+        return EntityColour_CREW_CYAN;
     case 1:
-        return PURPLE;
+        return EntityColour_CREW_PURPLE;
     case 2:
-        return YELLOW;
+        return EntityColour_CREW_YELLOW;
     case 3:
-        return RED;
+        return EntityColour_CREW_RED;
     case 4:
-        return GREEN;
+        return EntityColour_CREW_GREEN;
     case 5:
-        return BLUE;
+        return EntityColour_CREW_BLUE;
     default:
-        return 0;
+        return EntityColour_CREW_CYAN;
     }
 }
 

--- a/desktop_version/src/Graphics.h
+++ b/desktop_version/src/Graphics.h
@@ -40,6 +40,54 @@ enum ImageNames
 
 #define FADEMODE_IS_FADING(mode) ((mode) != FADE_NONE && (mode) != FADE_FULLY_BLACK)
 
+enum EntityColour
+{
+    EntityColour_CREW_CYAN = 0,
+    EntityColour_DEAD = 1,
+    EntityColour_ENEMY_DARK_ORANGE = 2,
+    EntityColour_TRINKET = 3,
+    EntityColour_INACTIVE_ENTITY = 4,
+    EntityColour_ACTIVE_ENTITY = 5,
+    EntityColour_ENEMY_RED = 6,
+    EntityColour_ENEMY_GREEN = 7,
+    EntityColour_ENEMY_PINK = 8,
+    EntityColour_ENEMY_YELLOW = 9,
+    EntityColour_WARP_TOKEN = 10,
+    EntityColour_ENEMY_CYAN = 11,
+    EntityColour_ENEMY_BLUE = 12,
+    EntityColour_CREW_GREEN = 13,
+    EntityColour_CREW_YELLOW = 14,
+    EntityColour_CREW_RED = 15,
+    EntityColour_CREW_BLUE = 16,
+    EntityColour_ENEMY_ORANGE = 17,
+    EntityColour_ENEMY_GRAY = 18,
+
+    EntityColour_CREW_GRAY = 19, // Despite the comment in the color code saying this is for enemies, it's used as a fallback for crew colors.
+
+    EntityColour_CREW_PURPLE = 20,
+    EntityColour_ENEMY_GRAVITRON = 21,
+    EntityColour_ENEMY_LIGHT_GRAY = 22,
+    EntityColour_GRAVITRON_INDICATOR = 23,
+    EntityColour_GRAVITY_LINE_TOUCHED = 24,
+    EntityColour_GRAVITY_LINE_ACTIVE = 25,
+    EntityColour_COIN = 26,
+    EntityColour_PARTICLE_RED = 27,
+    EntityColour_TROPHY_FINAL_LEVEL = 30,
+    EntityColour_TROPHY_SPACE_STATION_1 = 31,
+    EntityColour_TROPHY_SPACE_STATION_2 = 32,
+    EntityColour_TROPHY_TOWER = 33,
+    EntityColour_TROPHY_WARP_ZONE = 34,
+    EntityColour_TROPHY_LABORATORY = 35,
+    EntityColour_TROPHY_GOLD = 36,
+    EntityColour_TROPHY_GAME_COMPLETE = 37,
+    EntityColour_TROPHY_SILVER = 38,
+    EntityColour_TROPHY_BRONZE = 39,
+    EntityColour_TROPHY_FLASHY = 40,
+    EntityColour_TELEPORTER_INACTIVE = 100,
+    EntityColour_TELEPORTER_ACTIVE = 101,
+    EntityColour_TELEPORTER_FLASHING = 102
+};
+
 class Graphics
 {
 public:

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -2737,14 +2737,14 @@ void gameinput(void)
                                 int player = obj.getplayer();
                                 if (INBOUNDS_VEC(player, obj.entities))
                                 {
-                                    obj.entities[player].colour = 102;
+                                    obj.entities[player].colour = EntityColour_TELEPORTER_FLASHING;
                                 }
 
                                 int teleporter = obj.getteleporter();
                                 if (INBOUNDS_VEC(teleporter, obj.entities))
                                 {
                                     obj.entities[teleporter].tile = 6;
-                                    obj.entities[teleporter].colour = 102;
+                                    obj.entities[teleporter].colour = EntityColour_TELEPORTER_FLASHING;
                                 }
                                 //which teleporter script do we use? it depends on the companion!
                                 game.setstate(4000);
@@ -2768,16 +2768,16 @@ void gameinput(void)
                                 int player = obj.getplayer();
                                 if (INBOUNDS_VEC(player, obj.entities))
                                 {
-                                    obj.entities[player].colour = 102;
+                                    obj.entities[player].colour = EntityColour_TELEPORTER_FLASHING;
                                 }
                                 int companion = obj.getcompanion();
-                                if(INBOUNDS_VEC(companion, obj.entities)) obj.entities[companion].colour = 102;
+                                if(INBOUNDS_VEC(companion, obj.entities)) obj.entities[companion].colour = EntityColour_TELEPORTER_FLASHING;
 
                                 int teleporter = obj.getteleporter();
                                 if (INBOUNDS_VEC(teleporter, obj.entities))
                                 {
                                     obj.entities[teleporter].tile = 6;
-                                    obj.entities[teleporter].colour = 102;
+                                    obj.entities[teleporter].colour = EntityColour_TELEPORTER_FLASHING;
                                 }
                                 //which teleporter script do we use? it depends on the companion!
                                 game.setstate(3000);
@@ -3241,7 +3241,7 @@ static void mapmenuactionpress(const bool version2_2)
         int i = obj.getplayer();
         if (INBOUNDS_VEC(i, obj.entities))
         {
-            obj.entities[i].colour = 102;
+            obj.entities[i].colour = EntityColour_TELEPORTER_FLASHING;
         }
 
         //which teleporter script do we use? it depends on the companion!
@@ -3463,14 +3463,14 @@ void teleporterinput(void)
                 int i = obj.getplayer();
                 if (INBOUNDS_VEC(i, obj.entities))
                 {
-                    obj.entities[i].colour = 102;
+                    obj.entities[i].colour = EntityColour_TELEPORTER_FLASHING;
                 }
 
                 i = obj.getteleporter();
                 if (INBOUNDS_VEC(i, obj.entities))
                 {
                     obj.entities[i].tile = 6;
-                    obj.entities[i].colour = 102;
+                    obj.entities[i].colour = EntityColour_TELEPORTER_FLASHING;
                 }
                 //which teleporter script do we use? it depends on the companion!
                 game.setstate(4000);

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -486,28 +486,28 @@ int mapclass::maptiletoenemycol(int t)
     switch(t)
     {
     case 0:
-        return 11;
+        return EntityColour_ENEMY_CYAN;
         break;
     case 1:
-        return 6;
+        return EntityColour_ENEMY_RED;
         break;
     case 2:
-        return 8;
+        return EntityColour_ENEMY_PINK;
         break;
     case 3:
-        return 12;
+        return EntityColour_ENEMY_BLUE;
         break;
     case 4:
-        return 9;
+        return EntityColour_ENEMY_YELLOW;
         break;
     case 5:
-        return 7;
+        return EntityColour_ENEMY_GREEN;
         break;
     case 6:
-        return 18;
+        return EntityColour_ENEMY_GRAY;
         break;
     }
-    return 11;
+    return EntityColour_ENEMY_CYAN;
 }
 
 void mapclass::changefinalcol(int t)
@@ -2185,7 +2185,7 @@ void mapclass::loadlevel(int rx, int ry)
             {
                 //A slight varation - she's upside down
                 obj.createentity(249, 62, 18, 16, 0, 18);
-                int j = obj.getcrewman(BLUE);
+                int j = obj.getcrewman(EntityColour_CREW_BLUE);
                 if (INBOUNDS_VEC(j, obj.entities))
                 {
                     obj.entities[j].rule = 7;

--- a/desktop_version/src/Otherlevel.cpp
+++ b/desktop_version/src/Otherlevel.cpp
@@ -1,6 +1,7 @@
 #include "Otherlevel.h"
 
 #include "Game.h"
+#include "Graphics.h"
 #include "Entity.h"
 #include "MakeAndPlay.h"
 #include "UtilityClass.h"
@@ -8904,7 +8905,7 @@ const short* otherlevelclass::loadlevel(int rx, int ry)
 
             //violet
             obj.createentity(83, 126, 18, 20, 0, 18);
-            int crewman = obj.getcrewman(PURPLE);
+            int crewman = obj.getcrewman(EntityColour_CREW_PURPLE);
             if (INBOUNDS_VEC(crewman, obj.entities))
             {
                 obj.entities[crewman].rule = 7;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -134,16 +134,16 @@ void scriptclass::tokenize( const std::string& t )
 
 static int getcolorfromname(std::string name)
 {
-    if      (name == "player")     return CYAN;
-    else if (name == "cyan")       return CYAN;
-    else if (name == "red")        return RED;
-    else if (name == "green")      return GREEN;
-    else if (name == "yellow")     return YELLOW;
-    else if (name == "blue")       return BLUE;
-    else if (name == "purple")     return PURPLE;
-    else if (name == "customcyan") return CYAN;
-    else if (name == "gray")       return GRAY;
-    else if (name == "teleporter") return TELEPORTER;
+    if      (name == "player")     return EntityColour_CREW_CYAN;
+    else if (name == "cyan")       return EntityColour_CREW_CYAN;
+    else if (name == "red")        return EntityColour_CREW_RED;
+    else if (name == "green")      return EntityColour_CREW_GREEN;
+    else if (name == "yellow")     return EntityColour_CREW_YELLOW;
+    else if (name == "blue")       return EntityColour_CREW_BLUE;
+    else if (name == "purple")     return EntityColour_CREW_PURPLE;
+    else if (name == "customcyan") return EntityColour_CREW_CYAN;
+    else if (name == "gray")       return EntityColour_CREW_GRAY;
+    else if (name == "teleporter") return EntityColour_TELEPORTER_FLASHING;
 
     int color = help.Int(name.c_str(), -1);
     if (color < 0) return -1; // Not a number (or it's negative), so we give up
@@ -157,7 +157,6 @@ static int getcrewmanfromname(std::string name)
     if (color == -1) return -1; // ...Nope, return -1
     return obj.getcrewman(color);
 }
-
 
 /* Also used in gamestate 1001. */
 void foundtrinket_textbox1(textboxclass* THIS);
@@ -638,37 +637,37 @@ void scriptclass::run(void)
                 //the first word is the object to position relative to
                 if (words[1] == "player")
                 {
-                    i = obj.getcustomcrewman(0);
+                    i = obj.getcustomcrewman(EntityColour_CREW_CYAN);
                     j = obj.entities[i].dir;
                 }
                 else if (words[1] == "cyan")
                 {
-                    i = obj.getcustomcrewman(0);
+                    i = obj.getcustomcrewman(EntityColour_CREW_CYAN);
                     j = obj.entities[i].dir;
                 }
                 else if (words[1] == "purple")
                 {
-                    i = obj.getcustomcrewman(1);
+                    i = obj.getcustomcrewman(EntityColour_CREW_PURPLE);
                     j = obj.entities[i].dir;
                 }
                 else if (words[1] == "yellow")
                 {
-                    i = obj.getcustomcrewman(2);
+                    i = obj.getcustomcrewman(EntityColour_CREW_YELLOW);
                     j = obj.entities[i].dir;
                 }
                 else if (words[1] == "red")
                 {
-                    i = obj.getcustomcrewman(3);
+                    i = obj.getcustomcrewman(EntityColour_CREW_RED);
                     j = obj.entities[i].dir;
                 }
                 else if (words[1] == "green")
                 {
-                    i = obj.getcustomcrewman(4);
+                    i = obj.getcustomcrewman(EntityColour_CREW_GREEN);
                     j = obj.entities[i].dir;
                 }
                 else if (words[1] == "blue")
                 {
-                    i = obj.getcustomcrewman(5);
+                    i = obj.getcustomcrewman(EntityColour_CREW_BLUE);
                     j = obj.entities[i].dir;
                 }
                 else if (words[1] == "centerx")
@@ -910,7 +909,7 @@ void scriptclass::run(void)
                     obj.entities[i].lerpoldxp = obj.entities[i].xp;
                     obj.entities[i].lerpoldyp = obj.entities[i].yp;
                     obj.entities[i].size = 13;
-                    obj.entities[i].colour = 23;
+                    obj.entities[i].colour = EntityColour_GRAVITRON_INDICATOR;
                     obj.entities[i].cx = 36;// 6;
                     obj.entities[i].cy = 12+80;// 2;
                     obj.entities[i].h = 126-80;// 21;
@@ -925,7 +924,7 @@ void scriptclass::run(void)
                     obj.entities[i].xp = 100;
                     obj.entities[i].lerpoldxp = obj.entities[i].xp;
                     obj.entities[i].size = 0;
-                    obj.entities[i].colour = 0;
+                    obj.entities[i].colour = EntityColour_CREW_CYAN;
                     obj.entities[i].cx = 6;
                     obj.entities[i].cy = 2;
                     obj.entities[i].h = 21;
@@ -1022,47 +1021,47 @@ void scriptclass::run(void)
             {
                 if (words[1] == "player")
                 {
-                    i=obj.getcustomcrewman(0);
+                    i=obj.getcustomcrewman(EntityColour_CREW_CYAN);
                     obj.customcrewmoods[0]=ss_toi(words[2]);
                 }
                 else if (words[1] == "cyan")
                 {
-                    i=obj.getcustomcrewman(0);
+                    i=obj.getcustomcrewman(EntityColour_CREW_CYAN);
                     obj.customcrewmoods[0]=ss_toi(words[2]);
                 }
                 else if (words[1] == "customcyan")
                 {
-                    i=obj.getcustomcrewman(0);
+                    i=obj.getcustomcrewman(EntityColour_CREW_CYAN);
                     obj.customcrewmoods[0]=ss_toi(words[2]);
                 }
                 else if (words[1] == "red")
                 {
-                    i=obj.getcustomcrewman(3);
+                    i=obj.getcustomcrewman(EntityColour_CREW_RED);
                     obj.customcrewmoods[3]=ss_toi(words[2]);
                 }
                 else if (words[1] == "green")
                 {
-                    i=obj.getcustomcrewman(4);
+                    i=obj.getcustomcrewman(EntityColour_CREW_GREEN);
                     obj.customcrewmoods[4]=ss_toi(words[2]);
                 }
                 else if (words[1] == "yellow")
                 {
-                    i=obj.getcustomcrewman(2);
+                    i=obj.getcustomcrewman(EntityColour_CREW_YELLOW);
                     obj.customcrewmoods[2]=ss_toi(words[2]);
                 }
                 else if (words[1] == "blue")
                 {
-                    i=obj.getcustomcrewman(5);
+                    i=obj.getcustomcrewman(EntityColour_CREW_BLUE);
                     obj.customcrewmoods[5]=ss_toi(words[2]);
                 }
                 else if (words[1] == "purple")
                 {
-                    i=obj.getcustomcrewman(1);
+                    i=obj.getcustomcrewman(EntityColour_CREW_PURPLE);
                     obj.customcrewmoods[1]=ss_toi(words[2]);
                 }
                 else if (words[1] == "pink")
                 {
-                    i=obj.getcustomcrewman(1);
+                    i=obj.getcustomcrewman(EntityColour_CREW_PURPLE);
                     obj.customcrewmoods[1]=ss_toi(words[2]);
                 }
 
@@ -1188,7 +1187,7 @@ void scriptclass::run(void)
                 if (INBOUNDS_VEC(i, obj.entities))
                 {
                     obj.entities[i].tile = 6;
-                    obj.entities[i].colour = 102;
+                    obj.entities[i].colour = EntityColour_TELEPORTER_FLASHING;
                 }
             }
             else if (words[0] == "changecolour")
@@ -1650,7 +1649,7 @@ void scriptclass::run(void)
                 {
                     if (obj.entities[j].type == EntityType_TERMINAL)
                     {
-                        obj.entities[j].colour = 4;
+                        obj.entities[j].colour = EntityColour_INACTIVE_ENTITY;
                     }
                 }
                 if (ss_toi(words[1]) == 1)
@@ -1660,7 +1659,7 @@ void scriptclass::run(void)
                     {
                         if (obj.entities[j].xp == 88 && obj.entities[j].yp==80)
                         {
-                            obj.entities[j].colour = 5;
+                            obj.entities[j].colour = EntityColour_ACTIVE_ENTITY;
                         }
                     }
                 }
@@ -1671,7 +1670,7 @@ void scriptclass::run(void)
                     {
                         if (obj.entities[j].xp == 128 && obj.entities[j].yp==80)
                         {
-                            obj.entities[j].colour = 5;
+                            obj.entities[j].colour = EntityColour_ACTIVE_ENTITY;
                         }
                     }
                 }
@@ -1682,7 +1681,7 @@ void scriptclass::run(void)
                     {
                         if (obj.entities[j].xp == 176 && obj.entities[j].yp==80)
                         {
-                            obj.entities[j].colour = 5;
+                            obj.entities[j].colour = EntityColour_ACTIVE_ENTITY;
                         }
                     }
                 }
@@ -1693,7 +1692,7 @@ void scriptclass::run(void)
                     {
                         if (obj.entities[j].xp == 216 && obj.entities[j].yp==80)
                         {
-                            obj.entities[j].colour = 5;
+                            obj.entities[j].colour = EntityColour_ACTIVE_ENTITY;
                         }
                     }
                 }
@@ -1704,7 +1703,7 @@ void scriptclass::run(void)
                     {
                         if (obj.entities[j].xp == 88 && obj.entities[j].yp==128)
                         {
-                            obj.entities[j].colour = 5;
+                            obj.entities[j].colour = EntityColour_ACTIVE_ENTITY;
                         }
                     }
                 }
@@ -1715,7 +1714,7 @@ void scriptclass::run(void)
                     {
                         if (obj.entities[j].xp == 176 && obj.entities[j].yp==128)
                         {
-                            obj.entities[j].colour = 5;
+                            obj.entities[j].colour = EntityColour_ACTIVE_ENTITY;
                         }
                     }
                 }
@@ -1726,7 +1725,7 @@ void scriptclass::run(void)
                     {
                         if (obj.entities[j].xp == 40 && obj.entities[j].yp==40)
                         {
-                            obj.entities[j].colour = 5;
+                            obj.entities[j].colour = EntityColour_ACTIVE_ENTITY;
                         }
                     }
                 }
@@ -1737,7 +1736,7 @@ void scriptclass::run(void)
                     {
                         if (obj.entities[j].xp == 216 && obj.entities[j].yp==128)
                         {
-                            obj.entities[j].colour = 5;
+                            obj.entities[j].colour = EntityColour_ACTIVE_ENTITY;
                         }
                     }
                 }
@@ -1748,7 +1747,7 @@ void scriptclass::run(void)
                     {
                         if (obj.entities[j].xp == 128 && obj.entities[j].yp==128)
                         {
-                            obj.entities[j].colour = 5;
+                            obj.entities[j].colour = EntityColour_ACTIVE_ENTITY;
                         }
                     }
                 }
@@ -1759,7 +1758,7 @@ void scriptclass::run(void)
                     {
                         if (obj.entities[j].xp == 264 && obj.entities[j].yp==40)
                         {
-                            obj.entities[j].colour = 5;
+                            obj.entities[j].colour = EntityColour_ACTIVE_ENTITY;
                         }
                     }
                 }
@@ -1770,31 +1769,31 @@ void scriptclass::run(void)
                 if (words[1] == "red")
                 {
                     i = 3;
-                    crew_color = RED;
+                    crew_color = EntityColour_CREW_RED;
                 }
                 else if (words[1] == "green")
                 {
                     i = 4;
-                    crew_color = GREEN;
+                    crew_color = EntityColour_CREW_GREEN;
                 }
                 else if (words[1] == "yellow")
                 {
                     i = 2;
-                    crew_color = YELLOW;
+                    crew_color = EntityColour_CREW_YELLOW;
                 }
                 else if (words[1] == "blue")
                 {
                     i = 5;
-                    crew_color = BLUE;
+                    crew_color = EntityColour_CREW_BLUE;
                 }
                 else if (words[1] == "purple")
                 {
                     i = 1;
-                    crew_color = PURPLE;
+                    crew_color = EntityColour_CREW_PURPLE;
                 }
 
                 int crewman = obj.getcrewman(crew_color);
-                if (INBOUNDS_VEC(crewman, obj.entities) && crew_color == GREEN)
+                if (INBOUNDS_VEC(crewman, obj.entities) && crew_color == EntityColour_CREW_GREEN)
                 {
                     obj.createblock(5, obj.entities[crewman].xp - 32, obj.entities[crewman].yp-20, 96, 60, i, "", (i == 35));
                 }
@@ -1876,7 +1875,7 @@ void scriptclass::run(void)
                 i = obj.getteleporter();
                 if (INBOUNDS_VEC(i, obj.entities))
                 {
-                    obj.entities[i].colour = 101;
+                    obj.entities[i].colour = EntityColour_TELEPORTER_ACTIVE;
                 }
             }
             else if (words[0] == "foundtrinket")
@@ -1991,9 +1990,9 @@ void scriptclass::run(void)
             else if (words[0] == "createlastrescued")
             {
                 r = graphics.crewcolour(game.lastsaved);
-                if (r == 0 || r == PURPLE)
+                if (r == EntityColour_CREW_CYAN || r == EntityColour_CREW_PURPLE)
                 {
-                    r = GRAY; // Default to gray if invalid color.
+                    r = EntityColour_CREW_GRAY; // Default to gray if invalid color.
                 }
 
                 obj.createentity(200, 153, 18, r, 0, 19, 30);


### PR DESCRIPTION
## Changes:

Entity colors are just integers. Their colour ID gets passed through a big switch, returning different RGB values depending on the colour ID (and can also get affected by randomness or other game state.)

But because of this, there's a bunch of random numbers floating around, with no actual description on what they are other than comments which, while most of the time are accurate, only exist in the switch.

To fix this, this commit adds a new enum which labels every colour. While we can't use it as a type (as we need to allow colours outside of what are defined, in case people want a "pure white", and scripting can set any colour ID they want), colours have to stay as `int`.

Additionally, there seemed to be an old enum for specifically colors which get used for crewmates...? Which has now been removed.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
