### PR TITLE
Remove strange entity-wrapping code

### DIFF
--- a/desktop_version/src/Logic.cpp
+++ b/desktop_version/src/Logic.cpp
@@ -1125,41 +1125,6 @@ void gamelogic(void)
             }
         }
 
-        if (map.warpy && !map.warpx && !map.towermode)
-        {
-            size_t i;
-            for (i = 0; i < obj.entities.size(); ++i)
-            {
-                if ((obj.entities[i].type == EntityType_WARP_LINE_LEFT
-                    || obj.entities[i].type == EntityType_WARP_LINE_RIGHT
-                    || obj.entities[i].type == EntityType_WARP_LINE_TOP
-                    || obj.entities[i].type == EntityType_WARP_LINE_BOTTOM) /* Don't warp warp lines */
-                    || obj.entities[i].rule == 0) /* Don't warp the player */
-                {
-                    continue;
-                }
-
-                if (obj.entities[i].xp <= -30)
-                {
-                    if (obj.entities[i].isplatform)
-                    {
-                        obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp + 350, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
-                    }
-                    obj.entities[i].xp += 350;
-                    obj.entities[i].lerpoldxp += 350;
-                }
-                else if (obj.entities[i].xp > 320)
-                {
-                    if (obj.entities[i].isplatform)
-                    {
-                        obj.moveblockto(obj.entities[i].xp, obj.entities[i].yp, obj.entities[i].xp - 350, obj.entities[i].yp, obj.entities[i].w, obj.entities[i].h);
-                    }
-                    obj.entities[i].xp -= 350;
-                    obj.entities[i].lerpoldxp -= 350;
-                }
-            }
-        }
-
         if (!map.warpy && !map.towermode)
         {
             //Normal! Just change room


### PR DESCRIPTION
## Changes:

This removes a block of code that checks for specifically vertical screenwrap, and then does horizontal entity wrapping. Under normal circumstances, this code is never reached, because entity bounds aren't expanded in the x-direction if horizontal wrapping is disabled.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
