### PR TITLE
Set `id` and `loose_extra` fields no matter what

### DIFF
--- a/desktop_version/src/Music.cpp
+++ b/desktop_version/src/Music.cpp
@@ -381,6 +381,10 @@ public:
     MusicTrack(SDL_RWops *rw, const char* _id, bool _loose_extra)
     {
         SDL_zerop(this);
+
+        id = SDL_strdup(_id);
+        loose_extra = _loose_extra;
+
         if (rw->size(rw) <= 1)
         {
             // Don't bother
@@ -393,9 +397,6 @@ public:
         stb_vorbis_info vorbis_info;
         stb_vorbis_comment vorbis_comment;
 
-        id = SDL_strdup(_id);
-
-        loose_extra = _loose_extra;
         vorbis = stb_vorbis_open_memory(read_buf, rw->size(rw), &err, NULL);
         if (vorbis == NULL)
         {


### PR DESCRIPTION
## Changes:

The PR #1278 seems to have introduced a segfault. When an empty music track is found, it skips past `id` (and `loose_extra`) being set. Functions which use `id` expect a string, not NULL, causing a crash whenever `isextra` is called, which happens to be every time the `music` or `play` commands are invoked.

This fix simply moves the setting of these variables upwards, BEFORE the valid check, to make sure they're always set.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
