### PR TITLE
Improve clarity and usability of room coordinates

### DIFF
--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -1033,7 +1033,7 @@ static void draw_entities(void)
 
                 if (i == edent_under_cursor)
                 {
-                    text = help.disp_room_coords(entity->p1 / 40, entity->p2 / 30, 1);
+                    text = help.disp_room_coords(entity->p1 / 40, entity->p2 / 30, game.coords0 ? 0 : 1);
                 }
                 else
                 {
@@ -1152,7 +1152,7 @@ static void draw_entities(void)
 
             if (ed.tilex == x / 8 && ed.tiley == y / 8)
             {
-                text = help.disp_room_coords(entity->rx, entity->ry, 1);
+                text = help.disp_room_coords(entity->rx, entity->ry, game.coords0 ? 0 : 1);
             }
             else
             {
@@ -1622,7 +1622,7 @@ static void draw_main_ui(void)
     const RoomProperty* const room = cl.getroomprop(ed.levx, ed.levy);
 
     char coords[8];
-    help.disp_room_coords(coords, sizeof(coords), ed.levx, ed.levy, 1);
+    help.disp_room_coords(coords, sizeof(coords), ed.levx, ed.levy, game.coords0 ? 0 : 1);
 
     if (ed.toolbox_open)
     {
@@ -1831,7 +1831,7 @@ void editorrender(void)
                     buf, sizeof(buf), "%c%c%c%c%c",
                     len >= 1 ? key.keybuffer[0] : '_',
                     len >= 2 ? key.keybuffer[1] : '_',
-                    ';',
+                    game.coords0 ? ',' : ';',
                     len >= 3 ? key.keybuffer[2] : '_',
                     len >= 4 ? key.keybuffer[3] : '_'
                 );
@@ -2126,8 +2126,15 @@ static void input_submitted(void)
             break;
         }
 
-        ed.levx = SDL_clamp(SDL_strtol(coord_x, NULL, 10) - 1, 0, cl.mapwidth - 1);
-        ed.levy = SDL_clamp(SDL_strtol(coord_y, NULL, 10) - 1, 0, cl.mapheight - 1);
+        int x = SDL_strtol(coord_x, NULL, 10);
+        int y = SDL_strtol(coord_y, NULL, 10);
+        if (!game.coords0)
+        {
+            x--;
+            y--;
+        }
+        ed.levx = SDL_clamp(x, 0, cl.mapwidth - 1);
+        ed.levy = SDL_clamp(y, 0, cl.mapheight - 1);
         graphics.foregrounddrawn = false;
         graphics.backgrounddrawn = false;
         break;

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -1033,7 +1033,7 @@ static void draw_entities(void)
 
                 if (i == edent_under_cursor)
                 {
-                    text = "(" + help.String(entity->p1 / 40 + 1) + "," + help.String(entity->p2 / 30 + 1) + ")";
+                    text = help.disp_room_coords(entity->p1 / 40, entity->p2 / 30, 1);
                 }
                 else
                 {
@@ -1152,7 +1152,7 @@ static void draw_entities(void)
 
             if (ed.tilex == x / 8 && ed.tiley == y / 8)
             {
-                text = "(" + help.String(entity->rx + 1) + "," + help.String(entity->ry + 1) + ")";
+                text = help.disp_room_coords(entity->rx, entity->ry, 1);
             }
             else
             {
@@ -1622,7 +1622,7 @@ static void draw_main_ui(void)
     const RoomProperty* const room = cl.getroomprop(ed.levx, ed.levy);
 
     char coords[8];
-    SDL_snprintf(coords, sizeof(coords), "(%d,%d)", ed.levx + 1, ed.levy + 1);
+    help.disp_room_coords(coords, sizeof(coords), ed.levx, ed.levy, 1);
 
     if (ed.toolbox_open)
     {

--- a/desktop_version/src/Editor.cpp
+++ b/desktop_version/src/Editor.cpp
@@ -1820,23 +1820,44 @@ void editorrender(void)
             break;
         case EditorSubState_DRAW_INPUT:
         {
-            short lines;
-            std::string wrapped = font::string_wordwrap(0, loc::gettext(ed.current_text_desc.c_str()), 312, &lines);
-            short textheight = font::height(0) * lines + font::height(PR_FONT_LEVEL);
-
-            graphics.fill_rect(0, 238 - textheight, 320, 240, graphics.getRGB(32, 32, 32));
-            graphics.fill_rect(0, 239 - textheight, 320, 240, graphics.getRGB(0, 0, 0));
-            font::print_wrap(PR_RTL_XFLIP, 4, 240 - textheight, wrapped.c_str(), 255, 255, 255, 8, 312);
-            std::string input = key.keybuffer;
-            if (ed.entframe < 2)
+            std::string input;
+            uint32_t input_font = PR_FONT_LEVEL;
+            if (ed.current_text_mode == TEXT_GOTOROOM)
             {
-                input += "_";
+                input_font = PR_FONT_INTERFACE;
+                size_t len = key.keybuffer.length();
+                char buf[16];
+                SDL_snprintf(
+                    buf, sizeof(buf), "%c%c%c%c%c",
+                    len >= 1 ? key.keybuffer[0] : '_',
+                    len >= 2 ? key.keybuffer[1] : '_',
+                    ';',
+                    len >= 3 ? key.keybuffer[2] : '_',
+                    len >= 4 ? key.keybuffer[3] : '_'
+                );
+                input = buf;
             }
             else
             {
-                input += " ";
+                input = key.keybuffer;
+                if (ed.entframe < 2)
+                {
+                    input += "_";
+                }
+                else
+                {
+                    input += " ";
+                }
             }
-            font::print(PR_CEN | PR_FONT_LEVEL | PR_CJK_HIGH, -1, 232, input, 196, 196, 255 - help.glow);
+
+            short lines;
+            std::string wrapped = font::string_wordwrap(0, loc::gettext(ed.current_text_desc.c_str()), 312, &lines);
+            short textheight = font::height(0) * lines + font::height(input_font);
+
+            graphics.fill_rect(0, 238 - textheight, 320, 240, graphics.getRGB(32, 32, 32));
+            graphics.fill_rect(0, 239 - textheight, 320, 240, graphics.getRGB(0, 0, 0));
+            font::print_wrap(PR_RTL_XFLIP | PR_CJK_LOW, 4, 240 - textheight, wrapped.c_str(), 255, 255, 255, 8, 312);
+            font::print(PR_CEN | input_font | PR_CJK_HIGH, -1, 232, input, 196, 196, 255 - help.glow);
             break;
         }
         case EditorSubState_DRAW_WARPTOKEN:
@@ -2085,21 +2106,16 @@ static void input_submitted(void)
     {
     case TEXT_GOTOROOM:
     {
-        char coord_x[16];
-        char coord_y[16];
+        char coord_x[3];
+        char coord_y[3];
 
-        const char* comma = SDL_strchr(key.keybuffer.c_str(), ',');
-
-        bool valid_input = comma != NULL;
+        bool valid_input = key.keybuffer.length() >= 3;
 
         if (valid_input)
         {
-            SDL_strlcpy(
-                coord_x,
-                key.keybuffer.c_str(),
-                SDL_min((size_t) (comma - key.keybuffer.c_str() + 1), sizeof(coord_x))
-            );
-            SDL_strlcpy(coord_y, &comma[1], sizeof(coord_y));
+            const char* input = key.keybuffer.c_str();
+            SDL_strlcpy(coord_x, input, sizeof(coord_x));
+            SDL_strlcpy(coord_y, &input[2], sizeof(coord_y));
 
             valid_input = is_number(coord_x) && is_number(coord_y);
         }
@@ -2110,8 +2126,8 @@ static void input_submitted(void)
             break;
         }
 
-        ed.levx = SDL_clamp(help.Int(coord_x) - 1, 0, cl.mapwidth - 1);
-        ed.levy = SDL_clamp(help.Int(coord_y) - 1, 0, cl.mapheight - 1);
+        ed.levx = SDL_clamp(SDL_strtol(coord_x, NULL, 10) - 1, 0, cl.mapwidth - 1);
+        ed.levy = SDL_clamp(SDL_strtol(coord_y, NULL, 10) - 1, 0, cl.mapheight - 1);
         graphics.foregrounddrawn = false;
         graphics.backgrounddrawn = false;
         break;
@@ -3858,6 +3874,34 @@ void editorinput(void)
                     {
                         key.keybuffer.erase(key.keybuffer.begin() + i);
                     }
+                }
+            }
+            else if (ed.current_text_mode == TEXT_GOTOROOM)
+            {
+                // We only want to accept four digits here!
+                // See the loop above for a note on SIZE_MAX.
+                // FIXME: Honestly, I'm not a fan of this overflow juggling,
+                // but it's how two other loops here work, so I'll add my own.
+                // But maybe we should make it signed before someone else
+                // stares at this thinking "wait, won't that underflow badly?"
+                for (size_t i = key.keybuffer.length() - 1; i + 1 > 0; i--)
+                {
+                    char ch = key.keybuffer[i];
+                    if (i == 1 && (ch == ',' || ch == ';'))
+                    {
+                        key.keybuffer.erase(key.keybuffer.begin() + i);
+                        key.keybuffer.insert(key.keybuffer.begin(), '0');
+                        i++;
+                    }
+                    else if (ch < '0' || ch > '9' || i > 3)
+                    {
+                        key.keybuffer.erase(key.keybuffer.begin() + i);
+                    }
+                }
+
+                if (key.keybuffer.length() == 4)
+                {
+                    enter_pressed = true;
                 }
             }
 

--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -344,6 +344,7 @@ void Game::init(void)
     skipfakeload = false;
 
     ghostsenabled = false;
+    coords0 = false;
 
     cliplaytest = false;
     playx = 0;
@@ -4831,6 +4832,11 @@ void Game::deserializesettings(tinyxml2::XMLElement* dataNode, struct ScreenSett
             ghostsenabled = help.Int(pText);
         }
 
+        if (SDL_strcmp(pKey, "coords0") == 0)
+        {
+            coords0 = help.Int(pText);
+        }
+
         if (SDL_strcmp(pKey, "skipfakeload") == 0)
         {
             skipfakeload = help.Int(pText);
@@ -5133,6 +5139,8 @@ void Game::serializesettings(tinyxml2::XMLElement* dataNode, const struct Screen
     xml::update_tag(dataNode, "usingmmmmmm", music.usingmmmmmm);
 
     xml::update_tag(dataNode, "ghostsenabled", (int) ghostsenabled);
+
+    xml::update_tag(dataNode, "coords0", (int) coords0);
 
     xml::update_tag(dataNode, "skipfakeload", (int) skipfakeload);
 

--- a/desktop_version/src/Game.h
+++ b/desktop_version/src/Game.h
@@ -555,6 +555,7 @@ public:
 
     bool skipfakeload;
     bool ghostsenabled;
+    bool coords0;
 
     bool cliplaytest;
     int playx;

--- a/desktop_version/src/LevelDebugger.cpp
+++ b/desktop_version/src/LevelDebugger.cpp
@@ -241,7 +241,7 @@ namespace level_debugger
     void render_coords(int y, const char* text, int first, int second)
     {
         char buffer[SCREEN_WIDTH_CHARS + 1];
-        vformat_buf(buffer, sizeof(buffer), "{text}: ({first},{second})", "text:str, first:int, second:int", text, first, second);
+        vformat_buf(buffer, sizeof(buffer), "{text}: [{first},{second}]", "text:str, first:int, second:int", text, first, second);
         render_info(y, buffer);
     }
 

--- a/desktop_version/src/RoomnameTranslator.cpp
+++ b/desktop_version/src/RoomnameTranslator.cpp
@@ -154,7 +154,7 @@ namespace roomname_translator
         }
 
         vformat_buf(buffer, sizeof(buffer),
-            "({x|digits=2|spaces},{y|digits=2|spaces})",
+            "[{x|digits=2|spaces},{y|digits=2|spaces}]",
             "x:int, y:int",
             game.roomx % 100, game.roomy % 100
         );

--- a/desktop_version/src/UtilityClass.cpp
+++ b/desktop_version/src/UtilityClass.cpp
@@ -214,6 +214,24 @@ std::string UtilityClass::number_words(int _t, const char* number_class)
     }
 }
 
+void UtilityClass::disp_room_coords(char* buffer, const size_t buffer_size, int x, int y, int offset)
+{
+    // Takes room coordinates and display them as [0,0] or (1;1).
+    vformat_buf(
+        buffer, buffer_size,
+        offset == 1 ? "({x};{y})" : "[{x},{y}]",
+        "x:int, y:int",
+        x+offset, y+offset
+    );
+}
+
+std::string UtilityClass::disp_room_coords(int x, int y, int offset)
+{
+    char coords[8];
+    disp_room_coords(coords, sizeof(coords), x, y, offset);
+    return std::string(coords);
+}
+
 bool UtilityClass::intersects( SDL_Rect A, SDL_Rect B )
 {
     return (SDL_HasIntersection(&A, &B) == SDL_TRUE);

--- a/desktop_version/src/UtilityClass.h
+++ b/desktop_version/src/UtilityClass.h
@@ -109,6 +109,9 @@ public:
 
     std::string number_words(int _t, const char* number_class);
 
+    void disp_room_coords(char* buffer, const size_t buffer_size, int x, int y, int offset);
+    std::string disp_room_coords(int x, int y, int offset);
+
 
     static bool intersects( SDL_Rect A, SDL_Rect B );
 


### PR DESCRIPTION
## Changes:

Room coordinates in the VVVVVV community have always been a source of misunderstandings. VVVVVV's editor has always displayed (1,1)-(20,20), but `gotoroom(x,y)` has always used (0,0)-(19,19), so Ved has always had an option to display coordinates as such, and most Ved users I know seem to have always preferred that.

The problem is that both coordinate systems look the same, and not everyone is aware there are two systems. So when an internal scripting veteran says there's a wall glitch in room (7,15), you may be left staring at (7,15) not finding anything, until you decide to check (8,16), still not finding anything... Before you realize you had it the wrong way around and you should've looked at (6,14) instead.

We can't get rid of either of the two systems either, since both are actually preferred by different people (we have had at least one person say 1-indexing was more intuitive to them!) and both systems are even eternalized in different scripting commands.

After some discussion about how to solve the confusion, people seem to agree to change how editors display coordinates as follows:
- 1-indexed coordinates are always displayed as `(1;1)`-`(20;20)` (with the `,` replaced by a `;`)
- 0-indexed coordinates are always displayed as `[0,0]`-`[19,19]` (with the `()` replaced by `[]`)

The idea behind this is that people will likely copy what the editor says - so if the editor says (7;15) you'll likely write (7;15) or 7;15, and if the editor says [6,14] you'll likely write [6,14] or 6,14.
It's not waterproof, but it seems much more likely to succeed than something like (7,15)1 or (6,14)0, which would inevitably be shortened by people who are unaware of what it means.

Something similar is done with video timecodes, where 00:00:00:00 means one counting method and 00:00:00;00 or 00;00;00;00 means another.

So, VVVVVV's editor still displays coordinates as 1-indexed, but just shows them with a semicolon. The same change was made in Ved.

Another improvement is the "go to room" input. Previously, coordinates had to be entered as `x,y`, for example `9,15`. My initial thought was to make this input accept `;` as well, and to change the label to say `x;y`. Then I discovered not all translators carried over the exact `x,y` format! Instead of changing only part of the languages (now knowing some users are going to have an exceptionally hard time with this input...) or making sure every string is consistent, I decided it would be better to make the input more like Ved's "go to room" input.
    
The input is now shown as `__;__`. Only digits are accepted as input. Which means you can enter 9,15 as 0915. Or as 9,15 or 9;15: typing a comma or semicolon in the second position inserts a 0 before it.

https://github.com/user-attachments/assets/f36f6857-aa25-411f-b2fa-cdabd51313db

Lastly, there is now a (currently config-file-only) option to switch VVVVVV's editor to 0-indexed coordinates, which, if set, will be shown in the aforementioned [0,0] style.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
