### PR TITLE
Add `savewarpdir(rx,ry)` and `unsavewarpdir(rx,ry)`

### DIFF
--- a/desktop_version/src/Game.cpp
+++ b/desktop_version/src/Game.cpp
@@ -5994,6 +5994,38 @@ void Game::customloadquick(const std::string& savfile)
                 map.setregion(thisid, thisrx, thisry, thisrx2, thisry2);
             }
         }
+        else if (SDL_strcmp(pKey, "savedwarpdirs") == 0)
+        {
+            char buffer[16]; 
+            size_t start = 0; 
+            size_t i = 0; 
+                
+            while (next_split_s(buffer, sizeof(buffer), &start, pText, ',')) 
+            {
+                // Use array size from map.explored, since savedwarpdirs doesn't have a fixed size
+                if (i >= SDL_arraysize(map.explored)) 
+                {
+                    break;
+                }
+                
+                // If empty, ignore line
+                if (buffer[0] == '\0')
+                {
+                    ++i;
+                    continue;
+                }
+
+                int warpdir = help.Int(buffer);
+                map.savedwarpdirs[i] = warpdir;
+
+                int temprx = i % 20;
+                int tempry = i / 20;
+
+                cl.setroomwarpdir(temprx, tempry, warpdir);
+
+                ++i; 
+            } 
+        }
     }
 }
 
@@ -6355,6 +6387,21 @@ bool Game::customsavequick(const std::string& savfile)
         customcollect += help.String((int) obj.customcollect[i]) + ",";
     }
     xml::update_tag(msgs, "customcollect", customcollect.c_str());
+
+    std::string savedwarpdirs;
+    // savedwarpdirs won't contain values for each room. Reuse room count from map.explored instead
+    for (size_t i = 0; i < SDL_arraysize(map.explored); i++)
+    {
+        if (map.savedwarpdirs.count(i) == 0)
+        {
+            savedwarpdirs += ",";
+        }
+        else
+        {
+            savedwarpdirs += help.String(map.savedwarpdirs[i]) + ",";
+        }
+    }
+    xml::update_tag(msgs, "savedwarpdirs", savedwarpdirs.c_str());
 
     //Position
 

--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -66,6 +66,7 @@ mapclass::mapclass(void)
     SDL_memset(roomdeaths, 0, sizeof(roomdeaths));
     SDL_memset(roomdeathsfinal, 0, sizeof(roomdeathsfinal));
     resetmap();
+    savedwarpdirs.clear();
 
     setroomname("");
     hiddenname = "";
@@ -726,6 +727,18 @@ int mapclass::area(int _rx, int _ry)
             return 6;
         }
     }
+}
+
+void mapclass::savewarpdir(const int rx, const int ry, const int dir)
+{
+    const int roomnum = rx + ry*20;
+    savedwarpdirs[roomnum] = dir;
+}
+
+void mapclass::unsavewarpdir(const int rx, const int ry)
+{
+    const int roomnum = rx + ry*20;
+    savedwarpdirs.erase(roomnum);
 }
 
 bool mapclass::isexplored(const int rx, const int ry)

--- a/desktop_version/src/Map.h
+++ b/desktop_version/src/Map.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <string>
+#include <map>
 
 #include "Finalclass.h"
 #include "Labclass.h"
@@ -141,6 +142,11 @@ public:
 
     bool isexplored(const int rx, const int ry);
     void setexplored(const int rx, const int ry, const bool status);
+
+    std::map<int,int> savedwarpdirs;
+
+    void savewarpdir(const int rx, const int ry, const int dir);
+    void unsavewarpdir(const int rx, const int ry);
 
     bool revealmap;
 

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -289,6 +289,21 @@ void scriptclass::run(void)
                     position--;
                 }
             }
+            if (words[0] == "savewarpdir")
+            {
+                int temprx = ss_toi(words[1]) - 1;
+                int tempry = ss_toi(words[2]) - 1;
+
+                const RoomProperty* const room = cl.getroomprop(temprx, tempry);
+                map.savewarpdir(temprx, tempry, room->warpdir);
+            }
+            if (words[0] == "unsavewarpdir")
+            {
+                int temprx = ss_toi(words[1]) - 1;
+                int tempry = ss_toi(words[2]) - 1;
+
+                map.unsavewarpdir(temprx, tempry);
+            }
             if (words[0] == "destroy")
             {
                 if (words[1] == "gravitylines")
@@ -3427,6 +3442,7 @@ void scriptclass::hardreset(void)
     SDL_memset(map.roomdeaths, 0, sizeof(map.roomdeaths));
     SDL_memset(map.roomdeathsfinal, 0, sizeof(map.roomdeathsfinal));
     map.resetmap();
+    map.savedwarpdirs.clear();
     map.currentregion = 0;
     SDL_zeroa(map.region);
     //entityclass
@@ -3658,6 +3674,12 @@ bool scriptclass::loadcustom(const std::string& t)
             if(customtextmode==1){ add("endtext"); customtextmode=0;}
             add(lines[i]);
         }else if(words[0] == "ifwarp"){
+            if(customtextmode==1){ add("endtext"); customtextmode=0;}
+            add(lines[i]);
+        }else if(words[0] == "savewarpdir"){
+            if(customtextmode==1){ add("endtext"); customtextmode=0;}
+            add(lines[i]);
+        }else if(words[0] == "unsavewarpdir"){
             if(customtextmode==1){ add("endtext"); customtextmode=0;}
             add(lines[i]);
         }else if(words[0] == "iftrinkets"){


### PR DESCRIPTION
These commands are used to persist and unpersist warpdir states, causing them to be saved to the player's save file.

Save files contain a new property `savedwarpdirs`, which is a comma separated list of ints for each room, like the `worldmap` (explored) value. Unlike `worldmap`, only select rooms should be persisted, so all unpersisted entries are left blank instead of containing a 0.

The approach for this change has been discussed with both @NyakoFox and @mothbeanie.

Demonstration of the commands:
https://github.com/user-attachments/assets/bda1a8e6-2473-4af3-81ec-11cffaa75242

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
