### PR TITLE
Add confirmation and removal to bindings menu

### DIFF
--- a/desktop_version/lang/ar/strings.xml
+++ b/desktop_version/lang/ar/strings.xml
@@ -46,10 +46,8 @@
     <string english="unlock secret lab" translation="فتح المخبر السري" explanation="menu option"/>
     <string english="game pad" translation="يد التحكم" explanation="menu option"/>
     <string english="Game Pad Options" translation="إعدادات يد التحكم" explanation="title" max="20" max_local="20"/>
-    <string english="Game Pad" translation="يد التحكم" explanation="title" max="20" max_local="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="يمكنك تعيين أزرار يد التحكم
 	وضبط حساسيتها." explanation="" max="38*5" max_local="38*5"/>
-    <string english="Change controller options." translation="تغيير إعدادات يد التحكم." explanation="" max="38*2" max_local="38*2"/>
     <string english="language" translation="اللغة" explanation="menu option"/>
     <string english="Language" translation="اللغة" explanation="title" max="20" max_local="20"/>
     <string english="Change the language." translation="تغيير اللغة." explanation="" max="38*2" max_local="38*2"/>
@@ -139,19 +137,30 @@
     <string english="disable cutscenes" translation="تعطيل المشاهد" explanation="menu option"/>
     <string english="enable cutscenes" translation="تفعيل المشاهد" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="حساسية عصا يد التحكم" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="حساسية العصا" explanation="title" max="20" max_local="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="تغيير حساسية عصا التحكم." explanation="" max="38*3" max_local="38*3"/>
     <string english="Low" translation="منخفضة" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="متوسطة" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="عالية" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="تعيين العكس" explanation="menu option"/>
+    <string english="Bind Flip" translation="تعيين زر العكس" explanation="title" max="20" max_local="20"/>
     <string english="bind enter" translation="تعيين الدخول" explanation="menu option"/>
+    <string english="Bind Enter" translation="تعيين زر الدخول" explanation="title" max="20" max_local="20"/>
     <string english="bind menu" translation="تعيين القائمة" explanation="menu option"/>
+    <string english="Bind Menu" translation="تعيين زر القائمة" explanation="title" max="20" max_local="20"/>
     <string english="bind restart" translation="تعيين إعادة الغرفة" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="تعيين زر الإعادة" explanation="title" max="20" max_local="20"/>
     <string english="bind interact" translation="تعيين التفاعل" explanation="menu option"/>
+    <string english="Bind Interact" translation="تعيين زر التفاعل" explanation="title" max="20" max_local="20"/>
     <string english="Flip is bound to: " translation="العكس معين للزر: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="32"/>
     <string english="Enter is bound to: " translation="الدخول معين للزر: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="32"/>
     <string english="Menu is bound to: " translation="القائمة معينة للزر: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="32"/>
     <string english="Restart is bound to: " translation="إعادة الغرفة معينة للزر: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="32"/>
     <string english="Interact is bound to: " translation="التفاعل معين للزر: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="يرجى ضغط زر...|(أو ضغط ↑↓)" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2" max_local="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="إضافة {button}؟|اضغط ثانية للتأكيد" explanation="Bind the X button to this action? Press X again to really add it" max="38*2" max_local="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="إزالة {button}؟|اضغط ثانية للتأكيد" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2" max_local="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="زر التفاعل حاليا Enter !|راجع إعدادات التختيم السريع." explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2" max_local="38*2"/>
     <string english="ERROR: No language files found." translation="خطأ: لم نجد ملفات اللغة." explanation="" max="38*3" max_local="38*3"/>
     <string english="Language folder:" translation="مجلد اللغة: " explanation="" max="39" max_local="39"/>
     <string english="Repository language folder:" translation="مجلد اللغة في غيتهب: " explanation="Language folder from the Git repository" max="39" max_local="39"/>

--- a/desktop_version/lang/ca/strings.xml
+++ b/desktop_version/lang/ca/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="desbloca el laboratori secret" explanation="menu option"/>
     <string english="game pad" translation="controlador" explanation="menu option"/>
     <string english="Game Pad Options" translation="Controlador" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Controlador" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Reassigna els botons del controlador|i ajusta’n la sensibilitat." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Canvia les opcions del controlador." explanation="" max="38*2"/>
     <string english="language" translation="llengua" explanation="menu option"/>
     <string english="Language" translation="Llengua" explanation="title" max="20"/>
     <string english="Change the language." translation="Canvia la llengua." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="desactiva les escenes" explanation="menu option"/>
     <string english="enable cutscenes" translation="activa les escenes" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="sensibilitat de la palanca" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="" explanation="" max="38*3"/>
     <string english="Low" translation="Baixa" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Mitjana" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Alta" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="assigna gir" explanation="menu option"/>
+    <string english="Bind Flip" translation="" explanation="title" max="20"/>
     <string english="bind enter" translation="assigna retorn" explanation="menu option"/>
+    <string english="Bind Enter" translation="" explanation="title" max="20"/>
     <string english="bind menu" translation="assigna menú" explanation="menu option"/>
+    <string english="Bind Menu" translation="" explanation="title" max="20"/>
     <string english="bind restart" translation="assigna reinici" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="" explanation="title" max="20"/>
     <string english="bind interact" translation="assigna interacció" explanation="menu option"/>
+    <string english="Bind Interact" translation="" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="El gir està assignat a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="El retorn està assignat a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="El menú està assignat a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="El reinici està assignat a: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="La interacció està assignada a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="" explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="ERROR: No s’ha trobat cap fitxer de llengua." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Carpeta de llengua:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Carpeta de llengua del repositori:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/cy/strings.xml
+++ b/desktop_version/lang/cy/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="datgloi labordy cyfrinachol" explanation="menu option"/>
     <string english="game pad" translation="rheolydd" explanation="menu option"/>
     <string english="Game Pad Options" translation="Opsiynau Rheolydd" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Rheolydd" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Ail-rwymo botymau eich rheolydd ac addasu sensitifrwydd." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Newid opsiynau rheolydd." explanation="" max="38*2"/>
     <string english="language" translation="iaith" explanation="menu option"/>
     <string english="Language" translation="Iaith" explanation="title" max="20"/>
     <string english="Change the language." translation="Newid yr iaith." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="analluogi golygfeydd" explanation="menu option"/>
     <string english="enable cutscenes" translation="galluogi golygfeydd" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="sensitifrwydd ffon analog" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="" explanation="" max="38*3"/>
     <string english="Low" translation="Isel" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Canolig" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Uchel" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="gosod fflip" explanation="menu option"/>
+    <string english="Bind Flip" translation="" explanation="title" max="20"/>
     <string english="bind enter" translation="gosod mynd i mewn" explanation="menu option"/>
+    <string english="Bind Enter" translation="" explanation="title" max="20"/>
     <string english="bind menu" translation="gosod y ddewislen" explanation="menu option"/>
+    <string english="Bind Menu" translation="" explanation="title" max="20"/>
     <string english="bind restart" translation="gosod ailgychwyn" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="" explanation="title" max="20"/>
     <string english="bind interact" translation="gosod rhyngweithio" explanation="menu option"/>
+    <string english="Bind Interact" translation="" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="Mae fflip wedi&apos;i osod i: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="Mae Mynd i mewn wedi&apos;i osod i: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Mae&apos;r Ddewislen wedi&apos;i osod i: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Mae Ailgychwyn wedi&apos;i osod i: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Mae Rhyngweithio wedi&apos;i osod i: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="" explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="GWALL: Ni chanfuwyd ffeiliau iaith." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Ffolder iaith:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Ffolder iaith ystorfa:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/de/strings.xml
+++ b/desktop_version/lang/de/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="Geheimlabor freischalten" explanation="menu option"/>
     <string english="game pad" translation="gamepad" explanation="menu option"/>
     <string english="Game Pad Options" translation="Gamepad-Optionen" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Gamepad" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Belege deine Controller-Knöpfe neu." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Ändere Controller-Optionen." explanation="" max="38*2"/>
     <string english="language" translation="sprache" explanation="menu option"/>
     <string english="Language" translation="Sprache" explanation="title" max="20"/>
     <string english="Change the language." translation="Ändere die Spielsprache." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="sequenzen ausschalten" explanation="menu option"/>
     <string english="enable cutscenes" translation="sequenzen einschalten" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="analogstick-empfindlichkeit" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="" explanation="" max="38*3"/>
     <string english="Low" translation="Niedrig" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Mittel" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Hoch" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="flippen zuweisen" explanation="menu option"/>
+    <string english="Bind Flip" translation="" explanation="title" max="20"/>
     <string english="bind enter" translation="enter zuweisen" explanation="menu option"/>
+    <string english="Bind Enter" translation="" explanation="title" max="20"/>
     <string english="bind menu" translation="menü zuweisen" explanation="menu option"/>
+    <string english="Bind Menu" translation="" explanation="title" max="20"/>
     <string english="bind restart" translation="neustart zuweisen" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="" explanation="title" max="20"/>
     <string english="bind interact" translation="interagieren zuweisen" explanation="menu option"/>
