### PR TITLE
Fix two-frame script delay when respawning

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -785,12 +785,15 @@ void mapclass::resetplayer(void)
 void mapclass::resetplayer(const bool player_died)
 {
     bool was_in_tower = towermode;
+
+    game.deathseq = -1;
+
     if (game.roomx != game.saverx || game.roomy != game.savery)
     {
         gotoroom(game.saverx, game.savery);
+        twoframedelayfix();
     }
 
-    game.deathseq = -1;
     int i = obj.getplayer();
     if(INBOUNDS_VEC(i, obj.entities))
     {


### PR DESCRIPTION
## Changes:

At some point, there was some "kludge" added to the game which allowed script boxes to immediately get triggered when you enter a room, rather than the update order unfortunately causing scripts to trigger after two frames.

For some reason, dying and respawning in a room does not have the same fix, causing really bad inconsistencies for anything that needs precise timing.

Despite the initial implementation of the kludge being somewhat careless and breaking levels which relied on timing, this one should not break anything, but in fact fix things, surprisingly.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
