### PR TITLE
Fix the campaign trinket count missing from stats

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -3198,9 +3198,12 @@ void maprender(void)
         }
 
         /* Stats. */
-        int deaths_pos = (cl.numtrinkets() > 0) ? 102 : 72;
-        int time_pos = (cl.numtrinkets() > 0) ? 152 : 132;
-        if (cl.numtrinkets() > 0)
+
+        // Always show trinkets if you're in the main game, otherwise only show them if any exist in the level
+        bool show_trinkets = map.custommode ? (cl.numtrinkets() > 0) : true;
+        int deaths_pos = show_trinkets ? 102 : 72;
+        int time_pos = show_trinkets ? 152 : 132;
+        if (show_trinkets)
         {
             font::print(PR_CEN | FLIP_PR_CJK_HIGH, -1, FLIP(52, 8), loc::gettext("[Trinkets found]"), 196, 196, 255 - help.glow);
             char buffer[SCREEN_WIDTH_CHARS + 1];


### PR DESCRIPTION
## Changes:

PR #1226 tweaks both the crew and the stats screens. When there's no trinkets in the level, it removes the trinket count from the STATS screen in the menu. This, however, is missing a `custommode` check, meaning that the main game is ALSO missing the trinket count.

This PR fixes that oversight.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
