### PR TITLE
Fix mouse coordinates being wrong on HiDPI displays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
     runs-on: windows-latest
 
     env:
-      SDL_VERSION: 2.24.0
+      SDL_VERSION: 2.26.0
 
     steps:
     - uses: actions/checkout@v1

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -571,8 +571,20 @@ void KeyPoll::Poll(void)
     SDL_Rect rect;
     graphics.get_stretch_info(&rect);
 
-    mousex = (raw_mousex - rect.x) * SCREEN_WIDTH_PIXELS / rect.w;
-    mousey = (raw_mousey - rect.y) * SCREEN_HEIGHT_PIXELS / rect.h;
+    int window_width;
+    int window_height;
+    SDL_GetWindowSizeInPixels(gameScreen.m_window, &window_width, &window_height);
+
+    int scaled_window_width;
+    int scaled_window_height;
+    SDL_GetWindowSize(gameScreen.m_window, &scaled_window_width, &scaled_window_height);
+
+    float scale_x = (float)window_width / (float)scaled_window_width;
+    float scale_y = (float)window_height / (float)scaled_window_height;
+
+    // Use screen stretch information to modify the coordinates (as we implement stretching manually)
+    mousex = ((raw_mousex * scale_x) - rect.x) * SCREEN_WIDTH_PIXELS / rect.w;
+    mousey = ((raw_mousey * scale_y) - rect.y) * SCREEN_HEIGHT_PIXELS / rect.h;
 
     active_input_device_changed = keyboard_was_active != BUTTONGLYPHS_keyboard_is_active();
     should_recompute_textboxes |= active_input_device_changed;


### PR DESCRIPTION
## Changes:

When writing the initial stretch mode code, the existence of HiDPI displays completely slipped my mind -- or at least I didn't realize that they'd be a problem.

We implement scaling modes ourselves, so transforming the mouse coordinates to our 320x240 viewport is done manually. Unfortunately, that code did not take into account HiDPI scaling whatsoever, meaning that all of the math which assumes the window size and the renderer size is wrong.

To fix this, we use `SDL_GetWindowSizeInPixels` and `SDL_GetWindow` to find the scaling factor, and then apply that to the mouse coordinates to get the mouse coordinates in the pixel-space instead, and then we do all of our normal logic after.

Small code style thing: C-style casts without a following space (`(int)var`) was done intentionally here -- I talked to a few other contributors and we agreed that the extra space after the cast (`(int) var`) was unnecessary and annoying, and in the future it should probably be fixed when we're working on code around/near it, like how we treat other inconsistent styling.

**NOTE:** This is marked as a draft, as this is untested code. I use a Windows machine with no easy access to anything else where I can test scaling, so if someone could test the PR and report back, I'll mark this as ready and we can hopefully get this into a 2.4 patch.

**NOTE:** This **bumps the minimum SDL version to 2.26.0**, which adds `SDL_GetWindowSizeInPixels()`!

Closes #1235.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
