### PR TITLE
Fix uncommon division-by-zero

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3536,12 +3536,15 @@ void Graphics::get_stretch_info(SDL_Rect* rect)
         break;
     default:
         SDL_assert(0 && "Invalid scaling mode!");
-        /* Width and height should be nonzero to avoid division by zero. */
         rect->x = 0;
         rect->y = 0;
         rect->w = width;
         rect->h = height;
     }
+
+    // In case anything accidentally set the width/height to 0, we'll clamp it to avoid crashing from a division by 0
+    rect->w = SDL_max(1, rect->w);
+    rect->h = SDL_max(1, rect->h);
 }
 
 void Graphics::render(void)


### PR DESCRIPTION
## Changes:

Every now and then, the game crashes for me because of a division by zero, due to the rect returned by `Graphics::get_stretch_info`. I don't fully know how the width and height get set to 0, but this should protect against it.

As I always use integer scaling, my guess is that
`Screen::GetScreenSize` (which later calls `SDL_GetRendererOutputSize`) returns 0 sometimes, and the code trusts that -- but I know that windows and things can be finicky, so the clamp is probably a good idea.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
