### PR TITLE
Add WINXP option to CMakeLists.txt

### DIFF
--- a/desktop_version/CMakeLists.txt
+++ b/desktop_version/CMakeLists.txt
@@ -16,9 +16,14 @@ option(OFFICIAL_BUILD "Compile an official build of the game" OFF)
 
 option(MAKEANDPLAY "Compile a version of the game without the main campaign (provided for convenience; consider modifying MakeAndPlay.h instead" OFF)
 
-if(OFFICIAL_BUILD AND NOT MAKEANDPLAY)
-    set(STEAM ON)
-    set(GOG ON)
+option(WINXP "Compile with Windows XP support. You must set your toolkit version to v141_xp for this to work." OFF)
+
+if(OFFICIAL_BUILD)
+    set(WINXP ON)
+    if(NOT MAKEANDPLAY)
+        set(STEAM ON)
+        set(GOG ON)
+    endif()
 endif()
 
 option(REMOVE_ABSOLUTE_PATHS "If supported by the compiler, replace all absolute paths to source directories compiled into the binary (if any) with relative paths" ON)
@@ -367,6 +372,11 @@ if(BUNDLE_DEPENDENCIES)
     target_compile_definitions(physfs-static PRIVATE
         -DPHYSFS_SUPPORTS_DEFAULT=0 -DPHYSFS_SUPPORTS_ZIP=1
     )
+
+   if(MSVC AND WINXP)
+        target_compile_definitions(physfs-static PRIVATE -D_WIN32_WINNT=0x0501)
+    endif()
+
     add_library(faudio-static STATIC ${FAUDIO_SRC})
     target_include_directories(
         faudio-static PRIVATE


### PR DESCRIPTION
## Changes:

This is a new option (off by default, on for official builds) which tell Physfs to support Windows XP. Without it, it tries to use a function from Vista (existed in XP, but was an external thing).

For making a build that actually supports Windows XP, `cmake` must be invoked with `-T v141_xp`, and the toolchain must be installed in Visual Studio.

This PR was made as builds will use newer versions of Visual Studio moving forwards; but I don't think we want to give up XP yet.

Tested on VS2026 and a Windows XP machine that @Daaaav owns.

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of VVVVVV
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
