### PR TITLE
Add `everybodyhappy`

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1982,6 +1982,16 @@ void scriptclass::run(void)
                     }
                 }
             }
+            else if (words[0] == "everybodyhappy")
+            {
+                for (i = 0; i < (int) obj.entities.size(); i++)
+                {
+                    if (obj.entities[i].rule == 6 || obj.entities[i].rule == 0)
+                    {
+                        obj.entities[i].tile = 0;
+                    }
+                }
+            }
             else if (words[0] == "startintermission2")
             {
                 map.finalmode = true; //Enable final level mode


### PR DESCRIPTION
Works the same as `everybodysad`, but changes tile to 0 instead.

## Changes:

This PR adds a new internal command `everybodyhappy`. This acts as a counterpart to `everybodysad`, setting the tile of the player and crewmates to 0. Like with `everybodysad`, this does not work with recruitable crewmates.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
