### PR TITLE
Clamp editor mouse coordinates [NEEDS BACKPORT]

### DIFF
--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -3206,8 +3206,8 @@ void editorinput(void)
     ed.old_tilex = ed.tilex;
     ed.old_tiley = ed.tiley;
 
-    ed.tilex = key.mousex / 8;
-    ed.tiley = key.mousey / 8;
+    ed.tilex = SDL_clamp(key.mousex, 0, SCREEN_WIDTH_PIXELS - 1) / 8;
+    ed.tiley = SDL_clamp(key.mousey, 0, SCREEN_HEIGHT_PIXELS - 1) / 8;
 
     bool up_pressed = key.isDown(SDLK_UP) || key.isDown(SDL_CONTROLLER_BUTTON_DPAD_UP);
     bool down_pressed = key.isDown(SDLK_DOWN) || key.isDown(SDL_CONTROLLER_BUTTON_DPAD_DOWN);


### PR DESCRIPTION
## Changes:

The editor has never clamped mouse bounds, and instead relied on SDL to return clamped mouse coordinates. Unfortunately, in #1140, this detail was missed, and the behavior changed, allowing the cursor to leave the bounds of the screen.

This isn't much of a problem most of the time because anything that uses position as array indeces has bounds checks. Unfortunately, placing entities outside of a room's bounds leads to entities you can't ever touch ever again without modifying the level externally. This is the worst with checkpoints, as pressing Enter in a room will now take you to the out-of-bounds checkpoint, causing you to immediately wrap to another room.

This fix should be backported to 2.4, as the issue can lead to level files which need manual editing to fix!

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
