### PR TITLE
Fix vertical position of Comms Relay textbox

### DIFF
--- a/desktop_version/src/Graphics.cpp
+++ b/desktop_version/src/Graphics.cpp
@@ -3402,6 +3402,7 @@ static void commsrelay_textbox(textboxclass* THIS)
     THIS->wrap(11);
     THIS->resize();
     THIS->xp = 224 - THIS->w;
+    THIS->yp = 32 - THIS->h/2;
 }
 
 void Graphics::textboxcommsrelay(const char* text)


### PR DESCRIPTION
## Changes:

Fixes #1242.

Turns out it was a really simple fix - the X positions were good, but the Y positions were always at the top of the screen regardless of the height of the textbox. Now they're vertically centered respective to the speaker.

(Requesting a 2.4 backport since it's a minor fix to what's technically a 2.4 regression)

![Image](https://github.com/user-attachments/assets/f7a0dc3c-fd89-4db4-9f70-f4e552341f0b)



## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
