### PR TITLE
Crew screen tweaks for custom levels

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -425,22 +425,23 @@ void Graphics::print_level_creator(
     int width_for_face = 17;
     int total_width = width_for_face + font::len(print_flags, creator.c_str());
     int face_x, text_x, sprite_x;
+    int offset_x = -7;
     if (!font::is_rtl(print_flags))
     {
         face_x = (SCREEN_WIDTH_PIXELS - total_width) / 2;
         text_x = face_x + width_for_face;
-        sprite_x = 7;
+        sprite_x = 0;
     }
     else
     {
         face_x = (SCREEN_WIDTH_PIXELS + total_width) / 2;
         text_x = face_x - width_for_face;
         face_x -= 10; // sprite origin
-        sprite_x = 103;
+        sprite_x = 96;
         print_flags |= PR_RIGHT;
     }
     set_texture_color_mod(grphx.im_sprites, r, g, b);
-    draw_texture_part(grphx.im_sprites, face_x, y - 1, sprite_x, 2, 10, 10, 1, 1);
+    draw_texture_part(grphx.im_sprites, face_x + offset_x, y - 3, sprite_x, 0, 24, 12, 1, 1);
     set_texture_color_mod(grphx.im_sprites, 255, 255, 255);
     font::print(print_flags, text_x, y, creator, r, g, b);
 }

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -3102,26 +3102,30 @@ void maprender(void)
 
             font::print(title_flags | PR_2X | PR_CEN, -1, FLIP(45, 8), meta.title, 196, 196, 255 - help.glow);
             int sp = SDL_max(10, font::height(PR_FONT_LEVEL));
+            int desc_pos = (cl.numcrewmates() > 0) ? 70 : 70 + (sp*2);
             graphics.print_level_creator(creator_flags, FLIP(70, 8), meta.creator, 196, 196, 255 - help.glow);
-            font::print(PR_FONT_LEVEL | PR_CEN, -1, FLIP(70+sp, 8), meta.website, 196, 196, 255 - help.glow);
-            font::print(PR_FONT_LEVEL | PR_CEN, -1, FLIP(70+sp*3, 8), meta.Desc1, 196, 196, 255 - help.glow);
-            font::print(PR_FONT_LEVEL | PR_CEN, -1, FLIP(70+sp*4, 8), meta.Desc2, 196, 196, 255 - help.glow);
+            font::print(PR_FONT_LEVEL | PR_CEN, -1, FLIP(70 + sp, 8), meta.website, 196, 196, 255 - help.glow);
+            font::print(PR_FONT_LEVEL | PR_CEN, -1, FLIP(desc_pos + sp*3, 8), meta.Desc1, 196, 196, 255 - help.glow);
+            font::print(PR_FONT_LEVEL | PR_CEN, -1, FLIP(desc_pos + sp*4, 8), meta.Desc2, 196, 196, 255 - help.glow);
             if (sp <= 10)
             {
-                font::print(PR_FONT_LEVEL | PR_CEN, -1, FLIP(70+sp*5, 8), meta.Desc3, 196, 196, 255 - help.glow);
+                font::print(PR_FONT_LEVEL | PR_CEN, -1, FLIP(desc_pos + sp*5, 8), meta.Desc3, 196, 196, 255 - help.glow);
             }
 
-            int remaining = cl.numcrewmates() - game.crewmates();
+            if (cl.numcrewmates() > 0)
+            {
+                int remaining = cl.numcrewmates() - game.crewmates();
 
-            char buffer[SCREEN_WIDTH_CHARS + 1];
-            loc::gettext_plural_fill(
-                buffer, sizeof(buffer),
-                "{n_crew|wordy} crewmates remain",
-                "{n_crew|wordy} crewmate remains",
-                "n_crew:int",
-                remaining
-            );
-            font::print_wrap(PR_CEN, -1, FLIP(165, 8), buffer, 196, 196, 255 - help.glow);
+                char buffer[SCREEN_WIDTH_CHARS + 1];
+                loc::gettext_plural_fill(
+                    buffer, sizeof(buffer),
+                    "{n_crew|wordy} crewmates remain",
+                    "{n_crew|wordy} crewmate remains",
+                    "n_crew:int",
+                    remaining
+                );
+                font::print_wrap(PR_CEN, -1, FLIP(165, 8), buffer, 196, 196, 255 - help.glow);
+            }
         }
         else
         {
@@ -3194,21 +3198,26 @@ void maprender(void)
         }
 
         /* Stats. */