+    <string english="Bind Interact" translation="" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="Flippen ist belegt mit: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="Enter ist belegt mit: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Menü ist belegt mit: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Neustart ist belegt mit: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Interagieren ist belegt mit: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="" explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="FEHLER: keine Sprachdateien gefunden." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Sprachordner:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Repository-Sprachordner:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/en/strings.xml
+++ b/desktop_version/lang/en/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="" explanation="menu option"/>
     <string english="game pad" translation="" explanation="menu option"/>
     <string english="Game Pad Options" translation="" explanation="title" max="20"/>
-    <string english="Game Pad" translation="" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="" explanation="" max="38*5"/>
-    <string english="Change controller options." translation="" explanation="" max="38*2"/>
     <string english="language" translation="" explanation="menu option"/>
     <string english="Language" translation="" explanation="title" max="20"/>
     <string english="Change the language." translation="" explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="" explanation="menu option"/>
     <string english="enable cutscenes" translation="" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="" explanation="" max="38*3"/>
     <string english="Low" translation="" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="" explanation="menu option"/>
+    <string english="Bind Flip" translation="" explanation="title" max="20"/>
     <string english="bind enter" translation="" explanation="menu option"/>
+    <string english="Bind Enter" translation="" explanation="title" max="20"/>
     <string english="bind menu" translation="" explanation="menu option"/>
+    <string english="Bind Menu" translation="" explanation="title" max="20"/>
     <string english="bind restart" translation="" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="" explanation="title" max="20"/>
     <string english="bind interact" translation="" explanation="menu option"/>
+    <string english="Bind Interact" translation="" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="" explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="" explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="" explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="" explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="" explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="" explanation="the Interact action can't be configured now because it's the same as the Enter action. There's an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="" explanation="" max="38*3"/>
     <string english="Language folder:" translation="" explanation="" max="39"/>
     <string english="Repository language folder:" translation="" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/eo/strings.xml
+++ b/desktop_version/lang/eo/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="malŝlosi sekretan labon" explanation="menu option"/>
     <string english="game pad" translation="regilo" explanation="menu option"/>
     <string english="Game Pad Options" translation="Opcioj de regilo" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Regilo" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Reagordi butonojn kaj ŝanĝi sentemon." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Ŝanĝi regilajn agordojn." explanation="" max="38*2"/>
     <string english="language" translation="lingvo" explanation="menu option"/>
     <string english="Language" translation="Lingvo" explanation="title" max="20"/>
     <string english="Change the language." translation="Ŝanĝi la lingvon." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="malebligi interscenojn" explanation="menu option"/>
     <string english="enable cutscenes" translation="ebligi interscenojn" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="sentemo de analogbastono" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="Sentemo de bastono" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="Ŝanĝi la sentemon de la analogbastono." explanation="" max="38*3"/>
     <string english="Low" translation="Malalta" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Meza" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Alta" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="agordi renversiĝbutonon" explanation="menu option"/>
+    <string english="Bind Flip" translation="Renversiĝo" explanation="title" max="20"/>
     <string english="bind enter" translation="agordi enter-klavon" explanation="menu option"/>
+    <string english="Bind Enter" translation="Enter" explanation="title" max="20"/>
     <string english="bind menu" translation="agordi menubutonon" explanation="menu option"/>
+    <string english="Bind Menu" translation="Menuo" explanation="title" max="20"/>
     <string english="bind restart" translation="agordi rekomencbutonon" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="Rekomenco" explanation="title" max="20"/>
     <string english="bind interact" translation="agordi interagbutonon" explanation="menu option"/>
+    <string english="Bind Interact" translation="Interago" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="Renversiĝo agordita al: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="ENTER agordita al: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Menuo agordita al: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Rekomenco agordita al: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Interago agordita al: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="Premu butonon...|(aŭ premu ↑↓)" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="Ĉu aldoni {button}?|Premu denove por konfirmi" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="Ĉu forigi {button}?|Premu denove por konfirmi" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="Interago nune estas Enter!|Vidu la opciojn de kurludado." explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="ERARO: Neniuj lingvodosieroj troviĝis." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Lingvodosierujo:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Deponeja lingvodosierujo:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/es/strings.xml
+++ b/desktop_version/lang/es/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="desbloquea el laboratorio secreto" explanation="menu option"/>
     <string english="game pad" translation="mando" explanation="menu option"/>
     <string english="Game Pad Options" translation="Opciones de mando" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Mando" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Reasigna los botones de tu mando y ajusta su sensibilidad." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Cambia las opciones del mando." explanation="" max="38*2"/>
     <string english="language" translation="idioma" explanation="menu option"/>
     <string english="Language" translation="Idioma" explanation="title" max="20"/>
     <string english="Change the language." translation="Cambia el idioma." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="desactivar las cinemáticas" explanation="menu option"/>
     <string english="enable cutscenes" translation="activar las cinemáticas" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="sensibilidad del stick analógico" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="" explanation="" max="38*3"/>
     <string english="Low" translation="Baja" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Media" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Alta" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="asignar giro" explanation="menu option"/>
+    <string english="Bind Flip" translation="" explanation="title" max="20"/>
     <string english="bind enter" translation="asignar entrar" explanation="menu option"/>
+    <string english="Bind Enter" translation="" explanation="title" max="20"/>
     <string english="bind menu" translation="asignar menú" explanation="menu option"/>
+    <string english="Bind Menu" translation="" explanation="title" max="20"/>
     <string english="bind restart" translation="asignar reiniciar" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="" explanation="title" max="20"/>
     <string english="bind interact" translation="asignar interactuar" explanation="menu option"/>
+    <string english="Bind Interact" translation="" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="Giro está asignado a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="Entrar está asignado a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Menú está asignado a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Reinicio está asignado a: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Interactuar está asignado a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="" explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="ERROR: No se han detectado archivos de idioma." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Carpeta de idioma:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Carpeta de idioma de repositorio:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/es_419/strings.xml
+++ b/desktop_version/lang/es_419/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="desbloquea el laboratorio secreto" explanation="menu option"/>
     <string english="game pad" translation="control" explanation="menu option"/>
     <string english="Game Pad Options" translation="Opciones de control" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Control" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Reasigna los botones del control y ajusta su sensibilidad." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Cambia las opciones del control." explanation="" max="38*2"/>
     <string english="language" translation="idioma" explanation="menu option"/>
     <string english="Language" translation="Idioma" explanation="title" max="20"/>
     <string english="Change the language." translation="Cambia el idioma." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="desactivar las cinemáticas" explanation="menu option"/>
     <string english="enable cutscenes" translation="activar las cinemáticas" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="sensibilidad del stick analógico" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="" explanation="" max="38*3"/>
     <string english="Low" translation="Baja" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Media" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Alta" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="asignar volteo" explanation="menu option"/>
+    <string english="Bind Flip" translation="" explanation="title" max="20"/>
     <string english="bind enter" translation="asignar entrar" explanation="menu option"/>
+    <string english="Bind Enter" translation="" explanation="title" max="20"/>
     <string english="bind menu" translation="asignar menú" explanation="menu option"/>
+    <string english="Bind Menu" translation="" explanation="title" max="20"/>
     <string english="bind restart" translation="asignar reiniciar" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="" explanation="title" max="20"/>
     <string english="bind interact" translation="asignar interactuar" explanation="menu option"/>
+    <string english="Bind Interact" translation="" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="Volteo está asignado a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="Entrar está asignado a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Menú está asignado a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Reinicio está asignado a: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Interactuar está asignado a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="" explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="ERROR: No se detectaron archivos de idioma." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Carpeta de idioma:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Carpeta de idioma de repositorio:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/es_AR/strings.xml
+++ b/desktop_version/lang/es_AR/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="desbloquea el laboratorio secreto" explanation="menu option"/>
     <string english="game pad" translation="control" explanation="menu option"/>
     <string english="Game Pad Options" translation="Opciones de control" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Control" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Reasigna los botones del control y ajusta su sensibilidad." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Cambia las opciones del control." explanation="" max="38*2"/>
     <string english="language" translation="idioma" explanation="menu option"/>
     <string english="Language" translation="Idioma" explanation="title" max="20"/>
     <string english="Change the language." translation="Cambia el idioma." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="desactivar las cinemáticas" explanation="menu option"/>
     <string english="enable cutscenes" translation="activar las cinemáticas" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="sensibilidad del stick analógico" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="" explanation="" max="38*3"/>
     <string english="Low" translation="Baja" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Media" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Alta" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="asignar inversión" explanation="menu option"/>
+    <string english="Bind Flip" translation="" explanation="title" max="20"/>
     <string english="bind enter" translation="asignar entrar" explanation="menu option"/>
+    <string english="Bind Enter" translation="" explanation="title" max="20"/>
     <string english="bind menu" translation="asignar menú" explanation="menu option"/>
+    <string english="Bind Menu" translation="" explanation="title" max="20"/>
     <string english="bind restart" translation="asignar reiniciar" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="" explanation="title" max="20"/>
     <string english="bind interact" translation="asignar interactuar" explanation="menu option"/>
