### PR TITLE
Add edentity blocks & associated script commands

### DIFF
--- a/desktop_version/src/BlockV.h
+++ b/desktop_version/src/BlockV.h
@@ -5,6 +5,12 @@
 #include <stdint.h>
 #include <string>
 
+struct ActivityZone
+{
+    std::string colour;
+    std::string text;
+};
+
 class blockclass
 {
 public:

--- a/desktop_version/src/CustomLevels.cpp
+++ b/desktop_version/src/CustomLevels.cpp
@@ -7,6 +7,7 @@
 #include <tinyxml2.h>
 
 #include "Alloc.h"
+#include "BlockV.h"
 #include "Constants.h"
 #include "Editor.h"
 #include "Enums.h"
@@ -406,6 +407,8 @@ void customlevelclass::reset(void)
     map.specialroomnames.clear();
 
     player_colour = 0;
+
+    custom_activity_zones.clear();
 }
 
 const int* customlevelclass::loadlevel( int rxi, int ryi )
@@ -1429,6 +1432,49 @@ next:
         {
             player_colour = help.Int(pText);
             game.savecolour = player_colour;
+        }
+
+        if (SDL_strcmp(pKey, "ActivityZones") == 0)
+        {
+            for (tinyxml2::XMLElement* activityZoneElement = pElem->FirstChildElement(); activityZoneElement; activityZoneElement = activityZoneElement->NextSiblingElement())
+            {
+                if (SDL_strcmp(activityZoneElement->Value(), "activityZone") == 0)
+                {
+                    int id = -1;
+
+                    activityZoneElement->QueryIntAttribute("id", &id);
+
+                    if (id < 0)
+                    {
+                        continue;
+                    }
+
+                    const char* colour = activityZoneElement->Attribute("colour");
+                    const char* text = activityZoneElement->GetText();
+
+                    ActivityZone zone;
+
+                    if (colour != NULL)
+                    {
+                        zone.colour = std::string(colour);
+                    }
+                    else
+                    {
+                        zone.colour = "";
+                    }
+
+                    if (text != NULL)
+                    {
+                        zone.text = std::string(text);
+                    }
+                    else
+                    {
+                        zone.text = "";
+                    }
+
+                    custom_activity_zones[id] = zone;
+                }
+            }
         }
     }
 

--- a/desktop_version/src/CustomLevels.h
+++ b/desktop_version/src/CustomLevels.h
@@ -1,9 +1,12 @@
 #ifndef CUSTOMLEVELS_H
 #define CUSTOMLEVELS_H
 
+#include <map>
 #include <SDL.h>
 #include <string>
 #include <vector>
+
+#include "BlockV.h"
 
 class CustomEntity
 {
@@ -172,6 +175,8 @@ public:
     bool onewaycol_override;
 
     int player_colour;
+
+    std::map<int, ActivityZone> custom_activity_zones;
 };
 
 bool translate_title(const std::string& title);

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -1117,6 +1117,73 @@ static void draw_entities(void)
                     font::print(PR_FONT_LEVEL | PR_BOR | PR_CJK_HIGH, x, y - 8, entity->scriptname, 210, 210, 255);
                 }
                 break;
