### PR TITLE
Solve render recaching issues [NEEDS BACKPORT]

### DIFF
--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -3625,7 +3625,6 @@ void editorinput(void)
                 if (game.currentmenuname == Menu::ed_settings)
                 {
                     ed.state = EditorState_DRAW;
-                    gameScreen.recacheTextures();
                 }
                 else
                 {

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -7926,7 +7926,6 @@ void Game::mapmenuchange(const enum GameGamestate newgamestate, const bool user_
     gamestate = newgamestate;
     graphics.resumegamemode = false;
     mapheld = true;
-    gameScreen.recacheTextures();
 
     if (prevgamestate == GAMEMODE)
     {

--- a/desktop_version/src/KeyPoll.cpp
+++ b/desktop_version/src/KeyPoll.cpp
@@ -459,6 +459,10 @@ void KeyPoll::Poll(void)
             break;
         }
 
+        case SDL_RENDER_TARGETS_RESET:
+            gameScreen.recacheTextures();
+            break;
+
         /* Window Events */
         case SDL_WINDOWEVENT:
             switch (evt.window.event)
@@ -496,7 +500,6 @@ void KeyPoll::Poll(void)
                     }
                 }
                 SDL_DisableScreenSaver();
-                gameScreen.recacheTextures();
                 break;
             case SDL_WINDOWEVENT_FOCUS_LOST:
                 if (!game.disablepause)

--- a/desktop_version/src/Screen.cpp
+++ b/desktop_version/src/Screen.cpp
@@ -5,6 +5,8 @@
 
 #include "Alloc.h"
 #include "Constants.h"
+#include "CustomLevels.h"
+#include "Enums.h"
 #include "Exit.h"
 #include "FileSystemUtils.h"
 #include "Game.h"
@@ -14,6 +16,7 @@
 #include "GraphicsResources.h"
 #endif
 #include "InterimVersion.h"
+#include "Map.h"
 #include "Render.h"
 #include "Vlogging.h"
 
@@ -152,7 +155,6 @@ void Screen::ResizeScreen(int x, int y)
     if (!isWindowed || isForcedFullscreen())
     {
         int result = SDL_SetWindowFullscreen(m_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
-        recacheTextures();
         if (result != 0)
         {
             vlog_error("Error: could not set the game to fullscreen mode: %s", SDL_GetError());
@@ -175,7 +177,6 @@ void Screen::ResizeScreen(int x, int y)
                 SDL_WINDOWPOS_CENTERED_DISPLAY(windowDisplay)
             );
         }
-        recacheTextures();
     }
 }
 
@@ -352,8 +353,6 @@ void Screen::toggleVSync(void)
 {
     vsync = !vsync;
     SDL_RenderSetVSync(m_renderer, (int) vsync);
-
-    recacheTextures();
 }
 
 void Screen::recacheTextures(void)
@@ -366,14 +365,20 @@ void Screen::recacheTextures(void)
     graphics.towerbg.tdrawback = true;
     graphics.titlebg.tdrawback = true;
 
-    if (game.ingame_titlemode)
+    if (game.gamestate == MAPMODE || game.ingame_titlemode)
     {
-        // Redraw the cached gameplay texture if we're in the in-game menu.
+        // Redraw the cached gameplay texture if we're in the map screen.
         // Additionally, reset alpha so things don't jitter when re-entering gameplay.
         float oldAlpha = graphics.alpha;
         graphics.alpha = 0;
         gamerender();
         graphics.alpha = oldAlpha;
+    }
+
+    if (map.custommode)
+    {
+        // If we're in a custom level, regenerate the minimap, which also got cleared.
+        cl.generatecustomminimap();
     }
 }
 


### PR DESCRIPTION
## Changes:

Past solutions were just "recache the screen textures under these known circumstances" where whenever things OUTSIDE of those known circumstances happened, the issue would reoccur.

I recently learned about an SDL event, `SDL_RENDER_TARGETS_RESET`, which is for this exact problem. I ripped out all of the other places `Screen::recacheTextures()` was called, and just slotted it in there, and it worked perfectly.

...well, the old behavior worked perfectly; but the old behavior was flawed as well, because it only checked for "ingame_titlemode" (if you're in the main menu during gameplay) and forgot to check for the map screen... plus, it didn't ever regenerate the minimap in custom levels, which is another "persistant" render target.

Hopefully, this is the last time we'll ever have to think about this one. I'm certainly sick of it.

This should 100% be backported into 2.4, as the bug occurs there as well. (The commit shouldn't conflict if cherry-picked into `2.4-updates`.)

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