+    <string english="Bind Interact" translation="" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="Inversión está asignada a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="Entrar está asignado a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Menú está asignado a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Reinicio está asignado a: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Interactuar está asignado a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="" explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="ERROR: No se detectaron archivos de idioma." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Carpeta de idioma:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Carpeta de idioma de repositorio:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/fr/strings.xml
+++ b/desktop_version/lang/fr/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="déverrouiller le labo secret" explanation="menu option"/>
     <string english="game pad" translation="manette" explanation="menu option"/>
     <string english="Game Pad Options" translation="Options de manette" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Manette" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Reconfigurez les boutons de votre manette et ajustez sa sensibilité." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Modifiez les options de votre manette." explanation="" max="38*2"/>
     <string english="language" translation="langue" explanation="menu option"/>
     <string english="Language" translation="Langue" explanation="title" max="20"/>
     <string english="Change the language." translation="Changez de langue." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="désactiver les cinématiques" explanation="menu option"/>
     <string english="enable cutscenes" translation="activer les cinématiques" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="sensibilité du stick analogique" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="" explanation="" max="38*3"/>
     <string english="Low" translation="Basse" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Moyenne" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Haute" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="lier renverser" explanation="menu option"/>
+    <string english="Bind Flip" translation="" explanation="title" max="20"/>
     <string english="bind enter" translation="lier entrer" explanation="menu option"/>
+    <string english="Bind Enter" translation="" explanation="title" max="20"/>
     <string english="bind menu" translation="lier menu" explanation="menu option"/>
+    <string english="Bind Menu" translation="" explanation="title" max="20"/>
     <string english="bind restart" translation="lier recommencer" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="" explanation="title" max="20"/>
     <string english="bind interact" translation="lier interagir" explanation="menu option"/>
+    <string english="Bind Interact" translation="" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="Renverser est lié à : " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="Entrer est lié à : " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Menu est lié à : " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Recommencer est lié à : " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Interagir est lié à : " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="" explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="ERREUR : aucun fichier de langue trouvé." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Dossier de langue :" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Dossier de langue du dépôt :" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/ga/strings.xml
+++ b/desktop_version/lang/ga/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="díghlasáil an ~tsaotharlann rúnda" explanation="menu option"/>
     <string english="game pad" translation="rialaitheoir" explanation="menu option"/>
     <string english="Game Pad Options" translation="Rialaitheoir" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Rialaitheoir" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Athcheangail na cnaipí agus socraigh an íogaireacht." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Socruithe rialaitheora." explanation="" max="38*2"/>
     <string english="language" translation="teanga" explanation="menu option"/>
     <string english="Language" translation="Teanga" explanation="title" max="20"/>
     <string english="Change the language." translation="Athraigh an teanga." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="cuir preabradhairc as feidhm" explanation="menu option"/>
     <string english="enable cutscenes" translation="cuir preabradhairc i ~b~hfeidhm" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="íogaireacht" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="" explanation="" max="38*3"/>
     <string english="Low" translation="Íseal" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Meánach" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Ard" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="ceangail &apos;tiontaigh&apos;" explanation="menu option"/>
+    <string english="Bind Flip" translation="" explanation="title" max="20"/>
     <string english="bind enter" translation="ceangail &apos;enter&apos;" explanation="menu option"/>
+    <string english="Bind Enter" translation="" explanation="title" max="20"/>
     <string english="bind menu" translation="ceangail &apos;roghchlár&apos;" explanation="menu option"/>
+    <string english="Bind Menu" translation="" explanation="title" max="20"/>
     <string english="bind restart" translation="ceangail &apos;atosaigh&apos;" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="" explanation="title" max="20"/>
     <string english="bind interact" translation="ceangail &apos;idirghníomhaigh&apos;" explanation="menu option"/>
+    <string english="Bind Interact" translation="" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="Tiontaigh: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="Enter: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Roghchlár: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Atosaigh: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Idirghníomhaigh: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="" explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="EARRÁID: Níl na comhaid le fáil." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Fillteán teangacha:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Fillteán teangacha an stóir:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/it/strings.xml
+++ b/desktop_version/lang/it/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="sblocca laboratorio segreto" explanation="menu option"/>
     <string english="game pad" translation="gamepad" explanation="menu option"/>
     <string english="Game Pad Options" translation="Opzioni gamepad" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Gamepad" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Riassegna i comandi del controller e regola la sensibilità." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Modifica le opzioni del controller." explanation="" max="38*2"/>
     <string english="language" translation="lingua" explanation="menu option"/>
     <string english="Language" translation="Lingua" explanation="title" max="20"/>
     <string english="Change the language." translation="Cambia la lingua." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="disattiva filmati" explanation="menu option"/>
     <string english="enable cutscenes" translation="attiva filmati" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="sensibilità levetta analogica" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="" explanation="" max="38*3"/>
     <string english="Low" translation="Bassa" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Media" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Alta" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="assegna capovolgi" explanation="menu option"/>
+    <string english="Bind Flip" translation="" explanation="title" max="20"/>
     <string english="bind enter" translation="assegna invio" explanation="menu option"/>
+    <string english="Bind Enter" translation="" explanation="title" max="20"/>
     <string english="bind menu" translation="assegna menu" explanation="menu option"/>
+    <string english="Bind Menu" translation="" explanation="title" max="20"/>
     <string english="bind restart" translation="assegna ricomincia" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="" explanation="title" max="20"/>
     <string english="bind interact" translation="assegna interagisci" explanation="menu option"/>
+    <string english="Bind Interact" translation="" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="Capovolgi è assegnato a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="Invio è assegnato a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Menu è assegnato a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Ricomincia è assegnato a: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Interagisci è assegnato a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="" explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="ERRORE: Nessun file di lingua trovato." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Cartella lingue:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Cartella repository lingue:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/ja/strings.xml
+++ b/desktop_version/lang/ja/strings.xml
@@ -47,9 +47,7 @@
     <string english="unlock secret lab" translation="シークレットラボを強制解除" explanation="menu option"/>
     <string english="game pad" translation="ゲームパッド" explanation="menu option"/>
     <string english="Game Pad Options" translation="ゲームパッド設定" explanation="title" max="20" max_local="20"/>
-    <string english="Game Pad" translation="ゲームパッド設定" explanation="title" max="20" max_local="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="コントローラーのボタン割り当てや感度を変更する。" explanation="" max="38*5" max_local="38*4"/>
-    <string english="Change controller options." translation="コントローラーの設定を変更する。" explanation="" max="38*2" max_local="38*1"/>
     <string english="language" translation="言語" explanation="menu option"/>
     <string english="Language" translation="言語" explanation="title" max="20" max_local="20"/>
     <string english="Change the language." translation="ゲーム内で表示される言語を変更する。" explanation="" max="38*2" max_local="38*1"/>
@@ -142,19 +140,30 @@ OFFにしますか?" explanation="" max="38*6" max_local="38*5"/>
     <string english="disable cutscenes" translation="イベントシーンをOFF" explanation="menu option"/>
     <string english="enable cutscenes" translation="イベントシーンをON" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="アナログスティックの感度" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="" explanation="title" max="20" max_local="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="" explanation="" max="38*3" max_local="38*2"/>
     <string english="Low" translation="低" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="中" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="高" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="「フリップ」の割り当て" explanation="menu option"/>
+    <string english="Bind Flip" translation="" explanation="title" max="20" max_local="20"/>
     <string english="bind enter" translation="「決定」の割り当て" explanation="menu option"/>
+    <string english="Bind Enter" translation="" explanation="title" max="20" max_local="20"/>
     <string english="bind menu" translation="「メニュー」の割り当て" explanation="menu option"/>
+    <string english="Bind Menu" translation="" explanation="title" max="20" max_local="20"/>
     <string english="bind restart" translation="「リトライ」の割り当て" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="" explanation="title" max="20" max_local="20"/>
     <string english="bind interact" translation="「使用」の割り当て" explanation="menu option"/>
+    <string english="Bind Interact" translation="" explanation="title" max="20" max_local="20"/>
     <string english="Flip is bound to: " translation="「フリップ」ボタン: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="32"/>
     <string english="Enter is bound to: " translation="「決定」ボタン: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="32"/>
     <string english="Menu is bound to: " translation="「メニュー」ボタン: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="32"/>
     <string english="Restart is bound to: " translation="「リトライ」ボタン: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="32"/>
     <string english="Interact is bound to: " translation="「使用」ボタン: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2" max_local="38*1"/>
+    <string english="Add {button}?|Press again to confirm" translation="" explanation="Bind the X button to this action? Press X again to really add it" max="38*2" max_local="38*1"/>
+    <string english="Remove {button}?|Press again to confirm" translation="" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2" max_local="38*1"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="" explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2" max_local="38*1"/>
     <string english="ERROR: No language files found." translation="エラー: 言語ファイルが見つかりません。" explanation="" max="38*3" max_local="38*2"/>
     <string english="Language folder:" translation="言語フォルダー:" explanation="" max="39" max_local="39"/>
     <string english="Repository language folder:" translation="リポジトリ内の言語フォルダー:" explanation="Language folder from the Git repository" max="39" max_local="39"/>

