### PR TITLE
Fix "invalid" activity zones not spawning

### DIFF
--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -4011,7 +4011,11 @@ int entityclass::getcrewman(int t)
         }
     }
 
-    return -1;
+    // Return entity 0 as a fallback
+    // Unfortunately some levels rely on this, where targeting a non-existent crewman returns the first entity...
+    // Which, most of the time, is the player.
+
+    return 0;
 }
 
 int entityclass::getcustomcrewman(int t)


### PR DESCRIPTION
## Changes:

There's a problem in #1224 where it breaks spawning custom activity zones. After a bit of confusion after this was reported, I realized that I removed the fallback from `getcrewman` and changed the return value to `-1` if the entity isn't found, to avoid returning the wrong entity (entity 0, aka probably the player).

Unfortunately, it seems like a ton of levels (including my older ones) rely on this behavior.

Creating custom activity zones is a long process which uses a bunch of unintended behaviour, which includes targeting a crewmate with color
35. With the change I mentioned earlier, the `getcrewman` function would return `-1` instead, which was out of bounds of the entity array, so the game avoided spawning the activity zone at all. The prior behaviour of falling back to entity 0 (most likely the player) would spawn the activity zone around the player instead.

Nowadays, I try to spawn a crewmate with color 35 anyways so I can control where the box spawns (instead of on the player always), however most people don't (and haven't) so reverting this change seems best for now.

If we wanted to reintroduce the `-1` fallback in the future, things that call `getcrewman` would have to check for `-1` and use `0` instead, but that would require a lot more testing and studying where it's used, and I'd rather squash this bug quickly and worry about cleanliness later.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