+            case 20: // Activity Zones
+                graphics.draw_rect(x, y, entity->p1 * 8, entity->p2 * 8, graphics.getRGB(164, 164, 255));
+                graphics.draw_rect(x, y, 8, 8, graphics.getRGB(255, 255, 255));
+                if (i == edent_under_cursor)
+                {
+                    font::print(PR_FONT_LEVEL | PR_BOR | PR_CJK_HIGH, x, y - 8, entity->scriptname, 210, 210, 255);
+                }
+                break;
+            case 21: // Collision Boxes
+                graphics.draw_rect(x, y, entity->p1 * 8, entity->p2 * 8, graphics.getRGB(255, 255, 255));
+                graphics.draw_rect(x, y, 8, 8, graphics.getRGB(255, 255, 255));
+                break;
+            case 22: // Damage Boxes
+            {
+                int skull_x = x + (entity->p1 - 1) * 4;
+                int skull_y = y + (entity->p2 - 1) * 4;
+
+                font::print(PR_FONT_8X8 | PR_BOR, skull_x, skull_y, "\xE2\x98\xA0", 255, 192, 192);
+
+                graphics.draw_rect(x, y, entity->p1 * 8, entity->p2 * 8, graphics.getRGB(255, 164, 164));
+                graphics.draw_rect(x, y, 8, 8, graphics.getRGB(255, 255, 255));
+                break;
+            }
+            case 23: // Directional Boxes
+            {
+                // Move x and y to the center of the box
+                int arrow_x = x + (entity->p1 - 1) * 4;
+                int arrow_y = y + (entity->p2 - 1) * 4;
+
+                if (customentities[i].p3 == 0)
+                {
+                    // UP ARROW
+                    font::print(PR_FONT_8X8 | PR_BOR, arrow_x, arrow_y, "\xE2\x86\x91", 255, 255, 255);
+                }
+                else if (customentities[i].p3 == 1)
+                {
+                    // DOWN ARROW
+                    font::print(PR_FONT_8X8 | PR_BOR, arrow_x, arrow_y, "\xE2\x86\x93", 255, 255, 255);
+                }
+                else if (customentities[i].p3 == 2)
+                {
+                    // LEFT ARROW
+                    font::print(PR_FONT_8X8 | PR_BOR, arrow_x, arrow_y, "\xE2\x86\x90", 255, 255, 255);
+                }
+                else if (customentities[i].p3 == 3)
+                {
+                    // RIGHT ARROW
+                    font::print(PR_FONT_8X8 | PR_BOR, arrow_x, arrow_y, "\xE2\x86\x92", 255, 255, 255);
+                }
+                graphics.draw_rect(x, y, entity->p1 * 8, entity->p2 * 8, graphics.getRGB(255, 255, 164));
+                break;
+            }
+            case 24: // Safe Boxes
+                graphics.draw_rect(x, y, entity->p1 * 8, entity->p2 * 8, graphics.getRGB(164, 255, 255));
+                graphics.draw_rect(x, y, 8, 8, graphics.getRGB(255, 255, 255));
+                break;
+            case 25: // Gamestate Triggers
+            {
+                graphics.draw_rect(x, y, entity->p1 * 8, entity->p2 * 8, graphics.getRGB(164, 255, 164));
+                graphics.draw_rect(x, y, 8, 8, graphics.getRGB(255, 255, 255));
+
+                int arrow_x = x + (entity->p1 - 1) * 4;
+                int arrow_y = y + (entity->p2 - 1) * 4;
+
+                font::print(PR_FONT_LEVEL | PR_BOR | PR_CJK_HIGH, arrow_x, arrow_y, help.String(entity->p3), 255, 255, 255);
+                break;
+            }
             case 50: // Warp Lines
                 if (entity->p1 >= 2) // Horizontal
                 {

--- a/desktop_version/src/Entity.cpp
+++ b/desktop_version/src/Entity.cpp
@@ -3,6 +3,7 @@
 
 #include <SDL.h>
 
+#include "BlockV.h"
 #include "CustomLevels.h"
 #include "Font.h"
 #include "Game.h"
@@ -776,7 +777,7 @@ void entityclass::generateswnwave( int t )
     }
 }
 