--- a/desktop_version/lang/ko/strings.xml
+++ b/desktop_version/lang/ko/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="비밀 실험실 해금" explanation="menu option"/>
     <string english="game pad" translation="컨트롤러" explanation="menu option"/>
     <string english="Game Pad Options" translation="컨트롤러 설정" explanation="title" max="20" max_local="16"/>
-    <string english="Game Pad" translation="컨트롤러" explanation="title" max="20" max_local="16"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="컨트롤러의 버튼을 지정하고 민감도를 조정합니다." explanation="" max="38*5" max_local="30*5"/>
-    <string english="Change controller options." translation="컨트롤러 설정을 변경합니다." explanation="" max="38*2" max_local="30*2"/>
     <string english="language" translation="언어" explanation="menu option"/>
     <string english="Language" translation="언어" explanation="title" max="20" max_local="16"/>
     <string english="Change the language." translation="언어를 변경합니다." explanation="" max="38*2" max_local="30*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="컷신 비활성화" explanation="menu option"/>
     <string english="enable cutscenes" translation="컷신 활성화" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="아날로그 스틱 민감도" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="스틱 민감도" explanation="title" max="20" max_local="16"/>
+    <string english="Change the sensitivity of the analog stick." translation="아날로그 스틱의 민감도를 조절합니다." explanation="" max="38*3" max_local="30*3"/>
     <string english="Low" translation="낮음" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="중간" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="높음" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="뒤집기 키 설정" explanation="menu option"/>
+    <string english="Bind Flip" translation="뒤집기 키 설정" explanation="title" max="20" max_local="16"/>
     <string english="bind enter" translation="Enter 키 설정" explanation="menu option"/>
+    <string english="Bind Enter" translation="Enter 키 설정" explanation="title" max="20" max_local="16"/>
     <string english="bind menu" translation="메뉴 키 설정" explanation="menu option"/>
+    <string english="Bind Menu" translation="메뉴 키 설정" explanation="title" max="20" max_local="16"/>
     <string english="bind restart" translation="재시작 키 설정" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="재시작 키 설정" explanation="title" max="20" max_local="16"/>
     <string english="bind interact" translation="상호작용 키 설정" explanation="menu option"/>
+    <string english="Bind Interact" translation="상호작용 키 설정" explanation="title" max="20" max_local="16"/>
     <string english="Flip is bound to: " translation="뒤집기: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="25"/>
     <string english="Enter is bound to: " translation="ENTER: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="25"/>
     <string english="Menu is bound to: " translation="메뉴: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="25"/>
     <string english="Restart is bound to: " translation="재시작: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="25"/>
     <string english="Interact is bound to: " translation="상호작용: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="25"/>
+    <string english="Press a button...|(or press ↑↓)" translation="버튼을 누르세요...|(또는 ↑↓를 누르세요)" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2" max_local="30*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="{button} 버튼을 추가할까요?|확인하려면 한 번 더 누르세요" explanation="Bind the X button to this action? Press X again to really add it" max="38*2" max_local="30*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="{button} 버튼을 뺄까요?|확인하려면 한 번 더 누르세요" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2" max_local="30*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="상호작용은 현재 Enter 키입니다!|스피드런 설정을 보세요." explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2" max_local="30*2"/>
     <string english="ERROR: No language files found." translation="오류: 언어 파일을 찾을 수 없음." explanation="" max="38*3" max_local="30*3"/>
     <string english="Language folder:" translation="언어 폴더:" explanation="" max="39" max_local="31"/>
     <string english="Repository language folder:" translation="언어 폴더 저장 위치:" explanation="Language folder from the Git repository" max="39" max_local="31"/>

--- a/desktop_version/lang/nl/strings.xml
+++ b/desktop_version/lang/nl/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="geheim lab ontgrendelen" explanation="menu option"/>
     <string english="game pad" translation="gamepad" explanation="menu option"/>
     <string english="Game Pad Options" translation="Gamepadopties" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Gamepad" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Wijzig de knoppen van je controller en pas de gevoeligheid aan." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Wijzig controlleropties." explanation="" max="38*2"/>
     <string english="language" translation="taal" explanation="menu option"/>
     <string english="Language" translation="Taal" explanation="title" max="20"/>
     <string english="Change the language." translation="Wijzig de taal." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="cutscenes uitschakelen" explanation="menu option"/>
     <string english="enable cutscenes" translation="cutscenes inschakelen" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="gevoeligheid analoge stick" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="Stick-gevoeligheid" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="Wijzig de gevoeligheid van de analoge stick." explanation="" max="38*3"/>
     <string english="Low" translation="Laag" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Gemiddeld" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Hoog" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="omkeren toewijzen" explanation="menu option"/>
+    <string english="Bind Flip" translation="Omkeren" explanation="title" max="20"/>
     <string english="bind enter" translation="enter toewijzen" explanation="menu option"/>
+    <string english="Bind Enter" translation="Enter" explanation="title" max="20"/>
     <string english="bind menu" translation="menu toewijzen" explanation="menu option"/>
+    <string english="Bind Menu" translation="Menu" explanation="title" max="20"/>
     <string english="bind restart" translation="herstarten toewijzen" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="Herstarten" explanation="title" max="20"/>
     <string english="bind interact" translation="interactie toewijzen" explanation="menu option"/>
+    <string english="Bind Interact" translation="Interactie" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="Omkeren is toegewezen aan: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="Enter is toegewezen aan: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Menu is toegewezen aan: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Herstarten is toegewezen aan: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Interactie is toegewezen aan: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="Druk op een knop...|(of druk op ↑↓)" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="{button} toevoegen?|Druk nogmaals om te bevestigen" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="{button} verwijderen?|Druk nogmaals om te bevestigen" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="Interactie is momenteel Enter!|Zie speedrunopties." explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="FOUT: Geen taalbestanden gevonden." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Talenmap:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Talenmap van repository:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/pl/strings.xml
+++ b/desktop_version/lang/pl/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="odblokuj tajne laboratorium" explanation="menu option"/>
     <string english="game pad" translation="kontroler" explanation="menu option"/>
     <string english="Game Pad Options" translation="Opcje Kontrolera" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Kontroler" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Przypisuj przyciski kontrolera|i ustawiaj czułość." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Zmień opcje kontrolera." explanation="" max="38*2"/>
     <string english="language" translation="język" explanation="menu option"/>
     <string english="Language" translation="Język" explanation="title" max="20"/>
     <string english="Change the language." translation="Zmień język gry." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="wyłącz dialogi" explanation="menu option"/>
     <string english="enable cutscenes" translation="włącz dialogi" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="czułość drążka analogowego" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="" explanation="" max="38*3"/>
     <string english="Low" translation="Niska" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Średnia" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Wysoka" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="przypisz odwrót" explanation="menu option"/>
+    <string english="Bind Flip" translation="" explanation="title" max="20"/>
     <string english="bind enter" translation="przypisz wejście" explanation="menu option"/>
+    <string english="Bind Enter" translation="" explanation="title" max="20"/>
     <string english="bind menu" translation="przypisz menu" explanation="menu option"/>
+    <string english="Bind Menu" translation="" explanation="title" max="20"/>
     <string english="bind restart" translation="przypisz restart" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="" explanation="title" max="20"/>
     <string english="bind interact" translation="przypisz interakcję" explanation="menu option"/>
+    <string english="Bind Interact" translation="" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="Odwrót jest przypisany do: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="Wejście jest przypisane do: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Menu jest przypisane do: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Restart jest przypisany do: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Interakcje są przypisane do: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="" explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="BŁĄD: Nie znaleziono plików językowych." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Folder z językami:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Folder z repozytorium:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/pt_BR/strings.xml
+++ b/desktop_version/lang/pt_BR/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="desbloquear laboratório secreto" explanation="menu option"/>
     <string english="game pad" translation="controle" explanation="menu option"/>
     <string english="Game Pad Options" translation="Opções do controle" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Controle" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Reconfigura os botões e ajusta a sensibilidade." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Altera as opções do controle." explanation="" max="38*2"/>
     <string english="language" translation="idioma" explanation="menu option"/>
     <string english="Language" translation="Idioma" explanation="title" max="20"/>
     <string english="Change the language." translation="Altera o idioma." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="desativar cenas" explanation="menu option"/>
     <string english="enable cutscenes" translation="ativar cenas" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="sensibilidade do analógico" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="" explanation="" max="38*3"/>
     <string english="Low" translation="Baixa" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Média" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Alta" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="vincular inversão" explanation="menu option"/>
+    <string english="Bind Flip" translation="" explanation="title" max="20"/>
     <string english="bind enter" translation="vincular confirmar" explanation="menu option"/>
+    <string english="Bind Enter" translation="" explanation="title" max="20"/>
     <string english="bind menu" translation="vincular menu" explanation="menu option"/>
+    <string english="Bind Menu" translation="" explanation="title" max="20"/>
     <string english="bind restart" translation="vincular reiniciar" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="" explanation="title" max="20"/>
     <string english="bind interact" translation="vincular interagir" explanation="menu option"/>
