### PR TITLE
Add statedelay argument to `gamestate` command

### DIFF
--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1346,7 +1346,14 @@ void scriptclass::run(void)
             {
                 // Allow the gamestate command to bypass statelock, at least for now
                 game.state = ss_toi(words[1]);
-                game.statedelay = 0;
+                if (argexists[2])
+                {
+                    game.statedelay = ss_toi(words[2]);
+                }
+                else
+                {
+                    game.statedelay = 0;
+                }
             }
             else if (words[0] == "textboxactive")
             {


### PR DESCRIPTION
## Changes:

The `gamestate` command has an argument to set the gamestate, but the statedelay was always set to 0, despite the statedelay being an important part of the gamestate system. This commit adds an optional argument to set the statedelay.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