-void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*= 0*/, const std::string& script /*= ""*/, bool custom /*= false*/)
+void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*= 0*/, const std::string& script /*= ""*/, ActivityContext context /*= ActivityContext_NORMAL*/)
 {
     k = blocks.size();
 
@@ -852,6 +853,8 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
         block.wp = w;
         block.hp = h;
         block.rectset(xp, yp, w, h);
+
+        int original_trig = trig;
 
         //Ok, each and every activity zone in the game is initilised here. "Trig" in this case is a variable that
         //assigns all the details.
@@ -1068,7 +1071,7 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
             trig=0;
             break;
         case 35:
-            if (custom)
+            if (context != ActivityContext_NORMAL)
             {
                 block.prompt = "Press {button} to interact";
             }
@@ -1076,39 +1079,65 @@ void entityclass::createblock( int t, int xp, int yp, int w, int h, int trig /*=
             {
                 block.prompt = "Press {button} to activate terminal";
             }
-            block.script = "custom_"+customscript;
+            block.script = "custom_" + customscript;
             block.setblockcolour("orange");
             trig=0;
             break;
+        default:
+            block.script = "custom_" + customscript;
+            block.prompt = "Press {button} to interact";
+            block.setblockcolour("orange");
+            break;
         }
-        break;
-    }
 
-    if (customactivitytext != "")
-    {
-        block.prompt = customactivitytext;
-        block.gettext = false;
-        customactivitytext = "";
-    }
-    else
-    {
         block.gettext = true;
-    }
 
-    if (customactivitycolour != "")
-    {
-        block.setblockcolour(customactivitycolour.c_str());
-        customactivitycolour = "";
-    }
+        if (context == ActivityContext_CUSTOM)
+        {
+            block.script = "custom_" + customscript;
+        }
 
-    if (customactivitypositiony != -1)
-    {
-        block.activity_y = customactivitypositiony;
-        customactivitypositiony = -1;
-    }
-    else
-    {
-        block.activity_y = 0;
+        // Handle custom-defined activity zones
+        if (cl.custom_activity_zones.count(original_trig) > 0)
+        {
+            ActivityZone zone = cl.custom_activity_zones[original_trig];
+
+            if (zone.colour != "")
+            {
+                block.setblockcolour(zone.colour.c_str());
+            }
+
+            if (zone.text != "")
+            {
+                block.prompt = zone.text;
+                block.gettext = false;
+            }
+        }
+
+        if (customactivitytext != "")
+        {
+            block.prompt = customactivitytext;
+            block.gettext = false;
+            customactivitytext = "";
+        }
+
+        if (customactivitycolour != "")
+        {
+            block.setblockcolour(customactivitycolour.c_str());
+            customactivitycolour = "";
+        }
+
+        if (customactivitypositiony != -1)
+        {
+            block.activity_y = customactivitypositiony;
+            customactivitypositiony = -1;
+        }
+        else
+        {
+            block.activity_y = 0;
+        }
+
+        break;
     }
 
     if (!reuse)

--- a/desktop_version/src/Entity.h
+++ b/desktop_version/src/Entity.h
@@ -20,6 +20,13 @@ enum
     ACTIVITY = 5
 };
 
+enum ActivityContext
+{
+    ActivityContext_NORMAL = 0,
+    ActivityContext_INTERACT = 1,
+    ActivityContext_CUSTOM = 2
+};
+
 class entityclass
 {
 public:
@@ -52,7 +59,7 @@ public:
 
     void generateswnwave(int t);
 
-    void createblock(int t, int xp, int yp, int w, int h, int trig = 0, const std::string& script = "", bool custom = false);
+    void createblock(int t, int xp, int yp, int w, int h, int trig = 0, const std::string& script = "", ActivityContext context = ActivityContext_NORMAL);
 
     bool disableentity(int t);
 

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -90,6 +90,8 @@ mapclass::mapclass(void)
 
     currentregion = 0;
     SDL_zeroa(region);
+
+    tempscriptbox = 0;
 }
 
 static char roomname_static[SCREEN_WIDTH_CHARS];
@@ -1809,7 +1811,9 @@ void mapclass::loadlevel(int rx, int ry)
 
         // Entities have to be created HERE, akwardly
         int tempcheckpoints = 0;
-        int tempscriptbox = 0;
+
+        tempscriptbox = 0;
+
         for (size_t edi = 0; edi < customentities.size(); edi++)
         {
             // If entity is in this room, create it
@@ -1947,6 +1951,25 @@ void mapclass::loadlevel(int rx, int ry)
                 }
                 obj.createblock(TRIGGER, ex, ey, ent.p1 * 8, ent.p2 * 8, 300 + tempscriptbox, "custom_" + ent.scriptname);
                 tempscriptbox++;
+                break;
+            case 20: // Activity Zone
+                obj.customscript = ent.scriptname;
+                obj.createblock(ACTIVITY, ex, ey, ent.p1 * 8, ent.p2 * 8, ent.p3, "custom_" + ent.scriptname, ActivityContext_CUSTOM);
+                break;
+            case 21: // Collision Box
+                obj.createblock(BLOCK, ex, ey, ent.p1 * 8, ent.p2 * 8);
+                break;
+            case 22: // Damage Box
+                obj.createblock(DAMAGE, ex, ey, ent.p1 * 8, ent.p2 * 8);
+                break;
+            case 23: // Directional Box
+                obj.createblock(DIRECTIONAL, ex, ey, ent.p1 * 8, ent.p2 * 8, ent.p3);
+                break;
+            case 24: // Safe Box
+                obj.createblock(SAFE, ex, ey, ent.p1 * 8, ent.p2 * 8);
+                break;
+            case 25: // Trigger
+                obj.createblock(TRIGGER, ex, ey, ent.p1 * 8, ent.p2 * 8, ent.p3);
                 break;
             case 50: // Warp Lines
                 obj.customwarpmode=true;

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -230,6 +230,8 @@ public:
     int regionwidth, regionheight;
 
     MapRenderData get_render_data(void);
+
+    int tempscriptbox;
 };
 
 #ifndef MAP_DEFINITION

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -1032,6 +1032,47 @@ void scriptclass::run(void)
                 words[8] = word8;
                 words[9] = word9;
             }
+            else if (words[0] == "createcollision")
+            {
+                obj.createblock(BLOCK, ss_toi(words[1]), ss_toi(words[2]), ss_toi(words[3]), ss_toi(words[4]));
+            }
+            else if (words[0] == "createtrigger")
+            {
+                obj.createblock(TRIGGER, ss_toi(words[1]), ss_toi(words[2]), ss_toi(words[3]), ss_toi(words[4]), ss_toi(words[5]));
+            }
+            else if (words[0] == "createscript")
+            {
+                if (INBOUNDS_ARR(map.tempscriptbox, game.customscript))
+                {
+                    game.customscript[map.tempscriptbox] = words[5];
+                }
+
+                obj.createblock(TRIGGER, ss_toi(words[1]), ss_toi(words[2]), ss_toi(words[3]), ss_toi(words[4]), 300 + map.tempscriptbox, "custom_" + words[5]);
+                map.tempscriptbox++;
+            }
+            else if (words[0] == "createdamage")
+            {
+                obj.createblock(DAMAGE, ss_toi(words[1]), ss_toi(words[2]), ss_toi(words[3]), ss_toi(words[4]));
+            }
+            else if (words[0] == "createdirectional")
+            {
+                obj.createblock(DIRECTIONAL, ss_toi(words[1]), ss_toi(words[2]), ss_toi(words[3]), ss_toi(words[4]), ss_toi(words[5]));
+            }
+            else if (words[0] == "createsafe")
+            {
+                obj.createblock(SAFE, ss_toi(words[1]), ss_toi(words[2]), ss_toi(words[3]), ss_toi(words[4]));
+            }
+            else if (words[0] == "createactivity")
+            {
+                int id = 35;
+                if (argexists[6])
+                {
+                    id = ss_toi(words[6]);
+                }
+
+                obj.customscript = words[5];
+                obj.createblock(ACTIVITY, ss_toi(words[1]), ss_toi(words[2]), ss_toi(words[3]), ss_toi(words[4]), id, words[5], ActivityContext_CUSTOM);
+            }
             else if (words[0] == "createcrewman")
             {
                 // Note: Do not change the "r" variable, it's used in custom levels
@@ -1878,11 +1919,11 @@ void scriptclass::run(void)
                 int crewman = obj.getcrewman(crew_color);
                 if (INBOUNDS_VEC(crewman, obj.entities) && crew_color == EntityColour_CREW_GREEN)
                 {
-                    obj.createblock(5, obj.entities[crewman].xp - 32, obj.entities[crewman].yp-20, 96, 60, i, "", (i == 35));
+                    obj.createblock(5, obj.entities[crewman].xp - 32, obj.entities[crewman].yp-20, 96, 60, i, "", (i == 35) ? ActivityContext_INTERACT : ActivityContext_NORMAL);
                 }
                 else if (INBOUNDS_VEC(crewman, obj.entities))
                 {
-                    obj.createblock(5, obj.entities[crewman].xp - 32, 0, 96, 240, i, "", (i == 35));
+                    obj.createblock(5, obj.entities[crewman].xp - 32, 0, 96, 240, i, "", (i == 35) ? ActivityContext_INTERACT : ActivityContext_NORMAL);
                 }
             }
             else if (words[0] == "setactivitycolour")
@@ -2757,6 +2798,7 @@ void scriptclass::startgamemode(const enum StartMode mode)
         add_default_colours();
         cl.onewaycol_override = false;
         cl.player_colour = 0;
+        cl.custom_activity_zones.clear();
         break;
     }
 


### PR DESCRIPTION
## Changes:

This PR is a redo of #909 which improves the edentity handling, abstracting activity zone types to level data rather than being a part of entity data. This commit allows users to place down the game's "blocks" in the editor, being collision blocks, hurt boxes, gamestate triggers, script boxes, activity zones, "safe" boxes, and one-ways.

Activity zones now have some level XML to allow defining new activity zone IDs:
```xml
<ActivityZones>
    <activityZone id="36" colour="red"></activityZone>
    <activityZone id="37" colour="orange">Press {button} to do something</activityZone>
</ActivityZones>
```

These add IDs 36 and 37 (with 0-35 replacing the built-in ones), for use with custom spawned or placed activity zones. If the text is empty, it will use the built-in localization string "Press {button} to interact", and if "colour" is missing, it will default to "orange".

New commands:

- `createcollision(x,y,w,h)` - Creates a collision block
- `createtrigger(x,y,w,h,gamestate)` - Creates a gamestate trigger
- `createscript(x,y,w,h,script)` - Creates a (custom!) script box
- `createdamage(x,y,w,h)` - Creates a damage block
- `createdirectional(x,y,w,h,dir)` - Creates a "directional" block
- `createsafe(x,y,w,h)` - Creates a "safe" block
- `createactivity(x,y,w,h,script[,id])` - Creates an activity zone

If `id` is not passed into `createactivity`, it will default to 35.

Custom activity zones created this way can also be affected by `setactivitytext`, `setactivitycolour` and `setactivityposition`.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