+    <string english="Bind Interact" translation="" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="Inversão está vinculada a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="Confirmar está vinculado a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Menu está vinculado a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Reiniciar está vinculado a: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Interagir está vinculado a: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="" explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="ERRO: Nenhum arquivo de idioma encontrado." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Pasta de idioma:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Pasta de idioma do repositório:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/pt_PT/strings.xml
+++ b/desktop_version/lang/pt_PT/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="desbloquear laboratório secreto" explanation="menu option"/>
     <string english="game pad" translation="comando" explanation="menu option"/>
     <string english="Game Pad Options" translation="Comandos" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Comando" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Reconfigura os botões do comando e ajusta a sensibilidade." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Altera as opções do comando." explanation="" max="38*2"/>
     <string english="language" translation="idioma" explanation="menu option"/>
     <string english="Language" translation="Idioma" explanation="title" max="20"/>
     <string english="Change the language." translation="Altera o idioma." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="desativar cenas" explanation="menu option"/>
     <string english="enable cutscenes" translation="ativar cenas" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="sensibilidade do manípulo" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="Sensibilidade" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="Ajusta a sensibilidade do manípulo." explanation="" max="38*3"/>
     <string english="Low" translation="Baixa" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Média" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Alta" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="definir inversão" explanation="menu option"/>
+    <string english="Bind Flip" translation="Definir inversão" explanation="title" max="20"/>
     <string english="bind enter" translation="definir entrar" explanation="menu option"/>
+    <string english="Bind Enter" translation="Definir Enter" explanation="title" max="20"/>
     <string english="bind menu" translation="definir menu" explanation="menu option"/>
+    <string english="Bind Menu" translation="Definir menu" explanation="title" max="20"/>
     <string english="bind restart" translation="definir reiniciar" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="Definir reiniciar" explanation="title" max="20"/>
     <string english="bind interact" translation="definir interação" explanation="menu option"/>
+    <string english="Bind Interact" translation="Definir interagir" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="Inversão: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="Entrar: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Menu: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Reiniciar: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Interação: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="Prime um botão...|(ou prime ↑↓)" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="Adicionar {button}?|Prime de novo para confirmar" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="Remover {button}?|Prime de novo para confirmar" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="Interagir está no Enter!|Ver opções de corrida." explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="ERRO: Não há ficheiros de idioma." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Pasta de idioma:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Pasta de repositório de idioma:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/ru/strings.xml
+++ b/desktop_version/lang/ru/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="секретная лаборатория" explanation="menu option"/>
     <string english="game pad" translation="геймпад" explanation="menu option"/>
     <string english="Game Pad Options" translation="Настройки геймпада" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Геймпад" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Переназначьте кнопки контроллера и настройте чувствительность." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Измените настройки контроллера." explanation="" max="38*2"/>
     <string english="language" translation="язык" explanation="menu option"/>
     <string english="Language" translation="Язык" explanation="title" max="20"/>
     <string english="Change the language." translation="Смените язык." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="отключить катсцены" explanation="menu option"/>
     <string english="enable cutscenes" translation="включить катсцены" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="чувствительность джойстика" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="Чувствительность" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="Измените чувствительность джойстика." explanation="" max="38*3"/>
     <string english="Low" translation="Низкая" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Средняя" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Высокая" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="назначить переворот" explanation="menu option"/>
+    <string english="Bind Flip" translation="Переворот" explanation="title" max="20"/>
     <string english="bind enter" translation="назначить ввод" explanation="menu option"/>
+    <string english="Bind Enter" translation="Ввод" explanation="title" max="20"/>
     <string english="bind menu" translation="назначить меню" explanation="menu option"/>
+    <string english="Bind Menu" translation="Меню" explanation="title" max="20"/>
     <string english="bind restart" translation="назначить возврат" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="Возврат" explanation="title" max="20"/>
     <string english="bind interact" translation="назначить взаимодействие" explanation="menu option"/>
+    <string english="Bind Interact" translation="Взаимодействие" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="Переворот назначен на: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="Ввод назначен на: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Меню назначено на: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Возврат назначен на: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Взаимодействие назначено на: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="Нажмите на кнопку...|(или нажмите ↑↓)" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="Добавить {button}?|Нажмите ещё раз, чтобы подтвердить" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="Убрать {button}?|Нажмите ещё раз, чтобы подтвердить" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="Взаимодействие назначено на кнопку ввода! См. настройки спидрана." explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="ОШИБКА: Файлы локализации не обнаружены." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Папка локализации:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Папка локализации из репозитория:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/szl/strings.xml
+++ b/desktop_version/lang/szl/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="ôdymknij tajne laboratoriōm" explanation="menu option"/>
     <string english="game pad" translation="kōntroler" explanation="menu option"/>
     <string english="Game Pad Options" translation="Ôpcyje Kōntrolera" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Kōntroler" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Pożyń drugi rŏz knefle kōntrolera|i przipasuj czułoś." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Pōmiyń ôpcyje kōntrolera." explanation="" max="38*2"/>
     <string english="language" translation="gŏdka" explanation="menu option"/>
     <string english="Language" translation="Gŏdka" explanation="title" max="20"/>
     <string english="Change the language." translation="Pōmiyń gŏdka szpila." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="wyłōncz dialogi" explanation="menu option"/>
     <string english="enable cutscenes" translation="załōncz dialogi" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="czułoś drążka analogowego" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="" explanation="" max="38*3"/>
     <string english="Low" translation="Mało" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Strzednio" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Wielgo" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="przipisz ôdwrōt" explanation="menu option"/>
+    <string english="Bind Flip" translation="" explanation="title" max="20"/>
     <string english="bind enter" translation="przipisz wchōd" explanation="menu option"/>
+    <string english="Bind Enter" translation="" explanation="title" max="20"/>
     <string english="bind menu" translation="przipisz menu" explanation="menu option"/>
+    <string english="Bind Menu" translation="" explanation="title" max="20"/>
     <string english="bind restart" translation="przipisz resztart" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="" explanation="title" max="20"/>
     <string english="bind interact" translation="przipisz interakcyje" explanation="menu option"/>
+    <string english="Bind Interact" translation="" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="ôdwrōt je przipisany do: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="Wchōd je przipisany do: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Menu je przipisane do: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Resztart je przipisany do: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Interakcyje sōm przipisane do: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="" explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="FELER: Niy wysznupano plikōw ôd gŏdki." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Folder z gŏdkami:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Folder z repozytoriōm:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/tr/strings.xml
+++ b/desktop_version/lang/tr/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="gizli laboratuvarı aç" explanation="menu option"/>
     <string english="game pad" translation="kumanda seçenekleri" explanation="menu option"/>
     <string english="Game Pad Options" translation="Kumanda Seçenekleri" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Oyun Kumandası" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Oyun kumandasındaki tuşları tekrar ata|ve hassasiyeti ayarla." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Oyun kumandası seçeneklerini değiştir." explanation="" max="38*2"/>
     <string english="language" translation="dil" explanation="menu option"/>
     <string english="Language" translation="Dil" explanation="title" max="20"/>
     <string english="Change the language." translation="Dili değiştir." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="ara sahneleri devre dışı bırak" explanation="menu option"/>
     <string english="enable cutscenes" translation="ara sahneleri etkinleştir" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="analog çubuk hassasiyeti" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="Çubuk Hassasiyeti" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="Analog çubuk hassasiyetini değiştir." explanation="" max="38*3"/>
     <string english="Low" translation="Düşük" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Orta" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Yüksek" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="ata - ters dönme" explanation="menu option"/>
+    <string english="Bind Flip" translation="Ata - Ters Dönme" explanation="title" max="20"/>
     <string english="bind enter" translation="ata - girme" explanation="menu option"/>
+    <string english="Bind Enter" translation="Ata - Girme" explanation="title" max="20"/>
     <string english="bind menu" translation="ata - menü" explanation="menu option"/>
+    <string english="Bind Menu" translation="Ata - Menü" explanation="title" max="20"/>
     <string english="bind restart" translation="ata - yeniden başlatma" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="Ata - Y. Başlatma" explanation="title" max="20"/>
     <string english="bind interact" translation="ata - etkileşim" explanation="menu option"/>
+    <string english="Bind Interact" translation="Ata - Etkileşim" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="Ters Dönme: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="Girme: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Menü şuna atandı: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Yeniden Başlatma: " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Etkileşim: " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="Bir tuşa (veya ↑↓ tuşlarına) bas" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="{button} atansın mı?|Tekrar basarak onayla" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="{button} kaldırılsın mı?|Tekrar basarak onayla" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="Etkileşim tuşu şu an Enter!|Speedrun seçeneklerine bak." explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="HATA: Dil dosyaları bulunamadı." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Dil klasörü:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Depo dil klasörü:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/uk/strings.xml
+++ b/desktop_version/lang/uk/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="розблокувати секретну лабораторію" explanation="menu option"/>
     <string english="game pad" translation="ґеймпад" explanation="menu option"/>
     <string english="Game Pad Options" translation="Налаштувати ґеймпад" explanation="title" max="20"/>
-    <string english="Game Pad" translation="Ґеймпад" explanation="title" max="20"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="Перепризначити кнопки контролера й змінити чутливість." explanation="" max="38*5"/>
-    <string english="Change controller options." translation="Змінити налаштування контролера." explanation="" max="38*2"/>
     <string english="language" translation="мова" explanation="menu option"/>
     <string english="Language" translation="Мова" explanation="title" max="20"/>
     <string english="Change the language." translation="Змінити мову." explanation="" max="38*2"/>
