### PR TITLE
Correctly calculate FAudio block alignment

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -137,7 +137,7 @@ public:
         format.nSamplesPerSec = spec.freq;
         format.wFormatTag = FAUDIO_FORMAT_PCM;
         format.wBitsPerSample = SDL_AUDIO_BITSIZE(spec.format);
-        format.nBlockAlign = format.nChannels * format.wBitsPerSample;
+        format.nBlockAlign = format.nChannels * (format.wBitsPerSample / 8);
         format.nAvgBytesPerSec = format.nSamplesPerSec * format.nBlockAlign;
         format.cbSize = 0;
         valid = true;
@@ -161,7 +161,7 @@ end:
         format.wBitsPerSample = sizeof(float) * 8;
         format.nChannels = vorbis_info.channels;
         format.nSamplesPerSec = vorbis_info.sample_rate;
-        format.nBlockAlign = format.nChannels * format.wBitsPerSample;
+        format.nBlockAlign = format.nChannels * (format.wBitsPerSample / 8);
         format.nAvgBytesPerSec = format.nSamplesPerSec * format.nBlockAlign;
         format.cbSize = 0;
 
@@ -214,7 +214,7 @@ end:
                 }
                 FAudioBuffer faudio_buffer = {
                     FAUDIO_END_OF_STREAM, /* Flags */
-                    wav_length * 8, /* AudioBytes */
+                    wav_length, /* AudioBytes */
                     wav_buffer, /* AudioData */
                     0, /* playbegin */
                     0, /* playlength */
@@ -266,7 +266,7 @@ end:
                 format.nSamplesPerSec = audio_rate;
                 format.wFormatTag = FAUDIO_FORMAT_PCM;
                 format.wBitsPerSample = 16;
-                format.nBlockAlign = format.nChannels * format.wBitsPerSample;
+                format.nBlockAlign = format.nChannels * (format.wBitsPerSample / 8);
                 format.nAvgBytesPerSec = format.nSamplesPerSec * format.nBlockAlign;
                 format.cbSize = 0;
                 voice_formats[i] = format;
@@ -399,7 +399,7 @@ public:
         format.wBitsPerSample = sizeof(float) * 8;
         format.nChannels = vorbis_info.channels;
         format.nSamplesPerSec = vorbis_info.sample_rate;
-        format.nBlockAlign = format.nChannels * format.wBitsPerSample;
+        format.nBlockAlign = format.nChannels * (format.wBitsPerSample / 8);
         format.nAvgBytesPerSec = format.nSamplesPerSec * format.nBlockAlign;
         format.cbSize = 0;
 


### PR DESCRIPTION
## Changes:

This fixes music playback on FAudio 26.01.

FAudio 26.01 added bounds checks to FAudioSourceVoice_SubmitSourceBuffer in [033498ab08f5a1349ed5723a47aaa87163654be6](https://github.com/FNA-XNA/FAudio/commit/033498ab08f5a1349ed5723a47aaa87163654be6).

The calculation of nBlockAlign is currently incorrect. nBlockAlign is set to the block size in bits, not in bytes, causing this new bounds check to trip.

Similarly, the wav_length for sound effects is in bytes.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
