### PR TITLE
Fix audio buffer issues on some platforms

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -745,7 +745,7 @@ static void add_builtin_sound(const char* id)
 
 void musicclass::init(void)
 {
-    if (FAudioCreate(&faudioctx, 0, FAUDIO_DEFAULT_PROCESSOR))
+    if (FAudioCreate(&faudioctx, FAUDIO_1024_QUANTUM, FAUDIO_DEFAULT_PROCESSOR))
     {
         vlog_error("Unable to initialize FAudio");
         return;


### PR DESCRIPTION
## Changes:

On certain ports of the game, and possibly some Linux distros, the game's audio would crackle, or slow down with loud buzzing. This commit attempts to fix that, by enabling `FAUDIO_1024_QUANTUM`, which should increase the internal FAudio buffer size.

This could possibly be backported to 2.4, but I'm not sure how urgent it is. It's a shame we didn't fit this into the most recent backport version a few days ago... On the other hand, a new backport version could allow us to look into the font segfault that we completely forgot about. Either way, that's not relevant for this PR.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