@@ -135,19 +133,30 @@
     <string english="disable cutscenes" translation="деактивувати вставки" explanation="menu option"/>
     <string english="enable cutscenes" translation="активувати вставки" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="чутливість аналогового стика" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="" explanation="title" max="20"/>
+    <string english="Change the sensitivity of the analog stick." translation="" explanation="" max="38*3"/>
     <string english="Low" translation="Низька" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="Середня" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="Висока" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="призначити кнопку переверту" explanation="menu option"/>
+    <string english="Bind Flip" translation="" explanation="title" max="20"/>
     <string english="bind enter" translation="призначити кнопку введення" explanation="menu option"/>
+    <string english="Bind Enter" translation="" explanation="title" max="20"/>
     <string english="bind menu" translation="призначити кнопку меню" explanation="menu option"/>
+    <string english="Bind Menu" translation="" explanation="title" max="20"/>
     <string english="bind restart" translation="призначити кнопку перезапуску" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="" explanation="title" max="20"/>
     <string english="bind interact" translation="призначити кнопку взаємодії" explanation="menu option"/>
+    <string english="Bind Interact" translation="" explanation="title" max="20"/>
     <string english="Flip is bound to: " translation="Переверт призначено на " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Enter is bound to: " translation="Введення призначено на " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Menu is bound to: " translation="Меню призначено на " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Restart is bound to: " translation="Перезапуск призначено на " explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
     <string english="Interact is bound to: " translation="Взаємодію призначено на " explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32"/>
+    <string english="Press a button...|(or press ↑↓)" translation="" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2"/>
+    <string english="Add {button}?|Press again to confirm" translation="" explanation="Bind the X button to this action? Press X again to really add it" max="38*2"/>
+    <string english="Remove {button}?|Press again to confirm" translation="" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="" explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2"/>
     <string english="ERROR: No language files found." translation="ПОМИЛКА: Мовних файлів не знайдено." explanation="" max="38*3"/>
     <string english="Language folder:" translation="Мовна папка:" explanation="" max="39"/>
     <string english="Repository language folder:" translation="Мовна папка в сховищі:" explanation="Language folder from the Git repository" max="39"/>

--- a/desktop_version/lang/zh/strings.xml
+++ b/desktop_version/lang/zh/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="解锁秘密实验室" explanation="menu option"/>
     <string english="game pad" translation="手柄" explanation="menu option"/>
     <string english="Game Pad Options" translation="手柄选项" explanation="title" max="20" max_local="13"/>
-    <string english="Game Pad" translation="手柄" explanation="title" max="20" max_local="13"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="重新绑定你的控制器按钮和调整敏感度。" explanation="" max="38*5" max_local="25*4"/>
-    <string english="Change controller options." translation="改变控制器选项。" explanation="" max="38*2" max_local="25*1"/>
     <string english="language" translation="语言" explanation="menu option"/>
     <string english="Language" translation="语言" explanation="title" max="20" max_local="13"/>
     <string english="Change the language." translation="变更语言。" explanation="" max="38*2" max_local="25*1"/>
@@ -136,19 +134,30 @@
     <string english="disable cutscenes" translation="关闭过场" explanation="menu option"/>
     <string english="enable cutscenes" translation="开启过场" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="摇杆敏感度" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="摇杆敏感度" explanation="title" max="20" max_local="13"/>
+    <string english="Change the sensitivity of the analog stick." translation="更改摇杆的敏感度。" explanation="" max="38*3" max_local="25*2"/>
     <string english="Low" translation="低" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="中" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="高" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="绑定翻转" explanation="menu option"/>
+    <string english="Bind Flip" translation="绑定翻转" explanation="title" max="20" max_local="13"/>
     <string english="bind enter" translation="绑定回车" explanation="menu option"/>
+    <string english="Bind Enter" translation="绑定回车" explanation="title" max="20" max_local="13"/>
     <string english="bind menu" translation="绑定菜单" explanation="menu option"/>
+    <string english="Bind Menu" translation="绑定菜单" explanation="title" max="20" max_local="13"/>
     <string english="bind restart" translation="绑定重开" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="绑定重开" explanation="title" max="20" max_local="13"/>
     <string english="bind interact" translation="绑定交互" explanation="menu option"/>
+    <string english="Bind Interact" translation="绑定交互" explanation="title" max="20" max_local="13"/>
     <string english="Flip is bound to: " translation="翻转绑定为：" explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="21"/>
     <string english="Enter is bound to: " translation="回车绑定为：" explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="21"/>
     <string english="Menu is bound to: " translation="菜单绑定为：" explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="21"/>
     <string english="Restart is bound to: " translation="重开绑定为：" explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="21"/>
     <string english="Interact is bound to: " translation="交互绑定为：" explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="21"/>
+    <string english="Press a button...|(or press ↑↓)" translation="按下按钮……|（或按↑↓）" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2" max_local="25*1"/>
+    <string english="Add {button}?|Press again to confirm" translation="绑定到{button}？|再次按下来确认" explanation="Bind the X button to this action? Press X again to really add it" max="38*2" max_local="25*1"/>
+    <string english="Remove {button}?|Press again to confirm" translation="移除{button}？|再次按下来确认" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2" max_local="25*1"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="交互键是回车键！|请查看竞速玩家选项。" explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2" max_local="25*1"/>
     <string english="ERROR: No language files found." translation="错误：没有找到语言文件。" explanation="" max="38*3" max_local="25*2"/>
     <string english="Language folder:" translation="语言文件夹：" explanation="" max="39" max_local="26"/>
     <string english="Repository language folder:" translation="GitHub语言文件夹：" explanation="Language folder from the Git repository" max="39" max_local="26"/>

--- a/desktop_version/lang/zh_TW/strings.xml
+++ b/desktop_version/lang/zh_TW/strings.xml
@@ -46,9 +46,7 @@
     <string english="unlock secret lab" translation="解鎖秘密實驗室" explanation="menu option"/>
     <string english="game pad" translation="遊戲手把" explanation="menu option"/>
     <string english="Game Pad Options" translation="遊戲手把選項" explanation="title" max="20" max_local="13"/>
-    <string english="Game Pad" translation="遊戲手把" explanation="title" max="20" max_local="13"/>
     <string english="Rebind your controller&apos;s buttons and adjust sensitivity." translation="重新綁定你的控制器按鈕和調整敏感度。" explanation="" max="38*5" max_local="25*4"/>
-    <string english="Change controller options." translation="改變控制器選項。" explanation="" max="38*2" max_local="25*1"/>
     <string english="language" translation="語言" explanation="menu option"/>
     <string english="Language" translation="語言" explanation="title" max="20" max_local="13"/>
     <string english="Change the language." translation="變更語言。" explanation="" max="38*2" max_local="25*1"/>
@@ -136,19 +134,30 @@
     <string english="disable cutscenes" translation="關閉過場" explanation="menu option"/>
     <string english="enable cutscenes" translation="開啟過場" explanation="menu option"/>
     <string english="analog stick sensitivity" translation="搖桿敏感度" explanation="menu option"/>
+    <string english="Stick Sensitivity" translation="搖桿靈敏度" explanation="title" max="20" max_local="13"/>
+    <string english="Change the sensitivity of the analog stick." translation="調整搖桿靈敏度" explanation="" max="38*3" max_local="25*2"/>
     <string english="Low" translation="低" explanation="analog stick sensitivity, game pad menu"/>
     <string english="Medium" translation="中" explanation="analog stick sensitivity, game pad menu"/>
     <string english="High" translation="高" explanation="analog stick sensitivity, game pad menu"/>
     <string english="bind flip" translation="綁定翻轉" explanation="menu option"/>
+    <string english="Bind Flip" translation="綁定翻轉" explanation="title" max="20" max_local="13"/>
     <string english="bind enter" translation="綁定回車" explanation="menu option"/>
+    <string english="Bind Enter" translation="綁定回車" explanation="title" max="20" max_local="13"/>
     <string english="bind menu" translation="綁定菜單" explanation="menu option"/>
+    <string english="Bind Menu" translation="綁定菜單" explanation="title" max="20" max_local="13"/>
     <string english="bind restart" translation="綁定重開" explanation="menu option. In-game death key to restart at checkpoint"/>
+    <string english="Bind Restart" translation="綁定重開" explanation="title" max="20" max_local="13"/>
     <string english="bind interact" translation="綁定交互" explanation="menu option"/>
+    <string english="Bind Interact" translation="綁定交互" explanation="title" max="20" max_local="13"/>
     <string english="Flip is bound to: " translation="翻轉綁定為：" explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="21"/>
     <string english="Enter is bound to: " translation="回車綁定為：" explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="21"/>
     <string english="Menu is bound to: " translation="菜單綁定為：" explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="21"/>
     <string english="Restart is bound to: " translation="重開綁定為：" explanation="in-game death key to restart at checkpoint. Controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="21"/>
     <string english="Interact is bound to: " translation="交互綁定為：" explanation="controller binds, bound to A, B, X, Y, etc. These strings end with a space!" max="32" max_local="21"/>
