### PR TITLE
Update SheenBidi to 2.9.0

### DIFF
--- a/desktop_version/src/FontBidi.cpp
+++ b/desktop_version/src/FontBidi.cpp
@@ -1,6 +1,7 @@
 #include "FontBidi.h"
 
 #include <SDL.h>
+#include <SheenBidi/SheenBidi.h>
 
 #include "Alloc.h"
 #include "UTF8.h"
@@ -8,7 +9,6 @@
 extern "C"
 {
 #include <c-hashmap/map.h>
-#include <SheenBidi.h>
 }
 
 namespace font


### PR DESCRIPTION
## Changes:

This fixes our problem with Valgrind reporting a jump based on an uninitialized value; see https://github.com/Tehreer/SheenBidi/issues/19

Just to be sure nothing unexpected happens, I tested that this doesn't cause any changes in behavior by outputting bidi-transformed versions of all strings in strings.xml to a file for both our Arabic and Persian localizations before and after the update, and confirming that the files are the same.

This might be suitable for a 2.4 backport, but I'll leave that up to Ethan.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
