### PR TITLE
Fix two nuisance error messages

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -381,6 +381,12 @@ public:
     MusicTrack(SDL_RWops *rw, const char* _id, bool _loose_extra)
     {
         SDL_zerop(this);
+        if (rw->size(rw) <= 1)
+        {
+            // Don't bother
+            vlog_debug("Skipping empty music track");
+            goto end;
+        }
         read_buf = (Uint8*) SDL_malloc(rw->size(rw));
         SDL_RWread(rw, read_buf, rw->size(rw), 1);
         int err;

--- a/desktop_version/src/Script.cpp
+++ b/desktop_version/src/Script.cpp
@@ -347,7 +347,7 @@ void scriptclass::run(void)
                 int current = 0;
 
                 // Crawl through the string
-                for (int i = 0; i < words[1].size(); i++)
+                for (size_t i = 0; i < words[1].size(); i++)
                 {
                     // If the current character is a number, add it to the current version part
                     if (words[1][i] >= '0' && words[1][i] <= '9')


### PR DESCRIPTION
## Changes:

This PR gets rid of two messages I've seen a lot, one at runtime and one at compile time:
- `[ERROR] Unable to create Vorbis handle, error 30` if any music slots are empty (which is very common in custom levels)
- A warning about `for (int i` which should've been `for (size_t i`


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
