### PR TITLE
Fix TARGET_OS_IPHONE checks

### DIFF
--- a/desktop_version/src/ButtonGlyphs.cpp
+++ b/desktop_version/src/ButtonGlyphs.cpp
@@ -178,7 +178,7 @@ bool BUTTONGLYPHS_keyboard_is_available(void)
         return true;
     }
 
-#if defined(__ANDROID__) || defined(TARGET_OS_IPHONE)
+#if defined(__ANDROID__) || TARGET_OS_IPHONE
     return false;
 #else
     return !SDL_GetHintBoolean("SteamDeck", SDL_FALSE);

--- a/desktop_version/src/FileSystemUtils.cpp
+++ b/desktop_version/src/FileSystemUtils.cpp
@@ -1331,7 +1331,7 @@ static int PLATFORM_getOSDirectory(char* output, const size_t output_size)
     }
     SDL_snprintf(output, output_size, "%s/", externalStoragePath);
     return 1;
-#elif defined(TARGET_OS_IPHONE)
+#elif TARGET_OS_IPHONE
     // (ab)use SDL APIs to get the path to the Documents folder without needing Objective-C
     const char* prefsPath = SDL_GetPrefPath("", "");
     if (prefsPath == NULL)

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -381,7 +381,7 @@ void Game::init(void)
     screenshot_border_timer = 0;
     screenshot_saved_success = false;
 
-#if defined(__ANDROID__) || defined(TARGET_OS_IPHONE)
+#if defined(__ANDROID__) || TARGET_OS_IPHONE
     checkpoint_saving = true;
 #else
     checkpoint_saving = false;

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -383,7 +383,7 @@ bool Screen::isForcedFullscreen(void)
      * If you're working on a tenfoot-only build, add a def that always
      * returns true!
      */
-#if defined(__ANDROID__) || defined(TARGET_OS_IPHONE)
+#if defined(__ANDROID__) || TARGET_OS_IPHONE
     return true;
 #else
     return SDL_GetHintBoolean("SteamTenfoot", SDL_FALSE);

--- a/desktop_version/src/Vlogging.c
+++ b/desktop_version/src/Vlogging.c
@@ -3,7 +3,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if defined(__ANDROID__) || defined(TARGET_OS_IPHONE)
+#if defined(__ANDROID__) || TARGET_OS_IPHONE
 // forward to SDL logging on Android, since stdout/stderr are /dev/null
 // they exist on iOS, but just get forwarded to the system log anyway, so might as well provide proper metadata
 #define VLOG_USE_SDL 1


### PR DESCRIPTION
## Changes:

SDL will define this variable to 0 on non-iOS targets. I'm not sure how this didn't cause any issues until I was working on some macOS changes just now?


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