+    <string english="Press a button...|(or press ↑↓)" translation="按下按鈕……|（或按↑↓）" explanation="the arrows represent up/down buttons, or stick movement... So: press a controller button, or navigate away" max="38*2" max_local="25*1"/>
+    <string english="Add {button}?|Press again to confirm" translation="綁定到{button}？|再次按下以確認" explanation="Bind the X button to this action? Press X again to really add it" max="38*2" max_local="25*1"/>
+    <string english="Remove {button}?|Press again to confirm" translation="移除{button}？|再次按下以確認" explanation="Remove the binding of the X button for this action? Press X again to really remove it" max="38*2" max_local="25*1"/>
+    <string english="Interact is currently Enter!|See speedrunner options." translation="目前回車是交互鍵！|請查看競速玩家選項。" explanation="the Interact action can&apos;t be configured now because it&apos;s the same as the Enter action. There&apos;s an option in the Speedrunner options to split it off" max="38*2" max_local="25*1"/>
     <string english="ERROR: No language files found." translation="錯誤：沒有找到語言檔案。" explanation="" max="38*3" max_local="25*2"/>
     <string english="Language folder:" translation="語言資料夾：" explanation="" max="39" max_local="26"/>
     <string english="Repository language folder:" translation="GitHub語言資料夾：" explanation="Language folder from the Git repository" max="39" max_local="26"/>

