### PR TITLE
Load an unlimited amount of sounds

### DIFF
--- a/desktop_version/src/Music.h
+++ b/desktop_version/src/Music.h
@@ -95,6 +95,10 @@ public:
     int haltedsong;
 
     void playef(int t);
+    void playefid(const char* id);
+    bool soundidexists(const char* id);
+    bool soundisextra(int t);
+    const char* getsoundid(int t);
     void pauseef(void);
     void resumeef(void);
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -448,7 +448,14 @@ void scriptclass::run(void)
             }
             if (words[0] == "playef")
             {
-                music.playef(ss_toi(words[1]));
+                if (music.soundidexists(words[1].c_str()))
+                {
+                    music.playefid(words[1].c_str());
+                }
+                else if (!music.soundisextra(ss_toi(words[1])))
+                {
+                    music.playef(ss_toi(words[1]));
+                }
             }
             if (words[0] == "play")
             {


### PR DESCRIPTION
## Changes:

This commit allows the usage of new "extra" sounds in levels for use in custom level scripting. Including `squid.ogg` inside of your sounds folder will now allow for the usage of the command `playef(squid)`. Additionally, you can play built-in sounds by name this way too, instead of having to memorize the id (`playef(rescue)`).

However, you CANNOT play extra sounds through using their numerical IDs, since those can shift around depending on the filesystem (or if someone adds a new sound). Playing an extra sound by ID will NOT play the sound.

This is another attempt at #902, being loosely based off of that PR.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
