### PR TITLE
Add player colour as a level property

### DIFF
--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -1566,20 +1566,6 @@ bool customlevelclass::save(const std::string& _path)
         }
     }
 
-    if (player_colour != 0)
-    {
-        xml::update_tag(msg, "PlayerColour", player_colour);
-    }
-    else
-    {
-        // Get rid of this one as well, since older levels don't have this property anyways
-        tinyxml2::XMLElement* element;
-        while ((element = msg->FirstChildElement("PlayerColour")) != NULL)
-        {
-            doc.DeleteNode(element);
-        }
-    }
-
     xml::update_tag(data, "mapwidth", mapwidth);
 
     xml::update_tag(data, "mapheight", mapheight);
@@ -1698,6 +1684,21 @@ bool customlevelclass::save(const std::string& _path)
         }
     }
     xml::update_tag(data, "script", scriptString.c_str());
+
+
+    if (player_colour != 0)
+    {
+        xml::update_tag(data, "PlayerColour", player_colour);
+    }
+    else
+    {
+        // Get rid of this one as well, since older levels don't have this property anyways
+        tinyxml2::XMLElement* element;
+        while ((element = data->FirstChildElement("PlayerColour")) != NULL)
+        {
+            doc.DeleteNode(element);
+        }
+    }
 
     return FILESYSTEM_saveTiXml2Document(newpath.c_str(), doc);
 }

--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -404,6 +404,8 @@ void customlevelclass::reset(void)
     script.textbox_colours.clear();
     script.add_default_colours();
     map.specialroomnames.clear();
+
+    player_colour = 0;
 }
 
 const int* customlevelclass::loadlevel( int rxi, int ryi )
@@ -1414,6 +1416,11 @@ next:
                 map.specialroomnames.push_back(name);
             }
         }
+
+        if (SDL_strcmp(pKey, "PlayerColour") == 0)
+        {
+            player_colour = help.Int(pText);
+        }
     }
 
     if (mapwidth < maxwidth)
@@ -1553,6 +1560,20 @@ bool customlevelclass::save(const std::string& _path)
         // Also get rid of this one...
         tinyxml2::XMLElement* element;
         while ((element = msg->FirstChildElement("rtl")) != NULL)
+        {
+            doc.DeleteNode(element);
+        }
+    }
+
+    if (player_colour != 0)
+    {
+        xml::update_tag(msg, "PlayerColour", player_colour);
+    }
+    else
+    {
+        // Get rid of this one as well, since older levels don't have this property anyways
+        tinyxml2::XMLElement* element;
+        while ((element = msg->FirstChildElement("PlayerColour")) != NULL)
         {
             doc.DeleteNode(element);
         }

--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -1420,6 +1420,7 @@ next:
         if (SDL_strcmp(pKey, "PlayerColour") == 0)
         {
             player_colour = help.Int(pText);
+            game.savecolour = player_colour;
         }
     }
 

--- a/desktop_version/src/CustomLevels.h
+++ b/desktop_version/src/CustomLevels.h
@@ -170,6 +170,8 @@ public:
     SDL_Color getonewaycol(int rx, int ry);
     SDL_Color getonewaycol(void);
     bool onewaycol_override;
+
+    int player_colour;
 };
 
 bool translate_title(const std::string& title);

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -1048,11 +1048,11 @@ static void draw_entities(void)
 
                 if (entity->p1 == 0)  // Facing right
                 {
-                    graphics.draw_sprite(x - 4, y, 0, graphics.col_crewcyan);
+                    graphics.draw_sprite(x - 4, y, 0, graphics.getcol(cl.player_colour));
                 }
                 else // Non-zero is facing left
                 {
-                    graphics.draw_sprite(x - 4, y, 3, graphics.col_crewcyan);
+                    graphics.draw_sprite(x - 4, y, 3, graphics.getcol(cl.player_colour));
                 }
 
                 graphics.draw_rect(x, y, 16, 24, graphics.getRGB(255, 255, 164));
@@ -1958,6 +1958,8 @@ void editorrenderfixed(void)
     extern editorclass ed;
     const RoomProperty* const room = cl.getroomprop(ed.levx, ed.levy);
     graphics.updatetitlecolours();
+
+    graphics.trinketcolset = false;
 
     game.customcol = cl.getlevelcol(room->tileset, room->tilecol) + 1;
     ed.entcol = cl.getenemycol(game.customcol);

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1850,8 +1850,9 @@ void scriptclass::run(void)
                 i = obj.getplayer();
                 if (INBOUNDS_VEC(i, obj.entities))
                 {
-                    obj.entities[i].colour = 0;
+                    obj.entities[i].colour = cl.player_colour;
                 }
+                game.savecolour = cl.player_colour;
             }
             else if (words[0] == "changeplayercolour")
             {
@@ -2652,7 +2653,7 @@ void scriptclass::startgamemode(const enum StartMode mode)
         }
     }
 
-    /* Containers which need to be reset before gameplay starts
+    /* State which needs to be reset before gameplay starts
      * ex. before custom levels get loaded */
 
     switch (mode)
@@ -2662,6 +2663,8 @@ void scriptclass::startgamemode(const enum StartMode mode)
     default:
         textbox_colours.clear();
         add_default_colours();
+        cl.onewaycol_override = false;
+        cl.player_colour = 0;
         break;
     }
 
@@ -3207,7 +3210,7 @@ void scriptclass::hardreset(void)
         game.savey = 0;
         game.savegc = 0;
     }
-    game.savecolour = 0;
+    game.savecolour = cl.player_colour;
 
     game.intimetrial = false;
     game.timetrialcountdown = 0;


### PR DESCRIPTION
## Changes:

This PR adds a new XML property for the player's colour. It is 0 by default, but you can change it to any colour ID. For example, making the player use the trinket color is `<PlayerColour>3</PlayerColour>`.

This is mostly a quality-of-life addition, as the player's colour is always 0 unless changed by scripts. A lot of levels which use different player colours use an intro script which both changes the player's colour and sets their respawn colour, which works great for finished, completed levels, but makes playtesting a little more annoying as they will spawn in as the wrong colour. Adding a level property for the default player colour fixes this annoyance.

Additionally, this changes the behavior of `restoreplayercolour`. This command used to set the player's colour to 0 (ignoring the respawn colour, so when Viridian would die, they would revert to the respawn colour). Now, it sets both Viridian's colour AND the respawn colour to what was present in the level file. This way, you can temporarily change the player colour using the script commands, and then use `restoreplayercolour` to revert back to what the player colour normally is.

The start point colour has also changed, to show the player colour instead of always colour 0.

Like most changes like this, a way to change this in-editor does not yet exist, but is planned for the future.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
