### PR TITLE
Add sound(x), simplified version of internal command playef(x)

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -3437,6 +3437,10 @@ bool scriptclass::loadcustom(const std::string& t)
                 }else { tstring="play("+words[1]+")"; }
             }
             add(tstring);
+        }else if(words[0] == "sound") {
+            if(customtextmode==1){ add("endtext"); customtextmode=0;}
+            tstring="playef("+words[1]+")";
+            add(tstring);
         }else if(words[0] == "playremix"){
             add("play(15)");
         }else if(words[0] == "flash"){


### PR DESCRIPTION
## Changes:

Simplified scripting should now recognize sound(x) as a function with the same effect as playef(x).


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