--- a/desktop_version/src/ButtonGlyphs.cpp
+++ b/desktop_version/src/ButtonGlyphs.cpp
@@ -274,7 +274,7 @@ const char* BUTTONGLYPHS_get_wasd_text(void)
 
 const char* BUTTONGLYPHS_sdlbutton_to_glyph(const SDL_GameControllerButton button)
 {
-    if (button > SDL_CONTROLLER_BUTTON_RIGHTSHOULDER)
+    if (button < 0 || button > SDL_CONTROLLER_BUTTON_RIGHTSHOULDER)
     {
         SDL_assert(0 && "Unhandled button!");
         return glyph[GLYPH_UNKNOWN];

--- a/desktop_version/src/ButtonGlyphs.cpp
+++ b/desktop_version/src/ButtonGlyphs.cpp
@@ -272,7 +272,7 @@ const char* BUTTONGLYPHS_get_wasd_text(void)
     return loc::gettext("Press left/right to move");
 }
 
-static const char* sdlbutton_to_glyph(const SDL_GameControllerButton button)
+const char* BUTTONGLYPHS_sdlbutton_to_glyph(const SDL_GameControllerButton button)
 {
     if (button > SDL_CONTROLLER_BUTTON_RIGHTSHOULDER)
     {
@@ -292,7 +292,7 @@ static const char* glyph_for_vector(
         return NULL;
     }
 
-    return sdlbutton_to_glyph(buttons[index]);
+    return BUTTONGLYPHS_sdlbutton_to_glyph(buttons[index]);
 }
 
 const char* BUTTONGLYPHS_get_button(const ActionSet actionset, const Action action, int binding)

--- a/desktop_version/src/ButtonGlyphs.h
+++ b/desktop_version/src/ButtonGlyphs.h
@@ -20,6 +20,7 @@ void BUTTONGLYPHS_keyboard_set_active(bool active);
 void BUTTONGLYPHS_update_layout(SDL_GameController *c);
 
 const char* BUTTONGLYPHS_get_wasd_text(void);
+const char* BUTTONGLYPHS_sdlbutton_to_glyph(SDL_GameControllerButton button);
 const char* BUTTONGLYPHS_get_button(ActionSet actionset, Action action, int binding);
 
 char* BUTTONGLYPHS_get_all_gamepad_buttons(

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -254,6 +254,10 @@ void Game::init(void)
     levelpage=0;
     playcustomlevel=0;
 
+    gpmenu_lastbutton = SDL_CONTROLLER_BUTTON_INVALID;
+    gpmenu_confirming = false;
+    gpmenu_showremove = false;
+
     silence_settings_error = false;
 
     deathcounts = 0;
@@ -7009,7 +7013,7 @@ void Game::createmenu( enum Menu::MenuName t, bool samemenu/*= false*/ )
         option(loc::gettext("bind restart"));
         option(loc::gettext("bind interact"), separate_interact);
         option(loc::gettext("return"));
-        menuyoff = 0;
+        menuyoff = 12;
         maxspacing = 10;
         break;
     case Menu::language:

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -404,6 +404,10 @@ public:
     int creditposx, creditposy, creditposdelay;
     int oldcreditposx;
 
+    SDL_GameControllerButton gpmenu_lastbutton;
+    bool gpmenu_confirming;
+    bool gpmenu_showremove;
+
     bool silence_settings_error;
 
 

--- a/desktop_version/src/Input.cpp
+++ b/desktop_version/src/Input.cpp
@@ -35,6 +35,37 @@ static void updatebuttonmappings(int bind)
     ) {
         if (key.isDown(i))
         {
+            if (!game.gpmenu_confirming || i != game.gpmenu_lastbutton)
+            {
+                game.gpmenu_confirming = true;
+                game.gpmenu_lastbutton = i;
+
+                // Is this button already in the list for this action?
+                std::vector<SDL_GameControllerButton>* vec = NULL;
+                switch (bind)
+                {
+                case 1: vec = &game.controllerButton_flip; break;
+                case 2: vec = &game.controllerButton_map; break;
+                case 3: vec = &game.controllerButton_esc; break;
+                case 4: vec = &game.controllerButton_restart; break;
+                case 5: vec = &game.controllerButton_interact; break;
+                default: return;
+                }
+
+                game.gpmenu_showremove = false;
+                for (size_t j = 0; j < vec->size(); j += 1)
+                {
+                    if (i == (*vec)[j])
+                    {
+                        game.gpmenu_showremove = true;
+                        break;
+                    }
+                }
+
+                return;
+            }
+            game.gpmenu_confirming = false;
+
             bool dupe = false;
             switch (bind)
             {
@@ -46,13 +77,14 @@ static void updatebuttonmappings(int bind)
                     if (i == game.controllerButton_flip[j])
                     {
                         dupe = true;
+                        game.controllerButton_flip.erase(game.controllerButton_flip.begin() + j);
                     }
                 }
                 if (!dupe)
                 {
                     game.controllerButton_flip.push_back(i);
-                    music.playef(Sound_VIRIDIAN);
                 }
+                music.playef(Sound_VIRIDIAN);
                 for (j = 0; j < game.controllerButton_map.size(); j += 1)
                 {
                     if (i == game.controllerButton_map[j])
@@ -91,13 +123,14 @@ static void updatebuttonmappings(int bind)
                     if (i == game.controllerButton_map[j])
                     {
                         dupe = true;
+                        game.controllerButton_map.erase(game.controllerButton_map.begin() + j);
                     }
                 }
                 if (!dupe)
                 {
                     game.controllerButton_map.push_back(i);
-                    music.playef(Sound_VIRIDIAN);
                 }
+                music.playef(Sound_VIRIDIAN);
                 for (j = 0; j < game.controllerButton_flip.size(); j += 1)
                 {
                     if (i == game.controllerButton_flip[j])
@@ -136,13 +169,14 @@ static void updatebuttonmappings(int bind)
                     if (i == game.controllerButton_esc[j])
                     {
                         dupe = true;
+                        game.controllerButton_esc.erase(game.controllerButton_esc.begin() + j);
                     }
                 }
                 if (!dupe)
                 {
                     game.controllerButton_esc.push_back(i);
-                    music.playef(Sound_VIRIDIAN);
                 }
+                music.playef(Sound_VIRIDIAN);
                 for (j = 0; j < game.controllerButton_flip.size(); j += 1)
                 {
                     if (i == game.controllerButton_flip[j])
@@ -181,13 +215,14 @@ static void updatebuttonmappings(int bind)
                     if (i == game.controllerButton_restart[j])
                     {
                         dupe = true;
+                        game.controllerButton_restart.erase(game.controllerButton_restart.begin() + j);
                     }
                 }
                 if (!dupe)
                 {
                     game.controllerButton_restart.push_back(i);
-                    music.playef(Sound_VIRIDIAN);
                 }
+                music.playef(Sound_VIRIDIAN);
                 for (j = 0; j < game.controllerButton_flip.size(); j += 1)
                 {
                     if (i == game.controllerButton_flip[j])
@@ -226,13 +261,14 @@ static void updatebuttonmappings(int bind)
                     if (i == game.controllerButton_interact[j])
                     {
                         dupe = true;
+                        game.controllerButton_interact.erase(game.controllerButton_interact.begin() + j);
                     }
                 }
                 if (!dupe)
                 {
                     game.controllerButton_interact.push_back(i);
-                    music.playef(Sound_VIRIDIAN);
                 }
+                music.playef(Sound_VIRIDIAN);
                 for (j = 0; j < game.controllerButton_flip.size(); j += 1)
                 {
                     if (i == game.controllerButton_flip[j])
@@ -2525,6 +2561,11 @@ void titleinput(void)
                 else if (game.press_right)
                 {
                     game.currentmenuoption++;
+                }
+
+                if (game.currentmenuname == Menu::controller && (game.press_left || game.press_right))
+                {
+                    game.gpmenu_confirming = false;
                 }
             }
             else

--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -691,9 +691,6 @@ static void menurender(void)
     }
     case Menu::controller:
     {
-        font::print(PR_2X | PR_CEN, -1, 30, loc::gettext("Game Pad"), tr, tg, tb);
-        font::print_wrap(PR_CEN, -1, 55, loc::gettext("Change controller options."), tr, tg, tb);
-
         int spacing = font::height(0);
         spacing = SDL_max(spacing, 10);
 
@@ -701,12 +698,15 @@ static void menurender(void)
         {
         case 0:
         {
-            font::print(PR_RTL_XFLIP, 32, 75, loc::gettext("Low"), tr, tg, tb);
-            font::print(PR_CEN, -1, 75, loc::gettext("Medium"), tr, tg, tb);
-            font::print(PR_RIGHT | PR_RTL_XFLIP, 288, 75, loc::gettext("High"), tr, tg, tb);
+            font::print(PR_2X | PR_CEN, -1, 30, loc::gettext("Stick Sensitivity"), tr, tg, tb);
+            font::print_wrap(PR_CEN, -1, 55, loc::gettext("Change the sensitivity of the analog stick."), tr, tg, tb);
+
+            font::print(PR_RTL_XFLIP, 32, 95, loc::gettext("Low"), tr, tg, tb);
+            font::print(PR_CEN, -1, 95, loc::gettext("Medium"), tr, tg, tb);
+            font::print(PR_RIGHT | PR_RTL_XFLIP, 288, 95, loc::gettext("High"), tr, tg, tb);
             char slider[SCREEN_WIDTH_CHARS + 1];
             slider_get(slider, sizeof(slider), key.sensitivity, 5, 240);
-            font::print(PR_CEN, -1, 75+spacing, slider, tr, tg, tb);
+            font::print(PR_CEN, -1, 95+spacing, slider, tr, tg, tb);
             break;
         }
         case 1:
@@ -715,38 +715,117 @@ static void menurender(void)
         case 4:
         case 5:
         {
-            char buffer_a[SCREEN_WIDTH_CHARS + 1];
-            char buffer_b[SCREEN_WIDTH_CHARS + 1];
+            const char* title = "";
+            switch (game.currentmenuoption)
+            {
+            case 1: title = loc::gettext("Bind Flip"); break;
+            case 2: title = loc::gettext("Bind Enter"); break;
+            case 3: title = loc::gettext("Bind Menu"); break;
+            case 4: title = loc::gettext("Bind Restart"); break;
+            case 5: title = loc::gettext("Bind Interact"); break;
+            }
+            font::print(PR_2X | PR_CEN, -1, 30, title, tr, tg, tb);
 
-            SDL_snprintf(buffer_a, sizeof(buffer_a), "%s%s",
-                loc::gettext("Flip is bound to: "),
-                BUTTONGLYPHS_get_all_gamepad_buttons(buffer_b, sizeof(buffer_b), ActionSet_InGame, Action_InGame_ACTION)
-            );
-            font::print(PR_CEN, -1, 75, buffer_a, tr, tg, tb);
+            if (game.currentmenuoption == 5 && !game.separate_interact)
+            {
+                font::print_wrap(
+                    PR_CEN, -1, 55,
+                    loc::gettext("Interact is currently Enter!|See speedrunner options."),
+                    tr, tg, tb
+                );
+            }
+            else if (!game.gpmenu_confirming)
+            {
+                font::print_wrap(
+                    PR_CEN | PR_BRIGHTNESS(255 - help.glow*2), -1, 55,
+                    loc::gettext("Press a button...|(or press ↑↓)"),
+                    tr, tg, tb
+                );
+            }
+            else
+            {
+                char expl[SCREEN_WIDTH_CHARS*3 + 1];
+                const char* expl_template;
 
-            SDL_snprintf(buffer_a, sizeof(buffer_a), "%s%s",
-                loc::gettext("Enter is bound to: "),
-                BUTTONGLYPHS_get_all_gamepad_buttons(buffer_b, sizeof(buffer_b), ActionSet_InGame, Action_InGame_Map)
-            );
-            font::print(PR_CEN, -1, 75+spacing, buffer_a, tr, tg, tb);
+                if (game.gpmenu_showremove)
+                {
+                    expl_template = loc::gettext("Remove {button}?|Press again to confirm");
+                }
+                else
+                {
+                    expl_template = loc::gettext("Add {button}?|Press again to confirm");
+                }
 
-            SDL_snprintf(buffer_a, sizeof(buffer_a), "%s%s",
-                loc::gettext("Menu is bound to: "),
-                BUTTONGLYPHS_get_all_gamepad_buttons(buffer_b, sizeof(buffer_b), ActionSet_InGame, Action_InGame_Esc)
-            );
-            font::print(PR_CEN, -1, 75+spacing*2, buffer_a, tr, tg, tb);
+                vformat_buf(
+                    expl, sizeof(expl),
+                    expl_template,
+                    "button:str",
+                    BUTTONGLYPHS_sdlbutton_to_glyph(game.gpmenu_lastbutton)
+                );
 
-            SDL_snprintf(buffer_a, sizeof(buffer_a), "%s%s",
-                loc::gettext("Restart is bound to: "),
-                BUTTONGLYPHS_get_all_gamepad_buttons(buffer_b, sizeof(buffer_b), ActionSet_InGame, Action_InGame_Restart)
-            );
-            font::print(PR_CEN, -1, 75+spacing*3, buffer_a, tr, tg, tb);
+                font::print_wrap(PR_CEN, -1, 55, expl, tr, tg, tb);
+            }
 
-            SDL_snprintf(buffer_a, sizeof(buffer_a), "%s%s",
-                loc::gettext("Interact is bound to: "),
-                BUTTONGLYPHS_get_all_gamepad_buttons(buffer_b, sizeof(buffer_b), ActionSet_InGame, Action_InGame_Interact)
-            );
-            font::print(PR_CEN | PR_BRIGHTNESS(game.separate_interact ? 255 : 128), -1, 75+spacing*4, buffer_a, tr, tg, tb);
+            for (int bind = 1; bind <= 5; bind++)
+            {
+                char buffer_a[SCREEN_WIDTH_CHARS + 1];
+                char buffer_b[SCREEN_WIDTH_CHARS + 1];
+
+                const char* lbl;
+                ActionSet actionset;
+                int action;
+
+                switch (bind)
+                {
+                case 1:
+                    lbl = loc::gettext("Flip is bound to: ");
+                    actionset = ActionSet_InGame;
+                    action = Action_InGame_ACTION;
+                    break;
+                case 2:
+                    lbl = loc::gettext("Enter is bound to: ");
+                    actionset = ActionSet_InGame;
+                    action = Action_InGame_Map;
+                    break;
+                case 3:
+                    lbl = loc::gettext("Menu is bound to: ");
+                    actionset = ActionSet_InGame;
+                    action = Action_InGame_Esc;
+                    break;
+                case 4:
+                    lbl = loc::gettext("Restart is bound to: ");
+                    actionset = ActionSet_InGame;
+                    action = Action_InGame_Restart;
+                    break;
+                default:
+                    lbl = loc::gettext("Interact is bound to: ");
+                    actionset = ActionSet_InGame;
+                    action = Action_InGame_Interact;
+                }
+
+                SDL_snprintf(
+                    buffer_a, sizeof(buffer_a), "%s%s", lbl,
+                    BUTTONGLYPHS_get_all_gamepad_buttons(buffer_b, sizeof(buffer_b), actionset, action)
+                );
+
+                int brightness = 255;
+                if (bind == 5 && !game.separate_interact)
+                {
+                    brightness = 128;
+                }
+                else if (game.gpmenu_confirming && game.currentmenuoption == bind)
+                {
+                    brightness = 255 - help.glow*2;
+                }
+
+                font::print(
+                    PR_CEN | PR_BRIGHTNESS(brightness),
+                    -1, 85 + (spacing * (bind-1)),
+                    buffer_a,
+                    tr, tg, tb
+                );
+            }
+
             break;
         }
         }


### PR DESCRIPTION
## Changes:

This makes the following improvements to the gamepad bindings menu:

- The menu now shows a hint that you can press a button while any of the bind options are selected (or that you can navigate away from those options)
- Instead of button presses immediately setting a binding, they now ask for confirmation: press the same button a second time to confirm
- You can now remove a binding, the same way you add it (this has the same type of confirmation)
- This menu used to be inconsistent with pretty much every other menu in the game by showing a permanent title and description for the menu itself ("Game Pad", "Change controller options.") rather than showing a title and description for the currently selected option. This inconsistency is now fixed.

Demo video:

https://github.com/user-attachments/assets/9a52d350-1905-492b-860e-010a019d201f

(Terry agreed a 2.4 backport would be a good idea, see also https://github.com/TerryCavanagh/VVVVVV/pull/1228#issuecomment-2800021061)


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
