### PR TITLE
Fix double script execution when entering playtesting

### DIFF
--- a/desktop_version/src/Map.cpp
+++ b/desktop_version/src/Map.cpp
@@ -791,7 +791,10 @@ void mapclass::resetplayer(const bool player_died)
     if (game.roomx != game.saverx || game.roomy != game.savery)
     {
         gotoroom(game.saverx, game.savery);
-        twoframedelayfix();
+        if (player_died)
+        {
+            twoframedelayfix();
+        }
     }
 
     int i = obj.getplayer();


### PR DESCRIPTION
## Changes:

`twoframedelayfix()` now gets called in `resetplayer` due to #1258, to fix the two-frame script delay when you respawn. Unfortunately, there seems to be some strange bug where starting playtesting in a script box activates the script twice. While I'm not exactly sure WHY this happens logic-wise, we can quickly squash this issue by checking if the player is reset due to dying.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