-        font::print(PR_CEN | FLIP_PR_CJK_HIGH, -1, FLIP(52, 8), loc::gettext("[Trinkets found]"), 196, 196, 255 - help.glow);
-        char buffer[SCREEN_WIDTH_CHARS + 1];
-        vformat_buf(
-            buffer, sizeof(buffer),
-            loc::gettext("{n_trinkets|wordy} out of {max_trinkets|wordy}"),
-            "n_trinkets:int, max_trinkets:int",
-            game.trinkets(), max_trinkets
-        );
-        font::print(PR_CEN | FLIP_PR_CJK_LOW, -1, FLIP(64, 8), buffer, 96, 96, 96);
+        int deaths_pos = (cl.numtrinkets() > 0) ? 102 : 72;
+        int time_pos = (cl.numtrinkets() > 0) ? 152 : 132;
+        if (cl.numtrinkets() > 0)
+        {
+            font::print(PR_CEN | FLIP_PR_CJK_HIGH, -1, FLIP(52, 8), loc::gettext("[Trinkets found]"), 196, 196, 255 - help.glow);
+            char buffer[SCREEN_WIDTH_CHARS + 1];
+            vformat_buf(
+                buffer, sizeof(buffer),
+                loc::gettext("{n_trinkets|wordy} out of {max_trinkets|wordy}"),
+                "n_trinkets:int, max_trinkets:int",
+                game.trinkets(), max_trinkets
+            );
+            font::print(PR_CEN | FLIP_PR_CJK_LOW, -1, FLIP(64, 8), buffer, 96, 96, 96);
+        }
 
-        font::print(PR_CEN | FLIP_PR_CJK_HIGH, -1, FLIP(102, 8), loc::gettext("[Number of Deaths]"), 196, 196, 255 - help.glow);
-        font::print(PR_CEN | FLIP_PR_CJK_LOW, -1, FLIP(114, 8), help.String(game.deathcounts), 96, 96, 96);
+        font::print(PR_CEN | FLIP_PR_CJK_HIGH, -1, FLIP(deaths_pos, 8), loc::gettext("[Number of Deaths]"), 196, 196, 255 - help.glow);
+        font::print(PR_CEN | FLIP_PR_CJK_LOW, -1, FLIP(deaths_pos + 12, 8), help.String(game.deathcounts), 96, 96, 96);
 
-        font::print(PR_CEN | FLIP_PR_CJK_HIGH, -1, FLIP(152, 8), loc::gettext("[Time Taken]"), 196, 196, 255 - help.glow);
-        font::print(PR_CEN | FLIP_PR_CJK_LOW, -1, FLIP(164, 8), game.timestring(), 96, 96, 96);
+        font::print(PR_CEN | FLIP_PR_CJK_HIGH, -1, FLIP(time_pos, 8), loc::gettext("[Time Taken]"), 196, 196, 255 - help.glow);
+        font::print(PR_CEN | FLIP_PR_CJK_LOW, -1, FLIP(time_pos + 12, 8), game.timestring(), 96, 96, 96);
         break;
     }
     case 3:


### PR DESCRIPTION
## Changes:

Currently, if a custom level has zero crewmates, the "CREW" screen will look like this:

![test_before](https://github.com/user-attachments/assets/d4502bb1-15fa-405b-bcc7-cb07155f88ce)


However, many, many custom levels don't actually use rescueable crewmates, so seeing "Zero crewmates remain" for a level without any is rather odd. This commit modifies the crew (and stats) screens in custom levels to be more flexible.
If a level has no rescueable crewmates, that line will no longer display and the description will be moved down, like so:

![test_basic](https://github.com/user-attachments/assets/63dab815-4fac-465d-a0c6-d6c96686098a)


Additionally, if a level has no trinkets, the lines about how many trinkets you have are now removed from the "STATS" screen:

![test_statsbefore](https://github.com/user-attachments/assets/7b6cc0b4-c6cb-4ff8-8ec4-950460d79302)
![test_stats](https://github.com/user-attachments/assets/b59fcb00-f0fe-4045-8565-967645f6b81c)
(this accounts for language, of course)
![test_statszh](https://github.com/user-attachments/assets/713350a8-ec8b-45fb-944d-a6a5170fa8f8)


I've also increased the amount of space around the player head sprite that displays next to the author name to be more friendly to custom graphics. Instead of only rendering in a 10x10 bounding box, the two pixels above and 7 pixels on each side will also render now. Here are some examples with custom sprites from the most recent VVVVVV Discord contest:


Cat's First Level - stupid cat
![test_first](https://github.com/user-attachments/assets/5208d773-44a1-45ff-9887-2ecd8ebc2917)

Consuming Alkahest - mothbeanie & Allison Fleischer
![test_alka](https://github.com/user-attachments/assets/7b742089-2a1e-4f33-a665-56d3ac7b1c60)

the 50 move rule - sean (seaspaces)
![test_50](https://github.com/user-attachments/assets/93189b1d-cd00-45d1-b604-88c3b9307266)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
